### PR TITLE
strengthen ipython shell guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Changed user messages to use the same filled treatment as the prompt input.
 - Changed the interactive working indicator to show elapsed time while the agent is running.
 - Replaced the default system prompt with the model-agnostic RLM harness prompt.
+- Changed IPython prompt guidance to prefer `!cmd` and `%%bash` for shell commands.
 
 ### Fixed
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -52,7 +52,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	if (activeTools.includes("ipython")) {
 		parts.push(
 			"",
-			"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -44,8 +44,8 @@ except Exception as _prime_agent_rlm_error:
 const ipythonSchema = Type.Object({
 	code: Type.String({
 		description:
-			"Python code to execute. State (variables, imports, loaded data) persists across calls. " +
-			"Shell commands available via `!cmd` (single-line) or `%%bash` (multi-line cell).",
+			"Python or IPython shell code to execute. State (variables, imports, loaded data) persists across calls. " +
+			"Prefer `!cmd` for ordinary single-line shell commands and `%%bash` for multi-line shell scripts.",
 	}),
 });
 
@@ -114,10 +114,11 @@ export function createIpythonToolDefinition(
 		name: "ipython",
 		label: "ipython",
 		description:
-			"Execute Python code in a persistent IPython kernel. Variables, imports, and loaded data " +
-			"persist across calls. Shell commands available inside Python via `!cmd` (single-line) " +
-			"or `%%bash` (multi-line cells).",
-		promptSnippet: "ipython - execute Python in a persistent kernel; state survives across calls",
+			"Execute Python and shell commands in a persistent IPython kernel. Variables, imports, and loaded data " +
+			"persist across calls. Prefer `!cmd` for ordinary single-line shell commands and `%%bash` " +
+			"for multi-line shell scripts.",
+		promptSnippet:
+			"ipython - execute Python and shell commands in a persistent kernel; prefer `!cmd` and `%%bash` for shell work",
 		// The kernel is single-threaded — pi must not run two ipython calls in parallel within a batch.
 		executionMode: "sequential",
 		parameters: ipythonSchema,

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -42,7 +42,7 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
-				"Inside `ipython`, prefix single-line shell commands with `!` (for example `!ls -la`) and use `%%bash` for multi-line shell scripts.",
+				"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 				"",
 				"Call at most one built-in tool per turn.",
 			].join("\n"),
@@ -57,7 +57,7 @@ describe("buildRlmPrompt", () => {
 			allowRecursion: false,
 		});
 
-		expect(prompt).not.toContain("Inside `ipython`, prefix single-line shell commands");
+		expect(prompt).not.toContain("Use `ipython` for both Python and shell work");
 	});
 });
 
@@ -79,7 +79,9 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("await rlm.background('sub-task')");
 		expect(prompt).toContain("notify='wake'");
 		expect(prompt).toContain("notify='silent'");
-		expect(prompt).toContain("Inside `ipython`, prefix single-line shell commands with `!`");
+		expect(prompt).toContain("Use `ipython` for both Python and shell work");
+		expect(prompt).toContain("prefer IPython shell syntax");
+		expect(prompt).toContain("Do not wrap ordinary shell commands in Python subprocesses");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");
 		expect(prompt).not.toContain("Available tools:");


### PR DESCRIPTION
- clarifies that ipython is the preferred path for both python and shell work.
- updates tool metadata so shell syntax is visible in schema descriptions and snippets.
- covers the stronger prompt wording in the existing system prompt test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts prompt/tool descriptions and updates the associated tests and changelog, with no runtime behavior changes.
> 
> **Overview**
> Strengthens the `ipython` guidance in the RLM system prompt to explicitly prefer using IPython for repo shell work via `!cmd`/`%%bash` and to discourage wrapping shell commands in Python subprocesses.
> 
> Updates the `ipython` tool schema description and `promptSnippet` to surface the same shell-syntax guidance, and refreshes system prompt tests and the changelog to match the new wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917212823cd2843bb73c23c7849d03d2b865d013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->