### PR TITLE
Revert: add default extra Python packages to kernel bootstrap and system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added default extra Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic) to the kernel venv bootstrap and system prompt.
-
-
 ## [0.0.2] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,23 +8,10 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 3;
+const BOOTSTRAP_SCHEMA = 2;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
-export const DEFAULT_RLM_EXTRA_UV_ARGS = [
-	"requests",
-	"httpx",
-	"pyyaml",
-	"tomli",
-	"python-dotenv",
-	"pandas",
-	"numpy",
-	"scipy",
-	"beautifulsoup4",
-	"lxml",
-	"pydantic",
-];
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
@@ -39,7 +26,6 @@ interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
-	extraUvArgs?: string[];
 }
 
 function errorMessage(error: unknown): string {
@@ -280,35 +266,21 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 		const raw = await readFile(path.join(venv, BOOTSTRAP_VERSION_FILE), "utf8");
 		const parsed: unknown = JSON.parse(raw);
 		if (!isRecord(parsed) || typeof parsed.schema !== "number") return null;
-		const extraUvArgs =
-			Array.isArray(parsed.extraUvArgs) &&
-			parsed.extraUvArgs.every((v: unknown): v is string => typeof v === "string")
-				? (parsed.extraUvArgs as string[])
-				: undefined;
 		return {
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
 			runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
-			extraUvArgs,
 		};
 	} catch {
 		return null;
 	}
 }
 
-function extraUvArgsMatch(a: string[] | undefined, b: string[] | undefined): boolean {
-	if (a === b) return true;
-	if (!a || !b) return false;
-	if (a.length !== b.length) return false;
-	return a.every((v, i) => v === b[i]);
-}
-
 function bootstrapVersionCurrent(version: BootstrapVersion | null): boolean {
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
-		version.runtime === RUNTIME_REQUIREMENT &&
-		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
+		version.runtime === RUNTIME_REQUIREMENT
 	);
 }
 
@@ -317,7 +289,6 @@ async function writeBootstrapVersion(venv: string): Promise<void> {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
-		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 	};
 	await writeFile(path.join(venv, BOOTSTRAP_VERSION_FILE), `${JSON.stringify(version)}\n`, "utf8");
 }
@@ -347,15 +318,7 @@ async function bootstrapVenv(venv: string): Promise<void> {
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
-	await run(uv, [
-		"pip",
-		"install",
-		"--python",
-		python,
-		IPYKERNEL_REQUIREMENT,
-		runtimeRequirement,
-		...DEFAULT_RLM_EXTRA_UV_ARGS,
-	]);
+	await run(uv, ["pip", "install", "--python", python, IPYKERNEL_REQUIREMENT, runtimeRequirement]);
 	await writeBootstrapVersion(venv);
 }
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -1,5 +1,3 @@
-import { DEFAULT_RLM_EXTRA_UV_ARGS } from "../kernel/bootstrap.js";
-
 export interface RlmPromptOptions {
 	cwd: string;
 	skillsDir?: string;
@@ -54,8 +52,6 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
-			"",
-			`The kernel has these packages pre-installed: ${DEFAULT_RLM_EXTRA_UV_ARGS.join(", ")}. Import them directly; no \`pip install\` needed.`,
 		);
 	}
 


### PR DESCRIPTION
Reverts the monolithic #56 so it can be split into two separate PRs: (1) system prompt only, (2) bootstrap deps installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk revert that only changes the kernel venv bootstrap package set and prompt text; main risk is some workflows now needing manual `pip install` for previously preinstalled libs.
> 
> **Overview**
> Reverts the previous addition of a default “extra” Python dependency set for the IPython kernel.
> 
> Kernel bootstrap no longer installs the extra packages and the `.bootstrap-version` schema/contents are rolled back accordingly, and the RLM system prompt no longer claims those packages are pre-installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767cbe28f8bb85d8364593c9aba2f6ddb5b172b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert default extra Python packages from kernel bootstrap and system prompt
> - Rolls back the addition of default extra Python packages to the kernel venv bootstrap, so newly created kernels only install `ipykernel` and the resolved runtime requirement.
> - Removes the system prompt line in [`rlm.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/57/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) that told the model certain packages were pre-installed.
> - Downgrades `BOOTSTRAP_SCHEMA` from 3 to 2 in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/57/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae); existing environments recorded with schema 3 will be considered out of date and re-bootstrapped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 767cbe2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->