### PR TITLE
add r2 installer release flow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -192,6 +192,7 @@ jobs:
           TARBALL="release-artifacts/prime-agent-${VERSION}.tgz"
           INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL}"
           INSTALL_BASE_URL="${INSTALL_BASE_URL%/}"
+          export INSTALL_BASE_URL
 
           test -f "${TARBALL}"
           test -f release-artifacts/SHA256SUMS

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Publish to R2
         run: |
           VERSION="${RELEASE_TAG#v}"
-          RELEASE_PREFIX="prime-agent/releases/v${VERSION}"
+          RELEASE_PREFIX="releases/v${VERSION}"
           TARBALL="release-artifacts/prime-agent-${VERSION}.tgz"
           INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL}"
           INSTALL_BASE_URL="${INSTALL_BASE_URL%/}"
@@ -141,17 +141,17 @@ jobs:
             --content-type "text/plain" \
             --cache-control "public, max-age=31536000, immutable"
 
-          aws s3 cp release-artifacts/latest.json "s3://${R2_BUCKET}/prime-agent/latest.json" \
+          aws s3 cp release-artifacts/latest.json "s3://${R2_BUCKET}/latest.json" \
             --endpoint-url "${R2_ENDPOINT_URL}" \
             --content-type "application/json" \
             --cache-control "no-cache"
 
-          aws s3 cp release-artifacts/stable "s3://${R2_BUCKET}/prime-agent/stable" \
+          aws s3 cp release-artifacts/stable "s3://${R2_BUCKET}/stable" \
             --endpoint-url "${R2_ENDPOINT_URL}" \
             --content-type "text/plain" \
             --cache-control "no-cache"
 
-          aws s3 cp /tmp/prime-agent-install.sh "s3://${R2_BUCKET}/prime-agent/install.sh" \
+          aws s3 cp /tmp/prime-agent-install.sh "s3://${R2_BUCKET}/install.sh" \
             --endpoint-url "${R2_ENDPOINT_URL}" \
             --content-type "text/x-shellscript" \
             --cache-control "no-cache"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -12,17 +12,15 @@ on:
         description: 'Release tag to create or update (e.g., v0.0.1)'
         required: true
         type: string
-      ref:
-        description: 'Branch, tag, or SHA to build. Defaults to release_tag.'
-        required: false
-        type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release-context:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       build_ref: ${{ steps.context.outputs.build_ref }}
       release_tag: ${{ steps.context.outputs.release_tag }}
@@ -32,6 +30,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve release context
         id: context
@@ -40,14 +39,18 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
           GITHUB_SHA_VALUE: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
-          INPUT_REF: ${{ github.event.inputs.ref || '' }}
         run: |
           should_release=true
 
           if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+              echo "Manual releases must run from the default branch (${DEFAULT_BRANCH}), not ${REF_NAME}." >&2
+              exit 1
+            fi
             release_tag="$INPUT_RELEASE_TAG"
-            build_ref="$INPUT_REF"
+            build_ref="$GITHUB_SHA_VALUE"
           elif [ "$REF_TYPE" = tag ]; then
             release_tag="$REF_NAME"
             build_ref="$REF_NAME"
@@ -65,6 +68,10 @@ jobs:
             v*) ;;
             *) release_tag="v${release_tag}" ;;
           esac
+          if ! printf '%s\n' "$release_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release tag must be a plain semver tag like v0.0.1: ${release_tag}" >&2
+            exit 1
+          fi
 
           if [ -z "$build_ref" ]; then
             build_ref="$release_tag"
@@ -81,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-context
     if: needs.release-context.outputs.should_release == 'true'
+    permissions:
+      contents: read
     env:
       RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
       BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
@@ -89,6 +98,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ env.BUILD_REF }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -124,6 +134,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-context, build]
     if: needs.release-context.outputs.should_release == 'true'
+    permissions:
+      contents: write
     env:
       RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
       BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
@@ -138,6 +150,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ env.BUILD_REF }}
+          persist-credentials: false
 
       - name: Download release artifacts
         uses: actions/download-artifact@v4
@@ -188,7 +201,14 @@ jobs:
           test -n "${R2_BUCKET}"
           test -n "${R2_ENDPOINT_URL}"
 
