### PR TITLE
Adjust tool prompt guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ plans/
 .pi/hf-sessions-backup/
 collect.sh
 .kernel-venv/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@
 - No fluff or cheerful filler text
 - Technical prose only, be kind but direct (e.g., "Thanks @user" not "Thanks so much @user!")
 
+## Worktree Isolation
+
+- These rules apply to all agents and automation working on this repository.
+- Do not modify the main checkout at `/Users/kevin/pi/prime-agent` directly.
+- All changes to this repository must happen on a separate branch in a separate worktree under `/Users/kevin/pi/prime-agent/.worktrees/`.
+- Before editing files, create or reuse a task-specific worktree, for example `git worktree add -b <branch> /Users/kevin/pi/prime-agent/.worktrees/<task-slug> main`.
+- Treat `/Users/kevin/pi/prime-agent` as a read-only coordination checkout. It is fine to inspect files there, but do not edit, format, stage, commit, or otherwise mutate files there.
+- If you accidentally change files in the main checkout, stop and move your own changes into a branch worktree, then restore the main checkout to its previous state without touching unrelated user or agent work.
+
 ## Code Quality
 
 - Read files in full before making wide-ranging changes, before editing files you have not already fully inspected, and when the user asks you to investigate or audit something. Do not rely only on search snippets for broad changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,6 @@
 - No fluff or cheerful filler text
 - Technical prose only, be kind but direct (e.g., "Thanks @user" not "Thanks so much @user!")
 
-## Worktree Isolation
-
-- These rules apply to all agents and automation working on this repository.
-- Do not modify the main checkout at `/Users/kevin/pi/prime-agent` directly.
-- All changes to this repository must happen on a separate branch in a separate worktree under `/Users/kevin/pi/prime-agent/.worktrees/`.
-- Before editing files, create or reuse a task-specific worktree, for example `git worktree add -b <branch> /Users/kevin/pi/prime-agent/.worktrees/<task-slug> main`.
-- Treat `/Users/kevin/pi/prime-agent` as a read-only coordination checkout. It is fine to inspect files there, but do not edit, format, stage, commit, or otherwise mutate files there.
-- If you accidentally change files in the main checkout, stop and move your own changes into a branch worktree, then restore the main checkout to its previous state without touching unrelated user or agent work.
-
 ## Code Quality
 
 - Read files in full before making wide-ranging changes, before editing files you have not already fully inspected, and when the user asks you to investigate or audit something. Do not rely only on search snippets for broad changes.

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -47,6 +47,13 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		);
 	}
 
+	if (activeTools.includes("ipython")) {
+		parts.push(
+			"",
+			"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+		);
+	}
+
 	if (activeTools.length > 0) {
 		parts.push("", "Call at most one built-in tool per turn.");
 	}

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -297,12 +297,6 @@ export function createEditToolDefinition(
 			"Edit a single file using exact text replacement. Every edits[].oldText must match a unique, non-overlapping region of the original file. If two changes affect the same block or nearby lines, merge them into one edit instead of emitting overlapping edits. Do not include large unchanged regions just to connect distant changes.",
 		promptSnippet:
 			"Make precise file edits with exact text replacement, including multiple disjoint edits in one call",
-		promptGuidelines: [
-			"Use edit for precise changes (edits[].oldText must match exactly)",
-			"When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls",
-			"Each edits[].oldText is matched against the original file, not after earlier edits are applied. Do not emit overlapping or nested edits. Merge nearby changes into one edit.",
-			"Keep edits[].oldText as small as possible while still being unique in the file. Do not pad with large unchanged regions.",
-		],
 		parameters: editSchema,
 		renderShell: "self",
 		prepareArguments: prepareEditArguments,

--- a/packages/coding-agent/test/edit-tool-legacy-input.test.ts
+++ b/packages/coding-agent/test/edit-tool-legacy-input.test.ts
@@ -24,6 +24,11 @@ describe("edit tool prepareArguments", () => {
 		expect(definition.parameters.properties).not.toHaveProperty("newText");
 	});
 
+	it("does not add built-in edit guidance to the system prompt", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		expect(definition.promptGuidelines).toBeUndefined();
+	});
+
 	it("folds top-level oldText/newText into edits", () => {
 		const definition = createEditToolDefinition(process.cwd());
 		const prepared = definition.prepareArguments!({

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -20,7 +20,7 @@ function skill(name: string): Skill {
 }
 
 describe("buildRlmPrompt", () => {
-	test("matches the rlm harness prompt without recursion", () => {
+	test("builds the rlm prompt without recursion", () => {
 		const prompt = buildRlmPrompt({
 			cwd: "/repo",
 			messagesPath: "/repo/.pi/sessions/session.jsonl",
@@ -42,9 +42,22 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
+				"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+				"",
 				"Call at most one built-in tool per turn.",
 			].join("\n"),
 		);
+	});
+
+	test("only documents ipython shell prefixes when ipython is active", () => {
+		const prompt = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			activeTools: ["bash"],
+			allowRecursion: false,
+		});
+
+		expect(prompt).not.toContain("Inside `ipython`, prefix single-line shell commands");
 	});
 });
 
@@ -63,6 +76,7 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("Conversation log: /repo/.pi/sessions/session.jsonl");
 		expect(prompt).toContain("await rlm('sub-task')");
 		expect(prompt).toContain("asyncio.gather");
+		expect(prompt).toContain("Inside `ipython`, prefix single-line shell commands with `!`");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");
 		expect(prompt).not.toContain("Available tools:");


### PR DESCRIPTION
## Summary

- Remove built-in edit tool promptGuidelines so edit instructions stay in the tool schema/description instead of the system prompt
- Add a concise main RLM prompt line explaining `ipython` shell escapes: `!` for single-line commands and `%%bash` for multi-line scripts
- Keep the IPython guidance conditional on `ipython` being active
- Add prompt coverage for both behaviors
- Ignore local `.worktrees/`

## Validation

- `/Users/kevin/pi/prime-agent/node_modules/.bin/tsx /Users/kevin/pi/prime-agent/node_modules/vitest/dist/cli.js --run test/system-prompt.test.ts test/edit-tool-legacy-input.test.ts`
- `npm run check`
