### PR TITLE
feat(coding-agent): add default extra Python packages to kernel bootstrap and system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added default extra Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic) to the kernel venv bootstrap and system prompt.
+
+
 ## [0.0.2] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,10 +8,23 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 2;
+const BOOTSTRAP_SCHEMA = 3;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+export const DEFAULT_RLM_EXTRA_UV_ARGS = [
+	"requests",
+	"httpx",
+	"pyyaml",
+	"tomli",
+	"python-dotenv",
+	"pandas",
+	"numpy",
+	"scipy",
+	"beautifulsoup4",
+	"lxml",
+	"pydantic",
+];
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
@@ -26,6 +39,7 @@ interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
+	extraUvArgs?: string[];
 }
 
 function errorMessage(error: unknown): string {
@@ -266,21 +280,35 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 		const raw = await readFile(path.join(venv, BOOTSTRAP_VERSION_FILE), "utf8");
 		const parsed: unknown = JSON.parse(raw);
 		if (!isRecord(parsed) || typeof parsed.schema !== "number") return null;
+		const extraUvArgs =
+			Array.isArray(parsed.extraUvArgs) &&
+			parsed.extraUvArgs.every((v: unknown): v is string => typeof v === "string")
+				? (parsed.extraUvArgs as string[])
+				: undefined;
 		return {
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
 			runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
+			extraUvArgs,
 		};
 	} catch {
 		return null;
 	}
 }
 
+function extraUvArgsMatch(a: string[] | undefined, b: string[] | undefined): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.length !== b.length) return false;
+	return a.every((v, i) => v === b[i]);
+}
+
 function bootstrapVersionCurrent(version: BootstrapVersion | null): boolean {
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
-		version.runtime === RUNTIME_REQUIREMENT
+		version.runtime === RUNTIME_REQUIREMENT &&
+		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
 	);
 }
 
@@ -289,6 +317,7 @@ async function writeBootstrapVersion(venv: string): Promise<void> {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
+		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 	};
 	await writeFile(path.join(venv, BOOTSTRAP_VERSION_FILE), `${JSON.stringify(version)}\n`, "utf8");
 }
@@ -318,7 +347,15 @@ async function bootstrapVenv(venv: string): Promise<void> {
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
-	await run(uv, ["pip", "install", "--python", python, IPYKERNEL_REQUIREMENT, runtimeRequirement]);
+	await run(uv, [
+		"pip",
+		"install",
+		"--python",
+		python,
+		IPYKERNEL_REQUIREMENT,
+		runtimeRequirement,
+		...DEFAULT_RLM_EXTRA_UV_ARGS,
+	]);
 	await writeBootstrapVersion(venv);
 }
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_RLM_EXTRA_UV_ARGS } from "../kernel/bootstrap.js";
+
 export interface RlmPromptOptions {
 	cwd: string;
 	skillsDir?: string;
@@ -52,6 +54,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+			"",
+			`The kernel has these packages pre-installed: ${DEFAULT_RLM_EXTRA_UV_ARGS.join(", ")}. Import them directly; no \`pip install\` needed.`,
 		);
 	}
 


### PR DESCRIPTION
## Changes

- Add `DEFAULT_RLM_EXTRA_UV_ARGS` constant listing common Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic) installed into the kernel venv during bootstrap
- Bump `BOOTSTRAP_SCHEMA` to 3 so existing venvs are rebuilt with the new packages
- Track `extraUvArgs` in the bootstrap version file for proper cache invalidation
- Update the system prompt to inform agents that these packages are pre-installed and can be imported directly without `pip install`

### Files changed

- `packages/coding-agent/src/core/kernel/bootstrap.ts` - new constant, schema bump, version tracking, pip install call
- `packages/coding-agent/src/core/prompts/rlm.ts` - brief mention of available packages in the ipython section
- `packages/coding-agent/CHANGELOG.md` - entry under `[Unreleased]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Python kernel bootstrap to install additional third-party packages and invalidates existing venvs, which may impact bootstrap time/size and introduce dependency-related install failures.
> 
> **Overview**
> Adds a default set of common Python packages to the kernel venv bootstrap so `ipython` sessions can import them without extra installs.
> 
> Bumps the bootstrap schema and records `extraUvArgs` in `.bootstrap-version` to force venv rebuilds when the default package set changes, and updates the RLM system prompt to list the preinstalled packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7756b6f031e6c7daa4c1de02c63b0e142f062e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add default Python packages to kernel venv bootstrap and system prompt
> - Pre-installs a default set of packages (`requests`, `httpx`, `pyyaml`, `tomli`, `python-dotenv`, `pandas`, `numpy`, `scipy`, `beautifulsoup4`, `lxml`, `pydantic`) into the kernel virtualenv during bootstrap.
> - Bumps `BOOTSTRAP_SCHEMA` from 2 to 3 and adds `extraUvArgs` tracking to the version file, so environments are re-bootstrapped when the default package list changes.
> - Adds a line to the system prompt (when IPython is active) informing the model that these packages are pre-installed and importable.
> - Behavioral Change: existing kernel venvs will be re-bootstrapped on next use because the schema version and package list no longer match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7756b6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->