-          sed "s#__PRIME_AGENT_DOWNLOAD_BASE_URL__#${INSTALL_BASE_URL}#g" install.sh > /tmp/prime-agent-install.sh
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const baseUrl = process.env.INSTALL_BASE_URL;
+          if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
+          const installer = fs.readFileSync("install.sh", "utf8")
+            .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl);
+          fs.writeFileSync("/tmp/prime-agent-install.sh", installer);
+          NODE
 
           for artifact in release-artifacts/*.tgz; do
             aws s3 cp "${artifact}" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "${artifact}")" \

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check
-        run: npm run check
-
       - name: Build
         run: npm run build
+
+      - name: Check
+        run: npm run check
 
       - name: Pack private npm tarball
         env:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -2,6 +2,8 @@ name: Release Prime Agent
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -19,11 +21,69 @@ permissions:
   contents: write
 
 jobs:
+  release-context:
+    runs-on: ubuntu-latest
+    outputs:
+      build_ref: ${{ steps.context.outputs.build_ref }}
+      release_tag: ${{ steps.context.outputs.release_tag }}
+      should_release: ${{ steps.context.outputs.should_release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release context
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
+          INPUT_REF: ${{ github.event.inputs.ref || '' }}
+        run: |
+          should_release=true
+
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            release_tag="$INPUT_RELEASE_TAG"
+            build_ref="$INPUT_REF"
+          elif [ "$REF_TYPE" = tag ]; then
+            release_tag="$REF_NAME"
+            build_ref="$REF_NAME"
+          else
+            version=$(node -p "require('./package.json').version")
+            release_tag="v${version}"
+            build_ref="$GITHUB_SHA_VALUE"
+            if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+              echo "Tag ${release_tag} already exists; skipping release."
+              should_release=false
+            fi
+          fi
+
+          case "$release_tag" in
+            v*) ;;
+            *) release_tag="v${release_tag}" ;;
+          esac
+
+          if [ -z "$build_ref" ]; then
+            build_ref="$release_tag"
+          fi
+
+          echo "build_ref=$build_ref" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
+          echo "Release tag: $release_tag"
+          echo "Build ref: $build_ref"
+          echo "Should release: $should_release"
+
   build:
     runs-on: ubuntu-latest
+    needs: release-context
+    if: needs.release-context.outputs.should_release == 'true'
     env:
-      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
-      BUILD_REF: ${{ github.event.inputs.ref || github.event.inputs.release_tag || github.ref_name }}
+      RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
+      BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,10 +122,11 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [release-context, build]
+    if: needs.release-context.outputs.should_release == 'true'
     env:
-      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
-      BUILD_REF: ${{ github.event.inputs.ref || github.event.inputs.release_tag || github.ref_name }}
+      RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
+      BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,4 +1,4 @@
-name: Build Binaries
+name: Release Prime Agent
 
 on:
   push:
@@ -6,9 +6,13 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag to build (e.g., v0.12.0)'
+      release_tag:
+        description: 'Release tag to create or update (e.g., v0.0.1)'
         required: true
+        type: string
+      ref:
+        description: 'Branch, tag, or SHA to build. Defaults to release_tag.'
+        required: false
         type: string
 
 permissions:
@@ -18,17 +22,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+      BUILD_REF: ${{ github.event.inputs.ref || github.event.inputs.release_tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.RELEASE_TAG }}
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-        with:
-          bun-version: 1.2.20
+          ref: ${{ env.BUILD_REF }}
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -36,44 +36,124 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Build binaries
-        run: ./scripts/build-binaries.sh
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack private npm tarball
+        env:
+          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          test -n "${PRIME_AGENT_DOWNLOAD_BASE_URL}"
+          npm run release:pack -- --version "${VERSION}" --base-url "${PRIME_AGENT_DOWNLOAD_BASE_URL}"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prime-agent-release
+          path: packages/coding-agent/release/artifacts/*
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+      BUILD_REF: ${{ github.event.inputs.ref || github.event.inputs.release_tag || github.ref_name }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+      R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ env.BUILD_REF }}
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: prime-agent-release
+          path: release-artifacts
 
       - name: Extract changelog for this version
-        id: changelog
         run: |
-          VERSION="${RELEASE_TAG}"
-          VERSION="${VERSION#v}"  # Remove 'v' prefix
-          
-          # Extract changelog section for this version
-          cd packages/coding-agent
-          awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md > /tmp/release-notes.md
-          
-          # If empty, use a default message
+          VERSION="${RELEASE_TAG#v}"
+          awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" packages/coding-agent/CHANGELOG.md > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
-            echo "Release ${VERSION}" > /tmp/release-notes.md
+            echo "Release ${RELEASE_TAG}" > /tmp/release-notes.md
           fi
 
-      - name: Create GitHub Release and upload binaries
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd packages/coding-agent/binaries
-          
-          # Create release with changelog notes (or update if exists)
-          gh release create "${RELEASE_TAG}" \
-            --title "${RELEASE_TAG}" \
-            --notes-file /tmp/release-notes.md \
-            pi-darwin-arm64.tar.gz \
-            pi-darwin-x64.tar.gz \
-            pi-linux-x64.tar.gz \
-            pi-linux-arm64.tar.gz \
-            pi-windows-x64.zip \
-            2>/dev/null || \
-          gh release upload "${RELEASE_TAG}" \
-            pi-darwin-arm64.tar.gz \
-            pi-darwin-x64.tar.gz \
-            pi-linux-x64.tar.gz \
-            pi-linux-arm64.tar.gz \
-            pi-windows-x64.zip \
-            --clobber
+          target_args=()
+          if [ "${BUILD_REF}" != "${RELEASE_TAG}" ]; then
+            target_args=(--target "${BUILD_REF}")
+          fi
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" release-artifacts/* --clobber
+          else
+            gh release create "${RELEASE_TAG}" \
+              --title "${RELEASE_TAG}" \
+              "${target_args[@]}" \
+              --notes-file /tmp/release-notes.md \
+              release-artifacts/*
+          fi
+
+      - name: Publish to R2
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          RELEASE_PREFIX="prime-agent/releases/v${VERSION}"
+          TARBALL="release-artifacts/prime-agent-${VERSION}.tgz"
+          INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL}"
+          INSTALL_BASE_URL="${INSTALL_BASE_URL%/}"
+
+          test -f "${TARBALL}"
+          test -f release-artifacts/SHA256SUMS
+          test -f release-artifacts/stable
+          test -f release-artifacts/latest.json
+          test -n "${INSTALL_BASE_URL}"
+          test -n "${R2_BUCKET}"
+          test -n "${R2_ENDPOINT_URL}"
+
+          sed "s#__PRIME_AGENT_DOWNLOAD_BASE_URL__#${INSTALL_BASE_URL}#g" install.sh > /tmp/prime-agent-install.sh
+
+          for artifact in release-artifacts/*.tgz; do
+            aws s3 cp "${artifact}" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "${artifact}")" \
+              --endpoint-url "${R2_ENDPOINT_URL}" \
+              --content-type "application/gzip" \
+              --cache-control "public, max-age=31536000, immutable"
+          done
+
+          aws s3 cp release-artifacts/SHA256SUMS "s3://${R2_BUCKET}/${RELEASE_PREFIX}/SHA256SUMS" \
+            --endpoint-url "${R2_ENDPOINT_URL}" \
+            --content-type "text/plain" \
+            --cache-control "public, max-age=31536000, immutable"
+
+          aws s3 cp release-artifacts/latest.json "s3://${R2_BUCKET}/prime-agent/latest.json" \
+            --endpoint-url "${R2_ENDPOINT_URL}" \
+            --content-type "application/json" \
+            --cache-control "no-cache"
+
+          aws s3 cp release-artifacts/stable "s3://${R2_BUCKET}/prime-agent/stable" \
+            --endpoint-url "${R2_ENDPOINT_URL}" \
+            --content-type "text/plain" \
+            --cache-control "no-cache"
+
+          aws s3 cp /tmp/prime-agent-install.sh "s3://${R2_BUCKET}/prime-agent/install.sh" \
+            --endpoint-url "${R2_ENDPOINT_URL}" \
+            --content-type "text/x-shellscript" \
+            --cache-control "no-cache"
+
+          echo "Installer: ${INSTALL_BASE_URL}/install.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,10 @@ jobs:
       - name: Check
         run: npm run check
 
+      - name: Install uv
+        run: |
+          python3 -m pip install --user uv
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 Prime Agent is a hard fork of [pi](https://github.com/badlogic/pi-mono) rebuilt around an RLM-native coding and research harness. The TypeScript host keeps pi's terminal UI, provider layer, sessions, and extension machinery, while the model-facing runtime is centered on a persistent IPython kernel and recursive subagents.
 
+## Install
+
+Install the latest stable Prime Agent release:
+
+```sh
+curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
+```
+
+The installer downloads the published release tarball from R2, verifies its checksum, installs the `prime-agent` command with npm, and offers to install standalone Node.js if Node.js 20.6.0 or newer is not available.
+
+Start Prime Agent:
+
+```sh
+prime-agent
+```
+
+On first run, authenticate with `/login`.
+
+To update, rerun the install command. Releases are created from the root `package.json` version when changes merge to `main`; if the matching Git tag already exists, the release workflow skips publishing.
+
 ## Architecture
 
 Prime Agent keeps the core pieces that make pi a strong terminal agent: the TypeScript CLI, custom TUI renderer, model provider layer, session tree, slash commands, and extension/resource system. The main change is the model-facing runtime: instead of a large set of file and shell tools, the agent is centered on a persistent Python kernel.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Then start Prime Agent:
 prime-agent
 ```
 
-From this repository, use the source runner:
+Alternatively, to test local changes, clone this repository and use the source runner:
 
 ```bash
 npm ci

--- a/install.sh
+++ b/install.sh
@@ -52,13 +52,22 @@ main() {
 	fi
 
 	version="$(resolve_prime_agent_version "$@")"
-	tarball_url="$prime_agent_base_url/releases/v$version/$prime_agent_package-$version.tgz"
+	tarball_name="$prime_agent_package-$version.tgz"
+	tarball_url="$prime_agent_base_url/releases/v$version/$tarball_name"
 
-	printf 'This will run:\n\n  npm install -g %s\n\n' "$tarball_url"
+	printf 'This will download, verify, and install:\n\n  %s\n\n' "$tarball_url"
 	confirm_install
 
+	download_dir=$(create_temp_dir)
+	trap 'rm -rf "$download_dir"' EXIT
+	tarball_path="$download_dir/$tarball_name"
+
 	printf '\n'
-	install_prime_agent_package "$tarball_url"
+	download_prime_agent_package "$version" "$tarball_url" "$tarball_path"
+	printf '\n'
+	install_prime_agent_package "$tarball_path"
+	rm -rf "$download_dir"
+	trap - EXIT
 	printf '\nPrime Agent was installed successfully.\n'
 
 	if command -v "$prime_agent_cmd" >/dev/null 2>&1; then
@@ -77,6 +86,20 @@ Check npm's global bin directory with:
 Then add that directory to your shell PATH.
 EOF
 	fi
+}
+
+create_temp_dir() {
+	if command -v mktemp >/dev/null 2>&1; then
+		if tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/prime-agent-install.XXXXXX" 2>/dev/null); then
+			printf '%s' "$tmp_dir"
+			return
+		fi
+	fi
+
+	tmp_dir="${TMPDIR:-/tmp}/prime-agent-install.$$"
+	rm -rf "$tmp_dir"
+	mkdir -p "$tmp_dir"
+	printf '%s' "$tmp_dir"
 }
 
 run_preflight_checks() {
@@ -415,6 +438,53 @@ run_with_sudo() {
 	fi
 }
 
+download_prime_agent_package() {
+	version="$1"
+	tarball_url="$2"
+	tarball_path="$3"
+	download_dir=$(dirname "$tarball_path")
+	checksums_url="$prime_agent_base_url/releases/v$version/SHA256SUMS"
+	checksums_path="$download_dir/SHA256SUMS"
+
+	if ! command -v curl >/dev/null 2>&1; then
+		printf 'error: curl is required to download Prime Agent.\n' >&2
+		exit 1
+	fi
+
+	printf 'Downloading checksums...\n'
+	curl -fsSL "$checksums_url" -o "$checksums_path"
+
+	printf 'Downloading Prime Agent...\n'
+	curl -fL "$tarball_url" -o "$tarball_path"
+
+	verify_prime_agent_package_checksum "$checksums_path" "$tarball_path"
+}
+
+verify_prime_agent_package_checksum() {
+	checksums_path="$1"
+	tarball_path="$2"
+	checksum_dir=$(dirname "$tarball_path")
+	tarball_name=$(basename "$tarball_path")
+	selected_checksums_path="$checksum_dir/SHA256SUMS.selected"
+
+	if ! awk -v file="$tarball_name" '$2 == file { print; found = 1; exit } END { if (!found) exit 1 }' \
+		"$checksums_path" >"$selected_checksums_path"; then
+		printf 'error: checksum for %s was not found in %s\n' "$tarball_name" "$checksums_path" >&2
+		exit 1
+	fi
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		printf 'Verifying Prime Agent download\n'
+		(cd "$checksum_dir" && sha256sum -c "$(basename "$selected_checksums_path")")
+	elif command -v shasum >/dev/null 2>&1; then
+		printf 'Verifying Prime Agent download\n'
+		(cd "$checksum_dir" && shasum -a 256 -c "$(basename "$selected_checksums_path")")
+	else
+		printf 'error: sha256sum or shasum is required to verify the Prime Agent download.\n' >&2
+		exit 1
+	fi
+}
+
 confirm_install() {
 	if ! ( : <>/dev/tty ) 2>/dev/null; then
 		printf 'No terminal detected; continuing without confirmation.\n'
@@ -436,9 +506,9 @@ confirm_install() {
 }
 
 install_prime_agent_package() {
-	tarball_url="$1"
+	tarball_path="$1"
 	printf 'Installing Prime Agent...\n\n'
-	npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_url"
+	npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,6 @@ run_preflight_checks() {
 
 	if prime_agent_path=$(command -v "$prime_agent_cmd" 2>/dev/null); then
 		printf '%sExisting %s found at: %s%s\n' "$yellow" "$prime_agent_cmd" "$prime_agent_path" "$reset"
-		"$prime_agent_cmd" --version 2>/dev/null | sed "s/^/${yellow}/; s/\$/${reset}/" || true
 		printf '\n'
 	fi
 
@@ -348,6 +347,19 @@ install_node_standalone() {
 		rm -rf "$node_tmp_dir"
 		return 1
 	fi
+	case "$node_file" in
+		*/*|*\\*|*..*)
+			printf 'Unsafe Node.js archive name in checksum manifest: %s\n' "$node_file"
+			rm -rf "$node_tmp_dir"
+			return 1
+			;;
+		node-v*-"$node_platform"-"$node_arch".tar.xz) ;;
+		*)
+			printf 'Unexpected Node.js archive name in checksum manifest: %s\n' "$node_file"
+			rm -rf "$node_tmp_dir"
+			return 1
+			;;
+	esac
 
 	printf 'Downloading Node.js %s\n' "${node_file%.tar.xz}"
 	curl -fsSL "$node_dist_base/$node_file" -o "$node_tmp_dir/$node_file"

