### PR TITLE
fix rlm disposal race

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Changed the default active built-in tool set to `ipython`.
 - Replaced the default system prompt with the model-agnostic RLM harness prompt.
 
+### Fixed
+
+- Fixed `rlm.run` comm handlers to log failures and drain in-flight child runs during kernel disposal.
+
 ### Removed
 
 - Removed the legacy `read`, `write`, `grep`, `find`, and `ls` built-in tools.

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -661,7 +661,7 @@ export class KernelManager {
 		}
 
 		return (async () => {
-			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel child loops instead of only waiting.
+			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel long-running child loops.
 			try {
 				await this.waitForRlmRunsToSettle(inFlightRlmRuns, RLM_DISPOSE_TIMEOUT_MS);
 			} finally {
@@ -674,6 +674,7 @@ export class KernelManager {
 	disposeSync(): void {
 		this.state = "shutdown";
 		liveKernels.delete(this);
+		// TODO: replace this best-effort hard-exit path if Node exposes an awaitable process-exit cleanup hook.
 		this.cleanupResources();
 	}
 

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -513,35 +513,31 @@ export class KernelManager {
 		}
 		this.handledRlmCommIds.add(commId);
 
-		let task: Promise<void> | undefined;
-		task = (async () => {
+		const task = (async () => {
 			try {
+				const result = await this.handleRlmRunRequest(data);
 				try {
-					const result = await this.handleRlmRunRequest(data);
-					try {
-						await this.sendCommMessage(commId, { status: "ok", ...result });
-					} catch (replyError) {
-						console.error(
-							`[kernel] failed to send rlm.run ok reply for comm ${commId}: ${errorMessage(replyError)}`,
-						);
-					}
-				} catch (error) {
-					console.error(`[kernel] rlm.run failed for comm ${commId}: ${errorMessage(error)}`);
-					try {
-						await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
-					} catch (replyError) {
-						console.error(
-							`[kernel] failed to send rlm.run error reply for comm ${commId}: ${errorMessage(replyError)}`,
-						);
-					}
+					await this.sendCommMessage(commId, { status: "ok", ...result });
+				} catch (replyError) {
+					console.error(
+						`[kernel] failed to send rlm.run ok reply for comm ${commId}: ${errorMessage(replyError)}`,
+					);
 				}
-			} finally {
-				if (task) {
-					this.inFlightRlmRuns.delete(task);
+			} catch (error) {
+				console.error(`[kernel] rlm.run failed for comm ${commId}: ${errorMessage(error)}`);
+				try {
+					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
+				} catch (replyError) {
+					console.error(
+						`[kernel] failed to send rlm.run error reply for comm ${commId}: ${errorMessage(replyError)}`,
+					);
 				}
 			}
 		})();
 		this.inFlightRlmRuns.add(task);
+		void task.finally(() => {
+			this.inFlightRlmRuns.delete(task);
+		});
 	}
 
 	private async handleRlmRunRequest(data: unknown): Promise<RlmRunResult> {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -15,6 +15,7 @@ const PROTOCOL_VERSION = "5.3";
 const STARTUP_DELAY_MS = 500;
 const READY_TIMEOUT_MS = 5000;
 const DEFAULT_MAX_OUTPUT_CHARS = 65536;
+const RLM_DISPOSE_TIMEOUT_MS = 5000;
 
 export interface KernelManagerOptions {
 	/** Python interpreter that has `ipykernel` available. */
@@ -173,7 +174,7 @@ let signalHandlersInstalled = false;
 registerSessionResourceCleanup((sessionId) => {
 	for (const k of liveKernels) {
 		if (!sessionId || k.ownerSessionId === sessionId) {
-			k.dispose();
+			void k.dispose();
 		}
 	}
 });
@@ -188,7 +189,7 @@ function installSignalHandlersOnce(): void {
 
 	// `beforeExit` and signal handlers can await async cleanup. `exit`
 	// can only do sync work (Node won't run pending microtasks past it),
-	// so it falls back to `dispose()` which kills the child synchronously.
+	// so it falls back to `disposeSync()` which kills the child synchronously.
 	process.on("beforeExit", () => {
 		void asyncShutdown();
 	});
@@ -199,7 +200,7 @@ function installSignalHandlersOnce(): void {
 		void asyncShutdown().finally(() => process.exit(143));
 	});
 	process.on("exit", () => {
-		for (const k of liveKernels) k.dispose();
+		for (const k of liveKernels) k.disposeSync();
 	});
 }
 
@@ -220,6 +221,7 @@ export class KernelManager {
 	private kernelStderr = "";
 	/** Serializes execute() calls — Jupyter shell channel is request/reply. */
 	private executionQueue: Promise<unknown> = Promise.resolve();
+	private readonly inFlightRlmRuns = new Set<Promise<void>>();
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -511,14 +513,35 @@ export class KernelManager {
 		}
 		this.handledRlmCommIds.add(commId);
 
-		void (async () => {
+		let task: Promise<void> | undefined;
+		task = (async () => {
 			try {
-				const result = await this.handleRlmRunRequest(data);
-				await this.sendCommMessage(commId, { status: "ok", ...result });
-			} catch (error) {
-				await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) }).catch(() => {});
+				try {
+					const result = await this.handleRlmRunRequest(data);
+					try {
+						await this.sendCommMessage(commId, { status: "ok", ...result });
+					} catch (replyError) {
+						console.error(
+							`[kernel] failed to send rlm.run ok reply for comm ${commId}: ${errorMessage(replyError)}`,
+						);
+					}
+				} catch (error) {
+					console.error(`[kernel] rlm.run failed for comm ${commId}: ${errorMessage(error)}`);
+					try {
+						await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
+					} catch (replyError) {
+						console.error(
+							`[kernel] failed to send rlm.run error reply for comm ${commId}: ${errorMessage(replyError)}`,
+						);
+					}
+				}
+			} finally {
+				if (task) {
+					this.inFlightRlmRuns.delete(task);
+				}
 			}
 		})();
+		this.inFlightRlmRuns.add(task);
 	}
 
 	private async handleRlmRunRequest(data: unknown): Promise<RlmRunResult> {
@@ -575,6 +598,24 @@ export class KernelManager {
 		this.startPromise = undefined;
 	}
 
+	private async waitForRlmRunsToSettle(tasks: Promise<void>[], timeoutMs: number): Promise<void> {
+		let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const timeoutPromise = new Promise<"timeout">((resolve) => {
+			timeout = globalThis.setTimeout(() => resolve("timeout"), timeoutMs);
+			if (timeout && typeof timeout === "object" && "unref" in timeout) {
+				timeout.unref();
+			}
+		});
+
+		const result = await Promise.race([Promise.allSettled(tasks).then(() => "settled" as const), timeoutPromise]);
+		if (timeout) {
+			globalThis.clearTimeout(timeout);
+		}
+		if (result === "timeout") {
+			console.error(`[kernel] timed out waiting ${timeoutMs}ms for ${tasks.length} rlm.run task(s) during dispose`);
+		}
+	}
+
 	async shutdown(): Promise<void> {
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
@@ -613,8 +654,28 @@ export class KernelManager {
 		}
 	}
 
+	/** Graceful cleanup. Waits briefly for in-flight rlm.run handlers before closing sockets. */
+	dispose(): Promise<void> {
+		this.state = "shutdown";
+		liveKernels.delete(this);
+		const inFlightRlmRuns = [...this.inFlightRlmRuns];
+		if (inFlightRlmRuns.length === 0) {
+			this.cleanupResources();
+			return Promise.resolve();
+		}
+
+		return (async () => {
+			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel child loops instead of only waiting.
+			try {
+				await this.waitForRlmRunsToSettle(inFlightRlmRuns, RLM_DISPOSE_TIMEOUT_MS);
+			} finally {
+				this.cleanupResources();
+			}
+		})();
+	}
+
 	/** Synchronous best-effort cleanup. Safe to call from `process.on('exit')`. */
-	dispose(): void {
+	disposeSync(): void {
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		this.cleanupResources();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -10,7 +10,7 @@ import {
 	getModel,
 	type TextContent,
 } from "@earendil-works/pi-ai";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { KernelManager } from "../src/core/kernel/index.js";
@@ -102,6 +102,14 @@ async function waitFor(condition: () => boolean): Promise<void> {
 		}
 		await sleep(10);
 	}
+}
+
+async function expectSettlesWithin(promise: Promise<void>, timeoutMs: number): Promise<void> {
+	const result = await Promise.race([
+		promise.then(() => "settled" as const),
+		sleep(timeoutMs).then(() => "timeout" as const),
+	]);
+	expect(result).toBe("settled");
 }
 
 describe("AgentSession rlm recursion", () => {
@@ -234,7 +242,64 @@ describe("AgentSession rlm recursion", () => {
 				session_dir: null,
 			});
 		} finally {
-			manager.dispose();
+			await manager.dispose();
+		}
+	});
+
+	it("waits for in-flight rlm comm work during dispose and logs failures", async () => {
+		let started = false;
+		let handlerSettled = false;
+		let released = false;
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = () => {
+				if (released) return;
+				released = true;
+				resolve();
+			};
+		});
+		const manager = new KernelManager({
+			python: process.execPath,
+			rlmRunHandler: async () => {
+				started = true;
+				try {
+					await release;
+					throw new Error("child failed after dispose");
+				} finally {
+					handlerSettled = true;
+				}
+			},
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			const kernel = manager as unknown as KernelCommTestApi;
+
+			kernel.handleCommMessage(rlmCommOpen("comm-dispose", "slow child"));
+
+			await waitFor(() => started);
+			const disposePromise = manager.dispose();
+			let disposeSettled = false;
+			const trackedDispose = disposePromise.then(() => {
+				disposeSettled = true;
+			});
+
+			await sleep(25);
+			expect(disposeSettled).toBe(false);
+
+			releaseChild();
+			await expectSettlesWithin(trackedDispose, 1000);
+			expect(handlerSettled).toBe(true);
+
+			const logLines = errorSpy.mock.calls.map((call) => call.map(String).join(" "));
+			expect(logLines.some((line) => line.includes("[kernel] rlm.run failed for comm comm-dispose"))).toBe(true);
+			expect(
+				logLines.some((line) => line.includes("[kernel] failed to send rlm.run error reply for comm comm-dispose")),
+			).toBe(true);
+		} finally {
+			releaseChild();
+			await manager.dispose();
+			errorSpy.mockRestore();
 		}
 	});
 });


### PR DESCRIPTION
- tracks rlm.run comm tasks so kernel disposal waits briefly before closing channels.
- logs child run failures separately from comm reply send failures.
- adds a regression for disposing while a child comm handler is still in flight.
