### PR TITLE
fix rlm child usage aggregation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Changed the default active built-in tool set to `ipython`.
 - Replaced the default system prompt with the model-agnostic RLM harness prompt.
 
+### Fixed
+
+- Fixed RLM child usage aggregation so parent session totals include recursive child runs.
+
 ### Removed
 
 - Removed the legacy `read`, `write`, `grep`, `find`, and `ls` built-in tools.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fixed RLM child usage aggregation so parent session totals include recursive child runs.
+- Fixed RLM child usage aggregation so parent session totals include recursive child runs after session reloads.
 
 ### Removed
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -84,7 +84,7 @@ import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type { RlmRunResult, RlmUsage } from "./rlm-runtime.js";
-import type { BranchSummaryEntry, CompactionEntry } from "./session-manager.js";
+import type { BranchSummaryEntry, CompactionEntry, SessionMessageEntry } from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
 	getLatestCompactionEntry,
@@ -2553,12 +2553,22 @@ export class AgentSession {
 		return usage;
 	}
 
+	private _findAssistantEntryForMessage(message: AssistantMessage): SessionMessageEntry | undefined {
+		return this.sessionManager
+			.getEntries()
+			.find((entry): entry is SessionMessageEntry => entry.type === "message" && entry.message === message);
+	}
+
 	private _attributeRlmChildUsageToParent(childUsage: Usage): void {
 		const parentAssistant = this._findLastAssistantMessage();
 		if (!parentAssistant) {
 			return;
 		}
+		const parentEntry = this._findAssistantEntryForMessage(parentAssistant);
 		attributeChildUsage(parentAssistant.usage, childUsage);
+		if (parentEntry) {
+			this.sessionManager.appendChildUsageAttribution(parentEntry.id, childUsage, parentAssistant.usage);
+		}
 	}
 
 	private _assistantTurnCount(): number {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -272,6 +272,39 @@ function addUsage(total: RlmUsage, usage: Usage): void {
 	total.completion_tokens += usage.output;
 }
 
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function addAssistantUsage(total: Usage, usage: Usage): void {
+	total.input += usage.input;
+	total.output += usage.output;
+	total.cacheRead += usage.cacheRead;
+	total.cacheWrite += usage.cacheWrite;
+	total.totalTokens += usage.totalTokens;
+	total.cost.input += usage.cost.input;
+	total.cost.output += usage.cost.output;
+	total.cost.cacheRead += usage.cost.cacheRead;
+	total.cost.cacheWrite += usage.cost.cacheWrite;
+	total.cost.total += usage.cost.total;
+}
+
+function attributeChildUsage(parentUsage: Usage, childUsage: Usage): void {
+	const parentContextTokens =
+		parentUsage.totalTokens ||
+		parentUsage.input + parentUsage.output + parentUsage.cacheRead + parentUsage.cacheWrite;
+	addAssistantUsage(parentUsage, childUsage);
+	// Child work affects session-level billable totals, not the parent's model-facing context size.
+	parentUsage.totalTokens = parentContextTokens;
+}
+
 // ============================================================================
 // AgentSession Class
 // ============================================================================
@@ -2508,6 +2541,24 @@ export class AgentSession {
 		return usage;
 	}
 
+	private _assistantUsageForCurrentMessages(): Usage {
+		const usage = emptyUsage();
+		for (const message of this.agent.state.messages) {
+			if (message.role === "assistant") {
+				addAssistantUsage(usage, (message as AssistantMessage).usage);
+			}
+		}
+		return usage;
+	}
+
+	private _attributeRlmChildUsageToParent(childUsage: Usage): void {
+		const parentAssistant = this._findLastAssistantMessage();
+		if (!parentAssistant) {
+			return;
+		}
+		attributeChildUsage(parentAssistant.usage, childUsage);
+	}
+
 	private _assistantTurnCount(): number {
 		return this.agent.state.messages.filter((message) => message.role === "assistant").length;
 	}
@@ -2575,9 +2626,11 @@ export class AgentSession {
 			await child.prompt(prompt, { expandPromptTemplates: false, source: "extension" });
 			await child.agent.waitForIdle();
 			const answer = child.getLastAssistantText() ?? "";
+			const usage = child._usageForCurrentMessages();
+			this._attributeRlmChildUsageToParent(child._assistantUsageForCurrentMessages());
 			return {
 				answer,
-				usage: child._usageForCurrentMessages(),
+				usage,
 				turns: child._assistantTurnCount(),
 				session_dir: childSessionDir,
 			};

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -300,6 +300,8 @@ function attributeChildUsage(parentUsage: Usage, childUsage: Usage): void {
 	const parentContextTokens =
 		parentUsage.totalTokens ||
 		parentUsage.input + parentUsage.output + parentUsage.cacheRead + parentUsage.cacheWrite;
+	// Recursive children are launched from an assistant tool call, so the parent assistant
+	// message carries their billable usage for session-level cost totals.
 	addAssistantUsage(parentUsage, childUsage);
 	// Child work affects session-level billable totals, not the parent's model-facing context size.
 	parentUsage.totalTokens = parentContextTokens;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ImageContent, Message, TextContent, Usage } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
@@ -53,6 +53,8 @@ export interface SessionMessageEntry extends SessionEntryBase {
 	message: AgentMessage;
 }
 
+type AssistantSessionMessageEntry = SessionMessageEntry & { message: AssistantMessage };
+
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 	type: "thinking_level_change";
 	thinkingLevel: string;
@@ -101,6 +103,18 @@ export interface CustomEntry<T = unknown> extends SessionEntryBase {
 	data?: T;
 }
 
+/**
+ * Records usage folded into a parent assistant message after an RLM child run.
+ * The child usage is kept separately so audit/UI code can explain why the
+ * parent turn's aggregate usage exceeds the parent model response itself.
+ */
+export interface ChildUsageAttributionEntry extends SessionEntryBase {
+	type: "child_usage_attributed";
+	targetId: string;
+	childUsage: Usage;
+	aggregateUsage: Usage;
+}
+
 /** Label entry for user-defined bookmarks/markers on entries. */
 export interface LabelEntry extends SessionEntryBase {
 	type: "label";
@@ -142,6 +156,7 @@ export type SessionEntry =
 	| CompactionEntry
 	| BranchSummaryEntry
 	| CustomEntry
+	| ChildUsageAttributionEntry
 	| CustomMessageEntry
 	| LabelEntry
 	| SessionInfoEntry;
@@ -295,7 +310,41 @@ export function parseSessionEntries(content: string): FileEntry[] {
 		}
 	}
 
+	applyChildUsageAttributions(entries);
 	return entries;
+}
+
+function cloneUsage(usage: Usage): Usage {
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead,
+		cacheWrite: usage.cacheWrite,
+		totalTokens: usage.totalTokens,
+		cost: {
+			input: usage.cost.input,
+			output: usage.cost.output,
+			cacheRead: usage.cost.cacheRead,
+			cacheWrite: usage.cost.cacheWrite,
+			total: usage.cost.total,
+		},
+	};
+}
+
+function applyChildUsageAttributions(entries: FileEntry[]): void {
+	const assistantEntriesById = new Map<string, AssistantSessionMessageEntry>();
+	for (const entry of entries) {
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			assistantEntriesById.set(entry.id, entry as AssistantSessionMessageEntry);
+		}
+	}
+
+	for (const entry of entries) {
+		if (entry.type !== "child_usage_attributed") continue;
+		const target = assistantEntriesById.get(entry.targetId);
+		if (!target) continue;
+		target.message.usage = cloneUsage(entry.aggregateUsage);
+	}
 }
 
 export function getLatestCompactionEntry(entries: SessionEntry[]): CompactionEntry | null {
@@ -459,6 +508,7 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		return [];
 	}
 
