### PR TITLE
remove rlm background api

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Removed
 
+- Removed the RLM background API; recursive agents now use `rlm()`/`rlm.run()` with normal Python async tasks for background work.
 - Removed the legacy `read`, `write`, `grep`, `find`, and `ls` built-in tools.
 - Removed the local TPS extension that posted token/cache stats after each agent response.
 

--- a/packages/coding-agent/docs/kernel-and-rlm-recursion.md
+++ b/packages/coding-agent/docs/kernel-and-rlm-recursion.md
@@ -196,6 +196,9 @@ subscribe to iopub
 sleep briefly for ZeroMQ slow-joiner behavior
   |
   v
+start persistent iopub pump
+  |
+  v
 probeReady()
   |
   | sends kernel_info_request on shell
@@ -225,7 +228,7 @@ execute(code)
 send execute_request on shell
   |
   v
-read iopub messages
+wait for persistent iopub pump to finish active execution
   |
   | stream        -> stdout / stderr
   | execute_result -> final expression repr
@@ -381,7 +384,7 @@ loop.call_soon_threadsafe(...)
 
 ## TypeScript Comm Handling
 
-`KernelManager.executeInner()` watches IOPub messages. Comm messages are handled before the normal parent `msg_id` filter:
+`KernelManager` starts a persistent IOPub pump when the kernel starts. Comm messages are handled before the active execution `msg_id` filter:
 
 ```text
 for each iopub message:
@@ -389,13 +392,16 @@ for each iopub message:
     handleCommMessage(incoming)
     continue
 
+  if no active execution:
+    ignore
+
   if parent_header.msg_id != active execute_request:
     ignore
 
   handle stdout / stderr / result / error / idle
 ```
 
-This matters because `comm_open` messages may not use the active execute request as their parent.
+This matters because `comm_open` messages may not use the active execute request as their parent, and Python `asyncio` tasks can open RLM comms after the scheduling cell has already returned to idle.
 
 The comm handler tracks:
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -110,12 +110,7 @@ import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
-import type {
-	RlmBackgroundRunStartResult,
-	RlmBackgroundRunStatusResult,
-	RlmRunResult,
-	RlmUsage,
-} from "./rlm-runtime.js";
+import type { RlmRunResult, RlmUsage } from "./rlm-runtime.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionMessageEntry } from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
@@ -356,15 +351,11 @@ interface RlmChildRun {
 	prompt: string;
 	sessionDir: string;
 	status: RlmChildAgentStatus;
-	completionPolicy: BackgroundRlmCompletionPolicy;
 	result?: RlmRunResult;
 	error?: string;
 	task?: Promise<RlmRunResult>;
-	waiters: Set<() => void>;
 	abort: () => void;
 }
-
-type BackgroundRlmCompletionPolicy = "passive" | "wake" | "silent";
 
 // ============================================================================
 // Constants
@@ -372,36 +363,8 @@ type BackgroundRlmCompletionPolicy = "passive" | "wake" | "silent";
 
 /** Standard thinking levels */
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
-const BACKGROUND_RLM_COMPLETION_DEBOUNCE_MS = 250;
 
 function noopRlmChildAbort(): void {}
