### PR TITLE
improve goal status ux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed `/goal` updates in interactive mode to use a compact persistent lower-tray indicator instead of repeating the full goal in chat on every agent turn.
 - Fixed long cwd values in the startup splash from wrapping through the brand mark.
 - Fixed IPython kernel startup to let `ipykernel` bind OS-assigned ports instead of randomly selecting fixed ports.
 - Fixed RLM child usage aggregation so parent session totals include recursive child runs after session reloads.

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -199,12 +199,13 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 
 	private renderSplitLine(left: string, right: string, width: number): string {
 		const contentWidth = Math.max(1, width - this.paddingX);
-		const rightWidth = visibleWidth(right);
+		const renderedRight = this.truncate(right, contentWidth);
+		const rightWidth = visibleWidth(renderedRight);
 		const gapWidth = left ? 2 : 0;
 		const leftWidth = Math.max(0, contentWidth - rightWidth - gapWidth);
 		const renderedLeft = leftWidth > 0 ? this.truncate(left, leftWidth) : "";
 		const gap = Math.max(0, contentWidth - visibleWidth(renderedLeft) - rightWidth);
-		return `${" ".repeat(this.paddingX)}${renderedLeft}${" ".repeat(gap)}${right}`;
+		return `${" ".repeat(this.paddingX)}${renderedLeft}${" ".repeat(gap)}${renderedRight}`;
 	}
 
 	private subagentSummary(flat: readonly FlatChildAgentNode[], selected: boolean): string {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -199,11 +199,16 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 
 	private renderSplitLine(left: string, right: string, width: number): string {
 		const contentWidth = Math.max(1, width - this.paddingX);
-		const renderedRight = this.truncate(right, contentWidth);
-		const rightWidth = visibleWidth(renderedRight);
 		const gapWidth = left ? 2 : 0;
-		const leftWidth = Math.max(0, contentWidth - rightWidth - gapWidth);
-		const renderedLeft = leftWidth > 0 ? this.truncate(left, leftWidth) : "";
+		const leftWidth = visibleWidth(left);
+		const rightWidthLimit =
+			left && contentWidth > gapWidth && leftWidth + gapWidth + visibleWidth(right) > contentWidth
+				? contentWidth - gapWidth - Math.min(leftWidth, Math.max(1, Math.floor((contentWidth - gapWidth) / 3)))
+				: contentWidth;
+		const renderedRight = this.truncate(right, Math.max(0, rightWidthLimit));
+		const rightWidth = visibleWidth(renderedRight);
+		const renderedLeftWidth = Math.max(0, contentWidth - rightWidth - gapWidth);
+		const renderedLeft = renderedLeftWidth > 0 ? this.truncate(left, renderedLeftWidth) : "";
 		const gap = Math.max(0, contentWidth - visibleWidth(renderedLeft) - rightWidth);
 		return `${" ".repeat(this.paddingX)}${renderedLeft}${" ".repeat(gap)}${renderedRight}`;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3243,7 +3243,7 @@ export class InteractiveMode {
 			return goal.status !== "idle";
 		}
 		if (previous.status !== next.status) {
-			return goal.status !== "idle";
+			return true;
 		}
 		if (previous.goalId !== next.goalId) {
 			return goal.status !== "idle";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -291,6 +291,14 @@ type CompactionQueuedMessage = {
 	mode: "steer" | "followUp";
 };
 
+type GoalAnnouncementSnapshot = {
+	goalId?: string;
+	status: GoalState["status"];
+	objective?: string;
+	lastReason?: string;
+	lastError?: string;
+};
+
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 
 function isDeadTerminalError(error: unknown): boolean {
@@ -393,6 +401,8 @@ export class InteractiveMode {
 	// Status line tracking (for mutating immediately-sequential status updates)
 	private lastStatusSpacer: Spacer | undefined = undefined;
 	private lastStatusText: Text | undefined = undefined;
+	private lastGoalAnnouncement: GoalAnnouncementSnapshot | undefined = undefined;
+	private goalTrayTimer: NodeJS.Timeout | undefined = undefined;
 
 	// Streaming message tracking
 	private streamingComponent: AssistantMessageComponent | undefined = undefined;
@@ -546,6 +556,7 @@ export class InteractiveMode {
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
 		this.footer = new FooterComponent(this.session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+		this.setGoalAnnouncementBaseline(this.session.goalState);
 
 		// Load hide thinking block setting
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
@@ -1715,6 +1726,8 @@ export class InteractiveMode {
 		await this.updateAvailableProviderCount();
 		this.updateEditorBorderColor();
 		this.updateTerminalTitle();
+		this.setGoalAnnouncementBaseline(this.session.goalState);
+		this.syncGoalTray(this.session.goalState);
 	}
 
 	private async handleFatalRuntimeError(prefix: string, error: unknown): Promise<never> {
@@ -1733,6 +1746,8 @@ export class InteractiveMode {
 		this.streamingMessage = undefined;
 		this.pendingTools.clear();
 		this.resetChildAgentInspector();
+		this.setGoalAnnouncementBaseline(this.session.goalState);
+		this.syncGoalTray(this.session.goalState);
 		this.renderInitialMessages();
 	}
 
@@ -2689,6 +2704,11 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
+			if (text === "/goal" || text === "/goal status") {
+				this.handleGoalStatusCommand();
+				this.editor.setText("");
+				return;
+			}
 			if (text === "/changelog") {
 				this.handleChangelogCommand();
 				this.editor.setText("");
@@ -3160,35 +3180,137 @@ export class InteractiveMode {
 				break;
 
 			case "goal_update":
-				this.showStatus(this.formatGoalStatus(event.goal));
+				this.handleGoalUpdate(event.goal);
 				break;
 		}
 	}
 
+	private handleGoalUpdate(goal: GoalState): void {
+		this.syncGoalTray(goal);
+		if (this.shouldAnnounceGoalUpdate(goal)) {
+			this.showStatus(this.formatGoalStatus(goal));
+		} else {
+			this.ui.requestRender();
+		}
+	}
+
+	private syncGoalTray(goal: GoalState): void {
+		this.childAgentSummary.invalidate();
+		this.updateGoalTrayTimer(goal);
+	}
+
+	private updateGoalTrayTimer(goal: GoalState): void {
+		if (goal.status === "active") {
+			if (!this.goalTrayTimer) {
+				this.goalTrayTimer = setInterval(() => {
+					this.childAgentSummary.invalidate();
+					this.ui.requestRender();
+				}, 1000);
+				this.goalTrayTimer.unref?.();
+			}
+			return;
+		}
+		this.stopGoalTrayTimer();
+	}
+
+	private stopGoalTrayTimer(): void {
+		if (!this.goalTrayTimer) {
+			return;
+		}
+		clearInterval(this.goalTrayTimer);
+		this.goalTrayTimer = undefined;
+	}
+
+	private setGoalAnnouncementBaseline(goal: GoalState): void {
+		this.lastGoalAnnouncement = this.goalAnnouncementSnapshot(goal);
+	}
+
+	private goalAnnouncementSnapshot(goal: GoalState): GoalAnnouncementSnapshot {
+		return {
+			goalId: goal.goalId,
+			status: goal.status,
+			objective: goal.objective,
+			lastReason: goal.lastReason,
+			lastError: goal.lastError,
+		};
+	}
+
+	private shouldAnnounceGoalUpdate(goal: GoalState): boolean {
+		const previous = this.lastGoalAnnouncement;
+		const next = this.goalAnnouncementSnapshot(goal);
+		this.lastGoalAnnouncement = next;
+		if (!previous) {
+			return goal.status !== "idle";
+		}
+		if (previous.status !== next.status) {
+			return goal.status !== "idle";
+		}
+		if (previous.goalId !== next.goalId) {
+			return goal.status !== "idle";
+		}
+		switch (goal.status) {
+			case "active":
+				return false;
+			case "paused":
+			case "budget_limited":
+			case "complete":
+				return previous.lastReason !== next.lastReason;
+			case "error":
+				return previous.lastError !== next.lastError;
+			case "idle":
+				return false;
+			default: {
+				const _exhaustive: never = goal.status;
+				return _exhaustive;
+			}
+		}
+	}
+
 	private formatGoalStatus(goal: GoalState): string {
-		const objective = goal.objective ? `: ${goal.objective}` : "";
 		const usage = formatGoalUsage(goal);
 		const usageText = usage ? ` (${usage})` : "";
 		switch (goal.status) {
 			case "idle":
 				return "No active goal";
 			case "active":
-				return `Pursuing goal${usageText}${objective}`;
+				return goal.objective
+					? `Goal${this.formatGoalDetailSuffix(goal.objective, visibleWidth("Goal"))}`
+					: "Pursuing goal";
 			case "paused":
-				return goal.lastReason ? `Goal paused: ${goal.lastReason}` : "Goal paused (/goal resume)";
-			case "budget_limited":
 				return goal.lastReason
-					? `Goal budget limited${usageText}: ${goal.lastReason}`
-					: `Goal budget limited${usageText}`;
+					? `Goal paused${this.formatGoalDetailSuffix(goal.lastReason, visibleWidth("Goal paused"))}`
+					: "Goal paused (/goal resume)";
+			case "budget_limited":
+				if (goal.lastReason) {
+					const prefix = `Goal budget limited${usageText}`;
+					return prefix + this.formatGoalDetailSuffix(goal.lastReason, visibleWidth(prefix));
+				}
+				return `Goal budget limited${usageText}`;
 			case "complete":
-				return goal.lastReason ? `Goal complete: ${goal.lastReason}` : "Goal complete";
+				return goal.lastReason
+					? `Goal complete${this.formatGoalDetailSuffix(goal.lastReason, visibleWidth("Goal complete"))}`
+					: "Goal complete";
 			case "error":
-				return goal.lastError ? `Goal error: ${goal.lastError}` : "Goal error";
+				return goal.lastError
+					? `Goal error${this.formatGoalDetailSuffix(goal.lastError, visibleWidth("Goal error"))}`
+					: "Goal error";
 			default: {
 				const _exhaustive: never = goal.status;
 				return _exhaustive;
 			}
 		}
+	}
+
+	private formatGoalDetailSuffix(value: string | undefined, prefixWidth: number): string {
+		const detail = value?.replace(/\s+/g, " ").trim();
+		if (!detail) {
+			return "";
+		}
+		const availableWidth = Math.min(120, Math.max(1, this.ui.terminal.columns - prefixWidth - 2));
+		if (availableWidth < 8) {
+			return "";
+		}
+		return `: ${truncateToWidth(detail, availableWidth)}`;
 	}
 
 	private updateChildAgentInspector(child: RlmChildAgentSnapshot): void {
@@ -3254,18 +3376,52 @@ export class InteractiveMode {
 	}
 
 	private getTrayContextLabel(): string | undefined {
+		const goalLabel = this.getTrayGoalLabel();
 		const usage = this.session.getContextUsage();
 		if (!usage) {
-			return undefined;
+			return goalLabel;
 		}
 		if (usage.percent === null) {
-			return undefined;
+			return goalLabel;
 		}
 		const remainingPercent = Math.max(0, Math.min(100, 100 - usage.percent));
-		if (remainingPercent > 50) {
-			return undefined;
+		const contextLabel = remainingPercent <= 50 ? `${Math.round(remainingPercent)}% context left` : undefined;
+		return [goalLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;
+	}
+
+	private getTrayGoalLabel(): string | undefined {
+		const goal = this.session.goalState;
+		switch (goal.status) {
+			case "active":
+				return `Pursuing goal (${this.formatGoalElapsed(goal.timeUsedSeconds)})`;
+			case "paused":
+				return `Goal paused (${this.formatGoalElapsed(goal.timeUsedSeconds)})`;
+			case "budget_limited":
+				return `Goal budget limited (${this.formatGoalElapsed(goal.timeUsedSeconds)})`;
+			case "idle":
+			case "complete":
+			case "error":
+				return undefined;
+			default: {
+				const _exhaustive: never = goal.status;
+				return _exhaustive;
+			}
 		}
-		return `${Math.round(remainingPercent)}% context left`;
+	}
+
+	private formatGoalElapsed(seconds: number): string {
+		const totalSeconds = Math.max(0, Math.trunc(seconds));
+		if (totalSeconds < 60) {
+			return `${totalSeconds}s`;
+		}
+		const minutes = Math.floor(totalSeconds / 60);
+		const remainingSeconds = totalSeconds % 60;
+		if (minutes < 60) {
+			return `${minutes}m ${remainingSeconds.toString().padStart(2, "0")}s`;
+		}
+		const hours = Math.floor(minutes / 60);
+		const remainingMinutes = minutes % 60;
+		return `${hours}h ${remainingMinutes.toString().padStart(2, "0")}m`;
 	}
 
 	private openChildAgentList(): void {
@@ -5551,6 +5707,41 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private handleGoalStatusCommand(): void {
+		const goal = this.session.goalState;
+		if (goal.status === "idle" || !goal.objective) {
+			this.showStatus("No active goal");
+			return;
+		}
+
+		const lines = [
+			theme.bold("Goal"),
+			"",
+			`${theme.fg("dim", "Status:")} ${goal.status}`,
+			`${theme.fg("dim", "Objective:")} ${goal.objective}`,
+			`${theme.fg("dim", "Time:")} ${this.formatGoalElapsed(goal.timeUsedSeconds)}`,
+			`${theme.fg("dim", "Continuations:")} ${goal.continuationsUsed}`,
+			`${theme.fg("dim", "Tokens:")} ${goal.tokensUsed.toLocaleString()}${
+				goal.tokenBudget === undefined ? "" : ` / ${goal.tokenBudget.toLocaleString()}`
+			}`,
+		];
+		if (goal.tokenBudget !== undefined) {
+			lines.push(
+				`${theme.fg("dim", "Remaining:")} ${Math.max(0, goal.tokenBudget - goal.tokensUsed).toLocaleString()}`,
+			);
+		}
+		if (goal.lastReason) {
+			lines.push(`${theme.fg("dim", "Reason:")} ${goal.lastReason}`);
+		}
+		if (goal.lastError) {
+			lines.push(`${theme.fg("dim", "Error:")} ${goal.lastError}`);
+		}
+
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new Text(lines.join("\n"), 1, 0));
+		this.ui.requestRender();
+	}
+
 	private handleChangelogCommand(): void {
 		const changelogPath = getChangelogPath();
 		const allEntries = parseChangelog(changelogPath);
@@ -5900,6 +6091,7 @@ export class InteractiveMode {
 			this.ui.terminal.setProgress(false);
 		}
 		this.stopWorkingLoader();
+		this.stopGoalTrayTimer();
 		this.clearExtensionTerminalInputListeners();
 		this.footer.dispose();
 		this.footerDataProvider.dispose();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.js";
+import { emptyGoalState, type GoalState } from "../src/core/goals.js";
 import type { SourceInfo } from "../src/core/source-info.js";
 import { InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -81,6 +82,136 @@ describe("InteractiveMode.showStatus", () => {
 		// adds spacer + text
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});
+
+describe("InteractiveMode goal status announcements", () => {
+	test("does not announce active goal usage-only updates", () => {
+		type GoalAnnouncementHarness = {
+			lastGoalAnnouncement?: unknown;
+			setGoalAnnouncementBaseline(goal: GoalState): void;
+			shouldAnnounceGoalUpdate(goal: GoalState): boolean;
+		};
+		const fakeThis = Object.create(InteractiveMode.prototype) as GoalAnnouncementHarness;
+		const activeGoal: GoalState = {
+			active: true,
+			status: "active",
+			goalId: "goal-1",
+			objective: "ship the feature",
+			tokensUsed: 10,
+			timeUsedSeconds: 5,
+			continuationsUsed: 1,
+		};
+
+		fakeThis.setGoalAnnouncementBaseline(emptyGoalState());
+		expect(fakeThis.shouldAnnounceGoalUpdate(activeGoal)).toBe(true);
+		expect(
+			fakeThis.shouldAnnounceGoalUpdate({
+				...activeGoal,
+				tokensUsed: 20,
+				timeUsedSeconds: 15,
+				continuationsUsed: 2,
+			}),
+		).toBe(false);
+		expect(
+			fakeThis.shouldAnnounceGoalUpdate({
+				...activeGoal,
+				objective: "ship the feature and update docs",
+			}),
+		).toBe(false);
+	});
+});
+
+describe("InteractiveMode tray goal label", () => {
+	type TrayLabelHarness = {
+		runtimeHost: {
+			session: {
+				goalState: GoalState;
+				getContextUsage(): { contextWindow: number; percent: number | null } | undefined;
+			};
+		};
+		getTrayContextLabel(): string | undefined;
+	};
+	const getTrayContextLabel = (InteractiveMode.prototype as unknown as TrayLabelHarness).getTrayContextLabel;
+
+	test("shows active goals in the lower tray without an objective", () => {
+		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
+		fakeThis.runtimeHost = {
+			session: {
+				goalState: {
+					active: true,
+					status: "active",
+					objective: "a long objective that should not render in the tray",
+					tokensUsed: 0,
+					timeUsedSeconds: 65,
+					continuationsUsed: 1,
+				} satisfies GoalState,
+				getContextUsage: () => undefined,
+			},
+		};
+
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s)");
+	});
+
+	test("combines active goals with low-context signal in one lower-tray label", () => {
+		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
+		fakeThis.runtimeHost = {
+			session: {
+				goalState: {
+					active: true,
+					status: "active",
+					objective: "finish the task",
+					tokensUsed: 0,
+					timeUsedSeconds: 65,
+					continuationsUsed: 1,
+				} satisfies GoalState,
+				getContextUsage: () => ({ contextWindow: 100_000, percent: 75 }),
+			},
+		};
+
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 25% context left");
+	});
+});
+
+describe("InteractiveMode.handleGoalStatusCommand", () => {
+	test("prints current goal details without queuing through the agent", () => {
+		type GoalStatusCommandHarness = {
+			runtimeHost: {
+				session: {
+					goalState: GoalState;
+				};
+			};
+			chatContainer: Container;
+			ui: { requestRender(): void };
+			handleGoalStatusCommand(): void;
+			formatGoalElapsed(seconds: number): string;
+		};
+		const fakeThis = Object.create(InteractiveMode.prototype) as GoalStatusCommandHarness;
+		fakeThis.runtimeHost = {
+			session: {
+				goalState: {
+					active: true,
+					status: "active",
+					objective: "ship the feature",
+					tokenBudget: 1000,
+					tokensUsed: 125,
+					timeUsedSeconds: 65,
+					continuationsUsed: 2,
+				},
+			},
+		};
+		fakeThis.chatContainer = new Container();
+		fakeThis.ui = { requestRender: vi.fn() };
+
+		fakeThis.handleGoalStatusCommand();
+
+		const rendered = normalizeRenderedOutput(fakeThis.chatContainer);
+		expect(rendered).toContain("Goal");
+		expect(rendered).toContain("Status: active");
+		expect(rendered).toContain("Objective: ship the feature");
+		expect(rendered).toContain("Time: 1m 05s");
+		expect(rendered).toContain("Tokens: 125 / 1,000");
+		expect(fakeThis.ui.requestRender).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -120,6 +120,26 @@ describe("InteractiveMode goal status announcements", () => {
 			}),
 		).toBe(false);
 	});
+
+	test("announces a transition back to idle when a goal is cleared", () => {
+		type GoalAnnouncementHarness = {
+			setGoalAnnouncementBaseline(goal: GoalState): void;
+			shouldAnnounceGoalUpdate(goal: GoalState): boolean;
+		};
+		const fakeThis = Object.create(InteractiveMode.prototype) as GoalAnnouncementHarness;
+		fakeThis.setGoalAnnouncementBaseline({
+			active: true,
+			status: "active",
+			goalId: "goal-1",
+			objective: "ship the feature",
+			tokensUsed: 10,
+			timeUsedSeconds: 5,
+			continuationsUsed: 1,
+		});
+
+		expect(fakeThis.shouldAnnounceGoalUpdate(emptyGoalState())).toBe(true);
+		expect(fakeThis.shouldAnnounceGoalUpdate(emptyGoalState())).toBe(false);
+	});
 });
 
 describe("InteractiveMode tray goal label", () => {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -455,6 +455,29 @@ describe("marquee TUI components", () => {
 		expect(narrow).toContain("inspect t…");
 	});
 
+	test("keeps child agent summary visible when the right tray label is long", () => {
+		const summary = new ChildAgentSummaryComponent(
+			() => undefined,
+			() => "Pursuing goal (1m 05s) · 25% context left",
+		);
+		summary.setNodes([
+			{
+				id: "sub-a",
+				label: "inspect training logs",
+				status: "running",
+				sessionDir: "/tmp/session/sub-a",
+				transcript: [],
+			},
+		]);
+
+		const row = summary.render(32)[0] ?? "";
+		const text = stripAnsi(row);
+
+		expect(visibleWidth(row)).toBe(32);
+		expect(text).toContain("1 sub");
+		expect(text).toContain("Pursuing goal");
+	});
+
 	test("renders full child agent detail without internal scroll controls", () => {
 		const detailComponent = new ChildAgentDetailComponent(() => 6);
 		detailComponent.setNode({


### PR DESCRIPTION
- goal status now stays in the lower tray with elapsed time and shares space with low-context warnings.
- running /goal while the agent is busy now shows current goal details immediately.
- active goal updates no longer repeat the full objective every turn.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve goal status UX with a persistent tray indicator and compact chat announcements
> - Replaces repeated full goal messages in chat with a compact persistent lower-tray goal indicator that refreshes every second while a goal is active.
> - Suppresses chat announcements for usage-only active goal updates; only announces on status, reason, or error changes and idle transitions.
> - Adds `/goal` and `/goal status` commands to print current goal details (status, objective, elapsed time, token usage) directly in chat without queuing an agent turn.
> - Fixes truncation in [`child-agent-inspector.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/47/files#diff-c6e80ba5fe28e36eaaf2f0d66307dec3db0481b56d24b214c31d2530d49517a1) so long right-side tray labels no longer push the left-side child-agent summary off-screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1996a15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes in interactive TUI; main risk is regressions in status rendering/timers and command handling.
> 
> **Overview**
> Goal updates in interactive mode are now *debounced*: `goal_update` events only emit chat status lines on meaningful transitions (status/goal change, reason/error changes), while active-goal usage ticks update a compact lower-tray label instead of repeating the full objective.
> 
> Adds a `/goal` (and `/goal status`) command that prints a detailed goal status block immediately (status/objective/elapsed time/tokens/budget/reason/error) without routing through the agent, and updates tray rendering so long right-side labels are truncated to keep the left summary visible (with new/updated tests and changelog entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1996a15f7ebeb8b55c8eda2681e6419db059a8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->