### PR TITLE
condense ipython cells in tui

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -41,13 +41,14 @@ interface TracebackParts {
 }
 
 type CellBackground = "customMessageBg" | "toolPendingBg" | "toolErrorBg";
+type ExpandHintFormatter = (label: string) => string;
 
 const MAGIC_LINE_PATTERN = /^\s*!/;
 const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 
-// Collapse long kernel output to the last N lines with a "M earlier lines hidden" marker.
-// Mirrors the bash-execution preview cap so a long-running task doesn't flood the chat.
-const OUTPUT_PREVIEW_LINES = 20;
+// Mirrors Codex's compact tool-call rendering so long cells don't flood the chat.
+const OUTPUT_PREVIEW_LINES = 5;
+const INPUT_PREVIEW_LINES = 3;
 
 export function getIpythonCodeFromArgs(args: unknown): string {
 	if (!args || typeof args !== "object" || !("code" in args)) {
@@ -157,10 +158,18 @@ export class IPythonCellComponent implements Component {
 
 		const details = readDetails(this.state.details);
 		const lines: string[] = [];
+		let expandHintShown = false;
+		const withExpandHint: ExpandHintFormatter = (label) => {
+			if (expandHintShown) {
+				return theme.fg("muted", label);
+			}
+			expandHintShown = true;
+			return `${theme.fg("muted", label)} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
+		};
 
 		lines.push(this.panelLine(this.header(details), safeWidth));
 		const hasCode = this.renderCode(lines, safeWidth);
-		this.renderOutput(lines, safeWidth, details, hasCode);
+		this.renderOutput(lines, safeWidth, details, hasCode, withExpandHint);
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
 
@@ -202,11 +211,21 @@ export class IPythonCellComponent implements Component {
 		this.addBlank(lines, width);
 		const isBashCell = CELL_MAGIC_PATTERN.test(code.split("\n")[0] ?? "");
 		const rawLines = code.split("\n");
-		for (const [index, rawLine] of rawLines.entries()) {
+		const expanded = this.state.expanded ?? false;
+		const showCollapsed = !expanded && rawLines.length > INPUT_PREVIEW_LINES;
+		const visibleRawLines = showCollapsed ? rawLines.slice(0, INPUT_PREVIEW_LINES) : rawLines;
+		for (const [index, rawLine] of visibleRawLines.entries()) {
 			const prefix = index === 0 ? theme.fg("dim", "› ") : theme.fg("dim", "  ");
 			const highlighted = this.highlightInputLine(rawLine, isBashCell);
 			this.addWrapped(lines, prefix, highlighted || " ", width);
 		}
+
+		if (showCollapsed) {
+			const hidden = rawLines.length - INPUT_PREVIEW_LINES;
+			this.addWrapped(lines, "", theme.fg("muted", `… +${hidden} lines`), width);
+			return true;
+		}
+
 		return true;
 	}
 
@@ -218,7 +237,13 @@ export class IPythonCellComponent implements Component {
 		return highlighted[0] ?? theme.fg("mdCodeBlock", line);
 	}
 
-	private renderOutput(lines: string[], width: number, details: IpythonDetails, hasCode: boolean): void {
+	private renderOutput(
+		lines: string[],
+		width: number,
+		details: IpythonDetails,
+		hasCode: boolean,
+		withExpandHint: ExpandHintFormatter,
+	): void {
 		const blocks = this.state.content ?? [];
 		const text = textFromBlocks(blocks);
 		const imageCount = blocks.filter(isImageBlock).length;
@@ -238,10 +263,10 @@ export class IPythonCellComponent implements Component {
 
 		if (traceback?.output) {
 			startOutput();
-			this.renderOutputText(lines, width, traceback.output, "out");
+			this.renderOutputText(lines, width, traceback.output, "out", withExpandHint);
 		} else if (text.trim()) {
 			startOutput();
-			this.renderOutputText(lines, width, normalizeText(text), this.state.isError ? "err" : "out");
+			this.renderOutputText(lines, width, normalizeText(text), this.state.isError ? "err" : "out", withExpandHint);
 		} else if (this.state.isPartial || (this.state.executionStarted && !this.state.argsComplete)) {
 			startOutput();
 			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
@@ -256,12 +281,7 @@ export class IPythonCellComponent implements Component {
 				this.renderTraceback(lines, width, traceback.traceback);
 			} else {
 				this.addWrapped(lines, "", theme.fg("error", traceback.preview), width);
-				this.addWrapped(
-					lines,
-					"",
-					`${theme.fg("muted", "traceback collapsed")} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`,
-					width,
-				);
+				this.addWrapped(lines, "", withExpandHint("traceback collapsed"), width);
 			}
 		}
 
@@ -274,7 +294,13 @@ export class IPythonCellComponent implements Component {
 		}
 	}
 
-	private renderOutputText(lines: string[], width: number, text: string, label: "out" | "err"): void {
+	private renderOutputText(
+		lines: string[],
+		width: number,
+		text: string,
+		label: "out" | "err",
+		withExpandHint: ExpandHintFormatter,
+	): void {
 		const color = label === "err" ? "error" : "toolOutput";
 		const allLines = text.split("\n");
 		const expanded = this.state.expanded ?? false;
@@ -283,8 +309,7 @@ export class IPythonCellComponent implements Component {
 
 		if (showCollapsed) {
 			const hidden = allLines.length - OUTPUT_PREVIEW_LINES;
-			const headerHint = `${theme.fg("muted", `${hidden} earlier line${hidden === 1 ? "" : "s"} hidden`)} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
-			this.addWrapped(lines, "", headerHint, width);
+			this.addWrapped(lines, "", withExpandHint(`… +${hidden} lines`), width);
 		}
 
 		for (const line of visibleLines) {

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -46,7 +46,6 @@ type ExpandHintFormatter = (label: string) => string;
 const MAGIC_LINE_PATTERN = /^\s*!/;
 const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 
-// Mirrors Codex's compact tool-call rendering so long cells don't flood the chat.
 const OUTPUT_PREVIEW_LINES = 5;
 const INPUT_PREVIEW_LINES = 3;
 

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -83,6 +83,10 @@ function formatDuration(durationMs: number | undefined): string | undefined {
 	return `${(durationMs / 1000).toFixed(1)}s`;
 }
 
+function hiddenLinesLabel(hidden: number): string {
+	return `… +${hidden} line${hidden === 1 ? "" : "s"}`;
+}
+
 function isImageBlock(block: IPythonCellContentBlock): boolean {
 	return block.type === "image" && typeof block.data === "string" && typeof block.mimeType === "string";
 }
@@ -221,7 +225,7 @@ export class IPythonCellComponent implements Component {
 
 		if (showCollapsed) {
 			const hidden = rawLines.length - INPUT_PREVIEW_LINES;
-			this.addWrapped(lines, "", withExpandHint(`… +${hidden} lines`), width);
+			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
 			return true;
 		}
 
@@ -308,7 +312,7 @@ export class IPythonCellComponent implements Component {
 
 		if (showCollapsed) {
 			const hidden = allLines.length - OUTPUT_PREVIEW_LINES;
-			this.addWrapped(lines, "", withExpandHint(`… +${hidden} lines`), width);
+			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
 		}
 
 		for (const line of visibleLines) {

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -167,7 +167,7 @@ export class IPythonCellComponent implements Component {
 		};
 
 		lines.push(this.panelLine(this.header(details), safeWidth));
-		const hasCode = this.renderCode(lines, safeWidth);
+		const hasCode = this.renderCode(lines, safeWidth, withExpandHint);
 		this.renderOutput(lines, safeWidth, details, hasCode, withExpandHint);
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
@@ -199,7 +199,7 @@ export class IPythonCellComponent implements Component {
 		return { label: theme.fg("success", "done") };
 	}
 
-	private renderCode(lines: string[], width: number): boolean {
+	private renderCode(lines: string[], width: number, withExpandHint: ExpandHintFormatter): boolean {
 		const code = this.state.code.trimEnd();
 		if (!code) {
 			this.addBlank(lines, width);
@@ -221,7 +221,7 @@ export class IPythonCellComponent implements Component {
 
 		if (showCollapsed) {
 			const hidden = rawLines.length - INPUT_PREVIEW_LINES;
-			this.addWrapped(lines, "", theme.fg("muted", `… +${hidden} lines`), width);
+			this.addWrapped(lines, "", withExpandHint(`… +${hidden} lines`), width);
 			return true;
 		}
 

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -147,6 +147,35 @@ describe("marquee TUI components", () => {
 		expect(component.render(80)).toBe(afterInvalidate);
 	});
 
+	test("collapses long ipython input until tool expansion is enabled", () => {
+		const code = Array.from({ length: 8 }, (_, index) => `line_${index} = ${index}`).join("\n");
+		const output = Array.from({ length: 8 }, (_, index) => `out_${index}`).join("\n");
+		const state: IPythonCellState = {
+			code,
+			content: [{ type: "text", text: output }],
+			details: { status: "ok", durationMs: 15 },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		};
+		const component = new IPythonCellComponent(state);
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("line_0 = 0");
+		expect(collapsed).toContain("line_2 = 2");
+		expect(collapsed).not.toContain("line_3 = 3");
+		expect(collapsed).not.toContain("line_4 = 4");
+		expect(collapsed).not.toContain("line_7 = 7");
+		expect(collapsed).toContain("… +5 lines");
+		expect(collapsed).toContain("… +3 lines");
+		expect(collapsed.match(/to expand/g)?.length).toBe(1);
+
+		component.update({ ...state, expanded: true });
+		const expanded = stripAnsi(component.render(100).join("\n"));
+		expect(expanded).toContain("line_7 = 7");
+		expect(expanded).not.toContain("input lines hidden");
+	});
+
 	test("reflows cached ipython cells when terminal width changes", () => {
 		const state: IPythonCellState = {
 			code: "result = 'this is a deliberately long line that should wrap differently by terminal width'",

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -149,10 +149,9 @@ describe("marquee TUI components", () => {
 
 	test("collapses long ipython input until tool expansion is enabled", () => {
 		const code = Array.from({ length: 8 }, (_, index) => `line_${index} = ${index}`).join("\n");
-		const output = Array.from({ length: 8 }, (_, index) => `out_${index}`).join("\n");
 		const state: IPythonCellState = {
 			code,
-			content: [{ type: "text", text: output }],
+			content: [{ type: "text", text: "done" }],
 			details: { status: "ok", durationMs: 15 },
 			executionStarted: true,
 			argsComplete: true,
@@ -167,13 +166,30 @@ describe("marquee TUI components", () => {
 		expect(collapsed).not.toContain("line_4 = 4");
 		expect(collapsed).not.toContain("line_7 = 7");
 		expect(collapsed).toContain("… +5 lines");
-		expect(collapsed).toContain("… +3 lines");
 		expect(collapsed.match(/to expand/g)?.length).toBe(1);
 
 		component.update({ ...state, expanded: true });
 		const expanded = stripAnsi(component.render(100).join("\n"));
 		expect(expanded).toContain("line_7 = 7");
-		expect(expanded).not.toContain("input lines hidden");
+		expect(expanded).not.toContain("… +5 lines");
+	});
+
+	test("shows one expand hint when ipython input and output are both collapsed", () => {
+		const code = Array.from({ length: 8 }, (_, index) => `line_${index} = ${index}`).join("\n");
+		const output = Array.from({ length: 8 }, (_, index) => `out_${index}`).join("\n");
+		const component = new IPythonCellComponent({
+			code,
+			content: [{ type: "text", text: output }],
+			details: { status: "ok", durationMs: 15 },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("… +5 lines");
+		expect(collapsed).toContain("… +3 lines");
+		expect(collapsed.match(/to expand/g)?.length).toBe(1);
 	});
 
 	test("reflows cached ipython cells when terminal width changes", () => {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -192,6 +192,21 @@ describe("marquee TUI components", () => {
 		expect(collapsed.match(/to expand/g)?.length).toBe(1);
 	});
 
+	test("pluralizes singular collapsed ipython line markers", () => {
+		const component = new IPythonCellComponent({
+			code: Array.from({ length: 4 }, (_, index) => `line_${index} = ${index}`).join("\n"),
+			content: [{ type: "text", text: Array.from({ length: 6 }, (_, index) => `out_${index}`).join("\n") }],
+			details: { status: "ok", durationMs: 15 },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed.match(/… \+1 line\b/g)?.length).toBe(2);
+		expect(collapsed).not.toContain("… +1 lines");
+	});
+
 	test("reflows cached ipython cells when terminal width changes", () => {
 		const state: IPythonCellState = {
 			code: "result = 'this is a deliberately long line that should wrap differently by terminal width'",


### PR DESCRIPTION
- condenses long ipython input and output blocks so tool calls take less space in the tui.
- keeps full cell content available through the existing tool expansion shortcut.
- adds regression coverage for collapsed and expanded ipython cells.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Condense IPython cell input and output in the TUI
> - Collapses cell input to the first 3 lines and output to the last 5 lines (down from 20) when not expanded, using an ellipsis `… +N line(s)` marker.
> - Ensures only a single 'press to expand' key hint is shown per cell, even when both input and output are collapsed.
> - Changes are in [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/45/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) with coverage added in [marquee-components.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/45/files#diff-e64bda7bdf957b0f1d5ffd73064d138feea73841c600f8a8aebe0ff287ce3738).
> - Behavioral Change: collapsed output now shows 5 trailing lines instead of 20, which is a significant reduction in default visible content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9cedc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TUI rendering of IPython tool cells and add tests; main risk is unintended truncation/UX regressions when collapsed/expanded states toggle.
> 
> **Overview**
> Condenses IPython tool cell rendering in the TUI by collapsing long **input** (first 3 lines) and reducing the **output** preview to the last 5 lines, each showing a unified `… +N line(s)` marker until the cell is expanded.
> 
> Unifies and de-duplicates the “`to expand`” key hint so it appears at most once per cell render (even when input, output, and/or traceback are collapsed), and adds regression tests covering collapse/expand behavior and singular/plural markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cedc75a2bc4145dfd8ffb0332987f1e5cb525d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->