### PR TITLE
fix rlm kernel package prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added system prompt note listing pre-installed Python packages (requests, httpx, pyyaml, tomli, python-dotenv, pandas, numpy, scipy, beautifulsoup4, lxml, pydantic).
 - Added `DEFAULT_RLM_EXTRA_UV_ARGS` constant and kernel bootstrap installation of those packages; updated prompt to reference the constant instead of a hardcoded list.
 
+### Fixed
+
+- Fixed the RLM kernel package prompt to show importable module names and reject `PRIME_AGENT_KERNEL_PYTHON` overrides missing default kernel packages.
 
 ## [0.0.2] - 2026-05-20
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -12,19 +12,22 @@ const BOOTSTRAP_SCHEMA = 3;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
-export const DEFAULT_RLM_EXTRA_UV_ARGS = [
-	"requests",
-	"httpx",
-	"pyyaml",
-	"tomli",
-	"python-dotenv",
-	"pandas",
-	"numpy",
-	"scipy",
-	"beautifulsoup4",
-	"lxml",
-	"pydantic",
+const DEFAULT_RLM_EXTRA_PACKAGES = [
+	{ uvArg: "requests", importName: "requests", promptLabel: "requests" },
+	{ uvArg: "httpx", importName: "httpx", promptLabel: "httpx" },
+	{ uvArg: "pyyaml", importName: "yaml", promptLabel: "yaml (PyYAML)" },
+	{ uvArg: "tomli", importName: "tomli", promptLabel: "tomli" },
+	{ uvArg: "python-dotenv", importName: "dotenv", promptLabel: "dotenv (python-dotenv)" },
+	{ uvArg: "pandas", importName: "pandas", promptLabel: "pandas" },
+	{ uvArg: "numpy", importName: "numpy", promptLabel: "numpy" },
+	{ uvArg: "scipy", importName: "scipy", promptLabel: "scipy" },
+	{ uvArg: "beautifulsoup4", importName: "bs4", promptLabel: "bs4 (Beautiful Soup)" },
+	{ uvArg: "lxml", importName: "lxml", promptLabel: "lxml" },
+	{ uvArg: "pydantic", importName: "pydantic", promptLabel: "pydantic" },
 ];
+export const DEFAULT_RLM_EXTRA_UV_ARGS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.uvArg);
+export const DEFAULT_RLM_EXTRA_IMPORT_NAMES = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.importName);
+export const DEFAULT_RLM_EXTRA_IMPORT_LABELS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.promptLabel);
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
 const RUNTIME_READY_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