+	applyChildUsageAttributions(entries);
 	return entries;
 }
 
@@ -902,6 +952,27 @@ export class SessionManager {
 			id: generateId(this.byId),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/** Append an RLM child usage attribution and update the parent assistant aggregate in memory. */
+	appendChildUsageAttribution(targetId: string, childUsage: Usage, aggregateUsage: Usage): string {
+		const target = this.byId.get(targetId);
+		if (target?.type !== "message" || target.message.role !== "assistant") {
+			throw new Error(`Assistant message entry ${targetId} not found`);
+		}
+
+		target.message.usage = cloneUsage(aggregateUsage);
+		const entry: ChildUsageAttributionEntry = {
+			type: "child_usage_attributed",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			targetId,
+			childUsage: cloneUsage(childUsage),
+			aggregateUsage: cloneUsage(aggregateUsage),
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -303,7 +303,8 @@ class TreeList implements Component {
 				entry.type === "custom" ||
 				entry.type === "model_change" ||
 				entry.type === "thinking_level_change" ||
-				entry.type === "session_info";
+				entry.type === "session_info" ||
+				entry.type === "child_usage_attributed";
 
 			switch (this.filterMode) {
 				case "user-only":
@@ -549,6 +550,9 @@ class TreeList implements Component {
 			case "custom":
 				parts.push("custom", entry.customType);
 				break;
+			case "child_usage_attributed":
+				parts.push("child usage", entry.targetId);
+				break;
 			case "label":
 				parts.push("label", entry.label ?? "");
 				break;
@@ -769,6 +773,12 @@ class TreeList implements Component {
 			case "custom":
 				result = theme.fg("dim", `[custom: ${entry.customType}]`);
 				break;
+			case "child_usage_attributed": {
+				const input = entry.childUsage.input + entry.childUsage.cacheRead + entry.childUsage.cacheWrite;
+				const output = entry.childUsage.output;
+				result = theme.fg("dim", `[child usage: ${input} input, ${output} output]`);
+				break;
+			}
 			case "label":
 				result = theme.fg("dim", `[label: ${entry.label ?? "(cleared)"}]`);
 				break;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -196,6 +196,35 @@ describe("AgentSession rlm recursion", () => {
 		expect(parentEntry.message.usage.input).toBe(result.usage.prompt_tokens);
 		expect(parentEntry.message.usage.output).toBe(result.usage.completion_tokens);
 		expect(parentEntry.message.usage.cost.total).toBe(10);
+
+		const sessionFile = root.sessionManager.getSessionFile();
+		if (!sessionFile) {
+			throw new Error("parent session file was not created");
+		}
+		expect(readFileSync(sessionFile, "utf-8")).toContain('"type":"child_usage_attributed"');
+
+		const reloaded = SessionManager.open(sessionFile, join(tempDir, "sessions"));
+		const reloadedAttribution = reloaded.getEntries().find((entry) => entry.type === "child_usage_attributed");
+		if (!reloadedAttribution || reloadedAttribution.type !== "child_usage_attributed") {
+			throw new Error("child usage attribution entry was not persisted");
+		}
+		expect(reloadedAttribution.childUsage.input).toBe(result.usage.prompt_tokens);
+		expect(reloadedAttribution.childUsage.output).toBe(result.usage.completion_tokens);
+		expect(reloadedAttribution.aggregateUsage.input).toBe(result.usage.prompt_tokens);
+		expect(reloadedAttribution.aggregateUsage.output).toBe(result.usage.completion_tokens);
+		expect(reloadedAttribution.aggregateUsage.cost.total).toBe(10);
+
+		const reloadedParentEntry = reloaded.getEntries().find((entry) => entry.type === "message");
+		if (
+			!reloadedParentEntry ||
+			reloadedParentEntry.type !== "message" ||
+			reloadedParentEntry.message.role !== "assistant"
+		) {
+			throw new Error("reloaded parent assistant entry was not recorded");
+		}
+		expect(reloadedParentEntry.message.usage.input).toBe(result.usage.prompt_tokens);
+		expect(reloadedParentEntry.message.usage.output).toBe(result.usage.completion_tokens);
+		expect(reloadedParentEntry.message.usage.cost.total).toBe(10);
 	});
 
 	it("rejects child creation at the configured recursion depth cap", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -9,6 +9,7 @@ import {
 	createAssistantMessageEventStream,
 	getModel,
 	type TextContent,
+	type Usage,
 } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
@@ -35,21 +36,25 @@ function userText(context: Context): string {
 		.join("\n");
 }
 
-function assistantMessage(text: string): AssistantMessage {
+function usage(input = 7, output = 3): Usage {
+	return {
+		input,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input, output, cacheRead: 0, cacheWrite: 0, total: input + output },
+	};
+}
+
+function assistantMessage(text: string, messageUsage = usage()): AssistantMessage {
 	return {
 		role: "assistant",
 		content: [{ type: "text", text }],
 		api: model.api,
 		provider: model.provider,
 		model: model.id,
-		usage: {
-			input: 7,
-			output: 3,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 10,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
+		usage: messageUsage,
 		stopReason: "stop",
 		timestamp: Date.now(),
 	};
@@ -161,6 +166,36 @@ describe("AgentSession rlm recursion", () => {
 		expect(basename(result.session_dir!)).toMatch(/^sub-/);
 		expect(existsSync(result.session_dir!)).toBe(true);
 		expect(readdirSync(result.session_dir!).some((name) => name.endsWith(".jsonl"))).toBe(true);
+	});
+
+	it("adds child usage to the parent session aggregate", async () => {
+		const root = createSession();
+		const parentAssistant = assistantMessage("running ipython", usage(0, 0));
+		root.agent.state.messages.push(parentAssistant);
+		root.sessionManager.appendMessage(parentAssistant);
+
+		const before = root.getSessionStats();
+		const result = await root.runRlmChild("summarize shard 2");
+		const after = root.getSessionStats();
+
+		expect(result.usage).toEqual({ prompt_tokens: 7, completion_tokens: 3 });
+		expect(after.tokens.input).toBe(before.tokens.input + result.usage.prompt_tokens);
+		expect(after.tokens.output).toBe(before.tokens.output + result.usage.completion_tokens);
+		expect(after.tokens.total).toBe(
+			before.tokens.total + result.usage.prompt_tokens + result.usage.completion_tokens,
+		);
+		expect(after.cost).toBe(before.cost + 10);
+		expect(parentAssistant.usage.totalTokens).toBe(0);
+
+		const parentEntry = root.sessionManager
+			.getEntries()
+			.find((entry) => entry.type === "message" && entry.message === parentAssistant);
+		if (!parentEntry || parentEntry.type !== "message" || parentEntry.message.role !== "assistant") {
+			throw new Error("parent assistant entry was not recorded");
+		}
+		expect(parentEntry.message.usage.input).toBe(result.usage.prompt_tokens);
+		expect(parentEntry.message.usage.output).toBe(result.usage.completion_tokens);
+		expect(parentEntry.message.usage.cost.total).toBe(10);
 	});
 
 	it("rejects child creation at the configured recursion depth cap", async () => {


### PR DESCRIPTION
- fold rlm child usage into the parent assistant usage aggregate after child completion.
- preserve the child's own session log and rlm result shape while keeping parent context token accounting unchanged.
- add a recursion regression covering parent token and cost growth.
