### PR TITLE
preserve tui backgrounds across tab indentation

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added optional background surface rendering for editor components.
 - Added scrollback overlay rendering for full-screen overlays that should preserve native terminal scrollback.
 
+### Fixed
+
+- Fixed raw tabs in rendered TUI lines to preserve painted backgrounds across indentation.
+
 ## [0.74.0] - 2026-05-07
 
 ## [0.73.1] - 2026-05-07

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -263,10 +263,24 @@ export function visibleWidth(str: string): number {
  */
 const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;
 const THAI_LAO_AM_GLOBAL_REGEX = /[\u0e33\u0eb3]/g;
+const TAB_REGEX = /\t/;
+const TAB_GLOBAL_REGEX = /\t/g;
 
 export function normalizeTerminalOutput(str: string): string {
-	if (!THAI_LAO_AM_REGEX.test(str)) return str;
-	return str.replace(THAI_LAO_AM_GLOBAL_REGEX, (char) => (char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2"));
+	const hasThaiLaoAm = THAI_LAO_AM_REGEX.test(str);
+	const hasTab = TAB_REGEX.test(str);
+	if (!hasThaiLaoAm && !hasTab) return str;
+
+	let normalized = str;
+	if (hasThaiLaoAm) {
+		normalized = normalized.replace(THAI_LAO_AM_GLOBAL_REGEX, (char) =>
+			char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2",
+		);
+	}
+	if (hasTab) {
+		normalized = normalized.replace(TAB_GLOBAL_REGEX, "   ");
+	}
+	return normalized;
 }
 
 /**

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -64,6 +64,16 @@ function getCellItalic(terminal: VirtualTerminal, row: number, col: number): num
 	return cell.isItalic();
 }
 
+function getCellBg(terminal: VirtualTerminal, row: number, col: number): { mode: number; color: number } {
+	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;
+	const buffer = xterm.buffer.active;
+	const line = buffer.getLine(buffer.viewportY + row);
+	assert.ok(line, `Missing buffer line at row ${row}`);
+	const cell = line.getCell(col);
+	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
+	return { mode: cell.getBgColorMode(), color: cell.getBgColor() };
+}
+
 describe("TUI Kitty image cleanup", () => {
 	it("deletes changed image ids before drawing moved placements", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 10);
@@ -374,6 +384,25 @@ describe("TUI differential rendering", () => {
 		await terminal.waitForRender();
 
 		assert.strictEqual(getCellItalic(terminal, 1, 0), 0);
+		tui.stop();
+	});
+
+	it("expands tabs before writing rendered lines to the terminal", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 6);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["\x1b[48;5;236m512:\t\tcode\x1b[49m"];
+		tui.start();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(!writes.includes("\t"), "rendered terminal output should not contain raw tabs");
+		assert.ok(writes.includes("512:      code"), "tabs should expand to the measured three-column width");
+		assert.deepStrictEqual(getCellBg(terminal, 0, 4), getCellBg(terminal, 0, 0));
+		assert.deepStrictEqual(getCellBg(terminal, 0, 9), getCellBg(terminal, 0, 0));
+
 		tui.stop();
 	});
 


### PR DESCRIPTION
- raw tabs were moving the cursor without painting skipped indentation cells in rendered tui lines.

before & after:
<img width="743" height="872" alt="image" src="https://github.com/user-attachments/assets/3424ca40-782c-4593-b189-01f4a5dad2b3" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to output normalization plus a regression test; main impact is that any raw tab characters in rendered lines now become three spaces, which could slightly change alignment if callers relied on real tab stops.
> 
> **Overview**
> Fixes TUI rendering artifacts where raw `\t` characters moved the cursor without painting intermediate cells, breaking continuous background colors in indented regions.
> 
> `normalizeTerminalOutput()` now also expands tabs to a fixed three-space width (in addition to the existing Thai/Lao AM vowel normalization), and a new render test asserts no raw tabs are written and that background color remains consistent across the expanded indentation. The changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0e1746203e5591f48de4bdbffe8627def73ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand tab characters to spaces in TUI rendered lines to preserve painted backgrounds
> Raw tab characters in terminal output caused background colors to not be painted across the tab width. The fix replaces all tab characters with three spaces in [`normalizeTerminalOutput`](https://github.com/PrimeIntellect-ai/prime-agent/pull/38/files#diff-4c3f9017cf74053e3b6aca505c66afe64a6bb0e33edf0348d2f7dc436e594a93) before writing lines to the terminal.
>
> - Behavioral Change: strings containing tabs previously passed through `normalizeTerminalOutput` unchanged; they now have tabs expanded to three spaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff0e174.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->