### PR TITLE
add prime team selection to onboarding

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Prime team selection during Prime Inference login so team inference costs use the selected Prime CLI context.
+
 ### Changed
 
 - Changed the Prime Agent install script to use a bounded animated Prime Lab splash with centered progress and confirmation prompts.
@@ -13,6 +17,7 @@
 - Fixed update notifications and package docs to point at `prime-agent update` and use compact one-line alerts.
 - Fixed Prime CLI credentials from `prime login` to make Prime Inference models available on startup.
 - Fixed first-run search helper downloads to run quietly instead of printing over onboarding.
+- Fixed stale no-model and tmux/update startup notices from appearing during successful onboarding.
 
 ### Removed
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -586,8 +586,13 @@ export class AuthStorage {
 
 		const credential = this.data[providerId];
 		if (credential?.type === "api_key") {
+			if (credential.primeTeam === null) {
+				return undefined;
+			}
 			const selectedTeamId = credential.primeTeam?.teamId;
-			return selectedTeamId ? { "X-Prime-Team-ID": selectedTeamId } : undefined;
+			if (selectedTeamId) {
+				return { "X-Prime-Team-ID": selectedTeamId };
+			}
 		}
 
 		const teamId = primeCliConfig?.teamId;

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -18,12 +18,26 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "f
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
-import { loadPrimeCliConfig, PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
+import {
+	loadPrimeCliConfig,
+	PRIME_INFERENCE_PROVIDER_ID,
+	type PrimeCliConfig,
+	type PrimeTeam,
+} from "./prime-inference-auth.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
+
+export type PrimeTeamCredential = {
+	teamId: string;
+	name: string;
+	slug?: string;
+	role?: string;
+	createdAt?: string;
+};
 
 export type ApiKeyCredential = {
 	type: "api_key";
 	key: string;
+	primeTeam?: PrimeTeamCredential | null;
 };
 
 export type OAuthCredential = {
@@ -200,8 +214,8 @@ export class AuthStorage {
 	private fallbackResolver?: (provider: string) => string | undefined;
 	private loadError: Error | null = null;
 	private errors: Error[] = [];
-	private primeCliApiKeyCache: string | undefined;
-	private primeCliApiKeyCacheLoaded = false;
+	private primeCliConfigCache: PrimeCliConfig | undefined;
+	private primeCliConfigCacheLoaded = false;
 
 	private constructor(
 		private storage: AuthStorageBackend,
@@ -264,8 +278,8 @@ export class AuthStorage {
 	 * Reload credentials from storage.
 	 */
 	reload(): void {
-		this.primeCliApiKeyCache = undefined;
-		this.primeCliApiKeyCacheLoaded = false;
+		this.primeCliConfigCache = undefined;
+		this.primeCliConfigCacheLoaded = false;
 		let content: string | undefined;
 		try {
 			this.storage.withLock((current) => {
@@ -544,17 +558,74 @@ export class AuthStorage {
 		return getOAuthProviders();
 	}
 
-	private getPrimeCliApiKey(providerId: string): string | undefined {
+	setPrimeInferenceTeamSelection(team: PrimeTeam | null): void {
+		const credential = this.data[PRIME_INFERENCE_PROVIDER_ID];
+		if (credential?.type !== "api_key") {
+			return;
+		}
+		this.set(PRIME_INFERENCE_PROVIDER_ID, {
+			...credential,
+			primeTeam: team ? this.toPrimeTeamCredential(team) : null,
+		});
+	}
+
+	getPrimeInferenceTeamSelection(): PrimeTeamCredential | null | undefined {
+		const credential = this.data[PRIME_INFERENCE_PROVIDER_ID];
+		return credential?.type === "api_key" ? credential.primeTeam : undefined;
+	}
+
+	getProviderHeaders(providerId: string): Record<string, string> | undefined {
+		if (providerId !== PRIME_INFERENCE_PROVIDER_ID) {
+			return undefined;
+		}
+
+		const primeCliConfig = this.getPrimeCliConfig(providerId);
+		if (primeCliConfig?.teamIdFromEnv) {
+			return primeCliConfig.teamId ? { "X-Prime-Team-ID": primeCliConfig.teamId } : undefined;
+		}
+
+		const credential = this.data[providerId];
+		if (credential?.type === "api_key") {
+			const selectedTeamId = credential.primeTeam?.teamId;
+			return selectedTeamId ? { "X-Prime-Team-ID": selectedTeamId } : undefined;
+		}
+
+		const teamId = primeCliConfig?.teamId;
+		return teamId ? { "X-Prime-Team-ID": teamId } : undefined;
+	}
+
+	private toPrimeTeamCredential(team: PrimeTeam): PrimeTeamCredential {
+		const credential: PrimeTeamCredential = {
+			teamId: team.teamId,
+			name: team.name,
+		};
+		if (team.slug) {
+			credential.slug = team.slug;
+		}
+		if (team.role) {
+			credential.role = team.role;
+		}
+		if (team.createdAt) {
+			credential.createdAt = team.createdAt;
+		}
+		return credential;
+	}
+
+	private getPrimeCliConfig(providerId: string): PrimeCliConfig | undefined {
 		if (providerId !== PRIME_INFERENCE_PROVIDER_ID) {
 			return undefined;
 		}
 		if (!this.options.usePrimeCliConfig && !this.options.primeCliConfigPath) {
 			return undefined;
 		}
-		if (!this.primeCliApiKeyCacheLoaded) {
-			this.primeCliApiKeyCache = loadPrimeCliConfig(this.options.primeCliConfigPath).apiKey;
-			this.primeCliApiKeyCacheLoaded = true;
+		if (!this.primeCliConfigCacheLoaded) {
+			this.primeCliConfigCache = loadPrimeCliConfig(this.options.primeCliConfigPath);
+			this.primeCliConfigCacheLoaded = true;
 		}
-		return this.primeCliApiKeyCache;
+		return this.primeCliConfigCache;
+	}
+
+	private getPrimeCliApiKey(providerId: string): string | undefined {
+		return this.getPrimeCliConfig(providerId)?.apiKey;
 	}
 }

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -687,14 +687,15 @@ export class ModelRegistry {
 					: undefined);
 
 			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
+			const authStorageHeaders = this.authStorage.getProviderHeaders(model.provider);
 			const modelHeaders = resolveHeadersOrThrow(
 				this.modelRequestHeaders.get(this.getModelRequestKey(model.provider, model.id)),
 				`model "${model.provider}/${model.id}"`,
 			);
 
 			let headers =
-				model.headers || providerHeaders || modelHeaders
-					? { ...model.headers, ...providerHeaders, ...modelHeaders }
+				model.headers || authStorageHeaders || providerHeaders || modelHeaders
+					? { ...model.headers, ...authStorageHeaders, ...providerHeaders, ...modelHeaders }
 					: undefined;
 
 			if (providerConfig?.authHeader) {

--- a/packages/coding-agent/src/core/prime-inference-auth.ts
+++ b/packages/coding-agent/src/core/prime-inference-auth.ts
@@ -27,6 +27,10 @@ export type PrimeCliConfig = {
 	frontendUrl: string;
 	inferenceUrl: string;
 	path: string;
+	teamId?: string;
+	teamName?: string;
+	teamRole?: string;
+	teamIdFromEnv: boolean;
 };
 
 export type PrimeInferenceLoginCallbacks = {
@@ -60,6 +64,14 @@ export type PrimeInferenceAccessResult =
 			message: string;
 	  };
 
+export type PrimeTeam = {
+	teamId: string;
+	name: string;
+	slug?: string;
+	role?: string;
+	createdAt?: string;
+};
+
 function defaultPrimeCliConfigPath(): string {
 	return join(homedir(), ".prime", "config.json");
 }
@@ -80,11 +92,21 @@ function stringField(data: Record<string, unknown>, key: string): string | undef
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function stringEnv(name: string): string | undefined {
+	const value = process.env[name];
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberField(data: Record<string, unknown>, key: string): number | undefined {
+	const value = data[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function loadPrimeCliConfig(configPath: string = defaultPrimeCliConfigPath()): PrimeCliConfig {
+function readPrimeCliConfigData(configPath: string): Record<string, unknown> {
 	let data: Record<string, unknown> = {};
 	if (existsSync(configPath)) {
 		try {
@@ -96,14 +118,39 @@ export function loadPrimeCliConfig(configPath: string = defaultPrimeCliConfigPat
 			data = {};
 		}
 	}
+	return data;
+}
 
-	return {
-		apiKey: stringField(data, "api_key"),
+export function loadPrimeCliConfig(configPath: string = defaultPrimeCliConfigPath()): PrimeCliConfig {
+	const data = readPrimeCliConfigData(configPath);
+	const teamIdFromEnv = stringEnv("PRIME_TEAM_ID");
+	const teamId = teamIdFromEnv ?? stringField(data, "team_id");
+
+	const config: PrimeCliConfig = {
 		baseUrl: normalizeBaseUrl(stringField(data, "base_url")),
 		frontendUrl: normalizeUrl(stringField(data, "frontend_url"), DEFAULT_PRIME_FRONTEND_URL),
 		inferenceUrl: normalizeUrl(stringField(data, "inference_url"), DEFAULT_PRIME_INFERENCE_URL),
 		path: configPath,
+		teamIdFromEnv: teamIdFromEnv !== undefined,
 	};
+	const apiKey = stringField(data, "api_key");
+	if (apiKey) {
+		config.apiKey = apiKey;
+	}
+	if (teamId) {
+		config.teamId = teamId;
+	}
+	if (!teamIdFromEnv) {
+		const teamName = stringField(data, "team_name");
+		const teamRole = stringField(data, "team_role");
+		if (teamName) {
+			config.teamName = teamName;
+		}
+		if (teamRole) {
+			config.teamRole = teamRole;
+		}
+	}
+	return config;
 }
 
 function throwIfCancelled(signal?: AbortSignal): void {
@@ -199,6 +246,94 @@ async function readJsonObject(response: Response, context: string): Promise<Reco
 		throw new Error(`${context} returned an invalid response`);
 	}
 	return parsed;
+}
+
+function parsePrimeTeam(value: unknown): PrimeTeam | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+	const teamId = stringField(value, "teamId");
+	if (!teamId) {
+		return undefined;
+	}
+
+	const team: PrimeTeam = {
+		teamId,
+		name: stringField(value, "name") ?? "Unknown",
+	};
+	const slug = stringField(value, "slug");
+	const role = stringField(value, "role");
+	const createdAt = stringField(value, "createdAt");
+	if (slug) {
+		team.slug = slug;
+	}
+	if (role) {
+		team.role = role;
+	}
+	if (createdAt) {
+		team.createdAt = createdAt;
+	}
+	return team;
+}
+
+export async function fetchPrimeTeams(
+	apiKey: string,
+	baseUrl: string,
+	options: {
+		fetchFn?: typeof fetch;
+		requestTimeoutMs?: number;
+		signal?: AbortSignal;
+	} = {},
+): Promise<PrimeTeam[]> {
+	const fetchFn = options.fetchFn ?? fetch;
+	const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+	const teams: PrimeTeam[] = [];
+	let offset = 0;
+	const limit = 100;
+
+	while (true) {
+		const url = new URL(`${normalizeBaseUrl(baseUrl)}/api/v1/user/teams`);
+		url.searchParams.set("offset", String(offset));
+		url.searchParams.set("limit", String(limit));
+		const response = await fetchWithTimeout(
+			fetchFn,
+			url,
+			{
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+				},
+			},
+			requestTimeoutMs,
+			options.signal,
+		);
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch Prime teams: ${await readResponseMessage(response)}`);
+		}
+
+		const data = await readJsonObject(response, "Prime teams");
+		const batch = data.data;
+		if (!Array.isArray(batch)) {
+			throw new Error("Prime teams response missing team data");
+		}
+
+		for (const item of batch) {
+			const team = parsePrimeTeam(item);
+			if (team) {
+				teams.push(team);
+			}
+		}
+
+		const totalCount = numberField(data, "total_count") ?? teams.length;
+		if (batch.length === 0 || teams.length >= totalCount) {
+			break;
+		}
+		offset += limit;
+	}
+
+	return teams;
 }
 
 function createPrimeChallengeKeypair(): { privateKey: string; publicKey: string } {

--- a/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
@@ -1,0 +1,155 @@
+import { Container, type Focusable, fuzzyFilter, getKeybindings, Spacer, TruncatedText } from "@earendil-works/pi-tui";
+import type { PrimeTeam } from "../../../core/prime-inference-auth.js";
+import { theme } from "../theme/theme.js";
+import { MenuList, MenuPanel, MenuRow, MenuSearchInput } from "./menu-panel.js";
+
+type PrimeTeamOption = {
+	type: "personal" | "team";
+	team: PrimeTeam | null;
+};
+
+export class PrimeTeamSelectorComponent extends Container implements Focusable {
+	private readonly searchInput: MenuSearchInput;
+	private readonly listContainer: Container;
+	private readonly allOptions: PrimeTeamOption[];
+	private filteredOptions: PrimeTeamOption[];
+	private selectedIndex = 0;
+	private _focused = false;
+
+	constructor(
+		teams: PrimeTeam[],
+		private readonly currentTeamId: string | undefined,
+		private readonly onSelect: (team: PrimeTeam | null) => void,
+		private readonly onCancel: () => void,
+	) {
+		super();
+
+		this.allOptions = [{ type: "personal", team: null }, ...teams.map((team) => ({ type: "team" as const, team }))];
+		this.filteredOptions = this.allOptions;
+
+		const panel = new MenuPanel({
+			title: "Prime Team",
+			subtitle: "Choose which account pays for Prime Inference usage.",
+		});
+		this.addChild(panel);
+
+		this.searchInput = new MenuSearchInput("Search teams");
+		this.searchInput.onSubmit = () => {
+			const selected = this.filteredOptions[this.selectedIndex];
+			if (selected) {
+				this.onSelect(selected.team);
+			}
+		};
+		panel.addChild(this.searchInput);
+		panel.addChild(new Spacer(1));
+
+		this.listContainer = new MenuList();
+		panel.addChild(this.listContainer);
+		this.filterOptions("");
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.searchInput.focused = value;
+	}
+
+	private filterOptions(query: string): void {
+		this.filteredOptions = query
+			? fuzzyFilter(this.allOptions, query, (option) => this.getSearchText(option))
+			: this.allOptions;
+		this.selectedIndex = Math.max(0, Math.min(this.selectedIndex, Math.max(0, this.filteredOptions.length - 1)));
+		this.updateList();
+	}
+
+	private getSearchText(option: PrimeTeamOption): string {
+		if (option.type === "personal") {
+			return "personal account";
+		}
+		const team = option.team;
+		return team ? `${team.name} ${team.slug ?? ""} ${team.role ?? ""} ${team.teamId}` : "";
+	}
+
+	private updateList(): void {
+		this.listContainer.clear();
+
+		const maxVisible = 8;
+		const startIndex = Math.max(
+			0,
+			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredOptions.length - maxVisible),
+		);
+		const endIndex = Math.min(startIndex + maxVisible, this.filteredOptions.length);
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const option = this.filteredOptions[i];
+			if (!option) {
+				continue;
+			}
+			this.listContainer.addChild(
+				new MenuRow({
+					primary: this.getPrimary(option),
+					secondary: this.getSecondary(option),
+					meta: this.getMeta(option),
+					selected: i === this.selectedIndex,
+				}),
+			);
+		}
+
+		if (startIndex > 0 || endIndex < this.filteredOptions.length) {
+			this.listContainer.addChild(
+				new TruncatedText(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredOptions.length})`), 1, 0),
+			);
+		}
+
+		if (this.filteredOptions.length === 0) {
+			this.listContainer.addChild(new TruncatedText(theme.fg("muted", "No matching teams"), 1, 0));
+		}
+	}
+
+	private getPrimary(option: PrimeTeamOption): string {
+		return option.team?.name ?? "Personal";
+	}
+
+	private getSecondary(option: PrimeTeamOption): string {
+		if (!option.team) {
+			return "personal account";
+		}
+		const role = option.team.role?.toLowerCase() ?? "member";
+		return option.team.slug ? `slug: ${option.team.slug}, role: ${role}` : `role: ${role}`;
+	}
+
+	private getMeta(option: PrimeTeamOption): string {
+		const isCurrent = option.team ? option.team.teamId === this.currentTeamId : this.currentTeamId === undefined;
+		return isCurrent ? theme.fg("success", "current") : "";
+	}
+
+	handleInput(keyData: string): void {
+		const kb = getKeybindings();
+		if (kb.matches(keyData, "tui.select.up")) {
+			if (this.filteredOptions.length === 0) {
+				return;
+			}
+			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			this.updateList();
+		} else if (kb.matches(keyData, "tui.select.down")) {
+			if (this.filteredOptions.length === 0) {
+				return;
+			}
+			this.selectedIndex = Math.min(this.filteredOptions.length - 1, this.selectedIndex + 1);
+			this.updateList();
+		} else if (kb.matches(keyData, "tui.select.confirm")) {
+			const selected = this.filteredOptions[this.selectedIndex];
+			if (selected) {
+				this.onSelect(selected.team);
+			}
+		} else if (kb.matches(keyData, "tui.select.cancel")) {
+			this.onCancel();
+		} else {
+			this.searchInput.handleInput(keyData);
+			this.filterOptions(this.searchInput.getValue());
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5427,7 +5427,8 @@ export class InteractiveMode {
 			}
 
 			const storedTeam = this.session.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
-			const selectedTeam = await this.showPrimeTeamSelector(teams, storedTeam?.teamId ?? config.teamId);
+			const currentTeamId = storedTeam === null ? undefined : (storedTeam?.teamId ?? config.teamId);
+			const selectedTeam = await this.showPrimeTeamSelector(teams, currentTeamId);
 			if (selectedTeam !== undefined) {
 				this.session.modelRegistry.authStorage.setPrimeInferenceTeamSelection(selectedTeam);
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -190,17 +190,8 @@ class ExpandableText extends Text implements Expandable {
 	}
 }
 
-function formatSplashCwd(cwd: string): string {
+export function formatSplashCwd(cwd: string): string {
 	const normalized = cwd.replace(/\\/g, "/");
-	const worktreeMarker = "/.worktrees/";
-	const worktreeIndex = normalized.indexOf(worktreeMarker);
-	if (worktreeIndex >= 0) {
-		const repoRoot = normalized.slice(0, worktreeIndex);
-		const rest = normalized.slice(worktreeIndex + worktreeMarker.length);
-		const repoName = path.basename(repoRoot);
-		return `${repoName}/${rest}`;
-	}
-
 	const home = os.homedir().replace(/\\/g, "/");
 	if (home && normalized === home) {
 		return "~";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -315,6 +315,8 @@ type AuthenticationResult =
 
 type ModelSelectionResult = { status: "selected" } | { status: "cancelled" } | { status: "action"; actionId: string };
 
+type ModelFallbackWarningAction = "show" | "suppress" | "wait";
+
 const MODEL_SELECTOR_ACTIONS: readonly ModelSelectorAction[] = [
 	{ id: "add_provider", label: "Add provider...", description: "subscription or API key" },
 ];
@@ -919,23 +921,29 @@ export class InteractiveMode {
 			}
 			deferredStartupNotificationsShown = true;
 
-			newVersionPromise.then((newVersion) => {
-				if (newVersion) {
-					this.showNewVersionNotification(newVersion);
-				}
-			});
+			void newVersionPromise
+				.then((newVersion) => {
+					if (newVersion) {
+						this.showNewVersionNotification(newVersion);
+					}
+				})
+				.catch(() => {});
 
-			packageUpdatesPromise.then((updates) => {
-				if (updates.length > 0) {
-					this.showPackageUpdateNotification(updates);
-				}
-			});
+			void packageUpdatesPromise
+				.then((updates) => {
+					if (updates.length > 0) {
+						this.showPackageUpdateNotification(updates);
+					}
+				})
+				.catch(() => {});
 
-			tmuxKeyboardWarningPromise.then((warning) => {
-				if (warning) {
-					this.showWarning(warning);
-				}
-			});
+			void tmuxKeyboardWarningPromise
+				.then((warning) => {
+					if (warning) {
+						this.showWarning(warning);
+					}
+				})
+				.catch(() => {});
 		};
 
 		let modelFallbackWarningShown = false;
@@ -943,11 +951,14 @@ export class InteractiveMode {
 			if (modelFallbackWarningShown) {
 				return;
 			}
-			if (!this.shouldShowModelFallbackWarning(modelFallbackMessage, needsOnboarding)) {
+			const action = this.getModelFallbackWarningAction(modelFallbackMessage, needsOnboarding);
+			if (action === "wait") {
 				return;
 			}
 			modelFallbackWarningShown = true;
-			this.showWarning(modelFallbackMessage);
+			if (action === "show" && modelFallbackMessage) {
+				this.showWarning(modelFallbackMessage);
+			}
 		};
 
 		if (!needsOnboarding) {
@@ -986,21 +997,24 @@ export class InteractiveMode {
 		}
 	}
 
-	private shouldShowModelFallbackWarning(
+	private getModelFallbackWarningAction(
 		modelFallbackMessage: string | undefined,
 		startupNeededOnboarding: boolean,
-	): modelFallbackMessage is string {
+	): ModelFallbackWarningAction {
 		if (!modelFallbackMessage) {
-			return false;
+			return "suppress";
 		}
 		if (
 			startupNeededOnboarding &&
 			modelFallbackMessage === formatNoModelsAvailableMessage() &&
 			!this.shouldRunOnboarding()
 		) {
-			return false;
+			return "suppress";
 		}
-		return true;
+		if (startupNeededOnboarding && modelFallbackMessage === formatNoModelsAvailableMessage()) {
+			return "wait";
+		}
+		return "show";
 	}
 
 	private shouldRunOnboarding(): boolean {
@@ -5408,18 +5422,44 @@ export class InteractiveMode {
 		});
 	}
 
-	private async selectPrimeInferenceTeam(apiKey: string, dialog: LoginDialogComponent): Promise<string | undefined> {
-		const config = loadPrimeCliConfig();
+	private getPrimeInferenceDefaultTeamStatus(): string {
+		const storedTeam = this.session.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
+		if (storedTeam) {
+			return `Using team "${storedTeam.name}".`;
+		}
+		if (storedTeam === null) {
+			return "Using personal account.";
+		}
+		let config: ReturnType<typeof loadPrimeCliConfig>;
+		try {
+			config = loadPrimeCliConfig();
+		} catch {
+			return "Using personal account.";
+		}
 		if (config.teamIdFromEnv) {
-			this.session.modelRegistry.authStorage.reload();
 			return "Using team from PRIME_TEAM_ID.";
 		}
+		if (config.teamName) {
+			return `Using team "${config.teamName}".`;
+		}
+		if (config.teamId) {
+			return "Using Prime CLI team.";
+		}
+		return "Using personal account.";
+	}
 
+	private async selectPrimeInferenceTeam(apiKey: string, dialog: LoginDialogComponent): Promise<string | undefined> {
 		try {
+			const config = loadPrimeCliConfig();
+			if (config.teamIdFromEnv) {
+				this.session.modelRegistry.authStorage.reload();
+				return "Using team from PRIME_TEAM_ID.";
+			}
+
 			dialog.showProgress("Loading Prime teams...");
 			const teams = await fetchPrimeTeams(apiKey, config.baseUrl, { signal: dialog.signal });
 			if (dialog.signal.aborted) {
-				return undefined;
+				return this.getPrimeInferenceDefaultTeamStatus();
 			}
 			if (teams.length === 0) {
 				this.session.modelRegistry.authStorage.setPrimeInferenceTeamSelection(null);
@@ -5436,13 +5476,10 @@ export class InteractiveMode {
 				? `Using team "${selectedTeam.name}".`
 				: selectedTeam === null
 					? "Using personal account."
-					: undefined;
+					: this.getPrimeInferenceDefaultTeamStatus();
 		} catch {
-			if (dialog.signal.aborted) {
-				return undefined;
-			}
 			this.session.modelRegistry.authStorage.reload();
-			return undefined;
+			return this.getPrimeInferenceDefaultTeamStatus();
 		}
 	}
 
@@ -5481,20 +5518,14 @@ export class InteractiveMode {
 			}
 
 			const previousPrimeCredential = this.session.modelRegistry.authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
+			const previousPrimeTeam =
+				previousPrimeCredential?.type === "api_key" ? previousPrimeCredential.primeTeam : undefined;
 			this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
 				type: "api_key",
 				key: result.apiKey,
+				...(previousPrimeTeam !== undefined ? { primeTeam: previousPrimeTeam } : {}),
 			});
 			const teamStatus = await this.selectPrimeInferenceTeam(result.apiKey, dialog);
-			if (dialog.signal.aborted) {
-				if (previousPrimeCredential) {
-					this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, previousPrimeCredential);
-				} else {
-					this.session.modelRegistry.authStorage.remove(PRIME_INFERENCE_PROVIDER_ID);
-				}
-				closeDialog();
-				return { status: "cancelled" };
-			}
 
 			closeDialog();
 			return await this.completeProviderAuthentication(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5480,11 +5480,21 @@ export class InteractiveMode {
 				return { status: "cancelled" };
 			}
 
+			const previousPrimeCredential = this.session.modelRegistry.authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
 			this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
 				type: "api_key",
 				key: result.apiKey,
 			});
 			const teamStatus = await this.selectPrimeInferenceTeam(result.apiKey, dialog);
+			if (dialog.signal.aborted) {
+				if (previousPrimeCredential) {
+					this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, previousPrimeCredential);
+				} else {
+					this.session.modelRegistry.authStorage.remove(PRIME_INFERENCE_PROVIDER_ID);
+				}
+				closeDialog();
+				return { status: "cancelled" };
+			}
 
 			closeDialog();
 			return await this.completeProviderAuthentication(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -64,6 +64,7 @@ import {
 	type RlmChildAgentSnapshot,
 } from "../../core/agent-session.js";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.js";
+import { formatNoModelsAvailableMessage } from "../../core/auth-guidance.js";
 import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
@@ -81,9 +82,12 @@ import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
 import {
+	fetchPrimeTeams,
+	loadPrimeCliConfig,
 	loginPrimeInference,
 	PRIME_INFERENCE_PROVIDER_ID,
 	PRIME_INFERENCE_PROVIDER_NAME,
+	type PrimeTeam,
 } from "../../core/prime-inference-auth.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-names.js";
 import type { ResourceDiagnostic } from "../../core/resource-loader.js";
@@ -135,6 +139,7 @@ import {
 	OAuthSelectorComponent,
 } from "./components/oauth-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
+import { PrimeTeamSelectorComponent } from "./components/prime-team-selector.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
@@ -871,26 +876,9 @@ export class InteractiveMode {
 	async run(): Promise<void> {
 		await this.init();
 
-		// Start version check asynchronously
-		checkForNewPiVersion(this.version).then((newVersion) => {
-			if (newVersion) {
-				this.showNewVersionNotification(newVersion);
-			}
-		});
-
-		// Start package update check asynchronously
-		this.checkForPackageUpdates().then((updates) => {
-			if (updates.length > 0) {
-				this.showPackageUpdateNotification(updates);
-			}
-		});
-
-		// Check tmux keyboard setup asynchronously
-		this.checkTmuxKeyboardSetup().then((warning) => {
-			if (warning) {
-				this.showWarning(warning);
-			}
-		});
+		const newVersionPromise = checkForNewPiVersion(this.version);
+		const packageUpdatesPromise = this.checkForPackageUpdates();
+		const tmuxKeyboardWarningPromise = this.checkTmuxKeyboardSetup();
 
 		// Show startup warnings
 		const { migratedProviders, modelFallbackMessage, initialMessage, initialImages, initialMessages } = this.options;
@@ -933,9 +921,38 @@ export class InteractiveMode {
 		};
 
 		const needsOnboarding = this.shouldRunOnboarding();
+		let deferredStartupNotificationsShown = false;
+		const showDeferredStartupNotifications = () => {
+			if (deferredStartupNotificationsShown || this.shouldRunOnboarding()) {
+				return;
+			}
+			deferredStartupNotificationsShown = true;
+
+			newVersionPromise.then((newVersion) => {
+				if (newVersion) {
+					this.showNewVersionNotification(newVersion);
+				}
+			});
+
+			packageUpdatesPromise.then((updates) => {
+				if (updates.length > 0) {
+					this.showPackageUpdateNotification(updates);
+				}
+			});
+
+			tmuxKeyboardWarningPromise.then((warning) => {
+				if (warning) {
+					this.showWarning(warning);
+				}
+			});
+		};
+
 		let modelFallbackWarningShown = false;
 		const showModelFallbackWarning = () => {
-			if (!modelFallbackMessage || modelFallbackWarningShown) {
+			if (modelFallbackWarningShown) {
+				return;
+			}
+			if (!this.shouldShowModelFallbackWarning(modelFallbackMessage, needsOnboarding)) {
 				return;
 			}
 			modelFallbackWarningShown = true;
@@ -952,6 +969,7 @@ export class InteractiveMode {
 		}
 
 		if (promptReady) {
+			showDeferredStartupNotifications();
 			showModelFallbackWarning();
 			void this.maybeWarnAboutAnthropicSubscriptionAuth();
 			await sendInitialPrompts();
@@ -965,6 +983,7 @@ export class InteractiveMode {
 				this.showStatus("Complete onboarding to send the restored prompt.");
 				continue;
 			}
+			showDeferredStartupNotifications();
 			showModelFallbackWarning();
 			await sendInitialPrompts();
 			try {
@@ -974,6 +993,23 @@ export class InteractiveMode {
 				this.showError(errorMessage);
 			}
 		}
+	}
+
+	private shouldShowModelFallbackWarning(
+		modelFallbackMessage: string | undefined,
+		startupNeededOnboarding: boolean,
+	): modelFallbackMessage is string {
+		if (!modelFallbackMessage) {
+			return false;
+		}
+		if (
+			startupNeededOnboarding &&
+			modelFallbackMessage === formatNoModelsAvailableMessage() &&
+			!this.shouldRunOnboarding()
+		) {
+			return false;
+		}
+		return true;
 	}
 
 	private shouldRunOnboarding(): boolean {
@@ -5273,6 +5309,7 @@ export class InteractiveMode {
 		providerId: string,
 		providerName: string,
 		authType: "oauth" | "api_key",
+		statusSuffix?: string,
 	): Promise<AuthenticationResult> {
 		this.session.modelRegistry.refresh();
 
@@ -5280,7 +5317,9 @@ export class InteractiveMode {
 		await this.updateAvailableProviderCount();
 		this.footer.invalidate();
 		this.updateEditorBorderColor();
-		this.showStatus(`${actionLabel}. Credentials saved to ${getAuthPath()}`);
+		this.showStatus(
+			`${actionLabel}. Credentials saved to ${getAuthPath()}${statusSuffix ? `. ${statusSuffix}` : ""}`,
+		);
 		void this.maybeWarnAboutAnthropicSubscriptionAuth();
 		return {
 			status: "success",
@@ -5352,6 +5391,69 @@ export class InteractiveMode {
 		}
 	}
 
+	private showPrimeTeamSelector(
+		teams: PrimeTeam[],
+		currentTeamId: string | undefined,
+	): Promise<PrimeTeam | null | undefined> {
+		return new Promise((resolve) => {
+			let handle: OverlayHandle | undefined;
+			const close = () => {
+				handle?.hide();
+				this.ui.requestRender();
+			};
+			const selector = new PrimeTeamSelectorComponent(
+				teams,
+				currentTeamId,
+				(team) => {
+					close();
+					resolve(team);
+				},
+				() => {
+					close();
+					resolve(undefined);
+				},
+			);
+			handle = this.showFullPaneOverlay(selector, 78);
+		});
+	}
+
+	private async selectPrimeInferenceTeam(apiKey: string, dialog: LoginDialogComponent): Promise<string | undefined> {
+		const config = loadPrimeCliConfig();
+		if (config.teamIdFromEnv) {
+			this.session.modelRegistry.authStorage.reload();
+			return "Using team from PRIME_TEAM_ID.";
+		}
+
+		try {
+			dialog.showProgress("Loading Prime teams...");
+			const teams = await fetchPrimeTeams(apiKey, config.baseUrl, { signal: dialog.signal });
+			if (dialog.signal.aborted) {
+				return undefined;
+			}
+			if (teams.length === 0) {
+				this.session.modelRegistry.authStorage.setPrimeInferenceTeamSelection(null);
+				return "Using personal account.";
+			}
+
+			const storedTeam = this.session.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
+			const selectedTeam = await this.showPrimeTeamSelector(teams, storedTeam?.teamId ?? config.teamId);
+			if (selectedTeam !== undefined) {
+				this.session.modelRegistry.authStorage.setPrimeInferenceTeamSelection(selectedTeam);
+			}
+			return selectedTeam
+				? `Using team "${selectedTeam.name}".`
+				: selectedTeam === null
+					? "Using personal account."
+					: undefined;
+		} catch {
+			if (dialog.signal.aborted) {
+				return undefined;
+			}
+			this.session.modelRegistry.authStorage.reload();
+			return undefined;
+		}
+	}
+
 	private async showPrimeInferenceLoginDialog(): Promise<AuthenticationResult> {
 		const dialog = new LoginDialogComponent(
 			this.ui,
@@ -5390,12 +5492,14 @@ export class InteractiveMode {
 				type: "api_key",
 				key: result.apiKey,
 			});
+			const teamStatus = await this.selectPrimeInferenceTeam(result.apiKey, dialog);
 
 			closeDialog();
 			return await this.completeProviderAuthentication(
 				PRIME_INFERENCE_PROVIDER_ID,
 				PRIME_INFERENCE_PROVIDER_NAME,
 				"api_key",
+				teamStatus,
 			);
 		} catch (error: unknown) {
 			closeDialog();

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -229,6 +229,24 @@ describe("AuthStorage", () => {
 			expect(authStorage.getProviderHeaders("prime-inference")).toBeUndefined();
 		});
 
+		test("prime inference missing Agent team selection falls back to Prime CLI team", () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "cli-team" }));
+			writeAuthJson({
+				"prime-inference": {
+					type: "api_key",
+					key: "agent-key",
+				},
+			});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			expect(authStorage.getProviderHeaders("prime-inference")).toEqual({ "X-Prime-Team-ID": "cli-team" });
+		});
+
 		test("prime inference provider headers fall back to Prime CLI team until reload", () => {
 			const primeConfigPath = join(tempDir, "prime-config.json");
 			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "team-1" }));

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -185,6 +185,68 @@ describe("AuthStorage", () => {
 			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("changed-prime-key");
 		});
 
+		test("prime inference provider headers include selected Prime Agent team", () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "cli-team" }));
+			writeAuthJson({
+				"prime-inference": {
+					type: "api_key",
+					key: "agent-key",
+					primeTeam: { teamId: "team-1", name: "Research", slug: "research", role: "admin" },
+				},
+			});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			expect(authStorage.getProviderHeaders("prime-inference")).toEqual({ "X-Prime-Team-ID": "team-1" });
+			expect(authStorage.getPrimeInferenceTeamSelection()).toEqual({
+				teamId: "team-1",
+				name: "Research",
+				slug: "research",
+				role: "admin",
+			});
+		});
+
+		test("prime inference personal selection suppresses Prime CLI team fallback for stored Agent key", () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "cli-team" }));
+			writeAuthJson({
+				"prime-inference": {
+					type: "api_key",
+					key: "agent-key",
+					primeTeam: null,
+				},
+			});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			expect(authStorage.getProviderHeaders("prime-inference")).toBeUndefined();
+		});
+
+		test("prime inference provider headers fall back to Prime CLI team until reload", () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "team-1" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			expect(authStorage.getProviderHeaders("prime-inference")).toEqual({ "X-Prime-Team-ID": "team-1" });
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key", team_id: "team-2" }));
+			expect(authStorage.getProviderHeaders("prime-inference")).toEqual({ "X-Prime-Team-ID": "team-1" });
+
+			authStorage.reload();
+			expect(authStorage.getProviderHeaders("prime-inference")).toEqual({ "X-Prime-Team-ID": "team-2" });
+		});
+
 		test("apiKey command can use shell features like pipes", async () => {
 			writeAuthJson({
 				anthropic: { type: "api_key", key: "!echo 'hello world' | tr ' ' '-'" },

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -132,37 +132,49 @@ describe("InteractiveMode.showStatus", () => {
 describe("InteractiveMode startup onboarding warnings", () => {
 	type StartupWarningHarness = {
 		shouldRunOnboarding(): boolean;
-		shouldShowModelFallbackWarning(
+		getModelFallbackWarningAction(
 			modelFallbackMessage: string | undefined,
 			startupNeededOnboarding: boolean,
-		): modelFallbackMessage is string;
+		): "show" | "suppress" | "wait";
 	};
 
-	const shouldShowModelFallbackWarning = (InteractiveMode.prototype as unknown as StartupWarningHarness)
-		.shouldShowModelFallbackWarning;
+	const getModelFallbackWarningAction = (InteractiveMode.prototype as unknown as StartupWarningHarness)
+		.getModelFallbackWarningAction;
 
 	test("suppresses the stale no-model warning after onboarding selects a model", () => {
 		const fakeThis: StartupWarningHarness = {
 			shouldRunOnboarding: vi.fn(() => false),
-			shouldShowModelFallbackWarning,
+			getModelFallbackWarningAction,
 		};
 
-		expect(shouldShowModelFallbackWarning.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe(false);
+		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe("suppress");
+		expect(fakeThis.shouldRunOnboarding).toHaveBeenCalledTimes(1);
+	});
+
+	test("waits to suppress the stale no-model warning while onboarding is still needed", () => {
+		const fakeThis: StartupWarningHarness = {
+			shouldRunOnboarding: vi.fn(() => true),
+			getModelFallbackWarningAction,
+		};
+
+		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe("wait");
+		expect(fakeThis.shouldRunOnboarding).toHaveBeenCalledTimes(1);
 	});
 
 	test("keeps real model restore fallback warnings after onboarding", () => {
 		const fakeThis: StartupWarningHarness = {
 			shouldRunOnboarding: vi.fn(() => false),
-			shouldShowModelFallbackWarning,
+			getModelFallbackWarningAction,
 		};
 
 		expect(
-			shouldShowModelFallbackWarning.call(
+			getModelFallbackWarningAction.call(
 				fakeThis,
 				"Could not restore model anthropic/claude-old. Using prime-inference/openai/gpt-5.5.",
 				true,
 			),
-		).toBe(true);
+		).toBe("show");
+		expect(fakeThis.shouldRunOnboarding).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -7,6 +7,7 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
+import { formatNoModelsAvailableMessage } from "../src/core/auth-guidance.js";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.js";
 import { emptyGoalState, type GoalState } from "../src/core/goals.js";
 import type { SourceInfo } from "../src/core/source-info.js";
@@ -125,6 +126,43 @@ describe("InteractiveMode.showStatus", () => {
 		// adds spacer + text
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});
+
+describe("InteractiveMode startup onboarding warnings", () => {
+	type StartupWarningHarness = {
+		shouldRunOnboarding(): boolean;
+		shouldShowModelFallbackWarning(
+			modelFallbackMessage: string | undefined,
+			startupNeededOnboarding: boolean,
+		): modelFallbackMessage is string;
+	};
+
+	const shouldShowModelFallbackWarning = (InteractiveMode.prototype as unknown as StartupWarningHarness)
+		.shouldShowModelFallbackWarning;
+
+	test("suppresses the stale no-model warning after onboarding selects a model", () => {
+		const fakeThis: StartupWarningHarness = {
+			shouldRunOnboarding: vi.fn(() => false),
+			shouldShowModelFallbackWarning,
+		};
+
+		expect(shouldShowModelFallbackWarning.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe(false);
+	});
+
+	test("keeps real model restore fallback warnings after onboarding", () => {
+		const fakeThis: StartupWarningHarness = {
+			shouldRunOnboarding: vi.fn(() => false),
+			shouldShowModelFallbackWarning,
+		};
+
+		expect(
+			shouldShowModelFallbackWarning.call(
+				fakeThis,
+				"Could not restore model anthropic/claude-old. Using prime-inference/openai/gpt-5.5.",
+				true,
+			),
+		).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -11,7 +11,7 @@ import { formatNoModelsAvailableMessage } from "../src/core/auth-guidance.js";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.js";
 import { emptyGoalState, type GoalState } from "../src/core/goals.js";
 import type { SourceInfo } from "../src/core/source-info.js";
-import { InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
+import { formatSplashCwd, InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 function renderLastLine(container: Container, width = 120): string {
@@ -163,6 +163,19 @@ describe("InteractiveMode startup onboarding warnings", () => {
 				true,
 			),
 		).toBe(true);
+	});
+});
+
+describe("InteractiveMode splash cwd display", () => {
+	test("formats home-relative cwd paths", () => {
+		expect(formatSplashCwd(homedir())).toBe("~");
+		expect(formatSplashCwd(path.join(homedir(), "pi", "prime-agent"))).toBe("~/pi/prime-agent");
+	});
+
+	test("keeps worktree paths as cwd paths instead of repo branch labels", () => {
+		expect(formatSplashCwd(path.join(homedir(), "pi", "prime-agent", ".worktrees", "improve-onboarding"))).toBe(
+			"~/pi/prime-agent/.worktrees/improve-onboarding",
+		);
 	});
 });
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -157,6 +157,27 @@ describe("ModelRegistry", () => {
 			}
 		});
 
+		test("prime inference requests include selected Prime Agent team header", async () => {
+			const primeAuthStorage = AuthStorage.inMemory({
+				"prime-inference": {
+					type: "api_key",
+					key: "agent-key",
+					primeTeam: { teamId: "team-1", name: "Research" },
+				},
+			});
+			const registry = ModelRegistry.create(primeAuthStorage, modelsJsonPath);
+			const model = getModelsForProvider(registry, "prime-inference")[0];
+			expect(model).toBeDefined();
+
+			const auth = await registry.getApiKeyAndHeaders(model!);
+
+			expect(auth).toEqual({
+				ok: true,
+				apiKey: "agent-key",
+				headers: { "X-Prime-Team-ID": "team-1" },
+			});
+		});
+
 		test("baseUrl-only override does not affect other providers", () => {
 			writeRawModelsJson({
 				anthropic: overrideConfig("https://my-proxy.example.com/v1"),

--- a/packages/coding-agent/test/prime-inference-auth.test.ts
+++ b/packages/coding-agent/test/prime-inference-auth.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	checkPrimeInferenceAccess,
+	fetchPrimeTeams,
 	loadPrimeCliConfig,
 	loginPrimeInference,
 } from "../src/core/prime-inference-auth.js";
@@ -92,7 +93,84 @@ describe("Prime Inference auth", () => {
 			frontendUrl: "https://prime-app.example",
 			inferenceUrl: "https://api.pinference.ai/api/v1",
 			path: configPath,
+			teamIdFromEnv: false,
 		});
+	});
+
+	it("loads Prime CLI team selection", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				api_key: "prime-key",
+				team_id: "team-1",
+				team_name: "Research",
+				team_role: "admin",
+			}),
+		);
+
+		expect(loadPrimeCliConfig(configPath)).toMatchObject({
+			apiKey: "prime-key",
+			teamId: "team-1",
+			teamName: "Research",
+			teamRole: "admin",
+			teamIdFromEnv: false,
+		});
+	});
+
+	it("lets PRIME_TEAM_ID override Prime CLI team selection", () => {
+		const originalTeamId = process.env.PRIME_TEAM_ID;
+		process.env.PRIME_TEAM_ID = "env-team";
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				team_id: "file-team",
+				team_name: "Research",
+				team_role: "admin",
+			}),
+		);
+
+		try {
+			expect(loadPrimeCliConfig(configPath)).toMatchObject({
+				teamId: "env-team",
+				teamIdFromEnv: true,
+			});
+			expect(loadPrimeCliConfig(configPath).teamName).toBeUndefined();
+		} finally {
+			if (originalTeamId === undefined) {
+				delete process.env.PRIME_TEAM_ID;
+			} else {
+				process.env.PRIME_TEAM_ID = originalTeamId;
+			}
+		}
+	});
+
+	it("fetches Prime teams across paginated responses", async () => {
+		const requestedUrls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			requestedUrls.push(getUrl(input));
+			expect(getAuthorization(init)).toBe("Bearer prime-key");
+			if (requestedUrls.length === 1) {
+				return jsonResponse({
+					data: [{ teamId: "team-1", name: "Research", slug: "research", role: "admin" }],
+					total_count: 2,
+				});
+			}
+			return jsonResponse({
+				data: [{ teamId: "team-2", name: "Infra", slug: "infra", role: "member" }],
+				total_count: 2,
+			});
+		});
+
+		await expect(
+			fetchPrimeTeams("prime-key", "https://prime-api.example/api/v1", { fetchFn: fetchMock }),
+		).resolves.toEqual([
+			{ teamId: "team-1", name: "Research", slug: "research", role: "admin" },
+			{ teamId: "team-2", name: "Infra", slug: "infra", role: "member" },
+		]);
+		expect(requestedUrls).toEqual([
+			"https://prime-api.example/api/v1/user/teams?offset=0&limit=100",
+			"https://prime-api.example/api/v1/user/teams?offset=100&limit=100",
+		]);
 	});
 
 	it("checks Prime Inference access with Prime whoami permissions", async () => {

--- a/packages/coding-agent/test/prime-team-selector.test.ts
+++ b/packages/coding-agent/test/prime-team-selector.test.ts
@@ -37,6 +37,22 @@ describe("PrimeTeamSelectorComponent", () => {
 		expect(output).toContain("current");
 	});
 
+	it("marks personal as current when no team id is active", () => {
+		const selector = new PrimeTeamSelectorComponent(
+			[{ teamId: "team-1", name: "Research", slug: "research", role: "admin" }],
+			undefined,
+			() => {},
+			() => {},
+		);
+
+		const lines = stripAnsi(selector.render(100).join("\n")).split("\n");
+		const personalLine = lines.find((line) => line.includes("Personal"));
+		const teamLine = lines.find((line) => line.includes("Research"));
+
+		expect(personalLine).toContain("current");
+		expect(teamLine).not.toContain("current");
+	});
+
 	it("selects a team from the menu", () => {
 		let selectedTeamId: string | undefined;
 		const selector = new PrimeTeamSelectorComponent(

--- a/packages/coding-agent/test/prime-team-selector.test.ts
+++ b/packages/coding-agent/test/prime-team-selector.test.ts
@@ -1,0 +1,72 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { PrimeTeamSelectorComponent } from "../src/modes/interactive/components/prime-team-selector.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+describe("PrimeTeamSelectorComponent", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("renders personal and team options with current status", () => {
+		const selector = new PrimeTeamSelectorComponent(
+			[
+				{ teamId: "team-1", name: "Research", slug: "research", role: "admin" },
+				{ teamId: "team-2", name: "Infra", role: "member" },
+			],
+			"team-1",
+			() => {},
+			() => {},
+		);
+
+		const output = stripAnsi(selector.render(100).join("\n"));
+
+		expect(output).toContain("Prime Team");
+		expect(output).toContain("Personal");
+		expect(output).toContain("personal account");
+		expect(output).toContain("Research");
+		expect(output).toContain("slug: research, role: admin");
+		expect(output).toContain("Infra");
+		expect(output).toContain("role: member");
+		expect(output).toContain("current");
+	});
+
+	it("selects a team from the menu", () => {
+		let selectedTeamId: string | undefined;
+		const selector = new PrimeTeamSelectorComponent(
+			[{ teamId: "team-1", name: "Research", slug: "research", role: "admin" }],
+			undefined,
+			(team) => {
+				selectedTeamId = team?.teamId;
+			},
+			() => {},
+		);
+
+		selector.handleInput("\x1B[B");
+		selector.handleInput("\r");
+
+		expect(selectedTeamId).toBe("team-1");
+	});
+
+	it("cancels without selecting a team", () => {
+		let cancelled = false;
+		const selector = new PrimeTeamSelectorComponent(
+			[{ teamId: "team-1", name: "Research" }],
+			undefined,
+			() => {},
+			() => {
+				cancelled = true;
+			},
+		);
+
+		selector.handleInput("\x1B");
+
+		expect(cancelled).toBe(true);
+	});
+});


### PR DESCRIPTION
- prime inference login now asks users to choose personal or a team before model selection.
- selected teams are stored with prime agent credentials and sent on inference requests.
- startup onboarding warnings are deferred so fresh setup stays quiet after login.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how inference requests are billed (team header + credential shape) and login/onboarding flow; behavior is covered by new tests but affects auth and API usage.
> 
> **Overview**
> **Prime Inference login** now loads teams from the Prime API and opens a searchable overlay to pick **personal** or a **team**; the choice is stored on the `prime-inference` API key credential and drives **`X-Prime-Team-ID`** on model requests (with **`PRIME_TEAM_ID`** and explicit personal selection overriding CLI team fallback).
> 
> **Startup UX** defers version, package-update, and tmux warnings until onboarding finishes, and suppresses the stale “no models” fallback warning once login/model selection succeeds.
> 
> **Splash cwd** no longer rewrites `.worktrees/...` paths into repo-style labels—it shows the real path (still home-relative when applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdf13450463a8b0bb47fa4eee745bc6250f1ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Prime team selection to the Prime Inference onboarding flow
> - After a successful Prime Inference login, users are prompted to select a billing team (or personal account) via a new fuzzy-search overlay (`PrimeTeamSelectorComponent`); selection is persisted in `ApiKeyCredential.primeTeam`.
> - Outgoing Prime Inference requests now include an `X-Prime-Team-ID` header resolved from stored team selection, `PRIME_TEAM_ID` env override, or Prime CLI config via a new `AuthStorage.getProviderHeaders` method.
> - `loadPrimeCliConfig` now surfaces team fields (`teamId`, `teamName`, `teamRole`, `teamIdFromEnv`) and a new `fetchPrimeTeams` function retrieves available teams from the Prime API with pagination.
> - Stale startup notices (no-model warning, tmux/update banners) are suppressed during onboarding and deferred until after it completes.
> - Behavioral Change: `formatSplashCwd` no longer rewrites worktree paths to repo/branch labels; it now displays the raw normalized path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cdf134.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->