### PR TITLE
improve subagent tray + tui

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -90,7 +90,7 @@ export const KEYBINDINGS = {
 	},
 	"app.subagents.focus": {
 		defaultKeys: "alt+a",
-		description: "Focus child agents",
+		description: "Open child agents",
 	},
 	"app.session.toggleNamedFilter": {
 		defaultKeys: "ctrl+n",

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -88,7 +88,7 @@ interface FlatChildAgentNode {
 	depth: number;
 }
 
-interface SidebarLine {
+interface InspectorLine {
 	text: string;
 	selected: boolean;
 }
@@ -98,9 +98,129 @@ interface DetailSections {
 	bodyLines: string[];
 }
 
+function flattenChildAgentNodes(nodes: readonly ChildAgentInspectorNode[]): FlatChildAgentNode[] {
+	const result: FlatChildAgentNode[] = [];
+	const walk = (items: readonly ChildAgentInspectorNode[], depth: number): void => {
+		for (const node of items) {
+			result.push({ node, depth });
+			walk(node.children ?? [], depth + 1);
+		}
+	};
+	walk(nodes, 0);
+	return result;
+}
+
+function countRunning(nodes: readonly FlatChildAgentNode[]): number {
+	return nodes.filter((entry) => entry.node.status === "running").length;
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+	return count === 1 ? singular : plural;
+}
+
+export class ChildAgentSummaryComponent implements Component, Focusable {
+	focused = false;
+	private readonly paddingX = 1;
+	private nodes: readonly ChildAgentInspectorNode[] = [];
+	private hidden = false;
+
+	onOpen?: () => void;
+	onCancel?: () => void;
+
+	constructor(
+		private readonly getLocationLabel: () => string | undefined = () => undefined,
+		private readonly getContextLabel: () => string | undefined = () => undefined,
+		private readonly getOverrideLabel: () => string | undefined = () => undefined,
+	) {}
+
+	setNodes(nodes: readonly ChildAgentInspectorNode[]): void {
+		this.nodes = nodes;
+	}
+
+	setHidden(hidden: boolean): void {
+		this.hidden = hidden;
+	}
+
+	hasNodes(): boolean {
+		return flattenChildAgentNodes(this.nodes).length > 0;
+	}
+
+	invalidate(): void {
+		// Render output is derived from node state.
+	}
+
+	render(width: number): string[] {
+		if (this.hidden) {
+			return [];
+		}
+
+		const safeWidth = Math.max(1, width);
+		const flat = flattenChildAgentNodes(this.nodes);
+		const overrideLabel = this.getOverrideLabel()?.trim();
+		const locationLabel = this.getLocationLabel()?.trim();
+		const contextLabel = this.getContextLabel()?.trim();
+		const override = overrideLabel ? theme.fg("muted", overrideLabel) : "";
+		const location = !override && locationLabel ? theme.fg("muted", locationLabel) : "";
+		const context = contextLabel ? theme.fg("muted", contextLabel) : "";
+		const subagents = !override && flat.length > 0 ? this.subagentSummary(flat, this.focused) : "";
+		const leftSegments = [override, location, subagents].filter((segment) => segment.length > 0);
+		if (leftSegments.length === 0 && !context) {
+			return [];
+		}
+
+		const rawLeft = leftSegments.join(theme.fg("dim", "  "));
+		const paddedLine = context
+			? this.renderSplitLine(rawLeft, context, safeWidth)
+			: this.renderCompactLine(rawLeft, safeWidth);
+		return [paddedLine];
+	}
+
+	handleInput(data: string): void {
+		const kb = getKeybindings();
+		if (kb.matches(data, "tui.select.confirm")) {
+			this.onOpen?.();
+			return;
+		}
+		if (kb.matches(data, "tui.select.cancel") || kb.matches(data, "tui.select.up")) {
+			this.onCancel?.();
+		}
+	}
+
+	private truncate(line: string, width: number): string {
+		return truncateToWidth(line, width, "");
+	}
+
+	private renderCompactLine(line: string, width: number): string {
+		const panelWidth = Math.min(width, visibleWidth(line) + this.paddingX * 2);
+		const contentWidth = Math.max(1, panelWidth - this.paddingX * 2);
+		const truncated = this.truncate(line, contentWidth);
+		return `${" ".repeat(this.paddingX)}${truncated}${" ".repeat(Math.max(0, panelWidth - this.paddingX - visibleWidth(truncated)))}`;
+	}
+
+	private renderSplitLine(left: string, right: string, width: number): string {
+		const contentWidth = Math.max(1, width - this.paddingX);
+		const rightWidth = visibleWidth(right);
+		const gapWidth = left ? 2 : 0;
+		const leftWidth = Math.max(0, contentWidth - rightWidth - gapWidth);
+		const renderedLeft = leftWidth > 0 ? this.truncate(left, leftWidth) : "";
+		const gap = Math.max(0, contentWidth - visibleWidth(renderedLeft) - rightWidth);
+		return `${" ".repeat(this.paddingX)}${renderedLeft}${" ".repeat(gap)}${right}`;
+	}
+
+	private subagentSummary(flat: readonly FlatChildAgentNode[], selected: boolean): string {
+		const running = countRunning(flat);
+		const summary =
+			running > 0
+				? `${running} ${pluralize(running, "subagent")} running`
+				: `${flat.length} ${pluralize(flat.length, "subagent")}`;
+		const rendered = theme.bold(summary);
+		return selected ? theme.bg("selectedBg", rendered) : rendered;
+	}
+}
+
 export class ChildAgentInspectorComponent implements Component, Focusable {
 	focused = false;
-	private readonly paddingX = 2;
+	private readonly paddingX = 1;
 	private nodes: readonly ChildAgentInspectorNode[] = [];
 	private selectedId: string | undefined;
 
@@ -131,7 +251,11 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		}
 
 		const safeWidth = Math.max(1, width);
-		return this.renderSidebar(safeWidth).map((line) => this.panelLine(line.text, safeWidth, line.selected));
+		const lines = [theme.fg("borderMuted", "─".repeat(safeWidth))];
+		for (const line of this.renderList(safeWidth)) {
+			lines.push(this.panelLine(line.text, safeWidth, line.selected));
+		}
+		return lines;
 	}
 
 	handleInput(data: string): void {
@@ -168,17 +292,16 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		}
 	}
 