@@ -160,6 +163,16 @@ async function hasPrimeAgentRuntime(python: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+async function missingRlmExtraImportLabels(python: string): Promise<string[]> {
+	const missing: string[] = [];
+	for (const pkg of DEFAULT_RLM_EXTRA_PACKAGES) {
+		if (!(await pythonImports(python, pkg.importName))) {
+			missing.push(pkg.promptLabel);
+		}
+	}
+	return missing;
 }
 
 function bootstrapLockDir(venv: string): string {
@@ -370,8 +383,8 @@ async function kernelReady(python: string, venv: string): Promise<boolean> {
 function formatBootstrapFailure(error: unknown): Error {
 	return new Error(
 		`Failed to set up the Python kernel runtime. ${errorMessage(error)}\n` +
-			"First-time setup needs internet to install uv, Python, ipykernel, and prime-agent-runtime; once set up, prime-agent runs offline. " +
-			"Set PRIME_AGENT_KERNEL_PYTHON to a Python with ipykernel and a current prime-agent-runtime installed to skip auto-bootstrap.",
+			"First-time setup needs internet to install uv, Python, ipykernel, prime-agent-runtime, and default Python packages; once set up, prime-agent runs offline. " +
+			"Set PRIME_AGENT_KERNEL_PYTHON to a Python with ipykernel, a current prime-agent-runtime, and default Python packages installed to skip auto-bootstrap.",
 	);
 }
 
@@ -382,6 +395,12 @@ async function ensureKernelPythonUncached(): Promise<string> {
 		const missing: string[] = [];
 		if (!(await hasIpykernel(python))) missing.push("ipykernel");
 		if (!(await hasPrimeAgentRuntime(python))) missing.push("a current prime-agent-runtime with callable rlm.run");
+		if (missing.length === 0) {
+			const missingExtraImports = await missingRlmExtraImportLabels(python);
+			if (missingExtraImports.length > 0) {
+				missing.push(`default Python packages (${missingExtraImports.join(", ")})`);
+			}
+		}
 		if (missing.length === 0) return python;
 		throw new Error(`PRIME_AGENT_KERNEL_PYTHON points to a Python missing ${missing.join(" and ")}: ${python}`);
 	}

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_RLM_EXTRA_UV_ARGS } from "../kernel/bootstrap.js";
+import { DEFAULT_RLM_EXTRA_IMPORT_LABELS } from "../kernel/bootstrap.js";
 
 export interface RlmPromptOptions {
 	cwd: string;
@@ -55,7 +55,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 			"",
-			`The kernel has these packages pre-installed: ${DEFAULT_RLM_EXTRA_UV_ARGS.join(", ")}. Import them directly; no pip install needed.`,
+			`The kernel has these Python imports available: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}. Import them directly; no pip install needed.`,
 		);
 	}
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -2,7 +2,12 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ensureKernelPython, getKernelVenvDir } from "../src/core/kernel/bootstrap.js";
+import {
+	DEFAULT_RLM_EXTRA_IMPORT_NAMES,
+	DEFAULT_RLM_EXTRA_UV_ARGS,
+	ensureKernelPython,
+	getKernelVenvDir,
+} from "../src/core/kernel/bootstrap.js";
 
 let tempDir = "";
 let originalEnv: NodeJS.ProcessEnv;
@@ -17,7 +22,12 @@ function writeExecutable(filePath: string, content: string): void {
 function writeBootstrapVersion(venv: string): void {
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
-		`${JSON.stringify({ schema: 2, ipykernel: "ipykernel", runtime: "prime-agent-runtime" })}\n`,
+		`${JSON.stringify({
+			schema: 3,
+			ipykernel: "ipykernel",
+			runtime: "prime-agent-runtime",
+			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+		})}\n`,
 	);
 }
 
