### PR TITLE
fix prime-tui review follow-ups and unblock ci

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -143,7 +143,7 @@ describe("Context overflow error handling", () => {
 		it.skipIf(!githubCopilotToken)(
 			"claude-sonnet-4 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4");
+				const model = getModel("github-copilot", "claude-sonnet-4.5");
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -649,7 +649,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -658,7 +658,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -667,7 +667,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -676,7 +676,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -54,7 +54,7 @@ describe("Copilot Claude via Anthropic Messages", () => {
 	};
 
 	it("uses Bearer auth, Copilot headers, and valid Anthropic Messages payload", async () => {
-		const model = getModel("github-copilot", "claude-sonnet-4");
+		const model = getModel("github-copilot", "claude-sonnet-4.5");
 		expect(model.api).toBe("anthropic-messages");
 
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
@@ -85,14 +85,14 @@ describe("Copilot Claude via Anthropic Messages", () => {
 
 		// Payload is valid Anthropic Messages format
 		const params = mockState.createParams!;
-		expect(params.model).toBe("claude-sonnet-4");
+		expect(params.model).toBe("claude-sonnet-4.5");
 		expect(params.stream).toBe(true);
 		expect(params.max_tokens).toBeGreaterThan(0);
 		expect(Array.isArray(params.messages)).toBe(true);
 	});
 
 	it("includes interleaved-thinking beta when reasoning is enabled", async () => {
-		const model = getModel("github-copilot", "claude-sonnet-4");
+		const model = getModel("github-copilot", "claude-sonnet-4.5");
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
 		const s = streamAnthropic(model, context, {
 			apiKey: "tid_copilot_session_test_token",

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -451,7 +451,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -460,7 +460,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -106,7 +106,7 @@ describe("responseId E2E Tests", () => {
 			"Anthropic path should expose responseId",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await expectResponseId(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -1217,7 +1217,7 @@ describe("Generate E2E Tests", () => {
 	});
 
 	describe("GitHub Copilot Provider (claude-sonnet-4 via Anthropic Messages)", () => {
-		const llm = getModel("github-copilot", "claude-sonnet-4");
+		const llm = getModel("github-copilot", "claude-sonnet-4.5");
 
 		it.skipIf(!githubCopilotToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -293,7 +293,7 @@ describe("Token Statistics on Abort", () => {
 			"claude-sonnet-4 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -301,7 +301,7 @@ describe("Tool Call Without Result Tests", () => {
 			"claude-sonnet-4 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4");
+				const model = getModel("github-copilot", "claude-sonnet-4.5");
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -704,7 +704,7 @@ describe("totalTokens field", () => {
 			"claude-sonnet-4 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -13,7 +13,7 @@ function anthropicNormalizeToolCallId(
 
 function makeCopilotClaudeModel(): Model<"anthropic-messages"> {
 	return {
-		id: "claude-sonnet-4",
+		id: "claude-sonnet-4.5",
 		name: "Claude Sonnet 4",
 		api: "anthropic-messages",
 		provider: "github-copilot",

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -426,7 +426,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -435,7 +435,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -444,7 +444,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2678,7 +2678,10 @@ export class AgentSession {
 		let status: RlmChildAgentStatus = "running";
 		let answerPreview: string | undefined;
 		let durationMs: number | undefined;
-		let assistantTranscriptIndex: number | undefined;
+		// Index of the assistant entry currently being streamed. Cleared whenever the
+		// conversation moves on (new assistant message, tool call) so subsequent assistant
+		// text appends a fresh entry in chronological order instead of overwriting in place.
+		let currentAssistantIndex: number | undefined;
 		let lastToolTranscriptIndex: number | undefined;
 		const emitChildUpdate = () => {
 			this._emit({
@@ -2695,17 +2698,17 @@ export class AgentSession {
 				},
 			});
 		};
-		const setAssistantTranscript = (text: string) => {
+		const recordAssistantText = (text: string) => {
 			const compact = compactRlmText(text);
 			if (!compact) {
 				return;
 			}
 			answerPreview = compact;
-			if (assistantTranscriptIndex === undefined) {
-				assistantTranscriptIndex = transcript.length;
+			if (currentAssistantIndex === undefined) {
+				currentAssistantIndex = transcript.length;
 				transcript.push({ role: "assistant", text: compact });
 			} else {
-				transcript[assistantTranscriptIndex] = { role: "assistant", text: compact };
+				transcript[currentAssistantIndex] = { role: "assistant", text: compact };
 			}
 		};
 		emitChildUpdate();
@@ -2765,8 +2768,11 @@ export class AgentSession {
 						if (text) {
 							transcript.push({ role: "user", text });
 						}
+						currentAssistantIndex = undefined;
 					} else if (event.message.role === "assistant") {
-						setAssistantTranscript(readAssistantText(event.message as AssistantMessage));
+						// New assistant turn: append a fresh entry so prior text isn't overwritten.
+						currentAssistantIndex = undefined;
+						recordAssistantText(readAssistantText(event.message as AssistantMessage));
 					}
 					emitChildUpdate();
 					break;
@@ -2774,13 +2780,15 @@ export class AgentSession {
 				case "message_update":
 				case "message_end": {
 					if (event.message.role === "assistant") {
-						setAssistantTranscript(readAssistantText(event.message as AssistantMessage));
+						recordAssistantText(readAssistantText(event.message as AssistantMessage));
 						emitChildUpdate();
 					}
 					break;
 				}
 				case "tool_execution_start": {
 					const args = formatRlmToolArgs(event.args);
+					// Tool break: next assistant text starts a new entry after this tool row.
+					currentAssistantIndex = undefined;
 					lastToolTranscriptIndex = transcript.length;
 					transcript.push({
 						role: "tool",
@@ -2823,7 +2831,7 @@ export class AgentSession {
 			this._attributeRlmChildUsageToParent(child._assistantUsageForCurrentMessages());
 			status = "done";
 			durationMs = Date.now() - startedAt;
-			setAssistantTranscript(answer);
+			recordAssistantText(answer);
 			emitChildUpdate();
 			return {
 				answer,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2831,7 +2831,17 @@ export class AgentSession {
 			this._attributeRlmChildUsageToParent(child._assistantUsageForCurrentMessages());
 			status = "done";
 			durationMs = Date.now() - startedAt;
-			recordAssistantText(answer);
+			// Streaming events usually capture the final assistant text already. Only
+			// record again when it's missing — otherwise a child whose last streamed
+			// event was tool_execution_start would have currentAssistantIndex cleared,
+			// causing the final answer to be appended as a duplicate row.
+			const compactAnswer = compactRlmText(answer);
+			const lastAssistantText = [...transcript].reverse().find((line) => line.role === "assistant")?.text;
+			if (compactAnswer && compactAnswer !== lastAssistantText) {
+				recordAssistantText(answer);
+			} else if (compactAnswer) {
+				answerPreview = compactAnswer;
+			}
 			emitChildUpdate();
 			return {
 				answer,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -755,7 +755,7 @@ export class SettingsManager {
 	}
 
 	getQuietStartup(): boolean {
-		return this.settings.quietStartup ?? true;
+		return this.settings.quietStartup ?? false;
 	}
 
 	setQuietStartup(quiet: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -675,70 +675,78 @@ export class InteractiveMode {
 
 		// Brand splash: side-panel layout — white butterfly on the left, structured runtime
 		// metadata on the right. The mark carries the brand; no wordmark, no slogan.
-		// Cheatsheet behind --verbose.
-		const logoRaw = PRIME_LOGO_SMALL.split("\n");
-		const logoCanvasWidth = logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
-		const gutter = 4;
-		const cwdLabel = (() => {
-			let p = this.sessionManager.getCwd();
-			const home = process.env.HOME || process.env.USERPROFILE;
-			if (home && p.startsWith(home)) p = `~${p.slice(home.length)}`;
-			return p;
-		})();
-		const modelId = this.session.state.model?.id;
-		const labelWidth = 9;
-		const labelled = (label: string, value: string) =>
-			theme.fg("dim", label.padEnd(labelWidth)) + theme.fg("muted", value);
-		const metaLines = [
-			labelled("version", `v${this.version}`),
-			labelled("model", modelId ?? "—"),
-			labelled("cwd", cwdLabel),
-			"",
-			theme.fg("dim", "type to start"),
-		];
-		const metaStart = Math.max(0, Math.floor((logoRaw.length - metaLines.length) / 2));
-		const composed = logoRaw.map((line, i) => {
-			const colored = theme.fg("text", line);
-			const padding = " ".repeat(Math.max(0, logoCanvasWidth - visibleWidth(line) + gutter));
-			const meta = i >= metaStart && i < metaStart + metaLines.length ? metaLines[i - metaStart] : "";
-			return colored + padding + meta;
-		});
-		const brandBlock = composed.join("\n");
+		// Cheatsheet behind --verbose. `quietStartup` suppresses the splash entirely
+		// (matches pi-mono's old behaviour for users who want a bare prompt).
+		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
+			const logoRaw = PRIME_LOGO_SMALL.split("\n");
+			const logoCanvasWidth = logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+			const gutter = 4;
+			const cwdLabel = (() => {
+				let p = this.sessionManager.getCwd();
+				const home = process.env.HOME || process.env.USERPROFILE;
+				if (home && p.startsWith(home)) p = `~${p.slice(home.length)}`;
+				return p;
+			})();
+			const modelId = this.session.state.model?.id;
+			const labelWidth = 9;
+			const labelled = (label: string, value: string) =>
+				theme.fg("dim", label.padEnd(labelWidth)) + theme.fg("muted", value);
+			const metaLines = [
+				labelled("version", `v${this.version}`),
+				labelled("model", modelId ?? "—"),
+				labelled("cwd", cwdLabel),
+				"",
+				theme.fg("dim", "type to start"),
+			];
+			const metaStart = Math.max(0, Math.floor((logoRaw.length - metaLines.length) / 2));
+			const composed = logoRaw.map((line, i) => {
+				const colored = theme.fg("text", line);
+				const padding = " ".repeat(Math.max(0, logoCanvasWidth - visibleWidth(line) + gutter));
+				const meta = i >= metaStart && i < metaStart + metaLines.length ? metaLines[i - metaStart] : "";
+				return colored + padding + meta;
+			});
+			const brandBlock = composed.join("\n");
 
-		if (this.options.verbose) {
-			// Verbose: include the full keybinding cheatsheet under the brand mark.
-			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
-			const expandedInstructions = [
-				hint("app.interrupt", "to interrupt"),
-				hint("app.clear", "to clear"),
-				rawKeyHint(`${keyText("app.clear")} twice`, "to exit"),
-				hint("app.exit", "to exit (empty)"),
-				hint("app.suspend", "to suspend"),
-				keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
-				hint("app.thinking.cycle", "to cycle thinking level"),
-				rawKeyHint(`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`, "to cycle models"),
-				hint("app.model.select", "to select model"),
-				hint("app.tools.expand", "to expand tools"),
-				hint("app.thinking.toggle", "to expand thinking"),
-				hint("app.editor.external", "for external editor"),
-				rawKeyHint("/", "for commands"),
-				rawKeyHint("!", "to run bash"),
-				rawKeyHint("!!", "to run bash (no context)"),
-				hint("app.message.followUp", "to queue follow-up"),
-				hint("app.message.dequeue", "to edit all queued messages"),
-				hint("app.clipboard.pasteImage", "to paste image"),
-				rawKeyHint("drop files", "to attach"),
-			].join("\n");
-			const verboseBlock = `${brandBlock}\n\n${expandedInstructions}`;
-			this.builtInHeader = new Text(verboseBlock, 1, 0);
+			if (this.options.verbose) {
+				// Verbose: include the full keybinding cheatsheet under the brand mark.
+				const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
+				const expandedInstructions = [
+					hint("app.interrupt", "to interrupt"),
+					hint("app.clear", "to clear"),
+					rawKeyHint(`${keyText("app.clear")} twice`, "to exit"),
+					hint("app.exit", "to exit (empty)"),
+					hint("app.suspend", "to suspend"),
+					keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
+					hint("app.thinking.cycle", "to cycle thinking level"),
+					rawKeyHint(
+						`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`,
+						"to cycle models",
+					),
+					hint("app.model.select", "to select model"),
+					hint("app.tools.expand", "to expand tools"),
+					hint("app.thinking.toggle", "to expand thinking"),
+					hint("app.editor.external", "for external editor"),
+					rawKeyHint("/", "for commands"),
+					rawKeyHint("!", "to run bash"),
+					rawKeyHint("!!", "to run bash (no context)"),
+					hint("app.message.followUp", "to queue follow-up"),
+					hint("app.message.dequeue", "to edit all queued messages"),
+					hint("app.clipboard.pasteImage", "to paste image"),
+					rawKeyHint("drop files", "to attach"),
+				].join("\n");
+				const verboseBlock = `${brandBlock}\n\n${expandedInstructions}`;
+				this.builtInHeader = new Text(verboseBlock, 1, 0);
+			} else {
+				this.builtInHeader = new Text(brandBlock, 1, 0);
+			}
+			this.headerContainer.addChild(new Spacer(1));
+			this.headerContainer.addChild(this.builtInHeader);
+			this.headerContainer.addChild(new Spacer(1));
 		} else {
-			this.builtInHeader = new Text(brandBlock, 1, 0);
+			// Quiet startup: skip the splash and surrounding padding entirely.
+			this.builtInHeader = new Text("", 0, 0);
+			this.headerContainer.addChild(this.builtInHeader);
 		}
-
-		// Setup UI layout
-		this.headerContainer.addChild(new Spacer(1));
-		this.headerContainer.addChild(this.builtInHeader);
-		this.headerContainer.addChild(new Spacer(1));
 
 		this.mainContainer.addChild(this.chatContainer);
 		this.mainContainer.addChild(this.pendingMessagesContainer);


### PR DESCRIPTION
- fixes the brand-tui child-agent transcript so successive assistant turns append in chronological order instead of overwriting the first assistant slot after every tool call.
- restores the quietstartup setting (default false) and re-gates the prime splash on verbose-or-not-quiet, so users who opted into the silenced startup get the bare prompt again.
- unblocks ci by bumping the pinned model literal in the ai test suite from claude-sonnet-4 to claude-sonnet-4.5, since models.dev dropped the old id from its tool-capable list and tsgo now fails on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes touch interactive TUI startup behavior and child-agent transcript streaming logic, which could affect user-visible output ordering and header rendering, though scope is localized and well-guarded.
> 
> **Overview**
> Fixes `runRlmChild` transcript recording so streaming assistant text **appends new assistant turns in chronological order** (resetting the active assistant index on new turns/tool execution) and avoids duplicating the final answer when streaming already captured it.
> 
> Restores `quietStartup` semantics by changing its default to `false` and gating the Prime splash/header on `--verbose` *or* `!quietStartup`, enabling a truly blank startup when quiet mode is set.
> 
> Updates GitHub Copilot Anthropic test coverage to use the new model id `claude-sonnet-4.5` (replacing `claude-sonnet-4`) across multiple E2E/unit tests to keep CI passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4c4b2af7236151d5a2d549a6a98f09c88cd1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->