### PR TITLE
render subagent details like chat

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed long cwd values in the startup splash from wrapping through the brand mark.
 - Fixed IPython kernel startup to let `ipykernel` bind OS-assigned ports instead of randomly selecting fixed ports.
 - Fixed RLM child usage aggregation so parent session totals include recursive child runs after session reloads.
+- Fixed the RLM child-agent detail viewer to render messages, thinking, and tool output with the main chat presentation, open at the latest transcript output, and support scrolling.
 - Fixed `rlm.run` comm handlers to log failures and drain in-flight child runs during kernel disposal.
 
 ### Removed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fixed long cwd values in the startup splash from wrapping through the brand mark.
 - Fixed IPython kernel startup to let `ipykernel` bind OS-assigned ports instead of randomly selecting fixed ports.
 - Fixed RLM child usage aggregation so parent session totals include recursive child runs after session reloads.
-- Fixed the RLM child-agent detail viewer to render messages, thinking, and tool output with the main chat presentation, open at the latest transcript output, and support scrolling.
+- Fixed the RLM child-agent detail viewer to render messages, thinking, and tool output with the main chat presentation, open at the latest transcript output, and use terminal scrollback for native scrolling.
 - Fixed `rlm.run` comm handlers to log failures and drain in-flight child runs during kernel disposal.
 
 ### Removed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -106,6 +106,7 @@ import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-promp
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
+import { cloneUsage, emptyUsage } from "./usage.js";
 
 // ============================================================================
 // Skill Block Parsing
@@ -339,17 +340,6 @@ function addUsage(total: RlmUsage, usage: Usage): void {
 	total.completion_tokens += usage.output;
 }
 
-function emptyUsage(): Usage {
-	return {
-		input: 0,
-		output: 0,
-		cacheRead: 0,
-		cacheWrite: 0,
-		totalTokens: 0,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-	};
-}
-
 function addAssistantUsage(total: Usage, usage: Usage): void {
 	total.input += usage.input;
 	total.output += usage.output;
@@ -393,23 +383,6 @@ function readAssistantThinking(message: AssistantMessage): string {
 		.filter((block) => block.type === "thinking")
 		.map((block) => block.thinking)
 		.join("");
-}
-
-function cloneUsage(usage: Usage): Usage {
-	return {
-		input: usage.input,
-		output: usage.output,
-		cacheRead: usage.cacheRead,
-		cacheWrite: usage.cacheWrite,
-		totalTokens: usage.totalTokens,
-		cost: {
-			input: usage.cost.input,
-			output: usage.cost.output,
-			cacheRead: usage.cost.cacheRead,
-			cacheWrite: usage.cost.cacheWrite,
-			total: usage.cost.total,
-		},
-	};
 }
 
 function cloneTextImageContentBlock(block: TextContent | ImageContent): TextContent | ImageContent {
@@ -480,6 +453,19 @@ function cloneAssistantMessage(message: AssistantMessage): AssistantMessage {
 		stopReason: message.stopReason,
 		...(message.errorMessage !== undefined ? { errorMessage: message.errorMessage } : {}),
 		timestamp: message.timestamp,
+	};
+}
+
+function createAssistantTextMessage(text: string, model: Model<any>, timestamp = Date.now()): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp,
 	};
 }
 
@@ -2902,6 +2888,20 @@ export class AgentSession {
 				structuredTranscript[currentAssistantIndex] = entry;
 			}
 		};