@@ -45,6 +55,7 @@ function installFakeUv(): string {
 	const binDir = join(tempDir, "bin");
 	mkdirSync(binDir, { recursive: true });
 	const logPath = join(tempDir, "uv.log");
+	const extraImportCases = DEFAULT_RLM_EXTRA_IMPORT_NAMES.map((moduleName) => `    "import ${moduleName}") exit 0 ;;`);
 	process.env.UV_LOG = logPath;
 	process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
 	writeExecutable(
@@ -64,6 +75,7 @@ function installFakeUv(): string {
 			'if [ "$1" = "-c" ]; then',
 			'  case "$2" in',
 			'    "import ipykernel"|"import rlm") exit 0 ;;',
+			...extraImportCases,
 			`    "${RLM_RUNTIME_CHECK}") exit 0 ;;`,
 			"    *) exit 1 ;;",
 			"  esac",
@@ -109,7 +121,7 @@ describe("kernel bootstrap", () => {
 		expect(getKernelVenvDir()).toBe(venv);
 	});
 
-	it("bootstraps a missing venv with uv, ipykernel, and prime-agent-runtime", async () => {
+	it("bootstraps a missing venv with uv, ipykernel, prime-agent-runtime, and default extra packages", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
@@ -122,7 +134,16 @@ describe("kernel bootstrap", () => {
 		expect(log).toContain("pip install --python");
 		expect(log).toContain("ipykernel");
 		expect(log).toContain("prime-agent-runtime");
-		expect(readFileSync(join(venv, ".bootstrap-version"), "utf8")).toContain('"schema":2');
+		for (const uvArg of DEFAULT_RLM_EXTRA_UV_ARGS) {
+			expect(log).toContain(uvArg);
+		}
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version).toEqual({
+			schema: 3,
+			ipykernel: "ipykernel",
+			runtime: "prime-agent-runtime",
+			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+		});
 	});
 
 	it("shares concurrent bootstrap work in one process", async () => {
@@ -141,7 +162,7 @@ describe("kernel bootstrap", () => {
 		const venv = join(tempDir, "kernel-venv");
 		const python = join(venv, "bin", "python");
 		mkdirSync(join(venv, "bin"), { recursive: true });
-		writeFakePython(python, ["ipykernel", "rlm"]);
+		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		writeBootstrapVersion(venv);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
@@ -189,10 +210,22 @@ describe("kernel bootstrap", () => {
 
 	it("uses PRIME_AGENT_KERNEL_PYTHON as an override contract", async () => {
 		const overridePython = join(tempDir, "override-python");
-		writeFakePython(overridePython, ["ipykernel", "rlm"]);
+		writeFakePython(overridePython, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
 
 		await expect(ensureKernelPython()).resolves.toBe(overridePython);
+	});
+
+	it("rejects PRIME_AGENT_KERNEL_PYTHON missing default extra packages", async () => {
+		const overridePython = join(tempDir, "override-python");
+		writeFakePython(overridePython, [
+			"ipykernel",
+			"rlm",
+			...DEFAULT_RLM_EXTRA_IMPORT_NAMES.filter((name) => name !== "yaml"),
+		]);
+		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
+
+		await expect(ensureKernelPython()).rejects.toThrow(/default Python packages \(yaml \(PyYAML\)\)/);
 	});
 
 	it("rejects PRIME_AGENT_KERNEL_PYTHON with a stale rlm runtime", async () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { DEFAULT_RLM_EXTRA_IMPORT_LABELS } from "../src/core/kernel/bootstrap.js";
 import { buildRlmPrompt } from "../src/core/prompts/index.js";
 import type { Skill } from "../src/core/skills.js";
 import { buildSystemPrompt } from "../src/core/system-prompt.js";
@@ -43,6 +44,8 @@ describe("buildRlmPrompt", () => {
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
 				"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+				"",
+				`The kernel has these Python imports available: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}. Import them directly; no pip install needed.`,
 				"",
 				"Call at most one built-in tool per turn.",
 			].join("\n"),
@@ -91,6 +94,9 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");
 		expect(prompt).toContain("Use `ipython` for both Python and shell work");
+		expect(prompt).toContain("yaml (PyYAML)");
+		expect(prompt).toContain("dotenv (python-dotenv)");
+		expect(prompt).toContain("bs4 (Beautiful Soup)");
 		expect(prompt).toContain("prefer IPython shell syntax");
 		expect(prompt).toContain("Do not wrap ordinary shell commands in Python subprocesses");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");


### PR DESCRIPTION
- rlm prompts now describe importable module names for preinstalled kernel packages, including yaml, dotenv, and bs4.
- custom kernel overrides now fail fast if they do not provide the default package imports.
- bootstrap and prompt tests cover schema 3, extra package installs, and override validation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLM kernel package prompt to show importable module names instead of install args
> - Restructures the default RLM extra packages in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/60/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) from a flat string array into objects with `uvArg`, `importName`, and `promptLabel` fields, exposing derived exports for each use case.
> - Updates [`buildRlmPrompt`](https://github.com/PrimeIntellect-ai/prime-agent/pull/60/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) to use human-friendly import labels (e.g. `yaml (PyYAML)`, `bs4 (Beautiful Soup)`) instead of uv install tokens.
> - Rejects `PRIME_AGENT_KERNEL_PYTHON` overrides when any default extra package is not importable in the provided interpreter, listing the missing packages by prompt label in the error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8ca01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel bootstrap/override validation and bootstrap schema versioning; mistakes could break IPython kernel startup or reject valid user-provided interpreters.
> 
> **Overview**
> **RLM prompts now list importable module names (e.g. `yaml`, `dotenv`, `bs4`) instead of uv install args** by restructuring the default extra-package list into `{uvArg, importName, promptLabel}` metadata and updating `buildRlmPrompt`/system prompt expectations.
> 
> **Kernel bootstrap/override checks are tightened**: `PRIME_AGENT_KERNEL_PYTHON` is now rejected if any default extra package import is missing, and the bootstrap version schema is bumped to `3` with tests updated to assert extra-package installs and the new override failure case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8ca01491c3d08f4acf8f67998aae84195518d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->