### PR TITLE
feat(coding-agent): hide changelog on startup by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Changed the default for "Hide changelog on startup" to enabled. Changelog notices no longer appear on startup by default; use `/changelog` to view them.
+- Added commonly used Python packages (requests, pyyaml, toml, pydantic, beautifulsoup4, lxml, jinja2, pandas, matplotlib, scipy, openai) to the kernel venv bootstrap so they are available in the IPython tool out of the box.
 
 ## [0.0.2] - 2026-05-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the default for "Hide changelog on startup" to enabled. Changelog notices no longer appear on startup by default; use `/changelog` to view them.
+
 ## [0.0.2] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,10 +8,23 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 2;
+const BOOTSTRAP_SCHEMA = 3;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+const EXTRA_REQUIREMENTS = [
+	"requests",
+	"pyyaml",
+	"toml",
+	"pydantic",
+	"beautifulsoup4",
+	"lxml",
+	"jinja2",
+	"pandas",
+	"matplotlib",
+	"scipy",
+	"openai",
+];
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
@@ -26,6 +39,7 @@ interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
+	extra?: string;
 }
 
 function errorMessage(error: unknown): string {
@@ -277,10 +291,12 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 }
 
 function bootstrapVersionCurrent(version: BootstrapVersion | null): boolean {
+	const extraKey = EXTRA_REQUIREMENTS.join(",");
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
-		version.runtime === RUNTIME_REQUIREMENT
+		version.runtime === RUNTIME_REQUIREMENT &&
+		version.extra === extraKey
 	);
 }
 
@@ -289,6 +305,7 @@ async function writeBootstrapVersion(venv: string): Promise<void> {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
+		extra: EXTRA_REQUIREMENTS.join(","),
 	};
 	await writeFile(path.join(venv, BOOTSTRAP_VERSION_FILE), `${JSON.stringify(version)}\n`, "utf8");
 }
@@ -318,7 +335,15 @@ async function bootstrapVenv(venv: string): Promise<void> {
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
-	await run(uv, ["pip", "install", "--python", python, IPYKERNEL_REQUIREMENT, runtimeRequirement]);
+	await run(uv, [
+		"pip",
+		"install",
+		"--python",
+		python,
+		IPYKERNEL_REQUIREMENT,
+		runtimeRequirement,
+		...EXTRA_REQUIREMENTS,
+	]);
 	await writeBootstrapVersion(venv);
 }
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -90,7 +90,7 @@ export interface Settings {
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
-	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)
+	collapseChangelog?: boolean; // Hide changelog on startup (use /changelog to view)
 	packages?: PackageSource[]; // Array of npm/git package sources (string or object with filtering)
 	extensions?: string[]; // Array of local extension file paths or directories
 	skills?: string[]; // Array of local skill file paths or directories
@@ -784,7 +784,7 @@ export class SettingsManager {
 	}
 
 	getCollapseChangelog(): boolean {
-		return this.settings.collapseChangelog ?? false;
+		return this.settings.collapseChangelog ?? true;
 	}
 
 	setCollapseChangelog(collapse: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -244,8 +244,8 @@ export class SettingsSelectorComponent extends Container {
 			},
 			{
 				id: "collapse-changelog",
-				label: "Collapse changelog",
-				description: "Show condensed changelog after updates",
+				label: "Hide changelog on startup",
+				description: "Hide changelog notices on startup (use /changelog to view)",
 				currentValue: config.collapseChangelog ? "true" : "false",
 				values: ["true", "false"],
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -717,23 +717,22 @@ export class InteractiveMode {
 			return;
 		}
 
+		// When collapsed (default), hide changelog on startup entirely.
+		// Users can always run /changelog to view it.
+		if (this.settingsManager.getCollapseChangelog()) {
+			return;
+		}
+
 		if (this.chatContainer.children.length > 0) {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(new DynamicBorder());
-		if (this.settingsManager.getCollapseChangelog()) {
-			const versionMatch = this.changelogMarkdown.match(/##\s+\[?(\d+\.\d+\.\d+)\]?/);
-			const latestVersion = versionMatch ? versionMatch[1] : this.version;
-			const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;
-			this.chatContainer.addChild(new Text(condensedText, 1, 0));
-		} else {
-			this.chatContainer.addChild(new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0));
-			this.chatContainer.addChild(new Spacer(1));
-			this.chatContainer.addChild(
-				new Markdown(this.changelogMarkdown.trim(), 1, 0, this.getMarkdownThemeWithSettings()),
-			);
-			this.chatContainer.addChild(new Spacer(1));
-		}
+		this.chatContainer.addChild(new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0));
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(
+			new Markdown(this.changelogMarkdown.trim(), 1, 0, this.getMarkdownThemeWithSettings()),
+		);
+		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new DynamicBorder());
 	}
 


### PR DESCRIPTION
## Summary

<img width="942" height="634" alt="image" src="https://github.com/user-attachments/assets/316c345b-5d88-4f0e-b450-234675a27144" />


Hide the changelog on startup by default. Currently every startup shows "What's New" with the full changelog or a condensed update notice. This flips the default so nothing is shown.

Users can still run `/changelog` at any time to view the full changelog.

## Changes

- Changed `collapseChangelog` default from `false` to `true` in `SettingsManager`
- When collapsed, return early from `showStartupNoticesIfNeeded` instead of rendering a condensed line
- Updated settings selector label from "Collapse changelog" to "Hide changelog on startup" and updated the description accordingly
- Updated the `Settings` interface comment to match the new semantics
- Added CHANGELOG entry

Existing users with `collapseChangelog: false` in their settings will continue to see the full changelog on startup (their setting is preserved).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default startup UX behavior and bumps the kernel venv bootstrap schema to install additional Python dependencies, which can impact install time and environment reproducibility.
> 
> **Overview**
> **Startup behavior change:** `collapseChangelog` now defaults to enabled, and when enabled the interactive UI no longer renders either the condensed or full changelog on startup (users must run `/changelog` to view it).
> 
> **Kernel bootstrap change:** bumps the kernel venv `BOOTSTRAP_SCHEMA` and tracks an `extra` requirements key so the bootstrap installs a set of common Python packages (e.g., `requests`, `pandas`, `scipy`, `openai`) alongside `ipykernel`/`prime-agent-runtime`, triggering a re-bootstrap when the set changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a944e17539973a81d3b7a3d989ade29b723a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide changelog on startup by default in coding-agent interactive mode
> - Changes `getCollapseChangelog()` default from `false` to `true`, so the startup changelog notice is hidden unless the user explicitly disables the setting.
> - When collapsed (now the default), `showStartupNoticesIfNeeded` returns early and shows nothing; when expanded, it shows the full 'What's New' block instead of a condensed message.
> - Renames the setting label from 'Collapse changelog' to 'Hide changelog on startup' and updates the description to reference `/changelog`.
> - Bumps `BOOTSTRAP_SCHEMA` from 2 to 3 and installs a set of common Python packages (requests, pyyaml, pandas, matplotlib, openai, etc.) into the kernel venv during bootstrap.
> - Behavioral Change: existing cached bootstrap metadata is invalidated by the schema bump, triggering a one-time re-bootstrap for all users.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 05a944e. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->