--- a/install.sh
+++ b/install.sh
@@ -29,9 +29,7 @@ main() {
 		check_status=$?
 	fi
 
-	if [ "$check_status" -eq 0 ]; then
-		cat "$check_file"
-	fi
+	cat "$check_file"
 	rm -f "$check_file"
 
 	if [ "$check_status" -ne 0 ]; then
@@ -161,6 +159,10 @@ install_node_npm_interactive() {
 		apt) label="apt" ;;
 		apk) label="apk" ;;
 		standalone) label="standalone Node.js" ;;
+		*)
+			method=standalone
+			label="standalone Node.js"
+			;;
 	esac
 
 	if ! ( : <>/dev/tty ) 2>/dev/null; then
@@ -342,6 +344,9 @@ verify_node_standalone_download() {
 	elif command -v shasum >/dev/null 2>&1; then
 		printf 'Verifying Node.js download\n'
 		(cd "$checksum_dir" && shasum -a 256 -c SHASUMS256.selected)
+	else
+		printf 'error: sha256sum or shasum is required to verify the Node.js download.\n'
+		return 1
 	fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -18,34 +18,27 @@ main() {
 		exit 1
 	fi
 
-	check_file="${TMPDIR:-/tmp}/prime-agent-installer-checks.$$"
-	run_preflight_checks >"$check_file" &
-	check_pid=$!
+	start_preflight_checks
 
 	printf '\n\033[1m  Prime Agent Installer\033[0m\n\033[2m  Installing Prime Agent with npm.\033[0m\n\n'
 
-	if wait "$check_pid"; then
+	if finish_preflight_checks; then
 		check_status=0
 	else
 		check_status=$?
 	fi
-
-	cat "$check_file"
-	rm -f "$check_file"
 
 	if [ "$check_status" -ne 0 ]; then
 		if ! install_node_npm_interactive; then
 			exit "$check_status"
 		fi
 
-		check_file="${TMPDIR:-/tmp}/prime-agent-installer-checks.$$"
-		if run_preflight_checks >"$check_file"; then
+		start_preflight_checks
+		if finish_preflight_checks; then
 			check_status=0
 		else
 			check_status=$?
 		fi
-		cat "$check_file"
-		rm -f "$check_file"
 
 		if [ "$check_status" -ne 0 ]; then
 			exit "$check_status"
@@ -95,10 +88,27 @@ create_temp_dir() {
 		fi
 	fi
 
-	tmp_dir="${TMPDIR:-/tmp}/prime-agent-install.$$"
-	rm -rf "$tmp_dir"
-	mkdir -p "$tmp_dir"
-	printf '%s' "$tmp_dir"
+	printf 'error: mktemp is required to create a secure temporary directory.\n' >&2
+	exit 1
+}
+
+start_preflight_checks() {
+	preflight_dir=$(create_temp_dir)
+	preflight_file="$preflight_dir/preflight"
+	run_preflight_checks >"$preflight_file" &
+	preflight_pid=$!
+}
+
+finish_preflight_checks() {
+	if wait "$preflight_pid"; then
+		preflight_status=0
+	else
+		preflight_status=$?
+	fi
+
+	cat "$preflight_file"
+	rm -rf "$preflight_dir"
+	return "$preflight_status"
 }
 
 run_preflight_checks() {
@@ -324,9 +334,8 @@ install_node_standalone() {
 	}
 	node_dist_base="https://nodejs.org/dist/latest-v22.x"
 	node_base_dir=$(node_standalone_base_dir)
-	node_tmp_dir="${TMPDIR:-/tmp}/prime-agent-node.$$"
+	node_tmp_dir=$(create_temp_dir)
 
-	rm -rf "$node_tmp_dir"
 	mkdir -p "$node_tmp_dir" "$node_base_dir"
 
 	printf 'Resolving Node.js binary for %s-%s\n' "$node_platform" "$node_arch"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,8 @@ prime_agent_base_url="${prime_agent_base_url%/}"
 prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
 prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
 prime_agent_esc=$(printf '\033')
-readonly prime_agent_unconfigured_base_url prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc
+prime_agent_original_path="${PATH:-}"
+readonly prime_agent_unconfigured_base_url prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc prime_agent_original_path
 
 main() {
 	if [ "$prime_agent_base_url" = "$prime_agent_unconfigured_base_url" ]; then
@@ -70,12 +71,10 @@ main() {
 	trap - EXIT
 	printf '\nPrime Agent was installed successfully.\n'
 
-	if command -v "$prime_agent_cmd" >/dev/null 2>&1; then
+	if [ "${PRIME_AGENT_NODE_INSTALLED_STANDALONE:-0}" = 1 ]; then
+		configure_standalone_node_path
+	elif command -v "$prime_agent_cmd" >/dev/null 2>&1; then
 		printf '\nRun it with: %s\n' "$prime_agent_cmd"
-		if [ "${PRIME_AGENT_NODE_INSTALLED_STANDALONE:-0}" = 1 ]; then
-			printf 'If %s is not found in your shell yet, add this to your shell profile:\n\n' "$prime_agent_cmd"
-			printf '  export PATH="%s:$PATH"\n' "$PRIME_AGENT_STANDALONE_NODE_BIN"
-		fi
 	else
 		cat <<EOF
 The $prime_agent_cmd command was installed, but it is not on your PATH yet.
@@ -436,6 +435,121 @@ run_with_sudo() {
 	else
 		sudo "$@"
 	fi
+}
+
+configure_standalone_node_path() {
+	if original_prime_agent_path=$(resolve_prime_agent_with_original_path); then
+		case "$original_prime_agent_path" in
+			"$PRIME_AGENT_STANDALONE_NODE_BIN/"*)
+				printf '\nRun it with: %s\n' "$prime_agent_cmd"
+				return 0
+				;;
+		esac
+		printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
+		printf 'Your shell currently resolves %s to: %s\n' "$prime_agent_cmd" "$original_prime_agent_path"
+	else
+		printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
+	fi
+
+	profile=$(detect_shell_profile) || {
+		print_standalone_path_manual_instructions
+		return 0
+	}
+
+	if shell_profile_has_standalone_node_path "$profile"; then
+		printf '%s already contains %s.\n' "$profile" "$PRIME_AGENT_STANDALONE_NODE_BIN"
+		printf 'Restart your shell or run: . %s\n' "$profile"
+		return 0
+	fi
+
+	prompt_add_standalone_node_path "$profile"
+}
+
+resolve_prime_agent_with_original_path() {
+	saved_path=$PATH
+	PATH=$prime_agent_original_path
+	if command -v "$prime_agent_cmd" 2>/dev/null; then
+		status=0
+	else
+		status=$?
+	fi
+	PATH=$saved_path
+	return "$status"
+}
+
+detect_shell_profile() {
+	if [ -n "${PRIME_AGENT_SHELL_PROFILE:-}" ]; then
+		printf '%s' "$PRIME_AGENT_SHELL_PROFILE"
+		return 0
+	fi
+	if [ -z "${HOME:-}" ]; then
+		return 1
+	fi
+
+	shell_name="${SHELL:-}"
+	shell_name="${shell_name##*/}"
+	case "$shell_name" in
+		zsh)
+			printf '%s/.zshrc' "${ZDOTDIR:-$HOME}"
+			;;
+		bash)
+			printf '%s/.bashrc' "$HOME"
+			;;
+		*)
+			if [ -f "$HOME/.zshrc" ]; then
+				printf '%s/.zshrc' "$HOME"
+			elif [ -f "$HOME/.bashrc" ]; then
+				printf '%s/.bashrc' "$HOME"
+			else
+				printf '%s/.profile' "$HOME"
+			fi
+			;;
+	esac
+}
+
+shell_profile_has_standalone_node_path() {
+	profile="$1"
+	[ -f "$profile" ] && grep -F "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile" >/dev/null 2>&1
+}
+
+prompt_add_standalone_node_path() {
+	profile="$1"
+	path_line=$(standalone_node_path_line)
+
+	if ! ( : <>/dev/tty ) 2>/dev/null; then
+		print_standalone_path_manual_instructions
+		return 0
+	fi
+	exec 3<>/dev/tty
+
+	printf 'Add %s to your PATH in %s now? [Y/n] ' "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile" >&3
+	if ! IFS= read -r answer <&3; then
+		answer=
+	fi
+	exec 3>&-
+	case "$answer" in
+		n|N|no|NO)
+			print_standalone_path_manual_instructions
+			return 0
+			;;
+	esac
+
+	mkdir -p "$(dirname "$profile")"
+	{
+		printf '\n# Prime Agent standalone Node.js\n'
+		printf '%s\n' "$path_line"
+	} >>"$profile"
+	printf 'Added %s to %s.\n' "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile"
+	printf 'Restart your shell or run: . %s\n' "$profile"
+}
+
+print_standalone_path_manual_instructions() {
+	printf 'Add this to your shell profile to use %s from new shells:\n\n' "$prime_agent_cmd"
+	printf '  %s\n' "$(standalone_node_path_line)"
+}
+
+standalone_node_path_line() {
+	printf 'export PATH="%s:$PATH"' "$PRIME_AGENT_STANDALONE_NODE_BIN"
 }
 
 download_prime_agent_package() {

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+# Keep this sentinel split so release publishing only rewrites the install URL
+# below; local or unpublished copies still need an unreplaced value to compare.
 prime_agent_unconfigured_base_url="__PRIME_AGENT_DOWNLOAD_BASE""_URL__"
 prime_agent_base_url="${PRIME_AGENT_DOWNLOAD_BASE_URL:-__PRIME_AGENT_DOWNLOAD_BASE_URL__}"
 prime_agent_base_url="${prime_agent_base_url%/}"

--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,16 @@
 
 set -eu
 
+prime_agent_unconfigured_base_url="__PRIME_AGENT_DOWNLOAD_BASE""_URL__"
 prime_agent_base_url="${PRIME_AGENT_DOWNLOAD_BASE_URL:-__PRIME_AGENT_DOWNLOAD_BASE_URL__}"
 prime_agent_base_url="${prime_agent_base_url%/}"
 prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
 prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
 prime_agent_esc=$(printf '\033')
-readonly prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc
+readonly prime_agent_unconfigured_base_url prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc
 
 main() {
-	if [ "$prime_agent_base_url" = "__PRIME_AGENT_DOWNLOAD_BASE_URL__" ]; then
+	if [ "$prime_agent_base_url" = "$prime_agent_unconfigured_base_url" ]; then
 		printf 'error: installer download URL is not configured.\n' >&2
 		printf 'Set PRIME_AGENT_DOWNLOAD_BASE_URL or use the installer published by the release workflow.\n' >&2
 		exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,438 @@
+#!/bin/sh
+
+set -eu
+
+prime_agent_base_url="${PRIME_AGENT_DOWNLOAD_BASE_URL:-__PRIME_AGENT_DOWNLOAD_BASE_URL__}"
+prime_agent_base_url="${prime_agent_base_url%/}"
+prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
+prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
+prime_agent_esc=$(printf '\033')
+readonly prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc
+
+main() {
+	if [ "$prime_agent_base_url" = "__PRIME_AGENT_DOWNLOAD_BASE_URL__" ]; then
+		printf 'error: installer download URL is not configured.\n' >&2
+		printf 'Set PRIME_AGENT_DOWNLOAD_BASE_URL or use the installer published by the release workflow.\n' >&2
+		exit 1
+	fi
+
+	check_file="${TMPDIR:-/tmp}/prime-agent-installer-checks.$$"
+	run_preflight_checks >"$check_file" &
+	check_pid=$!
+
+	printf '\n\033[1m  Prime Agent Installer\033[0m\n\033[2m  Installing Prime Agent with npm.\033[0m\n\n'
+
+	if wait "$check_pid"; then
+		check_status=0
+	else
+		check_status=$?
+	fi
+
+	if [ "$check_status" -eq 0 ]; then
+		cat "$check_file"
+	fi
+	rm -f "$check_file"
+
+	if [ "$check_status" -ne 0 ]; then
+		if ! install_node_npm_interactive; then
+			exit "$check_status"
+		fi
+
+		check_file="${TMPDIR:-/tmp}/prime-agent-installer-checks.$$"
+		if run_preflight_checks >"$check_file"; then
+			check_status=0
+		else
+			check_status=$?
+		fi
+		cat "$check_file"
+		rm -f "$check_file"
+
+		if [ "$check_status" -ne 0 ]; then
+			exit "$check_status"
+		fi
+	fi
+
+	version="$(resolve_prime_agent_version "$@")"
+	tarball_url="$prime_agent_base_url/releases/v$version/$prime_agent_package-$version.tgz"
+
+	printf 'This will run:\n\n  npm install -g %s\n\n' "$tarball_url"
+	confirm_install
+
+	printf '\n'
+	install_prime_agent_package "$tarball_url"
+	printf '\nPrime Agent was installed successfully.\n'
+
+	if command -v "$prime_agent_cmd" >/dev/null 2>&1; then
+		printf '\nRun it with: %s\n' "$prime_agent_cmd"
+		if [ "${PRIME_AGENT_NODE_INSTALLED_STANDALONE:-0}" = 1 ]; then
+			printf 'If %s is not found in your shell yet, add this to your shell profile:\n\n' "$prime_agent_cmd"
+			printf '  export PATH="%s:$PATH"\n' "$PRIME_AGENT_STANDALONE_NODE_BIN"
+		fi
+	else
+		cat <<EOF
+The $prime_agent_cmd command was installed, but it is not on your PATH yet.
+Check npm's global bin directory with:
+
+  npm bin -g
+
+Then add that directory to your shell PATH.
+EOF
+	fi
+}
+
+run_preflight_checks() {
+	status=0
+	yellow="${prime_agent_esc}[33m"
+	reset="${prime_agent_esc}[0m"
+
+	if command -v node >/dev/null 2>&1; then
+		node_version=$(node --version)
+		if ! node -e 'const [major, minor, patch] = process.versions.node.split(".").map(Number); process.exit(major > 20 || (major === 20 && (minor > 6 || (minor === 6 && patch >= 0))) ? 0 : 1)' >/dev/null; then
+			printf 'error: Prime Agent requires Node.js 20.6.0 or newer. Found %s.\n' "$node_version"
+			status=1
+		fi
+	else
+		printf 'error: Node.js 20.6.0 or newer is required to install Prime Agent.\n'
+		status=1
+	fi
+
+	if ! command -v npm >/dev/null 2>&1; then
+		printf 'error: npm is required to install Prime Agent.\n'
+		status=1
+	fi
+
+	if [ "$status" -ne 0 ]; then
+		printf '\n'
+	fi
+
+	if prime_agent_path=$(command -v "$prime_agent_cmd" 2>/dev/null); then
+		printf '%sExisting %s found at: %s%s\n' "$yellow" "$prime_agent_cmd" "$prime_agent_path" "$reset"
+		"$prime_agent_cmd" --version 2>/dev/null | sed "s/^/${yellow}/; s/\$/${reset}/" || true
+		printf '\n'
+	fi
+
+	return "$status"
+}
+
+resolve_prime_agent_version() {
+	if [ "${1:-}" ]; then
+		normalize_version "$1"
+		return
+	fi
+
+	if [ "${PRIME_AGENT_VERSION:-}" ]; then
+		normalize_version "$PRIME_AGENT_VERSION"
+		return
+	fi
+
+	if ! command -v curl >/dev/null 2>&1; then
+		printf 'error: curl is required to resolve the latest Prime Agent version.\n' >&2
+		exit 1
+	fi
+
+	stable_version="$(curl -fsSL "$prime_agent_base_url/stable" | tr -d '[:space:]')"
+	if [ -z "$stable_version" ]; then
+		printf 'error: could not resolve latest Prime Agent version from %s/stable\n' "$prime_agent_base_url" >&2
+		exit 1
+	fi
+	normalize_version "$stable_version"
+}
+
+normalize_version() {
+	version="${1#v}"
+	case "$version" in
+		"")
+			printf 'error: empty Prime Agent version.\n' >&2
+			exit 1
+			;;
+		*[!0-9A-Za-z.-]*)
+			printf 'error: invalid Prime Agent version: %s\n' "$1" >&2
+			exit 1
+			;;
+	esac
+	printf '%s' "$version"
+}
+
+install_node_npm_interactive() {
+	method=$(detect_node_install_method)
+	case "$method" in
+		homebrew) label="Homebrew" ;;
+		apt) label="apt" ;;
+		apk) label="apk" ;;
+		standalone) label="standalone Node.js" ;;
+	esac
+
+	if ! ( : <>/dev/tty ) 2>/dev/null; then
+		printf 'No terminal detected; install Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+		return 1
+	fi
+	exec 3<>/dev/tty
+
+	printf 'Prime Agent needs Node.js 20.6.0 or newer and npm. Install them now with %s? [Y/n] ' "$label" >&3
+	if ! IFS= read -r answer <&3; then
+		answer=
+	fi
+	exec 3>&-
+	case "$answer" in
+		n|N|no|NO)
+			printf '\nInstall Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+			return 1
+			;;
+	esac
+
+	install_node_npm "$method" "$label"
+}
+
+detect_node_install_method() {
+	case "$(uname -s)" in
+		Darwin)
+			if command -v brew >/dev/null 2>&1; then
+				printf 'homebrew'
+			else
+				printf 'standalone'
+			fi
+			;;
+		Linux)
+			if command -v apt-cache >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1 && apt_node_candidate_is_new_enough; then
+				printf 'apt'
+			elif command -v apk >/dev/null 2>&1 && apk_node_candidate_is_new_enough; then
+				printf 'apk'
+			else
+				printf 'standalone'
+			fi
+			;;
+		*)
+			printf 'standalone'
+			;;
+	esac
+}
+
+apt_node_candidate_is_new_enough() {
+	version=$(apt-cache policy nodejs 2>/dev/null | awk '/Candidate:/ { print $2; exit }')
+	[ -n "$version" ] && [ "$version" != "(none)" ] && node_version_string_is_new_enough "$version"
+}
+
+apk_node_candidate_is_new_enough() {
+	version=$(apk search -x nodejs 2>/dev/null | awk -F- '/^nodejs-/ { print $2; exit }')
+	[ -n "$version" ] && node_version_string_is_new_enough "$version"
+}
+
+node_version_string_is_new_enough() {
+	version="${1#v}"
+	case "$version" in
+		[0-9]*) ;;
+		*) return 1 ;;
+	esac
+	version="${version%%[!0-9.]*}"
+	version_ifs=${IFS- }
+	IFS=.
+	set -- $version
+	IFS=$version_ifs
+	major="${1:-}"
+	minor="${2:-0}"
+	patch="${3:-0}"
+	case "$major" in ''|*[!0-9]*) return 1 ;; esac
+	case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
+	case "$patch" in ''|*[!0-9]*) patch=0 ;; esac
+
+	[ "$major" -gt 20 ] && return 0
+	[ "$major" -eq 20 ] && [ "$minor" -gt 6 ] && return 0
+	[ "$major" -eq 20 ] && [ "$minor" -eq 6 ] && [ "$patch" -ge 0 ] && return 0
+	return 1
+}
+
+install_node_npm() {
+	method="$1"
+	label="$2"
+
+	printf '\nInstalling Node.js and npm with %s...\n\n' "$label"
+	run_node_install_method "$method"
+
+	if [ "$method" = standalone ]; then
+		load_standalone_node
+		PRIME_AGENT_NODE_INSTALLED_STANDALONE=1
+	fi
+	hash -r
+	printf '\nNode.js and npm are installed.\n\n'
+}
+
+run_node_install_method() {
+	case "$1" in
+		homebrew) install_node_with_homebrew ;;
+		apt) install_node_with_apt ;;
+		apk) install_node_with_apk ;;
+		standalone) install_node_standalone ;;
+	esac
+}
+
+install_node_with_homebrew() {
+	if brew list node >/dev/null 2>&1; then
+		brew upgrade node
+	else
+		brew install node
+	fi
+}
+
+install_node_with_apt() {
+	print_sudo_note
+	if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+		apt-get update
+		apt-get install -y nodejs npm
+	else
+		sudo sh -c 'apt-get update && apt-get install -y nodejs npm'
+	fi
+}
+
+install_node_with_apk() {
+	print_sudo_note
+	run_with_sudo apk add --update-cache nodejs npm
+}
+
+install_node_standalone() {
+	node_platform=$(detect_node_binary_platform) || {
+		printf 'Unsupported operating system for automatic Node.js install: %s\n' "$(uname -s)"
+		return 1
+	}
+	node_arch=$(detect_node_binary_arch) || {
+		printf 'Unsupported CPU architecture for automatic Node.js install: %s\n' "$(uname -m)"
+		return 1
+	}
+	node_dist_base="https://nodejs.org/dist/latest-v22.x"
+	node_base_dir=$(node_standalone_base_dir)
+	node_tmp_dir="${TMPDIR:-/tmp}/prime-agent-node.$$"
+
+	rm -rf "$node_tmp_dir"
+	mkdir -p "$node_tmp_dir" "$node_base_dir"
+
+	printf 'Resolving Node.js binary for %s-%s\n' "$node_platform" "$node_arch"
+	curl -fsSL "$node_dist_base/SHASUMS256.txt" -o "$node_tmp_dir/SHASUMS256.txt"
+	node_file=$(awk -v suffix="-$node_platform-$node_arch.tar.xz" '
+		index($2, "node-v") == 1 && length($2) >= length(suffix) && substr($2, length($2) - length(suffix) + 1) == suffix { print $2; exit }
+	' "$node_tmp_dir/SHASUMS256.txt")
+	if [ -z "$node_file" ]; then
+		printf 'No Node.js binary is available for %s-%s.\n' "$node_platform" "$node_arch"
+		rm -rf "$node_tmp_dir"
+		return 1
+	fi
+
+	printf 'Downloading Node.js %s\n' "${node_file%.tar.xz}"
+	curl -fsSL "$node_dist_base/$node_file" -o "$node_tmp_dir/$node_file"
+	verify_node_standalone_download "$node_tmp_dir" "$node_file"
+	ensure_node_standalone_extract_tools "$node_platform"
+
+	node_dir="$node_base_dir/${node_file%.tar.xz}"
+	rm -rf "$node_dir"
+	printf 'Extracting Node.js to %s\n' "$node_dir"
+	tar -xf "$node_tmp_dir/$node_file" -C "$node_base_dir"
+	rm -f "$node_base_dir/current"
+	ln -s "$node_dir" "$node_base_dir/current"
+	rm -rf "$node_tmp_dir"
+	printf 'Node.js installed at %s\n' "$node_dir"
+}
+
+verify_node_standalone_download() {
+	checksum_dir="$1"
+	checksum_file_name="$2"
+	awk -v file="$checksum_file_name" '$2 == file { print }' "$checksum_dir/SHASUMS256.txt" >"$checksum_dir/SHASUMS256.selected"
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		printf 'Verifying Node.js download\n'
+		(cd "$checksum_dir" && sha256sum -c SHASUMS256.selected)
+	elif command -v shasum >/dev/null 2>&1; then
+		printf 'Verifying Node.js download\n'
+		(cd "$checksum_dir" && shasum -a 256 -c SHASUMS256.selected)
+	fi
+}
+
+ensure_node_standalone_extract_tools() {
+	extract_platform="$1"
+
+	if [ "$extract_platform" = linux ] && ! command -v xz >/dev/null 2>&1; then
+		printf 'Installing xz-utils for Node.js archive extraction\n'
+		print_sudo_note
+		if command -v apt-get >/dev/null 2>&1; then
+			run_with_sudo apt-get update
+			run_with_sudo apt-get install -y xz-utils
+		elif command -v apk >/dev/null 2>&1; then
+			run_with_sudo apk add --update-cache xz
+		else
+			printf 'xz is required to extract Node.js. Install xz and run this installer again.\n'
+			return 1
+		fi
+	fi
+}
+
+load_standalone_node() {
+	PRIME_AGENT_STANDALONE_NODE_BIN="$(node_standalone_base_dir)/current/bin"
+	PATH="$PRIME_AGENT_STANDALONE_NODE_BIN:$PATH"
+	export PRIME_AGENT_STANDALONE_NODE_BIN PATH
+}
+
+node_standalone_base_dir() {
+	if [ -n "${XDG_DATA_HOME:-}" ]; then
+		printf '%s/prime-agent-node' "$XDG_DATA_HOME"
+	else
+		printf '%s/.local/share/prime-agent-node' "$HOME"
+	fi
+}
+
+detect_node_binary_platform() {
+	case "$(uname -s)" in
+		Darwin) printf 'darwin' ;;
+		Linux) printf 'linux' ;;
+		*) return 1 ;;
+	esac
+}
+
+detect_node_binary_arch() {
+	case "$(uname -m)" in
+		x86_64|amd64) printf 'x64' ;;
+		arm64|aarch64) printf 'arm64' ;;
+		armv7l) printf 'armv7l' ;;
+		ppc64le) printf 'ppc64le' ;;
+		s390x) printf 's390x' ;;
+		*) return 1 ;;
+	esac
+}
+
+print_sudo_note() {
+	if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+		printf 'This may ask for your sudo password.\n\n'
+	fi
+}
+
+run_with_sudo() {
+	if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+		"$@"
+	else
+		sudo "$@"
+	fi
+}
+
+confirm_install() {
+	if ! ( : <>/dev/tty ) 2>/dev/null; then
+		printf 'No terminal detected; continuing without confirmation.\n'
+		return 0
+	fi
+	exec 3<>/dev/tty
+
+	printf 'Continue? [Y/n] ' >&3
+	if ! IFS= read -r answer <&3; then
+		answer=
+	fi
+	exec 3>&-
+	case "$answer" in
+		n|N|no|NO)
+			printf '\nInstallation cancelled.\n'
+			exit 0
+			;;
+	esac
+}
+
+install_prime_agent_package() {
+	tarball_url="$1"
+	printf 'Installing Prime Agent...\n\n'
+	npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_url"
+}
+
+main "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-monorepo",
-	"version": "0.0.3",
+	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-monorepo",
-			"version": "0.0.3",
+			"version": "0.0.1",
 			"workspaces": [
 				"packages/*",
 				"packages/web-ui/example",
@@ -16,7 +16,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.30.2",
+				"@earendil-works/pi-coding-agent": "^0.0.1",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -7326,10 +7326,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.0.1",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -7356,7 +7356,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -7398,13 +7398,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.74.0",
-				"@earendil-works/pi-ai": "^0.74.0",
-				"@earendil-works/pi-tui": "^0.74.0",
+				"@earendil-works/pi-agent-core": "^0.0.1",
+				"@earendil-works/pi-ai": "^0.0.1",
+				"@earendil-works/pi-tui": "^0.0.1",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -7447,14 +7447,14 @@
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-anthropic": {
 			"name": "pi-extension-custom-provider-anthropic",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.52.0"
 			}
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-gitlab-duo": {
 			"name": "pi-extension-custom-provider-gitlab-duo",
