### PR TITLE
add filesystem memory substrate

### DIFF
--- a/packages/coding-agent/src/core/memory/command.ts
+++ b/packages/coding-agent/src/core/memory/command.ts
@@ -1,0 +1,198 @@
+import { lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { isAbsolute, join, posix, relative, resolve, sep } from "node:path";
+import { ensureMemoryDirs } from "./init.js";
+import type { MemoryDirs, MemoryPathOptions } from "./paths.js";
+
+const MAX_MEMORY_FILE_BYTES = 128 * 1024;
+
+type MemoryScope = keyof MemoryDirs;
+
+interface MemoryFile {
+	scope: MemoryScope;
+	relativePath: string;
+	absolutePath: string;
+}
+
+interface ParsedMemoryPath {
+	scope?: MemoryScope;
+	relativePath: string;
+}
+
+export interface RunMemoryCommandOptions extends MemoryPathOptions {
+	maxFileBytes?: number;
+}
+
+function getScopeDir(dirs: MemoryDirs, scope: MemoryScope): string {
+	return dirs[scope];
+}
+
+function parseMemoryPath(input: string): ParsedMemoryPath {
+	const rawPath = input.trim();
+	if (!rawPath) {
+		throw new Error("Usage: /memory show <path>");
+	}
+	if (isAbsolute(rawPath) || /^[a-zA-Z]:[\\/]/.test(rawPath)) {
+		throw new Error("Memory paths must be relative to a memory directory.");
+	}
+
+	const slashPath = rawPath.replace(/\\/g, "/");
+	const scopedMatch = slashPath.match(/^(global|project)\/(.+)$/);
+	const scope = scopedMatch?.[1] as MemoryScope | undefined;
+	const unscopedPath = scopedMatch ? scopedMatch[2] : slashPath;
+	const normalized = posix.normalize(unscopedPath ?? "");
+
+	if (normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+		throw new Error("Memory paths must stay inside a memory directory.");
+	}
+
+	return {
+		scope,
+		relativePath: normalized,
+	};
+}
+
+function resolveRelativeMemoryPath(root: string, relativePath: string): string {
+	const rootPath = resolve(root);
+	const targetPath = resolve(rootPath, ...relativePath.split("/"));
+	const relativePathFromRoot = relative(rootPath, targetPath);
+	if (
+		relativePathFromRoot === ".." ||
+		relativePathFromRoot.startsWith(`..${sep}`) ||
+		isAbsolute(relativePathFromRoot)
+	) {
+		throw new Error("Memory paths must stay inside a memory directory.");
+	}
+	return targetPath;
+}
+
+function listMemoryFilesForScope(dirs: MemoryDirs, scope: MemoryScope): MemoryFile[] {
+	const root = getScopeDir(dirs, scope);
+	const files: MemoryFile[] = [];
+
+	const walk = (dir: string, prefix: string): void => {
+		const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+		for (const entry of entries) {
+			const absolutePath = join(dir, entry.name);
+			const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+			if (entry.isDirectory()) {
+				walk(absolutePath, relativePath);
+			} else if (entry.isFile()) {
+				files.push({ scope, relativePath, absolutePath });
+			}
+		}
+	};
+
+	walk(root, "");
+	return files;
+}
+
+function listMemoryFiles(dirs: MemoryDirs): MemoryFile[] {
+	return [...listMemoryFilesForScope(dirs, "global"), ...listMemoryFilesForScope(dirs, "project")];
+}
+
+function resolveMemoryFile(dirs: MemoryDirs, input: string): MemoryFile {
+	const parsed = parseMemoryPath(input);
+	if (parsed.scope) {
+		const absolutePath = resolveRelativeMemoryPath(getScopeDir(dirs, parsed.scope), parsed.relativePath);
+		let isFile = false;
+		try {
+			isFile = lstatSync(absolutePath).isFile();
+		} catch {
+			throw new Error(`Memory file not found: ${input}`);
+		}
+		if (!isFile) {
+			throw new Error(`Memory file not found: ${input}`);
+		}
+		return {
+			scope: parsed.scope,
+			relativePath: parsed.relativePath,
+			absolutePath,
+		};
+	}
+
+	const matches = listMemoryFiles(dirs).filter((file) => file.relativePath === parsed.relativePath);
+	if (matches.length === 0) {
+		throw new Error(`Memory file not found: ${input}`);
+	}
+	if (matches.length > 1) {
+		throw new Error(`Ambiguous memory file: use global/${parsed.relativePath} or project/${parsed.relativePath}.`);
+	}
+	return matches[0]!;
+}
+
+function formatMemoryList(dirs: MemoryDirs): string {
+	const files = listMemoryFiles(dirs);
+	const lines = ["Memory directories", `Global: ${dirs.global}`, `Project: ${dirs.project}`, "", "Files"];
+
+	for (const scope of ["global", "project"] as const) {
+		lines.push(`${scope}:`);
+		const scopedFiles = files.filter((file) => file.scope === scope);
+		if (scopedFiles.length === 0) {
+			lines.push("  (empty)");
+			continue;
+		}
+		for (const file of scopedFiles) {
+			lines.push(`  ${file.relativePath}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function showMemoryFile(dirs: MemoryDirs, inputPath: string, maxFileBytes: number): string {
+	const file = resolveMemoryFile(dirs, inputPath);
+	const bytes = readFileSync(file.absolutePath);
+	const truncated = bytes.byteLength > maxFileBytes;
+	const content = bytes.subarray(0, maxFileBytes).toString("utf-8");
+	const lines = [`Memory file: ${file.scope}/${file.relativePath}`, file.absolutePath, "", content];
+	if (truncated) {
+		lines.push("", `[truncated after ${maxFileBytes} bytes]`);
+	}
+	return lines.join("\n");
+}
+
+function clearMemoryDir(dir: string): void {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		rmSync(join(dir, entry.name), { recursive: true, force: true });
+	}
+}
+
+function clearMemory(dirs: MemoryDirs, scope: MemoryScope | "all"): string {
+	if (scope === "all" || scope === "global") {
+		clearMemoryDir(dirs.global);
+	}
+	if (scope === "all" || scope === "project") {
+		clearMemoryDir(dirs.project);
+	}
+
+	const label = scope === "all" ? "global and project" : scope;
+	return `Cleared ${label} memory.`;
+}
+
+function parseClearScope(scope: string | undefined): MemoryScope | "all" {
+	if (!scope || scope === "all") {
+		return "all";
+	}
+	if (scope === "global" || scope === "project") {
+		return scope;
+	}
+	throw new Error("Usage: /memory clear [global|project|all]");
+}
+
+export function runMemoryCommand(args: string, options: RunMemoryCommandOptions): string {
+	const dirs = ensureMemoryDirs(options);
+	const trimmedArgs = args.trim();
+	if (!trimmedArgs || trimmedArgs === "list") {
+		return formatMemoryList(dirs);
+	}
+
+	const [action, ...rest] = trimmedArgs.split(/\s+/);
+	if (action === "show") {
+		return showMemoryFile(dirs, rest.join(" "), options.maxFileBytes ?? MAX_MEMORY_FILE_BYTES);
+	}
+	if (action === "clear") {
+		return clearMemory(dirs, parseClearScope(rest[0]));
+	}
+
+	throw new Error("Usage: /memory [list|show <path>|clear [global|project|all]]");
+}

--- a/packages/coding-agent/src/core/memory/index.ts
+++ b/packages/coding-agent/src/core/memory/index.ts
@@ -1,0 +1,18 @@
+export {
+	type RunMemoryCommandOptions,
+	runMemoryCommand,
+} from "./command.js";
+export {
+	ensureMemoryDirs,
+	ensureMemoryDirsForExistingCwd,
+} from "./init.js";
+export {
+	formatMemoryPathForPrompt,
+	getGlobalMemoryDir,
+	getMemoryDirs,
+	getProjectMemoryDir,
+	MEMORY_DIR_NAME,
+	MEMORY_STATE_DIR_NAME,
+	type MemoryDirs,
+	type MemoryPathOptions,
+} from "./paths.js";

--- a/packages/coding-agent/src/core/memory/init.ts
+++ b/packages/coding-agent/src/core/memory/init.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { getMemoryDirs, type MemoryDirs, type MemoryPathOptions } from "./paths.js";
+
+function assertDirectory(dir: string): void {
+	const stat = statSync(dir);
+	if (!stat.isDirectory()) {
+		throw new Error(`Memory path is not a directory: ${dir}`);
+	}
+}
+
+export function ensureMemoryDirs(options: MemoryPathOptions): MemoryDirs {
+	const dirs = getMemoryDirs(options);
+	mkdirSync(dirs.global, { recursive: true });
+	mkdirSync(dirs.project, { recursive: true });
+	assertDirectory(dirs.global);
+	assertDirectory(dirs.project);
+	return dirs;
+}
+
+export function ensureMemoryDirsForExistingCwd(options: MemoryPathOptions): MemoryDirs {
+	const dirs = getMemoryDirs(options);
+	try {
+		if (!statSync(resolve(options.cwd)).isDirectory()) {
+			return dirs;
+		}
+		return ensureMemoryDirs(options);
+	} catch {
+		return dirs;
+	}
+}

--- a/packages/coding-agent/src/core/memory/paths.ts
+++ b/packages/coding-agent/src/core/memory/paths.ts
@@ -1,0 +1,35 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const MEMORY_STATE_DIR_NAME = ".prime-agent";
+export const MEMORY_DIR_NAME = "memory";
+
+export interface MemoryDirs {
+	global: string;
+	project: string;
+}
+
+export interface MemoryPathOptions {
+	cwd: string;
+	globalMemoryDir?: string;
+	projectMemoryDir?: string;
+}
+
+export function getGlobalMemoryDir(): string {
+	return join(homedir(), MEMORY_STATE_DIR_NAME, MEMORY_DIR_NAME);
+}
+
+export function getProjectMemoryDir(cwd: string): string {
+	return join(resolve(cwd), MEMORY_STATE_DIR_NAME, MEMORY_DIR_NAME);
+}
+
+export function getMemoryDirs(options: MemoryPathOptions): MemoryDirs {
+	return {
+		global: options.globalMemoryDir ?? getGlobalMemoryDir(),
+		project: options.projectMemoryDir ?? getProjectMemoryDir(options.cwd),
+	};
+}
+
+export function formatMemoryPathForPrompt(filePath: string): string {
+	return filePath.replace(/\\/g, "/");
+}

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -1,14 +1,17 @@
+import type { MemoryDirs } from "../memory/index.js";
+
 export interface RlmPromptOptions {
 	cwd: string;
 	skillsDir?: string;
 	installedSkills?: string[];
 	messagesPath: string;
+	memoryDirs?: MemoryDirs;
 	allowRecursion?: boolean;
 	activeTools?: string[];
 }
 
 export function buildRlmPrompt(options: RlmPromptOptions): string {
-	const { cwd, skillsDir, messagesPath } = options;
+	const { cwd, skillsDir, messagesPath, memoryDirs } = options;
 	const installedSkills = options.installedSkills ?? [];
 	const allowRecursion = options.allowRecursion ?? false;
 	const activeTools = options.activeTools ?? [];
@@ -20,6 +23,12 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		`Working directory: ${cwd}`,
 		`Conversation log: ${messagesPath}`,
 	];
+
+	if (memoryDirs) {
+		parts.push(
+			`Memory directories: global ${memoryDirs.global}; project ${memoryDirs.project}. Contents are not auto-injected; read and write files there from the kernel when relevant.`,
+		);
+	}
 
 	const skillLines: string[] = [];
 	if (skillsDir) {

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -25,6 +25,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
+	{ name: "memory", description: "List, show, or clear memory files" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
 	{ name: "fork", description: "Create a new fork from a previous user message" },

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -2,6 +2,7 @@
  * System prompt construction and project context loading
  */
 
+import { ensureMemoryDirsForExistingCwd, formatMemoryPathForPrompt } from "./memory/index.js";
 import { buildRlmPrompt } from "./prompts/index.js";
 import { formatSkillsForPrompt, type Skill } from "./skills.js";
 
@@ -52,6 +53,11 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	const contextFiles = providedContextFiles ?? [];
 	const skills = providedSkills ?? [];
 	const tools = selectedTools ?? ["ipython"];
+	const memoryDirs = ensureMemoryDirsForExistingCwd({ cwd });
+	const promptMemoryDirs = {
+		global: formatMemoryPathForPrompt(memoryDirs.global),
+		project: formatMemoryPathForPrompt(memoryDirs.project),
+	};
 
 	if (customPrompt) {
 		let prompt = customPrompt;
@@ -86,6 +92,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	let prompt = buildRlmPrompt({
 		cwd: promptCwd,
 		messagesPath: promptMessagesPath,
+		memoryDirs: promptMemoryDirs,
 		installedSkills: skills.filter((skill) => !skill.disableModelInvocation).map((skill) => skill.name),
 		activeTools: tools.filter((name) => name === "ipython" || name === "bash" || name === "edit"),
 		allowRecursion: false,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -70,6 +70,7 @@ import type {
 } from "../../core/extensions/index.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
+import { runMemoryCommand } from "../../core/memory/index.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { defaultModelPerProvider, findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
@@ -2481,6 +2482,11 @@ export class InteractiveMode {
 			}
 			if (text === "/session") {
 				this.handleSessionCommand();
+				this.editor.setText("");
+				return;
+			}
+			if (text === "/memory" || text.startsWith("/memory ")) {
+				this.handleMemoryCommand(text);
 				this.editor.setText("");
 				return;
 			}
@@ -5112,6 +5118,18 @@ export class InteractiveMode {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(info, 1, 0));
 		this.ui.requestRender();
+	}
+
+	private handleMemoryCommand(text: string): void {
+		const args = text === "/memory" ? "" : text.slice("/memory".length).trim();
+		try {
+			const output = runMemoryCommand(args, { cwd: this.sessionManager.getCwd() });
+			this.chatContainer.addChild(new Spacer(1));
+			this.chatContainer.addChild(new Text(output, 1, 0));
+			this.ui.requestRender();
+		} catch (error) {
+			this.showError(error instanceof Error ? error.message : String(error));
+		}
 	}
 
 	private handleChangelogCommand(): void {

--- a/packages/coding-agent/test/memory.test.ts
+++ b/packages/coding-agent/test/memory.test.ts
@@ -1,0 +1,105 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureMemoryDirs, getMemoryDirs, runMemoryCommand } from "../src/core/memory/index.js";
+import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.js";
+
+let tempRoot = "";
+
+afterEach(() => {
+	if (tempRoot) {
+		rmSync(tempRoot, { recursive: true, force: true });
+		tempRoot = "";
+	}
+});
+
+function createMemoryOptions() {
+	tempRoot = mkdtempSync(join(tmpdir(), "pi-memory-"));
+	const cwd = join(tempRoot, "project");
+	const globalMemoryDir = join(tempRoot, "global-memory");
+	mkdirSync(cwd, { recursive: true });
+	return { cwd, globalMemoryDir };
+}
+
+describe("memory paths", () => {
+	it("returns global and project memory directories", () => {
+		const options = createMemoryOptions();
+		const dirs = getMemoryDirs(options);
+
+		expect(dirs.global).toBe(options.globalMemoryDir);
+		expect(dirs.project).toBe(join(options.cwd, ".prime-agent", "memory"));
+	});
+
+	it("creates memory directories idempotently", () => {
+		const options = createMemoryOptions();
+		const first = ensureMemoryDirs(options);
+		const second = ensureMemoryDirs(options);
+
+		expect(existsSync(first.global)).toBe(true);
+		expect(existsSync(first.project)).toBe(true);
+		expect(second).toEqual(first);
+	});
+});
+
+describe("/memory command", () => {
+	it("is registered as a built-in slash command", () => {
+		expect(BUILTIN_SLASH_COMMANDS.some((command) => command.name === "memory")).toBe(true);
+	});
+
+	it("lists global and project memory files", () => {
+		const options = createMemoryOptions();
+		const dirs = ensureMemoryDirs(options);
+		writeFileSync(join(dirs.global, "user-prefs.md"), "terse prose");
+		writeFileSync(join(dirs.project, "project-notes.md"), "project note");
+
+		const output = runMemoryCommand("list", options);
+
+		expect(output).toContain(`Global: ${dirs.global}`);
+		expect(output).toContain(`Project: ${dirs.project}`);
+		expect(output).toContain("user-prefs.md");
+		expect(output).toContain("project-notes.md");
+	});
+
+	it("shows a memory file by relative path", () => {
+		const options = createMemoryOptions();
+		const dirs = ensureMemoryDirs(options);
+		writeFileSync(join(dirs.global, "user-prefs.md"), "# Preferences\n- terse prose");
+
+		const output = runMemoryCommand("show user-prefs.md", options);
+
+		expect(output).toContain("Memory file: global/user-prefs.md");
+		expect(output).toContain("# Preferences\n- terse prose");
+	});
+
+	it("requires a scope when a file path is ambiguous", () => {
+		const options = createMemoryOptions();
+		const dirs = ensureMemoryDirs(options);
+		writeFileSync(join(dirs.global, "notes.md"), "global");
+		writeFileSync(join(dirs.project, "notes.md"), "project");
+
+		expect(() => runMemoryCommand("show notes.md", options)).toThrow(/Ambiguous memory file/);
+		expect(runMemoryCommand("show project/notes.md", options)).toContain("project");
+	});
+
+	it("rejects paths outside memory directories", () => {
+		const options = createMemoryOptions();
+		ensureMemoryDirs(options);
+		writeFileSync(join(tempRoot, "outside.md"), "outside");
+
+		expect(() => runMemoryCommand("show ../outside.md", options)).toThrow(/inside a memory directory/);
+	});
+
+	it("clears memory files while keeping the directories", () => {
+		const options = createMemoryOptions();
+		const dirs = ensureMemoryDirs(options);
+		writeFileSync(join(dirs.global, "user-prefs.md"), "global");
+		writeFileSync(join(dirs.project, "project-notes.md"), "project");
+
+		expect(runMemoryCommand("clear", options)).toBe("Cleared global and project memory.");
+		expect(readdirSync(dirs.global)).toEqual([]);
+		expect(readdirSync(dirs.project)).toEqual([]);
+		expect(existsSync(dirs.global)).toBe(true);
+		expect(existsSync(dirs.project)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -24,6 +24,10 @@ describe("buildRlmPrompt", () => {
 		const prompt = buildRlmPrompt({
 			cwd: "/repo",
 			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			memoryDirs: {
+				global: "/home/user/.prime-agent/memory",
+				project: "/repo/.prime-agent/memory",
+			},
 			installedSkills: ["websearch"],
 			activeTools: ["ipython"],
 		});
@@ -36,6 +40,7 @@ describe("buildRlmPrompt", () => {
 				"",
 				"Working directory: /repo",
 				"Conversation log: /repo/.pi/sessions/session.jsonl",
+				"Memory directories: global /home/user/.prime-agent/memory; project /repo/.prime-agent/memory. Contents are not auto-injected; read and write files there from the kernel when relevant.",
 				"",
 				"Installed skills (pre-imported): `websearch`.",
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
@@ -60,6 +65,8 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("You are a coding agent.");
 		expect(prompt).toContain("Working directory: /repo");
 		expect(prompt).toContain("Conversation log: /repo/.pi/sessions/session.jsonl");
+		expect(prompt).toContain("Memory directories: global");
+		expect(prompt).toContain("project /repo/.prime-agent/memory");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");
 		expect(prompt).not.toContain("Available tools:");


### PR DESCRIPTION
- adds global and project memory directories under ~/.prime-agent/memory and <cwd>/.prime-agent/memory, created on first use.
- advertises memory paths in the rlm prompt without injecting file contents, so the model reads memory from the kernel when relevant.
- adds /memory list, /memory show, and /memory clear with regression coverage for path handling.
