### PR TITLE
add prime gpu skill

### DIFF
--- a/packages/python-skills/prime_gpu/README.md
+++ b/packages/python-skills/prime_gpu/README.md
@@ -1,0 +1,12 @@
+# prime_gpu
+
+RLM skill for Prime GPU availability and pod lifecycle operations.
+
+```python
+import prime_gpu
+
+available = await prime_gpu.run(action="availability", gpu_type="H100_80GB", gpu_count=8)
+pod = await prime_gpu.run(action="create", gpu_type="H100_80GB", gpu_count=1, name="debug", yes=True)
+```
+
+The package wraps `prime --plain availability ...` and `prime --plain pods ...`.

--- a/packages/python-skills/prime_gpu/SKILL.md
+++ b/packages/python-skills/prime_gpu/SKILL.md
@@ -1,0 +1,39 @@
+# prime_gpu
+
+Use `prime_gpu` to inspect GPU availability/pricing and manage Prime compute
+pods.
+
+## Python
+
+```python
+import prime_gpu
+
+types = await prime_gpu.run(action="gpu_types")
+available = await prime_gpu.run(action="availability", gpu_type="H100_80GB", gpu_count=8)
+pods = await prime_gpu.run(action="list")
+status = await prime_gpu.run(action="status", pod_id="pod_123")
+```
+
+Create and terminate pods explicitly:
+
+```python
+created = await prime_gpu.run(
+    action="create",
+    gpu_type="H100_80GB",
+    gpu_count=1,
+    name="debug-pod",
+    image="pytorch/pytorch:latest",
+    yes=True,
+)
+terminated = await prime_gpu.run(action="terminate", pod_id="pod_123", yes=True)
+```
+
+The return value includes `command`, `returncode`, `stdout`, `stderr`, and
+`data` when JSON output is parsed.
+
+## CLI
+
+```bash
+prime_gpu --action availability --gpu-type H100_80GB --gpu-count 8
+prime_gpu --action list
+```

--- a/packages/python-skills/prime_gpu/pyproject.toml
+++ b/packages/python-skills/prime_gpu/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rlm-skill-prime_gpu"
+version = "0.1.0"
+description = "RLM skill for Prime Intellect GPU availability and pod lifecycle."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["rlm"]
+
+[project.scripts]
+prime_gpu = "rlm.skill:cli"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/python-skills/prime_gpu/src/prime_gpu/__init__.py
+++ b/packages/python-skills/prime_gpu/src/prime_gpu/__init__.py
@@ -1,0 +1,3 @@
+from .prime_gpu import run
+
+__all__ = ["run"]

