### PR TITLE
Add Prime Team header logic for PI Inference (with fallback to prime config)

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -5,6 +5,7 @@ import type { KnownProvider } from "./types.js";
 
 // NEVER convert to top-level runtime imports - breaks browser/Vite builds (web-ui)
 let _existsSync: typeof existsSync | null = null;
+let _readFileSync: typeof readFileSync | null = null;
 let _homedir: typeof homedir | null = null;
 let _join: typeof join | null = null;
 
@@ -19,6 +20,7 @@ const NODE_PATH_SPECIFIER = "node:" + "path";
 if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
 	dynamicImport(NODE_FS_SPECIFIER).then((m) => {
 		_existsSync = (m as { existsSync: typeof existsSync }).existsSync;
+		_readFileSync = (m as { readFileSync: typeof readFileSync }).readFileSync;
 	});
 	dynamicImport(NODE_OS_SPECIFIER).then((m) => {
 		_homedir = (m as { homedir: typeof homedir }).homedir;
@@ -208,5 +210,23 @@ export function getEnvApiKey(provider: string): string | undefined {
 		}
 	}
 
+	return undefined;
+}
+
+// PRIME_TEAM_ID env var, falling back to team_id in ~/.prime/config.json.
+export function getPrimeTeamId(): string | undefined {
+	const fromEnv = process.env.PRIME_TEAM_ID || getProcEnv("PRIME_TEAM_ID");
+	if (fromEnv?.trim()) return fromEnv.trim();
+
+	if (!_existsSync || !_readFileSync || !_homedir || !_join) return undefined;
+	const configPath = _join(_homedir(), ".prime", "config.json");
+	if (!_existsSync(configPath)) return undefined;
+	try {
+		const parsed = JSON.parse(_readFileSync(configPath, "utf-8")) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			const teamId = (parsed as Record<string, unknown>).team_id;
+			if (typeof teamId === "string" && teamId.trim()) return teamId.trim();
+		}
+	} catch {}
 	return undefined;
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -10,7 +10,7 @@ import type {
 	ChatCompletionSystemMessageParam,
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
-import { getEnvApiKey } from "../env-api-keys.js";
+import { getEnvApiKey, getPrimeTeamId } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
 	AssistantMessage,
@@ -460,6 +460,11 @@ function createClient(
 			hasImages,
 		});
 		Object.assign(headers, copilotHeaders);
+	}
+
+	if (model.provider === "prime-inference") {
+		const teamId = getPrimeTeamId();
+		if (teamId) headers["X-Prime-Team-ID"] = teamId;
 	}
 
 	if (sessionId && compat.sendSessionAffinityHeaders) {


### PR DESCRIPTION
For OpenAI completions (which include Prime Inference), also make sure the `PRIME_TEAM_ID` is set for the `X-Prime-Team-ID` header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new request header behavior for `prime-inference` calls and introduces filesystem reads for `~/.prime/config.json` in Node/Bun, which could affect routing/tenancy and fail in unusual runtime environments.
> 
> **Overview**
> Ensures `prime-inference` requests sent via the OpenAI Completions client include `X-Prime-Team-ID` when available.
> 
> Introduces `getPrimeTeamId()` to resolve the team id from `PRIME_TEAM_ID` (with Bun `/proc/self/environ` fallback) and, if unset, from `~/.prime/config.json`, using dynamically imported `fs/os/path` to avoid browser/Vite runtime imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102783da95b4f7335770067ba657204d7093f3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `X-Prime-Team-ID` header to Prime Inference requests with fallback to `~/.prime/config.json`
> - Adds a new `getPrimeTeamId` function in [env-api-keys.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/54/files#diff-2348feed8ded6af482a24473231ace3a3ccc5ad8705195b9391ba0d50cfae913) that resolves a team ID from the `PRIME_TEAM_ID` environment variable, falling back to reading `~/.prime/config.json`.
> - In [openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/54/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246), `createClient` now attaches the `X-Prime-Team-ID` header when the provider is `prime-inference` and a team ID is resolvable.
> - File system access (`readFileSync`, `existsSync`) is lazy-loaded in Node/Bun environments to avoid issues in non-Node runtimes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 102783d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->