### PR TITLE
restart ipython kernel after compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -76,6 +76,7 @@ import {
 	wrapRegisteredTools,
 } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
+import type { KernelManager } from "./kernel/index.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -296,6 +297,7 @@ export class AgentSession {
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
+	private _ipythonKernelManagerRef: { current?: KernelManager } = {};
 
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
@@ -1577,6 +1579,10 @@ export class AgentSession {
 		return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
 	}
 
+	private async _restartIpythonKernelAfterCompaction(): Promise<void> {
+		await this._ipythonKernelManagerRef.current?.restart();
+	}
+
 	// =========================================================================
 	// Queue Mode Management
 	// =========================================================================
@@ -1705,6 +1711,7 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
+			await this._restartIpythonKernelAfterCompaction();
 
 			const compactionResult = {
 				summary,
@@ -1977,6 +1984,7 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
+			await this._restartIpythonKernelAfterCompaction();
 
 			const result: CompactionResult = {
 				summary,
@@ -2342,6 +2350,7 @@ export class AgentSession {
 					]),
 				)
 			: createAllToolDefinitions(this._cwd, {
+					ipython: { kernelManagerRef: this._ipythonKernelManagerRef },
 					bash: { commandPrefix: shellCommandPrefix, shellPath },
 				});
 

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -484,6 +484,9 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
+const KERNEL_RESTART_SUMMARY_WARNING =
+	"Note: the IPython kernel will be restarted after this summary. Python variables, imports, and in-memory state will be wiped. Files on disk are preserved — capture file paths and what they contain so the next agent can resume without redoing work.";
+
 const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
 
 Update the existing structured summary with new information. RULES:
@@ -545,6 +548,7 @@ export async function generateSummary(
 	if (customInstructions) {
 		basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
 	}
+	basePrompt = `${basePrompt}\n\n${KERNEL_RESTART_SUMMARY_WARNING}`;
 
 	// Serialize conversation to text so model doesn't try to continue it
 	// Convert to LLM messages first (handles custom types like bashExecution, custom, etc.)

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -232,24 +232,27 @@ export class KernelManager {
 		this.connection = info;
 		this.tempDir = tempDir;
 
-		this.kernel = spawn(this.options.python, ["-m", "ipykernel_launcher", "-f", connectionPath], {
+		const kernel = spawn(this.options.python, ["-m", "ipykernel_launcher", "-f", connectionPath], {
 			cwd: this.options.cwd,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		this.kernel = kernel;
 
-		this.kernel.stderr?.on("data", (buf: Buffer) => {
+		kernel.stderr?.on("data", (buf: Buffer) => {
 			const s = buf.toString();
 			this.kernelStderr += s;
 			process.stderr.write(`[kernel] ${s}`);
 		});
 
-		this.kernel.on("error", (err) => {
+		kernel.on("error", (err) => {
+			if (this.kernel !== kernel) return;
 			console.error(`[kernel] spawn error: ${err.message}`);
 			this.state = "shutdown";
 			liveKernels.delete(this);
 		});
 
-		this.kernel.on("exit", (code, signal) => {
+		kernel.on("exit", (code, signal) => {
+			if (this.kernel !== kernel) return;
 			if (this.state !== "shutdown") {
 				console.error(`[kernel] unexpected exit code=${code} signal=${signal}`);
 			}
@@ -272,6 +275,7 @@ export class KernelManager {
 			await this.probeReady();
 		} catch (e) {
 			await this.shutdown();
+			this.state = "idle";
 			throw e;
 		}
 
@@ -444,9 +448,31 @@ export class KernelManager {
 		await this.control.send(encode(msg, this.connection.key));
 	}
 
+	private cleanupResources(): void {
+		this.shell?.close();
+		this.iopub?.close();
+		this.control?.close();
+		this.shell = undefined;
+		this.iopub = undefined;
+		this.control = undefined;
+		try {
+			this.kernel?.kill("SIGTERM");
+		} catch {}
+		this.kernel = undefined;
+		this.connection = undefined;
+		if (this.tempDir) {
+			try {
+				rmSync(this.tempDir, { recursive: true, force: true });
+			} catch {}
+		}
+		this.tempDir = undefined;
+		this.startPromise = undefined;
+	}
+
 	async shutdown(): Promise<void> {
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
+			this.cleanupResources();
 			return;
 		}
 		this.state = "shutdown";
@@ -460,16 +486,24 @@ export class KernelManager {
 			}
 		} catch {}
 
-		this.shell?.close();
-		this.iopub?.close();
-		this.control?.close();
+		this.cleanupResources();
+	}
+
+	async restart(): Promise<void> {
+		const prev = this.executionQueue;
+		let resolveNext: () => void = () => {};
+		this.executionQueue = new Promise<void>((r) => {
+			resolveNext = r;
+		});
+		await prev;
+
 		try {
-			this.kernel?.kill("SIGTERM");
-		} catch {}
-		if (this.tempDir) {
-			try {
-				rmSync(this.tempDir, { recursive: true, force: true });
-			} catch {}
+			await this.shutdown();
+			this.state = "idle";
+			this.kernelStderr = "";
+			await this.start();
+		} finally {
+			resolveNext();
 		}
 	}
 
@@ -477,17 +511,7 @@ export class KernelManager {
 	dispose(): void {
 		this.state = "shutdown";
 		liveKernels.delete(this);
-		this.shell?.close();
-		this.iopub?.close();
-		this.control?.close();
-		try {
-			this.kernel?.kill("SIGTERM");
-		} catch {}
-		if (this.tempDir) {
-			try {
-				rmSync(this.tempDir, { recursive: true, force: true });
-			} catch {}
-		}
+		this.cleanupResources();
 	}
 
 	get isRunning(): boolean {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -24,6 +24,8 @@ export interface IpythonToolDetails {
 export interface IpythonToolOptions {
 	/** Defaults to {@link resolveKernelPython}. Must have `ipykernel` installed. */
 	python?: string;
+	/** Filled after the first kernel start so the owning session can restart it after compaction. */
+	kernelManagerRef?: { current?: KernelManager };
 }
 
 export function createIpythonToolDefinition(
@@ -34,6 +36,9 @@ export function createIpythonToolDefinition(
 	// same in-flight startup instead of creating two managers or skipping the
 	// not-yet-finished start().
 	let managerPromise: Promise<KernelManager> | undefined;
+	if (options?.kernelManagerRef) {
+		options.kernelManagerRef.current = undefined;
+	}
 
 	function getManager(): Promise<KernelManager> {
 		if (!managerPromise) {
@@ -46,6 +51,9 @@ export function createIpythonToolDefinition(
 				}
 				const m = new KernelManager({ python, cwd });
 				await m.start();
+				if (options?.kernelManagerRef) {
+					options.kernelManagerRef.current = m;
+				}
 				return m;
 			})();
 		}


### PR DESCRIPTION
- restart the active ipython kernel after manual or automatic compaction so in-memory state is released once context is summarized.
- keep pi's existing compaction prompt and framing, adding only the kernel-state warning requested for handoff summaries.
- expose the active kernel manager through the builtin ipython tool so the session can restart it without changing session storage or tool behavior.
