### PR TITLE
add prime inference browser login

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added automatic IPython kernel runtime bootstrap with uv-managed Python, `ipykernel`, and `prime-agent-runtime`.
 - Added `/goal` for long-running objectives that continue after early no-tool stops until the model marks the goal complete.
 - Added Prime Inference as a selectable built-in provider with `PRIME_API_KEY` and `/login` API-key authentication.
+- Added a first-class `/login` Prime Inference browser auth flow that can import existing Prime CLI credentials.
 - Added `/usage` to show token, cost, and context usage on demand.
 
 ### Changed

--- a/packages/coding-agent/src/core/prime-inference-auth.ts
+++ b/packages/coding-agent/src/core/prime-inference-auth.ts
@@ -189,7 +189,12 @@ async function readResponseMessage(response: Response): Promise<string> {
 }
 
 async function readJsonObject(response: Response, context: string): Promise<Record<string, unknown>> {
-	const parsed = (await response.json()) as unknown;
+	let parsed: unknown;
+	try {
+		parsed = (await response.json()) as unknown;
+	} catch {
+		throw new Error(`${context} returned an invalid response`);
+	}
 	if (!isRecord(parsed)) {
 		throw new Error(`${context} returned an invalid response`);
 	}
@@ -392,6 +397,7 @@ export async function loginPrimeInference(
 			signal: callbacks.signal,
 		});
 		if (access.ok) {
+			throwIfCancelled(callbacks.signal);
 			return { apiKey: config.apiKey, source: "prime-cli" };
 		}
 		callbacks.onProgress?.(
@@ -402,6 +408,7 @@ export async function loginPrimeInference(
 	}
 
 	const apiKey = await runPrimeBrowserLogin(config, callbacks, fetchFn, requestTimeoutMs, pollIntervalMs);
+	throwIfCancelled(callbacks.signal);
 	callbacks.onProgress?.("Checking Prime Inference access...");
 	const access = await checkPrimeInferenceAccess(apiKey, config.baseUrl, {
 		fetchFn,
@@ -412,5 +419,6 @@ export async function loginPrimeInference(
 		throw new Error(`Prime API key does not have Prime Inference access (${formatAccessFailure(access)})`);
 	}
 
+	throwIfCancelled(callbacks.signal);
 	return { apiKey, source: "browser" };
 }

--- a/packages/coding-agent/src/core/prime-inference-auth.ts
+++ b/packages/coding-agent/src/core/prime-inference-auth.ts
@@ -1,0 +1,416 @@
+import { Buffer } from "node:buffer";
+import { constants, generateKeyPairSync, privateDecrypt } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OAuthAuthInfo } from "@earendil-works/pi-ai";
+
+export const PRIME_INFERENCE_PROVIDER_ID = "prime-inference";
+export const PRIME_INFERENCE_PROVIDER_NAME = "Prime Inference";
+
+const DEFAULT_PRIME_API_BASE_URL = "https://api.primeintellect.ai";
+const DEFAULT_PRIME_FRONTEND_URL = "https://app.primeintellect.ai";
+const DEFAULT_PRIME_INFERENCE_URL = "https://api.pinference.ai/api/v1";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+export type PrimeInferenceAuthSource = "prime-cli" | "browser";
+
+export type PrimeInferenceLoginResult = {
+	apiKey: string;
+	source: PrimeInferenceAuthSource;
+};
+
+export type PrimeCliConfig = {
+	apiKey?: string;
+	baseUrl: string;
+	frontendUrl: string;
+	inferenceUrl: string;
+	path: string;
+};
+
+export type PrimeInferenceLoginCallbacks = {
+	onAuth: (info: OAuthAuthInfo) => void;
+	onProgress?: (message: string) => void;
+	signal?: AbortSignal;
+};
+
+export type PrimeInferenceLoginOptions = {
+	configPath?: string;
+	fetchFn?: typeof fetch;
+	pollIntervalMs?: number;
+	requestTimeoutMs?: number;
+};
+
+type PrimeChallengeConfig = {
+	baseUrl: string;
+	frontendUrl: string;
+};
+
+type PrimeChallengeResponse = {
+	challenge: string;
+	statusAuthToken: string;
+};
+
+export type PrimeInferenceAccessResult =
+	| { ok: true }
+	| {
+			ok: false;
+			status?: number;
+			message: string;
+	  };
+
+function defaultPrimeCliConfigPath(): string {
+	return join(homedir(), ".prime", "config.json");
+}
+
+function normalizeBaseUrl(value: string | undefined): string {
+	return (value || DEFAULT_PRIME_API_BASE_URL)
+		.trim()
+		.replace(/\/+$/, "")
+		.replace(/\/api\/v1$/, "");
+}
+
+function normalizeUrl(value: string | undefined, fallback: string): string {
+	return (value || fallback).trim().replace(/\/+$/, "");
+}
+
+function stringField(data: Record<string, unknown>, key: string): string | undefined {
+	const value = data[key];
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function loadPrimeCliConfig(configPath: string = defaultPrimeCliConfigPath()): PrimeCliConfig {
+	let data: Record<string, unknown> = {};
+	if (existsSync(configPath)) {
+		try {
+			const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
+			if (isRecord(parsed)) {
+				data = parsed;
+			}
+		} catch {
+			data = {};
+		}
+	}
+
+	return {
+		apiKey: stringField(data, "api_key"),
+		baseUrl: normalizeBaseUrl(stringField(data, "base_url")),
+		frontendUrl: normalizeUrl(stringField(data, "frontend_url"), DEFAULT_PRIME_FRONTEND_URL),
+		inferenceUrl: normalizeUrl(stringField(data, "inference_url"), DEFAULT_PRIME_INFERENCE_URL),
+		path: configPath,
+	};
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+	if (signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+
+		let timeout: NodeJS.Timeout;
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(new Error("Login cancelled"));
+		};
+		timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+async function fetchWithTimeout(
+	fetchFn: typeof fetch,
+	url: string | URL,
+	init: RequestInit,
+	timeoutMs: number,
+	signal?: AbortSignal,
+): Promise<Response> {
+	throwIfCancelled(signal);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	const onAbort = () => controller.abort();
+	signal?.addEventListener("abort", onAbort, { once: true });
+
+	try {
+		return await fetchFn(url, { ...init, signal: controller.signal });
+	} catch (error) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+		if (controller.signal.aborted) {
+			throw new Error("Prime Inference request timed out");
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
+async function readResponseMessage(response: Response): Promise<string> {
+	const text = await response.text().catch(() => "");
+	if (!text.trim()) {
+		return response.statusText || "Unknown error";
+	}
+
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		if (isRecord(parsed)) {
+			const error = parsed.error;
+			if (isRecord(error)) {
+				const message = stringField(error, "message");
+				if (message) return message;
+			}
+			const detail = stringField(parsed, "detail");
+			if (detail) return detail;
+			const message = stringField(parsed, "message");
+			if (message) return message;
+		}
+	} catch {
+		// Fall back to raw text.
+	}
+
+	return text.trim();
+}
+
+async function readJsonObject(response: Response, context: string): Promise<Record<string, unknown>> {
+	const parsed = (await response.json()) as unknown;
+	if (!isRecord(parsed)) {
+		throw new Error(`${context} returned an invalid response`);
+	}
+	return parsed;
+}
+
+function createPrimeChallengeKeypair(): { privateKey: string; publicKey: string } {
+	const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+		modulusLength: 2048,
+		publicExponent: 0x10001,
+		publicKeyEncoding: {
+			type: "spki",
+			format: "pem",
+		},
+		privateKeyEncoding: {
+			type: "pkcs8",
+			format: "pem",
+		},
+	});
+	return { privateKey, publicKey };
+}
+
+function decryptPrimeChallengeResult(privateKey: string, encryptedResult: string): string {
+	const decrypted = privateDecrypt(
+		{
+			key: privateKey,
+			padding: constants.RSA_PKCS1_OAEP_PADDING,
+			oaepHash: "sha256",
+		},
+		Buffer.from(encryptedResult, "base64"),
+	);
+	return decrypted.toString("utf-8");
+}
+
+async function generatePrimeChallenge(
+	config: PrimeChallengeConfig,
+	publicKey: string,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+	signal?: AbortSignal,
+): Promise<PrimeChallengeResponse> {
+	const response = await fetchWithTimeout(
+		fetchFn,
+		`${config.baseUrl}/api/v1/auth_challenge/generate`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ encryptionPublicKey: publicKey }),
+		},
+		timeoutMs,
+		signal,
+	);
+
+	if (!response.ok) {
+		throw new Error(`Failed to generate Prime login challenge: ${await readResponseMessage(response)}`);
+	}
+
+	const data = await readJsonObject(response, "Prime login challenge");
+	const challenge = stringField(data, "challenge");
+	const statusAuthToken = stringField(data, "status_auth_token");
+	if (!challenge || !statusAuthToken) {
+		throw new Error("Prime login challenge response missing required fields");
+	}
+
+	return { challenge, statusAuthToken };
+}
+
+async function pollPrimeChallengeResult(
+	config: PrimeChallengeConfig,
+	challenge: PrimeChallengeResponse,
+	privateKey: string,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+	pollIntervalMs: number,
+	signal?: AbortSignal,
+): Promise<string> {
+	while (true) {
+		throwIfCancelled(signal);
+
+		const statusUrl = new URL(`${config.baseUrl}/api/v1/auth_challenge/status`);
+		statusUrl.searchParams.set("challenge", challenge.challenge);
+		const response = await fetchWithTimeout(
+			fetchFn,
+			statusUrl,
+			{
+				method: "GET",
+				headers: { Authorization: `Bearer ${challenge.statusAuthToken}` },
+			},
+			timeoutMs,
+			signal,
+		);
+
+		if (response.status === 404) {
+			throw new Error("Prime login challenge expired");
+		}
+		if (!response.ok) {
+			throw new Error(`Failed to check Prime login status: ${await readResponseMessage(response)}`);
+		}
+
+		const data = await readJsonObject(response, "Prime login status");
+		const encryptedResult = stringField(data, "result");
+		if (encryptedResult) {
+			return decryptPrimeChallengeResult(privateKey, encryptedResult);
+		}
+
+		await abortableSleep(pollIntervalMs, signal);
+	}
+}
+
+async function runPrimeBrowserLogin(
+	config: PrimeChallengeConfig,
+	callbacks: PrimeInferenceLoginCallbacks,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+	pollIntervalMs: number,
+): Promise<string> {
+	const { privateKey, publicKey } = createPrimeChallengeKeypair();
+	const challenge = await generatePrimeChallenge(config, publicKey, fetchFn, timeoutMs, callbacks.signal);
+	const url = `${config.frontendUrl}/dashboard/tokens/challenge?code=${encodeURIComponent(challenge.challenge)}`;
+	callbacks.onAuth({ url, instructions: `Code: ${challenge.challenge}` });
+	return pollPrimeChallengeResult(config, challenge, privateKey, fetchFn, timeoutMs, pollIntervalMs, callbacks.signal);
+}
+
+export async function checkPrimeInferenceAccess(
+	apiKey: string,
+	baseUrl: string,
+	options: {
+		fetchFn?: typeof fetch;
+		requestTimeoutMs?: number;
+		signal?: AbortSignal;
+	} = {},
+): Promise<PrimeInferenceAccessResult> {
+	const fetchFn = options.fetchFn ?? fetch;
+	const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+	const url = `${normalizeBaseUrl(baseUrl)}/api/v1/user/whoami`;
+	const response = await fetchWithTimeout(
+		fetchFn,
+		url,
+		{
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				Accept: "application/json",
+			},
+		},
+		requestTimeoutMs,
+		options.signal,
+	);
+
+	if (!response.ok) {
+		return {
+			ok: false,
+			status: response.status,
+			message: await readResponseMessage(response),
+		};
+	}
+
+	const data = await readJsonObject(response, "Prime whoami");
+	const user = data.data;
+	if (!isRecord(user)) {
+		return { ok: false, message: "Prime whoami response missing user data" };
+	}
+
+	const scope = user.scope;
+	if (!isRecord(scope)) {
+		return { ok: false, message: "Prime token is missing permission scope data" };
+	}
+
+	const inference = scope.inference;
+	if (!isRecord(inference)) {
+		return { ok: false, message: "Prime token is missing inference permissions" };
+	}
+
+	if (inference.write === true) {
+		return { ok: true };
+	}
+
+	return { ok: false, message: "Prime token does not have inference write permission" };
+}
+
+function formatAccessFailure(result: Exclude<PrimeInferenceAccessResult, { ok: true }>): string {
+	const status = result.status === undefined ? "" : `HTTP ${result.status}: `;
+	return `${status}${result.message}`;
+}
+
+export async function loginPrimeInference(
+	callbacks: PrimeInferenceLoginCallbacks,
+	options: PrimeInferenceLoginOptions = {},
+): Promise<PrimeInferenceLoginResult> {
+	const config = loadPrimeCliConfig(options.configPath);
+	const fetchFn = options.fetchFn ?? fetch;
+	const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+	if (config.apiKey) {
+		callbacks.onProgress?.("Checking existing Prime CLI credentials...");
+		const access = await checkPrimeInferenceAccess(config.apiKey, config.baseUrl, {
+			fetchFn,
+			requestTimeoutMs,
+			signal: callbacks.signal,
+		});
+		if (access.ok) {
+			return { apiKey: config.apiKey, source: "prime-cli" };
+		}
+		callbacks.onProgress?.(
+			`Existing Prime CLI key cannot access Prime Inference (${formatAccessFailure(access)}). Starting browser login...`,
+		);
+	} else {
+		callbacks.onProgress?.("No Prime CLI API key found. Starting browser login...");
+	}
+
+	const apiKey = await runPrimeBrowserLogin(config, callbacks, fetchFn, requestTimeoutMs, pollIntervalMs);
+	callbacks.onProgress?.("Checking Prime Inference access...");
+	const access = await checkPrimeInferenceAccess(apiKey, config.baseUrl, {
+		fetchFn,
+		requestTimeoutMs,
+		signal: callbacks.signal,
+	});
+	if (!access.ok) {
+		throw new Error(`Prime API key does not have Prime Inference access (${formatAccessFailure(access)})`);
+	}
+
+	return { apiKey, source: "browser" };
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -81,6 +81,11 @@ import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.j
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { defaultModelPerProvider, findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
+import {
+	loginPrimeInference,
+	PRIME_INFERENCE_PROVIDER_ID,
+	PRIME_INFERENCE_PROVIDER_NAME,
+} from "../../core/prime-inference-auth.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-names.js";
 import type { ResourceDiagnostic } from "../../core/resource-loader.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
@@ -4956,14 +4961,20 @@ export class InteractiveMode {
 	}
 
 	private showLoginAuthTypeSelector(): void {
+		const primeInferenceLabel = "Use Prime Inference";
 		const subscriptionLabel = "Use a subscription";
 		const apiKeyLabel = "Use an API key";
+
 		this.showSelector((done) => {
 			const selector = new ExtensionSelectorComponent(
 				"Select authentication method:",
-				[subscriptionLabel, apiKeyLabel],
+				[primeInferenceLabel, subscriptionLabel, apiKeyLabel],
 				(option) => {
 					done();
+					if (option === primeInferenceLabel) {
+						void this.showPrimeInferenceLoginDialog();
+						return;
+					}
 					const authType = option === subscriptionLabel ? "oauth" : "api_key";
 					this.showLoginProviderSelector(authType);
 				},
@@ -5144,6 +5155,62 @@ export class InteractiveMode {
 		this.editorContainer.addChild(dialog);
 		this.ui.setFocus(dialog);
 		this.ui.requestRender();
+	}
+
+	private async showPrimeInferenceLoginDialog(): Promise<void> {
+		const previousModel = this.session.model;
+		const dialog = new LoginDialogComponent(
+			this.ui,
+			PRIME_INFERENCE_PROVIDER_ID,
+			(_success, _message) => {
+				// Completion handled below.
+			},
+			PRIME_INFERENCE_PROVIDER_NAME,
+		);
+
+		this.editorContainer.clear();
+		this.editorContainer.addChild(dialog);
+		this.ui.setFocus(dialog);
+		this.ui.requestRender();
+
+		const restoreEditor = () => {
+			this.editorContainer.clear();
+			this.editorContainer.addChild(this.editor);
+			this.ui.setFocus(this.editor);
+			this.ui.requestRender();
+		};
+
+		try {
+			const result = await loginPrimeInference({
+				onAuth: (info) => {
+					dialog.showAuth(info.url, info.instructions);
+					dialog.showWaiting("Waiting for browser authentication...");
+				},
+				onProgress: (message) => {
+					dialog.showProgress(message);
+				},
+				signal: dialog.signal,
+			});
+
+			this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
+				type: "api_key",
+				key: result.apiKey,
+			});
+
+			restoreEditor();
+			await this.completeProviderAuthentication(
+				PRIME_INFERENCE_PROVIDER_ID,
+				PRIME_INFERENCE_PROVIDER_NAME,
+				"api_key",
+				previousModel,
+			);
+		} catch (error: unknown) {
+			restoreEditor();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Login cancelled") {
+				this.showError(`Failed to login to ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
+			}
+		}
 	}
 
 	private async showApiKeyLoginDialog(providerId: string, providerName: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5192,6 +5192,11 @@ export class InteractiveMode {
 				signal: dialog.signal,
 			});
 
+			if (dialog.signal.aborted) {
+				restoreEditor();
+				return;
+			}
+
 			this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
 				type: "api_key",
 				key: result.apiKey,

--- a/packages/coding-agent/test/prime-inference-auth.test.ts
+++ b/packages/coding-agent/test/prime-inference-auth.test.ts
@@ -1,0 +1,196 @@
+import { Buffer } from "node:buffer";
+import { constants, publicEncrypt } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	checkPrimeInferenceAccess,
+	loadPrimeCliConfig,
+	loginPrimeInference,
+} from "../src/core/prime-inference-auth.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getUrl(input: string | URL | Request): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	return input.url;
+}
+
+function getJsonBody(init?: RequestInit): Record<string, unknown> {
+	if (typeof init?.body !== "string") {
+		throw new Error(`Expected string request body, got ${typeof init?.body}`);
+	}
+	return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+function getAuthorization(init?: RequestInit): string | undefined {
+	const headers = init?.headers;
+	if (!headers || Array.isArray(headers)) {
+		return undefined;
+	}
+	if (headers instanceof Headers) {
+		return headers.get("Authorization") ?? undefined;
+	}
+	const headerRecord = headers as Record<string, string | undefined>;
+	return headerRecord.Authorization ?? headerRecord.authorization;
+}
+
+function encryptChallengeResult(publicKey: string, value: string): string {
+	return publicEncrypt(
+		{
+			key: publicKey,
+			padding: constants.RSA_PKCS1_OAEP_PADDING,
+			oaepHash: "sha256",
+		},
+		Buffer.from(value, "utf-8"),
+	).toString("base64");
+}
+
+describe("Prime Inference auth", () => {
+	let tempDir: string;
+	let configPath: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-prime-auth-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		configPath = join(tempDir, "config.json");
+	});
+
+	afterEach(() => {
+		if (existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("loads Prime CLI config with defaults", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				api_key: "prime-key",
+				base_url: "https://prime-api.example/api/v1",
+				frontend_url: "https://prime-app.example/",
+			}),
+		);
+
+		expect(loadPrimeCliConfig(configPath)).toEqual({
+			apiKey: "prime-key",
+			baseUrl: "https://prime-api.example",
+			frontendUrl: "https://prime-app.example",
+			inferenceUrl: "https://api.pinference.ai/api/v1",
+			path: configPath,
+		});
+	});
+
+	it("checks Prime Inference access with Prime whoami permissions", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://prime-api.example/api/v1/user/whoami");
+			expect(init?.method).toBe("GET");
+			expect(getAuthorization(init)).toBe("Bearer prime-key");
+			return jsonResponse({ data: { scope: { inference: { read: true, write: true } } } });
+		});
+
+		await expect(
+			checkPrimeInferenceAccess("prime-key", "https://prime-api.example", { fetchFn: fetchMock }),
+		).resolves.toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("imports a valid Prime CLI key", async () => {
+		writeFileSync(configPath, JSON.stringify({ api_key: "prime-cli-key" }));
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://api.primeintellect.ai/api/v1/user/whoami");
+			expect(getAuthorization(init)).toBe("Bearer prime-cli-key");
+			return jsonResponse({ data: { scope: { inference: { write: true } } } });
+		});
+		const onAuth = vi.fn();
+
+		const result = await loginPrimeInference({ onAuth }, { configPath, fetchFn: fetchMock, requestTimeoutMs: 1000 });
+
+		expect(result).toEqual({ apiKey: "prime-cli-key", source: "prime-cli" });
+		expect(onAuth).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("falls back to browser login when the Prime CLI key cannot access inference", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				api_key: "old-key",
+				base_url: "https://prime-api.example",
+				frontend_url: "https://prime-app.example",
+				inference_url: "https://pinference.example/api/v1",
+			}),
+		);
+		let challengePublicKey = "";
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://prime-api.example/api/v1/user/whoami") {
+				const auth = getAuthorization(init);
+				if (auth === "Bearer old-key") {
+					return jsonResponse({ data: { scope: { inference: { read: true, write: false } } } });
+				}
+				if (auth === "Bearer browser-key") {
+					return jsonResponse({ data: { scope: { inference: { read: true, write: true } } } });
+				}
+			}
+			if (url === "https://prime-api.example/api/v1/auth_challenge/generate") {
+				challengePublicKey = String(getJsonBody(init).encryptionPublicKey);
+				return jsonResponse({ challenge: "challenge-code", status_auth_token: "status-token" });
+			}
+			if (url.startsWith("https://prime-api.example/api/v1/auth_challenge/status")) {
+				expect(getAuthorization(init)).toBe("Bearer status-token");
+				return jsonResponse({ result: encryptChallengeResult(challengePublicKey, "browser-key") });
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+		const onAuth = vi.fn();
+		const progress: string[] = [];
+
+		const result = await loginPrimeInference(
+			{
+				onAuth,
+				onProgress: (message) => progress.push(message),
+			},
+			{ configPath, fetchFn: fetchMock, pollIntervalMs: 0, requestTimeoutMs: 1000 },
+		);
+
+		expect(result).toEqual({ apiKey: "browser-key", source: "browser" });
+		expect(onAuth).toHaveBeenCalledWith({
+			url: "https://prime-app.example/dashboard/tokens/challenge?code=challenge-code",
+			instructions: "Code: challenge-code",
+		});
+		expect(progress.join("\n")).toContain("Existing Prime CLI key cannot access Prime Inference");
+	});
+
+	it("rejects an expired browser challenge", async () => {
+		writeFileSync(configPath, JSON.stringify({ base_url: "https://prime-api.example" }));
+		const fetchMock = vi.fn(async (input: string | URL | Request): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://prime-api.example/api/v1/auth_challenge/generate") {
+				return jsonResponse({ challenge: "challenge-code", status_auth_token: "status-token" });
+			}
+			if (url.startsWith("https://prime-api.example/api/v1/auth_challenge/status")) {
+				return new Response("expired", { status: 404 });
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		await expect(
+			loginPrimeInference({ onAuth: () => {} }, { configPath, fetchFn: fetchMock, pollIntervalMs: 0 }),
+		).rejects.toThrow("Prime login challenge expired");
+	});
+});

--- a/packages/coding-agent/test/prime-inference-auth.test.ts
+++ b/packages/coding-agent/test/prime-inference-auth.test.ts
@@ -109,6 +109,19 @@ describe("Prime Inference auth", () => {
 		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 
+	it("throws contextual errors for invalid Prime whoami JSON", async () => {
+		const fetchMock = vi.fn(async (): Promise<Response> => {
+			return new Response("not json", {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await expect(
+			checkPrimeInferenceAccess("prime-key", "https://prime-api.example", { fetchFn: fetchMock }),
+		).rejects.toThrow("Prime whoami returned an invalid response");
+	});
+
 	it("imports a valid Prime CLI key", async () => {
 		writeFileSync(configPath, JSON.stringify({ api_key: "prime-cli-key" }));
 		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -123,6 +136,29 @@ describe("Prime Inference auth", () => {
 		expect(result).toEqual({ apiKey: "prime-cli-key", source: "prime-cli" });
 		expect(onAuth).not.toHaveBeenCalled();
 		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("honors cancellation before returning an imported Prime CLI key", async () => {
+		writeFileSync(configPath, JSON.stringify({ api_key: "prime-cli-key" }));
+		const controller = new AbortController();
+		const fetchMock = vi.fn(async (): Promise<Response> => {
+			const response = jsonResponse({ data: { scope: { inference: { write: true } } } });
+			vi.spyOn(response, "json").mockImplementation(async () => {
+				controller.abort();
+				return { data: { scope: { inference: { write: true } } } };
+			});
+			return response;
+		});
+
+		await expect(
+			loginPrimeInference(
+				{
+					onAuth: () => {},
+					signal: controller.signal,
+				},
+				{ configPath, fetchFn: fetchMock, requestTimeoutMs: 1000 },
+			),
+		).rejects.toThrow("Login cancelled");
 	});
 
 	it("falls back to browser login when the Prime CLI key cannot access inference", async () => {


### PR DESCRIPTION
- adds prime inference as a first-class login option ahead of subscription and api key auth.
- imports usable prime cli credentials or runs the prime browser challenge flow.
- validates inference write access with whoami before saving the api key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive login path that exchanges browser challenge responses for API keys and persists credentials, touching auth/credential storage and external Prime endpoints. Risk is moderated by explicit permission checks via `whoami`, but failures could block login or store unusable keys.
> 
> **Overview**
> Adds a first-class **Prime Inference** option to `/login` in interactive mode, which runs a dedicated login dialog and stores the resulting API key in auth storage before completing provider authentication.
> 
> Introduces `prime-inference-auth.ts` to import existing Prime CLI credentials from `~/.prime/config.json` or fall back to a browser-based RSA challenge flow, then validates `inference.write` permission via `/api/v1/user/whoami` before accepting the key. Includes new Vitest coverage for config parsing/URL normalization, access checks, CLI key reuse, browser fallback, cancellation, and expired challenges, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1385f5b680c3f221242b07544c68e62e8a1e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Prime Inference browser login flow to the coding agent
> - Adds a new [`prime-inference-auth.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/52/files#diff-40ca3a9b7aa078d19662af60b81d2d9f1fa6c613c4ade40e87f2fbf8e63f0e07) module implementing a full login flow: imports an existing Prime CLI API key (`~/.prime/config.json`) if valid, or drives a browser-based RSA challenge flow to obtain one.
> - Verifies the acquired key has `inference.write` scope via the Prime `/api/v1/user/whoami` endpoint before accepting it.
> - Adds a 'Use Prime Inference' option in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/52/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) that opens an in-app login dialog, stores the API key in `authStorage`, and completes provider authentication on success.
> - Adds Vitest coverage for config loading, whoami checks, CLI key import, browser challenge flow, and expired challenge handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f1385f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->