-			"version": "0.74.0"
+			"version": "0.0.1"
 		},
 		"packages/coding-agent/examples/extensions/sandbox": {
 			"name": "pi-extension-sandbox",
@@ -7526,7 +7526,7 @@
 		},
 		"packages/coding-agent/examples/extensions/with-deps": {
 			"name": "pi-extension-with-deps",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -7556,7 +7556,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
@@ -7578,11 +7578,11 @@
 		},
 		"packages/web-ui": {
 			"name": "@earendil-works/pi-web-ui",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.74.0",
-				"@earendil-works/pi-tui": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.0.1",
+				"@earendil-works/pi-tui": "^0.0.1",
 				"@lmstudio/sdk": "^1.5.0",
 				"docx-preview": "^0.3.7",
 				"jszip": "^3.10.1",
@@ -7605,7 +7605,7 @@
 		},
 		"packages/web-ui/example": {
 			"name": "pi-web-ui-example",
-			"version": "0.74.0",
+			"version": "0.0.1",
 			"dependencies": {
 				"@earendil-works/pi-ai": "file:../../ai",
 				"@earendil-works/pi-web-ui": "file:../",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.0.3",
+	"version": "0.0.1",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.30.2",
+		"@earendil-works/pi-coding-agent": "^0.0.1",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"prepublishOnly": "npm run clean && npm run build && npm run check",
 		"publish": "npm run prepublishOnly && npm publish -ws --access public",
 		"publish:dry": "npm run prepublishOnly && npm publish -ws --access public --dry-run",
+		"release:pack": "node scripts/pack-prime-agent-release.mjs",
 		"release:patch": "node scripts/release.mjs patch",
 		"release:minor": "node scripts/release.mjs minor",
 		"release:major": "node scripts/release.mjs major",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.74.0",
+	"version": "0.0.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.74.0",
+		"@earendil-works/pi-ai": "^0.0.1",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.74.0",
+	"version": "0.0.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a pi-style installer script and R2-backed private npm tarball release pipeline for `prime-agent`.
 - Added automatic IPython kernel runtime bootstrap with uv-managed Python, `ipykernel`, and `prime-agent-runtime`.
 - Added `/goal` for long-running objectives that continue after early no-tool stops until the model marks the goal complete.
 - Added `/usage` to show token, cost, and context usage on demand.

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-custom-provider",
-  "version": "0.74.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-custom-provider",
-      "version": "0.74.0",
+      "version": "0.0.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
       }

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-anthropic",
   "private": true,
-  "version": "0.74.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-gitlab-duo",
   "private": true,
-  "version": "0.74.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/with-deps/package-lock.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-with-deps",
-  "version": "0.74.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-with-deps",
-      "version": "0.74.0",
+      "version": "0.0.1",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/packages/coding-agent/examples/extensions/with-deps/package.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-with-deps",
   "private": true,
-  "version": "0.74.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.74.0",
+	"version": "0.0.1",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -40,9 +40,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.74.0",
-		"@earendil-works/pi-ai": "^0.74.0",
-		"@earendil-works/pi-tui": "^0.74.0",
+		"@earendil-works/pi-agent-core": "^0.0.1",
+		"@earendil-works/pi-ai": "^0.0.1",
+		"@earendil-works/pi-tui": "^0.0.1",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -3,6 +3,8 @@ import { constants, existsSync } from "node:fs";
 import { access, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { stderr, stdin } from "node:process";
+import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +12,7 @@ const BOOTSTRAP_SCHEMA = 2;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
 const BOOTSTRAP_VERSION_FILE = ".bootstrap-version";
@@ -221,12 +224,19 @@ async function ensureUv(): Promise<string> {
 	const localUv = path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
 	if (await isExecutable(localUv)) return localUv;
 
+	if (process.env.PRIME_AGENT_INSTALL_UV !== "1" && !(await confirmUvInstall())) {
+		throw new Error(
+			`uv is required to set up the Python kernel. Install uv yourself: ${UV_INSTALL_COMMAND}, ` +
+				"or set PRIME_AGENT_INSTALL_UV=1 to let prime-agent run that installer.",
+		);
+	}
+
 	process.stderr.write("› installing uv (one-time)…\n");
 	try {
-		await run("sh", ["-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"], { stdio: "inherit" });
+		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: "inherit" });
 	} catch (error) {
 		throw new Error(
-			`couldn't install uv from astral.sh; install it yourself: curl -LsSf https://astral.sh/uv/install.sh | sh, then re-run prime-agent. ${errorMessage(error)}`,
+			`couldn't install uv from astral.sh; install it yourself: ${UV_INSTALL_COMMAND}, then re-run prime-agent. ${errorMessage(error)}`,
 		);
 	}
 
@@ -234,6 +244,21 @@ async function ensureUv(): Promise<string> {
 	const installedFromPath = await findExecutable("uv");
 	if (installedFromPath) return installedFromPath;
 	throw new Error("uv install completed but binary not found at ~/.local/bin/uv");
+}
+
+async function confirmUvInstall(): Promise<boolean> {
+	if (process.env.PRIME_AGENT_INSTALL_UV === "0") return false;
+	if (!stdin.isTTY || !stderr.isTTY) return false;
+
+	const rl = createInterface({ input: stdin, output: stderr });
+	try {
+		const answer = (await rl.question("Prime Agent needs uv to set up Python. Install uv from astral.sh now? [Y/n] "))
+			.trim()
+			.toLowerCase();
+		return answer !== "n" && answer !== "no";
+	} finally {
+		rl.close();
+	}
 }
 
 async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | null> {

--- a/packages/coding-agent/src/postinstall.ts
+++ b/packages/coding-agent/src/postinstall.ts
@@ -1,5 +1,9 @@
 import { ensureKernelPython } from "./core/kernel/bootstrap.js";
 
+if (process.env.PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL !== "1") {
+	process.exit(0);
+}
+
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.74.0",
+	"version": "0.0.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/web-ui/example/package.json
+++ b/packages/web-ui/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-web-ui-example",
-  "version": "0.74.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-web-ui",
-	"version": "0.74.0",
+	"version": "0.0.1",
 	"description": "Reusable web UI components for AI chat interfaces powered by @earendil-works/pi-ai",
 	"type": "module",
 	"main": "dist/index.js",
@@ -18,8 +18,8 @@
 	},
 	"dependencies": {
 		"@lmstudio/sdk": "^1.5.0",
-		"@earendil-works/pi-ai": "^0.74.0",
-		"@earendil-works/pi-tui": "^0.74.0",
+		"@earendil-works/pi-ai": "^0.0.1",
+		"@earendil-works/pi-tui": "^0.0.1",
 		"typebox": "^1.1.24",
 		"docx-preview": "^0.3.7",
 		"jszip": "^3.10.1",

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -14,7 +14,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -111,6 +111,14 @@ function writeJson(path, value) {
 
 function packagePath(packageDir) {
 	return join(root, "packages", packageDir);
+}
+
+function assertSafeOutputDir(outDir) {
+	const relativeToReleaseRoot = relative(defaultOutputDir, outDir);
+	if (relativeToReleaseRoot === "" || (!relativeToReleaseRoot.startsWith("..") && !isAbsolute(relativeToReleaseRoot))) {
+		return;
+	}
+	throw new Error(`Refusing to remove output directory outside ${defaultOutputDir}: ${outDir}`);
 }
 
 function packageJsonPath(packageDir) {
@@ -244,6 +252,7 @@ function main() {
 
 	const stagingRoot = join(args.outDir, "packages");
 	const artifactsDir = join(args.outDir, "artifacts");
+	assertSafeOutputDir(args.outDir);
 	rmSync(args.outDir, { force: true, recursive: true });
 	mkdirSync(stagingRoot, { recursive: true });
 	mkdirSync(artifactsDir, { recursive: true });

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// TODO: Remove this R2 tarball packer once prime-agent and its internal workspace
+// dependencies are published through a real npm release flow.
+
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -65,6 +65,7 @@ function parseArgs(args) {
 			case "-h":
 				printHelp();
 				process.exit(0);
+				break;
 			default:
 				throw new Error(`Unknown argument: ${arg}`);
 		}

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -144,6 +144,13 @@ function rewriteInternalDependencies(dependencies, internalPackageUrls) {
 	return rewritten;
 }
 
+function releaseScripts(sourceScripts) {
+	if (!sourceScripts?.postinstall) return undefined;
+	return {
+		postinstall: sourceScripts.postinstall,
+	};
+}
+
 function createReleasePackageJson(sourcePackage, packageName, releaseVersion, internalPackageUrls) {
 	const packageJson = {
 		...sourcePackage,
@@ -151,10 +158,10 @@ function createReleasePackageJson(sourcePackage, packageName, releaseVersion, in
 		version: releaseVersion,
 		dependencies: rewriteInternalDependencies(sourcePackage.dependencies, internalPackageUrls),
 		optionalDependencies: rewriteInternalDependencies(sourcePackage.optionalDependencies, internalPackageUrls),
+		scripts: releaseScripts(sourcePackage.scripts),
 	};
 
 	delete packageJson.devDependencies;
-	delete packageJson.scripts;
 	delete packageJson.overrides;
 	delete packageJson.private;
 

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultOutputDir = join(root, "packages", "coding-agent", "release");
+const defaultBaseUrl = process.env.PRIME_AGENT_DOWNLOAD_BASE_URL;
+const publicPackageName = process.env.PRIME_AGENT_PACKAGE_NAME || "prime-agent";
+const publicCommandName = process.env.PRIME_AGENT_CMD || "prime-agent";
+
+const releasePackages = [
+	{ packageDir: "ai", publicName: undefined },
+	{ packageDir: "tui", publicName: undefined },
+	{ packageDir: "agent", publicName: undefined },
+	{ packageDir: "coding-agent", publicName: publicPackageName },
+];
+
+function parseArgs(args) {
+	const parsed = {
+		baseUrl: defaultBaseUrl,
+		outDir: defaultOutputDir,
+		version: undefined,
+	};
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		switch (arg) {
+			case "--base-url": {
+				const value = args[i + 1];
+				if (!value) throw new Error("--base-url requires a value");
+				parsed.baseUrl = value;
+				i += 1;
+				break;
+			}
+			case "--out-dir": {
+				const value = args[i + 1];
+				if (!value) throw new Error("--out-dir requires a value");
+				parsed.outDir = resolve(root, value);
+				i += 1;
+				break;
+			}
+			case "--version": {
+				const value = args[i + 1];
+				if (!value) throw new Error("--version requires a value");
+				parsed.version = normalizeVersion(value);
+				i += 1;
+				break;
+			}
+			case "--help":
+			case "-h":
+				printHelp();
+				process.exit(0);
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	if (!parsed.baseUrl) {
+		throw new Error("--base-url or PRIME_AGENT_DOWNLOAD_BASE_URL is required");
+	}
+
+	parsed.baseUrl = parsed.baseUrl.replace(/\/+$/, "");
+	return parsed;
+}
+
+function printHelp() {
+	console.log(`Usage: node scripts/pack-prime-agent-release.mjs --base-url url [--version x.y.z] [--out-dir path]
+
+Creates private npm tarballs for R2 distribution:
+
+  <out-dir>/artifacts/prime-agent-<version>.tgz
+  <out-dir>/artifacts/earendil-works-pi-ai-<version>.tgz
+  <out-dir>/artifacts/earendil-works-pi-agent-core-<version>.tgz
+  <out-dir>/artifacts/earendil-works-pi-tui-<version>.tgz
+  <out-dir>/artifacts/SHA256SUMS
+  <out-dir>/artifacts/stable
+  <out-dir>/artifacts/latest.json
+`);
+}
+
+function normalizeVersion(version) {
+	const normalized = version.startsWith("v") ? version.slice(1) : version;
+	if (!/^[0-9A-Za-z.-]+$/.test(normalized)) {
+		throw new Error(`Invalid release version: ${version}`);
+	}
+	return normalized;
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function packagePath(packageDir) {
+	return join(root, "packages", packageDir);
+}
+
+function packageJsonPath(packageDir) {
+	return join(packagePath(packageDir), "package.json");
+}
+
+function requireBuiltPackage(packageDir) {
+	const dist = join(packagePath(packageDir), "dist");
+	if (!existsSync(dist)) {
+		throw new Error(`Missing ${dist}. Run npm run build before packing a release.`);
+	}
+}
+
+function copyIfExists(source, target) {
+	if (existsSync(source)) {
+		cpSync(source, target, { recursive: true });
+	}
+}
+
+function npmTarballName(packageName, version) {
+	return `${packageName.replace(/^@/, "").replace("/", "-")}-${version}.tgz`;
+}
+
+function releaseTarballUrl(baseUrl, version, packageName) {
+	return `${baseUrl}/releases/v${version}/${npmTarballName(packageName, version)}`;
+}
+
+function rewriteInternalDependencies(dependencies, internalPackageUrls) {
+	if (!dependencies) return undefined;
+	const rewritten = {};
+	for (const [name, range] of Object.entries(dependencies)) {
+		rewritten[name] = internalPackageUrls.get(name) || range;
+	}
+	return rewritten;
+}
+
+function createReleasePackageJson(sourcePackage, packageName, releaseVersion, internalPackageUrls) {
+	const packageJson = {
+		...sourcePackage,
+		name: packageName,
+		version: releaseVersion,
+		dependencies: rewriteInternalDependencies(sourcePackage.dependencies, internalPackageUrls),
+		optionalDependencies: rewriteInternalDependencies(sourcePackage.optionalDependencies, internalPackageUrls),
+	};
+
+	delete packageJson.devDependencies;
+	delete packageJson.scripts;
+	delete packageJson.overrides;
+	delete packageJson.private;
+
+	if (packageName === publicPackageName) {
+		packageJson.bin = {
+			[publicCommandName]: "dist/cli.js",
+		};
+		packageJson.piConfig = {
+			...(packageJson.piConfig || {}),
+			name: publicCommandName,
+			configDir: ".prime/agent",
+		};
+	}
+
+	return packageJson;
+}
+
+function copyPackageContents(sourceDir, targetDir, packageJson) {
+	mkdirSync(targetDir, { recursive: true });
+	writeJson(join(targetDir, "package.json"), packageJson);
+
+	for (const entry of ["dist", "docs", "examples", "postinstall.cjs", "README.md", "CHANGELOG.md"]) {
+		copyIfExists(join(sourceDir, entry), join(targetDir, entry));
+	}
+}
+
+function run(command, args, cwd) {
+	const result = spawnSync(command, args, {
+		cwd,
+		stdio: "pipe",
+		encoding: "utf8",
+	});
+
+	if (result.status !== 0) {
+		if (result.stdout) process.stdout.write(result.stdout);
+		if (result.stderr) process.stderr.write(result.stderr);
+		throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+	}
+
+	if (result.stderr) process.stderr.write(result.stderr);
+	return result.stdout.trim();
+}
+
+function sha256File(path) {
+	const hash = createHash("sha256");
+	hash.update(readFileSync(path));
+	return hash.digest("hex");
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const sourcePackages = new Map(
+		releasePackages.map((releasePackage) => [
+			releasePackage.packageDir,
+			readJson(packageJsonPath(releasePackage.packageDir)),
+		]),
+	);
+	const cliPackage = sourcePackages.get("coding-agent");
+	const releaseVersion = args.version || normalizeVersion(process.env.PRIME_AGENT_VERSION || cliPackage.version);
+
+	for (const releasePackage of releasePackages) {
+		requireBuiltPackage(releasePackage.packageDir);
+	}
+
+	const packageNames = new Map();
+	for (const releasePackage of releasePackages) {
+		const sourcePackage = sourcePackages.get(releasePackage.packageDir);
+		packageNames.set(releasePackage.packageDir, releasePackage.publicName || sourcePackage.name);
+	}
+
+	const internalPackageUrls = new Map();
+	for (const releasePackage of releasePackages) {
+		if (releasePackage.packageDir === "coding-agent") continue;
+		const packageName = packageNames.get(releasePackage.packageDir);
+		internalPackageUrls.set(packageName, releaseTarballUrl(args.baseUrl, releaseVersion, packageName));
+	}
+
+	const stagingRoot = join(args.outDir, "packages");
+	const artifactsDir = join(args.outDir, "artifacts");
+	rmSync(args.outDir, { force: true, recursive: true });
+	mkdirSync(stagingRoot, { recursive: true });
+	mkdirSync(artifactsDir, { recursive: true });
+
+	const tarballs = [];
+	for (const releasePackage of releasePackages) {
+		const sourcePackage = sourcePackages.get(releasePackage.packageDir);
+		const packageName = packageNames.get(releasePackage.packageDir);
+		const stagingDir = join(stagingRoot, releasePackage.packageDir);
+		const packageJson = createReleasePackageJson(
+			sourcePackage,
+			packageName,
+			releaseVersion,
+			internalPackageUrls,
+		);
+
+		copyPackageContents(packagePath(releasePackage.packageDir), stagingDir, packageJson);
+
+		const tarballName = run("npm", ["pack", stagingDir, "--pack-destination", artifactsDir, "--silent"], root)
+			.split("\n")
+			.at(-1);
+		if (!tarballName) {
+			throw new Error(`npm pack did not report a tarball name for ${packageName}`);
+		}
+
+		const tarballPath = join(artifactsDir, basename(tarballName));
+		if (!existsSync(tarballPath) || !statSync(tarballPath).isFile()) {
+			throw new Error(`npm pack did not create ${tarballPath}`);
+		}
+
+		tarballs.push({
+			name: packageName,
+			file: basename(tarballPath),
+			sha256: sha256File(tarballPath),
+		});
+	}
+
+	tarballs.sort((left, right) => left.file.localeCompare(right.file));
+	writeFileSync(
+		join(artifactsDir, "SHA256SUMS"),
+		tarballs.map((tarball) => `${tarball.sha256}  ${tarball.file}`).join("\n") + "\n",
+	);
+	writeFileSync(join(artifactsDir, "stable"), `v${releaseVersion}\n`);
+	writeJson(join(artifactsDir, "latest.json"), {
+		version: `v${releaseVersion}`,
+		package: publicPackageName,
+		tarball: `releases/v${releaseVersion}/${npmTarballName(publicPackageName, releaseVersion)}`,
+		tarballs: tarballs.map((tarball) => ({
+			package: tarball.name,
+			file: tarball.file,
+			sha256: tarball.sha256,
+		})),
+	});
+
+	for (const tarball of tarballs) {
+		console.log(`Created ${join(artifactsDir, tarball.file)}`);
+	}
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}


### PR DESCRIPTION
- setup installer release flow for temp beta
- published to cloudflare r2, security by obscurity for now
- current ``scripts/pack-prime-agent-release.mjs`` is not ideal but temporary since we're not publishing 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new release automation that publishes install scripts and artifacts to R2/GitHub Releases, where misconfiguration could ship broken or insecure installs. Runtime behavior also changes by gating kernel bootstrap and prompting for `uv` installation.
> 
> **Overview**
> **Adds a new release pipeline for `prime-agent`.** The `build-binaries.yml` workflow is replaced with a `Release Prime Agent` flow that resolves release context (tag/manual/main), builds/checks, generates private npm tarball artifacts, creates/updates a GitHub Release, and publishes tarballs + `SHA256SUMS`, `stable`, `latest.json`, and a rewritten `install.sh` to an R2 bucket.
> 
> **Introduces a distribution installer and packer.** Adds `install.sh` to download tarballs from the configured CDN/R2 base URL, verify checksums, and `npm install -g` the CLI (with optional Node installation help), plus `scripts/pack-prime-agent-release.mjs` to stage/pack workspace tarballs, rewrite internal deps to CDN URLs, and emit metadata/checksums.
> 
> **Tweaks runtime/install behavior and versions.** Kernel bootstrap now prompts before auto-installing `uv` (or requires `PRIME_AGENT_INSTALL_UV=1`) and `postinstall` skips kernel bootstrapping unless `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1`; CI installs `uv` explicitly. Workspace/package versions and internal dependency ranges are reset to `0.0.1`, and the README now documents the new installer entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25997abe108b563378e68cddc83f500efcda2251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add R2 installer release flow for Prime Agent
> - Adds [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/39/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f), a POSIX shell installer that resolves the target version from R2, downloads and verifies the npm tarball, and installs via `npm install -g`. Optionally bootstraps Node.js >= 20.6.0 via Homebrew, apt, apk, or a standalone distribution.
> - Replaces the old `build-binaries` CI workflow with a `Release Prime Agent` pipeline in [.github/workflows/build-binaries.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/39/files#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2e) that determines semver tags, builds and packs artifacts, creates a GitHub Release, and publishes tarballs, `SHA256SUMS`, `latest.json`, and stable markers to an S3-compatible R2 bucket.
> - Adds [scripts/pack-prime-agent-release.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/39/files#diff-9dd43bd6a4a36a4d005682430f238282f0f2144bc51ed40c2159f18056ec751c) to rewrite internal workspace dependencies to versioned tarball URLs and produce the release artifact set.
> - `postinstall` in [packages/coding-agent/src/postinstall.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/39/files#diff-7ad5f703362453158c7061179b9ff708182aa81ed8a09e12d5f5bfe9b3b0ac6b) no longer bootstraps the Python kernel by default; set `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1` to re-enable.
> - `ensureUv()` in [packages/coding-agent/src/core/kernel/bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/39/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) now prompts interactively before installing uv; set `PRIME_AGENT_INSTALL_UV=1` to skip the prompt or `=0` to skip installation entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25997ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->