### PR TITLE
Document ipython shell prefixes in RLM prompt

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -47,6 +47,13 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		);
 	}
 
+	if (activeTools.includes("ipython")) {
+		parts.push(
+			"",
+			"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+		);
+	}
+
 	if (activeTools.length > 0) {
 		parts.push("", "Call at most one built-in tool per turn.");
 	}

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -20,7 +20,7 @@ function skill(name: string): Skill {
 }
 
 describe("buildRlmPrompt", () => {
-	test("matches the rlm harness prompt without recursion", () => {
+	test("builds the rlm prompt without recursion", () => {
 		const prompt = buildRlmPrompt({
 			cwd: "/repo",
 			messagesPath: "/repo/.pi/sessions/session.jsonl",
@@ -42,9 +42,22 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
+				"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+				"",
 				"Call at most one built-in tool per turn.",
 			].join("\n"),
 		);
+	});
+
+	test("only documents ipython shell prefixes when ipython is active", () => {
+		const prompt = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			activeTools: ["bash"],
+			allowRecursion: false,
+		});
+
+		expect(prompt).not.toContain("Inside `ipython`, prefix single-line shell commands");
 	});
 });
 
@@ -63,6 +76,7 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("Conversation log: /repo/.pi/sessions/session.jsonl");
 		expect(prompt).toContain("await rlm('sub-task')");
 		expect(prompt).toContain("asyncio.gather");
+		expect(prompt).toContain("Inside `ipython`, prefix single-line shell commands with `!`");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");
 		expect(prompt).not.toContain("Available tools:");


### PR DESCRIPTION
## Summary

- Add a concise main RLM prompt line explaining `ipython` shell escapes: `!` for single-line commands and `%%bash` for multi-line scripts
- Keep the guidance conditional on `ipython` being active
- Update system prompt coverage

## Validation

- `/Users/kevin/pi/prime-agent/node_modules/.bin/tsx /Users/kevin/pi/prime-agent/node_modules/vitest/dist/cli.js --run test/system-prompt.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds conditional instructional text to generated prompts and updates tests; no runtime logic beyond prompt string composition.
> 
> **Overview**
> Adds an `ipython`-specific hint to the `buildRlmPrompt` output explaining shell escapes (`!` for single-line commands, `%%bash` for multi-line scripts), and only includes it when `activeTools` contains `ipython`.
> 
> Updates system prompt tests to assert the new line is present when `ipython` is selected and absent otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dffaf74e3ae6893965888ac4ac1bb0516cab7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->