-	private renderSidebar(width: number): SidebarLine[] {
+	private renderList(width: number): InspectorLine[] {
 		const contentWidth = Math.max(1, width - this.paddingX * 2);
 		const flat = this.flatten();
-		const running = flat.filter((entry) => entry.node.status === "running").length;
+		const running = countRunning(flat);
 		const targetHeight = Math.max(0, this.getViewportHeight());
-		const lines: SidebarLine[] = [{ text: this.headerLine(running, flat.length, contentWidth), selected: false }];
+		const lines: InspectorLine[] = [{ text: this.headerLine(running, flat.length, contentWidth), selected: false }];
 		const availableRows = targetHeight > 0 ? Math.max(0, targetHeight - 2) : flat.length;
 		if (availableRows === 0) {
 			return lines;
 		}
-		lines.push({ text: "", selected: false });
 
 		const selectedIndex = Math.max(
 			0,
@@ -189,7 +312,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			const selected = this.focused && entry.node.id === this.selectedId;
 			lines.push({ text: this.renderListEntry(entry, contentWidth, selected), selected });
 		}
-		while (targetHeight > 0 && lines.length < targetHeight) {
+		while (targetHeight > 0 && lines.length < targetHeight - 1) {
 			lines.push({ text: "", selected: false });
 		}
 		return lines;
@@ -202,15 +325,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		return this.truncate(line, width, "…");
 	}
 	private flatten(): FlatChildAgentNode[] {
-		const result: FlatChildAgentNode[] = [];
-		const walk = (nodes: readonly ChildAgentInspectorNode[], depth: number): void => {
-			for (const node of nodes) {
-				result.push({ node, depth });
-				walk(node.children ?? [], depth + 1);
-			}
-		};
-		walk(this.nodes, 0);
-		return result;
+		return flattenChildAgentNodes(this.nodes);
 	}
 
 	private moveSelection(delta: number): void {
@@ -227,8 +342,9 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 	}
 
 	private headerLine(running: number, total: number, width: number): string {
-		const left = theme.bold("agents");
-		const right = theme.fg("muted", `${running}/${total} running`);
+		const left = theme.bold("subagents");
+		const right =
+			running > 0 ? theme.fg("muted", `${running} running · ${total} total`) : theme.fg("muted", `${total} total`);
 		const gap = " ".repeat(Math.max(1, width - visibleWidth(left) - visibleWidth(right)));
 		return this.truncate(`${left}${gap}${right}`, width);
 	}
@@ -253,7 +369,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		const truncated = this.truncate(line, contentWidth);
 		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
 		const padded = `${" ".repeat(this.paddingX)}${paddedContent}${" ".repeat(this.paddingX)}`;
-		return selected ? theme.bg("selectedBg", padded) : theme.bg("customMessageBg", padded);
+		return selected ? theme.bg("selectedBg", padded) : padded;
 	}
 
 	private truncate(line: string, width: number, ellipsis = ""): string {
@@ -270,7 +386,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	onCancel?: () => void;
 
 	constructor(
-		private readonly getViewportHeight: () => number = () => 0,
+		_getViewportHeight: () => number = () => 0,
 		private readonly options: ChildAgentDetailOptions = {},
 	) {}
 
@@ -288,13 +404,8 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
-		const targetHeight = Math.max(0, this.getViewportHeight());
 		const sections = this.renderDetail(safeWidth);
-		const lines = [...sections.headerLines, ...sections.bodyLines];
-		while (lines.length < targetHeight) {
-			lines.push(this.panelLine("", safeWidth));
-		}
-		return lines;
+		return [...sections.headerLines, ...sections.bodyLines];
 	}
 
 	handleInput(data: string): void {
@@ -438,9 +549,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	private panelLine(line: string, width: number): string {
-		const truncated = this.truncate(line, width);
-		const padded = truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
-		return theme.bg("customMessageBg", padded);
+		return this.truncate(line, width);
 	}
 
 	private truncate(line: string, width: number): string {

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -12,6 +12,7 @@ export class CustomEditor extends Editor {
 	public onEscape?: () => void;
 	public onCtrlD?: () => void;
 	public onPasteImage?: () => void;
+	public onMoveBelowPrompt?: () => boolean;
 	/** Handler for extension-registered shortcuts. Returns true if handled. */
 	public onExtensionShortcut?: (data: string) => boolean;
 
@@ -72,6 +73,16 @@ export class CustomEditor extends Editor {
 				handler();
 				return;
 			}
+		}
+
+		if (
+			this.keybindings.matches(data, "tui.editor.cursorDown") &&
+			!this.isShowingAutocomplete() &&
+			!this.isHistoryNavigationActive() &&
+			this.isCursorOnLastVisualLine() &&
+			this.onMoveBelowPrompt?.()
+		) {
+			return;
 		}
 
 		// Pass to parent for editor handling

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -9,6 +9,7 @@ export {
 	ChildAgentInspectorComponent,
 	type ChildAgentInspectorNode,
 	type ChildAgentStatus,
+	ChildAgentSummaryComponent,
 	type ChildAgentTranscriptLine,
 } from "./child-agent-inspector.js";
 export { CompactionSummaryMessageComponent } from "./compaction-summary-message.js";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -109,6 +109,7 @@ import {
 	ChildAgentInspectorComponent,
 	type ChildAgentInspectorNode,
 	type ChildAgentStructuredTranscriptEntry,
+	ChildAgentSummaryComponent,
 	type ChildAgentTranscriptLine,
 } from "./components/child-agent-inspector.js";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.js";
@@ -285,72 +286,6 @@ class BrandSplashHeader implements Component {
 	}
 }
 
-function isTerminalImageLine(line: string): boolean {
-	return line.includes("\x1b_G") || line.includes("\x1b]1337;File=");
-}
-
-class RightSidebarLayoutComponent implements Component {
-	private readonly preferredSidebarWidth = 34;
-	private readonly minSidebarWidth = 28;
-	private readonly minSideBySideWidth = 88;
-	private readonly gapWidth = 1;
-
-	constructor(
-		private readonly main: Component,
-		private readonly sidebar: Component,
-		private readonly getViewportHeight: () => number,
-	) {}
-
-	invalidate(): void {
-		this.main.invalidate?.();
-		this.sidebar.invalidate?.();
-	}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(1, width);
-		const probeSidebarLines = this.sidebar.render(1);
-		if (probeSidebarLines.length === 0) {
-			return this.main.render(safeWidth);
-		}
-
-		if (safeWidth < this.minSideBySideWidth) {
-			const sidebarHeight = Math.min(8, Math.max(1, this.getViewportHeight()));
-			const sidebarLines = this.sidebar.render(safeWidth).slice(0, sidebarHeight);
-			return [...sidebarLines, ...this.main.render(safeWidth)];
-		}
-
-		const sidebarWidth = Math.min(
-			this.preferredSidebarWidth,
-			Math.max(this.minSidebarWidth, Math.floor(safeWidth * 0.28)),
-		);
-		const mainWidth = Math.max(1, safeWidth - sidebarWidth - this.gapWidth);
-		const mainLines = this.main.render(mainWidth);
-		const viewportHeight = Math.max(1, this.getViewportHeight());
-		const sidebarLines = this.sidebar.render(sidebarWidth).slice(0, viewportHeight);
-		const height = Math.max(mainLines.length, viewportHeight);
-		const sidebarStart = Math.max(0, height - viewportHeight);
-		const blankSidebarLine = theme.bg("customMessageBg", " ".repeat(sidebarWidth));
-		const lines: string[] = [];
-
-		for (let index = 0; index < height; index++) {
-			const rawMainLine = mainLines[index] ?? "";
-			if (isTerminalImageLine(rawMainLine)) {
-				lines.push(rawMainLine);
-				continue;
-			}
-			const mainLine = truncateToWidth(rawMainLine, mainWidth, "");
-			const paddedMainLine = mainLine + " ".repeat(Math.max(0, mainWidth - visibleWidth(mainLine)));
-			const sidebarLine =
-				index >= sidebarStart
-					? truncateToWidth(sidebarLines[index - sidebarStart] ?? blankSidebarLine, sidebarWidth, "")
-					: blankSidebarLine;
-			lines.push(`${paddedMainLine}${" ".repeat(this.gapWidth)}${sidebarLine}`);
-		}
-
-		return lines;
-	}
-}
-
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
@@ -430,8 +365,8 @@ export class InteractiveMode {
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
 	private fdPath: string | undefined;
 	private mainContainer: Container;
+	private mainViewContainer: Container;
 	private editorContainer: Container;
-	private shellLayout: RightSidebarLayoutComponent;
 	private footer: FooterComponent;
 	private footerDataProvider: FooterDataProvider;
 	// Stored so the same manager can be injected into custom editors, selectors, and extension UI.
@@ -466,13 +401,14 @@ export class InteractiveMode {
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 
-	// RLM child-agent inspector, kept as a right sidebar instead of chat-flow content.
+	// RLM child-agent tray: compact entry below the editor, bounded list/detail in the main view.
+	private childAgentSummary: ChildAgentSummaryComponent;
 	private childAgentInspector: ChildAgentInspectorComponent;
 	private childAgentDetail: ChildAgentDetailComponent;
-	private childAgentDetailOverlayHandle: OverlayHandle | undefined;
 	private childAgentSnapshots = new Map<string, RlmChildAgentSnapshot>();
 	private childAgentNodes: ChildAgentInspectorNode[] = [];
 	private childAgentDetailNodeId: string | undefined;
+	private childAgentPanelMode: "list" | "detail" | undefined;
 
 	// Tool output expansion state
 	private toolOutputExpanded = false;
@@ -567,10 +503,10 @@ export class InteractiveMode {
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
-		this.childAgentInspector = new ChildAgentInspectorComponent(() => this.ui.terminal.rows);
-		this.childAgentInspector.onCancel = () => this.unfocusChildAgentInspector();
+		this.childAgentInspector = new ChildAgentInspectorComponent(() => this.getChildAgentPanelRows());
+		this.childAgentInspector.onCancel = () => this.closeChildAgentPanel();
 		this.childAgentInspector.onOpenDetail = (nodeId) => this.openChildAgentDetail(nodeId);
-		this.childAgentDetail = new ChildAgentDetailComponent(() => this.ui.terminal.rows, {
+		this.childAgentDetail = new ChildAgentDetailComponent(() => this.getChildAgentPanelRows(), {
 			ui: this.ui,
 			getCwd: () => this.sessionManager.getCwd(),
 			getToolDefinition: (toolName) => this.getRegisteredToolDefinition(toolName),
@@ -583,7 +519,7 @@ export class InteractiveMode {
 			getHideThinkingBlock: () => this.hideThinkingBlock,
 			getHiddenThinkingLabel: () => this.hiddenThinkingLabel,
 		});
-		this.childAgentDetail.onCancel = () => this.closeChildAgentDetail();
+		this.childAgentDetail.onCancel = () => this.showChildAgentList();
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
 		this.keybindings = KeybindingsManager.create();
@@ -596,13 +532,17 @@ export class InteractiveMode {
 		});
 		this.editor = this.defaultEditor;
 		this.mainContainer = new Container();
+		this.mainViewContainer = new Container();
+		this.restoreMainAgentView();
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor as Component);
-		this.shellLayout = new RightSidebarLayoutComponent(
-			this.mainContainer,
-			this.childAgentInspector,
-			() => this.ui.terminal.rows,
+		this.childAgentSummary = new ChildAgentSummaryComponent(
+			() => this.getTrayLocationLabel(),
+			() => this.getTrayContextLabel(),
+			() => this.getTrayOverrideLabel(),
 		);
+		this.childAgentSummary.onOpen = () => this.openChildAgentList();
+		this.childAgentSummary.onCancel = () => this.focusEditor();
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
 		this.footer = new FooterComponent(this.session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
@@ -847,15 +787,14 @@ export class InteractiveMode {
 			this.headerContainer.addChild(this.builtInHeader);
 		}
 
-		this.mainContainer.addChild(this.chatContainer);
-		this.mainContainer.addChild(this.pendingMessagesContainer);
-		this.mainContainer.addChild(this.statusContainer);
+		this.mainContainer.addChild(this.mainViewContainer);
 		this.renderWidgets(); // Initialize with default spacer
 		this.mainContainer.addChild(this.widgetContainerAbove);
 		this.mainContainer.addChild(this.editorContainer);
+		this.mainContainer.addChild(this.childAgentSummary);
 		this.mainContainer.addChild(this.widgetContainerBelow);
 		this.mainContainer.addChild(this.footer);
-		this.ui.addChild(this.shellLayout);
+		this.ui.addChild(this.mainContainer);
 		this.ui.setFocus(this.editor);
 
 		this.setupKeyHandlers();
@@ -2412,6 +2351,11 @@ export class InteractiveMode {
 	 */
 	private setCustomEditorComponent(factory: EditorFactory | undefined): void {
 		this.editorComponentFactory = factory;
+		if (this.childAgentPanelMode) {
+			this.restoreMainAgentView();
+		}
+		this.childAgentPanelMode = undefined;
+		this.childAgentSummary.setHidden(false);
 
 		// Save text from current editor before switching
 		const currentText = this.editor.getText();
@@ -2454,6 +2398,9 @@ export class InteractiveMode {
 				}
 				if (!customEditor.onPasteImage) {
 					customEditor.onPasteImage = () => this.defaultEditor.onPasteImage?.();
+				}
+				if (!customEditor.onMoveBelowPrompt) {
+					customEditor.onMoveBelowPrompt = () => this.defaultEditor.onMoveBelowPrompt?.();
 				}
 				if (!customEditor.onExtensionShortcut) {
 					customEditor.onExtensionShortcut = (data: string) => this.defaultEditor.onExtensionShortcut?.(data);
@@ -2645,6 +2592,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.session.tree", () => this.showTreeSelector());
 		this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());
 		this.defaultEditor.onAction("app.session.resume", () => this.showSessionSelector());
+		this.defaultEditor.onMoveBelowPrompt = () => this.focusChildAgentSummary();
 
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;
@@ -3244,6 +3192,7 @@ export class InteractiveMode {
 	private updateChildAgentInspector(child: RlmChildAgentSnapshot): void {
 		this.childAgentSnapshots.set(child.id, child);
 		this.childAgentNodes = this.buildChildAgentInspectorNodes();
+		this.childAgentSummary.setNodes(this.childAgentNodes);
 		this.childAgentInspector.setNodes(this.childAgentNodes);
 		if (this.childAgentDetailNodeId) {
 			this.childAgentDetail.setNode(this.findChildAgentInspectorNode(this.childAgentDetailNodeId));
@@ -3251,14 +3200,94 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private restoreMainAgentView(): void {
+		this.mainViewContainer.clear();
+		this.mainViewContainer.addChild(this.chatContainer);
+		this.mainViewContainer.addChild(this.pendingMessagesContainer);
+		this.mainViewContainer.addChild(this.statusContainer);
+	}
+
 	private resetChildAgentInspector(): void {
 		this.childAgentSnapshots.clear();
 		this.childAgentNodes = [];
+		this.childAgentSummary.setNodes([]);
+		this.childAgentSummary.setHidden(false);
 		this.childAgentInspector.setNodes([]);
 		this.childAgentDetail.setNode(undefined);
 		this.childAgentDetailNodeId = undefined;
-		this.childAgentDetailOverlayHandle?.hide();
-		this.childAgentDetailOverlayHandle = undefined;
+		if (this.childAgentPanelMode) {
+			this.closeChildAgentPanel();
+		}
+	}
+
+	private getChildAgentPanelRows(): number {
+		const rows = this.ui.terminal.rows;
+		return Math.max(4, Math.min(12, Math.floor(rows * 0.4)));
+	}
+
+	private focusEditor(): void {
+		this.ui.setFocus(this.editor);
+		this.ui.requestRender();
+	}
+
+	private focusChildAgentSummary(): boolean {
+		if (!this.childAgentSummary.hasNodes() || this.childAgentPanelMode || this.getTrayOverrideLabel()) {
+			return false;
+		}
+		this.ui.setFocus(this.childAgentSummary);
+		this.ui.requestRender();
+		return true;
+	}
+
+	private getTrayOverrideLabel(): string | undefined {
+		const text = this.editor.getExpandedText?.() ?? this.editor.getText();
+		if (!this.session.isStreaming || !text.trim()) {
+			return undefined;
+		}
+		return `${keyText("app.message.followUp")} to queue message`;
+	}
+
+	private getTrayLocationLabel(): string | undefined {
+		return this.footerDataProvider.getGitBranch() ?? formatSplashCwd(this.sessionManager.getCwd());
+	}
+
+	private getTrayContextLabel(): string | undefined {
+		const usage = this.session.getContextUsage();
+		if (!usage) {
+			return undefined;
+		}
+		if (usage.percent === null) {
+			return undefined;
+		}
+		const remainingPercent = Math.max(0, Math.min(100, 100 - usage.percent));
+		if (remainingPercent > 50) {
+			return undefined;
+		}
+		return `${Math.round(remainingPercent)}% context left`;
+	}
+
+	private openChildAgentList(): void {
+		if (this.childAgentNodes.length === 0) {
+			return;
+		}
+		this.showChildAgentList();
+	}
+
+	private showChildAgentList(): void {
+		if (this.childAgentNodes.length === 0) {
+			this.closeChildAgentPanel();
+			return;
+		}
+		this.childAgentPanelMode = "list";
+		this.childAgentDetailNodeId = undefined;
+		this.childAgentDetail.setNode(undefined);
+		this.childAgentSummary.setHidden(true);
+		this.childAgentInspector.setNodes(this.childAgentNodes);
+		this.editorContainer.clear();
+		this.mainViewContainer.clear();
+		this.mainViewContainer.addChild(this.childAgentInspector);
+		this.ui.setFocus(this.childAgentInspector);
+		this.ui.requestRender();
 	}
 
 	private openChildAgentDetail(nodeId: string): void {
@@ -3266,42 +3295,33 @@ export class InteractiveMode {
 		if (!node) {
 			return;
 		}
+		this.childAgentPanelMode = "detail";
 		this.childAgentDetailNodeId = nodeId;
 		this.childAgentDetail.setNode(node);
-		this.childAgentDetailOverlayHandle?.hide();
-		this.childAgentDetailOverlayHandle = this.ui.showOverlay(this.childAgentDetail, {
-			width: "100%",
-			anchor: "top-left",
-			margin: 0,
-			scrollback: true,
-		});
+		this.childAgentSummary.setHidden(true);
+		this.editorContainer.clear();
+		this.mainViewContainer.clear();
+		this.mainViewContainer.addChild(this.childAgentDetail);
+		this.ui.setFocus(this.childAgentDetail);
 		this.ui.requestRender();
 	}
 
 	private focusChildAgentInspector(): void {
-		if (this.childAgentSnapshots.size === 0) {
+		if (this.childAgentNodes.length === 0) {
 			return;
 		}
-		this.ui.setFocus(this.childAgentInspector);
-		this.ui.requestRender();
+		this.showChildAgentList();
 	}
 
-	private unfocusChildAgentInspector(): void {
-		this.closeChildAgentDetail(false);
-		this.ui.setFocus(this.editor);
-		this.ui.requestRender();
-	}
-
-	private closeChildAgentDetail(focusInspector = true): void {
-		this.childAgentDetailOverlayHandle?.hide();
-		this.childAgentDetailOverlayHandle = undefined;
+	private closeChildAgentPanel(): void {
+		this.childAgentPanelMode = undefined;
 		this.childAgentDetailNodeId = undefined;
 		this.childAgentDetail.setNode(undefined);
-		if (focusInspector && this.childAgentSnapshots.size > 0) {
-			this.ui.setFocus(this.childAgentInspector);
-		} else {
-			this.ui.setFocus(this.editor);
-		}
+		this.childAgentSummary.setHidden(false);
+		this.restoreMainAgentView();
+		this.editorContainer.clear();
+		this.editorContainer.addChild(this.editor);
+		this.ui.setFocus(this.editor);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2353,6 +2353,8 @@ export class InteractiveMode {
 		this.editorComponentFactory = factory;
 		if (this.childAgentPanelMode) {
 			this.restoreMainAgentView();
+			this.childAgentDetailNodeId = undefined;
+			this.childAgentDetail.setNode(undefined);
 		}
 		this.childAgentPanelMode = undefined;
 		this.childAgentSummary.setHidden(false);

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -43,7 +43,7 @@
 		"toolTitle": "",
 		"toolOutput": "gray",
 
-		"mdHeading": "#f0c674",
+		"mdHeading": "#b294bb",
 		"mdLink": "#81a2be",
 		"mdLinkUrl": "dimGray",
 		"mdCode": "accent",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -42,7 +42,7 @@
 		"toolTitle": "",
 		"toolOutput": "mediumGray",
 
-		"mdHeading": "yellow",
+		"mdHeading": "#7e57c2",
 		"mdLink": "blue",
 		"mdLinkUrl": "dimGray",
 		"mdCode": "teal",

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -50,7 +50,7 @@
 		"toolTitle": "",
 		"toolOutput": "muted",
 
-		"mdHeading": "warning",
+		"mdHeading": "primarySoft",
 		"mdLink": "info",
 		"mdLinkUrl": "dim",
 		"mdCode": "neutral",

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -7,6 +7,7 @@ import {
 	ChildAgentDetailComponent,
 	ChildAgentInspectorComponent,
 	type ChildAgentInspectorNode,
+	ChildAgentSummaryComponent,
 } from "../src/modes/interactive/components/child-agent-inspector.js";
 import { IPythonCellComponent, type IPythonCellState } from "../src/modes/interactive/components/ipython-cell.js";
 import { SubAgentTreeComponent } from "../src/modes/interactive/components/sub-agent-tree.js";
@@ -23,14 +24,6 @@ class HostComponent implements Component {
 	invalidate(): void {
 		this.child.invalidate();
 	}
-}
-
-class EmptyComponent implements Component {
-	render(): string[] {
-		return [];
-	}
-
-	invalidate(): void {}
 }
 
 function createFakeTui(): TUI {
@@ -173,7 +166,11 @@ describe("marquee TUI components", () => {
 		expect(expanded).toContain("assistant: no anomaly found in this shard");
 	});
 
-	test("renders child agent inspector as a sidebar with full-screen detail handoff", () => {
+	test("renders child agent summary and bounded inspector list", () => {
+		const summary = new ChildAgentSummaryComponent(
+			() => "agents-sidebar",
+			() => "37% context left",
+		);
 		const component = new ChildAgentInspectorComponent();
 		const node: ChildAgentInspectorNode = {
 			id: "sub-a",
@@ -224,16 +221,51 @@ describe("marquee TUI components", () => {
 				},
 			],
 		};
+		summary.setNodes([node]);
 		component.setNodes([node]);
 
+		const summaryText = stripAnsi(summary.render(60).join("\n"));
+		expect(summaryText).toContain("agents-sidebar");
+		expect(summaryText).toContain("37% context left");
+		expect(summaryText).toContain("1 subagent running");
+		expect(summaryText).not.toContain("2 total");
+		expect(summary.render(60)).toHaveLength(1);
+
+		summary.focused = true;
+		const focusedSummary = stripAnsi(summary.render(60).join("\n"));
+		expect(focusedSummary).toContain("agents-sidebar");
+		expect(focusedSummary).toContain("37% context left");
+		expect(focusedSummary).toContain("1 subagent running");
+		expect(focusedSummary).not.toContain("▌");
+		const summaryRow = summary.render(60).at(-1) ?? "";
+		expect(visibleWidth(summaryRow)).toBe(60);
+		expect(stripAnsi(summaryRow).endsWith("37% context left")).toBe(true);
+
+		const queueSummary = new ChildAgentSummaryComponent(
+			() => "agents-sidebar",
+			() => "37% context left",
+			() => "alt+enter to queue message",
+		);
+		queueSummary.setNodes([node]);
+		const queueText = stripAnsi(queueSummary.render(60).join("\n"));
+		expect(queueText).toContain("alt+enter to queue message");
+		expect(queueText).toContain("37% context left");
+		expect(queueText).not.toContain("1 subagent running");
+		expect(queueSummary.render(60)).toHaveLength(1);
+
 		const compact = stripAnsi(component.render(42).join("\n"));
-		expect(compact).toContain("  agents");
-		expect(compact).toContain("1/2 running");
+		expect(compact).toContain("subagents");
+		expect(compact).toContain("─");
+		expect(visibleWidth(component.render(42)[0] ?? "")).toBe(42);
+		expect(compact).toContain("1 running · 2 total");
 		expect(compact).toContain("running · inspect training logs");
 		expect(compact).toContain("done · check shard 2");
 		expect(compact).not.toContain("└─");
 		expect(compact).not.toContain("├─");
 		expect(compact).not.toContain("assistant: reading shard metrics");
+		for (const line of component.render(96)) {
+			expect(visibleWidth(line)).toBe(96);
+		}
 
 		component.focused = true;
 		const focused = stripAnsi(component.render(42).join("\n"));
@@ -262,7 +294,6 @@ describe("marquee TUI components", () => {
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 		expect(detail).not.toContain("tool: bash");
-		expect(detailLines).toHaveLength(20);
 
 		component.handleInput("\x1b");
 		const returned = stripAnsi(component.render(42).join("\n"));
@@ -274,13 +305,11 @@ describe("marquee TUI components", () => {
 		}
 
 		const narrow = stripAnsi(component.render(24).join("\n"));
-		expect(narrow).toContain("inspect…");
+		expect(narrow).toContain("inspect t…");
 	});
 
-	test("opens child agent detail in terminal scrollback at the bottom", async () => {
-		const terminal = new VirtualTerminal(48, 8);
-		const tui = new TUI(terminal);
-		const detailComponent = new ChildAgentDetailComponent(() => terminal.rows, { ui: tui });
+	test("renders full child agent detail without internal scroll controls", () => {
+		const detailComponent = new ChildAgentDetailComponent(() => 6);
 		detailComponent.setNode({
 			id: "sub-scroll",
 			label: "inspect long output",
@@ -292,25 +321,13 @@ describe("marquee TUI components", () => {
 			})),
 		});
 
-		tui.addChild(new EmptyComponent());
-		tui.showOverlay(detailComponent, {
-			width: "100%",
-			anchor: "top-left",
-			margin: 0,
-			scrollback: true,
-		});
-		tui.start();
-		await terminal.waitForRender();
-
-		const viewport = stripAnsi(terminal.getViewport().join("\n"));
-		expect(viewport).toContain("fallback transcript row 12");
-		expect(viewport).toContain("fallback transcript row 08");
-		expect(viewport).not.toContain("fallback transcript row 01");
-
-		const scrollBuffer = stripAnsi(terminal.getScrollBuffer().join("\n"));
-		expect(scrollBuffer).toContain("fallback transcript row 01");
-		expect(scrollBuffer).toContain("fallback transcript row 12");
-		tui.stop();
+		const firstLines = detailComponent.render(48);
+		const first = stripAnsi(firstLines.join("\n"));
+		expect(first).toContain("fallback transcript row 01");
+		expect(first).toContain("fallback transcript row 12");
+		expect(first).not.toContain("↑");
+		expect(first).not.toContain("↓");
+		expect(firstLines.length).toBeGreaterThan(6);
 	});
 
 	test("routes built-in ipython tool rows through the cell renderer", () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -369,6 +369,14 @@ export class Editor implements Component, Focusable {
 		return currentVisualLine === visualLines.length - 1;
 	}
 
+	protected isHistoryNavigationActive(): boolean {
+		return this.historyIndex > -1;
+	}
+
+	protected isCursorOnLastVisualLine(): boolean {
+		return this.isOnLastVisualLine();
+	}
+
 	private navigateHistory(direction: 1 | -1): void {
 		this.lastAction = null;
 		if (this.history.length === 0) return;


### PR DESCRIPTION
- replaces the subagent sidebar with a compact tray and full-width selector.
- opens subagent detail as the main transcript view instead of a bottom panel.
- adds branch, low-context, and queue-message hints below the prompt.


https://github.com/user-attachments/assets/6a7444d2-6445-465a-9719-c68b5fc0b14b






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to significant interactive TUI layout/focus changes (new tray, new navigation paths, and editor key handling) that could introduce regressions in keyboard flow or rendering across terminal sizes.
> 
> **Overview**
> Replaces the right-hand subagent sidebar/overlay with a **compact tray** below the editor (`ChildAgentSummaryComponent`) that shows branch/context/queue hints and opens a full-width subagent list/detail view in the main panel.
> 
> Updates navigation and focus flow: `alt+a` now opens the subagent panel, subagent detail is shown as the main view (not an overlay), and the editor can move focus to the tray when pressing cursor-down at the bottom of the prompt.
> 
> Polishes rendering/styling (header text, borders, selection backgrounds) and tweaks markdown heading colors across themes; tests are updated to validate the new tray/list/detail behavior and sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca5e314ea467021ee7d181621d643dd4fdb475b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->