### PR TITLE
feat(coding-agent): add system prompt note listing pre-installed Python packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added system prompt note listing pre-installed Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic).
+
+
 ## [0.0.2] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -52,6 +52,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+			"",
+			"The kernel has requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, and pydantic pre-installed. Import them directly; no pip install needed.",
 		);
 	}
 


### PR DESCRIPTION
## Changes

- Add a brief line to the system prompt (ipython section) listing pre-installed Python packages: requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic

No bootstrap/dependency changes in this PR. The actual package installation will follow in a separate PR.

### Files changed

- `packages/coding-agent/src/core/prompts/rlm.ts` - added package availability note
- `packages/coding-agent/CHANGELOG.md` - entry under `[Unreleased]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts prompt text and changelog; no runtime, dependency, or execution-path changes.
> 
> **Overview**
> Updates the `coding-agent` RLM system prompt shown when the `ipython` tool is active to explicitly list Python packages that are already available in the kernel (e.g., `requests`, `pandas`, `numpy`, `pydantic`) so agents avoid unnecessary installs.
> 
> Adds a matching `[Unreleased]` changelog entry documenting the new prompt guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1bf3a735224ff0fb9c295bf4b2206a5a894a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-installed Python package list to coding agent system prompt
> When `ipython` is an active tool, [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/58/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) now appends a note listing pre-installed packages (`requests`, `httpx`, `pyyaml`, `tomli`, `python-dotenv`, `pandas`, `numpy`, `scipy`, `beautifulsoup4`, `lxml`, `pydantic`) and instructs the agent to import them directly without running `pip install`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab1bf3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->