### PR TITLE
add experimental prime python worker backend

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added automatic IPython kernel runtime bootstrap with uv-managed Python, `ipykernel`, and `prime-agent-runtime`.
+- Added experimental `PRIME_AGENT_PYTHON_BACKEND=prime-worker` support for running the `ipython` tool through an IPython stdio JSON-RPC worker instead of the Jupyter/ZMQ transport.
 - Added `/goal` for long-running objectives that continue after early no-tool stops until the model marks the goal complete.
 - Added `/usage` to show token, cost, and context usage on demand.
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -93,7 +93,7 @@ pi
 
 Then just talk to pi. By default, pi gives the model one tool: `ipython`. The model uses the persistent kernel to read files, run commands, edit code, and inspect data. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [pi packages](#pi-packages).
 
-The Python kernel runtime is set up automatically on first invocation. Set `PRIME_AGENT_KERNEL_PYTHON` to use an existing Python environment with `ipykernel`.
+The Python kernel runtime is set up automatically on first invocation. Set `PRIME_AGENT_KERNEL_PYTHON` to use an existing Python environment with `ipykernel`. The default Python backend is the Jupyter/ZMQ IPython kernel; `PRIME_AGENT_PYTHON_BACKEND=prime-worker` enables the experimental stdio worker backend that keeps IPython but removes the Jupyter/ZMQ transport path.
 
 **Platform notes:** [Windows](docs/windows.md) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
 
@@ -634,6 +634,7 @@ pi --thinking high "Solve this complex problem"
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |
 | `PI_TELEMETRY` | Override install/update telemetry. Use `1`/`true`/`yes` to enable or `0`/`false`/`no` to disable. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
+| `PRIME_AGENT_PYTHON_BACKEND` | Python execution backend: `jupyter-zmq` (default) or `prime-worker` (experimental) |
 | `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `ipykernel` instead of auto-bootstrapping `~/.prime/agent/kernel-venv` |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 

--- a/packages/coding-agent/docs/kernel-and-rlm-recursion.md
+++ b/packages/coding-agent/docs/kernel-and-rlm-recursion.md
@@ -4,7 +4,18 @@ This document explains the IPython kernel transport and the recursive `rlm` sub-
 
 The important design constraint is that the Python `rlm` package in the kernel is only a shim. It preserves the model-facing API from `rlm-harness`, but it does not run a child agent loop in Python. Child agents are run by the TypeScript host through the same `AgentSession` machinery as the parent.
 
+Prime Agent has two Python execution backends:
+
+```text
+PRIME_AGENT_PYTHON_BACKEND=jupyter-zmq  # default
+PRIME_AGENT_PYTHON_BACKEND=prime-worker # experimental
+```
+
+`jupyter-zmq` is the existing Jupyter protocol backend described below. `prime-worker` keeps IPython as the execution engine but replaces local TCP ports, Jupyter connection files, and Node `zeromq` sockets with a long-lived Python worker process over stdio JSON-RPC.
+
 ## High-Level Shape
+
+Default Jupyter/ZMQ backend:
 
 ```text
 AgentSession (TypeScript)
@@ -18,6 +29,24 @@ KernelManager (TypeScript)
 IPython kernel process (Python)
   |
   | has prime-agent-runtime installed as module "rlm"
+  v
+model-executed Python code
+```
+
+Experimental Prime worker backend:
+
+```text
+AgentSession (TypeScript)
+  |
+  | owns an ipython tool
+  v
+PrimeWorkerManager (TypeScript)
+  |
+  | newline-delimited JSON-RPC over child process stdio
+  v
+prime_agent_worker (Python)
+  |
+  | embedded IPython InteractiveShell
   v
 model-executed Python code
 ```
@@ -72,9 +101,54 @@ prime-agent-runtime/src/rlm/__init__.py
   Python shim installed into ~/.prime/agent/kernel-venv. Exposes rlm, rlm.run(),
   RLMResult, and TokenUsage.
 
+prime-agent-runtime/src/prime_agent_worker/__main__.py
+  Experimental stdio JSON-RPC worker. Embeds IPython and injects a host-backed
+  rlm object without using Jupyter comms.
+
 scripts/setup-kernel-venv.sh
   Thin wrapper around the automatic kernel bootstrap.
 ```
+
+## Backend Selection
+
+`packages/coding-agent/src/core/tools/ipython.ts` selects the backend lazily on the first `ipython` tool call.
+
+The default is:
+
+```bash
+PRIME_AGENT_PYTHON_BACKEND=jupyter-zmq
+```
+
+This starts `KernelManager` and uses the Jupyter protocol over ZeroMQ. It is the production path.
+
+The experimental worker is enabled with:
+
+```bash
+PRIME_AGENT_PYTHON_BACKEND=prime-worker
+```
+
+This starts `PrimeWorkerManager`, which spawns:
+
+```bash
+python -m prime_agent_worker
+```
+
+The worker backend still uses the same automatic Python bootstrap and the same persistent IPython semantics: variables persist across cells, IPython shell escapes such as `!pwd` work, cell magics such as `%%bash` work, top-level `await` works, and `rlm` remains the defining model-facing API. What changes is only the transport between TypeScript and Python.
+
+The worker backend does not use:
+
+- local TCP ports
+- Jupyter connection files
+- Jupyter comm messages
+- Node `zeromq`
+
+It does still use:
+
+- `prime-agent-runtime`
+- IPython
+- the TypeScript `AgentSession.runRlmChild()` implementation for recursive children
+
+Abort behavior differs by transport. `jupyter-zmq` sends a Jupyter `interrupt_request` on the control channel. `prime-worker` terminates the Python worker on abort and starts a fresh worker on the next execution. This is intentionally conservative for cross-platform local installs.
 
 ## ZeroMQ Jupyter Kernel Setup
 
@@ -290,6 +364,8 @@ await rlm.run("subtask")
 Both delegate to the same shim implementation.
 
 If `prime-agent-runtime` is missing from the kernel environment, startup remains non-fatal. The fallback `rlm` object raises a clear `RuntimeError` only when code actually calls `rlm.run(...)` or `rlm(...)`.
+
+With `PRIME_AGENT_PYTHON_BACKEND=prime-worker`, `prime_agent_worker` injects the callable `rlm` object directly into the IPython namespace and also installs a host-backed `rlm` module for `import rlm`. No Jupyter comms are involved in this path; RLM calls are JSON-RPC requests from the worker back to `PrimeWorkerManager`.
 
 ## Python RLM Shim
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -268,6 +268,8 @@ pi --tools bash,edit -p "Review the code"
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |
 | `PI_TELEMETRY` | Override install/update telemetry: `1`/`true`/`yes` or `0`/`false`/`no`. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache where supported |
+| `PRIME_AGENT_PYTHON_BACKEND` | Python execution backend: `jupyter-zmq` (default) or `prime-worker` (experimental) |
+| `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `ipykernel` instead of auto-bootstrapping `~/.prime/agent/kernel-venv` |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 ## Design Principles

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -349,6 +349,8 @@ ${chalk.bold("Environment Variables:")}
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no
   PI_SHARE_VIEWER_URL              - Base URL for /share command (default: https://pi.dev/session/)
+  PRIME_AGENT_PYTHON_BACKEND       - Python backend: jupyter-zmq (default) or prime-worker (experimental)
+  PRIME_AGENT_KERNEL_PYTHON        - Existing Python with ipykernel and prime-agent-runtime
 
 ${chalk.bold("Built-in Tool Names:")}
   ipython - Execute Python in a persistent IPython kernel

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -105,10 +105,10 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import type { KernelManager } from "./kernel/index.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
+import type { PythonExecutionBackend } from "./python-backend/types.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type {
 	RlmBackgroundRunStartResult,
@@ -709,7 +709,7 @@ export class AgentSession {
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
 	private _disposed = false;
-	private _ipythonKernelManagerRef: { current?: KernelManager } = {};
+	private _ipythonKernelManagerRef: { current?: PythonExecutionBackend } = {};
 	private _rlmDepth: number;
 	private _rlmMaxDepth: number;
 	private _rlmSessionDir?: string;

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -6,11 +6,12 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 1;
+const BOOTSTRAP_SCHEMA = 2;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
-const RUNTIME_READY_CHECK = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
+const RUNTIME_READY_CHECK =
+	"import rlm; import prime_agent_worker; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
 const BOOTSTRAP_VERSION_FILE = ".bootstrap-version";
 const BOOTSTRAP_LOCK_NAME = ".bootstrap.lock";
 const BOOTSTRAP_LOCK_RETRY_MS = 100;

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -8,6 +8,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
+import type { PythonExecutionBackend } from "../python-backend/types.js";
 import type {
 	RlmBackgroundRunHandler,
 	RlmBackgroundRunStatusHandler,
@@ -267,7 +268,7 @@ function installSignalHandlersOnce(): void {
 
 // ---- kernel manager ------------------------------------------------------
 
-export class KernelManager {
+export class KernelManager implements PythonExecutionBackend {
 	private readonly options: Pick<
 		KernelManagerOptions,
 		| "python"

--- a/packages/coding-agent/src/core/python-backend/prime-worker.ts
+++ b/packages/coding-agent/src/core/python-backend/prime-worker.ts
@@ -105,7 +105,7 @@ function parseOptionalString(value: unknown, name: string): string | undefined {
 }
 
 function parseOptionalNumber(value: unknown, name: string): number | undefined {
-	if (value === undefined) return undefined;
+	if (value === undefined || value === null) return undefined;
 	return parseNumber(value, name);
 }
 

--- a/packages/coding-agent/src/core/python-backend/prime-worker.ts
+++ b/packages/coding-agent/src/core/python-backend/prime-worker.ts
@@ -1,0 +1,596 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
+import { ensureKernelPython } from "../kernel/bootstrap.js";
+import type {
+	RlmBackgroundRunHandler,
+	RlmBackgroundRunStatusHandler,
+	RlmBackgroundRunStatusResult,
+	RlmBackgroundRunWaitHandler,
+	RlmRunHandler,
+	RlmRunResult,
+} from "../rlm-runtime.js";
+import type { PythonExecuteOptions, PythonExecuteResult, PythonExecutionBackend } from "./types.js";
+
+const DEFAULT_MAX_OUTPUT_CHARS = 65536;
+const WORKER_READY_TIMEOUT_MS = 5000;
+const RLM_DISPOSE_TIMEOUT_MS = 5000;
+
+type JsonRpcId = number | string;
+
+interface JsonRpcError {
+	code: number;
+	message: string;
+	data?: unknown;
+}
+
+interface JsonRpcRequest {
+	jsonrpc: "2.0";
+	id: JsonRpcId;
+	method: string;
+	params?: unknown;
+}
+
+interface JsonRpcNotification {
+	jsonrpc: "2.0";
+	method: string;
+	params?: unknown;
+}
+
+interface JsonRpcResponse {
+	jsonrpc: "2.0";
+	id: JsonRpcId;
+	result?: unknown;
+	error?: JsonRpcError;
+}
+
+interface PendingRequest<T> {
+	resolve: (value: T) => void;
+	reject: (error: Error) => void;
+}
+
+export interface PrimeWorkerManagerOptions {
+	/** Python interpreter that has `prime_agent_worker` and IPython available. Defaults to the auto-bootstrapped runtime. */
+	python?: string;
+	cwd?: string;
+	env?: Record<string, string>;
+	sessionId?: string;
+	rlmRunHandler?: RlmRunHandler;
+	rlmBackgroundRunHandler?: RlmBackgroundRunHandler;
+	rlmBackgroundStatusHandler?: RlmBackgroundRunStatusHandler;
+	rlmBackgroundWaitHandler?: RlmBackgroundRunWaitHandler;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+	return typeof value === "number" || typeof value === "string";
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+	return isRecord(value) && value.jsonrpc === "2.0" && typeof value.method === "string" && isJsonRpcId(value.id);
+}
+
+function isJsonRpcNotification(value: unknown): value is JsonRpcNotification {
+	return isRecord(value) && value.jsonrpc === "2.0" && typeof value.method === "string" && !("id" in value);
+}
+
+function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+	return isRecord(value) && value.jsonrpc === "2.0" && isJsonRpcId(value.id) && !("method" in value);
+}
+
+function isStreamName(value: unknown): value is "stdout" | "stderr" {
+	return value === "stdout" || value === "stderr";
+}
+
+function parseString(value: unknown, name: string): string {
+	if (typeof value !== "string") throw new Error(`${name} must be a string`);
+	return value;
+}
+
+function parseNumber(value: unknown, name: string): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${name} must be a finite number`);
+	return value;
+}
+
+function parseOptionalString(value: unknown, name: string): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	return parseString(value, name);
+}
+
+function parseOptionalNumber(value: unknown, name: string): number | undefined {
+	if (value === undefined) return undefined;
+	return parseNumber(value, name);
+}
+
+function parseStringArray(value: unknown, name: string): string[] {
+	if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+		throw new Error(`${name} must be a string array`);
+	}
+	return value;
+}
+
+function parseErrorPayload(value: unknown): PythonExecuteResult["error"] {
+	if (value === undefined || value === null) return undefined;
+	if (!isRecord(value)) throw new Error("error must be an object");
+	return {
+		ename: parseString(value.ename, "error.ename"),
+		evalue: parseString(value.evalue, "error.evalue"),
+		traceback: parseStringArray(value.traceback, "error.traceback"),
+	};
+}
+
+function parseExecuteResult(value: unknown): PythonExecuteResult {
+	if (!isRecord(value)) throw new Error("worker execute result must be an object");
+	const status = value.status;
+	if (status !== "ok" && status !== "error" && status !== "aborted") {
+		throw new Error("worker execute result status must be ok, error, or aborted");
+	}
+	return {
+		stdout: parseString(value.stdout, "stdout"),
+		stderr: parseString(value.stderr, "stderr"),
+		result: parseOptionalString(value.result, "result"),
+		status,
+		error: parseErrorPayload(value.error),
+		durationMs: parseNumber(value.durationMs, "durationMs"),
+	};
+}
+
+function parseRecord(value: unknown, name: string): Record<string, unknown> {
+	if (value === undefined) return {};
+	if (!isRecord(value)) throw new Error(`${name} must be an object`);
+	return value;
+}
+
+function parseRlmRunRequest(value: unknown): { prompt: string; kwargs: Record<string, unknown> } {
+	if (!isRecord(value)) throw new Error("rlm request params must be an object");
+	return {
+		prompt: parseString(value.prompt, "prompt"),
+		kwargs: parseRecord(value.kwargs, "kwargs"),
+	};
+}
+
+function parseRlmStatusRequest(value: unknown): { id: string } {
+	if (!isRecord(value)) throw new Error("rlm status params must be an object");
+	return { id: parseString(value.id, "id") };
+}
+
+function parseRlmWaitRequest(value: unknown): { id: string; timeoutMs?: number } {
+	if (!isRecord(value)) throw new Error("rlm wait params must be an object");
+	return { id: parseString(value.id, "id"), timeoutMs: parseOptionalNumber(value.timeoutMs, "timeoutMs") };
+}
+
+function parseOutputNotification(value: unknown): { executeId: JsonRpcId; stream: "stdout" | "stderr"; text: string } {
+	if (!isRecord(value)) throw new Error("output params must be an object");
+	if (!isJsonRpcId(value.execute_id)) throw new Error("output execute_id must be a JSON-RPC id");
+	if (!isStreamName(value.stream)) throw new Error("output stream must be stdout or stderr");
+	return { executeId: value.execute_id, stream: value.stream, text: parseString(value.text, "text") };
+}
+
+function formatWorkerError(error: JsonRpcError): Error {
+	if (error.data === undefined) return new Error(error.message);
+	return new Error(`${error.message}: ${JSON.stringify(error.data)}`);
+}
+
+const liveWorkers = new Set<PrimeWorkerManager>();
+
+registerSessionResourceCleanup((sessionId) => {
+	for (const worker of liveWorkers) {
+		if (!sessionId || worker.ownerSessionId === sessionId) {
+			void worker.dispose();
+		}
+	}
+});
+
+export class PrimeWorkerManager implements PythonExecutionBackend {
+	private readonly options: PrimeWorkerManagerOptions;
+	private worker?: ChildProcess;
+	private lines?: ReadlineInterface;
+	private workerStderr = "";
+	private nextRequestId = 1;
+	private readonly pending = new Map<string, PendingRequest<unknown>>();
+	private readonly activeOutputHandlers = new Map<string, (chunk: string, name: "stdout" | "stderr") => void>();
+	private readonly inFlightRlmRuns = new Set<Promise<unknown>>();
+	private executionQueue: Promise<unknown> = Promise.resolve();
+	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
+	private startPromise?: Promise<void>;
+
+	constructor(options: PrimeWorkerManagerOptions) {
+		this.options = {
+			python: options.python,
+			cwd: options.cwd,
+			env: options.env,
+			sessionId: options.sessionId,
+			rlmRunHandler: options.rlmRunHandler,
+			rlmBackgroundRunHandler: options.rlmBackgroundRunHandler,
+			rlmBackgroundStatusHandler: options.rlmBackgroundStatusHandler,
+			rlmBackgroundWaitHandler: options.rlmBackgroundWaitHandler,
+		};
+	}
+
+	get ownerSessionId(): string | undefined {
+		return this.options.sessionId;
+	}
+
+	get isRunning(): boolean {
+		return this.state === "running" && this.worker !== undefined && this.worker.exitCode === null;
+	}
+
+	async start(): Promise<void> {
+		if (!this.startPromise) {
+			this.startPromise = this.doStart();
+		}
+		return this.startPromise;
+	}
+
+	private async doStart(): Promise<void> {
+		if (this.state === "running") return;
+		if (this.state !== "idle") return;
+
+		this.state = "starting";
+		this.workerStderr = "";
+
+		let python: string;
+		try {
+			python = this.options.python ?? (await ensureKernelPython());
+			this.options.python = python;
+		} catch (error) {
+			this.state = "idle";
+			this.startPromise = undefined;
+			throw error;
+		}
+
+		const worker = spawn(python, ["-m", "prime_agent_worker"], {
+			cwd: this.options.cwd,
+			env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+
+		this.worker = worker;
+		liveWorkers.add(this);
+
+		worker.stderr?.on("data", (buf: Buffer) => {
+			const text = buf.toString();
+			this.workerStderr += text;
+			process.stderr.write(`[prime-worker] ${text}`);
+		});
+
+		worker.on("error", (error) => {
+			if (this.worker !== worker) return;
+			console.error(`[prime-worker] spawn error: ${error.message}`);
+			this.cleanupWorker(new Error(`Python worker spawn error: ${error.message}`), "idle");
+		});
+
+		worker.on("exit", (code, signal) => {
+			if (this.worker !== worker) return;
+			const reason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+			const tail = this.workerStderr.slice(-2048);
+			this.cleanupWorker(new Error(`Python worker exited with ${reason}. stderr:\n${tail || "(empty)"}`), "idle");
+		});
+
+		if (!worker.stdout || !worker.stdin) {
+			this.cleanupWorker(new Error("Python worker did not expose stdio pipes"), "idle");
+			throw new Error("Python worker did not expose stdio pipes");
+		}
+
+		this.lines = createInterface({ input: worker.stdout });
+		this.lines.on("line", (line) => {
+			this.handleLine(line);
+		});
+
+		this.state = "running";
+
+		try {
+			await this.withTimeout(
+				this.request("ping", {}),
+				WORKER_READY_TIMEOUT_MS,
+				"Python worker did not become ready",
+			);
+		} catch (error) {
+			const message = errorMessage(error);
+			this.cleanupWorker(new Error(message), "idle");
+			throw error;
+		}
+	}
+
+	private withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+		let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeout = globalThis.setTimeout(() => reject(new Error(message)), timeoutMs);
+			if (timeout && typeof timeout === "object" && "unref" in timeout) timeout.unref();
+		});
+		return Promise.race([promise, timeoutPromise]).finally(() => {
+			if (timeout) globalThis.clearTimeout(timeout);
+		});
+	}
+
+	private nextId(): JsonRpcId {
+		const id = this.nextRequestId;
+		this.nextRequestId += 1;
+		return id;
+	}
+
+	private request<T>(method: string, params: unknown): Promise<T> {
+		const id = this.nextId();
+		return this.requestWithId<T>(id, method, params);
+	}
+
+	private requestWithId<T>(id: JsonRpcId, method: string, params: unknown): Promise<T> {
+		const worker = this.worker;
+		if (!worker?.stdin || worker.stdin.destroyed) {
+			return Promise.reject(new Error("Python worker is not running"));
+		}
+
+		const key = String(id);
+		let rejectRequest: (error: Error) => void = () => {};
+		const promise = new Promise<T>((resolve, reject) => {
+			rejectRequest = reject;
+			this.pending.set(key, {
+				resolve: (value) => resolve(value as T),
+				reject,
+			});
+		});
+
+		const message: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+		const line = `${JSON.stringify(message)}\n`;
+		worker.stdin.write(line, (error) => {
+			if (!error) return;
+			this.pending.delete(key);
+			rejectRequest(error);
+		});
+
+		return promise;
+	}
+
+	private sendResponse(id: JsonRpcId, result: unknown): void {
+		this.writeMessage({ jsonrpc: "2.0", id, result }).catch((error) => {
+			console.error(`[prime-worker] failed to write response: ${error.message}`);
+		});
+	}
+
+	private sendErrorResponse(id: JsonRpcId, code: number, message: string, data?: unknown): void {
+		this.writeMessage({ jsonrpc: "2.0", id, error: { code, message, data } }).catch((error) => {
+			console.error(`[prime-worker] failed to write error response: ${error.message}`);
+		});
+	}
+
+	private writeMessage(message: JsonRpcResponse): Promise<void> {
+		const worker = this.worker;
+		if (!worker?.stdin || worker.stdin.destroyed) {
+			return Promise.reject(new Error("Python worker is not running"));
+		}
+		const line = `${JSON.stringify(message)}\n`;
+		return new Promise((resolve, reject) => {
+			worker.stdin!.write(line, (error) => {
+				if (error) reject(error);
+				else resolve();
+			});
+		});
+	}
+
+	private handleLine(line: string): void {
+		if (!line.trim()) return;
+
+		let message: unknown;
+		try {
+			message = JSON.parse(line);
+		} catch {
+			console.error(`[prime-worker] invalid JSON from worker: ${line}`);
+			return;
+		}
+
+		if (isJsonRpcResponse(message)) {
+			this.handleResponse(message);
+			return;
+		}
+
+		if (isJsonRpcRequest(message)) {
+			void this.handleWorkerRequest(message);
+			return;
+		}
+
+		if (isJsonRpcNotification(message)) {
+			this.handleNotification(message);
+			return;
+		}
+
+		console.error(`[prime-worker] unexpected message from worker: ${line}`);
+	}
+
+	private handleResponse(message: JsonRpcResponse): void {
+		const pending = this.pending.get(String(message.id));
+		if (!pending) return;
+		this.pending.delete(String(message.id));
+
+		if (message.error) {
+			pending.reject(formatWorkerError(message.error));
+			return;
+		}
+		pending.resolve(message.result);
+	}
+
+	private handleNotification(message: JsonRpcNotification): void {
+		if (message.method !== "output") return;
+		try {
+			const output = parseOutputNotification(message.params);
+			this.activeOutputHandlers.get(String(output.executeId))?.(output.text, output.stream);
+		} catch (error) {
+			console.error(`[prime-worker] bad output notification: ${errorMessage(error)}`);
+		}
+	}
+
+	private async handleWorkerRequest(message: JsonRpcRequest): Promise<void> {
+		try {
+			const result = await this.dispatchWorkerRequest(message.method, message.params);
+			this.sendResponse(message.id, result);
+		} catch (error) {
+			this.sendErrorResponse(message.id, -32000, errorMessage(error));
+		}
+	}
+
+	private async dispatchWorkerRequest(method: string, params: unknown): Promise<unknown> {
+		switch (method) {
+			case "rlm.run":
+				return this.trackRlmRun(this.handleRlmRun(params));
+			case "rlm.background":
+				return this.trackRlmRun(this.handleRlmBackgroundRun(params));
+			case "rlm.background_status":
+				return this.trackRlmRun(this.handleRlmBackgroundStatus(params));
+			case "rlm.background_wait":
+				return this.trackRlmRun(this.handleRlmBackgroundWait(params));
+			default:
+				throw new Error(`unknown worker request method: ${method}`);
+		}
+	}
+
+	private async trackRlmRun<T>(promise: Promise<T>): Promise<T> {
+		this.inFlightRlmRuns.add(promise);
+		try {
+			return await promise;
+		} finally {
+			this.inFlightRlmRuns.delete(promise);
+		}
+	}
+
+	private async handleRlmRun(params: unknown): Promise<RlmRunResult> {
+		if (!this.options.rlmRunHandler) throw new Error("rlm.run handler is not configured");
+		return this.options.rlmRunHandler(parseRlmRunRequest(params));
+	}
+
+	private async handleRlmBackgroundRun(params: unknown): Promise<unknown> {
+		if (!this.options.rlmBackgroundRunHandler) throw new Error("rlm.background handler is not configured");
+		return this.options.rlmBackgroundRunHandler(parseRlmRunRequest(params));
+	}
+
+	private async handleRlmBackgroundStatus(params: unknown): Promise<RlmBackgroundRunStatusResult> {
+		if (!this.options.rlmBackgroundStatusHandler) throw new Error("rlm.background_status handler is not configured");
+		return this.options.rlmBackgroundStatusHandler(parseRlmStatusRequest(params));
+	}
+
+	private async handleRlmBackgroundWait(params: unknown): Promise<RlmBackgroundRunStatusResult> {
+		if (!this.options.rlmBackgroundWaitHandler) throw new Error("rlm.background_wait handler is not configured");
+		return this.options.rlmBackgroundWaitHandler(parseRlmWaitRequest(params));
+	}
+
+	async execute(code: string, options: PythonExecuteOptions = {}): Promise<PythonExecuteResult> {
+		const prev = this.executionQueue;
+		let resolveNext: () => void = () => {};
+		this.executionQueue = new Promise<void>((resolve) => {
+			resolveNext = resolve;
+		});
+		await prev;
+
+		try {
+			await this.start();
+			if (options.signal?.aborted) {
+				return { stdout: "", stderr: "", status: "aborted", durationMs: 0 };
+			}
+
+			const executeId = this.nextId();
+			if (options.onStream) this.activeOutputHandlers.set(String(executeId), options.onStream);
+
+			const startedAt = Date.now();
+			let abortListener: (() => void) | undefined;
+			let aborted = false;
+			const requestPromise = this.requestWithId<unknown>(executeId, "execute", {
+				code,
+				execute_id: executeId,
+				max_output_chars: options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS,
+			});
+
+			const abortPromise = new Promise<PythonExecuteResult>((resolve) => {
+				abortListener = () => {
+					aborted = true;
+					requestPromise.catch(() => undefined);
+					this.cleanupWorker(new Error("Python worker execution aborted"), "idle");
+					resolve({ stdout: "", stderr: "", status: "aborted", durationMs: Date.now() - startedAt });
+				};
+				options.signal?.addEventListener("abort", abortListener, { once: true });
+			});
+
+			try {
+				const raw = await Promise.race([requestPromise.then(parseExecuteResult), abortPromise]);
+				return raw;
+			} finally {
+				if (abortListener) options.signal?.removeEventListener("abort", abortListener);
+				if (!aborted) requestPromise.catch(() => undefined);
+				this.activeOutputHandlers.delete(String(executeId));
+			}
+		} finally {
+			resolveNext();
+		}
+	}
+
+	async restart(): Promise<void> {
+		const prev = this.executionQueue;
+		let resolveNext: () => void = () => {};
+		this.executionQueue = new Promise<void>((resolve) => {
+			resolveNext = resolve;
+		});
+		await prev;
+
+		try {
+			this.cleanupWorker(new Error("Python worker restarted"), "idle");
+			this.workerStderr = "";
+			await this.start();
+		} finally {
+			resolveNext();
+		}
+	}
+
+	async dispose(): Promise<void> {
+		this.state = "shutdown";
+		liveWorkers.delete(this);
+		const inFlight = [...this.inFlightRlmRuns];
+		if (inFlight.length > 0) {
+			await this.waitForRlmRunsToSettle(inFlight, RLM_DISPOSE_TIMEOUT_MS);
+		}
+		this.cleanupWorker(new Error("Python worker disposed"), "shutdown");
+	}
+
+	private async waitForRlmRunsToSettle(tasks: Promise<unknown>[], timeoutMs: number): Promise<void> {
+		let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const timeoutPromise = new Promise<"timeout">((resolve) => {
+			timeout = globalThis.setTimeout(() => resolve("timeout"), timeoutMs);
+			if (timeout && typeof timeout === "object" && "unref" in timeout) timeout.unref();
+		});
+
+		const result = await Promise.race([Promise.allSettled(tasks).then(() => "settled" as const), timeoutPromise]);
+		if (timeout) globalThis.clearTimeout(timeout);
+		if (result === "timeout") {
+			console.error(
+				`[prime-worker] timed out waiting ${timeoutMs}ms for ${tasks.length} rlm request(s) during dispose`,
+			);
+		}
+	}
+
+	private cleanupWorker(reason: Error, nextState: "idle" | "shutdown"): void {
+		for (const pending of this.pending.values()) {
+			pending.reject(reason);
+		}
+		this.pending.clear();
+		this.activeOutputHandlers.clear();
+
+		this.lines?.removeAllListeners();
+		this.lines?.close();
+		this.lines = undefined;
+
+		const worker = this.worker;
+		this.worker = undefined;
+		if (worker && worker.exitCode === null && !worker.killed) {
+			worker.removeAllListeners("exit");
+			worker.removeAllListeners("error");
+			worker.kill();
+		}
+
+		this.startPromise = undefined;
+		this.state = nextState;
+		if (nextState === "shutdown") liveWorkers.delete(this);
+	}
+}