-
-function parseBackgroundRlmCompletionPolicy(value: unknown): BackgroundRlmCompletionPolicy {
-	if (value === undefined) {
-		return "passive";
-	}
-	if (value === true) {
-		return "wake";
-	}
-	if (value === false || value === null) {
-		return "silent";
-	}
-	if (value === "passive" || value === "wake" || value === "silent") {
-		return value;
-	}
-	throw new Error("rlm.background notify must be 'passive', 'wake', 'silent', true, or false");
-}
-
-function extractBackgroundRlmOptions(kwargs: Record<string, unknown>): {
-	childKwargs: Record<string, unknown>;
-	completionPolicy: BackgroundRlmCompletionPolicy;
-} {
-	const { notify, ...childKwargs } = kwargs;
-	return {
-		childKwargs,
-		completionPolicy: parseBackgroundRlmCompletionPolicy(notify),
-	};
-}
 
 function parseDepth(value: string | undefined, fallback: number, name: string): number {
 	if (value === undefined || value === "") {
@@ -714,10 +677,7 @@ export class AgentSession {
 	private _rlmMaxDepth: number;
 	private _rlmSessionDir?: string;
 	private _rlmParentNodeId?: string;
-	private _backgroundRlmRuns = new Map<string, RlmChildRun>();
-	private _pendingBackgroundRlmCompletions: RlmChildRun[] = [];
-	private _backgroundRlmCompletionTimer?: ReturnType<typeof globalThis.setTimeout>;
-	private _backgroundRlmQueueDrainPromise?: Promise<void>;
+	private _activeRlmChildRuns = new Map<string, RlmChildRun>();
 
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
@@ -1655,19 +1615,13 @@ export class AgentSession {
 			return;
 		}
 		this._disposed = true;
-		for (const run of this._backgroundRlmRuns.values()) {
+		for (const run of this._activeRlmChildRuns.values()) {
 			if (run.status === "running" || run.status === "queued") {
 				run.status = "cancelled";
 				run.error = "Parent session disposed";
 				run.abort();
-				this._resolveRlmChildRunWaiters(run);
 			}
 		}
-		if (this._backgroundRlmCompletionTimer) {
-			globalThis.clearTimeout(this._backgroundRlmCompletionTimer);
-			this._backgroundRlmCompletionTimer = undefined;
-		}
-		this._pendingBackgroundRlmCompletions = [];
 		this._pendingNextTurnMessages = [];
 		this._steeringMessages = [];
 		this._followUpMessages = [];
@@ -3300,10 +3254,6 @@ export class AgentSession {
 						env: this._rlmKernelEnv(),
 						sessionId: this.sessionId,
 						rlmRunHandler: ({ prompt, kwargs }) => this.runRlmChild(prompt, kwargs),
-						rlmBackgroundRunHandler: ({ prompt, kwargs }) =>
-							Promise.resolve(this.startBackgroundRlmChild(prompt, kwargs)),
-						rlmBackgroundStatusHandler: ({ id }) => Promise.resolve(this.getBackgroundRlmChildStatus(id)),
-						rlmBackgroundWaitHandler: ({ id, timeoutMs }) => this.waitForBackgroundRlmChild(id, timeoutMs),
 					},
 					bash: { commandPrefix: shellCommandPrefix, shellPath },
 				});
@@ -3467,14 +3417,7 @@ export class AgentSession {
 		return this.agent.state.messages.filter((message) => message.role === "assistant").length;
 	}
 
-	private _startRlmChildRun(
-		prompt: string,
-		kwargs: Record<string, unknown> = {},
-		options: {
-			notifyParentOnCompletion?: boolean;
-			completionPolicy?: BackgroundRlmCompletionPolicy;
-		} = {},
-	): RlmChildRun {
+	private _startRlmChildRun(prompt: string, kwargs: Record<string, unknown> = {}): RlmChildRun {
 		const unsupportedKwargs = Object.keys(kwargs);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
@@ -3503,10 +3446,9 @@ export class AgentSession {
 			prompt,
 			sessionDir: childSessionDir,
 			status: "running",
-			completionPolicy: options.completionPolicy ?? "passive",
-			waiters: new Set(),
 			abort: noopRlmChildAbort,
 		};
+		this._activeRlmChildRuns.set(run.id, run);
 		// Index of the assistant entry currently being streamed. Cleared whenever the
 		// conversation moves on (new assistant message, tool call) so subsequent assistant
 		// text appends a fresh entry in chronological order instead of overwriting in place.
@@ -3787,19 +3729,10 @@ export class AgentSession {
 				unsubscribeChild();
 				child.dispose();
 				run.abort = noopRlmChildAbort;
+				this._activeRlmChildRuns.delete(run.id);
 			}
 		})();
 		run.task = task;
-		void task.then(
-			() => this._resolveRlmChildRunWaiters(run),
-			() => this._resolveRlmChildRunWaiters(run),
-		);
-		if (options.notifyParentOnCompletion) {
-			void task.then(
-				() => this._queueBackgroundRlmChildCompletion(run),
-				() => this._queueBackgroundRlmChildCompletion(run),
-			);
-		}
 		return run;
 	}
 
@@ -3809,219 +3742,6 @@ export class AgentSession {
 			throw new Error("RLM child failed to start");
 		}
 		return await run.task;
-	}
-
-	startBackgroundRlmChild(prompt: string, kwargs: Record<string, unknown> = {}): RlmBackgroundRunStartResult {
-		const { childKwargs, completionPolicy } = extractBackgroundRlmOptions(kwargs);
-		const run = this._startRlmChildRun(prompt, childKwargs, {
-			notifyParentOnCompletion: completionPolicy !== "silent",
-			completionPolicy,
-		});
-		this._backgroundRlmRuns.set(run.id, run);
-		return {
-			id: run.id,
-			state: run.status,
-			session_dir: run.sessionDir,
-		};
-	}
-
-	getBackgroundRlmChildStatus(id: string): RlmBackgroundRunStatusResult {
-		return this._backgroundRlmChildSnapshot(this._getBackgroundRlmChildRun(id));
-	}
-
-	async waitForBackgroundRlmChild(id: string, timeoutMs?: number): Promise<RlmBackgroundRunStatusResult> {
-		const run = this._getBackgroundRlmChildRun(id);
-		if (run.status !== "running" && run.status !== "queued") {
-			return this._backgroundRlmChildSnapshot(run);
-		}
-
-		let timedOut = false;
-		await new Promise<void>((resolve) => {
-			let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
-			const done = () => {
-				run.waiters.delete(done);
-				if (timeout) {
-					globalThis.clearTimeout(timeout);
-				}
-				resolve();
-			};
-			run.waiters.add(done);
-			if (run.status !== "running" && run.status !== "queued") {
-				done();
-				return;
-			}
-			if (timeoutMs !== undefined) {
-				timeout = globalThis.setTimeout(() => {
-					timedOut = true;
-					done();
-				}, timeoutMs);
-				if (timeout && typeof timeout === "object" && "unref" in timeout) {
-					timeout.unref();
-				}
-			}
-		});
-
-		return {
-			...this._backgroundRlmChildSnapshot(run),
-			timed_out: timedOut && (run.status === "running" || run.status === "queued"),
-		};
-	}
-
-	private _getBackgroundRlmChildRun(id: string): RlmChildRun {
-		const run = this._backgroundRlmRuns.get(id);
-		if (!run) {
-			throw new Error(`Unknown background rlm child: ${id}`);
-		}
-		return run;
-	}
-
-	private _backgroundRlmChildSnapshot(run: RlmChildRun): RlmBackgroundRunStatusResult {
-		return {
-			id: run.id,
-			state: run.status,
-			session_dir: run.sessionDir,
-			result: run.result,
-			error: run.error,
-		};
-	}
-
-	private _resolveRlmChildRunWaiters(run: RlmChildRun): void {
-		for (const waiter of run.waiters) {
-			waiter();
-		}
-		run.waiters.clear();
-	}
-
-	private _queueBackgroundRlmChildCompletion(run: RlmChildRun): void {
-		if (this._disposed || run.status === "cancelled") {
-			return;
-		}
-		this._pendingBackgroundRlmCompletions.push(run);
-		if (this._backgroundRlmCompletionTimer) {
-			return;
-		}
-		this._backgroundRlmCompletionTimer = globalThis.setTimeout(() => {
-			this._backgroundRlmCompletionTimer = undefined;
-			if (this._disposed) {
-				this._pendingBackgroundRlmCompletions = [];
-				return;
-			}
-			void this._flushBackgroundRlmChildCompletions();
-		}, BACKGROUND_RLM_COMPLETION_DEBOUNCE_MS);
-		if (
-			this._backgroundRlmCompletionTimer &&
-			typeof this._backgroundRlmCompletionTimer === "object" &&
-			"unref" in this._backgroundRlmCompletionTimer
-		) {
-			this._backgroundRlmCompletionTimer.unref();
-		}
-	}
-
-	private _formatBackgroundRlmCompletionNotice(runs: readonly RlmChildRun[]): string {
-		const plural = runs.length === 1 ? "child has" : "children have";
-		const lines = [
-			"Background RLM completion notice. This message is hidden from the user.",
-			"",
-			`${runs.length} background RLM ${plural} finished.`,
-			"",
-		];
-		for (const run of runs) {
-			const prompt = compactRlmText(run.prompt, 80);
-			if (run.result) {
-				const answer = compactRlmText(run.result.answer || "(empty)", 240);
-				lines.push(`- ${run.id} done: ${prompt}`);
-				lines.push(`  Answer preview: ${answer}`);
-			} else {
-				lines.push(`- ${run.id} failed: ${prompt}`);
-				lines.push(`  Error: ${compactRlmText(run.error ?? "unknown error", 240)}`);
-			}
-		}
-		lines.push(
-			"",
-			"If you told the user you would report background completions, send a concise update now. Otherwise keep this result in mind and avoid an unsolicited status reply.",
-			"Use the saved handle's status(), wait(), or result() methods when you need full details.",
-		);
-		return lines.join("\n");
-	}
-
-	private _ensureBackgroundRlmQueueDrain(): void {
-		if (this._disposed) {
-			return;
-		}
-		if (this._backgroundRlmQueueDrainPromise) {
-			return;
-		}
-		this._backgroundRlmQueueDrainPromise = (async () => {
-			try {
-				while (true) {
-					await this.agent.waitForIdle();
-					if (this._disposed) {
-						return;
-					}
-					if (!this.agent.hasQueuedMessages()) {
-						return;
-					}
-					try {
-						await this.agent.continue();
-						await this.waitForRetry();
-					} catch (error) {
-						if (this._disposed) {
-							return;
-						}
-						if (this.isStreaming) {
-							continue;
-						}
-						throw error;
-					}
-				}
-			} catch (error) {
-				console.error(`[rlm] failed to wake parent agent for background child completion: ${String(error)}`);
-			} finally {
-				this._backgroundRlmQueueDrainPromise = undefined;
-			}
-		})();
-	}
-
-	private async _flushBackgroundRlmChildCompletions(): Promise<void> {
-		if (this._disposed) {
-			this._pendingBackgroundRlmCompletions = [];
-			return;
-		}
-		const runs = this._pendingBackgroundRlmCompletions.splice(0);
-		if (runs.length === 0 || this._disposed) {
-			return;
-		}
-		const content = this._formatBackgroundRlmCompletionNotice(runs);
-		const shouldWakeParent = runs.some((run) => run.completionPolicy === "wake");
-		try {
-			await this.sendCustomMessage(
-				{
-					customType: "rlm_background_result",
-					content,
-					display: false,
-					details: {
-						runs: runs.map((run) => ({
-							id: run.id,
-							prompt: run.prompt,
-							status: run.status,
-							sessionDir: run.sessionDir,
-							result: run.result,
-							error: run.error,
-						})),
-					},
-				},
-				this.isStreaming
-					? { deliverAs: shouldWakeParent ? "followUp" : "nextTurn" }
-					: shouldWakeParent
-						? { triggerTurn: true }
-						: undefined,
-			);
-			if (this.isStreaming && shouldWakeParent) {
-				this._ensureBackgroundRlmQueueDrain();
-			}
-		} catch (error) {
-			console.error(`[rlm] failed to deliver background child completion notice: ${String(error)}`);
-		}
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -6,11 +6,12 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 1;
+const BOOTSTRAP_SCHEMA = 2;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
-const RUNTIME_READY_CHECK = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
+const RUNTIME_READY_CHECK =
+	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
 const BOOTSTRAP_VERSION_FILE = ".bootstrap-version";
 const BOOTSTRAP_LOCK_NAME = ".bootstrap.lock";
 const BOOTSTRAP_LOCK_RETRY_MS = 100;
@@ -318,7 +319,7 @@ async function ensureKernelPythonUncached(): Promise<string> {
 		const python = path.resolve(expandHome(override));
 		const missing: string[] = [];
 		if (!(await hasIpykernel(python))) missing.push("ipykernel");
-		if (!(await hasPrimeAgentRuntime(python))) missing.push("a current prime-agent-runtime with rlm.background");
+		if (!(await hasPrimeAgentRuntime(python))) missing.push("a current prime-agent-runtime with callable rlm.run");
 		if (missing.length === 0) return python;
 		throw new Error(`PRIME_AGENT_KERNEL_PYTHON points to a Python missing ${missing.join(" and ")}: ${python}`);
 	}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -529,7 +529,7 @@ export class KernelManager {
 				await shell.send(encode(msg, conn.key));
 			} catch (error) {
 				this.rejectActiveExecution(error instanceof Error ? error : new Error(String(error)));
-				throw error;
+				return await resultPromise;
 			}
 			return await resultPromise;
 		} finally {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -94,12 +94,28 @@ interface ActiveExecution {
 	reject: (error: Error) => void;
 }
 
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error: Error) => void;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (error: Error) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
 }
 
 // ---- wire format ---------------------------------------------------------
