### PR TITLE
add prime hub skill

### DIFF
--- a/packages/python-skills/prime_hub/README.md
+++ b/packages/python-skills/prime_hub/README.md
@@ -1,0 +1,12 @@
+# prime_hub
+
+RLM skill for searching Prime Intellect Environments Hub entries.
+
+```python
+import prime_hub
+
+results = await prime_hub.run(query="wordle", max_results=10)
+```
+
+The package wraps `prime --plain env list --search ... --output json` and
+returns command metadata plus parsed JSON output when the CLI emits JSON.

--- a/packages/python-skills/prime_hub/SKILL.md
+++ b/packages/python-skills/prime_hub/SKILL.md
@@ -1,0 +1,31 @@
+# prime_hub
+
+Use `prime_hub` to search Prime Intellect Environments Hub before pulling,
+installing, evaluating, or training against an environment.
+
+## Python
+
+```python
+import prime_hub
+
+results = await prime_hub.run(
+    query="browser",
+    max_results=10,
+    tags=["openenv"],
+)
+```
+
+The return value includes:
+
+- `command`: the exact `prime` argv used
+- `returncode`, `stdout`, `stderr`
+- `data`: parsed JSON when `prime` emits valid JSON
+
+## CLI
+
+```bash
+prime_hub --query browser --max-results 10 --tags openenv
+```
+
+Use `data["environments"]` to inspect environment names, descriptions,
+versions, tags, stars, and action status.

--- a/packages/python-skills/prime_hub/pyproject.toml
+++ b/packages/python-skills/prime_hub/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rlm-skill-prime_hub"
+version = "0.1.0"
+description = "RLM skill for searching Prime Intellect environment hub entries."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["rlm"]
+
+[project.scripts]
+prime_hub = "rlm.skill:cli"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/python-skills/prime_hub/src/prime_hub/__init__.py
+++ b/packages/python-skills/prime_hub/src/prime_hub/__init__.py
@@ -1,0 +1,3 @@
+from .prime_hub import run
+
+__all__ = ["run"]

--- a/packages/python-skills/prime_hub/src/prime_hub/prime_hub.py
+++ b/packages/python-skills/prime_hub/src/prime_hub/prime_hub.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+from typing import Literal
+
+
+def _run_prime(args: list[str], timeout_seconds: float) -> dict[str, object]:
+    prime = shutil.which("prime")
+    if prime is None:
+        raise RuntimeError("prime CLI not found on PATH")
+
+    command = [prime, "--plain", *args]
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    data: object | None = None
+    if stdout:
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            data = None
+
+    return {
+        "command": ["prime", "--plain", *args],
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "data": data,
+    }
+
+
+async def run(
+    query: str = "",
+    max_results: int = 20,
+    page: int = 1,
+    owner: str | None = None,
+    visibility: Literal["PUBLIC", "PRIVATE"] | None = None,
+    tags: list[str] | None = None,
+    action_status: Literal["SUCCESS", "FAILED", "RUNNING", "PENDING"] | None = None,
+    sort: Literal["name", "created_at", "updated_at", "stars"] = "stars",
+    order: Literal["asc", "desc"] = "desc",
+    include_actions: bool = True,
+    starred: bool = False,
+    mine: bool = False,
+    timeout_seconds: float = 60.0,
+) -> dict[str, object]:
+    """Search Prime Intellect Environments Hub entries.
+
+    Args:
+        query: Search string matched against environment names and descriptions.
+        max_results: Items per page to request.
+        page: Page number to request.
+        owner: Optional owner filter.
+        visibility: Optional visibility filter.
+        tags: Optional tag filters. Repeatable.
+        action_status: Optional environment action status filter.
+        sort: Sort key.
+        order: Sort order.
+        include_actions: Include action status columns in the CLI request.
+        starred: Return only starred environments.
+        mine: Return only environments owned by the active account or team.
+        timeout_seconds: CLI timeout in seconds.
+
+    Returns:
+        A dictionary with command metadata and parsed hub search data.
+    """
+    if max_results < 1:
+        raise ValueError("max_results must be at least 1")
+    if page < 1:
+        raise ValueError("page must be at least 1")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    args = [
+        "env",
+        "list",
+        "--output",
+        "json",
+        "--num",
+        str(max_results),
+        "--page",
+        str(page),
+        "--sort",
+        sort,
+        "--order",
+        order,
+    ]
+    cleaned_query = query.strip()
+    if cleaned_query:
+        args.extend(["--search", cleaned_query])
+    if owner:
+        args.extend(["--owner", owner])
+    if visibility:
+        args.extend(["--visibility", visibility])
+    for tag in tags or []:
+        if tag.strip():
+            args.extend(["--tag", tag.strip()])
+    if action_status:
+        args.extend(["--action-status", action_status])
+    if include_actions:
+        args.append("--show-actions")
+    if starred:
+        args.append("--starred")
+    if mine:
+        args.append("--mine")
+
+    return await asyncio.to_thread(_run_prime, args, timeout_seconds)

--- a/packages/python-skills/prime_hub/tests/test_prime_hub.py
+++ b/packages/python-skills/prime_hub/tests/test_prime_hub.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import prime_hub
+
+
+class PrimeHubTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_builds_search_command_and_parses_json(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["prime"],
+            returncode=0,
+            stdout='{"environments":[{"environment":"primeintellect/wordle"}],"total":1}',
+            stderr="",
+        )
+
+        with (
+            patch("prime_hub.prime_hub.shutil.which", return_value="/bin/prime"),
+            patch("prime_hub.prime_hub.subprocess.run", return_value=completed) as run,
+        ):
+            result = await prime_hub.run(
+                query="wordle",
+                max_results=5,
+                tags=["game"],
+                include_actions=True,
+            )
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:4], ["/bin/prime", "--plain", "env", "list"])
+        self.assertIn("--search", command)
+        self.assertIn("wordle", command)
+        self.assertIn("--tag", command)
+        self.assertEqual(result["returncode"], 0)
+        self.assertEqual(result["data"]["total"], 1)
+
+    async def test_run_requires_positive_page(self) -> None:
+        with self.assertRaisesRegex(ValueError, "page"):
+            await prime_hub.run(page=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- adds a standalone rlm-skill-prime_hub package for Environments Hub search.
- wraps prime --plain env list --search with json output and returns parsed command results.
- includes package-local usage docs and offline command-building tests.
