### PR TITLE
fix auto compaction threshold checks

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -637,6 +637,7 @@ export class AgentSession {
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
 	private _overflowRecoveryAttempted = false;
+	private _continueAfterThresholdCompaction = false;
 
 	// Branch summarization state
 	private _branchSummaryAbortController: AbortController | undefined = undefined;
@@ -826,7 +827,7 @@ export class AgentSession {
 	}
 
 	private _installAgentTurnHook(): void {
-		this.agent.shouldStopAfterTurn = (context) => this._shouldStopAfterGoalTurn(context);
+		this.agent.shouldStopAfterTurn = (context) => this._shouldStopAfterTurn(context);
 	}
 
 	// =========================================================================
@@ -1234,7 +1235,7 @@ export class AgentSession {
 		return true;
 	}
 
-	private _shouldStopAfterGoalTurn(context: ShouldStopAfterTurnContext): boolean {
+	private _shouldStopAfterTurn(context: ShouldStopAfterTurnContext): boolean {
 		if (this._stopGoalContinuationForTerminalMessage(context.message)) {
 			return true;
 		}
@@ -1245,7 +1246,32 @@ export class AgentSession {
 		} catch {
 			// Goal accounting must not interrupt the core agent loop.
 		}
+		if (this._shouldStopForThresholdCompaction(context)) {
+			return true;
+		}
 		return false;
+	}
+
+	private _shouldStopForThresholdCompaction(context: ShouldStopAfterTurnContext): boolean {
+		this._continueAfterThresholdCompaction = false;
+		const settings = this.settingsManager.getCompactionSettings();
+		if (!settings.enabled) return false;
+
+		const contextWindow = this.model?.contextWindow ?? 0;
+		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
+		const compactionTimestamp = compactionEntry ? new Date(compactionEntry.timestamp).getTime() : undefined;
+		if (compactionTimestamp !== undefined && context.message.timestamp <= compactionTimestamp) {
+			return false;
+		}
+
+		const contextTokens = this._getThresholdContextTokens(context.message, compactionTimestamp);
+		if (contextTokens === undefined || !shouldCompact(contextTokens, contextWindow, settings)) {
+			return false;
+		}
+
+		const lastMessage = this.agent.state.messages[this.agent.state.messages.length - 1];
+		this._continueAfterThresholdCompaction = lastMessage !== undefined && lastMessage.role !== "assistant";
+		return true;
 	}
 
 	private createGoalFromTool(objective: string, tokenBudget: number | undefined): GoalState {
@@ -2662,11 +2688,35 @@ export class AgentSession {
 	 *
 	 * Two cases:
 	 * 1. Overflow: LLM returned context overflow error, remove error message from agent state, compact, auto-retry
-	 * 2. Threshold: Context over threshold, compact, NO auto-retry (user continues manually)
+	 * 2. Threshold: Context over threshold, compact, and continue only for stopped in-progress loops or queued messages
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
+	private _getThresholdContextTokens(
+		assistantMessage: AssistantMessage,
+		compactionTimestamp: number | undefined,
+	): number | undefined {
+		const messages = this.agent.state.messages;
+		const estimate = estimateContextTokens(messages);
+		if (estimate.lastUsageIndex !== null) {
+			// Verify the usage source is post-compaction. Kept pre-compaction messages
+			// have stale usage reflecting the old (larger) context and would falsely
+			// trigger compaction right after one just finished.
+			const usageMsg = messages[estimate.lastUsageIndex];
+			if (
+				compactionTimestamp !== undefined &&
+				usageMsg.role === "assistant" &&
+				(usageMsg as AssistantMessage).timestamp <= compactionTimestamp
+			) {
+				return undefined;
+			}
+			return estimate.tokens;
+		}
+		if (assistantMessage.stopReason === "error") return undefined;
+		return calculateContextTokens(assistantMessage.usage);
+	}
+
 	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
@@ -2687,8 +2737,9 @@ export class AgentSession {
 		// compaction boundary. This prevents a stale pre-compaction usage/error
 		// from retriggering compaction on the first prompt after compaction.
 		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
+		const compactionTimestamp = compactionEntry ? new Date(compactionEntry.timestamp).getTime() : undefined;
 		const assistantIsFromBeforeCompaction =
-			compactionEntry !== null && assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
+			compactionTimestamp !== undefined && assistantMessage.timestamp <= compactionTimestamp;
 		if (assistantIsFromBeforeCompaction) {
 			return false;
 		}
@@ -2718,29 +2769,11 @@ export class AgentSession {
 			return await this._runAutoCompaction("overflow", true);
 		}
 
-		// Case 2: Threshold - context is getting large
-		// For error messages (no usage data), estimate from last successful response.
-		// This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
-		let contextTokens: number;
-		if (assistantMessage.stopReason === "error") {
-			const messages = this.agent.state.messages;
-			const estimate = estimateContextTokens(messages);
-			if (estimate.lastUsageIndex === null) return false; // No usage data at all
-			// Verify the usage source is post-compaction. Kept pre-compaction messages
-			// have stale usage reflecting the old (larger) context and would falsely
-			// trigger compaction right after one just finished.
-			const usageMsg = messages[estimate.lastUsageIndex];
-			if (
-				compactionEntry &&
-				usageMsg.role === "assistant" &&
-				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
-			) {
-				return false;
-			}
-			contextTokens = estimate.tokens;
-		} else {
-			contextTokens = calculateContextTokens(assistantMessage.usage);
-		}
+		// Case 2: Threshold - context is getting large.
+		// Use the full-session estimate so messages appended after the last successful
+		// assistant usage are included, matching the /usage context display.
+		const contextTokens = this._getThresholdContextTokens(assistantMessage, compactionTimestamp);
+		if (contextTokens === undefined) return false;
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			return await this._runAutoCompaction("threshold", false);
 		}
@@ -2752,6 +2785,8 @@ export class AgentSession {
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
+		const shouldContinueAfterThreshold = reason === "threshold" && this._continueAfterThresholdCompaction;
+		this._continueAfterThresholdCompaction = false;
 
 		this._emit({ type: "compaction_start", reason });
 		this._autoCompactionAbortController = new AbortController();
@@ -2901,9 +2936,9 @@ export class AgentSession {
 					this.agent.continue().catch(() => {});
 				}, 100);
 				return true;
-			} else if (this.agent.hasQueuedMessages()) {
-				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
-				// Kick the loop so queued messages are actually delivered.
+			} else if (shouldContinueAfterThreshold || this.agent.hasQueuedMessages()) {
+				// Threshold compaction can intentionally stop a tool loop between turns.
+				// Queued follow-up/steering/custom messages can also be waiting.
 				setTimeout(() => {
 					this.agent.continue().catch(() => {});
 				}, 100);

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,10 +1,12 @@
-import { type AssistantMessage, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
+import type { AgentMessage, ShouldStopAfterTurnContext } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHarness, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
 	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+	_shouldStopAfterTurn: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 };
 
 function createUsage(totalTokens: number) {
@@ -248,6 +250,74 @@ describe("AgentSession compaction characterization", () => {
 		await sessionInternals._checkCompaction(errorAssistant);
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+	});
+
+	it("triggers threshold compaction when trailing context exceeds the model window", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const successfulAssistant = createAssistant(harness, {
+			stopReason: "stop",
+			totalTokens: 10_000,
+			timestamp: Date.now(),
+		});
+		harness.session.agent.state.messages = [
+			{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: Date.now() - 1000 },
+			successfulAssistant,
+			{
+				role: "custom",
+				customType: "large-context",
+				content: [{ type: "text", text: "x".repeat(800_000) }],
+				display: false,
+				timestamp: Date.now() + 500,
+			},
+		];
+
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+
+		await sessionInternals._checkCompaction(successfulAssistant, false);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+	});
+
+	it("stops a tool loop for threshold compaction before the next model call", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const successfulAssistant = createAssistant(harness, {
+			stopReason: "toolUse",
+			totalTokens: 10_000,
+			timestamp: Date.now(),
+		});
+		const toolResult: ToolResultMessage<unknown> = {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "large-context",
+			content: [{ type: "text", text: "x".repeat(800_000) }],
+			isError: false,
+			timestamp: Date.now() + 500,
+		};
+		const messages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: Date.now() - 1000 },
+			successfulAssistant,
+			toolResult,
+		];
+		harness.session.agent.state.messages = messages;
+
+		const shouldStop = await sessionInternals._shouldStopAfterTurn({
+			message: successfulAssistant,
+			toolResults: [toolResult],
+			context: { systemPrompt: harness.session.systemPrompt, messages, tools: [] },
+			newMessages: [successfulAssistant, toolResult],
+		});
+
+		expect(shouldStop).toBe(true);
 	});
 
 	it("does not trigger threshold compaction for error messages when no prior usage exists", async () => {


### PR DESCRIPTION
- threshold compaction now uses the same current context estimate shown by usage.
- long tool loops stop between turns when context crosses the threshold, then resume after compaction.
- added regressions for trailing context and tool-result growth.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix threshold compaction checks in `AgentSession` to stop turns mid-loop
> - Adds `_shouldStopForThresholdCompaction` to interrupt agent turns when context tokens exceed the compaction threshold, including mid-loop between assistant and tool turns.
> - Introduces `_getThresholdContextTokens` to compute a consistent session-wide token estimate post-compaction, replacing duplicated inline logic in `_checkCompaction`.
> - After threshold compaction, `_runAutoCompaction` automatically resumes execution if the stop occurred mid-loop (last message not from assistant) or if there are queued messages.
> - Behavioral Change: the agent now stops after a turn for threshold compaction before the next model call, where previously this check did not fire during tool loops.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 914865a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core agent loop stop/continue behavior and compaction triggering, which could affect long-running tool loops and queued message delivery.
> 
> **Overview**
> **Threshold auto-compaction is now triggered using a session-wide context token estimate** (including trailing non-assistant messages) and ignores stale pre-compaction usage to avoid immediate re-compactions.
> 
> **Agent turns can now stop between tool loop turns when the compaction threshold is exceeded**, and `_runAutoCompaction` will automatically `continue()` afterward when the stop occurred mid-loop or when messages are queued.
> 
> Adds regression tests covering trailing-context growth and stopping a `toolUse` loop before the next model call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914865a4885539a5ff4662ef3f9d1a2a29d858bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->