--- a/packages/coding-agent/src/core/python-backend/types.ts
+++ b/packages/coding-agent/src/core/python-backend/types.ts
@@ -1,0 +1,24 @@
+export interface PythonExecuteOptions {
+	signal?: AbortSignal;
+	onStream?: (chunk: string, name: "stdout" | "stderr") => void;
+	/** Cap stdout / stderr / result at this many characters. */
+	maxOutputChars?: number;
+}
+
+export interface PythonExecuteResult {
+	stdout: string;
+	stderr: string;
+	/** Last expression result, if the cell produced one. */
+	result?: string;
+	status: "ok" | "error" | "aborted";
+	error?: { ename: string; evalue: string; traceback: string[] };
+	durationMs: number;
+}
+
+export interface PythonExecutionBackend {
+	start(): Promise<void>;
+	execute(code: string, options?: PythonExecuteOptions): Promise<PythonExecuteResult>;
+	restart(): Promise<void>;
+	dispose(): Promise<void>;
+	readonly isRunning: boolean;
+}

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -3,6 +3,8 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import { KernelManager } from "../kernel/index.js";
+import { PrimeWorkerManager } from "../python-backend/prime-worker.js";
+import type { PythonExecutionBackend } from "../python-backend/types.js";
 import type {
 	RlmBackgroundRunHandler,
 	RlmBackgroundRunStatusHandler,
@@ -67,7 +69,17 @@ export interface IpythonToolOptions {
 	rlmBackgroundStatusHandler?: RlmBackgroundRunStatusHandler;
 	rlmBackgroundWaitHandler?: RlmBackgroundRunWaitHandler;
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
-	kernelManagerRef?: { current?: KernelManager };
+	kernelManagerRef?: { current?: PythonExecutionBackend };
+}
+
+type PythonBackendName = "jupyter-zmq" | "prime-worker";
+
+function getPythonBackendName(): PythonBackendName {
+	const value = process.env.PRIME_AGENT_PYTHON_BACKEND ?? "jupyter-zmq";
+	if (value === "jupyter-zmq" || value === "prime-worker") return value;
+	throw new Error(
+		`Unsupported PRIME_AGENT_PYTHON_BACKEND=${JSON.stringify(value)}. Expected "jupyter-zmq" or "prime-worker".`,
+	);
 }
 
 export function createIpythonToolDefinition(
@@ -77,15 +89,16 @@ export function createIpythonToolDefinition(
 	// Memoize the entire create+start so concurrent first calls all await the
 	// same in-flight startup instead of creating two managers or skipping the
 	// not-yet-finished start().
-	let managerPromise: Promise<KernelManager> | undefined;
+	let managerPromise: Promise<PythonExecutionBackend> | undefined;
 	if (options?.kernelManagerRef) {
 		options.kernelManagerRef.current = undefined;
 	}
 
-	function getManager(): Promise<KernelManager> {
+	function getManager(): Promise<PythonExecutionBackend> {
 		if (!managerPromise) {
 			managerPromise = (async () => {
-				const m = new KernelManager({
+				const backendName = getPythonBackendName();
+				const commonOptions = {
 					python: options?.python,
 					cwd,
 					env: options?.env,
@@ -94,12 +107,18 @@ export function createIpythonToolDefinition(
 					rlmBackgroundRunHandler: options?.rlmBackgroundRunHandler,
 					rlmBackgroundStatusHandler: options?.rlmBackgroundStatusHandler,
 					rlmBackgroundWaitHandler: options?.rlmBackgroundWaitHandler,
-				});
+				};
+				const m: PythonExecutionBackend =
+					backendName === "prime-worker"
+						? new PrimeWorkerManager(commonOptions)
+						: new KernelManager(commonOptions);
 				await m.start();
-				const bootstrap = await m.execute(RLM_BOOTSTRAP_CODE);
-				if (bootstrap.status !== "ok") {
-					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
-					throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+				if (backendName === "jupyter-zmq") {
+					const bootstrap = await m.execute(RLM_BOOTSTRAP_CODE);
+					if (bootstrap.status !== "ok") {
+						const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+						throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+					}
 				}
 				if (options?.kernelManagerRef) {
 					options.kernelManagerRef.current = m;

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -15,14 +15,18 @@ function writeExecutable(filePath: string, content: string): void {
 function writeBootstrapVersion(venv: string): void {
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
-		`${JSON.stringify({ schema: 1, ipykernel: "ipykernel", runtime: "prime-agent-runtime" })}\n`,
+		`${JSON.stringify({ schema: 2, ipykernel: "ipykernel", runtime: "prime-agent-runtime" })}\n`,
 	);
 }
 
 function writeFakePython(filePath: string, importableModules: readonly string[]): void {
-	const rlmRuntimeCheck = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
+	const rlmRuntimeCheck =
+		"import rlm; import prime_agent_worker; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
 	const cases = importableModules.map((moduleName) => `    "import ${moduleName}") exit 0 ;;`).join("\n");
-	const runtimeCase = importableModules.includes("rlm") ? `    "${rlmRuntimeCheck}") exit 0 ;;` : "";
+	const runtimeCase =
+		importableModules.includes("rlm") && importableModules.includes("prime_agent_worker")
+			? `    "${rlmRuntimeCheck}") exit 0 ;;`
+			: "";
 	writeExecutable(
 		filePath,
 		[
@@ -46,7 +50,8 @@ function installFakeUv(): string {
 	const logPath = join(tempDir, "uv.log");
 	process.env.UV_LOG = logPath;
 	process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
-	const rlmRuntimeCheck = "import rlm; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
+	const rlmRuntimeCheck =
+		"import rlm; import prime_agent_worker; assert hasattr(rlm, 'background'); assert hasattr(rlm.rlm, 'background')";
 	writeExecutable(
 		join(binDir, "uv"),
 		[
@@ -63,7 +68,7 @@ function installFakeUv(): string {
 			"#!/bin/sh",
 			'if [ "$1" = "-c" ]; then',
 			'  case "$2" in',
-			'    "import ipykernel"|"import rlm") exit 0 ;;',
+			'    "import ipykernel"|"import rlm"|"import prime_agent_worker") exit 0 ;;',
 			`    "${rlmRuntimeCheck}") exit 0 ;;`,
 			"    *) exit 1 ;;",
 			"  esac",
@@ -122,7 +127,7 @@ describe("kernel bootstrap", () => {
 		expect(log).toContain("pip install --python");
 		expect(log).toContain("ipykernel");
 		expect(log).toContain("prime-agent-runtime");
-		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toContain('"schema":1');
+		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toContain('"schema":2');
 	});
 
 	it("shares concurrent bootstrap work in one process", async () => {
@@ -141,7 +146,7 @@ describe("kernel bootstrap", () => {
 		const venv = join(tempDir, "kernel-venv");
 		const python = join(venv, "bin", "python");
 		mkdirSync(join(venv, "bin"), { recursive: true });
-		writeFakePython(python, ["ipykernel", "rlm"]);
+		writeFakePython(python, ["ipykernel", "rlm", "prime_agent_worker"]);
 		writeBootstrapVersion(venv);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
@@ -189,7 +194,7 @@ describe("kernel bootstrap", () => {
 
 	it("uses PRIME_AGENT_KERNEL_PYTHON as an override contract", async () => {
 		const overridePython = join(tempDir, "override-python");
-		writeFakePython(overridePython, ["ipykernel", "rlm"]);
+		writeFakePython(overridePython, ["ipykernel", "rlm", "prime_agent_worker"]);
 		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
 
 		await expect(ensureKernelPython()).resolves.toBe(overridePython);

--- a/packages/coding-agent/test/python-backend-parity.test.ts
+++ b/packages/coding-agent/test/python-backend-parity.test.ts
@@ -103,6 +103,19 @@ describe("Python backend parity", () => {
 					'import subprocess, sys\nsubprocess.run([sys.executable, "-c", "print(\'subprocess-ok\')"], check=True)',
 				);
 				expect(subprocess.text).toContain("subprocess-ok");
+				const stdin = await execute(
+					tool,
+					[
+						"try:",
+						'    input("blocked")',
+						"except Exception as error:",
+						'    print("stdin-blocked", type(error).__name__)',
+						"import subprocess, sys",
+						"subprocess.run([sys.executable, \"-c\", \"import sys; print('stdin-empty', sys.stdin.read() == '')\"], check=True)",
+					].join("\n"),
+				);
+				expect(stdin.text).toContain("stdin-blocked");
+				expect(stdin.text).toContain("stdin-empty True");
 
 				const streams = await execute(tool, 'import sys\nprint("out")\nprint("err", file=sys.stderr)');
 				expect(streams.text).toContain("out");
@@ -116,6 +129,9 @@ describe("Python backend parity", () => {
 
 				const longOutput = await execute(tool, 'print("x" * 70000)');
 				expect(longOutput.text).toContain("[... output truncated at 65536 chars ...]");
+				const longResult = await execute(tool, '"x" * 70000');
+				expect(longResult.text).toContain("[... output truncated at 65536 chars ...]");
+				expect(longResult.text.length).toBeLessThan(66000);
 			}, 120_000);
 
 			it("restarts with a clean namespace", async () => {
@@ -158,6 +174,10 @@ describe("Python backend parity", () => {
 						"print(s.state)",
 						"r = await h.result(timeout=1)",
 						"print(r.answer)",
+						"s2 = await h.wait()",
+						"print(s2.state)",
+						"r2 = await h.result()",
+						"print(r2.answer)",
 					].join("\n"),
 				);
 				expect(background.text).toContain("bg:job");

--- a/packages/coding-agent/test/python-backend-parity.test.ts
+++ b/packages/coding-agent/test/python-backend-parity.test.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PythonExecutionBackend } from "../src/core/python-backend/types.js";
+import { createIpythonToolDefinition, type IpythonToolDetails } from "../src/core/tools/ipython.js";
+
+const BACKENDS = ["jupyter-zmq", "prime-worker"] as const;
+
+let tempDir = "";
+let originalEnv: NodeJS.ProcessEnv;
+let activeBackendRefs: Array<{ current?: PythonExecutionBackend }> = [];
+
+function contentText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.map((item) => (item.type === "text" ? (item.text ?? "") : "")).join("");
+}
+
+function makeTool() {
+	const kernelManagerRef: { current?: PythonExecutionBackend } = {};
+	activeBackendRefs.push(kernelManagerRef);
+	return createIpythonToolDefinition(tempDir, {
+		kernelManagerRef,
+		rlmRunHandler: async ({ prompt }) => ({
+			answer: `answer:${prompt}`,
+			usage: { prompt_tokens: prompt.length, completion_tokens: 3 },
+			turns: 2,
+			session_dir: join(tempDir, "child-session"),
+		}),
+		rlmBackgroundRunHandler: async ({ prompt }) => ({
+			id: `bg:${prompt}`,
+			state: "running",
+			session_dir: join(tempDir, "background-session"),
+		}),
+		rlmBackgroundStatusHandler: async ({ id }) => ({
+			id,
+			state: "running",
+			session_dir: join(tempDir, "background-session"),
+		}),
+		rlmBackgroundWaitHandler: async ({ id }) => ({
+			id,
+			state: "done",
+			session_dir: join(tempDir, "background-session"),
+			result: {
+				answer: `background:${id}`,
+				usage: { prompt_tokens: 5, completion_tokens: 7 },
+				turns: 1,
+				session_dir: join(tempDir, "background-child-session"),
+			},
+		}),
+	});
+}
+
+async function execute(
+	tool: ReturnType<typeof makeTool>,
+	code: string,
+	signal?: AbortSignal,
+): Promise<{ text: string; details: IpythonToolDetails; isError?: boolean }> {
+	const ctx = {} as Parameters<typeof tool.execute>[4];
+	const result = await tool.execute("test", { code }, signal, undefined, ctx);
+	const isError = "isError" in result && typeof result.isError === "boolean" ? result.isError : undefined;
+	return {
+		text: contentText(result),
+		details: result.details,
+		isError,
+	};
+}
+
+describe("Python backend parity", () => {
+	afterEach(async () => {
+		await Promise.allSettled(activeBackendRefs.map((ref) => ref.current?.dispose()));
+		activeBackendRefs = [];
+		process.env = originalEnv;
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	for (const backend of BACKENDS) {
+		describe(backend, () => {
+			beforeEach(() => {
+				originalEnv = { ...process.env };
+				tempDir = mkdtempSync(join(tmpdir(), `prime-agent-${backend}-`));
+				process.env.PRIME_AGENT_PYTHON_BACKEND = backend;
+				process.env.PRIME_AGENT_KERNEL_VENV = join(tempDir, "kernel-venv");
+			});
+
+			it("executes IPython cells and preserves session lifecycle", async () => {
+				const tool = makeTool();
+
+				await execute(tool, "import math\nx = math.sqrt(1764)");
+				await expect(execute(tool, "print(int(x))")).resolves.toMatchObject({ text: "42\n" });
+				await expect(execute(tool, "6 * 7")).resolves.toMatchObject({ text: "42" });
+
+				const pwd = await execute(tool, "!pwd");
+				expect(pwd.text.trim()).toBe(realpathSync(tempDir));
+				await expect(execute(tool, "%%bash\necho bash-ok")).resolves.toMatchObject({ text: "bash-ok\n" });
+				await expect(
+					execute(tool, 'import asyncio\nawait asyncio.sleep(0)\nprint("await-ok")'),
+				).resolves.toMatchObject({ text: "await-ok\n" });
+				const subprocess = await execute(
+					tool,
+					'import subprocess, sys\nsubprocess.run([sys.executable, "-c", "print(\'subprocess-ok\')"], check=True)',
+				);
+				expect(subprocess.text).toContain("subprocess-ok");
+
+				const streams = await execute(tool, 'import sys\nprint("out")\nprint("err", file=sys.stderr)');
+				expect(streams.text).toContain("out");
+				expect(streams.text).toContain("err");
+
+				const error = await execute(tool, 'raise ValueError("bad-value")');
+				expect(error.isError).toBe(true);
+				expect(error.details.status).toBe("error");
+				expect(error.details.errorEname).toBe("ValueError");
+				expect(error.text).toContain("bad-value");
+
+				const longOutput = await execute(tool, 'print("x" * 70000)');
+				expect(longOutput.text).toContain("[... output truncated at 65536 chars ...]");
+			}, 120_000);
+
+			it("restarts with a clean namespace", async () => {
+				const kernelManagerRef: { current?: PythonExecutionBackend } = {};
+				activeBackendRefs.push(kernelManagerRef);
+				const tool = createIpythonToolDefinition(tempDir, { kernelManagerRef });
+
+				await execute(tool, "x = 1");
+				await kernelManagerRef.current?.restart();
+
+				const result = await execute(tool, 'print("x" in globals())');
+				expect(result.text).toBe("False\n");
+			}, 120_000);
+
+			it("round-trips foreground and background RLM requests", async () => {
+				const tool = makeTool();
+
+				const foreground = await execute(
+					tool,
+					[
+						"import asyncio",
+						"import rlm as rlm_module",
+						'results = await asyncio.gather(rlm("one"), rlm.run("two", temperature=0))',
+						'module_result = await rlm_module("three")',
+						"print([r.answer for r in results])",
+						"print(module_result.answer)",
+						"print(results[0].usage.prompt_tokens)",
+					].join("\n"),
+				);
+				expect(foreground.text).toContain("answer:one");
+				expect(foreground.text).toContain("answer:two");
+				expect(foreground.text).toContain("3");
+
+				const background = await execute(
+					tool,
+					[
+						'h = await rlm.background("job", notify="silent")',
+						"print(h.id)",
+						"s = await h.status()",
+						"print(s.state)",
+						"r = await h.result(timeout=1)",
+						"print(r.answer)",
+					].join("\n"),
+				);
+				expect(background.text).toContain("bg:job");
+				expect(background.text).toContain("running");
+				expect(background.text).toContain("background:bg:job");
+			}, 120_000);
+
+			it("aborts long-running code and remains usable", async () => {
+				const tool = makeTool();
+				const controller = new AbortController();
+				const pending = execute(tool, "import time\ntime.sleep(10)", controller.signal);
+
+				globalThis.setTimeout(() => controller.abort(), 100);
+
+				const aborted = await pending;
+				expect(aborted.isError).toBe(true);
+				expect(aborted.details.status).toBe("aborted");
+
+				const recovered = await execute(tool, 'print("alive")');
+				expect(recovered.text).toBe("alive\n");
+			}, 120_000);
+		});
+	}
+});

--- a/prime-agent-runtime/pyproject.toml
+++ b/prime-agent-runtime/pyproject.toml
@@ -12,4 +12,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/rlm"]
+packages = ["src/rlm", "src/prime_agent_worker"]

--- a/prime-agent-runtime/src/prime_agent_worker/__init__.py
+++ b/prime-agent-runtime/src/prime_agent_worker/__init__.py
@@ -1,0 +1,1 @@
+"""Prime Agent IPython worker runtime."""

--- a/prime-agent-runtime/src/prime_agent_worker/__main__.py
+++ b/prime-agent-runtime/src/prime_agent_worker/__main__.py
@@ -37,11 +37,66 @@ def duplicate_protocol_stdout() -> Any:
 		return sys.stdout
 
 
+def duplicate_protocol_stdin() -> Any:
+	try:
+		fd = os.dup(sys.stdin.fileno())
+		return os.fdopen(
+			fd,
+			"r",
+			encoding=getattr(sys.stdin, "encoding", None) or "utf-8",
+			errors="replace",
+			buffering=1,
+		)
+	except Exception:
+		return sys.stdin
+
+
+def truncate_text(value: str, max_chars: int) -> str:
+	if len(value) <= max_chars:
+		return value
+	return value[:max_chars] + f"\n[... output truncated at {max_chars} chars ...]"
+
+
 def strip_ipython_displayhook(stdout: str, result_text: str | None) -> str:
 	if result_text is None:
 		return stdout
 	pattern = re.compile(rf"^Out\[\d+\]: {re.escape(result_text)}\n?", re.MULTILINE)
-	return pattern.sub("", stdout, count=1)
+	stripped = pattern.sub("", stdout, count=1)
+	if stripped != stdout:
+		return stripped
+
+	matches = list(re.finditer(r"(^|\n)Out\[\d+\]: ", stdout))
+	if not matches:
+		return stdout
+	match = matches[-1]
+	return stdout[: match.start() + (1 if match.group(1) else 0)]
+
+
+class RedirectedStdin:
+	def __init__(self) -> None:
+		self._saved_fd: int | None = None
+		self._old_stdin: Any | None = None
+		self._stdin: Any | None = None
+
+	def __enter__(self) -> None:
+		self._old_stdin = sys.stdin
+		self._saved_fd = os.dup(0)
+		devnull_fd = os.open(os.devnull, os.O_RDONLY)
+		try:
+			os.dup2(devnull_fd, 0)
+		finally:
+			os.close(devnull_fd)
+		self._stdin = open(os.devnull, "r", encoding=getattr(self._old_stdin, "encoding", None) or "utf-8")
+		sys.stdin = self._stdin
+
+	def __exit__(self, exc_type: Any, exc_value: Any, traceback_value: Any) -> None:
+		if self._stdin is not None:
+			self._stdin.close()
+		if self._old_stdin is not None:
+			sys.stdin = self._old_stdin
+		if self._saved_fd is not None:
+			os.dup2(self._saved_fd, 0)
+			os.close(self._saved_fd)
 
 
 class RpcError(Exception):
@@ -53,7 +108,7 @@ class RpcError(Exception):
 class JsonRpcPeer:
 	def __init__(self) -> None:
 		self._stdout = duplicate_protocol_stdout()
-		self._stdin = sys.stdin
+		self._stdin = duplicate_protocol_stdin()
 		self._write_lock = threading.Lock()
 		self._next_id = 1
 		self._pending: dict[str, asyncio.Future[Any]] = {}
@@ -214,7 +269,8 @@ def capture_output(peer: JsonRpcPeer, execute_id: Any, max_chars: int) -> Iterat
 	sys.stdout = stdout
 	sys.stderr = stderr
 	try:
-		yield stdout, stderr
+		with RedirectedStdin():
+			yield stdout, stderr
 	finally:
 		try:
 			sys.stdout.flush()
@@ -416,6 +472,7 @@ class PrimeWorker:
 				}
 			elif execution_result.result is not None:
 				result_text = repr(execution_result.result)
+				result_text = truncate_text(result_text, max_chars)
 
 		return {
 			"stdout": strip_ipython_displayhook(stdout.getvalue(), result_text),

--- a/prime-agent-runtime/src/prime_agent_worker/__main__.py
+++ b/prime-agent-runtime/src/prime_agent_worker/__main__.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import sys
+import threading
+import time
+import traceback
+import types
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+from IPython.core.interactiveshell import InteractiveShell
+
+JSONRPC_VERSION = "2.0"
+
+
+def is_record(value: Any) -> bool:
+	return isinstance(value, dict)
+
+
+def duplicate_protocol_stdout() -> Any:
+	try:
+		fd = os.dup(sys.stdout.fileno())
+		return os.fdopen(
+			fd,
+			"w",
+			encoding=getattr(sys.stdout, "encoding", None) or "utf-8",
+			errors="replace",
+			buffering=1,
+		)
+	except Exception:
+		return sys.stdout
+
+
+def strip_ipython_displayhook(stdout: str, result_text: str | None) -> str:
+	if result_text is None:
+		return stdout
+	pattern = re.compile(rf"^Out\[\d+\]: {re.escape(result_text)}\n?", re.MULTILINE)
+	return pattern.sub("", stdout, count=1)
+
+
+class RpcError(Exception):
+	def __init__(self, message: str, data: Any | None = None) -> None:
+		super().__init__(message)
+		self.data = data
+
+
+class JsonRpcPeer:
+	def __init__(self) -> None:
+		self._stdout = duplicate_protocol_stdout()
+		self._stdin = sys.stdin
+		self._write_lock = threading.Lock()
+		self._next_id = 1
+		self._pending: dict[str, asyncio.Future[Any]] = {}
+		self._loop = asyncio.get_running_loop()
+		self.app: PrimeWorker | None = None
+
+	def send_sync(self, message: dict[str, Any]) -> None:
+		payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False)
+		with self._write_lock:
+			self._stdout.write(payload)
+			self._stdout.write("\n")
+			self._stdout.flush()
+
+	def notify_sync(self, method: str, params: dict[str, Any]) -> None:
+		self.send_sync({"jsonrpc": JSONRPC_VERSION, "method": method, "params": params})
+
+	async def request(self, method: str, params: dict[str, Any]) -> Any:
+		request_id = self._next_id
+		self._next_id += 1
+		future: asyncio.Future[Any] = self._loop.create_future()
+		self._pending[str(request_id)] = future
+		self.send_sync({"jsonrpc": JSONRPC_VERSION, "id": request_id, "method": method, "params": params})
+		return await future
+
+	async def read_loop(self) -> None:
+		while True:
+			line = await asyncio.to_thread(self._stdin.readline)
+			if line == "":
+				return
+			line = line.strip()
+			if not line:
+				continue
+			try:
+				message = json.loads(line)
+			except json.JSONDecodeError:
+				continue
+			await self.handle_message(message)
+
+	async def handle_message(self, message: Any) -> None:
+		if not is_record(message):
+			return
+
+		if "method" in message and "id" in message:
+			asyncio.create_task(self.handle_request(message))
+			return
+
+		if "method" in message:
+			return
+
+		request_id = str(message.get("id"))
+		future = self._pending.pop(request_id, None)
+		if future is None or future.done():
+			return
+
+		error = message.get("error")
+		if is_record(error):
+			future.set_exception(RpcError(str(error.get("message", "RPC error")), error.get("data")))
+			return
+
+		future.set_result(message.get("result"))
+
+	async def handle_request(self, message: dict[str, Any]) -> None:
+		request_id = message.get("id")
+		try:
+			if self.app is None:
+				raise RpcError("worker is not initialized")
+			result = await self.app.dispatch(str(message.get("method")), message.get("params"))
+			self.send_sync({"jsonrpc": JSONRPC_VERSION, "id": request_id, "result": result})
+		except Exception as exc:
+			self.send_sync(
+				{
+					"jsonrpc": JSONRPC_VERSION,
+					"id": request_id,
+					"error": {"code": -32000, "message": str(exc), "data": traceback.format_exc()},
+				}
+			)
+
+
+class OutputCapture:
+	def __init__(self, peer: JsonRpcPeer, execute_id: Any, stream: str, max_chars: int) -> None:
+		self.peer = peer
+		self.execute_id = execute_id
+		self.stream = stream
+		self.max_chars = max_chars
+		self.parts: list[str] = []
+		self.length = 0
+		self.truncated = False
+		self._lock = threading.Lock()
+		self.encoding = "utf-8"
+		self.errors = "replace"
+
+	def write(self, text: str) -> int:
+		if text:
+			self.peer.notify_sync(
+				"output",
+				{"execute_id": self.execute_id, "stream": self.stream, "text": text},
+			)
+			with self._lock:
+				self._append(text)
+		return len(text)
+
+	def flush(self) -> None:
+		return None
+
+	def isatty(self) -> bool:
+		return False
+
+	def _append(self, text: str) -> None:
+		if self.length >= self.max_chars:
+			self.truncated = True
+			return
+
+		remaining = self.max_chars - self.length
+		if len(text) > remaining:
+			self.parts.append(text[:remaining])
+			self.length = self.max_chars
+			self.truncated = True
+			return
+
+		self.parts.append(text)
+		self.length += len(text)
+
+	def getvalue(self) -> str:
+		with self._lock:
+			value = "".join(self.parts)
+			if self.truncated:
+				return value + f"\n[... output truncated at {self.max_chars} chars ...]"
+			return value
+
+
+def redirect_fd_to_capture(fd: int, capture: OutputCapture) -> tuple[int, threading.Thread]:
+	read_fd, write_fd = os.pipe()
+	saved_fd = os.dup(fd)
+	os.dup2(write_fd, fd)
+	os.close(write_fd)
+
+	def read_pipe() -> None:
+		with os.fdopen(read_fd, "rb", closefd=True) as stream:
+			while True:
+				chunk = stream.read(4096)
+				if not chunk:
+					return
+				capture.write(chunk.decode("utf-8", errors="replace"))
+
+	thread = threading.Thread(target=read_pipe, daemon=True)
+	thread.start()
+	return saved_fd, thread
+
+
+@contextmanager
+def capture_output(peer: JsonRpcPeer, execute_id: Any, max_chars: int) -> Iterator[tuple[OutputCapture, OutputCapture]]:
+	stdout = OutputCapture(peer, execute_id, "stdout", max_chars)
+	stderr = OutputCapture(peer, execute_id, "stderr", max_chars)
+	old_stdout = sys.stdout
+	old_stderr = sys.stderr
+	saved_stdout_fd, stdout_thread = redirect_fd_to_capture(1, stdout)
+	saved_stderr_fd, stderr_thread = redirect_fd_to_capture(2, stderr)
+	sys.stdout = stdout
+	sys.stderr = stderr
+	try:
+		yield stdout, stderr
+	finally:
+		try:
+			sys.stdout.flush()
+			sys.stderr.flush()
+		except Exception:
+			pass
+		sys.stdout = old_stdout
+		sys.stderr = old_stderr
+		os.dup2(saved_stdout_fd, 1)
+		os.close(saved_stdout_fd)
+		os.dup2(saved_stderr_fd, 2)
+		os.close(saved_stderr_fd)
+		stdout_thread.join(timeout=1)
+		stderr_thread.join(timeout=1)
+
+
+@dataclass
+class TokenUsage:
+	prompt_tokens: int
+	completion_tokens: int
+
+
+@dataclass
+class RLMResult:
+	answer: str
+	usage: TokenUsage
+	turns: int
+	session_dir: Path | None = None
+
+
+@dataclass
+class RLMBackgroundStatus:
+	id: str
+	state: str
+	session_dir: Path | None = None
+	result: RLMResult | None = None
+	error: str | None = None
+	timed_out: bool = False
+
+
+class RLMBackgroundHandle:
+	def __init__(self, host: HostRLM, id: str, state: str, session_dir: Path | None = None) -> None:
+		self._host = host
+		self.id = id
+		self.state = state
+		self.session_dir = session_dir
+
+	async def status(self) -> RLMBackgroundStatus:
+		return await self._host.background_status(self.id)
+
+	async def wait(self, timeout: float | None = None) -> RLMBackgroundStatus:
+		timeout_ms = None if timeout is None else int(timeout * 1000)
+		return await self._host.background_wait(self.id, timeout_ms=timeout_ms)
+
+	async def result(self, timeout: float | None = None) -> RLMResult:
+		status = await self.wait(timeout=timeout)
+		if status.result is not None:
+			return status.result
+		if status.timed_out:
+			raise TimeoutError(f"RLM background run {self.id} did not finish before timeout")
+		if status.error:
+			raise RuntimeError(status.error)
+		raise RuntimeError(f"RLM background run {self.id} is {status.state}")
+
+
+class HostRLM:
+	def __init__(self, peer: JsonRpcPeer) -> None:
+		self.peer = peer
+
+	def _ensure_recursion_allowed(self) -> None:
+		depth = int(os.environ.get("RLM_DEPTH", "0"))
+		max_depth = int(os.environ.get("RLM_MAX_DEPTH", "5"))
+		if depth >= max_depth:
+			raise RuntimeError(f"RLM recursion limit reached: depth {depth} >= max depth {max_depth}")
+
+	async def __call__(self, prompt: str, **kwargs: Any) -> RLMResult:
+		return await self.run(prompt, **kwargs)
+
+	async def run(self, prompt: str, **kwargs: Any) -> RLMResult:
+		self._ensure_recursion_allowed()
+		payload = await self.peer.request("rlm.run", {"prompt": prompt, "kwargs": kwargs})
+		return self._to_result(payload)
+
+	async def background(self, prompt: str, **kwargs: Any) -> RLMBackgroundHandle:
+		self._ensure_recursion_allowed()
+		payload = await self.peer.request("rlm.background", {"prompt": prompt, "kwargs": kwargs})
+		return RLMBackgroundHandle(
+			self,
+			id=str(payload["id"]),
+			state=str(payload["state"]),
+			session_dir=self._to_path(payload.get("session_dir")),
+		)
+
+	async def background_status(self, id: str) -> RLMBackgroundStatus:
+		payload = await self.peer.request("rlm.background_status", {"id": id})
+		return self._to_status(payload)
+
+	async def background_wait(self, id: str, timeout_ms: int | None = None) -> RLMBackgroundStatus:
+		payload = await self.peer.request("rlm.background_wait", {"id": id, "timeoutMs": timeout_ms})
+		return self._to_status(payload)
+
+	def _to_path(self, value: Any) -> Path | None:
+		if value is None:
+			return None
+		return Path(str(value))
+
+	def _to_usage(self, payload: Any) -> TokenUsage:
+		return TokenUsage(
+			prompt_tokens=int(payload.get("prompt_tokens", 0)),
+			completion_tokens=int(payload.get("completion_tokens", 0)),
+		)
+
+	def _to_result(self, payload: Any) -> RLMResult:
+		return RLMResult(
+			answer=str(payload.get("answer", "")),
+			usage=self._to_usage(payload.get("usage", {})),
+			turns=int(payload.get("turns", 0)),
+			session_dir=self._to_path(payload.get("session_dir")),
+		)
+
+	def _to_status(self, payload: Any) -> RLMBackgroundStatus:
+		result_payload = payload.get("result")
+		return RLMBackgroundStatus(
+			id=str(payload.get("id", "")),
+			state=str(payload.get("state", "")),
+			session_dir=self._to_path(payload.get("session_dir")),
+			result=None if result_payload is None else self._to_result(result_payload),
+			error=None if payload.get("error") is None else str(payload.get("error")),
+			timed_out=bool(payload.get("timed_out", False)),
+		)
+
+
+class CallableRLMModule(types.ModuleType):
+	def __call__(self, prompt: str, **kwargs: Any) -> Any:
+		return self.rlm(prompt, **kwargs)
+
+
+def install_rlm_module(host: HostRLM) -> None:
+	module = CallableRLMModule("rlm")
+	module.rlm = host
+	module.run = host.run
+	module.background = host.background
+	module.background_status = host.background_status
+	module.background_wait = host.background_wait
+	module.TokenUsage = TokenUsage
+	module.RLMResult = RLMResult
+	module.RLMBackgroundStatus = RLMBackgroundStatus
+	module.RLMBackgroundHandle = RLMBackgroundHandle
+	sys.modules["rlm"] = module
+
+
+class PrimeWorker:
+	def __init__(self, peer: JsonRpcPeer) -> None:
+		self.peer = peer
+		self.shell = InteractiveShell.instance()
+		self.host_rlm = HostRLM(peer)
+		install_rlm_module(self.host_rlm)
+		self.shell.user_ns["rlm"] = self.host_rlm
+
+	async def dispatch(self, method: str, params: Any) -> Any:
+		if method == "ping":
+			return {"ok": True}
+		if method == "execute":
+			return await self.execute(params)
+		if method == "shutdown":
+			asyncio.get_running_loop().call_soon(asyncio.get_running_loop().stop)
+			return {"ok": True}
+		raise RpcError(f"unknown method: {method}")
+
+	async def execute(self, params: Any) -> dict[str, Any]:
+		if not is_record(params):
+			raise RpcError("execute params must be an object")
+		code = str(params.get("code", ""))
+		execute_id = params.get("execute_id")
+		max_chars = int(params.get("max_output_chars", 65536))
+		started_at = time.monotonic()
+
+		error_payload = None
+		result_text = None
+		with capture_output(self.peer, execute_id, max_chars) as (stdout, stderr):
+			try:
+				transformed_cell = self.shell.transform_cell(code)
+				preprocessing_exc_tuple = None
+			except Exception:
+				transformed_cell = code
+				preprocessing_exc_tuple = sys.exc_info()
+			execution_result = await self.shell.run_cell_async(
+				code,
+				store_history=True,
+				transformed_cell=transformed_cell,
+				preprocessing_exc_tuple=preprocessing_exc_tuple,
+			)
+			error = execution_result.error_before_exec or execution_result.error_in_exec
+			if error is not None:
+				error_payload = {
+					"ename": type(error).__name__,
+					"evalue": str(error),
+					"traceback": traceback.format_exception(type(error), error, error.__traceback__),
+				}
+			elif execution_result.result is not None:
+				result_text = repr(execution_result.result)
+
+		return {
+			"stdout": strip_ipython_displayhook(stdout.getvalue(), result_text),
+			"stderr": stderr.getvalue(),
+			"result": result_text,
+			"status": "error" if error_payload is not None else "ok",
+			"error": error_payload,
+			"durationMs": int((time.monotonic() - started_at) * 1000),
+		}
+
+
+async def main() -> None:
+	peer = JsonRpcPeer()
+	app = PrimeWorker(peer)
+	peer.app = app
+	await peer.read_loop()
+
+
+if __name__ == "__main__":
+	asyncio.run(main())


### PR DESCRIPTION
- adds an experimental prime-worker backend for the ipython tool while keeping jupyter-zmq as the default.
- preserves rlm, background runs, persistent ipython state, shell escapes, restarts, and abort recovery.
- adds parity coverage across both python backends and documents the environment flag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add experimental `prime-worker` stdio JSON-RPC Python execution backend
> - Adds a new `PrimeWorkerManager` backend in [prime-worker.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/36/files#diff-18e804b34159b40336a9d84984d8cd66587a883fb24b5f07b84ba6fdadc5e1dc) that runs a long-lived `python -m prime_agent_worker` subprocess, communicating over newline-delimited JSON-RPC on stdio instead of Jupyter/ZMQ.
> - The Python worker in [__main__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/36/files#diff-3b8e61af9727cfd193ea6e9190f66398a425e43fc4210c9e73363cde62a7b9ef) embeds an IPython `InteractiveShell`, streams stdout/stderr as notifications, enforces output caps, and proxies `rlm.run/background/status/wait` calls back to the TypeScript host.
> - Backend selection is controlled by the `PRIME_AGENT_PYTHON_BACKEND` env var (`jupyter-zmq` or `prime-worker`); the ipython tool skips RLM bootstrap code injection when using the worker backend.
> - Bootstrap schema is incremented to 2: `ensureKernelPython` now requires both `rlm` and `prime_agent_worker` to be importable before marking an environment as ready.
> - Risk: abort is implemented by terminating and recreating the worker process, which resets all in-kernel state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3255114. 13 files reviewed, 8 issues evaluated, 1 issue filtered, 4 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/coding-agent/src/core/kernel/index.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 335](https://github.com/PrimeIntellect-ai/prime-agent/blob/3255114c4501a0bfd8f1778b682346886d9f3264/packages/coding-agent/src/core/kernel/index.ts#L335): If `ensureKernelPython()` fails in `doStart()`, the `state` is reset to `"idle"` (line 336) but `startPromise` is not cleared. Subsequent calls to `start()` will return the cached rejected promise forever, making the kernel unrecoverable without creating a new instance. The other error-recovery paths (lines 376-381 and 396-401) correctly call `shutdown()` which invokes `cleanupResources()` to clear `startPromise`, but the early failure path does not. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->