--- a/packages/python-skills/prime_gpu/src/prime_gpu/prime_gpu.py
+++ b/packages/python-skills/prime_gpu/src/prime_gpu/prime_gpu.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+from typing import Literal
+
+
+Action = Literal[
+    "gpu_types",
+    "availability",
+    "disks",
+    "list",
+    "history",
+    "status",
+    "create",
+    "terminate",
+]
+
+
+def _run_prime(args: list[str], timeout_seconds: float) -> dict[str, object]:
+    prime = shutil.which("prime")
+    if prime is None:
+        raise RuntimeError("prime CLI not found on PATH")
+
+    command = [prime, "--plain", *args]
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    data: object | None = None
+    if stdout:
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            data = None
+
+    return {
+        "command": ["prime", "--plain", *args],
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "data": data,
+    }
+
+
+def _require(value: str | None, name: str) -> str:
+    if value is None or not value.strip():
+        raise ValueError(f"{name} is required")
+    return value.strip()
+
+
+def _append_optional(args: list[str], flag: str, value: object | None) -> None:
+    if value is not None:
+        args.extend([flag, str(value)])
+
+
+async def run(
+    action: Action = "availability",
+    pod_id: str | None = None,
+    gpu_type: str | None = None,
+    gpu_count: int | None = None,
+    regions: str | None = None,
+    socket: str | None = None,
+    provider: str | None = None,
+    disks: list[str] | None = None,
+    group_similar: bool = True,
+    limit: int = 100,
+    offset: int = 0,
+    watch: bool = False,
+    id: str | None = None,
+    cloud_id: str | None = None,
+    name: str | None = None,
+    disk_size: int | None = None,
+    vcpus: int | None = None,
+    memory: int | None = None,
+    image: str | None = None,
+    custom_template_id: str | None = None,
+    team_id: str | None = None,
+    env: list[str] | None = None,
+    share_with_team: bool = False,
+    yes: bool = False,
+    output_json: bool = True,
+    timeout_seconds: float = 300.0,
+) -> dict[str, object]:
+    """Run a Prime GPU availability or pod lifecycle operation.
+
+    Args:
+        action: Operation to run.
+        pod_id: Pod ID for status or terminate.
+        gpu_type: GPU type filter or create value.
+        gpu_count: Number of GPUs for availability or create.
+        regions: Availability region filter.
+        socket: Availability socket filter.
+        provider: Availability provider filter.
+        disks: Disk IDs for availability filtering or pod attachment.
+        group_similar: Group similar availability resources.
+        limit: Number of pods/history rows to list.
+        offset: Number of pods/history rows to skip.
+        watch: Watch pod list output.
+        id: Short availability ID for pod create.
+        cloud_id: Cloud provider ID for pod create.
+        name: Pod name for create.
+        disk_size: Disk size in GB for create.
+        vcpus: vCPU count for create.
+        memory: Memory in GB for create.
+        image: Image name for create.
+        custom_template_id: Custom template ID for create.
+        team_id: Team ID for create.
+        env: Environment variables for create as KEY=value strings.
+        share_with_team: Share created pod with team members.
+        yes: Skip create or terminate confirmation prompts.
+        output_json: Request JSON output for commands that support it.
+        timeout_seconds: CLI timeout in seconds.
+
+    Returns:
+        A dictionary with command metadata and parsed JSON output when present.
+    """
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if gpu_count is not None and gpu_count < 1:
+        raise ValueError("gpu_count must be at least 1")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    if action == "gpu_types":
+        args = ["availability", "gpu-types"]
+        if output_json:
+            args.extend(["--output", "json"])
+    elif action == "availability":
+        args = ["availability", "list"]
+        _append_optional(args, "--gpu-type", gpu_type)
+        _append_optional(args, "--gpu-count", gpu_count)
+        _append_optional(args, "--regions", regions)
+        _append_optional(args, "--socket", socket)
+        _append_optional(args, "--provider", provider)
+        for disk in disks or []:
+            if disk.strip():
+                args.extend(["--disks", disk.strip()])
+        args.append("--group-similar" if group_similar else "--no-group-similar")
+        if output_json:
+            args.extend(["--output", "json"])
+    elif action == "disks":
+        args = ["availability", "disks"]
+        if output_json:
+            args.extend(["--output", "json"])
+    elif action == "list":
+        args = ["pods", "list", "--limit", str(limit), "--offset", str(offset)]
+        if output_json:
+            args.extend(["--output", "json"])
+        if watch:
+            args.append("--watch")
+    elif action == "history":
+        args = ["pods", "history", "--limit", str(limit), "--offset", str(offset)]
+        if output_json:
+            args.extend(["--output", "json"])
+    elif action == "status":
+        args = ["pods", "status", _require(pod_id, "pod_id")]
+        if output_json:
+            args.extend(["--output", "json"])
+    elif action == "create":
+        args = ["pods", "create"]
+        _append_optional(args, "--id", id)
+        _append_optional(args, "--cloud-id", cloud_id)
+        _append_optional(args, "--gpu-type", gpu_type)
+        _append_optional(args, "--gpu-count", gpu_count)
+        _append_optional(args, "--name", name)
+        _append_optional(args, "--disk-size", disk_size)
+        _append_optional(args, "--vcpus", vcpus)
+        _append_optional(args, "--memory", memory)
+        _append_optional(args, "--image", image)
+        _append_optional(args, "--custom-template-id", custom_template_id)
+        _append_optional(args, "--team-id", team_id)
+        for disk in disks or []:
+            if disk.strip():
+                args.extend(["--disks", disk.strip()])
+        for item in env or []:
+            if item.strip():
+                args.extend(["--env", item.strip()])
+        if share_with_team:
+            args.append("--share-with-team")
+        if yes:
+            args.append("--yes")
+    elif action == "terminate":
+        args = ["pods", "terminate", _require(pod_id, "pod_id")]
+        if yes:
+            args.append("--yes")
+    else:
+        raise ValueError(f"unsupported action: {action}")
+
+    return await asyncio.to_thread(_run_prime, args, timeout_seconds)

--- a/packages/python-skills/prime_gpu/tests/test_prime_gpu.py
+++ b/packages/python-skills/prime_gpu/tests/test_prime_gpu.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import prime_gpu
+
+
+class PrimeGpuTests(unittest.IsolatedAsyncioTestCase):
+    async def test_availability_builds_json_command(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["prime"],
+            returncode=0,
+            stdout='{"gpu_resources":[],"total_count":0}',
+            stderr="",
+        )
+
+        with (
+            patch("prime_gpu.prime_gpu.shutil.which", return_value="/bin/prime"),
+            patch("prime_gpu.prime_gpu.subprocess.run", return_value=completed) as run,
+        ):
+            result = await prime_gpu.run(
+                action="availability",
+                gpu_type="H100_80GB",
+                gpu_count=8,
+                regions="united_states",
+            )
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:4], ["/bin/prime", "--plain", "availability", "list"])
+        self.assertIn("--gpu-type", command)
+        self.assertIn("--output", command)
+        self.assertEqual(result["data"]["total_count"], 0)
+
+    async def test_create_builds_pod_command(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["prime"],
+            returncode=0,
+            stdout="created",
+            stderr="",
+        )
+
+        with (
+            patch("prime_gpu.prime_gpu.shutil.which", return_value="/bin/prime"),
+            patch("prime_gpu.prime_gpu.subprocess.run", return_value=completed) as run,
+        ):
+            result = await prime_gpu.run(
+                action="create",
+                gpu_type="A100_80GB",
+                gpu_count=1,
+                name="debug",
+                env=["FOO=bar"],
+                yes=True,
+            )
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:4], ["/bin/prime", "--plain", "pods", "create"])
+        self.assertIn("--env", command)
+        self.assertIn("--yes", command)
+        self.assertIsNone(result["data"])
+
+    async def test_status_requires_pod_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "pod_id"):
+            await prime_gpu.run(action="status")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- adds a standalone rlm-skill-prime_gpu package for GPU availability and pod lifecycle operations.
- wraps prime --plain availability and pods commands for search, create, status, list, history, and terminate.
- includes package-local docs and offline command-building tests.
