### PR TITLE
feat(coding-agent): add DEFAULT_RLM_EXTRA_UV_ARGS constant and kernel bootstrap package installation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added system prompt note listing pre-installed Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic).
+- Added `DEFAULT_RLM_EXTRA_UV_ARGS` constant and kernel bootstrap installation of those packages; updated prompt to reference the constant instead of a hardcoded list.
 
 
 ## [0.0.2] - 2026-05-20

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,10 +8,23 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 2;
+const BOOTSTRAP_SCHEMA = 3;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+export const DEFAULT_RLM_EXTRA_UV_ARGS = [
+	"requests",
+	"httpx",
+	"pyyaml",
+	"tomli",
+	"python-dotenv",
+	"pandas",
+	"numpy",
+	"scipy",
+	"beautifulsoup4",
+	"lxml",
+	"pydantic",
+];
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
@@ -26,6 +39,7 @@ interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
+	extraUvArgs?: string[];
 }
 
 function errorMessage(error: unknown): string {
@@ -266,21 +280,35 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 		const raw = await readFile(path.join(venv, BOOTSTRAP_VERSION_FILE), "utf8");
 		const parsed: unknown = JSON.parse(raw);
 		if (!isRecord(parsed) || typeof parsed.schema !== "number") return null;
+		const extraUvArgs =
+			Array.isArray(parsed.extraUvArgs) &&
+			parsed.extraUvArgs.every((v: unknown): v is string => typeof v === "string")
+				? (parsed.extraUvArgs as string[])
+				: undefined;
 		return {
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
 			runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
+			extraUvArgs,
 		};
 	} catch {
 		return null;
 	}
 }
 
+function extraUvArgsMatch(a: string[] | undefined, b: string[] | undefined): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.length !== b.length) return false;
+	return a.every((v, i) => v === b[i]);
+}
+
 function bootstrapVersionCurrent(version: BootstrapVersion | null): boolean {
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
-		version.runtime === RUNTIME_REQUIREMENT
+		version.runtime === RUNTIME_REQUIREMENT &&
+		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
 	);
 }
 
@@ -289,6 +317,7 @@ async function writeBootstrapVersion(venv: string): Promise<void> {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
+		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 	};
 	await writeFile(path.join(venv, BOOTSTRAP_VERSION_FILE), `${JSON.stringify(version)}\n`, "utf8");
 }
@@ -318,7 +347,15 @@ async function bootstrapVenv(venv: string): Promise<void> {
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
-	await run(uv, ["pip", "install", "--python", python, IPYKERNEL_REQUIREMENT, runtimeRequirement]);
+	await run(uv, [
+		"pip",
+		"install",
+		"--python",
+		python,
+		IPYKERNEL_REQUIREMENT,
+		runtimeRequirement,
+		...DEFAULT_RLM_EXTRA_UV_ARGS,
+	]);
 	await writeBootstrapVersion(venv);
 }
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_RLM_EXTRA_UV_ARGS } from "../kernel/bootstrap.js";
+
 export interface RlmPromptOptions {
 	cwd: string;
 	skillsDir?: string;
@@ -53,7 +55,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 			"",
-			"The kernel has requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, and pydantic pre-installed. Import them directly; no pip install needed.",
+			`The kernel has these packages pre-installed: ${DEFAULT_RLM_EXTRA_UV_ARGS.join(", ")}. Import them directly; no pip install needed.`,
 		);
 	}
 


### PR DESCRIPTION
## Changes

Builds on #58 (system prompt mention of pre-installed packages).

- Add `export const DEFAULT_RLM_EXTRA_UV_ARGS` listing common Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic)
- Bump `BOOTSTRAP_SCHEMA` from 2 to 3 so existing venvs are rebuilt with the new packages
- Track `extraUvArgs` in the bootstrap version file for proper cache invalidation
- Pass `...DEFAULT_RLM_EXTRA_UV_ARGS` to the `uv pip install` call in `bootstrapVenv`
- Update the system prompt to reference `DEFAULT_RLM_EXTRA_UV_ARGS` dynamically instead of a hardcoded string

### Files changed

- `packages/coding-agent/src/core/kernel/bootstrap.ts` - constant, schema bump, version tracking, pip install
- `packages/coding-agent/src/core/prompts/rlm.ts` - import constant, replace hardcoded string with dynamic reference
- `packages/coding-agent/CHANGELOG.md` - added entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Python kernel bootstrap to install additional dependencies and to invalidate/rebuild existing venvs, which could impact agent startup and reproducibility if package resolution changes.
> 
> **Overview**
> Adds a shared `DEFAULT_RLM_EXTRA_UV_ARGS` package list and uses it to **install common Python dependencies** during kernel venv bootstrap via `uv pip install`.
> 
> Bumps the bootstrap schema and records `extraUvArgs` in `.bootstrap-version` so existing kernel venvs are rebuilt when the default package set changes, and updates the RLM system prompt to render the preinstalled package list dynamically from the same constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20aec4679fe47e48c990793d19d7f2c681557c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DEFAULT_RLM_EXTRA_UV_ARGS` constant and pre-install default Python packages in kernel bootstrap
> - Adds `DEFAULT_RLM_EXTRA_UV_ARGS` in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/59/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) listing default packages (`requests`, `httpx`, `pyyaml`, `pandas`, `numpy`, `scipy`, `pydantic`, etc.) to pre-install in new kernel virtual environments.
> - Extends the bootstrap version file to persist `extraUvArgs` and updates the current-ness check to require an exact match against `DEFAULT_RLM_EXTRA_UV_ARGS`.
> - Replaces the hardcoded package list in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/59/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) with a dynamically assembled string from the constant.
> - Risk: Bumps `BOOTSTRAP_SCHEMA` from 2 to 3, so all existing environments will be considered stale and trigger a full re-bootstrap on next use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20aec46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->