+		const recordAssistantText = (text: string, sourceMessage?: AssistantMessage) => {
+			const compact = compactRlmText(text);
+			if (!compact) {
+				return;
+			}
+			const sourceCompact = sourceMessage
+				? compactRlmText(readAssistantText(sourceMessage)) || compactRlmText(readAssistantThinking(sourceMessage))
+				: undefined;
+			const message =
+				sourceMessage && sourceCompact === compact
+					? sourceMessage
+					: createAssistantTextMessage(text, model, sourceMessage?.timestamp);
+			recordAssistantMessage(message);
+		};
 		const recordUserMessage = (message: UserMessage) => {
 			const text = compactRlmText(readTextBlocks(message.content));
 			if (!text) {
@@ -3086,9 +3086,7 @@ export class AgentSession {
 			const lastAssistantText = [...transcript].reverse().find((line) => line.role === "assistant")?.text;
 			if (compactAnswer && compactAnswer !== lastAssistantText) {
 				const lastAssistant = child._findLastAssistantMessage();
-				if (lastAssistant) {
-					recordAssistantMessage(lastAssistant);
-				}
+				recordAssistantText(answer, lastAssistant);
 			} else if (compactAnswer) {
 				answerPreview = compactAnswer;
 			}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -25,7 +25,15 @@ import {
 	type AgentTool,
 	type ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent, Message, Model, TextContent, Usage } from "@earendil-works/pi-ai";
+import type {
+	AssistantMessage,
+	ImageContent,
+	Message,
+	Model,
+	TextContent,
+	Usage,
+	UserMessage,
+} from "@earendil-works/pi-ai";
 import {
 	clampThinkingLevel,
 	cleanupSessionResources,
@@ -133,6 +141,43 @@ export interface RlmChildAgentTranscriptLine {
 	text: string;
 }
 
+export interface RlmChildAgentToolResult {
+	content: (TextContent | ImageContent)[];
+	details?: unknown;
+	isError: boolean;
+}
+
+export interface RlmChildAgentMessageTranscriptEntry {
+	type: "message";
+	role: "user" | "assistant";
+	text: string;
+	message: UserMessage | AssistantMessage;
+}
+
+export interface RlmChildAgentToolTranscriptEntry {
+	type: "tool";
+	role: "tool";
+	text: string;
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+	result?: RlmChildAgentToolResult;
+	isPartial: boolean;
+	executionStarted: boolean;
+	argsComplete: boolean;
+}
+
+export interface RlmChildAgentSystemTranscriptEntry {
+	type: "system";
+	role: "system";
+	text: string;
+}
+
+export type RlmChildAgentStructuredTranscriptEntry =
+	| RlmChildAgentMessageTranscriptEntry
+	| RlmChildAgentToolTranscriptEntry
+	| RlmChildAgentSystemTranscriptEntry;
+
 export interface RlmChildAgentSnapshot {
 	id: string;
 	parentId?: string;
@@ -142,6 +187,7 @@ export interface RlmChildAgentSnapshot {
 	answerPreview?: string;
 	sessionDir: string;
 	transcript: readonly RlmChildAgentTranscriptLine[];
+	structuredTranscript?: readonly RlmChildAgentStructuredTranscriptEntry[];
 }
 
 /** Session-specific events that extend the core AgentEvent */
@@ -340,6 +386,137 @@ function readAssistantText(message: AssistantMessage): string {
 		.filter((block) => block.type === "text")
 		.map((block) => block.text)
 		.join("");
+}
+
+function readAssistantThinking(message: AssistantMessage): string {
+	return message.content
+		.filter((block) => block.type === "thinking")
+		.map((block) => block.thinking)
+		.join("");
+}
+
+function cloneUsage(usage: Usage): Usage {
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead,
+		cacheWrite: usage.cacheWrite,
+		totalTokens: usage.totalTokens,
+		cost: {
+			input: usage.cost.input,
+			output: usage.cost.output,
+			cacheRead: usage.cost.cacheRead,
+			cacheWrite: usage.cost.cacheWrite,
+			total: usage.cost.total,
+		},
+	};
+}
+
+function cloneTextImageContentBlock(block: TextContent | ImageContent): TextContent | ImageContent {
+	if (block.type === "text") {
+		return {
+			type: "text",
+			text: block.text,
+			...(block.textSignature !== undefined ? { textSignature: block.textSignature } : {}),
+		};
+	}
+	return {
+		type: "image",
+		data: block.data,
+		mimeType: block.mimeType,
+	};
+}
+
+function cloneUserMessage(message: UserMessage): UserMessage {
+	return {
+		role: "user",
+		content:
+			typeof message.content === "string"
+				? message.content
+				: message.content.map((block) => cloneTextImageContentBlock(block)),
+		timestamp: message.timestamp,
+	};
+}
+
+function cloneAssistantContentBlock(block: AssistantMessage["content"][number]): AssistantMessage["content"][number] {
+	switch (block.type) {
+		case "text":
+			return {
+				type: "text",
+				text: block.text,
+				...(block.textSignature !== undefined ? { textSignature: block.textSignature } : {}),
+			};
+		case "thinking":
+			return {
+				type: "thinking",
+				thinking: block.thinking,
+				...(block.thinkingSignature !== undefined ? { thinkingSignature: block.thinkingSignature } : {}),
+				...(block.redacted !== undefined ? { redacted: block.redacted } : {}),
+			};
+		case "toolCall":
+			return {
+				type: "toolCall",
+				id: block.id,
+				name: block.name,
+				arguments: { ...block.arguments },
+				...(block.thoughtSignature !== undefined ? { thoughtSignature: block.thoughtSignature } : {}),
+			};
+	}
+}
+
+function cloneAssistantMessage(message: AssistantMessage): AssistantMessage {
+	return {
+		role: "assistant",
+		content: message.content.map((block) => cloneAssistantContentBlock(block)),
+		api: message.api,
+		provider: message.provider,
+		model: message.model,
+		...(message.responseModel !== undefined ? { responseModel: message.responseModel } : {}),
+		...(message.responseId !== undefined ? { responseId: message.responseId } : {}),
+		...(message.diagnostics !== undefined
+			? { diagnostics: message.diagnostics.map((diagnostic) => ({ ...diagnostic })) }
+			: {}),
+		usage: cloneUsage(message.usage),
+		stopReason: message.stopReason,
+		...(message.errorMessage !== undefined ? { errorMessage: message.errorMessage } : {}),
+		timestamp: message.timestamp,
+	};
+}
+
+function cloneUnknownTextImageContentBlock(block: unknown): TextContent | ImageContent | undefined {
+	if (!block || typeof block !== "object" || !("type" in block)) {
+		return undefined;
+	}
+	const typedBlock = block as { type?: unknown; text?: unknown; data?: unknown; mimeType?: unknown };
+	if (typedBlock.type === "text" && typeof typedBlock.text === "string") {
+		return { type: "text", text: typedBlock.text };
+	}
+	if (typedBlock.type === "image" && typeof typedBlock.data === "string" && typeof typedBlock.mimeType === "string") {
+		return { type: "image", data: typedBlock.data, mimeType: typedBlock.mimeType };
+	}
+	return undefined;
+}
+
+function cloneRlmToolResult(result: unknown, isError: boolean): RlmChildAgentToolResult | undefined {
+	if (!result || typeof result !== "object" || !("content" in result)) {
+		return undefined;
+	}
+	const resultRecord = result as { content?: unknown; details?: unknown };
+	if (!Array.isArray(resultRecord.content)) {
+		return undefined;
+	}
+	const content: (TextContent | ImageContent)[] = [];
+	for (const block of resultRecord.content) {
+		const cloned = cloneUnknownTextImageContentBlock(block);
+		if (cloned) {
+			content.push(cloned);
+		}
+	}
+	return {
+		content,
+		...(resultRecord.details !== undefined ? { details: resultRecord.details } : {}),
+		isError,
+	};
 }
 
 function readToolResultText(result: unknown): string | undefined {
@@ -2674,6 +2851,7 @@ export class AgentSession {
 		const childNodeId = basename(childSessionDir);
 		const startedAt = Date.now();
 		const transcript: RlmChildAgentTranscriptLine[] = [];
+		const structuredTranscript: RlmChildAgentStructuredTranscriptEntry[] = [];
 		const label = compactRlmText(prompt, 80) || "child agent";
 		let status: RlmChildAgentStatus = "running";
 		let answerPreview: string | undefined;
@@ -2695,21 +2873,69 @@ export class AgentSession {
 					answerPreview,
 					sessionDir: childSessionDir,
 					transcript: [...transcript],
+					structuredTranscript: [...structuredTranscript],
 				},
 			});
 		};
-		const recordAssistantText = (text: string) => {
-			const compact = compactRlmText(text);
+		const recordAssistantMessage = (message: AssistantMessage) => {
+			const text = compactRlmText(readAssistantText(message));
+			const thinking = compactRlmText(readAssistantThinking(message));
+			const compact = text || thinking;
 			if (!compact) {
 				return;
 			}
-			answerPreview = compact;
+			if (text) {
+				answerPreview = text;
+			}
+			const entry: RlmChildAgentMessageTranscriptEntry = {
+				type: "message",
+				role: "assistant",
+				text: compact,
+				message: cloneAssistantMessage(message),
+			};
 			if (currentAssistantIndex === undefined) {
 				currentAssistantIndex = transcript.length;
 				transcript.push({ role: "assistant", text: compact });
+				structuredTranscript.push(entry);
 			} else {
 				transcript[currentAssistantIndex] = { role: "assistant", text: compact };
+				structuredTranscript[currentAssistantIndex] = entry;
 			}
+		};
+		const recordUserMessage = (message: UserMessage) => {
+			const text = compactRlmText(readTextBlocks(message.content));
+			if (!text) {
+				return;
+			}
+			transcript.push({ role: "user", text });
+			structuredTranscript.push({
+				type: "message",
+				role: "user",
+				text,
+				message: cloneUserMessage(message),
+			});
+		};
+		const createToolTranscriptEntry = (
+			event: { toolCallId: string; toolName: string; args?: unknown },
+			text: string,
+			result: RlmChildAgentToolResult | undefined,
+			isPartial: boolean,
+		): RlmChildAgentToolTranscriptEntry => {
+			const entry: RlmChildAgentToolTranscriptEntry = {
+				type: "tool",
+				role: "tool",
+				text,
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				args: event.args,
+				isPartial,
+				executionStarted: true,
+				argsComplete: true,
+			};
+			if (result) {
+				entry.result = result;
+			}
+			return entry;
 		};
 		emitChildUpdate();
 
@@ -2764,15 +2990,12 @@ export class AgentSession {
 			switch (event.type) {
 				case "message_start": {
 					if (event.message.role === "user") {
-						const text = compactRlmText(readTextBlocks(event.message.content));
-						if (text) {
-							transcript.push({ role: "user", text });
-						}
+						recordUserMessage(event.message);
 						currentAssistantIndex = undefined;
 					} else if (event.message.role === "assistant") {
 						// New assistant turn: append a fresh entry so prior text isn't overwritten.
 						currentAssistantIndex = undefined;
-						recordAssistantText(readAssistantText(event.message as AssistantMessage));
+						recordAssistantMessage(event.message as AssistantMessage);
 					}
 					emitChildUpdate();
 					break;
@@ -2780,30 +3003,40 @@ export class AgentSession {
 				case "message_update":
 				case "message_end": {
 					if (event.message.role === "assistant") {
-						recordAssistantText(readAssistantText(event.message as AssistantMessage));
+						recordAssistantMessage(event.message as AssistantMessage);
 						emitChildUpdate();
 					}
 					break;
 				}
 				case "tool_execution_start": {
 					const args = formatRlmToolArgs(event.args);
+					const text = args ? `${event.toolName} running ${args}` : `${event.toolName} running`;
 					// Tool break: next assistant text starts a new entry after this tool row.
 					currentAssistantIndex = undefined;
 					lastToolTranscriptIndex = transcript.length;
-					transcript.push({
-						role: "tool",
-						text: args ? `${event.toolName} running ${args}` : `${event.toolName} running`,
-					});
+					transcript.push({ role: "tool", text });
+					structuredTranscript.push(createToolTranscriptEntry(event, text, undefined, true));
 					emitChildUpdate();
 					break;
 				}
 				case "tool_execution_update": {
 					const text = readToolResultText(event.partialResult);
-					if (text && lastToolTranscriptIndex !== undefined) {
-						transcript[lastToolTranscriptIndex] = {
-							role: "tool",
-							text: `${event.toolName} running: ${compactRlmText(text)}`,
-						};
+					if (lastToolTranscriptIndex !== undefined) {
+						const previous = structuredTranscript[lastToolTranscriptIndex];
+						const summary = text
+							? `${event.toolName} running: ${compactRlmText(text)}`
+							: transcript[lastToolTranscriptIndex]?.text || `${event.toolName} running`;
+						transcript[lastToolTranscriptIndex] = { role: "tool", text: summary };
+						structuredTranscript[lastToolTranscriptIndex] = createToolTranscriptEntry(
+							{
+								toolCallId: event.toolCallId,
+								toolName: event.toolName,
+								args: previous?.type === "tool" ? previous.args : event.args,
+							},
+							summary,
+							cloneRlmToolResult(event.partialResult, false),
+							true,
+						);
 						emitChildUpdate();
 					}
 					break;
@@ -2811,11 +3044,25 @@ export class AgentSession {
 				case "tool_execution_end": {
 					const text = readToolResultText(event.result);
 					const summary = text ? `${event.toolName}: ${compactRlmText(text)}` : `${event.toolName} done`;
+					const previous =
+						lastToolTranscriptIndex === undefined ? undefined : structuredTranscript[lastToolTranscriptIndex];
+					const entry = createToolTranscriptEntry(
+						{
+							toolCallId: event.toolCallId,
+							toolName: event.toolName,
+							args: previous?.type === "tool" ? previous.args : undefined,
+						},
+						summary,
+						cloneRlmToolResult(event.result, event.isError),
+						false,
+					);
 					if (lastToolTranscriptIndex === undefined) {
 						lastToolTranscriptIndex = transcript.length;
 						transcript.push({ role: "tool", text: summary });
+						structuredTranscript.push(entry);
 					} else {
 						transcript[lastToolTranscriptIndex] = { role: "tool", text: summary };
+						structuredTranscript[lastToolTranscriptIndex] = entry;
 					}
 					emitChildUpdate();
 					break;
@@ -2838,7 +3085,10 @@ export class AgentSession {
 			const compactAnswer = compactRlmText(answer);
 			const lastAssistantText = [...transcript].reverse().find((line) => line.role === "assistant")?.text;
 			if (compactAnswer && compactAnswer !== lastAssistantText) {
-				recordAssistantText(answer);
+				const lastAssistant = child._findLastAssistantMessage();
+				if (lastAssistant) {
+					recordAssistantMessage(lastAssistant);
+				}
 			} else if (compactAnswer) {
 				answerPreview = compactAnswer;
 			}
@@ -2852,7 +3102,9 @@ export class AgentSession {
 		} catch (error) {
 			status = "error";
 			durationMs = Date.now() - startedAt;
-			transcript.push({ role: "system", text: error instanceof Error ? error.message : String(error) });
+			const text = error instanceof Error ? error.message : String(error);
+			transcript.push({ role: "system", text });
+			structuredTranscript.push({ type: "system", role: "system", text });
 			emitChildUpdate();
 			throw error;
 		} finally {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -24,6 +24,7 @@ import {
 	createCompactionSummaryMessage,
 	createCustomMessage,
 } from "./messages.js";
+import { cloneUsage } from "./usage.js";
 
 export const CURRENT_SESSION_VERSION = 3;
 
@@ -312,23 +313,6 @@ export function parseSessionEntries(content: string): FileEntry[] {
 
 	applyChildUsageAttributions(entries);
 	return entries;
-}
-
-function cloneUsage(usage: Usage): Usage {
-	return {
-		input: usage.input,
-		output: usage.output,
-		cacheRead: usage.cacheRead,
-		cacheWrite: usage.cacheWrite,
-		totalTokens: usage.totalTokens,
-		cost: {
-			input: usage.cost.input,
-			output: usage.cost.output,
-			cacheRead: usage.cost.cacheRead,
-			cacheWrite: usage.cost.cacheWrite,
-			total: usage.cost.total,
-		},
-	};
 }
 
 function applyChildUsageAttributions(entries: FileEntry[]): void {

--- a/packages/coding-agent/src/core/usage.ts
+++ b/packages/coding-agent/src/core/usage.ts
@@ -1,0 +1,35 @@
+import type { Usage } from "@earendil-works/pi-ai";
+
+export function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		},
+	};
+}
+
+export function cloneUsage(usage: Usage): Usage {
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead,
+		cacheWrite: usage.cacheWrite,
+		totalTokens: usage.totalTokens,
+		cost: {
+			input: usage.cost.input,
+			output: usage.cost.output,
+			cacheRead: usage.cost.cacheRead,
+			cacheWrite: usage.cost.cacheWrite,
+			total: usage.cost.total,
+		},
+	};
+}

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -1,12 +1,20 @@
+import type { AssistantMessage, ImageContent, TextContent, UserMessage } from "@earendil-works/pi-ai";
 import {
 	type Component,
 	type Focusable,
 	getKeybindings,
+	type MarkdownTheme,
+	Text,
+	type TUI,
 	truncateToWidth,
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import type { ToolDefinition } from "../../../core/extensions/types.js";
 import { theme } from "../theme/theme.js";
+import { AssistantMessageComponent } from "./assistant-message.js";
+import { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";
+import { UserMessageComponent } from "./user-message.js";
 
 export type ChildAgentStatus = "queued" | "running" | "done" | "error" | "cancelled";
 
@@ -14,6 +22,43 @@ export interface ChildAgentTranscriptLine {
 	role: "user" | "assistant" | "tool" | "system";
 	text: string;
 }
+
+export interface ChildAgentToolResult {
+	content: (TextContent | ImageContent)[];
+	details?: unknown;
+	isError: boolean;
+}
+
+export interface ChildAgentMessageTranscriptEntry {
+	type: "message";
+	role: "user" | "assistant";
+	text: string;
+	message: UserMessage | AssistantMessage;
+}
+
+export interface ChildAgentToolTranscriptEntry {
+	type: "tool";
+	role: "tool";
+	text: string;
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+	result?: ChildAgentToolResult;
+	isPartial: boolean;
+	executionStarted: boolean;
+	argsComplete: boolean;
+}
+
+export interface ChildAgentSystemTranscriptEntry {
+	type: "system";
+	role: "system";
+	text: string;
+}
+
+export type ChildAgentStructuredTranscriptEntry =
+	| ChildAgentMessageTranscriptEntry
+	| ChildAgentToolTranscriptEntry
+	| ChildAgentSystemTranscriptEntry;
 
 export interface ChildAgentInspectorNode {
 	id: string;
@@ -23,7 +68,19 @@ export interface ChildAgentInspectorNode {
 	answerPreview?: string;
 	sessionDir: string;
 	transcript: readonly ChildAgentTranscriptLine[];
+	structuredTranscript?: readonly ChildAgentStructuredTranscriptEntry[];
 	children?: readonly ChildAgentInspectorNode[];
+}
+
+export interface ChildAgentDetailOptions {
+	ui?: TUI;
+	getCwd?: () => string;
+	getToolDefinition?: (toolName: string) => ToolDefinition | undefined;
+	getToolOptions?: () => ToolExecutionOptions;
+	getMarkdownTheme?: () => MarkdownTheme;
+	getToolsExpanded?: () => boolean;
+	getHideThinkingBlock?: () => boolean;
+	getHiddenThinkingLabel?: () => string;
 }
 
 interface FlatChildAgentNode {
@@ -34,6 +91,11 @@ interface FlatChildAgentNode {
 interface SidebarLine {
 	text: string;
 	selected: boolean;
+}
+
+interface DetailSections {
+	headerLines: string[];
+	bodyLines: string[];
 }
 
 export class ChildAgentInspectorComponent implements Component, Focusable {
@@ -202,58 +264,231 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 export class ChildAgentDetailComponent implements Component, Focusable {
 	focused = false;
 	private node: ChildAgentInspectorNode | undefined;
+	private transcriptComponents: Component[] = [];
+	private readonly fallbackTui = { requestRender: () => {} } as TUI;
+	private scrollOffset = 0;
+	private lastMaxScrollOffset = 0;
+	private stickToBottom = true;
 
 	onCancel?: () => void;
 
-	constructor(private readonly getViewportHeight: () => number = () => 0) {}
+	constructor(
+		private readonly getViewportHeight: () => number = () => 0,
+		private readonly options: ChildAgentDetailOptions = {},
+	) {}
 
 	setNode(node: ChildAgentInspectorNode | undefined): void {
+		const previousNodeId = this.node?.id;
 		this.node = node;
+		this.rebuildTranscriptComponents();
+		if (!node) {
+			this.scrollOffset = 0;
+			this.lastMaxScrollOffset = 0;
+			this.stickToBottom = true;
+			return;
+		}
+		if (node.id !== previousNodeId || this.stickToBottom) {
+			this.scrollOffset = Number.MAX_SAFE_INTEGER;
+			this.stickToBottom = true;
+		}
 	}
 
 	invalidate(): void {
-		// Render output is derived from node state.
+		this.rebuildTranscriptComponents();
+		for (const component of this.transcriptComponents) {
+			component.invalidate?.();
+		}
+		if (this.stickToBottom) {
+			this.scrollOffset = Number.MAX_SAFE_INTEGER;
+		}
 	}
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const lines = this.renderDetail(safeWidth);
 		const targetHeight = Math.max(0, this.getViewportHeight());
+		const sections = this.renderDetail(safeWidth);
+		const lines = this.applyViewport(sections, targetHeight);
 		while (lines.length < targetHeight) {
-			lines.push("");
+			lines.push(this.panelLine("", safeWidth));
 		}
-		return lines.map((line) => this.panelLine(line, safeWidth));
+		return lines;
 	}
 
 	handleInput(data: string): void {
 		const kb = getKeybindings();
 		if (kb.matches(data, "tui.select.cancel")) {
 			this.onCancel?.();
+			return;
+		}
+		if (kb.matches(data, "tui.select.up")) {
+			this.moveScroll(-1);
+			return;
+		}
+		if (kb.matches(data, "tui.select.down")) {
+			this.moveScroll(1);
+			return;
+		}
+		if (kb.matches(data, "tui.select.pageUp")) {
+			this.moveScroll(-this.pageScrollDelta());
+			return;
+		}
+		if (kb.matches(data, "tui.select.pageDown")) {
+			this.moveScroll(this.pageScrollDelta());
 		}
 	}
 
-	private renderDetail(width: number): string[] {
+	private renderDetail(width: number): DetailSections {
 		const selected = this.node;
 		if (!selected) {
-			return [this.headerLine(theme.fg("muted", "agent unavailable"), width)];
+			return {
+				headerLines: [this.panelLine(this.headerLine(theme.fg("muted", "agent unavailable"), width), width)],
+				bodyLines: [],
+			};
 		}
 
-		const lines = [this.headerLine(`${this.statusLabel(selected.status)} ${theme.fg("dim", selected.label)}`, width)];
+		const headerLines = [
+			this.panelLine(
+				this.headerLine(`${this.statusLabel(selected.status)} ${theme.fg("dim", selected.label)}`, width),
+				width,
+			),
+		];
 		const sessionDirParts = selected.sessionDir.split("/");
 		const leaf = sessionDirParts[sessionDirParts.length - 1];
 		if (leaf) {
-			lines.push(this.truncate(theme.fg("dim", leaf), width));
+			headerLines.push(this.panelLine(this.truncate(theme.fg("dim", leaf), width), width));
 		}
-		lines.push(theme.fg("borderMuted", "─".repeat(width)));
+		headerLines.push(this.panelLine(theme.fg("borderMuted", "─".repeat(width)), width));
+
+		const bodyLines: string[] = [];
+		if (selected.structuredTranscript && selected.structuredTranscript.length > 0) {
+			for (const component of this.transcriptComponents) {
+				bodyLines.push(...component.render(width));
+			}
+			return { headerLines, bodyLines };
+		}
 		for (const line of selected.transcript) {
 			const label = theme.fg("dim", `${line.role}: `);
 			const wrapped = wrapTextWithAnsi(line.text, Math.max(1, width - visibleWidth(label)));
 			for (const [index, wrappedLine] of wrapped.entries()) {
 				const prefix = index === 0 ? label : " ".repeat(visibleWidth(label));
-				lines.push(this.truncate(prefix + wrappedLine, width));
+				bodyLines.push(this.panelLine(this.truncate(prefix + wrappedLine, width), width));
 			}
 		}
-		return lines;
+		return { headerLines, bodyLines };
+	}
+
+	private applyViewport(sections: DetailSections, targetHeight: number): string[] {
+		if (targetHeight === 0) {
+			return [...sections.headerLines, ...sections.bodyLines];
+		}
+
+		const headerLines = sections.headerLines.slice(0, targetHeight);
+		const bodyHeight = Math.max(0, targetHeight - headerLines.length);
+		if (bodyHeight === 0) {
+			this.lastMaxScrollOffset = 0;
+			this.scrollOffset = 0;
+			return headerLines;
+		}
+
+		const maxScrollOffset = Math.max(0, sections.bodyLines.length - bodyHeight);
+		this.lastMaxScrollOffset = maxScrollOffset;
+		if (this.stickToBottom) {
+			this.scrollOffset = maxScrollOffset;
+		} else {
+			this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxScrollOffset));
+			if (this.scrollOffset === maxScrollOffset) {
+				this.stickToBottom = true;
+			}
+		}
+
+		const visibleBodyLines = sections.bodyLines.slice(this.scrollOffset, this.scrollOffset + bodyHeight);
+		return [...headerLines, ...visibleBodyLines];
+	}
+
+	private moveScroll(delta: number): void {
+		const nextOffset = Math.max(0, Math.min(this.scrollOffset + delta, this.lastMaxScrollOffset));
+		if (nextOffset === this.scrollOffset) {
+			return;
+		}
+		this.scrollOffset = nextOffset;
+		this.stickToBottom = this.scrollOffset === this.lastMaxScrollOffset;
+		this.options.ui?.requestRender();
+	}
+
+	private pageScrollDelta(): number {
+		return Math.max(1, this.getViewportHeight() - 4);
+	}
+
+	private rebuildTranscriptComponents(): void {
+		const transcript = this.node?.structuredTranscript;
+		if (!transcript || transcript.length === 0) {
+			this.transcriptComponents = [];
+			return;
+		}
+
+		const components: Component[] = [];
+		for (const entry of transcript) {
+			switch (entry.type) {
+				case "message":
+					components.push(this.createMessageComponent(entry));
+					break;
+				case "tool":
+					components.push(this.createToolComponent(entry));
+					break;
+				case "system":
+					components.push(new Text(theme.fg("error", entry.text), 1, 0));
+					break;
+			}
+		}
+		this.transcriptComponents = components;
+	}
+
+	private createMessageComponent(entry: ChildAgentMessageTranscriptEntry): Component {
+		if (entry.message.role === "user") {
+			const text = this.readUserMessageText(entry.message);
+			return text
+				? new UserMessageComponent(text, this.options.getMarkdownTheme?.())
+				: new Text(theme.fg("userMessageText", entry.text), 1, 0);
+		}
+		return new AssistantMessageComponent(
+			entry.message,
+			this.options.getHideThinkingBlock?.() ?? false,
+			this.options.getMarkdownTheme?.(),
+			this.options.getHiddenThinkingLabel?.() ?? "Thinking...",
+		);
+	}
+
+	private createToolComponent(entry: ChildAgentToolTranscriptEntry): Component {
+		const component = new ToolExecutionComponent(
+			entry.toolName,
+			entry.toolCallId,
+			entry.args,
+			this.options.getToolOptions?.() ?? {},
+			this.options.getToolDefinition?.(entry.toolName),
+			this.options.ui ?? this.fallbackTui,
+			this.options.getCwd?.() ?? process.cwd(),
+		);
+		component.setExpanded(this.options.getToolsExpanded?.() ?? false);
+		if (entry.executionStarted) {
+			component.markExecutionStarted();
+		}
+		if (entry.argsComplete) {
+			component.setArgsComplete();
+		}
+		if (entry.result) {
+			component.updateResult(entry.result, entry.isPartial);
+		}
+		return component;
+	}
+
+	private readUserMessageText(message: UserMessage): string {
+		if (typeof message.content === "string") {
+			return message.content;
+		}
+		return message.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join("");
 	}
 
 	private headerLine(text: string, width: number): string {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -266,9 +266,6 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	private node: ChildAgentInspectorNode | undefined;
 	private transcriptComponents: Component[] = [];
 	private readonly fallbackTui = { requestRender: () => {} } as TUI;
-	private scrollOffset = 0;
-	private lastMaxScrollOffset = 0;
-	private stickToBottom = true;
 
 	onCancel?: () => void;
 
@@ -278,19 +275,8 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	) {}
 
 	setNode(node: ChildAgentInspectorNode | undefined): void {
-		const previousNodeId = this.node?.id;
 		this.node = node;
 		this.rebuildTranscriptComponents();
-		if (!node) {
-			this.scrollOffset = 0;
-			this.lastMaxScrollOffset = 0;
-			this.stickToBottom = true;
-			return;
-		}
-		if (node.id !== previousNodeId || this.stickToBottom) {
-			this.scrollOffset = Number.MAX_SAFE_INTEGER;
-			this.stickToBottom = true;
-		}
 	}
 
 	invalidate(): void {
@@ -298,16 +284,13 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 		for (const component of this.transcriptComponents) {
 			component.invalidate?.();
 		}
-		if (this.stickToBottom) {
-			this.scrollOffset = Number.MAX_SAFE_INTEGER;
-		}
 	}
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
 		const targetHeight = Math.max(0, this.getViewportHeight());
 		const sections = this.renderDetail(safeWidth);
-		const lines = this.applyViewport(sections, targetHeight);
+		const lines = [...sections.headerLines, ...sections.bodyLines];
 		while (lines.length < targetHeight) {
 			lines.push(this.panelLine("", safeWidth));
 		}
@@ -318,22 +301,6 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 		const kb = getKeybindings();
 		if (kb.matches(data, "tui.select.cancel")) {
 			this.onCancel?.();
-			return;
-		}
-		if (kb.matches(data, "tui.select.up")) {
-			this.moveScroll(-1);
-			return;
-		}
-		if (kb.matches(data, "tui.select.down")) {
-			this.moveScroll(1);
-			return;
-		}
-		if (kb.matches(data, "tui.select.pageUp")) {
-			this.moveScroll(-this.pageScrollDelta());
-			return;
-		}
-		if (kb.matches(data, "tui.select.pageDown")) {
-			this.moveScroll(this.pageScrollDelta());
 		}
 	}
 
@@ -375,48 +342,6 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			}
 		}
 		return { headerLines, bodyLines };
-	}
-
-	private applyViewport(sections: DetailSections, targetHeight: number): string[] {
-		if (targetHeight === 0) {
-			return [...sections.headerLines, ...sections.bodyLines];
-		}
-
-		const headerLines = sections.headerLines.slice(0, targetHeight);
-		const bodyHeight = Math.max(0, targetHeight - headerLines.length);
-		if (bodyHeight === 0) {
-			this.lastMaxScrollOffset = 0;
-			this.scrollOffset = 0;
-			return headerLines;
-		}
-
-		const maxScrollOffset = Math.max(0, sections.bodyLines.length - bodyHeight);
-		this.lastMaxScrollOffset = maxScrollOffset;
-		if (this.stickToBottom) {
-			this.scrollOffset = maxScrollOffset;
-		} else {
-			this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxScrollOffset));
-			if (this.scrollOffset === maxScrollOffset) {
-				this.stickToBottom = true;
-			}
-		}
-
-		const visibleBodyLines = sections.bodyLines.slice(this.scrollOffset, this.scrollOffset + bodyHeight);
-		return [...headerLines, ...visibleBodyLines];
-	}
-
-	private moveScroll(delta: number): void {
-		const nextOffset = Math.max(0, Math.min(this.scrollOffset + delta, this.lastMaxScrollOffset));
-		if (nextOffset === this.scrollOffset) {
-			return;
-		}
-		this.scrollOffset = nextOffset;
-		this.stickToBottom = this.scrollOffset === this.lastMaxScrollOffset;
-		this.options.ui?.requestRender();
-	}
-
-	private pageScrollDelta(): number {
-		return Math.max(1, this.getViewportHeight() - 4);
 	}
 
 	private rebuildTranscriptComponents(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3271,9 +3271,9 @@ export class InteractiveMode {
 		this.childAgentDetailOverlayHandle?.hide();
 		this.childAgentDetailOverlayHandle = this.ui.showOverlay(this.childAgentDetail, {
 			width: "100%",
-			maxHeight: "100%",
 			anchor: "top-left",
 			margin: 0,
+			scrollback: true,
 		});
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -106,6 +106,7 @@ import {
 	ChildAgentDetailComponent,
 	ChildAgentInspectorComponent,
 	type ChildAgentInspectorNode,
+	type ChildAgentStructuredTranscriptEntry,
 	type ChildAgentTranscriptLine,
 } from "./components/child-agent-inspector.js";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.js";
@@ -567,7 +568,19 @@ export class InteractiveMode {
 		this.childAgentInspector = new ChildAgentInspectorComponent(() => this.ui.terminal.rows);
 		this.childAgentInspector.onCancel = () => this.unfocusChildAgentInspector();
 		this.childAgentInspector.onOpenDetail = (nodeId) => this.openChildAgentDetail(nodeId);
-		this.childAgentDetail = new ChildAgentDetailComponent(() => this.ui.terminal.rows);
+		this.childAgentDetail = new ChildAgentDetailComponent(() => this.ui.terminal.rows, {
+			ui: this.ui,
+			getCwd: () => this.sessionManager.getCwd(),
+			getToolDefinition: (toolName) => this.getRegisteredToolDefinition(toolName),
+			getToolOptions: () => ({
+				showImages: this.settingsManager.getShowImages(),
+				imageWidthCells: this.settingsManager.getImageWidthCells(),
+			}),
+			getMarkdownTheme: () => this.getMarkdownThemeWithSettings(),
+			getToolsExpanded: () => this.toolOutputExpanded,
+			getHideThinkingBlock: () => this.hideThinkingBlock,
+			getHiddenThinkingLabel: () => this.hiddenThinkingLabel,
+		});
 		this.childAgentDetail.onCancel = () => this.closeChildAgentDetail();
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
@@ -3280,6 +3293,9 @@ export class InteractiveMode {
 					role: line.role,
 					text: line.text,
 				}),
+			),
+			structuredTranscript: child.structuredTranscript?.map(
+				(entry): ChildAgentStructuredTranscriptEntry => ({ ...entry }),
 			),
 			children: childrenByParent.get(child.id)?.map(build),
 		});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -169,6 +169,7 @@ describe("AgentSession rlm recursion", () => {
 			label: string;
 			answerPreview?: string;
 			transcript: readonly { role: string; text: string }[];
+			structuredTranscript?: readonly { type: string; role: string; text: string }[];
 		}> = [];
 		root.subscribe((event) => {
 			if (event.type === "rlm_child_update") {
@@ -191,6 +192,12 @@ describe("AgentSession rlm recursion", () => {
 		expect(doneUpdate?.answerPreview).toBe("child answer: summarize shard 1");
 		expect(doneUpdate?.transcript).toContainEqual({ role: "user", text: "summarize shard 1" });
 		expect(doneUpdate?.transcript).toContainEqual({ role: "assistant", text: "child answer: summarize shard 1" });
+		expect(doneUpdate?.structuredTranscript).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "message", role: "user", text: "summarize shard 1" }),
+				expect.objectContaining({ type: "message", role: "assistant", text: "child answer: summarize shard 1" }),
+			]),
+		);
 	});
 
 	it("adds child usage to the parent session aggregate", async () => {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -1,3 +1,4 @@
+import type { AssistantMessage, Usage, UserMessage } from "@earendil-works/pi-ai";
 import { type Component, TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test } from "vitest";
@@ -28,6 +29,42 @@ function createFakeTui(): TUI {
 	return {
 		requestRender: () => {},
 	} as unknown as TUI;
+}
+
+const EMPTY_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	},
+};
+
+function createUserMessage(text: string): UserMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+function createAssistantMessage(text: string, thinking?: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [...(thinking ? [{ type: "thinking" as const, thinking }] : []), { type: "text", text }],
+		api: "test-api",
+		provider: "test-provider",
+		model: "test-model",
+		usage: EMPTY_USAGE,
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
 }
 
 async function renderInVirtualTerminal(component: Component, width = 100, height = 30): Promise<string> {
@@ -138,6 +175,36 @@ describe("marquee TUI components", () => {
 			transcript: [
 				{ role: "user", text: "inspect training logs" },
 				{ role: "assistant", text: "reading shard metrics" },
+				{ role: "tool", text: "bash: hi" },
+			],
+			structuredTranscript: [
+				{
+					type: "message",
+					role: "user",
+					text: "inspect training logs",
+					message: createUserMessage("inspect training logs"),
+				},
+				{
+					type: "message",
+					role: "assistant",
+					text: "reading shard metrics",
+					message: createAssistantMessage("reading shard metrics", "checking loss curve"),
+				},
+				{
+					type: "tool",
+					role: "tool",
+					text: "bash: hi",
+					toolCallId: "tool-sub-a",
+					toolName: "bash",
+					args: { command: "echo hi" },
+					result: {
+						content: [{ type: "text", text: "hi" }],
+						isError: false,
+					},
+					isPartial: false,
+					executionStarted: true,
+					argsComplete: true,
+				},
 			],
 			children: [
 				{
@@ -173,15 +240,21 @@ describe("marquee TUI components", () => {
 		expect(openedNodeId).toBe("sub-a");
 		expect(stripAnsi(component.render(42).join("\n"))).not.toContain("assistant: reading shard metrics");
 
-		const detailComponent = new ChildAgentDetailComponent(() => 12);
+		const detailComponent = new ChildAgentDetailComponent(() => 20);
 		detailComponent.setNode(node);
 		const detailLines = detailComponent.render(42);
 		const detail = stripAnsi(detailLines.join("\n"));
 		expect(detail).toContain("running inspect training logs");
 		expect(detail).toContain("sub-a");
-		expect(detail).toContain("user: inspect training logs");
-		expect(detail).toContain("assistant: reading shard metrics");
-		expect(detailLines).toHaveLength(12);
+		expect(detail).toContain("inspect training logs");
+		expect(detail).toContain("checking loss curve");
+		expect(detail).toContain("reading shard metrics");
+		expect(detail).toContain("$ echo hi");
+		expect(detail).toContain("hi");
+		expect(detail).not.toContain("user: inspect training logs");
+		expect(detail).not.toContain("assistant: reading shard metrics");
+		expect(detail).not.toContain("tool: bash");
+		expect(detailLines).toHaveLength(20);
 
 		component.handleInput("\x1b");
 		const returned = stripAnsi(component.render(42).join("\n"));
@@ -194,6 +267,36 @@ describe("marquee TUI components", () => {
 
 		const narrow = stripAnsi(component.render(24).join("\n"));
 		expect(narrow).toContain("inspect…");
+	});
+
+	test("opens child agent detail at the bottom and scrolls through the transcript", () => {
+		const detailComponent = new ChildAgentDetailComponent(() => 8);
+		detailComponent.setNode({
+			id: "sub-scroll",
+			label: "inspect long output",
+			status: "done",
+			sessionDir: "/tmp/session/sub-scroll",
+			transcript: Array.from({ length: 12 }, (_, index) => ({
+				role: "assistant" as const,
+				text: `fallback transcript row ${String(index + 1).padStart(2, "0")}`,
+			})),
+		});
+
+		const bottom = stripAnsi(detailComponent.render(48).join("\n"));
+		expect(bottom).toContain("fallback transcript row 12");
+		expect(bottom).toContain("fallback transcript row 08");
+		expect(bottom).not.toContain("fallback transcript row 01");
+
+		detailComponent.handleInput("\x1b[5~");
+		const scrolledUp = stripAnsi(detailComponent.render(48).join("\n"));
+		expect(scrolledUp).toContain("fallback transcript row 04");
+		expect(scrolledUp).toContain("fallback transcript row 08");
+		expect(scrolledUp).not.toContain("fallback transcript row 12");
+
+		detailComponent.handleInput("\x1b[6~");
+		const scrolledDown = stripAnsi(detailComponent.render(48).join("\n"));
+		expect(scrolledDown).toContain("fallback transcript row 12");
+		expect(scrolledDown).not.toContain("fallback transcript row 01");
 	});
 
 	test("routes built-in ipython tool rows through the cell renderer", () => {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -25,6 +25,14 @@ class HostComponent implements Component {
 	}
 }
 
+class EmptyComponent implements Component {
+	render(): string[] {
+		return [];
+	}
+
+	invalidate(): void {}
+}
+
 function createFakeTui(): TUI {
 	return {
 		requestRender: () => {},
@@ -269,8 +277,10 @@ describe("marquee TUI components", () => {
 		expect(narrow).toContain("inspect…");
 	});
 
-	test("opens child agent detail at the bottom and scrolls through the transcript", () => {
-		const detailComponent = new ChildAgentDetailComponent(() => 8);
+	test("opens child agent detail in terminal scrollback at the bottom", async () => {
+		const terminal = new VirtualTerminal(48, 8);
+		const tui = new TUI(terminal);
+		const detailComponent = new ChildAgentDetailComponent(() => terminal.rows, { ui: tui });
 		detailComponent.setNode({
 			id: "sub-scroll",
 			label: "inspect long output",
@@ -282,21 +292,25 @@ describe("marquee TUI components", () => {
 			})),
 		});
 
-		const bottom = stripAnsi(detailComponent.render(48).join("\n"));
-		expect(bottom).toContain("fallback transcript row 12");
-		expect(bottom).toContain("fallback transcript row 08");
-		expect(bottom).not.toContain("fallback transcript row 01");
+		tui.addChild(new EmptyComponent());
+		tui.showOverlay(detailComponent, {
+			width: "100%",
+			anchor: "top-left",
+			margin: 0,
+			scrollback: true,
+		});
+		tui.start();
+		await terminal.waitForRender();
 
-		detailComponent.handleInput("\x1b[5~");
-		const scrolledUp = stripAnsi(detailComponent.render(48).join("\n"));
-		expect(scrolledUp).toContain("fallback transcript row 04");
-		expect(scrolledUp).toContain("fallback transcript row 08");
-		expect(scrolledUp).not.toContain("fallback transcript row 12");
+		const viewport = stripAnsi(terminal.getViewport().join("\n"));
+		expect(viewport).toContain("fallback transcript row 12");
+		expect(viewport).toContain("fallback transcript row 08");
+		expect(viewport).not.toContain("fallback transcript row 01");
 
-		detailComponent.handleInput("\x1b[6~");
-		const scrolledDown = stripAnsi(detailComponent.render(48).join("\n"));
-		expect(scrolledDown).toContain("fallback transcript row 12");
-		expect(scrolledDown).not.toContain("fallback transcript row 01");
+		const scrollBuffer = stripAnsi(terminal.getScrollBuffer().join("\n"));
+		expect(scrollBuffer).toContain("fallback transcript row 01");
+		expect(scrollBuffer).toContain("fallback transcript row 12");
+		tui.stop();
 	});
 
 	test("routes built-in ipython tool rows through the cell renderer", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added optional background surface rendering for editor components.
+- Added scrollback overlay rendering for full-screen overlays that should preserve native terminal scrollback.
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -146,6 +146,8 @@ export interface OverlayOptions {
 	minWidth?: number;
 	/** Maximum height in rows, or percentage of terminal height (e.g., "50%") */
 	maxHeight?: SizeValue;
+	/** Render overlay content into terminal scrollback instead of clipping it to the visible viewport. */
+	scrollback?: boolean;
 
 	// === Positioning - anchor-based ===
 	/** Anchor point for positioning (default: 'center') */
@@ -760,13 +762,14 @@ export class TUI extends Container {
 		const result = [...lines];
 
 		// Pre-render all visible overlays and calculate positions
-		const rendered: { overlayLines: string[]; row: number; col: number; w: number }[] = [];
+		const rendered: { overlayLines: string[]; row: number; col: number; w: number; scrollback: boolean }[] = [];
 		let minLinesNeeded = result.length;
 
 		const visibleEntries = this.overlayStack.filter((e) => this.isOverlayVisible(e));
 		visibleEntries.sort((a, b) => a.focusOrder - b.focusOrder);
 		for (const entry of visibleEntries) {
 			const { component, options } = entry;
+			const scrollback = options?.scrollback === true;
 
 			// Get layout with height=0 first to determine width and maxHeight
 			// (width and maxHeight don't depend on overlay height)
@@ -783,7 +786,7 @@ export class TUI extends Container {
 			// Get final row/col with actual overlay height
 			const { row, col } = this.resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 
-			rendered.push({ overlayLines, row, col, w: width });
+			rendered.push({ overlayLines, row, col, w: width, scrollback });
 			minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 		}
 
@@ -800,9 +803,10 @@ export class TUI extends Container {
 		const viewportStart = Math.max(0, workingHeight - termHeight);
 
 		// Composite each overlay
-		for (const { overlayLines, row, col, w } of rendered) {
+		for (const { overlayLines, row, col, w, scrollback } of rendered) {
+			const overlayStart = scrollback ? Math.max(0, workingHeight - (row + overlayLines.length)) : viewportStart;
 			for (let i = 0; i < overlayLines.length; i++) {
-				const idx = viewportStart + row + i;
+				const idx = overlayStart + row + i;
 				if (idx >= 0 && idx < result.length) {
 					// Defensive: truncate overlay line to declared width before compositing
 					// (components should already respect width, but this ensures it)

--- a/packages/tui/test/overlay-options.test.ts
+++ b/packages/tui/test/overlay-options.test.ts
@@ -219,6 +219,29 @@ describe("TUI overlay options", () => {
 			assert.ok(scrollBuffer.includes("line 08"), "Expected final overlay line in scrollback");
 			tui.stop();
 		});
+
+		it("should align scrollback overlays with the bottom of existing content", async () => {
+			const terminal = new VirtualTerminal(20, 5);
+			const tui = new TUI(terminal);
+			const content = new StaticOverlay(Array.from({ length: 20 }, (_, index) => `base ${index + 1}`));
+			const overlay = new StaticOverlay(
+				Array.from({ length: 8 }, (_, index) => `modal ${String(index + 1).padStart(2, "0")}`),
+			);
+
+			tui.addChild(content);
+			tui.showOverlay(overlay, { anchor: "top-left", width: "100%", scrollback: true });
+			tui.start();
+			await renderAndFlush(tui, terminal);
+
+			const viewport = terminal.getViewport().join("\n");
+			assert.ok(viewport.includes("modal 08"), `Expected bottom overlay line in viewport, got:\n${viewport}`);
+			assert.ok(!viewport.includes("modal 01"), `Expected top overlay line in scrollback only, got:\n${viewport}`);
+
+			const scrollBuffer = terminal.getScrollBuffer().join("\n");
+			assert.ok(scrollBuffer.includes("modal 01"), "Expected first overlay line in scrollback");
+			assert.ok(scrollBuffer.includes("modal 08"), "Expected final overlay line in scrollback");
+			tui.stop();
+		});
 	});
 
 	describe("anchor positioning", () => {

--- a/packages/tui/test/overlay-options.test.ts
+++ b/packages/tui/test/overlay-options.test.ts
@@ -197,6 +197,30 @@ describe("TUI overlay options", () => {
 		});
 	});
 
+	describe("scrollback", () => {
+		it("should preserve full overlay content in terminal scrollback while showing the bottom", async () => {
+			const terminal = new VirtualTerminal(20, 5);
+			const tui = new TUI(terminal);
+			const overlay = new StaticOverlay(
+				Array.from({ length: 8 }, (_, index) => `line ${String(index + 1).padStart(2, "0")}`),
+			);
+
+			tui.addChild(new EmptyContent());
+			tui.showOverlay(overlay, { anchor: "top-left", width: "100%", scrollback: true });
+			tui.start();
+			await renderAndFlush(tui, terminal);
+
+			const viewport = terminal.getViewport().join("\n");
+			assert.ok(viewport.includes("line 08"), `Expected bottom overlay line in viewport, got:\n${viewport}`);
+			assert.ok(!viewport.includes("line 01"), `Expected top overlay line in scrollback only, got:\n${viewport}`);
+
+			const scrollBuffer = terminal.getScrollBuffer().join("\n");
+			assert.ok(scrollBuffer.includes("line 01"), "Expected first overlay line in scrollback");
+			assert.ok(scrollBuffer.includes("line 08"), "Expected final overlay line in scrollback");
+			tui.stop();
+		});
+	});
+
 	describe("anchor positioning", () => {
 		it("should position overlay at top-left", async () => {
 			const terminal = new VirtualTerminal(80, 24);


### PR DESCRIPTION
- subagent detail views now keep structured messages, thinking, and tool output instead of plain transcript dumps.
- detail overlays open at the latest transcript output and support configurable scroll keys.
- added regressions for structured child transcripts and detail scrolling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both RLM child-run event payloads and the TUI overlay compositor; regressions could break child transcript rendering or overlay positioning/scroll behavior in interactive mode.
> 
> **Overview**
> Child agent updates now include a **structured transcript** (user/assistant messages with thinking, plus tool calls with args/results) in addition to the old plain text lines, and the interactive child-agent detail view renders these entries using the same chat/tool components as the main UI.
> 
> Full-screen detail overlays gain a new `scrollback` mode in `pi-tui` so long transcripts open at the latest output and preserve earlier lines in native terminal scrollback. Usage helpers (`emptyUsage`/`cloneUsage`) are centralized in a new core module, and tests are updated/added to cover structured child transcripts and scrollback overlay behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da934d37455de7f81a5284c1e35f0992f07dd751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->