@@ -510,28 +526,30 @@ export class KernelManager {
 		opts.signal?.addEventListener("abort", onAbort);
 
 		try {
-			const resultPromise = new Promise<ExecuteResult>((resolve, reject) => {
-				this.activeExecution = {
-					requestMsgId,
-					started,
-					maxChars,
-					opts,
-					stdout: "",
-					stderr: "",
-					stdoutTruncated: false,
-					stderrTruncated: false,
-					status: "ok",
-					resolve,
-					reject,
-				};
-			});
+			const result = createDeferred<ExecuteResult>();
+			const execution: ActiveExecution = {
+				requestMsgId,
+				started,
+				maxChars,
+				opts,
+				stdout: "",
+				stderr: "",
+				stdoutTruncated: false,
+				stderrTruncated: false,
+				status: "ok",
+				resolve: result.resolve,
+				reject: result.reject,
+			};
+			this.activeExecution = execution;
 			try {
 				await shell.send(encode(msg, conn.key));
 			} catch (error) {
-				this.rejectActiveExecution(error instanceof Error ? error : new Error(String(error)));
-				return await resultPromise;
+				if (this.activeExecution === execution) {
+					this.activeExecution = undefined;
+				}
+				throw error instanceof Error ? error : new Error(String(error));
 			}
-			return await resultPromise;
+			return await result.promise;
 		} finally {
 			opts.signal?.removeEventListener("abort", onAbort);
 		}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -8,14 +8,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
-import type {
-	RlmBackgroundRunHandler,
-	RlmBackgroundRunStatusHandler,
-	RlmBackgroundRunStatusResult,
-	RlmBackgroundRunWaitHandler,
-	RlmRunHandler,
-	RlmRunResult,
-} from "../rlm-runtime.js";
+import type { RlmRunHandler, RlmRunResult } from "../rlm-runtime.js";
 import { ensureKernelPython } from "./bootstrap.js";
 
 const DELIM = Buffer.from("<IDS|MSG>");
@@ -34,9 +27,6 @@ export interface KernelManagerOptions {
 	env?: Record<string, string>;
 	sessionId?: string;
 	rlmRunHandler?: RlmRunHandler;
-	rlmBackgroundRunHandler?: RlmBackgroundRunHandler;
-	rlmBackgroundStatusHandler?: RlmBackgroundRunStatusHandler;
-	rlmBackgroundWaitHandler?: RlmBackgroundRunWaitHandler;
 	/** Default: "prime-agent". */
 	username?: string;
 }
@@ -59,7 +49,7 @@ export interface ExecuteResult {
 	durationMs: number;
 }
 
-type RlmCommResult = RlmRunResult | RlmBackgroundRunStatusResult;
+type RlmCommResult = RlmRunResult;
 
 interface ConnectionInfo {
 	ip: string;
@@ -88,22 +78,28 @@ interface JupyterMessage {
 	content: Record<string, unknown>;
 }
 
+interface ActiveExecution {
+	requestMsgId: string;
+	started: number;
+	maxChars: number;
+	opts: ExecuteOptions;
+	stdout: string;
+	stderr: string;
+	stdoutTruncated: boolean;
+	stderrTruncated: boolean;
+	result?: string;
+	error?: ExecuteResult["error"];
+	status: ExecuteResult["status"];
+	resolve: (result: ExecuteResult) => void;
+	reject: (error: Error) => void;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
-}
-
-function parseOptionalTimeoutMs(value: unknown): number | undefined {
-	if (value === undefined || value === null) {
-		return undefined;
-	}
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		throw new Error("rlm.run background wait timeout_ms must be a non-negative number");
-	}
-	return value;
 }
 
 // ---- wire format ---------------------------------------------------------
@@ -268,17 +264,7 @@ function installSignalHandlersOnce(): void {
 // ---- kernel manager ------------------------------------------------------
 
 export class KernelManager {
-	private readonly options: Pick<
-		KernelManagerOptions,
-		| "python"
-		| "cwd"
-		| "env"
-		| "sessionId"
-		| "rlmRunHandler"
-		| "rlmBackgroundRunHandler"
-		| "rlmBackgroundStatusHandler"
-		| "rlmBackgroundWaitHandler"
-	> &
+	private readonly options: Pick<KernelManagerOptions, "python" | "cwd" | "env" | "sessionId" | "rlmRunHandler"> &
 		Required<Pick<KernelManagerOptions, "username">>;
 	private readonly session = uuid();
 	private readonly commTargets = new Map<string, string>();
@@ -287,11 +273,13 @@ export class KernelManager {
 	private shell?: Dealer;
 	private iopub?: Subscriber;
 	private control?: Dealer;
+	private iopubPumpPromise?: Promise<void>;
 	private connection?: ConnectionInfo;
 	private tempDir?: string;
 	private kernelStderr = "";
 	/** Serializes execute() calls — Jupyter shell channel is request/reply. */
 	private executionQueue: Promise<unknown> = Promise.resolve();
+	private activeExecution?: ActiveExecution;
 	private readonly inFlightRlmRuns = new Set<Promise<void>>();
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
@@ -304,9 +292,6 @@ export class KernelManager {
 			env: options.env,
 			sessionId: options.sessionId,
 			rlmRunHandler: options.rlmRunHandler,
-			rlmBackgroundRunHandler: options.rlmBackgroundRunHandler,
-			rlmBackgroundStatusHandler: options.rlmBackgroundStatusHandler,
-			rlmBackgroundWaitHandler: options.rlmBackgroundWaitHandler,
 			username: options.username ?? "prime-agent",
 		};
 	}
@@ -389,6 +374,7 @@ export class KernelManager {
 
 		// ZMQ PUB/SUB slow-joiner: give the subscription a brief chance to reach the kernel before first execute.
 		await sleep(IOPUB_SUBSCRIBE_DELAY_MS);
+		this.startIopubPump();
 
 		try {
 			await this.probeReady();
@@ -494,7 +480,6 @@ export class KernelManager {
 	private async executeInner(code: string, opts: ExecuteOptions, started: number): Promise<ExecuteResult> {
 		const conn = this.connection!;
 		const shell = this.shell!;
-		const iopub = this.iopub!;
 		const maxChars = opts.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
 
 		const msg = buildMessage(
@@ -515,20 +500,55 @@ export class KernelManager {
 		if (opts.signal?.aborted) {
 			return { stdout: "", stderr: "", status: "aborted", durationMs: Date.now() - started };
 		}
-		await shell.send(encode(msg, conn.key));
-
-		let stdout = "";
-		let stderr = "";
-		let stdoutTruncated = false;
-		let stderrTruncated = false;
-		let result: string | undefined;
-		let error: ExecuteResult["error"];
-		let status: ExecuteResult["status"] = "ok";
+		if (this.activeExecution) {
+			throw new Error("Kernel already has an active execution");
+		}
 
 		const onAbort = () => {
 			this.interrupt().catch(() => {});
 		};
 		opts.signal?.addEventListener("abort", onAbort);
+
+		try {
+			const resultPromise = new Promise<ExecuteResult>((resolve, reject) => {
+				this.activeExecution = {
+					requestMsgId,
+					started,
+					maxChars,
+					opts,
+					stdout: "",
+					stderr: "",
+					stdoutTruncated: false,
+					stderrTruncated: false,
+					status: "ok",
+					resolve,
+					reject,
+				};
+			});
+			try {
+				await shell.send(encode(msg, conn.key));
+			} catch (error) {
+				this.rejectActiveExecution(error instanceof Error ? error : new Error(String(error)));
+				throw error;
+			}
+			return await resultPromise;
+		} finally {
+			opts.signal?.removeEventListener("abort", onAbort);
+		}
+	}
+
+	private startIopubPump(): void {
+		if (this.iopubPumpPromise) {
+			return;
+		}
+		this.iopubPumpPromise = this.runIopubPump();
+	}
+
+	private async runIopubPump(): Promise<void> {
+		const iopub = this.iopub;
+		if (!iopub) {
+			return;
+		}
 
 		try {
 			for await (const frames of iopub) {
@@ -539,53 +559,100 @@ export class KernelManager {
 					this.handleCommMessage(incoming);
 					continue;
 				}
-				if ((incoming.parent_header as { msg_id?: string }).msg_id !== requestMsgId) continue;
-
-				if (t === "stream") {
-					const c = incoming.content as { name: "stdout" | "stderr"; text: string };
-					if (c.name === "stdout") {
-						if (stdout.length < maxChars) {
-							stdout += c.text;
-							if (stdout.length > maxChars) {
-								stdout = stdout.slice(0, maxChars);
-								stdoutTruncated = true;
-							}
-						}
-					} else {
-						if (stderr.length < maxChars) {
-							stderr += c.text;
-							if (stderr.length > maxChars) {
-								stderr = stderr.slice(0, maxChars);
-								stderrTruncated = true;
-							}
-						}
-					}
-					opts.onStream?.(c.text, c.name);
-				} else if (t === "execute_result") {
-					const c = incoming.content as { data: Record<string, string> };
-					if (c.data["text/plain"]) result = c.data["text/plain"];
-				} else if (t === "error") {
-					const c = incoming.content as { ename: string; evalue: string; traceback: string[] };
-					error = c;
-					status = "error";
-				} else if (t === "status") {
-					const c = incoming.content as { execution_state: string };
-					if (c.execution_state === "idle") break;
-				}
+				this.handleExecutionMessage(incoming);
+			}
+		} catch (error) {
+			if ((this.state as string) !== "shutdown") {
+				console.error(`[kernel] iopub pump failed: ${errorMessage(error)}`);
+				this.rejectActiveExecution(new Error(`Kernel IOPub channel failed: ${errorMessage(error)}`));
 			}
 		} finally {
-			opts.signal?.removeEventListener("abort", onAbort);
+			if (this.iopub === iopub) {
+				this.iopubPumpPromise = undefined;
+			}
+		}
+	}
+
+	private handleExecutionMessage(incoming: JupyterMessage): void {
+		const execution = this.activeExecution;
+		if (!execution) {
+			return;
+		}
+		if ((incoming.parent_header as { msg_id?: string }).msg_id !== execution.requestMsgId) {
+			return;
 		}
 
-		if (stdoutTruncated) stdout += `\n[... output truncated at ${maxChars} chars ...]`;
-		if (stderrTruncated) stderr += `\n[... output truncated at ${maxChars} chars ...]`;
-		if (result !== undefined && result.length > maxChars) {
-			result = `${result.slice(0, maxChars)}\n[... output truncated at ${maxChars} chars ...]`;
+		const t = incoming.header.msg_type;
+		if (t === "stream") {
+			const c = incoming.content as { name: "stdout" | "stderr"; text: string };
+			if (c.name === "stdout") {
+				if (execution.stdout.length < execution.maxChars) {
+					execution.stdout += c.text;
+					if (execution.stdout.length > execution.maxChars) {
+						execution.stdout = execution.stdout.slice(0, execution.maxChars);
+						execution.stdoutTruncated = true;
+					}
+				}
+			} else if (c.name === "stderr") {
+				if (execution.stderr.length < execution.maxChars) {
+					execution.stderr += c.text;
+					if (execution.stderr.length > execution.maxChars) {
+						execution.stderr = execution.stderr.slice(0, execution.maxChars);
+						execution.stderrTruncated = true;
+					}
+				}
+			}
+			execution.opts.onStream?.(c.text, c.name);
+		} else if (t === "execute_result") {
+			const c = incoming.content as { data: Record<string, string> };
+			if (c.data["text/plain"]) execution.result = c.data["text/plain"];
+		} else if (t === "error") {
+			const c = incoming.content as { ename: string; evalue: string; traceback: string[] };
+			execution.error = c;
+			execution.status = "error";
+		} else if (t === "status") {
+			const c = incoming.content as { execution_state: string };
+			if (c.execution_state === "idle") {
+				this.finishActiveExecution(execution);
+			}
+		}
+	}
+
+	private finishActiveExecution(execution: ActiveExecution): void {
+		if (this.activeExecution !== execution) {
+			return;
+		}
+		this.activeExecution = undefined;
+
+		let stdout = execution.stdout;
+		let stderr = execution.stderr;
+		let result = execution.result;
+		let status = execution.status;
+		if (execution.stdoutTruncated) stdout += `\n[... output truncated at ${execution.maxChars} chars ...]`;
+		if (execution.stderrTruncated) stderr += `\n[... output truncated at ${execution.maxChars} chars ...]`;
+		if (result !== undefined && result.length > execution.maxChars) {
+			result = `${result.slice(0, execution.maxChars)}\n[... output truncated at ${execution.maxChars} chars ...]`;
 		}
 
-		if (opts.signal?.aborted) status = "aborted";
+		if (execution.opts.signal?.aborted) status = "aborted";
 
-		return { stdout, stderr, result, error, status, durationMs: Date.now() - started };
+		execution.resolve({
+			stdout,
+			stderr,
+			result,
+			error: execution.error,
+			status,
+			durationMs: Date.now() - execution.started,
+		});
+	}
+
+	private rejectActiveExecution(error: Error): void {
+		const execution = this.activeExecution;
+		if (!execution) {
+			return;
+		}
+		this.activeExecution = undefined;
+		execution.reject(error);
 	}
 
 	private handleCommMessage(incoming: JupyterMessage): void {
@@ -670,40 +737,6 @@ export class KernelManager {
 			return handler({ prompt: data.prompt, kwargs });
 		}
 
-		if (data.type === "background") {
-			const handler = this.options.rlmBackgroundRunHandler;
-			if (!handler) {
-				throw new Error("rlm.background is not available in this session");
-			}
-			if (typeof data.prompt !== "string") {
-				throw new Error("rlm.background prompt must be a string");
-			}
-			const kwargs = isRecord(data.kwargs) ? data.kwargs : {};
-			return handler({ prompt: data.prompt, kwargs });
-		}
-
-		if (data.type === "background_status") {
-			const handler = this.options.rlmBackgroundStatusHandler;
-			if (!handler) {
-				throw new Error("rlm.background status is not available in this session");
-			}
-			if (typeof data.id !== "string") {
-				throw new Error("rlm.background status id must be a string");
-			}
-			return handler({ id: data.id });
-		}
-
-		if (data.type === "background_wait") {
-			const handler = this.options.rlmBackgroundWaitHandler;
-			if (!handler) {
-				throw new Error("rlm.background wait is not available in this session");
-			}
-			if (typeof data.id !== "string") {
-				throw new Error("rlm.background wait id must be a string");
-			}
-			return handler({ id: data.id, timeoutMs: parseOptionalTimeoutMs(data.timeout_ms) });
-		}
-
 		throw new Error("rlm.run comm payload must have a supported type");
 	}
 
@@ -723,12 +756,14 @@ export class KernelManager {
 	}
 
 	private cleanupResources(): void {
+		this.rejectActiveExecution(new Error("Kernel has been shut down"));
 		this.shell?.close();
 		this.iopub?.close();
 		this.control?.close();
 		this.shell = undefined;
 		this.iopub = undefined;
 		this.control = undefined;
+		this.iopubPumpPromise = undefined;
 		try {
 			this.kernel?.kill("SIGTERM");
 		} catch {}

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -45,7 +45,6 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
 			"For long-running sub-agents that should not block your own Python work, create normal asyncio tasks such as `task = asyncio.create_task(rlm('sub-task'))`, continue locally, then use `task.done()` or `result = await task` when you need the result.",
-			"Do not use a special background RLM API. `await rlm(...)` is the ground-truth result path; background behavior is ordinary Python task scheduling.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -44,8 +44,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
-			"For long-running sub-agents that should keep the conversation responsive, start and store asyncio tasks, then return from the IPython call immediately, e.g. `tasks = globals().setdefault('rlm_tasks', {}); tasks['name'] = asyncio.create_task(rlm('sub-task'))`.",
-			"Use a later IPython call to check `tasks['name'].done()` or collect results with `result = await tasks['name']` when you need the `RLMResult`.",
+			"For long-running sub-agents that should keep the conversation responsive, create or reuse a simple named task dictionary such as `rlm_tasks`, save tasks with `rlm_tasks['name'] = asyncio.create_task(rlm('sub-task'))`, print a short started status, and return from the IPython call immediately.",
+			"Use a later IPython call to check `rlm_tasks['name'].done()` or collect results with `result = await rlm_tasks['name']` when you need the `RLMResult`.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -44,7 +44,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
-			"For long-running sub-agents that should not block your own Python work, create normal asyncio tasks such as `task = asyncio.create_task(rlm('sub-task'))`, continue locally, then use `task.done()` or `result = await task` when you need the result.",
+			"For long-running sub-agents that should keep the conversation responsive, start and store asyncio tasks, then return from the IPython call immediately, e.g. `tasks = globals().setdefault('rlm_tasks', {}); tasks['name'] = asyncio.create_task(rlm('sub-task'))`.",
+			"Use a later IPython call to check `tasks['name'].done()` or collect results with `result = await tasks['name']` when you need the `RLMResult`.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -44,8 +44,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
-			"For long-running sub-agents that should keep the conversation responsive, create or reuse a simple named task dictionary such as `rlm_tasks`, save tasks with `rlm_tasks['name'] = asyncio.create_task(rlm('sub-task'))`, print a short started status, and return from the IPython call immediately.",
-			"Use a later IPython call to check `rlm_tasks['name'].done()` or collect results with `result = await rlm_tasks['name']` when you need the `RLMResult`.",
+			"For sub-agent work that can run in the background, use normal asyncio tasks such as `asyncio.create_task(rlm('sub-task'))` so you do not block the main execution path; check or await the task later when you need the result.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -44,7 +44,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
-			"For sub-agent work that can run in the background, use normal asyncio tasks such as `asyncio.create_task(rlm('sub-task'))` so you do not block the main execution path; check or await the task later when you need the result.",
+			"For sub-agent work that can run in the background, keep the task handle from `asyncio.create_task(rlm('sub-task'))` so you do not block the main execution path; use normal task callbacks, `task.done()`, or `await task` later to observe completion and read the returned `RLMResult.answer`.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -44,8 +44,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
 			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
-			"For long-running sub-agents that should not block your own work, use `handle = await rlm.background('sub-task')`. The returned handle has `.id`, `.session_dir`, `await handle.status()`, `await handle.wait(timeout=30)`, and `await handle.result(timeout=30)`. By default, completion notices are kept passive and become context on a later turn.",
-			"Use `await rlm.background('sub-task', notify='wake')` only when the user explicitly asked to be told as soon as background work finishes. Wake notifications are batched, hidden from the user, and may start a later assistant turn so you can send a concise update. Use `notify='silent'` when you only want to poll the handle yourself.",
+			"For long-running sub-agents that should not block your own Python work, create normal asyncio tasks such as `task = asyncio.create_task(rlm('sub-task'))`, continue locally, then use `task.done()` or `result = await task` when you need the result.",
+			"Do not use a special background RLM API. `await rlm(...)` is the ground-truth result path; background behavior is ordinary Python task scheduling.",
 		);
 	}
 

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -15,39 +15,4 @@ export interface RlmRunResult {
 	session_dir: string | null;
 }
 
-export type RlmBackgroundRunState = "queued" | "running" | "done" | "error" | "cancelled";
-
-export interface RlmBackgroundRunRequest {
-	prompt: string;
-	kwargs: Record<string, unknown>;
-}
-
-export interface RlmBackgroundRunStartResult {
-	id: string;
-	state: RlmBackgroundRunState;
-	session_dir: string | null;
-}
-
-export interface RlmBackgroundRunStatusResult extends RlmBackgroundRunStartResult {
-	result?: RlmRunResult;
-	error?: string;
-	timed_out?: boolean;
-}
-
-export interface RlmBackgroundRunStatusRequest {
-	id: string;
-}
-
-export interface RlmBackgroundRunWaitRequest {
-	id: string;
-	timeoutMs?: number;
-}
-
 export type RlmRunHandler = (request: RlmRunRequest) => Promise<RlmRunResult>;
-export type RlmBackgroundRunHandler = (request: RlmBackgroundRunRequest) => Promise<RlmBackgroundRunStartResult>;
-export type RlmBackgroundRunStatusHandler = (
-	request: RlmBackgroundRunStatusRequest,
-) => Promise<RlmBackgroundRunStatusResult>;
-export type RlmBackgroundRunWaitHandler = (
-	request: RlmBackgroundRunWaitRequest,
-) => Promise<RlmBackgroundRunStatusResult>;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -3,15 +3,16 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import { KernelManager } from "../kernel/index.js";
-import type {
-	RlmBackgroundRunHandler,
-	RlmBackgroundRunStatusHandler,
-	RlmBackgroundRunWaitHandler,
-	RlmRunHandler,
-} from "../rlm-runtime.js";
+import type { RlmRunHandler } from "../rlm-runtime.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const RLM_BOOTSTRAP_CODE = `
+try:
+    import nest_asyncio as _prime_agent_nest_asyncio
+    _prime_agent_nest_asyncio.apply()
+except Exception:
+    pass
+
 try:
     import rlm as _prime_agent_rlm_module
     rlm = _prime_agent_rlm_module.rlm
@@ -20,14 +21,6 @@ except Exception as _prime_agent_rlm_error:
 
     class _PrimeAgentMissingRlm:
         async def run(self, prompt, **kwargs):
-            raise RuntimeError(
-                "prime-agent-runtime is not installed in this IPython kernel. "
-                "Remove ~/.prime/agent/kernel-venv so prime-agent can rebuild it, or set "
-                "PRIME_AGENT_KERNEL_PYTHON to a kernel environment with prime-agent-runtime installed. "
-                f"Import error: {_PRIME_AGENT_RLM_IMPORT_ERROR}"
-            )
-
-        async def background(self, prompt, **kwargs):
             raise RuntimeError(
                 "prime-agent-runtime is not installed in this IPython kernel. "
                 "Remove ~/.prime/agent/kernel-venv so prime-agent can rebuild it, or set "
@@ -63,9 +56,6 @@ export interface IpythonToolOptions {
 	env?: Record<string, string>;
 	sessionId?: string;
 	rlmRunHandler?: RlmRunHandler;
-	rlmBackgroundRunHandler?: RlmBackgroundRunHandler;
-	rlmBackgroundStatusHandler?: RlmBackgroundRunStatusHandler;
-	rlmBackgroundWaitHandler?: RlmBackgroundRunWaitHandler;
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
 }
@@ -91,9 +81,6 @@ export function createIpythonToolDefinition(
 					env: options?.env,
 					sessionId: options?.sessionId,
 					rlmRunHandler: options?.rlmRunHandler,
-					rlmBackgroundRunHandler: options?.rlmBackgroundRunHandler,
-					rlmBackgroundStatusHandler: options?.rlmBackgroundStatusHandler,
-					rlmBackgroundWaitHandler: options?.rlmBackgroundWaitHandler,
 				});
 				await m.start();
 				const bootstrap = await m.execute(RLM_BOOTSTRAP_CODE);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -102,6 +102,28 @@ interface KernelPumpTestApi {
 	startIopubPump(): void;
 }
 
+interface KernelExecuteTestApi {
+	start: () => Promise<void>;
+	state: "idle" | "starting" | "running" | "shutdown";
+	activeExecution?: unknown;
+	shell?: {
+		send(frames: Buffer[]): Promise<void>;
+		close(): void;
+	};
+	connection?: {
+		ip: string;
+		transport: "tcp";
+		shell_port: number;
+		iopub_port: number;
+		stdin_port: number;
+		control_port: number;
+		hb_port: number;
+		signature_scheme: "hmac-sha256";
+		key: string;
+		kernel_name: string;
+	};
+}
+
 function rlmCommOpenData(commId: string, data: Record<string, unknown>): TestCommMessage {
 	return {
 		header: { msg_type: "comm_open" },
@@ -494,6 +516,39 @@ print(_result.answer)
 
 			expect(finished.status).toBe("ok");
 			expect(finished.stdout.trim()).toBe("answer:detached child after idle");
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("clears active execution when execute_request send fails", async () => {
+		const manager = new KernelManager({ python: process.execPath });
+		const kernel = manager as unknown as KernelExecuteTestApi;
+		const sendError = new Error("send failed");
+		kernel.start = async () => {};
+		kernel.state = "running";
+		kernel.shell = {
+			send: async (_frames: Buffer[]) => {
+				throw sendError;
+			},
+			close: () => {},
+		};
+		kernel.connection = {
+			ip: "127.0.0.1",
+			transport: "tcp",
+			shell_port: 1,
+			iopub_port: 2,
+			stdin_port: 3,
+			control_port: 4,
+			hb_port: 5,
+			signature_scheme: "hmac-sha256",
+			key: "",
+			kernel_name: "python3",
+		};
+
+		try {
+			await expect(manager.execute("print('hello')")).rejects.toThrow("send failed");
+			expect(kernel.activeExecution).toBeUndefined();
 		} finally {
 			await manager.dispose();
 		}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -455,6 +455,50 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
+	it("handles rlm calls from asyncio tasks after the scheduling cell is idle", async () => {
+		const prompts: string[] = [];
+		const manager = new KernelManager({
+			cwd: tempDir,
+			rlmRunHandler: async ({ prompt }) => {
+				prompts.push(prompt);
+				return {
+					answer: `answer:${prompt}`,
+					usage: { prompt_tokens: 1, completion_tokens: 1 },
+					turns: 1,
+					session_dir: null,
+				};
+			},
+		});
+
+		try {
+			const scheduled = await manager.execute(`
+import asyncio
+import rlm
+
+async def _delayed_rlm():
+    await asyncio.sleep(0.05)
+    return await rlm.run("detached child after idle")
+
+_task = asyncio.create_task(_delayed_rlm())
+print("scheduled")
+`);
+
+			expect(scheduled.status).toBe("ok");
+			expect(scheduled.stdout.trim()).toBe("scheduled");
+			await waitFor(() => prompts.includes("detached child after idle"));
+
+			const finished = await manager.execute(`
+_result = await _task
+print(_result.answer)
+`);
+
+			expect(finished.status).toBe("ok");
+			expect(finished.stdout.trim()).toBe("answer:detached child after idle");
+		} finally {
+			await manager.dispose();
+		}
+	});
+
 	it("rejects removed background rlm comm request types", async () => {
 		const replies: CapturedCommReply[] = [];
 		const manager = new KernelManager({

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -87,33 +87,19 @@ interface CapturedCommReply {
 	data: Record<string, unknown>;
 }
 
-interface InspectableBackgroundRun {
+interface InspectableRlmRun {
 	abort: () => void;
-}
-
-interface InspectableBackgroundSession {
-	_backgroundRlmRuns: Map<string, InspectableBackgroundRun>;
-}
-
-interface InspectableBackgroundCompletionRun {
-	id: string;
-	prompt: string;
-	status: "done";
-	sessionDir: string | null;
-	result: {
-		answer: string;
-		usage: { prompt_tokens: number; completion_tokens: number };
-		turns: number;
-		session_dir: string | null;
-	};
-	completionPolicy: "passive" | "wake" | "silent";
+	status: string;
 	error?: string;
 }
 
-interface InspectableBackgroundCompletionSession {
-	_queueBackgroundRlmChildCompletion(run: InspectableBackgroundCompletionRun): void;
-	_pendingBackgroundRlmCompletions: InspectableBackgroundCompletionRun[];
-	_backgroundRlmCompletionTimer?: ReturnType<typeof globalThis.setTimeout>;
+interface InspectableRlmSession {
+	_activeRlmChildRuns: Map<string, InspectableRlmRun>;
+}
+
+interface KernelPumpTestApi {
+	iopub: AsyncIterable<Buffer[]> & { close(): void };
+	startIopubPump(): void;
 }
 
 function rlmCommOpenData(commId: string, data: Record<string, unknown>): TestCommMessage {
@@ -131,6 +117,29 @@ function rlmCommOpenData(commId: string, data: Record<string, unknown>): TestCom
 
 function rlmCommOpen(commId: string, prompt: string, kwargs: Record<string, unknown> = {}): TestCommMessage {
 	return rlmCommOpenData(commId, { type: "run", prompt, kwargs });
+}
+
+function encodeTestMessage(message: TestCommMessage): Buffer[] {
+	return [
+		Buffer.from("<IDS|MSG>"),
+		Buffer.from(""),
+		Buffer.from(JSON.stringify(message.header)),
+		Buffer.from(JSON.stringify(message.parent_header)),
+		Buffer.from(JSON.stringify(message.metadata)),
+		Buffer.from(JSON.stringify(message.content)),
+	];
+}
+
+function asyncFrames(frames: Buffer[][]): AsyncIterable<Buffer[]> & { close(): void } {
+	return {
+		close: () => {},
+		async *[Symbol.asyncIterator]() {
+			for (const frame of frames) {
+				await sleep(0);
+				yield frame;
+			}
+		},
+	};
 }
 
 async function waitFor(condition: () => boolean): Promise<void> {
@@ -308,13 +317,12 @@ describe("AgentSession rlm recursion", () => {
 		);
 	});
 
-	it("starts a background child without blocking and records a passive hidden completion notice", async () => {
+	it("cancels active rlm children when the parent session is disposed", async () => {
 		let releaseChild: () => void = () => {};
 		const release = new Promise<void>((resolve) => {
 			releaseChild = resolve;
 		});
 		let childStarted = false;
-		const parentInputs: string[] = [];
 		const root = createSession({
 			streamFn: (_model, context) => {
 				const text = userText(context);
@@ -324,214 +332,23 @@ describe("AgentSession rlm recursion", () => {
 					void release.then(() => {
 						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
 					});
-				} else {
-					parentInputs.push(text);
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`parent saw: ${text}`) });
-					});
 				}
 				return stream;
 			},
 		});
 
-		const start = root.startBackgroundRlmChild("slow shard");
-		const run = (root as unknown as InspectableBackgroundSession)._backgroundRlmRuns.get(start.id);
-		const activeAbort = run?.abort;
-
-		expect(start.state).toBe("running");
-		expect(start.id).toMatch(/^sub-/);
+		const runPromise = root.runRlmChild("slow shard");
 		await waitFor(() => childStarted);
-		expect(root.getBackgroundRlmChildStatus(start.id)).toMatchObject({
-			id: start.id,
-			state: "running",
-			session_dir: start.session_dir,
-		});
-
-		releaseChild();
-		const finished = await root.waitForBackgroundRlmChild(start.id, 1000);
-
-		expect(finished.state).toBe("done");
-		expect(finished.result?.answer).toBe("child answer: slow shard");
-		await waitFor(() => {
-			const notice = root.messages.find(
-				(message) => message.role === "custom" && message.customType === "rlm_background_result",
-			);
-			return notice?.role === "custom" && notice.display === false;
-		});
-		const notice = root.messages.find(
-			(message) => message.role === "custom" && message.customType === "rlm_background_result",
-		);
-		expect(notice?.role).toBe("custom");
-		if (notice?.role !== "custom") {
-			throw new Error("background completion notice was not recorded");
-		}
-		expect(notice.display).toBe(false);
-		expect(notice.content).toContain("1 background RLM child has finished.");
-		expect(notice.content).toContain("Answer preview: child answer: slow shard");
-		expect(run?.abort).not.toBe(activeAbort);
-		await sleep(350);
-		expect(parentInputs).toEqual([]);
-	});
-
-	it("wakes the parent when a background child is started with notify wake", async () => {
-		let releaseChild: () => void = () => {};
-		const release = new Promise<void>((resolve) => {
-			releaseChild = resolve;
-		});
-		let childStarted = false;
-		const parentInputs: string[] = [];
-		const root = createSession({
-			streamFn: (_model, context) => {
-				const text = userText(context);
-				const stream = createAssistantMessageEventStream();
-				if (text === "slow shard") {
-					childStarted = true;
-					void release.then(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
-					});
-				} else {
-					parentInputs.push(text);
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`parent saw: ${text}`) });
-					});
-				}
-				return stream;
-			},
-		});
-
-		const start = root.startBackgroundRlmChild("slow shard", { notify: "wake" });
-
-		await waitFor(() => childStarted);
-		releaseChild();
-		const finished = await root.waitForBackgroundRlmChild(start.id, 1000);
-
-		expect(finished.state).toBe("done");
-		await waitFor(() => parentInputs.length === 1);
-		expect(parentInputs[0]).toContain("Background RLM completion notice");
-		expect(parentInputs[0]).toContain("1 background RLM child has finished.");
-		expect(parentInputs[0]).toContain("Answer preview: child answer: slow shard");
-		expect(root.getLastAssistantText()).toContain("parent saw: Background RLM completion notice");
-	});
-
-	it("delivers background completion follow-ups while the parent is still running", async () => {
-		let releaseParent: () => void = () => {};
-		const parentRelease = new Promise<void>((resolve) => {
-			releaseParent = resolve;
-		});
-		let parentStarted = false;
-		const parentInputs: string[] = [];
-		const root = createSession({
-			streamFn: (_model, context) => {
-				const text = userText(context);
-				const stream = createAssistantMessageEventStream();
-				if (text === "parent turn") {
-					parentStarted = true;
-					void parentRelease.then(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage("parent done") });
-					});
-				} else if (text === "slow shard") {
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
-					});
-				} else {
-					parentInputs.push(text);
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`parent saw: ${text}`) });
-					});
-				}
-				return stream;
-			},
-		});
-
-		const parentRun = root.prompt("parent turn");
-		await waitFor(() => parentStarted && root.isStreaming);
-		const start = root.startBackgroundRlmChild("slow shard", { notify: "wake" });
-		const finished = await root.waitForBackgroundRlmChild(start.id, 1000);
-
-		expect(finished.state).toBe("done");
-		await sleep(350);
-		expect(parentInputs).toEqual([]);
-
-		releaseParent();
-		await parentRun;
-
-		expect(parentInputs).toHaveLength(1);
-		expect(parentInputs[0]).toContain("Background RLM completion notice");
-		expect(parentInputs[0]).toContain("Answer preview: child answer: slow shard");
-	});
-
-	it("does not drain queued background completion follow-ups after dispose", async () => {
-		let releaseParent: () => void = () => {};
-		const parentRelease = new Promise<void>((resolve) => {
-			releaseParent = resolve;
-		});
-		let parentStarted = false;
-		const parentInputs: string[] = [];
-		const root = createSession({
-			streamFn: (_model, context) => {
-				const text = userText(context);
-				const stream = createAssistantMessageEventStream();
-				if (text === "parent turn") {
-					parentStarted = true;
-					void parentRelease.then(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage("parent done") });
-					});
-				} else if (text === "slow shard") {
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
-					});
-				} else {
-					parentInputs.push(text);
-					queueMicrotask(() => {
-						stream.push({ type: "done", reason: "stop", message: assistantMessage(`parent saw: ${text}`) });
-					});
-				}
-				return stream;
-			},
-		});
-
-		const parentRun = root.prompt("parent turn");
-		await waitFor(() => parentStarted && root.isStreaming);
-		const start = root.startBackgroundRlmChild("slow shard", { notify: "wake" });
-		await expect(root.waitForBackgroundRlmChild(start.id, 1000)).resolves.toMatchObject({ state: "done" });
-		await sleep(350);
+		const runs = (root as unknown as InspectableRlmSession)._activeRlmChildRuns;
+		expect(runs.size).toBe(1);
+		const run = [...runs.values()][0];
 
 		root.dispose();
