### PR TITLE
polish installer startup flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -642,7 +642,7 @@ prime_agent_run_quiet_with_animation() {
 	detail="$3"
 	shift 3
 
-	prime_agent_run_quiet_with_animation_steps "$title" "$status" "$detail" "$@"
+	prime_agent_run_quiet_with_animation_command "$title" "$status" "$detail" pulse "$@"
 }
 
 prime_agent_run_quiet_with_animation_steps() {
@@ -650,6 +650,16 @@ prime_agent_run_quiet_with_animation_steps() {
 	status="$2"
 	details="$3"
 	shift 3
+
+	prime_agent_run_quiet_with_animation_command "$title" "$status" "$details" static "$@"
+}
+
+prime_agent_run_quiet_with_animation_command() {
+	title="$1"
+	status="$2"
+	details="$3"
+	status_mode="$4"
+	shift 4
 
 	if [ "$prime_agent_screen_enabled" != 1 ]; then
 		printf '%s\n' "$status" >&2
@@ -663,7 +673,11 @@ prime_agent_run_quiet_with_animation_steps() {
 	command_pid=$!
 
 	while kill -0 "$command_pid" 2>/dev/null; do
-		prime_agent_screen "$title" "$(prime_agent_static_progress_title "$status")" "$(prime_agent_animation_detail "$details")" ""
+		case "$status_mode" in
+			static) status_display=$(prime_agent_static_progress_title "$status") ;;
+			*) status_display="$status$(prime_agent_pulse)" ;;
+		esac
+		prime_agent_screen "$title" "$status_display" "$(prime_agent_animation_detail "$details")" ""
 		sleep 0.18
 	done
 

--- a/install.sh
+++ b/install.sh
@@ -629,10 +629,6 @@ prime_agent_animation_detail() {
 		*'
 '*)
 			detail_count=$(printf '%s\n' "$details" | wc -l | tr -d ' ')
-			if [ "$detail_count" -lt 1 ]; then
-				printf '%s' "$details"
-				return
-			fi
 			detail_index=$(((prime_agent_screen_frame / 12) % detail_count + 1))
 			printf '%s\n' "$details" | sed -n "${detail_index}p"
 			;;

--- a/install.sh
+++ b/install.sh
@@ -101,8 +101,6 @@ main() {
 
 	if [ "${PRIME_AGENT_NODE_INSTALLED_STANDALONE:-0}" = 1 ]; then
 		prime_agent_screen "Prime Agent installed" "" "Checking your shell PATH." ""
-		prime_agent_restore_terminal
-		printf '\n'
 		configure_standalone_node_path
 	elif command -v "$prime_agent_cmd" >/dev/null 2>&1; then
 		if [ "$prime_agent_screen_enabled" = 1 ]; then
@@ -618,10 +616,43 @@ prime_agent_pulse() {
 	esac
 }
 
+prime_agent_static_progress_title() {
+	case "$1" in
+		*...) printf '%s' "$1" ;;
+		*) printf '%s...' "$1" ;;
+	esac
+}
+
+prime_agent_animation_detail() {
+	details="$1"
+	case "$details" in
+		*'
+'*)
+			detail_count=$(printf '%s\n' "$details" | wc -l | tr -d ' ')
+			if [ "$detail_count" -lt 1 ]; then
+				printf '%s' "$details"
+				return
+			fi
+			detail_index=$(((prime_agent_screen_frame / 12) % detail_count + 1))
+			printf '%s\n' "$details" | sed -n "${detail_index}p"
+			;;
+		*) printf '%s' "$details" ;;
+	esac
+}
+
 prime_agent_run_quiet_with_animation() {
 	title="$1"
 	status="$2"
 	detail="$3"
+	shift 3
+
+	prime_agent_run_quiet_with_animation_steps "$title" "$status" "$detail" "$@"
+}
+
+prime_agent_run_quiet_with_animation_steps() {
+	title="$1"
+	status="$2"
+	details="$3"
 	shift 3
 
 	if [ "$prime_agent_screen_enabled" != 1 ]; then
@@ -636,7 +667,7 @@ prime_agent_run_quiet_with_animation() {
 	command_pid=$!
 
 	while kill -0 "$command_pid" 2>/dev/null; do
-		prime_agent_screen "$title" "$status$(prime_agent_pulse)" "$detail" ""
+		prime_agent_screen "$title" "$(prime_agent_static_progress_title "$status")" "$(prime_agent_animation_detail "$details")" ""
 		sleep 0.18
 	done
 
@@ -914,14 +945,22 @@ install_node_npm() {
 	method="$1"
 	label="$2"
 
-	if [ "$prime_agent_screen_enabled" = 1 ]; then
-		prime_agent_screen "Installing Node.js and npm" "" "Using $label." ""
-		prime_agent_restore_terminal
-		printf '\n'
-	else
+	if [ "$prime_agent_screen_enabled" != 1 ]; then
 		printf '\nInstalling Node.js and npm with %s...\n\n' "$label"
+		run_node_install_method "$method"
+	else
+		prepare_sudo_for_node_install "$method"
+		node_install_details="Using $label.
+Resolving Node.js packages.
+Downloading Node.js runtime.
+Installing npm.
+Preparing Prime Agent setup."
+		prime_agent_run_quiet_with_animation_steps \
+			"Installing Node.js and npm" \
+			"Installing Node.js and npm" \
+			"$node_install_details" \
+			run_node_install_method "$method"
 	fi
-	run_node_install_method "$method"
 
 	if [ "$method" = standalone ]; then
 		load_standalone_node
@@ -933,6 +972,38 @@ install_node_npm() {
 	else
 		printf '\nNode.js and npm are installed.\n\n'
 	fi
+}
+
+node_install_needs_sudo() {
+	if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+		return 1
+	fi
+
+	case "$1" in
+		apt|apk)
+			return 0
+			;;
+		standalone)
+			[ "$(uname -s)" = Linux ] || return 1
+			command -v xz >/dev/null 2>&1 && return 1
+			command -v apt-get >/dev/null 2>&1 || command -v apk >/dev/null 2>&1
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+prepare_sudo_for_node_install() {
+	method="$1"
+	if ! node_install_needs_sudo "$method"; then
+		return 0
+	fi
+
+	prime_agent_screen "Preparing Node.js install" "" "This may ask for your sudo password." ""
+	prime_agent_restore_terminal
+	printf '\n'
+	sudo -v
 }
 
 run_node_install_method() {
@@ -1107,24 +1178,44 @@ configure_standalone_node_path() {
 	if original_prime_agent_path=$(resolve_prime_agent_with_original_path); then
 		case "$original_prime_agent_path" in
 			"$PRIME_AGENT_STANDALONE_NODE_BIN/"*)
-				printf '\nRun it with: %s\n' "$prime_agent_cmd"
+				if [ "$prime_agent_screen_enabled" = 1 ]; then
+					prime_agent_screen "Prime Agent installed" "" "Run it with: $prime_agent_cmd" ""
+				else
+					printf '\nRun it with: %s\n' "$prime_agent_cmd"
+				fi
 				return 0
 				;;
 		esac
-		printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
-		printf 'Your shell currently resolves %s to: %s\n' "$prime_agent_cmd" "$original_prime_agent_path"
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_screen "Prime Agent installed" "" "PATH update needed for $prime_agent_cmd." ""
+		else
+			printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
+			printf 'Your shell currently resolves %s to: %s\n' "$prime_agent_cmd" "$original_prime_agent_path"
+		fi
 	else
-		printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_screen "Prime Agent installed" "" "PATH update needed for $prime_agent_cmd." ""
+		else
+			printf '%s was installed, but your shell is not using that install yet.\n' "$prime_agent_cmd"
+		fi
 	fi
 
 	profile=$(detect_shell_profile) || {
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_restore_terminal
+			printf '\n'
+		fi
 		print_standalone_path_manual_instructions
 		return 0
 	}
 
 	if shell_profile_has_standalone_node_path "$profile"; then
-		printf '%s already contains %s.\n' "$profile" "$PRIME_AGENT_STANDALONE_NODE_BIN"
-		printf 'Restart your shell or run: . %s\n' "$profile"
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_screen "Prime Agent installed" "" "Restart your shell or run: . $profile" ""
+		else
+			printf '%s already contains %s.\n' "$profile" "$PRIME_AGENT_STANDALONE_NODE_BIN"
+			printf 'Restart your shell or run: . %s\n' "$profile"
+		fi
 		return 0
 	fi
 
@@ -1186,21 +1277,25 @@ prompt_add_standalone_node_path() {
 		"Add standalone Node.js to your PATH?" \
 		"Updates $profile so future shells can run $prime_agent_cmd." \
 		"Update PATH? [Y/n]"; then
-		prime_agent_restore_terminal
-		printf '\n'
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_restore_terminal
+			printf '\n'
+		fi
 		print_standalone_path_manual_instructions
 		return 0
 	fi
 
-	prime_agent_restore_terminal
-	printf '\n'
 	mkdir -p "$(dirname "$profile")"
 	{
 		printf '\n# Prime Agent standalone Node.js\n'
 		printf '%s\n' "$path_line"
 	} >>"$profile"
-	printf 'Added %s to %s.\n' "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile"
-	printf 'Restart your shell or run: . %s\n' "$profile"
+	if [ "$prime_agent_screen_enabled" = 1 ]; then
+		prime_agent_screen "Prime Agent installed" "" "Restart your shell or run: . $profile" ""
+	else
+		printf 'Added %s to %s.\n' "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile"
+		printf 'Restart your shell or run: . %s\n' "$profile"
+	fi
 }
 
 print_standalone_path_manual_instructions() {
@@ -1315,11 +1410,16 @@ confirm_install() {
 
 install_prime_agent_package() {
 	tarball_path="$1"
-	prime_agent_run_quiet_with_animation \
+	npm_install_details="Preparing global install.
+Linking command binaries.
+Installing runtime packages.
+Preloading search tools.
+Finalizing npm install."
+	prime_agent_run_quiet_with_animation_steps \
 		"Installing Prime Agent" \
 		"Installing Prime Agent" \
-		"Running npm install -g." \
-		npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+		"$npm_install_details" \
+		env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
 }
 
 main "$@"

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -297,8 +297,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras", () => {
-		it("qwen-3-235b - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("cerebras", "qwen-3-235b-a22b-instruct-2507");
+		it("gpt-oss-120b - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("cerebras", "gpt-oss-120b");
 			const result = await testContextOverflow(model, process.env.CEREBRAS_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -149,7 +149,7 @@ describe("Token Statistics on Abort", () => {
 	});
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras Provider", () => {
-		const llm = getModel("cerebras", "qwen-3-235b-a22b-instruct-2507");
+		const llm = getModel("cerebras", "gpt-oss-120b");
 
 		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
 			await testTokensOnAbort(llm);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 - Changed the Prime Agent install script to use a bounded animated Prime Lab splash with centered progress and confirmation prompts.
 - Changed startup onboarding to guide unauthenticated users through login and model selection before the first agent turn.
+- Changed installer npm and Node.js setup progress to keep command output hidden behind the splash and rotate detail text.
 
 ### Fixed
 
 - Fixed update notifications and package docs to point at `prime-agent update` and use compact one-line alerts.
+- Fixed Prime CLI credentials from `prime login` to make Prime Inference models available on startup.
+- Fixed first-run search helper downloads to run quietly instead of printing over onboarding.
 
 ### Removed
 

--- a/packages/coding-agent/postinstall.cjs
+++ b/packages/coding-agent/postinstall.cjs
@@ -9,6 +9,6 @@ if (!existsSync(script)) {
 
 const result = spawnSync(process.execPath, [script], { stdio: "inherit" });
 if (result.error) {
-	console.error(`prime-agent: python kernel setup skipped: ${result.error.message}`);
+	console.error(`prime-agent: postinstall setup skipped: ${result.error.message}`);
 }
 process.exit(0);

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -200,6 +200,8 @@ export class AuthStorage {
 	private fallbackResolver?: (provider: string) => string | undefined;
 	private loadError: Error | null = null;
 	private errors: Error[] = [];
+	private primeCliApiKeyCache: string | undefined;
+	private primeCliApiKeyCacheLoaded = false;
 
 	private constructor(
 		private storage: AuthStorageBackend,
@@ -262,6 +264,8 @@ export class AuthStorage {
 	 * Reload credentials from storage.
 	 */
 	reload(): void {
+		this.primeCliApiKeyCache = undefined;
+		this.primeCliApiKeyCacheLoaded = false;
 		let content: string | undefined;
 		try {
 			this.storage.withLock((current) => {
@@ -547,6 +551,10 @@ export class AuthStorage {
 		if (!this.options.usePrimeCliConfig && !this.options.primeCliConfigPath) {
 			return undefined;
 		}
-		return loadPrimeCliConfig(this.options.primeCliConfigPath).apiKey;
+		if (!this.primeCliApiKeyCacheLoaded) {
+			this.primeCliApiKeyCache = loadPrimeCliConfig(this.options.primeCliConfigPath).apiKey;
+			this.primeCliApiKeyCacheLoaded = true;
+		}
+		return this.primeCliApiKeyCache;
 	}
 }

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -18,6 +18,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "f
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
+import { loadPrimeCliConfig, PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 
 export type ApiKeyCredential = {
@@ -35,8 +36,13 @@ export type AuthStorageData = Record<string, AuthCredential>;
 
 export type AuthStatus = {
 	configured: boolean;
-	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
+	source?: "stored" | "runtime" | "environment" | "prime_cli" | "fallback" | "models_json_key" | "models_json_command";
 	label?: string;
+};
+
+export type AuthStorageOptions = {
+	primeCliConfigPath?: string;
+	usePrimeCliConfig?: boolean;
 };
 
 type LockResult<T> = {
@@ -195,22 +201,26 @@ export class AuthStorage {
 	private loadError: Error | null = null;
 	private errors: Error[] = [];
 
-	private constructor(private storage: AuthStorageBackend) {
+	private constructor(
+		private storage: AuthStorageBackend,
+		private options: AuthStorageOptions = {},
+	) {
 		this.reload();
 	}
 
-	static create(authPath?: string): AuthStorage {
-		return new AuthStorage(new FileAuthStorageBackend(authPath ?? join(getAgentDir(), "auth.json")));
+	static create(authPath?: string, options?: AuthStorageOptions): AuthStorage {
+		const authOptions = options ?? { usePrimeCliConfig: authPath === undefined };
+		return new AuthStorage(new FileAuthStorageBackend(authPath ?? join(getAgentDir(), "auth.json")), authOptions);
 	}
 
-	static fromStorage(storage: AuthStorageBackend): AuthStorage {
-		return new AuthStorage(storage);
+	static fromStorage(storage: AuthStorageBackend, options?: AuthStorageOptions): AuthStorage {
+		return new AuthStorage(storage, options);
 	}
 
-	static inMemory(data: AuthStorageData = {}): AuthStorage {
+	static inMemory(data: AuthStorageData = {}, options?: AuthStorageOptions): AuthStorage {
 		const storage = new InMemoryAuthStorageBackend();
 		storage.withLock(() => ({ result: undefined, next: JSON.stringify(data, null, 2) }));
-		return AuthStorage.fromStorage(storage);
+		return AuthStorage.fromStorage(storage, options);
 	}
 
 	/**
@@ -332,6 +342,7 @@ export class AuthStorage {
 		if (this.runtimeOverrides.has(provider)) return true;
 		if (this.data[provider]) return true;
 		if (getEnvApiKey(provider)) return true;
+		if (this.getPrimeCliApiKey(provider)) return true;
 		if (this.fallbackResolver?.(provider)) return true;
 		return false;
 	}
@@ -351,6 +362,10 @@ export class AuthStorage {
 		const envKeys = findEnvKeys(provider);
 		if (envKeys?.[0]) {
 			return { configured: false, source: "environment", label: envKeys[0] };
+		}
+
+		if (this.getPrimeCliApiKey(provider)) {
+			return { configured: false, source: "prime_cli", label: "Prime CLI" };
 		}
 
 		if (this.fallbackResolver?.(provider)) {
@@ -507,6 +522,9 @@ export class AuthStorage {
 		const envKey = getEnvApiKey(providerId);
 		if (envKey) return envKey;
 
+		const primeCliKey = this.getPrimeCliApiKey(providerId);
+		if (primeCliKey) return primeCliKey;
+
 		// Fall back to custom resolver (e.g., models.json custom providers)
 		if (options?.includeFallback !== false) {
 			return this.fallbackResolver?.(providerId) ?? undefined;
@@ -520,5 +538,15 @@ export class AuthStorage {
 	 */
 	getOAuthProviders() {
 		return getOAuthProviders();
+	}
+
+	private getPrimeCliApiKey(providerId: string): string | undefined {
+		if (providerId !== PRIME_INFERENCE_PROVIDER_ID) {
+			return undefined;
+		}
+		if (!this.options.usePrimeCliConfig && !this.options.primeCliConfigPath) {
+			return undefined;
+		}
+		return loadPrimeCliConfig(this.options.primeCliConfigPath).apiKey;
 	}
 }

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -532,7 +532,7 @@ export async function findInitialModel(options: {
 	// 3. Try saved default from settings
 	if (defaultProvider && defaultModelId) {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
-		if (found) {
+		if (found && modelRegistry.hasConfiguredAuth(found)) {
 			model = found;
 			if (defaultThinkingLevel) {
 				thinkingLevel = defaultThinkingLevel;

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -169,6 +169,8 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		switch (status.source) {
 			case "environment":
 				return theme.fg("success", `env: ${status.label ?? "API key"}`);
+			case "prime_cli":
+				return theme.fg("success", status.label ?? "Prime CLI");
 			case "runtime":
 				return theme.fg("success", "runtime API key");
 			case "fallback":

--- a/packages/coding-agent/src/postinstall.ts
+++ b/packages/coding-agent/src/postinstall.ts
@@ -1,6 +1,10 @@
 import { ensureKernelPython } from "./core/kernel/bootstrap.js";
+import { ensureTool } from "./utils/tools-manager.js";
 
-if (process.env.PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL !== "1") {
+const bootstrapKernel = process.env.PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL === "1";
+const bootstrapTools = process.env.PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL === "1";
+
+if (!bootstrapKernel && !bootstrapTools) {
 	process.exit(0);
 }
 
@@ -13,7 +17,12 @@ function oneLine(message: string): string {
 }
 
 try {
-	await ensureKernelPython();
+	if (bootstrapTools) {
+		await Promise.all([ensureTool("fd", true), ensureTool("rg", true)]);
+	}
+	if (bootstrapKernel) {
+		await ensureKernelPython();
+	}
 } catch (error) {
-	console.error(`prime-agent: python kernel setup skipped: ${oneLine(errorMessage(error))}`);
+	console.error(`prime-agent: postinstall setup skipped: ${oneLine(errorMessage(error))}`);
 }

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -246,7 +246,7 @@ const TERMUX_PACKAGES: Record<string, string> = {
 
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable
-export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Promise<string | undefined> {
+export async function ensureTool(tool: "fd" | "rg", silent: boolean = true): Promise<string | undefined> {
 	const existingPath = getToolPath(tool);
 	if (existingPath) {
 		return existingPath;

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -167,6 +167,24 @@ describe("AuthStorage", () => {
 			});
 		});
 
+		test("prime cli config fallback is cached until reload", async () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "changed-prime-key" }));
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
+
+			authStorage.reload();
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("changed-prime-key");
+		});
+
 		test("apiKey command can use shell features like pipes", async () => {
 			writeAuthJson({
 				anthropic: { type: "api_key", key: "!echo 'hello world' | tr ' ' '-'" },

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -148,6 +148,25 @@ describe("AuthStorage", () => {
 			expect(apiKey).toBe("literal_api_key_value");
 		});
 
+		test("prime inference falls back to Prime CLI config when enabled", async () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
+			expect(authStorage.hasAuth("prime-inference")).toBe(true);
+			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
+				configured: false,
+				source: "prime_cli",
+				label: "Prime CLI",
+			});
+		});
+
 		test("apiKey command can use shell features like pipes", async () => {
 			writeAuthJson({
 				anthropic: { type: "api_key", key: "!echo 'hello world' | tr ' ' '-'" },

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -434,4 +434,37 @@ describe("default model selection", () => {
 		expect(result.model?.provider).toBe("vercel-ai-gateway");
 		expect(result.model?.id).toBe("anthropic/claude-opus-4-6");
 	});
+
+	test("findInitialModel skips saved defaults without configured auth", async () => {
+		const savedDefault = mockModels[0];
+		const primeModel: Model<"anthropic-messages"> = {
+			id: "openai/gpt-5.5",
+			name: "GPT 5.5 (Prime Inference)",
+			api: "anthropic-messages",
+			provider: "prime-inference",
+			baseUrl: "https://api.pinference.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		const registry = {
+			find: (provider: string, modelId: string) =>
+				[savedDefault, primeModel].find((model) => model.provider === provider && model.id === modelId),
+			hasConfiguredAuth: (model: Model<"anthropic-messages">) => model.provider === "prime-inference",
+			getAvailable: async () => [primeModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: savedDefault.provider,
+			defaultModelId: savedDefault.id,
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.provider).toBe("prime-inference");
+		expect(result.model?.id).toBe("openai/gpt-5.5");
+	});
 });


### PR DESCRIPTION
- installer progress now keeps node and npm output behind the splash while rotating detail text during long steps.
- postinstall preloads search helpers for installer installs, and runtime helper downloads stay quiet.
- prime cli credentials now make prime inference models available, and stale saved defaults are skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install-time auth resolution and default model selection at startup; installer behavior changes are UX-focused but sudo/node path flows affect many environments.
> 
> **Overview**
> Polishes **installer startup** and **first-run auth** so long steps stay on the animated splash and Prime Inference works without duplicating keys in `auth.json`.
> 
> **Installer (`install.sh`)** runs Node/npm and global `npm install` behind the splash with **rotating detail lines** (static title + stepped messages) instead of dumping terminal output; failures still surface captured logs. **Sudo** is prompted once up front when apt/apk/standalone Linux installs need it. **PATH** guidance after standalone Node install uses splash screens when screen mode is on, with fewer mid-flow terminal restores.
> 
> **Prime CLI → Prime Inference:** `AuthStorage` resolves `prime-inference` API keys from Prime CLI config (cached until `reload`), exposes `prime_cli` in auth status/UI, and **`findInitialModel`** ignores saved defaults that lack configured auth so startup can pick an authenticated model (e.g. Prime Inference after `prime login`).
> 
> **Postinstall / tools:** installer sets `PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1` so postinstall can preload **`fd`/`rg`** quietly; `ensureTool` defaults to **silent** downloads.
> 
> **Tests:** Cerebras integration tests switch model id to `gpt-oss-120b`; new auth-storage and model-resolver coverage for Prime CLI fallback and auth-gated defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d0d0b5ac4af9e774c7886e40f8030a8af9b6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish installer startup flow with animated progress and Prime CLI credential support
> - Refactors `install.sh` to show step-based animated splash screens during Node/npm install, rotating through multi-line detail strings using new `prime_agent_run_quiet_with_animation_steps` and `prime_agent_animation_detail` helpers; command output is suppressed unless errors occur.
> - Adds `node_install_needs_sudo` and `prepare_sudo_for_node_install` helpers to proactively prompt for sudo credentials before installation begins, with terminal restore only when screen mode is active.
> - Integrates Prime CLI config as an auth source in `AuthStorage`: `getApiKey`, `hasAuth`, and `getAuthStatus` for `prime-inference` now fall back to the Prime CLI config file, with reload-aware caching and a `'prime_cli'` source label in the UI.
> - Adds `PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL` flag to postinstall, enabling quiet parallel download of `fd` and `rg` search tools during npm install; `ensureTool` now defaults to silent mode.
> - Fixes `findInitialModel` to skip saved default models that lack configured auth, falling back to other available authenticated models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3d0d0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->