### PR TITLE
Add long-running goal continuation loop

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a continuation-message hook for host-owned policies that should keep the agent loop running after explicit follow-ups are drained.
+
 ## [0.74.0] - 2026-05-07
 
 ## [0.73.1] - 2026-05-07

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -161,6 +161,7 @@ async function runLoop(
 	streamFn?: StreamFn,
 ): Promise<void> {
 	let firstTurn = true;
+	let lastTurn: Parameters<NonNullable<AgentLoopConfig["getContinuationMessages"]>>[0] | undefined;
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 
@@ -214,6 +215,12 @@ async function runLoop(
 			}
 
 			await emit({ type: "turn_end", message, toolResults });
+			lastTurn = {
+				message,
+				toolResults,
+				context: currentContext,
+				newMessages,
+			};
 
 			if (
 				await config.shouldStopAfterTurn?.({
@@ -235,6 +242,12 @@ async function runLoop(
 		if (followUpMessages.length > 0) {
 			// Set as pending so inner loop processes them
 			pendingMessages = followUpMessages;
+			continue;
+		}
+
+		const continuationMessages = lastTurn ? (await config.getContinuationMessages?.(lastTurn, signal)) || [] : [];
+		if (continuationMessages.length > 0) {
+			pendingMessages = continuationMessages;
 			continue;
 		}
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,6 +20,7 @@ import type {
 	AgentTool,
 	BeforeToolCallContext,
 	BeforeToolCallResult,
+	GetContinuationMessagesContext,
 	StreamFn,
 	ToolExecutionMode,
 } from "./types.js";
@@ -101,6 +102,7 @@ export interface AgentOptions {
 	onResponse?: SimpleStreamOptions["onResponse"];
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+	getContinuationMessages?: (context: GetContinuationMessagesContext, signal?: AbortSignal) => Promise<AgentMessage[]>;
 	steeringMode?: QueueMode;
 	followUpMode?: QueueMode;
 	sessionId?: string;
@@ -175,6 +177,10 @@ export class Agent {
 		context: AfterToolCallContext,
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
+	public getContinuationMessages?: (
+		context: GetContinuationMessagesContext,
+		signal?: AbortSignal,
+	) => Promise<AgentMessage[]>;
 	private activeRun?: ActiveRun;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
@@ -197,6 +203,7 @@ export class Agent {
 		this.onResponse = options.onResponse;
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
+		this.getContinuationMessages = options.getContinuationMessages;
 		this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
 		this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
 		this.sessionId = options.sessionId;
@@ -432,6 +439,7 @@ export class Agent {
 				return this.steeringQueue.drain();
 			},
 			getFollowUpMessages: async () => this.followUpQueue.drain(),
+			getContinuationMessages: async (context, signal) => this.getContinuationMessages?.(context, signal) ?? [],
 		};
 	}
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -112,6 +112,9 @@ export interface ShouldStopAfterTurnContext {
 	newMessages: AgentMessage[];
 }
 
+/** Context passed to `getContinuationMessages`. */
+export interface GetContinuationMessagesContext extends ShouldStopAfterTurnContext {}
+
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
 
@@ -212,6 +215,20 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Contract: must not throw or reject. Return [] when no follow-up messages are available.
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
+
+	/**
+	 * Returns continuation messages when the agent would otherwise stop.
+	 *
+	 * Called after follow-up messages have been polled and none are available.
+	 * If messages are returned, they're added to the context and the agent
+	 * continues with another turn.
+	 *
+	 * Use this for host-owned continuation policies such as long-running goals.
+	 * Explicit follow-up messages always take precedence over continuation messages.
+	 *
+	 * Contract: must not throw or reject. Return [] when no continuation should run.
+	 */
+	getContinuationMessages?: (context: GetContinuationMessagesContext, signal?: AbortSignal) => Promise<AgentMessage[]>;
 
 	/**
 	 * Tool execution mode.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -650,6 +650,106 @@ describe("agentLoop with AgentMessage", () => {
 		expect(sawInterruptInContext).toBe(true);
 	});
 
+	it("should inject continuation messages when the agent would otherwise stop", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+
+		let continuationPolls = 0;
+		let sawContinuationInContext = false;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			getContinuationMessages: async ({ message }) => {
+				continuationPolls++;
+				expect(message.role).toBe("assistant");
+				if (continuationPolls === 1) {
+					return [createUserMessage("continue")];
+				}
+				return [];
+			},
+		};
+
+		let callIndex = 0;
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, (_model, ctx) => {
+			if (callIndex === 1) {
+				sawContinuationInContext = ctx.messages.some(
+					(message) => message.role === "user" && message.content === "continue",
+				);
+			}
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage([{ type: "text", text: callIndex === 0 ? "paused" : "done" }]);
+				mockStream.push({ type: "done", reason: "stop", message });
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const _event of stream) {
+			// consume
+		}
+
+		const messages = await stream.result();
+		expect(callIndex).toBe(2);
+		expect(continuationPolls).toBe(2);
+		expect(sawContinuationInContext).toBe(true);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "user", "assistant"]);
+	});
+
+	it("should prefer explicit follow-up messages before continuation messages", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		};
+
+		let followUpDelivered = false;
+		let continuationPolls = 0;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			getFollowUpMessages: async () => {
+				if (followUpDelivered) {
+					return [];
+				}
+				followUpDelivered = true;
+				return [createUserMessage("follow up")];
+			},
+			getContinuationMessages: async () => {
+				continuationPolls++;
+				return [];
+			},
+		};
+
+		let callIndex = 0;
+		let sawFollowUpInContext = false;
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, (_model, ctx) => {
+			if (callIndex === 1) {
+				sawFollowUpInContext = ctx.messages.some(
+					(message) => message.role === "user" && message.content === "follow up",
+				);
+			}
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage([{ type: "text", text: callIndex === 0 ? "paused" : "done" }]);
+				mockStream.push({ type: "done", reason: "stop", message });
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const _event of stream) {
+			// consume
+		}
+
+		expect(callIndex).toBe(2);
+		expect(continuationPolls).toBe(1);
+		expect(sawFollowUpInContext).toBe(true);
+	});
+
 	it("should force sequential execution when a tool has executionMode=sequential even with default parallel config", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		let firstResolved = false;

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,9 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
+const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
 		testTimeout: 30000, // 30 seconds for API calls
+	},
+	resolve: {
+		alias: [
+			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
+			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
+			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
+			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
+		],
 	},
 });

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -143,7 +143,7 @@ describe("Context overflow error handling", () => {
 		it.skipIf(!githubCopilotToken)(
 			"claude-sonnet-4 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4");
+				const model = getModel("github-copilot", "claude-sonnet-4.5");
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -649,7 +649,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -658,7 +658,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -667,7 +667,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -676,7 +676,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -54,7 +54,7 @@ describe("Copilot Claude via Anthropic Messages", () => {
 	};
 
 	it("uses Bearer auth, Copilot headers, and valid Anthropic Messages payload", async () => {
-		const model = getModel("github-copilot", "claude-sonnet-4");
+		const model = getModel("github-copilot", "claude-sonnet-4.5");
 		expect(model.api).toBe("anthropic-messages");
 
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
@@ -85,14 +85,14 @@ describe("Copilot Claude via Anthropic Messages", () => {
 
 		// Payload is valid Anthropic Messages format
 		const params = mockState.createParams!;
-		expect(params.model).toBe("claude-sonnet-4");
+		expect(params.model).toBe("claude-sonnet-4.5");
 		expect(params.stream).toBe(true);
 		expect(params.max_tokens).toBeGreaterThan(0);
 		expect(Array.isArray(params.messages)).toBe(true);
 	});
 
 	it("includes interleaved-thinking beta when reasoning is enabled", async () => {
-		const model = getModel("github-copilot", "claude-sonnet-4");
+		const model = getModel("github-copilot", "claude-sonnet-4.5");
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
 		const s = streamAnthropic(model, context, {
 			apiKey: "tid_copilot_session_test_token",

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -451,7 +451,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -460,7 +460,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -106,7 +106,7 @@ describe("responseId E2E Tests", () => {
 			"Anthropic path should expose responseId",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await expectResponseId(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -1217,7 +1217,7 @@ describe("Generate E2E Tests", () => {
 	});
 
 	describe("GitHub Copilot Provider (claude-sonnet-4 via Anthropic Messages)", () => {
-		const llm = getModel("github-copilot", "claude-sonnet-4");
+		const llm = getModel("github-copilot", "claude-sonnet-4.5");
 
 		it.skipIf(!githubCopilotToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -293,7 +293,7 @@ describe("Token Statistics on Abort", () => {
 			"claude-sonnet-4 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -301,7 +301,7 @@ describe("Tool Call Without Result Tests", () => {
 			"claude-sonnet-4 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4");
+				const model = getModel("github-copilot", "claude-sonnet-4.5");
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -704,7 +704,7 @@ describe("totalTokens field", () => {
 			"claude-sonnet-4 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -13,7 +13,7 @@ function anthropicNormalizeToolCallId(
 
 function makeCopilotClaudeModel(): Model<"anthropic-messages"> {
 	return {
-		id: "claude-sonnet-4",
+		id: "claude-sonnet-4.5",
 		name: "Claude Sonnet 4",
 		api: "anthropic-messages",
 		provider: "github-copilot",

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -426,7 +426,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -435,7 +435,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -444,7 +444,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4");
+				const llm = getModel("github-copilot", "claude-sonnet-4.5");
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added automatic IPython kernel runtime bootstrap with uv-managed Python, `ipykernel`, and `prime-agent-runtime`.
+- Added `/goal` for long-running objectives that continue after early no-tool stops until a classifier marks the goal complete or the continuation limit is reached.
 
 ### Changed
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2678,7 +2678,10 @@ export class AgentSession {
 		let status: RlmChildAgentStatus = "running";
 		let answerPreview: string | undefined;
 		let durationMs: number | undefined;
-		let assistantTranscriptIndex: number | undefined;
+		// Index of the assistant entry currently being streamed. Cleared whenever the
+		// conversation moves on (new assistant message, tool call) so subsequent assistant
+		// text appends a fresh entry in chronological order instead of overwriting in place.
+		let currentAssistantIndex: number | undefined;
 		let lastToolTranscriptIndex: number | undefined;
 		const emitChildUpdate = () => {
 			this._emit({
@@ -2695,17 +2698,17 @@ export class AgentSession {
 				},
 			});
 		};
-		const setAssistantTranscript = (text: string) => {
+		const recordAssistantText = (text: string) => {
 			const compact = compactRlmText(text);
 			if (!compact) {
 				return;
 			}
 			answerPreview = compact;
-			if (assistantTranscriptIndex === undefined) {
-				assistantTranscriptIndex = transcript.length;
+			if (currentAssistantIndex === undefined) {
+				currentAssistantIndex = transcript.length;
 				transcript.push({ role: "assistant", text: compact });
 			} else {
-				transcript[assistantTranscriptIndex] = { role: "assistant", text: compact };
+				transcript[currentAssistantIndex] = { role: "assistant", text: compact };
 			}
 		};
 		emitChildUpdate();
@@ -2765,8 +2768,11 @@ export class AgentSession {
 						if (text) {
 							transcript.push({ role: "user", text });
 						}
+						currentAssistantIndex = undefined;
 					} else if (event.message.role === "assistant") {
-						setAssistantTranscript(readAssistantText(event.message as AssistantMessage));
+						// New assistant turn: append a fresh entry so prior text isn't overwritten.
+						currentAssistantIndex = undefined;
+						recordAssistantText(readAssistantText(event.message as AssistantMessage));
 					}
 					emitChildUpdate();
 					break;
@@ -2774,13 +2780,15 @@ export class AgentSession {
 				case "message_update":
 				case "message_end": {
 					if (event.message.role === "assistant") {
-						setAssistantTranscript(readAssistantText(event.message as AssistantMessage));
+						recordAssistantText(readAssistantText(event.message as AssistantMessage));
 						emitChildUpdate();
 					}
 					break;
 				}
 				case "tool_execution_start": {
 					const args = formatRlmToolArgs(event.args);
+					// Tool break: next assistant text starts a new entry after this tool row.
+					currentAssistantIndex = undefined;
 					lastToolTranscriptIndex = transcript.length;
 					transcript.push({
 						role: "tool",
@@ -2823,7 +2831,7 @@ export class AgentSession {
 			this._attributeRlmChildUsageToParent(child._assistantUsageForCurrentMessages());
 			status = "done";
 			durationMs = Date.now() - startedAt;
-			setAssistantTranscript(answer);
+			recordAssistantText(answer);
 			emitChildUpdate();
 			return {
 				answer,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -23,12 +23,14 @@ import {
 	type AgentMessage,
 	type AgentState,
 	type AgentTool,
+	type GetContinuationMessagesContext,
 	type ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent, Usage } from "@earendil-works/pi-ai";
 import {
 	clampThinkingLevel,
 	cleanupSessionResources,
+	completeSimple,
 	getSupportedThinkingLevels,
 	isContextOverflow,
 	modelsAreEqual,
@@ -144,6 +146,18 @@ export interface RlmChildAgentSnapshot {
 	transcript: readonly RlmChildAgentTranscriptLine[];
 }
 
+export type GoalStatus = "idle" | "running" | "classifying" | "complete" | "stopped" | "limit_reached" | "error";
+
+export interface GoalState {
+	active: boolean;
+	status: GoalStatus;
+	objective?: string;
+	maxContinuations: number;
+	continuationsUsed: number;
+	lastReason?: string;
+	lastError?: string;
+}
+
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| AgentEvent
@@ -165,7 +179,8 @@ export type AgentSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
-	| { type: "rlm_child_update"; child: RlmChildAgentSnapshot };
+	| { type: "rlm_child_update"; child: RlmChildAgentSnapshot }
+	| { type: "goal_update"; goal: GoalState };
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -266,12 +281,27 @@ interface ToolDefinitionEntry {
 	sourceInfo: SourceInfo;
 }
 
+type GoalSlashCommand =
+	| { kind: "status" }
+	| { kind: "stop" }
+	| { kind: "start"; objective: string; maxContinuations: number };
+
+interface GoalClassification {
+	complete: boolean;
+	reason: string;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
 
 /** Standard thinking levels */
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
+const DEFAULT_GOAL_MAX_CONTINUATIONS = 50;
+const GOAL_CLASSIFIER_MAX_TOKENS = 256;
+const GOAL_CONTINUATION_CUSTOM_TYPE = "goal_continuation";
+const GOAL_CLASSIFIER_SYSTEM_PROMPT =
+	"You are a strict completion classifier for a long-running coding agent goal. Return only JSON.";
 
 function parseDepth(value: string | undefined, fallback: number, name: string): number {
 	if (value === undefined || value === "") {
@@ -408,6 +438,13 @@ export class AgentSession {
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 
+	private _goalState: GoalState = {
+		active: false,
+		status: "idle",
+		maxContinuations: DEFAULT_GOAL_MAX_CONTINUATIONS,
+		continuationsUsed: 0,
+	};
+
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
@@ -486,6 +523,7 @@ export class AgentSession {
 		// (session persistence, extensions, auto-compaction, retry logic)
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
 		this._installAgentToolHooks();
+		this._installAgentContinuationHook();
 
 		this._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
@@ -584,6 +622,10 @@ export class AgentSession {
 		};
 	}
 
+	private _installAgentContinuationHook(): void {
+		this.agent.getContinuationMessages = (context, signal) => this._getGoalContinuationMessages(context, signal);
+	}
+
 	// =========================================================================
 	// Event Subscription
 	// =========================================================================
@@ -601,6 +643,324 @@ export class AgentSession {
 			steering: [...this._steeringMessages],
 			followUp: [...this._followUpMessages],
 		});
+	}
+
+	private _emitGoalUpdate(): void {
+		this._emit({ type: "goal_update", goal: this.goalState });
+	}
+
+	private _setGoalState(next: GoalState): void {
+		this._goalState = next;
+		this._emitGoalUpdate();
+	}
+
+	private _startGoal(objective: string, maxContinuations: number): void {
+		this._setGoalState({
+			active: true,
+			status: "running",
+			objective,
+			maxContinuations,
+			continuationsUsed: 0,
+		});
+	}
+
+	private _finishGoal(status: Exclude<GoalStatus, "idle" | "running" | "classifying">, reason?: string): void {
+		this._setGoalState({
+			...this._goalState,
+			active: false,
+			status,
+			lastReason: reason,
+		});
+	}
+
+	private _finishGoalWithError(errorMessage: string): void {
+		this._setGoalState({
+			...this._goalState,
+			active: false,
+			status: "error",
+			lastReason: errorMessage,
+			lastError: errorMessage,
+		});
+	}
+
+	private _finishGoalForTerminalAssistantMessage(message: AssistantMessage): void {
+		if (!this._goalState.active) {
+			return;
+		}
+
+		if (message.stopReason === "aborted") {
+			this._finishGoal("stopped", "Aborted by user");
+			return;
+		}
+
+		if (message.stopReason === "error") {
+			this._finishGoalWithError(message.errorMessage || "Assistant response failed");
+		}
+	}
+
+	private _parseGoalSlashCommand(text: string): GoalSlashCommand | undefined {
+		if (text !== "/goal" && !text.startsWith("/goal ")) {
+			return undefined;
+		}
+
+		const rest = text.slice("/goal".length).trim();
+		if (!rest || rest === "status") {
+			return { kind: "status" };
+		}
+		if (rest === "stop") {
+			return { kind: "stop" };
+		}
+
+		let maxContinuations = DEFAULT_GOAL_MAX_CONTINUATIONS;
+		let objective = rest;
+		const firstToken = rest.split(/\s+/, 1)[0] ?? "";
+		if (firstToken === "--turns" || firstToken.startsWith("--turns=")) {
+			let valueText: string;
+			if (firstToken === "--turns") {
+				const withoutFlag = rest.slice("--turns".length).trimStart();
+				const nextSpace = withoutFlag.search(/\s/);
+				if (nextSpace < 0) {
+					throw new Error("Usage: /goal --turns <count> <objective>");
+				}
+				valueText = withoutFlag.slice(0, nextSpace);
+				objective = withoutFlag.slice(nextSpace + 1).trim();
+			} else {
+				valueText = firstToken.slice("--turns=".length);
+				objective = rest.slice(firstToken.length).trim();
+			}
+
+			const parsed = Number.parseInt(valueText, 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				throw new Error("Goal turn limit must be a positive integer");
+			}
+			maxContinuations = parsed;
+		}
+
+		if (!objective) {
+			throw new Error("Usage: /goal [--turns <count>] <objective>");
+		}
+
+		return { kind: "start", objective, maxContinuations };
+	}
+
+	private _createGoalInitialPrompt(objective: string): string {
+		return `Work toward this long-running goal until it is complete.\n\n<untrusted_objective>\n${objective}\n</untrusted_objective>`;
+	}
+
+	private _createGoalContinuationPrompt(objective: string, reason: string | undefined): string {
+		const reasonText = reason ? `\n\nClassifier reason: ${reason}` : "";
+		return `Continue working toward the active long-running goal. The previous assistant turn stopped without requesting a tool.${reasonText}\n\n<untrusted_objective>\n${objective}\n</untrusted_objective>\n\nTake the next concrete step. Use available tools when useful.`;
+	}
+
+	private async _handleGoalSlashCommand(
+		text: string,
+		images: ImageContent[] | undefined,
+	): Promise<{ handled: true } | { handled: false; text: string; images?: ImageContent[] }> {
+		const command = this._parseGoalSlashCommand(text);
+		if (!command) {
+			return { handled: false, text, images };
+		}
+
+		if (command.kind === "status") {
+			this._emitGoalUpdate();
+			return { handled: true };
+		}
+
+		if (command.kind === "stop") {
+			if (this._goalState.active) {
+				this._finishGoal("stopped", "Stopped by user");
+			} else {
+				this._emitGoalUpdate();
+			}
+			return { handled: true };
+		}
+
+		this._startGoal(command.objective, command.maxContinuations);
+		const promptText = this._createGoalInitialPrompt(command.objective);
+		if (this.isStreaming) {
+			await this._queueFollowUp(promptText, images);
+			return { handled: true };
+		}
+
+		return { handled: false, text: promptText, images };
+	}
+
+	private _formatGoalTranscriptMessage(message: AgentMessage): string | undefined {
+		switch (message.role) {
+			case "user": {
+				const text = readTextBlocks(message.content).trim();
+				return text ? `user: ${text}` : undefined;
+			}
+			case "assistant": {
+				const text = readAssistantText(message as AssistantMessage).trim();
+				return text ? `assistant: ${text}` : undefined;
+			}
+			case "toolResult": {
+				const text = readTextBlocks(message.content).trim();
+				return text ? `tool ${message.toolName}: ${text}` : `tool ${message.toolName}: done`;
+			}
+			case "custom": {
+				if (!message.display && message.customType === GOAL_CONTINUATION_CUSTOM_TYPE) {
+					return undefined;
+				}
+				const text = typeof message.content === "string" ? message.content : readTextBlocks(message.content);
+				return text.trim() ? `custom ${message.customType}: ${text.trim()}` : undefined;
+			}
+			case "bashExecution": {
+				const status = message.cancelled ? "cancelled" : message.exitCode === 0 ? "succeeded" : "failed";
+				const output = message.output.trim();
+				return output ? `bash ${status}: ${output}` : `bash ${status}`;
+			}
+			case "branchSummary":
+				return `branch summary: ${message.summary}`;
+			case "compactionSummary":
+				return `compaction summary: ${message.summary}`;
+			default: {
+				const _exhaustive: never = message;
+				return _exhaustive;
+			}
+		}
+	}
+
+	private _buildGoalTranscript(messages: AgentMessage[]): string {
+		return messages
+			.slice(-30)
+			.map((message) => this._formatGoalTranscriptMessage(message))
+			.filter((line): line is string => line !== undefined)
+			.join("\n\n");
+	}
+
+	private _parseGoalClassification(text: string): GoalClassification {
+		const start = text.indexOf("{");
+		const end = text.lastIndexOf("}");
+		if (start < 0 || end < start) {
+			throw new Error("Goal classifier returned no JSON object");
+		}
+
+		const parsed: unknown = JSON.parse(text.slice(start, end + 1));
+		if (!parsed || typeof parsed !== "object") {
+			throw new Error("Goal classifier returned invalid JSON");
+		}
+
+		const record = parsed as Record<string, unknown>;
+		if (typeof record.complete !== "boolean") {
+			throw new Error("Goal classifier response is missing complete");
+		}
+
+		return {
+			complete: record.complete,
+			reason: typeof record.reason === "string" ? record.reason : "",
+		};
+	}
+
+	private async _classifyGoalCompletion(
+		objective: string,
+		context: GetContinuationMessagesContext,
+		signal?: AbortSignal,
+	): Promise<GoalClassification> {
+		const model = this.model;
+		if (!model) {
+			throw new Error(formatNoModelSelectedMessage());
+		}
+
+		const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+		const transcript = this._buildGoalTranscript(context.context.messages);
+		const promptText = `Decide whether the active goal is fully complete based on the recent transcript.\n\nReturn only JSON in this shape:\n{"complete":true|false,"reason":"short reason"}\n\nMark complete true only if the requested goal has actually been achieved.\n\n<untrusted_objective>\n${objective}\n</untrusted_objective>\n\n<recent_transcript>\n${transcript}\n</recent_transcript>`;
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: promptText }],
+				timestamp: Date.now(),
+			},
+		];
+		const completionOptions =
+			model.reasoning && this.thinkingLevel !== "off"
+				? {
+						maxTokens: GOAL_CLASSIFIER_MAX_TOKENS,
+						signal,
+						apiKey,
+						headers,
+						reasoning: this.thinkingLevel,
+					}
+				: {
+						maxTokens: GOAL_CLASSIFIER_MAX_TOKENS,
+						signal,
+						apiKey,
+						headers,
+					};
+		const response = await completeSimple(
+			model,
+			{ systemPrompt: GOAL_CLASSIFIER_SYSTEM_PROMPT, messages },
+			completionOptions,
+		);
+		if (response.stopReason === "error") {
+			throw new Error(response.errorMessage || "Goal classifier failed");
+		}
+
+		const text = readAssistantText(response);
+		return this._parseGoalClassification(text);
+	}
+
+	private async _getGoalContinuationMessages(
+		context: GetContinuationMessagesContext,
+		signal?: AbortSignal,
+	): Promise<AgentMessage[]> {
+		const goal = this._goalState;
+		if (!goal.active || !goal.objective || signal?.aborted) {
+			return [];
+		}
+
+		const hasToolCalls = context.message.content.some((content) => content.type === "toolCall");
+		if (hasToolCalls || context.toolResults.length > 0) {
+			return [];
+		}
+
+		if (goal.continuationsUsed >= goal.maxContinuations) {
+			this._finishGoal("limit_reached", `Reached ${goal.maxContinuations} continuation turn limit`);
+			return [];
+		}
+
+		this._setGoalState({ ...goal, status: "classifying" });
+		let classification: GoalClassification;
+		try {
+			classification = await this._classifyGoalCompletion(goal.objective, context, signal);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			classification = { complete: false, reason: `Classifier failed: ${message}` };
+			this._setGoalState({ ...this._goalState, status: "running", lastError: message });
+		}
+
+		if (!this._goalState.active || this._goalState.objective !== goal.objective || signal?.aborted) {
+			return [];
+		}
+
+		if (classification.complete) {
+			this._finishGoal("complete", classification.reason);
+			return [];
+		}
+
+		const nextContinuationsUsed = this._goalState.continuationsUsed + 1;
+		this._setGoalState({
+			...this._goalState,
+			status: "running",
+			continuationsUsed: nextContinuationsUsed,
+			lastReason: classification.reason,
+			lastError: undefined,
+		});
+
+		const continuation: CustomMessage<{ objective: string; classifierReason?: string; continuationsUsed: number }> = {
+			role: "custom",
+			customType: GOAL_CONTINUATION_CUSTOM_TYPE,
+			content: this._createGoalContinuationPrompt(goal.objective, classification.reason),
+			display: false,
+			details: {
+				objective: goal.objective,
+				classifierReason: classification.reason || undefined,
+				continuationsUsed: nextContinuationsUsed,
+			},
+			timestamp: Date.now(),
+		};
+		return [continuation];
 	}
 
 	// Track last assistant message for auto-compaction check
@@ -738,7 +1098,10 @@ export class AgentSession {
 			}
 
 			this._resolveRetry();
-			await this._checkCompaction(msg);
+			const compactionWillRetry = await this._checkCompaction(msg);
+			if (!compactionWillRetry) {
+				this._finishGoalForTerminalAssistantMessage(msg);
+			}
 		}
 	}
 
@@ -1033,6 +1396,10 @@ export class AgentSession {
 		return this.sessionManager.getSessionName();
 	}
 
+	get goalState(): GoalState {
+		return { ...this._goalState };
+	}
+
 	/** Scoped models for cycling (from --models flag) */
 	get scopedModels(): ReadonlyArray<{ model: Model<any>; thinkingLevel?: ThinkingLevel }> {
 		return this._scopedModels;
@@ -1124,15 +1491,31 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
-		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
+		let expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		let messages: AgentMessage[] | undefined;
 
 		try {
+			let currentText = text;
+			let currentImages = options?.images;
+
+			if (expandPromptTemplates) {
+				const goalCommandResult = await this._handleGoalSlashCommand(currentText, currentImages);
+				if (goalCommandResult.handled) {
+					preflightResult?.(true);
+					return;
+				}
+				if (goalCommandResult.text !== currentText) {
+					currentText = goalCommandResult.text;
+					currentImages = goalCommandResult.images;
+					expandPromptTemplates = false;
+				}
+			}
+
 			// Handle extension commands first (execute immediately, even during streaming)
 			// Extension commands manage their own LLM interaction via pi.sendMessage()
-			if (expandPromptTemplates && text.startsWith("/")) {
-				const handled = await this._tryExecuteExtensionCommand(text);
+			if (expandPromptTemplates && currentText.startsWith("/")) {
+				const handled = await this._tryExecuteExtensionCommand(currentText);
 				if (handled) {
 					// Extension command executed, no prompt to send
 					preflightResult?.(true);
@@ -1141,8 +1524,6 @@ export class AgentSession {
 			}
 
 			// Emit input event for extension interception (before skill/template expansion)
-			let currentText = text;
-			let currentImages = options?.images;
 			if (this._extensionRunner.hasHandlers("input")) {
 				const inputResult = await this._extensionRunner.emitInput(
 					currentText,
@@ -1545,6 +1926,9 @@ export class AgentSession {
 	 */
 	async abort(): Promise<void> {
 		this.abortRetry();
+		if (this._goalState.active) {
+			this._finishGoal("stopped", "Aborted by user");
+		}
 		this.agent.abort();
 		await this.agent.waitForIdle();
 	}
@@ -1927,12 +2311,12 @@ export class AgentSession {
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
-	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<void> {
+	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
-		if (!settings.enabled) return;
+		if (!settings.enabled) return false;
 
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
-		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return;
+		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return false;
 
 		const contextWindow = this.model?.contextWindow ?? 0;
 
@@ -1950,7 +2334,7 @@ export class AgentSession {
 		const assistantIsFromBeforeCompaction =
 			compactionEntry !== null && assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
 		if (assistantIsFromBeforeCompaction) {
-			return;
+			return false;
 		}
 
 		// Case 1: Overflow - LLM returned context overflow error
@@ -1965,7 +2349,7 @@ export class AgentSession {
 					errorMessage:
 						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
 				});
-				return;
+				return false;
 			}
 
 			this._overflowRecoveryAttempted = true;
@@ -1975,8 +2359,7 @@ export class AgentSession {
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.state.messages = messages.slice(0, -1);
 			}
-			await this._runAutoCompaction("overflow", true);
-			return;
+			return await this._runAutoCompaction("overflow", true);
 		}
 
 		// Case 2: Threshold - context is getting large
@@ -1986,7 +2369,7 @@ export class AgentSession {
 		if (assistantMessage.stopReason === "error") {
 			const messages = this.agent.state.messages;
 			const estimate = estimateContextTokens(messages);
-			if (estimate.lastUsageIndex === null) return; // No usage data at all
+			if (estimate.lastUsageIndex === null) return false; // No usage data at all
 			// Verify the usage source is post-compaction. Kept pre-compaction messages
 			// have stale usage reflecting the old (larger) context and would falsely
 			// trigger compaction right after one just finished.
@@ -1996,21 +2379,22 @@ export class AgentSession {
 				usageMsg.role === "assistant" &&
 				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
 			) {
-				return;
+				return false;
 			}
 			contextTokens = estimate.tokens;
 		} else {
 			contextTokens = calculateContextTokens(assistantMessage.usage);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
-			await this._runAutoCompaction("threshold", false);
+			return await this._runAutoCompaction("threshold", false);
 		}
+		return false;
 	}
 
 	/**
 	 * Internal: Run auto-compaction with events.
 	 */
-	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<void> {
+	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 
 		this._emit({ type: "compaction_start", reason });
@@ -2025,7 +2409,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
@@ -2037,7 +2421,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 			const { apiKey, headers } = authResult;
 
@@ -2052,7 +2436,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -2075,7 +2459,7 @@ export class AgentSession {
 						aborted: true,
 						willRetry: false,
 					});
-					return;
+					return false;
 				}
 
 				if (extensionResult?.compaction) {
@@ -2120,7 +2504,7 @@ export class AgentSession {
 					aborted: true,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			this.sessionManager.appendCompaction(summary, firstKeptEntryId, tokensBefore, details, fromExtension);
@@ -2160,6 +2544,7 @@ export class AgentSession {
 				setTimeout(() => {
 					this.agent.continue().catch(() => {});
 				}, 100);
+				return true;
 			} else if (this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
@@ -2167,6 +2552,7 @@ export class AgentSession {
 					this.agent.continue().catch(() => {});
 				}, 100);
 			}
+			return false;
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
 			this._emit({
@@ -2180,6 +2566,7 @@ export class AgentSession {
 						? `Context overflow recovery failed: ${errorMessage}`
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
+			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2831,7 +2831,17 @@ export class AgentSession {
 			this._attributeRlmChildUsageToParent(child._assistantUsageForCurrentMessages());
 			status = "done";
 			durationMs = Date.now() - startedAt;
-			recordAssistantText(answer);
+			// Streaming events usually capture the final assistant text already. Only
+			// record again when it's missing — otherwise a child whose last streamed
+			// event was tool_execution_start would have currentAssistantIndex cleared,
+			// causing the final answer to be appended as a duplicate row.
+			const compactAnswer = compactRlmText(answer);
+			const lastAssistantText = [...transcript].reverse().find((line) => line.role === "assistant")?.text;
+			if (compactAnswer && compactAnswer !== lastAssistantText) {
+				recordAssistantText(answer);
+			} else if (compactAnswer) {
+				answerPreview = compactAnswer;
+			}
 			emitChildUpdate();
 			return {
 				answer,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -755,7 +755,7 @@ export class SettingsManager {
 	}
 
 	getQuietStartup(): boolean {
-		return this.settings.quietStartup ?? true;
+		return this.settings.quietStartup ?? false;
 	}
 
 	setQuietStartup(quiet: boolean): void {

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -34,6 +34,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "logout", description: "Remove provider authentication" },
 	{ name: "new", description: "Start a new session" },
 	{ name: "compact", description: "Manually compact the session context" },
+	{ name: "goal", description: "Run a long-running goal until complete" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -675,70 +675,78 @@ export class InteractiveMode {
 
 		// Brand splash: side-panel layout — white butterfly on the left, structured runtime
 		// metadata on the right. The mark carries the brand; no wordmark, no slogan.
-		// Cheatsheet behind --verbose.
-		const logoRaw = PRIME_LOGO_SMALL.split("\n");
-		const logoCanvasWidth = logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
-		const gutter = 4;
-		const cwdLabel = (() => {
-			let p = this.sessionManager.getCwd();
-			const home = process.env.HOME || process.env.USERPROFILE;
-			if (home && p.startsWith(home)) p = `~${p.slice(home.length)}`;
-			return p;
-		})();
-		const modelId = this.session.state.model?.id;
-		const labelWidth = 9;
-		const labelled = (label: string, value: string) =>
-			theme.fg("dim", label.padEnd(labelWidth)) + theme.fg("muted", value);
-		const metaLines = [
-			labelled("version", `v${this.version}`),
-			labelled("model", modelId ?? "—"),
-			labelled("cwd", cwdLabel),
-			"",
-			theme.fg("dim", "type to start"),
-		];
-		const metaStart = Math.max(0, Math.floor((logoRaw.length - metaLines.length) / 2));
-		const composed = logoRaw.map((line, i) => {
-			const colored = theme.fg("text", line);
-			const padding = " ".repeat(Math.max(0, logoCanvasWidth - visibleWidth(line) + gutter));
-			const meta = i >= metaStart && i < metaStart + metaLines.length ? metaLines[i - metaStart] : "";
-			return colored + padding + meta;
-		});
-		const brandBlock = composed.join("\n");
+		// Cheatsheet behind --verbose. `quietStartup` suppresses the splash entirely
+		// (matches pi-mono's old behaviour for users who want a bare prompt).
+		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
+			const logoRaw = PRIME_LOGO_SMALL.split("\n");
+			const logoCanvasWidth = logoRaw.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+			const gutter = 4;
+			const cwdLabel = (() => {
+				let p = this.sessionManager.getCwd();
+				const home = process.env.HOME || process.env.USERPROFILE;
+				if (home && p.startsWith(home)) p = `~${p.slice(home.length)}`;
+				return p;
+			})();
+			const modelId = this.session.state.model?.id;
+			const labelWidth = 9;
+			const labelled = (label: string, value: string) =>
+				theme.fg("dim", label.padEnd(labelWidth)) + theme.fg("muted", value);
+			const metaLines = [
+				labelled("version", `v${this.version}`),
+				labelled("model", modelId ?? "—"),
+				labelled("cwd", cwdLabel),
+				"",
+				theme.fg("dim", "type to start"),
+			];
+			const metaStart = Math.max(0, Math.floor((logoRaw.length - metaLines.length) / 2));
+			const composed = logoRaw.map((line, i) => {
+				const colored = theme.fg("text", line);
+				const padding = " ".repeat(Math.max(0, logoCanvasWidth - visibleWidth(line) + gutter));
+				const meta = i >= metaStart && i < metaStart + metaLines.length ? metaLines[i - metaStart] : "";
+				return colored + padding + meta;
+			});
+			const brandBlock = composed.join("\n");
 
-		if (this.options.verbose) {
-			// Verbose: include the full keybinding cheatsheet under the brand mark.
-			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
-			const expandedInstructions = [
-				hint("app.interrupt", "to interrupt"),
-				hint("app.clear", "to clear"),
-				rawKeyHint(`${keyText("app.clear")} twice`, "to exit"),
-				hint("app.exit", "to exit (empty)"),
-				hint("app.suspend", "to suspend"),
-				keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
-				hint("app.thinking.cycle", "to cycle thinking level"),
-				rawKeyHint(`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`, "to cycle models"),
-				hint("app.model.select", "to select model"),
-				hint("app.tools.expand", "to expand tools"),
-				hint("app.thinking.toggle", "to expand thinking"),
-				hint("app.editor.external", "for external editor"),
-				rawKeyHint("/", "for commands"),
-				rawKeyHint("!", "to run bash"),
-				rawKeyHint("!!", "to run bash (no context)"),
-				hint("app.message.followUp", "to queue follow-up"),
-				hint("app.message.dequeue", "to edit all queued messages"),
-				hint("app.clipboard.pasteImage", "to paste image"),
-				rawKeyHint("drop files", "to attach"),
-			].join("\n");
-			const verboseBlock = `${brandBlock}\n\n${expandedInstructions}`;
-			this.builtInHeader = new Text(verboseBlock, 1, 0);
+			if (this.options.verbose) {
+				// Verbose: include the full keybinding cheatsheet under the brand mark.
+				const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
+				const expandedInstructions = [
+					hint("app.interrupt", "to interrupt"),
+					hint("app.clear", "to clear"),
+					rawKeyHint(`${keyText("app.clear")} twice`, "to exit"),
+					hint("app.exit", "to exit (empty)"),
+					hint("app.suspend", "to suspend"),
+					keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
+					hint("app.thinking.cycle", "to cycle thinking level"),
+					rawKeyHint(
+						`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`,
+						"to cycle models",
+					),
+					hint("app.model.select", "to select model"),
+					hint("app.tools.expand", "to expand tools"),
+					hint("app.thinking.toggle", "to expand thinking"),
+					hint("app.editor.external", "for external editor"),
+					rawKeyHint("/", "for commands"),
+					rawKeyHint("!", "to run bash"),
+					rawKeyHint("!!", "to run bash (no context)"),
+					hint("app.message.followUp", "to queue follow-up"),
+					hint("app.message.dequeue", "to edit all queued messages"),
+					hint("app.clipboard.pasteImage", "to paste image"),
+					rawKeyHint("drop files", "to attach"),
+				].join("\n");
+				const verboseBlock = `${brandBlock}\n\n${expandedInstructions}`;
+				this.builtInHeader = new Text(verboseBlock, 1, 0);
+			} else {
+				this.builtInHeader = new Text(brandBlock, 1, 0);
+			}
+			this.headerContainer.addChild(new Spacer(1));
+			this.headerContainer.addChild(this.builtInHeader);
+			this.headerContainer.addChild(new Spacer(1));
 		} else {
-			this.builtInHeader = new Text(brandBlock, 1, 0);
+			// Quiet startup: skip the splash and surrounding padding entirely.
+			this.builtInHeader = new Text("", 0, 0);
+			this.headerContainer.addChild(this.builtInHeader);
 		}
-
-		// Setup UI layout
-		this.headerContainer.addChild(new Spacer(1));
-		this.headerContainer.addChild(this.builtInHeader);
-		this.headerContainer.addChild(new Spacer(1));
 
 		this.mainContainer.addChild(this.chatContainer);
 		this.mainContainer.addChild(this.pendingMessagesContainer);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -60,6 +60,7 @@ import {
 import {
 	type AgentSession,
 	type AgentSessionEvent,
+	type GoalState,
 	parseSkillBlock,
 	type RlmChildAgentSnapshot,
 } from "../../core/agent-session.js";
@@ -3075,6 +3076,35 @@ export class InteractiveMode {
 			case "rlm_child_update":
 				this.updateChildAgentInspector(event.child);
 				break;
+
+			case "goal_update":
+				this.showStatus(this.formatGoalStatus(event.goal));
+				break;
+		}
+	}
+
+	private formatGoalStatus(goal: GoalState): string {
+		const objective = goal.objective ? `: ${goal.objective}` : "";
+		const progress = `${goal.continuationsUsed}/${goal.maxContinuations}`;
+		switch (goal.status) {
+			case "idle":
+				return "No active goal";
+			case "running":
+				return `Goal running (${progress})${objective}`;
+			case "classifying":
+				return `Checking goal completion (${progress})${objective}`;
+			case "complete":
+				return goal.lastReason ? `Goal complete: ${goal.lastReason}` : "Goal complete";
+			case "stopped":
+				return "Goal stopped";
+			case "limit_reached":
+				return goal.lastReason ? `Goal limit reached: ${goal.lastReason}` : "Goal limit reached";
+			case "error":
+				return goal.lastError ? `Goal error: ${goal.lastError}` : "Goal error";
+			default: {
+				const _exhaustive: never = goal.status;
+				return _exhaustive;
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -442,6 +442,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 					autoCompactionEnabled: session.autoCompactionEnabled,
 					messageCount: session.messages.length,
 					pendingMessageCount: session.pendingMessageCount,
+					goal: session.goalState,
 				};
 				return success(id, "get_state", state);
 			}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,7 +7,7 @@
 
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model } from "@earendil-works/pi-ai";
-import type { SessionStats } from "../../core/agent-session.js";
+import type { GoalState, SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { SourceInfo } from "../../core/source-info.js";
@@ -101,6 +101,7 @@ export interface RpcSessionState {
 	autoCompactionEnabled: boolean;
 	messageCount: number;
 	pendingMessageCount: number;
+	goal: GoalState;
 }
 
 // ============================================================================

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -1,0 +1,146 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getAssistantTexts, getMessageText, type Harness } from "./harness.js";
+
+describe("AgentSession goals", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("stops when the classifier marks the goal complete", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("I wrote the greeting."),
+			fauxAssistantMessage('{"complete":true,"reason":"greeting is written"}'),
+		]);
+
+		await harness.session.prompt("/goal write a greeting");
+
+		expect(getAssistantTexts(harness)).toEqual(["I wrote the greeting."]);
+		expect(getMessageText(harness.session.messages[0])).toContain("write a greeting");
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			continuationsUsed: 0,
+			lastReason: "greeting is written",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("injects a hidden continuation when the classifier marks the goal incomplete", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("I need another step."),
+			fauxAssistantMessage('{"complete":false,"reason":"not done yet"}'),
+			fauxAssistantMessage("The goal is done now."),
+			fauxAssistantMessage('{"complete":true,"reason":"done"}'),
+		]);
+
+		await harness.session.prompt("/goal finish the task");
+
+		expect(getAssistantTexts(harness)).toEqual(["I need another step.", "The goal is done now."]);
+		const hiddenContinuation = harness.session.messages.find(
+			(message) => message.role === "custom" && message.customType === "goal_continuation",
+		);
+		expect(hiddenContinuation).toMatchObject({
+			role: "custom",
+			display: false,
+		});
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			continuationsUsed: 1,
+			lastReason: "done",
+		});
+	});
+
+	it("continues by default when the classifier output is malformed", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("I stopped early."),
+			fauxAssistantMessage("not json"),
+			fauxAssistantMessage("Now it is done."),
+			fauxAssistantMessage('{"complete":true,"reason":"done"}'),
+		]);
+
+		await harness.session.prompt("/goal complete despite classifier parse failure");
+
+		expect(getAssistantTexts(harness)).toEqual(["I stopped early.", "Now it is done."]);
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			continuationsUsed: 1,
+			lastReason: "done",
+		});
+	});
+
+	it("stops at the configured continuation limit", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("First stop."),
+			fauxAssistantMessage('{"complete":false,"reason":"needs more"}'),
+			fauxAssistantMessage("Second stop."),
+		]);
+
+		await harness.session.prompt("/goal --turns 1 keep working");
+
+		expect(getAssistantTexts(harness)).toEqual(["First stop.", "Second stop."]);
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "limit_reached",
+			continuationsUsed: 1,
+			lastReason: "Reached 1 continuation turn limit",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("marks the goal as errored on terminal provider errors", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" })]);
+
+		await harness.session.prompt("/goal do work");
+
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "error",
+			lastError: "invalid_api_key",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("marks the goal as stopped on aborted runs", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "aborted" })]);
+
+		await harness.session.prompt("/goal do work");
+
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "stopped",
+			lastReason: "Aborted by user",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("reports status without consuming a provider response", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("unused")]);
+
+		await harness.session.prompt("/goal status");
+
+		expect(harness.session.messages).toEqual([]);
+		expect(harness.eventsOfType("goal_update").at(-1)?.goal.status).toBe("idle");
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+});

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,9 +22,11 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });


### PR DESCRIPTION
## Summary

- Add a core agent-loop continuation hook that runs after explicit follow-ups are drained.
- Add `/goal` for long-running objectives with classifier-based completion, `/goal status`, `/goal stop`, and `--turns`.
- Surface goal state in TUI status updates and RPC session state.
- Add focused regression coverage for continuation ordering, completion, parse failures, limits, provider errors, and aborts.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-loop.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-goal.test.ts`
- `npm run check`