-		releaseParent();
-		await parentRun;
-		await sleep(50);
 
-		expect(parentInputs).toEqual([]);
-	});
-
-	it("ignores background completion callbacks that arrive after dispose", async () => {
-		const root = createSession();
-		root.dispose();
-
-		const inspectable = root as unknown as InspectableBackgroundCompletionSession;
-		const entriesBefore = root.sessionManager.getEntries().length;
-		inspectable._queueBackgroundRlmChildCompletion({
-			id: "sub-after-dispose",
-			prompt: "finished shard",
-			status: "done",
-			sessionDir: null,
-			result: {
-				answer: "finished answer",
-				usage: { prompt_tokens: 1, completion_tokens: 1 },
-				turns: 1,
-				session_dir: null,
-			},
-			completionPolicy: "passive",
-		});
-
-		await sleep(350);
-
-		expect(inspectable._pendingBackgroundRlmCompletions).toEqual([]);
-		expect(inspectable._backgroundRlmCompletionTimer).toBeUndefined();
-		expect(root.sessionManager.getEntries()).toHaveLength(entriesBefore);
-		expect(
-			root.messages.some((message) => message.role === "custom" && message.customType === "rlm_background_result"),
-		).toBe(false);
+		expect(run.status).toBe("cancelled");
+		expect(run.error).toBe("Parent session disposed");
+		releaseChild();
+		await expect(runPromise).rejects.toThrow();
 	});
 
 	it("runs parallel rlm comm requests independently", async () => {
@@ -595,25 +412,58 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
-	it("handles background rlm comm requests", async () => {
+	it("handles rlm comm requests from the iopub pump outside active execution", async () => {
+		const replies: CapturedCommReply[] = [];
+		let promptSeen = "";
+		const manager = new KernelManager({
+			python: process.execPath,
+			rlmRunHandler: async ({ prompt }) => {
+				promptSeen = prompt;
+				return {
+					answer: `answer:${prompt}`,
+					usage: { prompt_tokens: 1, completion_tokens: 1 },
+					turns: 1,
+					session_dir: null,
+				};
+			},
+		});
+
+		try {
+			const kernel = manager as unknown as KernelCommTestApi & KernelPumpTestApi;
+			kernel.sendCommMessage = async (commId, data) => {
+				replies.push({ commId, data });
+			};
+			kernel.iopub = asyncFrames([encodeTestMessage(rlmCommOpen("comm-detached", "detached child"))]);
+
+			kernel.startIopubPump();
+
+			await waitFor(() => replies.length === 1);
+
+			expect(promptSeen).toBe("detached child");
+			expect(replies[0]).toEqual({
+				commId: "comm-detached",
+				data: {
+					status: "ok",
+					answer: "answer:detached child",
+					usage: { prompt_tokens: 1, completion_tokens: 1 },
+					turns: 1,
+					session_dir: null,
+				},
+			});
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("rejects removed background rlm comm request types", async () => {
 		const replies: CapturedCommReply[] = [];
 		const manager = new KernelManager({
 			python: process.execPath,
-			rlmBackgroundRunHandler: async ({ prompt }) => ({
-				id: "bg-1",
-				state: "running",
-				session_dir: `/tmp/${prompt}`,
-			}),
-			rlmBackgroundStatusHandler: async ({ id }) => ({
-				id,
-				state: "running",
-				session_dir: "/tmp/slow",
-			}),
-			rlmBackgroundWaitHandler: async ({ id, timeoutMs }) => ({
-				id,
-				state: "running",
-				session_dir: "/tmp/slow",
-				timed_out: timeoutMs === 25,
+			rlmRunHandler: async () => ({
+				answer: "unused",
+				usage: { prompt_tokens: 1, completion_tokens: 1 },
+				turns: 1,
+				session_dir: null,
 			}),
 		});
 
@@ -624,32 +474,15 @@ describe("AgentSession rlm recursion", () => {
 			};
 
 			kernel.handleCommMessage(rlmCommOpenData("comm-bg", { type: "background", prompt: "slow", kwargs: {} }));
-			kernel.handleCommMessage(rlmCommOpenData("comm-status", { type: "background_status", id: "bg-1" }));
-			kernel.handleCommMessage(
-				rlmCommOpenData("comm-wait", { type: "background_wait", id: "bg-1", timeout_ms: 25 }),
-			);
 
-			await waitFor(() => replies.length === 3);
+			await waitFor(() => replies.length === 1);
 
-			const byCommId = new Map(replies.map((reply) => [reply.commId, reply.data]));
-			expect(byCommId.get("comm-bg")).toEqual({
-				status: "ok",
-				id: "bg-1",
-				state: "running",
-				session_dir: "/tmp/slow",
-			});
-			expect(byCommId.get("comm-status")).toEqual({
-				status: "ok",
-				id: "bg-1",
-				state: "running",
-				session_dir: "/tmp/slow",
-			});
-			expect(byCommId.get("comm-wait")).toEqual({
-				status: "ok",
-				id: "bg-1",
-				state: "running",
-				session_dir: "/tmp/slow",
-				timed_out: true,
+			expect(replies[0]).toEqual({
+				commId: "comm-bg",
+				data: {
+					status: "error",
+					error: "rlm.run comm payload must have a supported type",
+				},
 			});
 		} finally {
 			await manager.dispose();

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -6,6 +6,8 @@ import { ensureKernelPython, getKernelVenvDir } from "../src/core/kernel/bootstr
 
 let tempDir = "";
 let originalEnv: NodeJS.ProcessEnv;
+const RLM_RUNTIME_CHECK =
+	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
 
 function writeExecutable(filePath: string, content: string): void {
 	writeFileSync(filePath, content);
@@ -15,14 +17,13 @@ function writeExecutable(filePath: string, content: string): void {
 function writeBootstrapVersion(venv: string): void {
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
-		`${JSON.stringify({ schema: 1, ipykernel: "ipykernel", runtime: "prime-agent-runtime" })}\n`,
+		`${JSON.stringify({ schema: 2, ipykernel: "ipykernel", runtime: "prime-agent-runtime" })}\n`,
 	);
 }
 
 function writeFakePython(filePath: string, importableModules: readonly string[]): void {
-	const rlmRuntimeCheck = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
 	const cases = importableModules.map((moduleName) => `    "import ${moduleName}") exit 0 ;;`).join("\n");
-	const runtimeCase = importableModules.includes("rlm") ? `    "${rlmRuntimeCheck}") exit 0 ;;` : "";
+	const runtimeCase = importableModules.includes("rlm") ? `    "${RLM_RUNTIME_CHECK}") exit 0 ;;` : "";
 	writeExecutable(
 		filePath,
 		[
@@ -46,7 +47,6 @@ function installFakeUv(): string {
 	const logPath = join(tempDir, "uv.log");
 	process.env.UV_LOG = logPath;
 	process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
-	const rlmRuntimeCheck = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
 	writeExecutable(
 		join(binDir, "uv"),
 		[
@@ -64,7 +64,7 @@ function installFakeUv(): string {
 			'if [ "$1" = "-c" ]; then',
 			'  case "$2" in',
 			'    "import ipykernel"|"import rlm") exit 0 ;;',
-			`    "${rlmRuntimeCheck}") exit 0 ;;`,
+			`    "${RLM_RUNTIME_CHECK}") exit 0 ;;`,
 			"    *) exit 1 ;;",
 			"  esac",
 			"fi",
@@ -122,7 +122,7 @@ describe("kernel bootstrap", () => {
 		expect(log).toContain("pip install --python");
 		expect(log).toContain("ipykernel");
 		expect(log).toContain("prime-agent-runtime");
-		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toContain('"schema":1');
+		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toContain('"schema":2');
 	});
 
 	it("shares concurrent bootstrap work in one process", async () => {
@@ -200,7 +200,7 @@ describe("kernel bootstrap", () => {
 		writeFakePython(overridePython, ["ipykernel"]);
 		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
 
-		await expect(ensureKernelPython()).rejects.toThrow(/current prime-agent-runtime with rlm\.background/);
+		await expect(ensureKernelPython()).rejects.toThrow(/current prime-agent-runtime with callable rlm\.run/);
 	});
 
 	it("fails an invalid PRIME_AGENT_KERNEL_PYTHON without bootstrapping", async () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -76,9 +76,11 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("Conversation log: /repo/.pi/sessions/session.jsonl");
 		expect(prompt).toContain("await rlm('sub-task')");
 		expect(prompt).toContain("asyncio.gather");
-		expect(prompt).toContain("await rlm.background('sub-task')");
-		expect(prompt).toContain("notify='wake'");
-		expect(prompt).toContain("notify='silent'");
+		expect(prompt).toContain("asyncio.create_task");
+		expect(prompt).toContain("await task");
+		expect(prompt).not.toContain("rlm.background");
+		expect(prompt).not.toContain("notify='wake'");
+		expect(prompt).not.toContain("notify='silent'");
 		expect(prompt).toContain("Use `ipython` for both Python and shell work");
 		expect(prompt).toContain("prefer IPython shell syntax");
 		expect(prompt).toContain("Do not wrap ordinary shell commands in Python subprocesses");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -79,7 +79,11 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("asyncio.create_task");
 		expect(prompt).toContain("sub-agent work that can run in the background");
 		expect(prompt).toContain("do not block the main execution path");
-		expect(prompt).toContain("check or await the task later");
+		expect(prompt).toContain("keep the task handle");
+		expect(prompt).toContain("normal task callbacks");
+		expect(prompt).toContain("task.done()");
+		expect(prompt).toContain("await task");
+		expect(prompt).toContain("RLMResult.answer");
 		expect(prompt).not.toContain("simple named task dictionary");
 		expect(prompt).not.toContain("rlm_tasks");
 		expect(prompt).not.toContain("globals().setdefault");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -77,11 +77,11 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("await rlm('sub-task')");
 		expect(prompt).toContain("asyncio.gather");
 		expect(prompt).toContain("asyncio.create_task");
-		expect(prompt).toContain("return from the IPython call immediately");
-		expect(prompt).toContain("simple named task dictionary");
-		expect(prompt).toContain("rlm_tasks['name'] = asyncio.create_task");
-		expect(prompt).toContain("Use a later IPython call");
-		expect(prompt).toContain("await rlm_tasks['name']");
+		expect(prompt).toContain("sub-agent work that can run in the background");
+		expect(prompt).toContain("do not block the main execution path");
+		expect(prompt).toContain("check or await the task later");
+		expect(prompt).not.toContain("simple named task dictionary");
+		expect(prompt).not.toContain("rlm_tasks");
 		expect(prompt).not.toContain("globals().setdefault");
 		expect(prompt).not.toContain("rlm.background");
 		expect(prompt).not.toContain("notify='wake'");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -77,7 +77,10 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("await rlm('sub-task')");
 		expect(prompt).toContain("asyncio.gather");
 		expect(prompt).toContain("asyncio.create_task");
-		expect(prompt).toContain("await task");
+		expect(prompt).toContain("return from the IPython call immediately");
+		expect(prompt).toContain("globals().setdefault('rlm_tasks', {})");
+		expect(prompt).toContain("Use a later IPython call");
+		expect(prompt).toContain("await tasks['name']");
 		expect(prompt).not.toContain("rlm.background");
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -78,9 +78,11 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("asyncio.gather");
 		expect(prompt).toContain("asyncio.create_task");
 		expect(prompt).toContain("return from the IPython call immediately");
-		expect(prompt).toContain("globals().setdefault('rlm_tasks', {})");
+		expect(prompt).toContain("simple named task dictionary");
+		expect(prompt).toContain("rlm_tasks['name'] = asyncio.create_task");
 		expect(prompt).toContain("Use a later IPython call");
-		expect(prompt).toContain("await tasks['name']");
+		expect(prompt).toContain("await rlm_tasks['name']");
+		expect(prompt).not.toContain("globals().setdefault");
 		expect(prompt).not.toContain("rlm.background");
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");

--- a/prime-agent-runtime/pyproject.toml
+++ b/prime-agent-runtime/pyproject.toml
@@ -5,6 +5,7 @@ description = "Kernel-side runtime shim for Prime Agent recursion"
 requires-python = ">=3.10"
 dependencies = [
   "ipykernel",
+  "nest-asyncio",
 ]
 
 [build-system]

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -39,38 +39,6 @@ class RLMResult:
     turns: int = 0
 
 
-@dataclass
-class RLMBackgroundStatus:
-    id: str
-    state: str
-    session_dir: Path | None = None
-    result: RLMResult | None = None
-    error: str | None = None
-    timed_out: bool = False
-
-
-@dataclass
-class RLMBackgroundHandle:
-    id: str
-    session_dir: Path | None = None
-
-    async def status(self) -> RLMBackgroundStatus:
-        return await background_status(self.id)
-
-    async def wait(self, timeout: float | None = None) -> RLMBackgroundStatus:
-        return await background_wait(self.id, timeout=timeout)
-
-    async def result(self, timeout: float | None = None) -> RLMResult:
-        status = await self.wait(timeout=timeout)
-        if status.result is not None:
-            return status.result
-        if status.timed_out:
-            raise TimeoutError(f"background rlm child {self.id!r} is still running")
-        if status.error:
-            raise RuntimeError(status.error)
-        raise RuntimeError(f"background rlm child {self.id!r} has no result")
-
-
 def _env_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -124,22 +92,6 @@ def _result_from_payload(payload: dict[str, Any]) -> RLMResult:
     )
 
 
-def _status_from_payload(payload: dict[str, Any]) -> RLMBackgroundStatus:
-    session_dir_payload = payload.get("session_dir")
-    session_dir = Path(session_dir_payload) if isinstance(session_dir_payload, str) else None
-    result_payload = payload.get("result")
-    result = _result_from_payload(result_payload) if isinstance(result_payload, dict) else None
-    error_payload = payload.get("error")
-    return RLMBackgroundStatus(
-        id=str(payload.get("id", "")),
-        state=str(payload.get("state", "")),
-        session_dir=session_dir,
-        result=result,
-        error=str(error_payload) if error_payload is not None else None,
-        timed_out=bool(payload.get("timed_out", False)),
-    )
-
-
 async def _host_request(data: dict[str, Any]) -> dict[str, Any]:
     if Comm is None:
         raise RuntimeError("Jupyter comm support is unavailable in this kernel")
@@ -187,49 +139,9 @@ async def run(prompt: str, **kwargs: Any) -> RLMResult:
     return _result_from_payload(payload)
 
 
-async def background(prompt: str, **kwargs: Any) -> RLMBackgroundHandle:
-    """Start a recursive Prime Agent child and return immediately with a handle.
-
-    notify controls parent notification behavior:
-    - "passive" (default): make the result available to a later parent turn.
-    - "wake": wake the parent agent so it can report the result.
-    - "silent": do not notify the parent agent; poll the returned handle.
-    """
-    if not isinstance(prompt, str):
-        raise TypeError(f"prompt must be str, got {type(prompt).__name__}")
-    _ensure_recursion_allowed()
-    payload = await _host_request({"type": "background", "prompt": prompt, "kwargs": kwargs})
-    session_dir_payload = payload.get("session_dir")
-    session_dir = Path(session_dir_payload) if isinstance(session_dir_payload, str) else None
-    child_id = payload.get("id")
-    if not isinstance(child_id, str) or not child_id:
-        raise RuntimeError("rlm.background response did not include a child id")
-    return RLMBackgroundHandle(id=child_id, session_dir=session_dir)
-
-
-async def background_status(child_id: str) -> RLMBackgroundStatus:
-    if not isinstance(child_id, str):
-        raise TypeError(f"child_id must be str, got {type(child_id).__name__}")
-    payload = await _host_request({"type": "background_status", "id": child_id})
-    return _status_from_payload(payload)
-
-
-async def background_wait(child_id: str, timeout: float | None = None) -> RLMBackgroundStatus:
-    if not isinstance(child_id, str):
-        raise TypeError(f"child_id must be str, got {type(child_id).__name__}")
-    if timeout is not None and timeout < 0:
-        raise ValueError("timeout must be non-negative")
-    timeout_ms = None if timeout is None else int(timeout * 1000)
-    payload = await _host_request({"type": "background_wait", "id": child_id, "timeout_ms": timeout_ms})
-    return _status_from_payload(payload)
-
-
 class _RLMCallable:
     async def run(self, prompt: str, **kwargs: Any) -> RLMResult:
         return await run(prompt, **kwargs)
-
-    async def background(self, prompt: str, **kwargs: Any) -> RLMBackgroundHandle:
-        return await background(prompt, **kwargs)
 
     async def __call__(self, prompt: str, **kwargs: Any) -> RLMResult:
         return await run(prompt, **kwargs)
@@ -246,13 +158,8 @@ class _CallableModule(types.ModuleType):
 sys.modules[__name__].__class__ = _CallableModule
 
 __all__ = [
-    "RLMBackgroundHandle",
-    "RLMBackgroundStatus",
     "RLMResult",
     "TokenUsage",
-    "background",
-    "background_status",
-    "background_wait",
     "rlm",
     "run",
 ]


### PR DESCRIPTION
- removes the separate background rlm api so recursive agents use callable rlm as the only result path.
- keeps subagent viewer updates by tracking active rlm children from the shared run path.
- adds a persistent iopub pump so python asyncio tasks can call rlm after a cell goes idle.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove RLM background API from kernel, runtime, and agent session
> - Removes `rlm.background()`, `rlm.background_status()`, and `rlm.background_wait()` from both the Python runtime ([`rlm/__init__.py`](https://github.com/PrimeIntellect-ai/prime-agent/pull/34/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3)) and TypeScript layers; only `rlm.run()` remains.
> - Replaces the per-execution IOPub read loop with a persistent IOPub pump in [`KernelManager`](https://github.com/PrimeIntellect-ai/prime-agent/pull/34/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac), so `rlm.run` comms from asyncio tasks are handled outside active executions.
> - Updates the system prompt to recommend `asyncio.gather` and tasks instead of background API calls.
> - Adds `nest-asyncio` as a runtime dependency and applies `nest_asyncio.apply()` in the IPython tool bootstrap to support nested event loops.
> - Risk: Any existing Python code calling `rlm.background*` functions or TypeScript code using background comm types will fail; `BOOTSTRAP_SCHEMA` bumps to 2, rejecting older runtimes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2c8093.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `rlm.background*` API across TS/Python, which is a breaking change for any callers, and refactors kernel IOPub handling to a persistent pump that could affect execution/comm message ordering.
> 
> **Overview**
> **Removes the RLM background API** end-to-end: deletes `rlm.background()`/`background_status()`/`background_wait()` from the Python runtime and TypeScript (`rlm-runtime` types, `KernelManager` comm handling, and `AgentSession` helpers), and updates prompts/docs/tests to use standard `asyncio` tasks for “background” work.
> 
> **Refactors kernel message handling** by introducing a persistent IOPub pump that continuously processes comm messages (including when no execution is active), while `execute()` now tracks a single `activeExecution` and completes when an idle status arrives; bootstrap/runtime checks and schema are bumped to require a runtime with callable `rlm.run` and no `background`, and the runtime adds `nest-asyncio` to support nested async patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c809331e15deb270070c0463ea0940e70a4ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->