### PR TITLE
prepare 0.0.5 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"workspaces": [
 				"packages/*",
 				"packages/web-ui/example",
@@ -16,7 +16,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.0.4",
+				"@earendil-works/pi-coding-agent": "^0.0.5",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -7326,10 +7326,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.0.4",
+				"@earendil-works/pi-ai": "^0.0.5",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -7356,7 +7356,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -7398,13 +7398,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.0.4",
-				"@earendil-works/pi-ai": "^0.0.4",
-				"@earendil-works/pi-tui": "^0.0.4",
+				"@earendil-works/pi-agent-core": "^0.0.5",
+				"@earendil-works/pi-ai": "^0.0.5",
+				"@earendil-works/pi-tui": "^0.0.5",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -7556,7 +7556,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
@@ -7578,11 +7578,11 @@
 		},
 		"packages/web-ui": {
 			"name": "@earendil-works/pi-web-ui",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.0.4",
-				"@earendil-works/pi-tui": "^0.0.4",
+				"@earendil-works/pi-ai": "^0.0.5",
+				"@earendil-works/pi-tui": "^0.0.5",
 				"@lmstudio/sdk": "^1.5.0",
 				"docx-preview": "^0.3.7",
 				"jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.0.4",
+		"@earendil-works/pi-coding-agent": "^0.0.5",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.0.4",
+		"@earendil-works/pi-ai": "^0.0.5",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -41,9 +41,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.0.4",
-		"@earendil-works/pi-ai": "^0.0.4",
-		"@earendil-works/pi-tui": "^0.0.4",
+		"@earendil-works/pi-agent-core": "^0.0.5",
+		"@earendil-works/pi-ai": "^0.0.5",
+		"@earendil-works/pi-tui": "^0.0.5",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-web-ui",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Reusable web UI components for AI chat interfaces powered by @earendil-works/pi-ai",
 	"type": "module",
 	"main": "dist/index.js",
@@ -18,8 +18,8 @@
 	},
 	"dependencies": {
 		"@lmstudio/sdk": "^1.5.0",
-		"@earendil-works/pi-ai": "^0.0.4",
-		"@earendil-works/pi-tui": "^0.0.4",
+		"@earendil-works/pi-ai": "^0.0.5",
+		"@earendil-works/pi-tui": "^0.0.5",
 		"typebox": "^1.1.24",
 		"docx-preview": "^0.3.7",
 		"jszip": "^3.10.1",


### PR DESCRIPTION
- bumps the root and published package versions to 0.0.5.
- syncs internal workspace dependency ranges and lockfile metadata for the release.
- leaves example and private workspace versions unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and lockfile updates with no runtime or API code changes in the diff.
> 
> **Overview**
> Prepares the **0.0.5** release by bumping the root `prime-agent` workspace and all published `@earendil-works/pi-*` packages from **0.0.4** to **0.0.5**, and updating internal `^0.0.5` dependency ranges between those packages (e.g. `pi-coding-agent` → `pi-agent-core`, `pi-ai`, `pi-tui`).
> 
> `package-lock.json` is updated so locked workspace package versions and dependency metadata match the new release. No application source or behavior changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49a8fd8e0795bea9fdd824cd11420abe0893262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all packages to version 0.0.5
> Increments the version from `0.0.4` to `0.0.5` across all packages in the monorepo, including `pi-ai`, `pi-agent`, `pi-coding-agent`, `pi-tui`, and `pi-web-ui`, and updates their cross-package dependency ranges accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f49a8fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->