### PR TITLE
add python-backed skills

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -126,9 +126,9 @@ describe("Context overflow error handling", () => {
 	describe("GitHub Copilot (OAuth)", () => {
 		// OpenAI model via Copilot
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should detect overflow via isContextOverflow",
+			"gpt-5-mini - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "gpt-4o");
+				const model = getModel("github-copilot", "gpt-5-mini");
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -610,37 +610,37 @@ describe("AI Providers Empty Message Tests", () => {
 
 	describe("GitHub Copilot Provider Empty Messages", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty content array",
+			"gpt-5-mini - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty string content",
+			"gpt-5-mini - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle whitespace-only content",
+			"gpt-5-mini - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty assistant message in conversation",
+			"gpt-5-mini - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -430,19 +430,19 @@ describe("Tool Results with Images", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle tool result with only image",
+			"gpt-5-mini - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle tool result with text and image",
+			"gpt-5-mini - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -281,10 +281,10 @@ describe("Token Statistics on Abort", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should include token stats when aborted mid-stream",
+			"gpt-5-mini - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -289,10 +289,10 @@ describe("Tool Call Without Result Tests", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should filter out tool calls without corresponding tool results",
+			"gpt-5-mini - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "gpt-4o");
+				const model = getModel("github-copilot", "gpt-5-mini");
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -640,10 +640,10 @@ describe("totalTokens field", () => {
 		);
 
 		it(
-			"google/gemini-2.0-flash-001 - should return totalTokens equal to sum of components",
+			"google/gemini-2.5-flash - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openrouter", "google/gemini-2.0-flash-001");
+				const llm = getModel("openrouter", "google/gemini-2.5-flash");
 
 				console.log(`\nOpenRouter / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.OPENROUTER_API_KEY });
@@ -680,10 +680,10 @@ describe("totalTokens field", () => {
 
 	describe("GitHub Copilot (OAuth)", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should return totalTokens equal to sum of components",
+			"gpt-5-mini - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -396,28 +396,28 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 
 	describe("GitHub Copilot Provider Unicode Handling", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle emoji in tool results",
+			"gpt-5-mini - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle real-world LinkedIn comment data with emoji",
+			"gpt-5-mini - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle unpaired high surrogate (0xD83D) in tool results",
+			"gpt-5-mini - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-5-mini");
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Prime team selection during Prime Inference login so team inference costs use the selected Prime CLI context.
+- Added Python-backed skills that install into the persistent IPython kernel and are exposed alongside markdown skills.
 
 ### Changed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -282,17 +282,23 @@ Place in `~/.prime/agent/prompts/`, `.prime/agent/prompts/`, or a [Prime Agent p
 
 ### Skills
 
-On-demand capability packages following the [Agent Skills standard](https://agentskills.io). Invoke via `/skill:name` or let the agent load them automatically.
+On-demand capability packages following the [Agent Skills standard](https://agentskills.io). At startup, Prime Agent gives the model each visible skill's name, type, description, and location. The full `SKILL.md` stays out of context until the model inspects it with `ipython` or you explicitly invoke `/skill:name`.
 
 ```markdown
 <!-- ~/.prime/agent/skills/my-skill/SKILL.md -->
+---
+name: my-skill
+description: Use this skill when the user asks about X.
+---
+
 # My Skill
-Use this skill when the user asks about X.
 
 ## Steps
 1. Do this
 2. Then that
 ```
+
+Skills can also be Python-backed. A Python skill is a normal skill directory with `SKILL.md` plus a Python package at `src/<import_name>/`. Prime Agent installs it into the persistent IPython kernel and exposes it by import name, so the model can call it directly, inspect it with `help()`, or use any console scripts the skill declares.
 
 Place in `~/.prime/agent/skills/`, `~/.agents/skills/`, `.prime/agent/skills/`, or `.agents/skills/` (from `cwd` up through parent directories) or a [Prime Agent package](#prime-agent-packages) to share with others. See [docs/skills.md](docs/skills.md).
 

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -1,15 +1,16 @@
-> pi can create skills. Ask it to build one for your use case.
+> Prime Agent can create skills. Ask it to build one for your use case.
 
 # Skills
 
-Skills are self-contained capability packages that the agent loads on-demand. A skill provides specialized workflows, setup instructions, helper scripts, and reference documentation for specific tasks.
+Skills are self-contained capability packages that Prime Agent loads on demand. A skill provides specialized workflows, setup instructions, helper scripts, and reference documentation for specific tasks.
 
-Pi implements the [Agent Skills standard](https://agentskills.io/specification), warning about violations but remaining lenient.
+Prime Agent implements the [Agent Skills standard](https://agentskills.io/specification), warning about violations but remaining lenient. It also supports Python-backed skills: a superset of markdown skills that install Python packages into the persistent IPython kernel.
 
 ## Table of Contents
 
 - [Locations](#locations)
 - [How Skills Work](#how-skills-work)
+- [Python-Backed Skills](#python-backed-skills)
 - [Skill Commands](#skill-commands)
 - [Skill Structure](#skill-structure)
 - [Frontmatter](#frontmatter)
@@ -21,20 +22,20 @@ Pi implements the [Agent Skills standard](https://agentskills.io/specification),
 
 > **Security:** Skills can instruct the model to perform any action and may include executable code the model invokes. Review skill content before use.
 
-Pi loads skills from:
+Prime Agent loads skills from:
 
 - Global:
-  - `~/.pi/agent/skills/`
+  - `~/.prime/agent/skills/`
   - `~/.agents/skills/`
 - Project:
-  - `.pi/skills/`
+  - `.prime/agent/skills/`
   - `.agents/skills/` in `cwd` and ancestor directories (up to git repo root, or filesystem root when not in a repo)
 - Packages: `skills/` directories or `pi.skills` entries in `package.json`
 - Settings: `skills` array with files or directories
 - CLI: `--skill <path>` (repeatable, additive even with `--no-skills`)
 
 Discovery rules:
-- In `~/.pi/agent/skills/` and `.pi/skills/`, direct root `.md` files are discovered as individual skills
+- In `~/.prime/agent/skills/` and `.prime/agent/skills/`, direct root `.md` files are discovered as individual skills
 - In all skill locations, directories containing `SKILL.md` are discovered recursively
 - In `~/.agents/skills/` and project `.agents/skills/`, root `.md` files are ignored
 
@@ -53,7 +54,7 @@ To use skills from Claude Code or OpenAI Codex, add their directories to setting
 }
 ```
 
-For project-level Claude Code skills, add to `.pi/settings.json`:
+For project-level Claude Code skills, add to `.prime/agent/settings.json`:
 
 ```json
 {
@@ -63,12 +64,74 @@ For project-level Claude Code skills, add to `.pi/settings.json`:
 
 ## How Skills Work
 
-1. At startup, pi scans skill locations and extracts names and descriptions
-2. The system prompt includes available skills in XML format per the [specification](https://agentskills.io/integrate-skills)
-3. When a task matches, the agent uses `ipython` to load the full SKILL.md (models don't always do this; use prompting or `/skill:name` to force it)
+1. At startup, Prime Agent scans skill locations and extracts names, descriptions, type, and file locations
+2. The system prompt includes visible skills in XML format per the [specification](https://agentskills.io/integrate-skills)
+3. When a task matches, the agent uses `ipython` to load the full `SKILL.md` (models don't always do this; use prompting or `/skill:name` to force it)
 4. The agent follows the instructions, using relative paths to reference scripts and assets
 
 This is progressive disclosure: only descriptions are always in context, full instructions load on-demand.
+
+Skills with `disable-model-invocation: true` are hidden from the startup skill list. They can still be invoked explicitly with `/skill:name`.
+
+## Python-Backed Skills
+
+A Python-backed skill uses the same `SKILL.md` metadata and invocation behavior as a markdown skill, but also provides a Python package for the IPython kernel.
+
+```
+web-search/
+├── SKILL.md
+├── pyproject.toml
+└── src/
+    └── web_search/
+        └── __init__.py
+```
+
+Detection rules:
+- `SKILL.md` is still required
+- `pyproject.toml` marks the skill as Python-backed
+- the import name is the skill name with hyphens converted to underscores
+- `src/<import_name>/__init__.py` must exist
+
+For `web-search`, Prime Agent exposes `web_search` in IPython. If the module defines `run()`, the module is wrapped as an async callable:
+
+```python
+await web_search("prime agent skills")
+await web_search.run("prime agent skills")
+help(web_search)
+```
+
+Python skills are installed editable into the kernel venv during kernel setup. By default this is `~/.prime/agent/kernel-venv`; set `PRIME_AGENT_KERNEL_VENV` to override it. If `pyproject.toml` changes, Prime Agent rebuilds the kernel venv so dependency changes are picked up.
+
+If you set `PRIME_AGENT_KERNEL_PYTHON`, Prime Agent does not install packages into that environment. The Python must already have `ipykernel`, `prime-agent-runtime`, and the default runtime packages installed. Missing Python skill imports are disabled with a warning and calling the skill raises a `RuntimeError`.
+
+### Optional CLI Command
+
+A Python skill can expose a shell command by declaring a console script in `pyproject.toml`. The script name must exactly match the Python import name, including underscores:
+
+```toml
+[project]
+name = "web-search"
+version = "0.1.0"
+dependencies = ["requests"]
+
+[project.scripts]
+web_search = "rlm.skill:cli"
+```
+
+The `rlm.skill:cli` helper imports `web_search.run`, parses CLI arguments with `tyro`, awaits async results, and prints non-`None` return values.
+
+```python
+async def run(query: str, limit: int = 5) -> str:
+    """Search the web and return a concise summary."""
+    ...
+```
+
+The model can then call the skill from normal Python or from shell mode:
+
+```python
+await web_search("prime agent")
+!web_search "prime agent" --limit 3
+```
 
 ## Skill Commands
 
@@ -175,7 +238,7 @@ description: Helps with PDFs.
 
 ## Validation
 
-Pi validates skills against the Agent Skills standard. Most issues produce warnings but still load the skill:
+Prime Agent validates skills against the Agent Skills standard. Most issues produce warnings but still load the skill:
 
 - Name doesn't match parent directory
 - Name exceeds 64 characters or contains invalid characters

--- a/packages/coding-agent/examples/sdk/04-skills.ts
+++ b/packages/coding-agent/examples/sdk/04-skills.ts
@@ -22,6 +22,7 @@ const customSkill: Skill = {
 	baseDir: "/virtual",
 	sourceInfo: createSyntheticSourceInfo("/virtual/SKILL.md", { source: "sdk" }),
 	disableModelInvocation: false,
+	kind: "markdown",
 };
 
 const loader = new DefaultResourceLoader({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -119,6 +119,7 @@ import {
 	SessionManager,
 } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
+import { getPythonSkillRuntimeInfo } from "./skills.js";
 import type { SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
@@ -3276,6 +3277,7 @@ export class AgentSession {
 	}): void {
 		const shellCommandPrefix = this.settingsManager.getShellCommandPrefix();
 		const shellPath = this.settingsManager.getShellPath();
+		const pythonSkills = getPythonSkillRuntimeInfo(this._resourceLoader.getSkills().skills);
 		const configuredBaseToolDefinitions = this._baseToolsOverride
 			? Object.fromEntries(
 					Object.entries(this._baseToolsOverride).map(([name, tool]) => [
@@ -3289,6 +3291,7 @@ export class AgentSession {
 						env: this._rlmKernelEnv(),
 						sessionId: this.sessionId,
 						rlmRunHandler: ({ prompt, kwargs }) => this.runRlmChild(prompt, kwargs),
+						pythonSkills,
 					},
 					bash: { commandPrefix: shellCommandPrefix, shellPath },
 				});

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,7 +8,7 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-const BOOTSTRAP_SCHEMA = 3;
+const BOOTSTRAP_SCHEMA = 4;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
@@ -24,6 +24,7 @@ const DEFAULT_RLM_EXTRA_PACKAGES = [
 	{ uvArg: "beautifulsoup4", importName: "bs4", promptLabel: "bs4 (Beautiful Soup)" },
 	{ uvArg: "lxml", importName: "lxml", promptLabel: "lxml" },
 	{ uvArg: "pydantic", importName: "pydantic", promptLabel: "pydantic" },
+	{ uvArg: "tyro", importName: "tyro", promptLabel: "tyro" },
 ];
 export const DEFAULT_RLM_EXTRA_UV_ARGS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.uvArg);
 export const DEFAULT_RLM_EXTRA_IMPORT_NAMES = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.importName);
@@ -38,11 +39,29 @@ const BOOTSTRAP_LOCK_STALE_WITHOUT_PID_MS = 30_000;
 
 let inFlightEnsureKernelPython: { key: string; promise: Promise<string> } | null = null;
 
+export interface KernelPythonSkill {
+	name: string;
+	importName: string;
+	packagePath: string;
+	pyprojectPath: string;
+}
+
+export interface EnsureKernelPythonOptions {
+	pythonSkills?: readonly KernelPythonSkill[];
+}
+
+interface BootstrapPythonSkill {
+	importName: string;
+	packagePath: string;
+	pyprojectPath: string;
+}
+
 interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
 	extraUvArgs?: string[];
+	pythonSkills?: BootstrapPythonSkill[];
 }
 
 function errorMessage(error: unknown): string {
@@ -81,12 +100,32 @@ function expandHome(filePath: string): string {
 	return filePath;
 }
 
-function ensureKernelPythonKey(): string {
+function normalizePythonSkills(pythonSkills: readonly KernelPythonSkill[] | undefined): BootstrapPythonSkill[] {
+	const byKey = new Map<string, BootstrapPythonSkill>();
+	for (const skill of pythonSkills ?? []) {
+		const packagePath = path.resolve(skill.packagePath);
+		const pyprojectPath = path.resolve(skill.pyprojectPath);
+		const key = `${skill.importName}\0${packagePath}`;
+		byKey.set(key, {
+			importName: skill.importName,
+			packagePath,
+			pyprojectPath,
+		});
+	}
+	return [...byKey.values()].sort((a, b) => {
+		const packageCompare = a.packagePath.localeCompare(b.packagePath);
+		if (packageCompare !== 0) return packageCompare;
+		return a.importName.localeCompare(b.importName);
+	});
+}
+
+function ensureKernelPythonKey(options: EnsureKernelPythonOptions): string {
 	return [
 		process.env.PRIME_AGENT_KERNEL_PYTHON ?? "",
 		process.env.PRIME_AGENT_KERNEL_VENV ?? "",
 		process.env.HOME ?? "",
 		process.env.XDG_DATA_HOME ?? "",
+		JSON.stringify(normalizePythonSkills(options.pythonSkills)),
 	].join("\0");
 }
 
@@ -170,6 +209,19 @@ async function missingRlmExtraImportLabels(python: string): Promise<string[]> {
 	for (const pkg of DEFAULT_RLM_EXTRA_PACKAGES) {
 		if (!(await pythonImports(python, pkg.importName))) {
 			missing.push(pkg.promptLabel);
+		}
+	}
+	return missing;
+}
+
+async function missingPythonSkillImportLabels(
+	python: string,
+	pythonSkills: readonly KernelPythonSkill[],
+): Promise<string[]> {
+	const missing: string[] = [];
+	for (const skill of pythonSkills) {
+		if (!(await pythonImports(python, skill.importName))) {
+			missing.push(`${skill.name} (${skill.importName})`);
 		}
 	}
 	return missing;
@@ -298,11 +350,24 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 			parsed.extraUvArgs.every((v: unknown): v is string => typeof v === "string")
 				? (parsed.extraUvArgs as string[])
 				: undefined;
+		const pythonSkills =
+			Array.isArray(parsed.pythonSkills) &&
+			parsed.pythonSkills.every((v: unknown): v is BootstrapPythonSkill => {
+				if (!isRecord(v)) return false;
+				return (
+					typeof v.importName === "string" &&
+					typeof v.packagePath === "string" &&
+					typeof v.pyprojectPath === "string"
+				);
+			})
+				? (parsed.pythonSkills as BootstrapPythonSkill[])
+				: undefined;
 		return {
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
 			runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
 			extraUvArgs,
+			pythonSkills,
 		};
 	} catch {
 		return null;
@@ -316,21 +381,39 @@ function extraUvArgsMatch(a: string[] | undefined, b: string[] | undefined): boo
 	return a.every((v, i) => v === b[i]);
 }
 
-function bootstrapVersionCurrent(version: BootstrapVersion | null): boolean {
+function pythonSkillsMatch(a: BootstrapPythonSkill[] | undefined, b: readonly BootstrapPythonSkill[]): boolean {
+	const left = a ?? [];
+	if (left.length !== b.length) return false;
+	return left.every((skill, index) => {
+		const expected = b[index];
+		return (
+			skill.importName === expected.importName &&
+			skill.packagePath === expected.packagePath &&
+			skill.pyprojectPath === expected.pyprojectPath
+		);
+	});
+}
+
+function bootstrapVersionCurrent(
+	version: BootstrapVersion | null,
+	pythonSkills: readonly BootstrapPythonSkill[],
+): boolean {
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
 		version.runtime === RUNTIME_REQUIREMENT &&
-		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
+		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS) &&
+		pythonSkillsMatch(version.pythonSkills, pythonSkills)
 	);
 }
 
-async function writeBootstrapVersion(venv: string): Promise<void> {
+async function writeBootstrapVersion(venv: string, pythonSkills: readonly BootstrapPythonSkill[]): Promise<void> {
 	const version: BootstrapVersion = {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
 		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+		pythonSkills: [...pythonSkills],
 	};
 	await writeFile(path.join(venv, BOOTSTRAP_VERSION_FILE), `${JSON.stringify(version)}\n`, "utf8");
 }
@@ -352,11 +435,12 @@ async function resolveRuntimeRequirement(): Promise<string> {
 	return RUNTIME_REQUIREMENT;
 }
 
-async function bootstrapVenv(venv: string): Promise<void> {
+async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPythonSkill[]): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv();
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
+	const pythonSkillInstallArgs = pythonSkills.flatMap((skill) => ["--editable", skill.packagePath]);
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
@@ -368,15 +452,20 @@ async function bootstrapVenv(venv: string): Promise<void> {
 		IPYKERNEL_REQUIREMENT,
 		runtimeRequirement,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
+		...pythonSkillInstallArgs,
 	]);
-	await writeBootstrapVersion(venv);
+	await writeBootstrapVersion(venv, pythonSkills);
 }
 
-async function kernelReady(python: string, venv: string): Promise<boolean> {
+async function kernelReady(
+	python: string,
+	venv: string,
+	pythonSkills: readonly BootstrapPythonSkill[],
+): Promise<boolean> {
 	return (
 		(await hasIpykernel(python)) &&
 		(await hasPrimeAgentRuntime(python)) &&
-		bootstrapVersionCurrent(await readBootstrapVersion(venv))
+		bootstrapVersionCurrent(await readBootstrapVersion(venv), pythonSkills)
 	);
 }
 
@@ -388,7 +477,8 @@ function formatBootstrapFailure(error: unknown): Error {
 	);
 }
 
-async function ensureKernelPythonUncached(): Promise<string> {
+async function ensureKernelPythonUncached(options: EnsureKernelPythonOptions): Promise<string> {
+	const pythonSkills = normalizePythonSkills(options.pythonSkills);
 	const override = process.env.PRIME_AGENT_KERNEL_PYTHON;
 	if (override) {
 		const python = path.resolve(expandHome(override));
@@ -401,17 +491,23 @@ async function ensureKernelPythonUncached(): Promise<string> {
 				missing.push(`default Python packages (${missingExtraImports.join(", ")})`);
 			}
 		}
+		if (missing.length === 0 && pythonSkills.length > 0) {
+			const missingPythonSkills = await missingPythonSkillImportLabels(python, options.pythonSkills ?? []);
+			if (missingPythonSkills.length > 0) {
+				missing.push(`Python skills (${missingPythonSkills.join(", ")})`);
+			}
+		}
 		if (missing.length === 0) return python;
 		throw new Error(`PRIME_AGENT_KERNEL_PYTHON points to a Python missing ${missing.join(" and ")}: ${python}`);
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
 	const python = path.join(venv, "bin", "python");
-	if (await kernelReady(python, venv)) return python;
+	if (await kernelReady(python, venv, pythonSkills)) return python;
 
 	const releaseLock = await acquireBootstrapLock(venv);
 	try {
-		if (await kernelReady(python, venv)) return python;
+		if (await kernelReady(python, venv, pythonSkills)) return python;
 
 		const hadVenv = existsSync(venv);
 		process.stderr.write("› setting up python kernel (one-time, ~30s)…\n");
@@ -420,7 +516,7 @@ async function ensureKernelPythonUncached(): Promise<string> {
 			await rm(venv, { recursive: true, force: true });
 		}
 
-		await bootstrapVenv(venv);
+		await bootstrapVenv(venv, pythonSkills);
 	} catch (error) {
 		throw formatBootstrapFailure(error);
 	} finally {
@@ -431,11 +527,11 @@ async function ensureKernelPythonUncached(): Promise<string> {
 	return python;
 }
 
-export function ensureKernelPython(): Promise<string> {
-	const key = ensureKernelPythonKey();
+export function ensureKernelPython(options: EnsureKernelPythonOptions = {}): Promise<string> {
+	const key = ensureKernelPythonKey(options);
 	if (inFlightEnsureKernelPython?.key === key) return inFlightEnsureKernelPython.promise;
 
-	const promise = ensureKernelPythonUncached().finally(() => {
+	const promise = ensureKernelPythonUncached(options).finally(() => {
 		if (inFlightEnsureKernelPython?.promise === promise) inFlightEnsureKernelPython = null;
 	});
 	inFlightEnsureKernelPython = { key, promise };

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -8,6 +8,7 @@ import { stderr, stdin } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import type { PythonSkillRuntimeInfo } from "../skills.js";
 
 const BOOTSTRAP_SCHEMA = 4;
 const PYTHON_VERSION = "3.11";
@@ -40,12 +41,7 @@ const BOOTSTRAP_LOCK_STALE_WITHOUT_PID_MS = 30_000;
 
 let inFlightEnsureKernelPython: { key: string; promise: Promise<string> } | null = null;
 
-export interface KernelPythonSkill {
-	name: string;
-	importName: string;
-	packagePath: string;
-	pyprojectPath: string;
-}
+export type KernelPythonSkill = PythonSkillRuntimeInfo;
 
 export interface EnsureKernelPythonOptions {
 	pythonSkills?: readonly KernelPythonSkill[];
@@ -130,13 +126,13 @@ function normalizePythonSkills(pythonSkills: readonly KernelPythonSkill[] | unde
 	});
 }
 
-function ensureKernelPythonKey(options: EnsureKernelPythonOptions): string {
+function ensureKernelPythonKey(pythonSkills: readonly BootstrapPythonSkill[]): string {
 	return [
 		process.env.PRIME_AGENT_KERNEL_PYTHON ?? "",
 		process.env.PRIME_AGENT_KERNEL_VENV ?? "",
 		process.env.HOME ?? "",
 		process.env.XDG_DATA_HOME ?? "",
-		JSON.stringify(normalizePythonSkills(options.pythonSkills)),
+		JSON.stringify(pythonSkills),
 	].join("\0");
 }
 
@@ -457,6 +453,7 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 	const uv = await ensureUv();
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
+	const installedPythonSkills: BootstrapPythonSkill[] = [];
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
@@ -472,13 +469,14 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 	for (const skill of pythonSkills) {
 		try {
 			await run(uv, ["pip", "install", "--python", python, "--editable", skill.packagePath]);
+			installedPythonSkills.push(skill);
 		} catch (error) {
 			process.stderr.write(
 				`Warning: Python skill ${skill.importName} failed to install and will be unavailable: ${errorMessage(error)}\n`,
 			);
 		}
 	}
-	await writeBootstrapVersion(venv, pythonSkills);
+	await writeBootstrapVersion(venv, installedPythonSkills);
 }
 
 async function kernelReady(
@@ -501,8 +499,10 @@ function formatBootstrapFailure(error: unknown): Error {
 	);
 }
 
-async function ensureKernelPythonUncached(options: EnsureKernelPythonOptions): Promise<string> {
-	const pythonSkills = normalizePythonSkills(options.pythonSkills);
+async function ensureKernelPythonUncached(
+	options: EnsureKernelPythonOptions,
+	pythonSkills: readonly BootstrapPythonSkill[],
+): Promise<string> {
 	const override = process.env.PRIME_AGENT_KERNEL_PYTHON;
 	if (override) {
 		const python = path.resolve(expandHome(override));
@@ -554,10 +554,11 @@ async function ensureKernelPythonUncached(options: EnsureKernelPythonOptions): P
 }
 
 export function ensureKernelPython(options: EnsureKernelPythonOptions = {}): Promise<string> {
-	const key = ensureKernelPythonKey(options);
+	const pythonSkills = normalizePythonSkills(options.pythonSkills);
+	const key = ensureKernelPythonKey(pythonSkills);
 	if (inFlightEnsureKernelPython?.key === key) return inFlightEnsureKernelPython.promise;
 
-	const promise = ensureKernelPythonUncached(options).finally(() => {
+	const promise = ensureKernelPythonUncached(options, pythonSkills).finally(() => {
 		if (inFlightEnsureKernelPython?.promise === promise) inFlightEnsureKernelPython = null;
 	});
 	inFlightEnsureKernelPython = { key, promise };

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { constants, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { constants, existsSync, readFileSync } from "node:fs";
 import { access, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -54,6 +55,7 @@ interface BootstrapPythonSkill {
 	importName: string;
 	packagePath: string;
 	pyprojectPath: string;
+	pyprojectHash: string;
 }
 
 interface BootstrapVersion {
@@ -100,6 +102,14 @@ function expandHome(filePath: string): string {
 	return filePath;
 }
 
+function fileContentHash(filePath: string): string {
+	try {
+		return `sha256:${createHash("sha256").update(readFileSync(filePath)).digest("hex")}`;
+	} catch {
+		return "unreadable";
+	}
+}
+
 function normalizePythonSkills(pythonSkills: readonly KernelPythonSkill[] | undefined): BootstrapPythonSkill[] {
 	const byKey = new Map<string, BootstrapPythonSkill>();
 	for (const skill of pythonSkills ?? []) {
@@ -110,6 +120,7 @@ function normalizePythonSkills(pythonSkills: readonly KernelPythonSkill[] | unde
 			importName: skill.importName,
 			packagePath,
 			pyprojectPath,
+			pyprojectHash: fileContentHash(pyprojectPath),
 		});
 	}
 	return [...byKey.values()].sort((a, b) => {
@@ -350,18 +361,23 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 			parsed.extraUvArgs.every((v: unknown): v is string => typeof v === "string")
 				? (parsed.extraUvArgs as string[])
 				: undefined;
-		const pythonSkills =
-			Array.isArray(parsed.pythonSkills) &&
-			parsed.pythonSkills.every((v: unknown): v is BootstrapPythonSkill => {
-				if (!isRecord(v)) return false;
-				return (
-					typeof v.importName === "string" &&
-					typeof v.packagePath === "string" &&
-					typeof v.pyprojectPath === "string"
-				);
-			})
-				? (parsed.pythonSkills as BootstrapPythonSkill[])
-				: undefined;
+		let pythonSkills: BootstrapPythonSkill[] | undefined;
+		if (Array.isArray(parsed.pythonSkills)) {
+			if (
+				!parsed.pythonSkills.every((v: unknown): v is BootstrapPythonSkill => {
+					if (!isRecord(v)) return false;
+					return (
+						typeof v.importName === "string" &&
+						typeof v.packagePath === "string" &&
+						typeof v.pyprojectPath === "string" &&
+						typeof v.pyprojectHash === "string"
+					);
+				})
+			) {
+				return null;
+			}
+			pythonSkills = parsed.pythonSkills as BootstrapPythonSkill[];
+		}
 		return {
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
@@ -389,7 +405,8 @@ function pythonSkillsMatch(a: BootstrapPythonSkill[] | undefined, b: readonly Bo
 		return (
 			skill.importName === expected.importName &&
 			skill.packagePath === expected.packagePath &&
-			skill.pyprojectPath === expected.pyprojectPath
+			skill.pyprojectPath === expected.pyprojectPath &&
+			skill.pyprojectHash === expected.pyprojectHash
 		);
 	});
 }
@@ -440,7 +457,6 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 	const uv = await ensureUv();
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
-	const pythonSkillInstallArgs = pythonSkills.flatMap((skill) => ["--editable", skill.packagePath]);
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
@@ -452,8 +468,16 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 		IPYKERNEL_REQUIREMENT,
 		runtimeRequirement,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
-		...pythonSkillInstallArgs,
 	]);
+	for (const skill of pythonSkills) {
+		try {
+			await run(uv, ["pip", "install", "--python", python, "--editable", skill.packagePath]);
+		} catch (error) {
+			process.stderr.write(
+				`Warning: Python skill ${skill.importName} failed to install and will be unavailable: ${errorMessage(error)}\n`,
+			);
+		}
+	}
 	await writeBootstrapVersion(venv, pythonSkills);
 }
 
@@ -494,7 +518,9 @@ async function ensureKernelPythonUncached(options: EnsureKernelPythonOptions): P
 		if (missing.length === 0 && pythonSkills.length > 0) {
 			const missingPythonSkills = await missingPythonSkillImportLabels(python, options.pythonSkills ?? []);
 			if (missingPythonSkills.length > 0) {
-				missing.push(`Python skills (${missingPythonSkills.join(", ")})`);
+				process.stderr.write(
+					`Warning: Python skills unavailable in PRIME_AGENT_KERNEL_PYTHON and will be disabled: ${missingPythonSkills.join(", ")}\n`,
+				);
 			}
 		}
 		if (missing.length === 0) return python;

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -412,11 +412,16 @@ function bootstrapVersionCurrent(
 	pythonSkills: readonly BootstrapPythonSkill[],
 ): boolean {
 	return (
+		version !== null && bootstrapBaseVersionCurrent(version) && pythonSkillsMatch(version.pythonSkills, pythonSkills)
+	);
+}
+
+function bootstrapBaseVersionCurrent(version: BootstrapVersion | null): boolean {
+	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
 		version.runtime === RUNTIME_REQUIREMENT &&
-		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS) &&
-		pythonSkillsMatch(version.pythonSkills, pythonSkills)
+		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
 	);
 }
 
@@ -453,7 +458,6 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 	const uv = await ensureUv();
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
-	const installedPythonSkills: BootstrapPythonSkill[] = [];
 
 	await run(uv, ["python", "install", PYTHON_VERSION]);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
@@ -466,7 +470,28 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 		runtimeRequirement,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
+	await syncPythonSkills(uv, venv, python, pythonSkills);
+}
+
+async function syncPythonSkills(
+	uv: string,
+	venv: string,
+	python: string,
+	pythonSkills: readonly BootstrapPythonSkill[],
+): Promise<void> {
+	const version = await readBootstrapVersion(venv);
+	const installedPythonSkills: BootstrapPythonSkill[] = [];
+	const currentPythonSkills = new Map(
+		(version?.pythonSkills ?? []).map((skill) => [`${skill.importName}\0${skill.packagePath}`, skill]),
+	);
+
 	for (const skill of pythonSkills) {
+		const existingSkill = currentPythonSkills.get(`${skill.importName}\0${skill.packagePath}`);
+		if (existingSkill?.pyprojectPath === skill.pyprojectPath && existingSkill.pyprojectHash === skill.pyprojectHash) {
+			installedPythonSkills.push(skill);
+			continue;
+		}
+
 		try {
 			await run(uv, ["pip", "install", "--python", python, "--editable", skill.packagePath]);
 			installedPythonSkills.push(skill);
@@ -477,6 +502,14 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 		}
 	}
 	await writeBootstrapVersion(venv, installedPythonSkills);
+}
+
+async function kernelBaseReady(python: string, venv: string): Promise<boolean> {
+	return (
+		(await hasIpykernel(python)) &&
+		(await hasPrimeAgentRuntime(python)) &&
+		bootstrapBaseVersionCurrent(await readBootstrapVersion(venv))
+	);
 }
 
 async function kernelReady(
@@ -534,6 +567,10 @@ async function ensureKernelPythonUncached(
 	const releaseLock = await acquireBootstrapLock(venv);
 	try {
 		if (await kernelReady(python, venv, pythonSkills)) return python;
+		if (await kernelBaseReady(python, venv)) {
+			await syncPythonSkills(await ensureUv(), venv, python, pythonSkills);
+			return python;
+		}
 
 		const hadVenv = existsSync(venv);
 		process.stderr.write("› setting up python kernel (one-time, ~30s)…\n");

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -9,7 +9,7 @@ import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
 import type { RlmRunHandler, RlmRunResult } from "../rlm-runtime.js";
-import { ensureKernelPython } from "./bootstrap.js";
+import { ensureKernelPython, type KernelPythonSkill } from "./bootstrap.js";
 
 const DELIM = Buffer.from("<IDS|MSG>");
 const PROTOCOL_VERSION = "5.3";
@@ -27,6 +27,7 @@ export interface KernelManagerOptions {
 	env?: Record<string, string>;
 	sessionId?: string;
 	rlmRunHandler?: RlmRunHandler;
+	pythonSkills?: readonly KernelPythonSkill[];
 	/** Default: "prime-agent". */
 	username?: string;
 }
@@ -280,7 +281,10 @@ function installSignalHandlersOnce(): void {
 // ---- kernel manager ------------------------------------------------------
 
 export class KernelManager {
-	private readonly options: Pick<KernelManagerOptions, "python" | "cwd" | "env" | "sessionId" | "rlmRunHandler"> &
+	private readonly options: Pick<
+		KernelManagerOptions,
+		"python" | "cwd" | "env" | "sessionId" | "rlmRunHandler" | "pythonSkills"
+	> &
 		Required<Pick<KernelManagerOptions, "username">>;
 	private readonly session = uuid();
 	private readonly commTargets = new Map<string, string>();
@@ -308,6 +312,7 @@ export class KernelManager {
 			env: options.env,
 			sessionId: options.sessionId,
 			rlmRunHandler: options.rlmRunHandler,
+			pythonSkills: options.pythonSkills,
 			username: options.username ?? "prime-agent",
 		};
 	}
@@ -330,7 +335,7 @@ export class KernelManager {
 
 		let python: string;
 		try {
-			python = this.options.python ?? (await ensureKernelPython());
+			python = this.options.python ?? (await ensureKernelPython({ pythonSkills: this.options.pythonSkills }));
 			this.options.python = python;
 		} catch (error) {
 			this.state = "idle";

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -29,12 +29,12 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	}
 	if (installedSkills.length > 0) {
 		const installed = installedSkills.map((skill) => `\`${skill}\``).join(", ");
-		skillLines.push(`Installed skills (pre-imported): ${installed}.`);
+		skillLines.push(`Installed Python skills (pre-imported): ${installed}.`);
 		skillLines.push(
-			"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+			"Each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 		);
 		skillLines.push(
-			"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
+			"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 		);
 	}
 	if (skillLines.length > 0) {

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -29,10 +29,11 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	}
 	if (installedSkills.length > 0) {
 		const installed = installedSkills.map((skill) => `\`${skill}\``).join(", ");
-		skillLines.push(`Installed Python skills (pre-imported): ${installed}.`);
+		skillLines.push(`Configured Python skills for IPython: ${installed}.`);
 		skillLines.push(
-			"Each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+			"When available, each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 		);
+		skillLines.push("If a Python skill is unavailable, calling it raises a RuntimeError with the import error.");
 		skillLines.push(
 			"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 		);

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -447,7 +447,7 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 	const lines = [
 		"\n\nThe following skills provide specialized instructions for specific tasks.",
 		"Use ipython to inspect a skill's file when the task matches its description.",
-		"Skills with a python_import are pre-installed in the persistent IPython kernel and can be called directly by that import name.",
+		"Skills with a python_import are prepared in the persistent IPython kernel when available and can be called directly by that import name.",
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 		"",
 		"<available_skills>",
@@ -515,8 +515,10 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 
 	const skillMap = new Map<string, Skill>();
 	const realPathSet = new Set<string>();
+	const pythonImportMap = new Map<string, Skill>();
 	const allDiagnostics: ResourceDiagnostic[] = [];
 	const collisionDiagnostics: ResourceDiagnostic[] = [];
+	const pythonImportDiagnostics: ResourceDiagnostic[] = [];
 
 	function addSkills(result: LoadSkillsResult) {
 		allDiagnostics.push(...result.diagnostics);
@@ -545,6 +547,18 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 			} else {
 				skillMap.set(skill.name, skill);
 				realPathSet.add(realPath);
+				if (skill.kind === "python") {
+					const existingPythonSkill = pythonImportMap.get(skill.python.importName);
+					if (existingPythonSkill) {
+						pythonImportDiagnostics.push({
+							type: "warning",
+							message: `python import name "${skill.python.importName}" is shared by skills "${existingPythonSkill.name}" and "${skill.name}"`,
+							path: skill.filePath,
+						});
+					} else {
+						pythonImportMap.set(skill.python.importName, skill);
+					}
+				}
 			}
 		}
 	}
@@ -604,6 +618,6 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 
 	return {
 		skills: Array.from(skillMap.values()),
-		diagnostics: [...allDiagnostics, ...collisionDiagnostics],
+		diagnostics: [...allDiagnostics, ...collisionDiagnostics, ...pythonImportDiagnostics],
 	};
 }

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -72,13 +72,37 @@ export interface SkillFrontmatter {
 	[key: string]: unknown;
 }
 
-export interface Skill {
+export type SkillKind = "markdown" | "python";
+
+export interface SkillPythonMetadata {
+	importName: string;
+	packagePath: string;
+	pyprojectPath: string;
+}
+
+interface BaseSkill {
 	name: string;
 	description: string;
 	filePath: string;
 	baseDir: string;
 	sourceInfo: SourceInfo;
 	disableModelInvocation: boolean;
+}
+
+export interface MarkdownSkill extends BaseSkill {
+	kind: "markdown";
+	python?: undefined;
+}
+
+export interface PythonSkill extends BaseSkill {
+	kind: "python";
+	python: SkillPythonMetadata;
+}
+
+export type Skill = MarkdownSkill | PythonSkill;
+
+export interface PythonSkillRuntimeInfo extends SkillPythonMetadata {
+	name: string;
 }
 
 export interface LoadSkillsResult {
@@ -160,6 +184,79 @@ function createSkillSourceInfo(filePath: string, baseDir: string, source: string
 		default:
 			return createSyntheticSourceInfo(filePath, { source, baseDir });
 	}
+}
+
+function pythonImportNameForSkill(name: string): string {
+	return name.replaceAll("-", "_");
+}
+
+function isValidPythonImportName(name: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+function detectPythonSkill(
+	skillDir: string,
+	name: string,
+	diagnostics: ResourceDiagnostic[],
+): SkillPythonMetadata | null {
+	const pyprojectPath = join(skillDir, "pyproject.toml");
+	if (!existsSync(pyprojectPath)) {
+		return null;
+	}
+
+	try {
+		if (!statSync(pyprojectPath).isFile()) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	const importName = pythonImportNameForSkill(name);
+	if (!isValidPythonImportName(importName)) {
+		diagnostics.push({
+			type: "warning",
+			message: `python skill import name "${importName}" is invalid`,
+			path: pyprojectPath,
+		});
+		return null;
+	}
+
+	const packageInitPath = join(skillDir, "src", importName, "__init__.py");
+	try {
+		if (!statSync(packageInitPath).isFile()) {
+			diagnostics.push({
+				type: "warning",
+				message: `python skill package src/${importName}/__init__.py not found`,
+				path: pyprojectPath,
+			});
+			return null;
+		}
+	} catch {
+		diagnostics.push({
+			type: "warning",
+			message: `python skill package src/${importName}/__init__.py not found`,
+			path: pyprojectPath,
+		});
+		return null;
+	}
+
+	return {
+		importName,
+		packagePath: skillDir,
+		pyprojectPath,
+	};
+}
+
+export function getPythonSkillRuntimeInfo(skills: readonly Skill[]): PythonSkillRuntimeInfo[] {
+	return skills
+		.filter((skill): skill is PythonSkill => skill.kind === "python")
+		.map((skill) => ({
+			name: skill.name,
+			importName: skill.python.importName,
+			packagePath: skill.python.packagePath,
+			pyprojectPath: skill.python.pyprojectPath,
+		}));
 }
 
 /**
@@ -311,15 +408,18 @@ function loadSkillFromFile(
 			return { skill: null, diagnostics };
 		}
 
+		const python = basename(filePath) === "SKILL.md" ? detectPythonSkill(skillDir, name, diagnostics) : null;
+		const baseSkill: BaseSkill = {
+			name,
+			description: frontmatter.description,
+			filePath,
+			baseDir: skillDir,
+			sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
+			disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+		};
+
 		return {
-			skill: {
-				name,
-				description: frontmatter.description,
-				filePath,
-				baseDir: skillDir,
-				sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
-				disableModelInvocation: frontmatter["disable-model-invocation"] === true,
-			},
+			skill: python ? { ...baseSkill, kind: "python", python } : { ...baseSkill, kind: "markdown" },
 			diagnostics,
 		};
 	} catch (error) {
@@ -346,7 +446,8 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 
 	const lines = [
 		"\n\nThe following skills provide specialized instructions for specific tasks.",
-		"Use ipython to load a skill's file when the task matches its description.",
+		"Use ipython to inspect a skill's file when the task matches its description.",
+		"Skills with a python_import are pre-installed in the persistent IPython kernel and can be called directly by that import name.",
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 		"",
 		"<available_skills>",
@@ -355,6 +456,10 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 	for (const skill of visibleSkills) {
 		lines.push("  <skill>");
 		lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+		lines.push(`    <type>${skill.kind}</type>`);
+		if (skill.kind === "python") {
+			lines.push(`    <python_import>${escapeXml(skill.python.importName)}</python_import>`);
+		}
 		lines.push(`    <description>${escapeXml(skill.description)}</description>`);
 		lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
 		lines.push("  </skill>");

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -3,7 +3,7 @@
  */
 
 import { buildRlmPrompt } from "./prompts/index.js";
-import { formatSkillsForPrompt, type Skill } from "./skills.js";
+import { formatSkillsForPrompt, getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
 
 export interface BuildSystemPromptOptions {
 	/** Custom system prompt (replaces default). */
@@ -55,6 +55,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	const contextFiles = providedContextFiles ?? [];
 	const skills = providedSkills ?? [];
 	const tools = selectedTools ?? ["ipython"];
+	const visibleSkills = skills.filter((skill) => !skill.disableModelInvocation);
 
 	if (customPrompt) {
 		let prompt = customPrompt;
@@ -89,7 +90,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	let prompt = buildRlmPrompt({
 		cwd: promptCwd,
 		messagesPath: promptMessagesPath,
-		installedSkills: skills.filter((skill) => !skill.disableModelInvocation).map((skill) => skill.name),
+		installedSkills: getPythonSkillRuntimeInfo(visibleSkills).map((skill) => skill.importName),
 		activeTools: tools.filter((name) => name === "ipython" || name === "bash" || name === "edit"),
 		allowRecursion,
 	});

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,9 +4,10 @@ import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import { KernelManager } from "../kernel/index.js";
 import type { RlmRunHandler } from "../rlm-runtime.js";
+import type { PythonSkillRuntimeInfo } from "../skills.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
-const RLM_BOOTSTRAP_CODE = `
+const RLM_BOOTSTRAP_BASE_CODE = `
 try:
     import nest_asyncio as _prime_agent_nest_asyncio
     _prime_agent_nest_asyncio.apply()
@@ -34,6 +35,52 @@ except Exception as _prime_agent_rlm_error:
     rlm = _PrimeAgentMissingRlm()
 `.trim();
 
+export function buildRlmBootstrapCode(pythonSkills: readonly PythonSkillRuntimeInfo[] = []): string {
+	const importNames = [...new Set(pythonSkills.map((skill) => skill.importName))];
+	if (importNames.length === 0) {
+		return RLM_BOOTSTRAP_BASE_CODE;
+	}
+
+	return `
+${RLM_BOOTSTRAP_BASE_CODE}
+
+import importlib as _prime_agent_importlib
+import inspect as _prime_agent_inspect
+import sys as _prime_agent_sys
+import types as _prime_agent_types
+
+class _PrimeAgentCallableSkillModule(_prime_agent_types.ModuleType):
+    async def __call__(self, *args, **kwargs):
+        result = self.run(*args, **kwargs)
+        if _prime_agent_inspect.isawaitable(result):
+            return await result
+        return result
+
+def _prime_agent_wrap_skill_module(module):
+    run = getattr(module, "run", None)
+    if not callable(run):
+        return module
+    if isinstance(module, _PrimeAgentCallableSkillModule):
+        return module
+    wrapped = _PrimeAgentCallableSkillModule(module.__name__)
+    wrapped.__dict__.update(module.__dict__)
+    try:
+        wrapped.__signature__ = _prime_agent_inspect.signature(run)
+    except Exception:
+        pass
+    doc = getattr(run, "__doc__", None)
+    if doc:
+        wrapped.__doc__ = doc
+    _prime_agent_sys.modules[module.__name__] = wrapped
+    return wrapped
+
+for _prime_agent_skill_name in ${JSON.stringify(importNames)}:
+    globals()[_prime_agent_skill_name] = _prime_agent_wrap_skill_module(
+        _prime_agent_importlib.import_module(_prime_agent_skill_name)
+    )
+`.trim();
+}
+
 const ipythonSchema = Type.Object({
 	code: Type.String({
 		description:
@@ -56,6 +103,7 @@ export interface IpythonToolOptions {
 	env?: Record<string, string>;
 	sessionId?: string;
 	rlmRunHandler?: RlmRunHandler;
+	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
 }
@@ -81,9 +129,10 @@ export function createIpythonToolDefinition(
 					env: options?.env,
 					sessionId: options?.sessionId,
 					rlmRunHandler: options?.rlmRunHandler,
+					pythonSkills: options?.pythonSkills,
 				});
 				await m.start();
-				const bootstrap = await m.execute(RLM_BOOTSTRAP_CODE);
+				const bootstrap = await m.execute(buildRlmBootstrapCode(options?.pythonSkills));
 				if (bootstrap.status !== "ok") {
 					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
 					throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -56,6 +56,24 @@ class _PrimeAgentCallableSkillModule(_prime_agent_types.ModuleType):
             return await result
         return result
 
+class _PrimeAgentUnavailableSkill:
+    def __init__(self, name, error):
+        self.__name__ = name
+        self._prime_agent_import_error = error
+        self.__doc__ = f"Python skill {name} is unavailable: {error}"
+
+    async def run(self, *args, **kwargs):
+        raise RuntimeError(
+            f"Python skill {self.__name__} is unavailable in this IPython kernel. "
+            f"Import error: {self._prime_agent_import_error}"
+        )
+
+    async def __call__(self, *args, **kwargs):
+        return await self.run(*args, **kwargs)
+
+    def __repr__(self):
+        return f"<unavailable Python skill {self.__name__!r}: {self._prime_agent_import_error}>"
+
 def _prime_agent_wrap_skill_module(module):
     run = getattr(module, "run", None)
     if not callable(run):
@@ -74,10 +92,19 @@ def _prime_agent_wrap_skill_module(module):
     _prime_agent_sys.modules[module.__name__] = wrapped
     return wrapped
 
+_PRIME_AGENT_SKILL_IMPORT_ERRORS = {}
+
 for _prime_agent_skill_name in ${JSON.stringify(importNames)}:
-    globals()[_prime_agent_skill_name] = _prime_agent_wrap_skill_module(
-        _prime_agent_importlib.import_module(_prime_agent_skill_name)
-    )
+    try:
+        globals()[_prime_agent_skill_name] = _prime_agent_wrap_skill_module(
+            _prime_agent_importlib.import_module(_prime_agent_skill_name)
+        )
+    except Exception as _prime_agent_skill_error:
+        _PRIME_AGENT_SKILL_IMPORT_ERRORS[_prime_agent_skill_name] = str(_prime_agent_skill_error)
+        globals()[_prime_agent_skill_name] = _PrimeAgentUnavailableSkill(
+            _prime_agent_skill_name,
+            str(_prime_agent_skill_error),
+        )
 `.trim();
 }
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -207,12 +207,18 @@ export {
 // Skills
 export {
 	formatSkillsForPrompt,
+	getPythonSkillRuntimeInfo,
 	type LoadSkillsFromDirOptions,
 	type LoadSkillsResult,
 	loadSkills,
 	loadSkillsFromDir,
+	type MarkdownSkill,
+	type PythonSkill,
+	type PythonSkillRuntimeInfo,
 	type Skill,
 	type SkillFrontmatter,
+	type SkillKind,
+	type SkillPythonMetadata,
 } from "./core/skills.js";
 export { createSyntheticSourceInfo } from "./core/source-info.js";
 // Tools

--- a/packages/coding-agent/test/fixtures/skills/python-package-missing/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/python-package-missing/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: python-package-missing
+description: A Python skill missing its import package.
+---
+
+# Python Package Missing

--- a/packages/coding-agent/test/fixtures/skills/python-package-missing/pyproject.toml
+++ b/packages/coding-agent/test/fixtures/skills/python-package-missing/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "python-package-missing"
+version = "0.1.0"

--- a/packages/coding-agent/test/fixtures/skills/python-skill/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/python-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: python-skill
+description: A Python-backed skill for testing.
+---
+
+# Python Skill
+
+Use the `python_skill` import.

--- a/packages/coding-agent/test/fixtures/skills/python-skill/pyproject.toml
+++ b/packages/coding-agent/test/fixtures/skills/python-skill/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "python-skill"
+version = "0.1.0"
+dependencies = ["prime-agent-runtime"]
+
+[project.scripts]
+python_skill = "rlm.skill:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/python_skill"]

--- a/packages/coding-agent/test/fixtures/skills/python-skill/src/python_skill/__init__.py
+++ b/packages/coding-agent/test/fixtures/skills/python-skill/src/python_skill/__init__.py
@@ -1,0 +1,3 @@
+async def run(value: str = "ok") -> str:
+    """Return the provided value."""
+    return value

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildRlmBootstrapCode } from "../src/core/tools/ipython.js";
+
+describe("IPython RLM bootstrap", () => {
+	it("guards Python skill imports so a broken skill does not abort bootstrap", () => {
+		const code = buildRlmBootstrapCode([
+			{
+				name: "broken-skill",
+				importName: "broken_skill",
+				packagePath: "/tmp/broken-skill",
+				pyprojectPath: "/tmp/broken-skill/pyproject.toml",
+			},
+		]);
+
+		expect(code).toContain("except Exception as _prime_agent_skill_error");
+		expect(code).toContain("_PrimeAgentUnavailableSkill");
+		expect(code).toContain("_PRIME_AGENT_SKILL_IMPORT_ERRORS");
+		expect(code).toContain("globals()[_prime_agent_skill_name] = _PrimeAgentUnavailableSkill");
+	});
+});

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,12 +16,16 @@ let originalEnv: NodeJS.ProcessEnv;
 const RLM_RUNTIME_CHECK =
 	"import rlm; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')";
 
+function pyprojectHash(pyprojectPath: string): string {
+	return `sha256:${createHash("sha256").update(readFileSync(pyprojectPath)).digest("hex")}`;
+}
+
 function writeExecutable(filePath: string, content: string): void {
 	writeFileSync(filePath, content);
 	chmodSync(filePath, 0o755);
 }
 
-function writeBootstrapVersion(venv: string): void {
+function writeBootstrapVersion(venv: string, pythonSkills: readonly KernelPythonSkill[] = []): void {
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
 		`${JSON.stringify({
@@ -28,7 +33,12 @@ function writeBootstrapVersion(venv: string): void {
 			ipykernel: "ipykernel",
 			runtime: "prime-agent-runtime",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
-			pythonSkills: [],
+			pythonSkills: pythonSkills.map((skill) => ({
+				importName: skill.importName,
+				packagePath: skill.packagePath,
+				pyprojectPath: skill.pyprojectPath,
+				pyprojectHash: pyprojectHash(skill.pyprojectPath),
+			})),
 		})}\n`,
 	);
 }
@@ -85,7 +95,7 @@ function installFakeUv(): string {
 		join(binDir, "uv"),
 		[
 			"#!/bin/sh",
-			"set -eu",
+			"set -e",
 			'printf "%s\\n" "$*" >> "$UV_LOG"',
 			'if [ "$1" = "python" ]; then',
 			"  exit 0",
@@ -109,6 +119,11 @@ function installFakeUv(): string {
 			"  exit 0",
 			"fi",
 			'if [ "$1" = "pip" ]; then',
+			'  for arg in "$@"; do',
+			'    if [ "$UV_FAIL_ARG" != "" ] && [ "$arg" = "$UV_FAIL_ARG" ]; then',
+			"      exit 1",
+			"    fi",
+			"  done",
 			"  exit 0",
 			"fi",
 			"exit 2",
@@ -186,8 +201,84 @@ describe("kernel bootstrap", () => {
 				importName: pythonSkill.importName,
 				packagePath: pythonSkill.packagePath,
 				pyprojectPath: pythonSkill.pyprojectPath,
+				pyprojectHash: pyprojectHash(pythonSkill.pyprojectPath),
 			},
 		]);
+	});
+
+	it("rebuilds a warm venv when a Python skill pyproject changes", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const python = join(venv, "bin", "python");
+		const pythonSkill = createPythonSkill();
+		mkdirSync(join(venv, "bin"), { recursive: true });
+		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		writeBootstrapVersion(venv, [pythonSkill]);
+		writeFileSync(
+			pythonSkill.pyprojectPath,
+			`[project]
+name = "${pythonSkill.name}"
+version = "0.1.0"
+dependencies = ["httpx"]
+`,
+		);
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+
+		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(python);
+
+		const log = readFileSync(logPath, "utf8");
+		expect(log).toContain(`venv ${venv} --python 3.11 --seed`);
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version.pythonSkills[0].pyprojectHash).toBe(pyprojectHash(pythonSkill.pyprojectPath));
+	});
+
+	it("continues when a Python skill editable install fails", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const goodSkill = createPythonSkill("good-skill");
+		const brokenSkill = createPythonSkill("broken-skill");
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		process.env.UV_FAIL_ARG = brokenSkill.packagePath;
+
+		await expect(ensureKernelPython({ pythonSkills: [goodSkill, brokenSkill] })).resolves.toBe(
+			join(venv, "bin", "python"),
+		);
+
+		const log = readFileSync(logPath, "utf8");
+		expect(log).toContain(`--editable ${goodSkill.packagePath}`);
+		expect(log).toContain(`--editable ${brokenSkill.packagePath}`);
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version.pythonSkills).toHaveLength(2);
+	});
+
+	it("rebuilds a warm venv with legacy unhashed Python skill manifest entries", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const python = join(venv, "bin", "python");
+		const pythonSkill = createPythonSkill();
+		mkdirSync(join(venv, "bin"), { recursive: true });
+		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		writeFileSync(
+			join(venv, ".bootstrap-version"),
+			`${JSON.stringify({
+				schema: 4,
+				ipykernel: "ipykernel",
+				runtime: "prime-agent-runtime",
+				extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+				pythonSkills: [
+					{
+						importName: pythonSkill.importName,
+						packagePath: pythonSkill.packagePath,
+						pyprojectPath: pythonSkill.pyprojectPath,
+					},
+				],
+			})}\n`,
+		);
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+
+		await expect(ensureKernelPython()).resolves.toBe(python);
+
+		expect(readFileSync(logPath, "utf8")).toContain(`venv ${venv} --python 3.11 --seed`);
 	});
 
 	it("shares concurrent bootstrap work in one process", async () => {
@@ -260,15 +351,13 @@ describe("kernel bootstrap", () => {
 		await expect(ensureKernelPython()).resolves.toBe(overridePython);
 	});
 
-	it("rejects PRIME_AGENT_KERNEL_PYTHON missing Python skill imports", async () => {
+	it("allows PRIME_AGENT_KERNEL_PYTHON missing Python skill imports", async () => {
 		const overridePython = join(tempDir, "override-python");
 		const pythonSkill = createPythonSkill();
 		writeFakePython(overridePython, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
 
-		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).rejects.toThrow(
-			/Python skills \(web-search \(web_search\)\)/,
-		);
+		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(overridePython);
 	});
 
 	it("rejects PRIME_AGENT_KERNEL_PYTHON missing default extra packages", async () => {

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -232,7 +232,7 @@ dependencies = ["httpx"]
 		expect(version.pythonSkills[0].pyprojectHash).toBe(pyprojectHash(pythonSkill.pyprojectPath));
 	});
 
-	it("continues when a Python skill editable install fails", async () => {
+	it("continues when a Python skill editable install fails and retries it next startup", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
 		const goodSkill = createPythonSkill("good-skill");
@@ -248,7 +248,24 @@ dependencies = ["httpx"]
 		expect(log).toContain(`--editable ${goodSkill.packagePath}`);
 		expect(log).toContain(`--editable ${brokenSkill.packagePath}`);
 		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
-		expect(version.pythonSkills).toHaveLength(2);
+		expect(version.pythonSkills).toEqual([
+			{
+				importName: goodSkill.importName,
+				packagePath: goodSkill.packagePath,
+				pyprojectPath: goodSkill.pyprojectPath,
+				pyprojectHash: pyprojectHash(goodSkill.pyprojectPath),
+			},
+		]);
+
+		await expect(ensureKernelPython({ pythonSkills: [goodSkill, brokenSkill] })).resolves.toBe(
+			join(venv, "bin", "python"),
+		);
+
+		const retryLog = readFileSync(logPath, "utf8");
+		expect(retryLog.split("\n").filter((line) => line.startsWith(`venv ${venv} `))).toHaveLength(2);
+		expect(
+			retryLog.split("\n").filter((line) => line.includes(`--editable ${brokenSkill.packagePath}`)),
+		).toHaveLength(2);
 	});
 
 	it("rebuilds a warm venv with legacy unhashed Python skill manifest entries", async () => {

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -7,6 +7,7 @@ import {
 	DEFAULT_RLM_EXTRA_UV_ARGS,
 	ensureKernelPython,
 	getKernelVenvDir,
+	type KernelPythonSkill,
 } from "../src/core/kernel/bootstrap.js";
 
 let tempDir = "";
@@ -23,12 +24,34 @@ function writeBootstrapVersion(venv: string): void {
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
 		`${JSON.stringify({
-			schema: 3,
+			schema: 4,
 			ipykernel: "ipykernel",
 			runtime: "prime-agent-runtime",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+			pythonSkills: [],
 		})}\n`,
 	);
+}
+
+function createPythonSkill(name = "web-search"): KernelPythonSkill {
+	const packagePath = join(tempDir, "skills", name);
+	const importName = name.replaceAll("-", "_");
+	const pyprojectPath = join(packagePath, "pyproject.toml");
+	mkdirSync(join(packagePath, "src", importName), { recursive: true });
+	writeFileSync(
+		pyprojectPath,
+		`[project]
+name = "${name}"
+version = "0.1.0"
+`,
+	);
+	writeFileSync(join(packagePath, "src", importName, "__init__.py"), "async def run():\n    return 'ok'\n");
+	return {
+		name,
+		importName,
+		packagePath,
+		pyprojectPath,
+	};
 }
 
 function writeFakePython(filePath: string, importableModules: readonly string[]): void {
@@ -139,11 +162,32 @@ describe("kernel bootstrap", () => {
 		}
 		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
 		expect(version).toEqual({
-			schema: 3,
+			schema: 4,
 			ipykernel: "ipykernel",
 			runtime: "prime-agent-runtime",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+			pythonSkills: [],
 		});
+	});
+
+	it("installs Python skills into the bootstrapped venv", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const pythonSkill = createPythonSkill();
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+
+		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(join(venv, "bin", "python"));
+
+		const log = readFileSync(logPath, "utf8");
+		expect(log).toContain(`--editable ${pythonSkill.packagePath}`);
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version.pythonSkills).toEqual([
+			{
+				importName: pythonSkill.importName,
+				packagePath: pythonSkill.packagePath,
+				pyprojectPath: pythonSkill.pyprojectPath,
+			},
+		]);
 	});
 
 	it("shares concurrent bootstrap work in one process", async () => {
@@ -214,6 +258,17 @@ describe("kernel bootstrap", () => {
 		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
 
 		await expect(ensureKernelPython()).resolves.toBe(overridePython);
+	});
+
+	it("rejects PRIME_AGENT_KERNEL_PYTHON missing Python skill imports", async () => {
+		const overridePython = join(tempDir, "override-python");
+		const pythonSkill = createPythonSkill();
+		writeFakePython(overridePython, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		process.env.PRIME_AGENT_KERNEL_PYTHON = overridePython;
+
+		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).rejects.toThrow(
+			/Python skills \(web-search \(web_search\)\)/,
+		);
 	});
 
 	it("rejects PRIME_AGENT_KERNEL_PYTHON missing default extra packages", async () => {

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -206,7 +206,7 @@ describe("kernel bootstrap", () => {
 		]);
 	});
 
-	it("rebuilds a warm venv when a Python skill pyproject changes", async () => {
+	it("syncs a warm venv when a Python skill pyproject changes", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
 		const python = join(venv, "bin", "python");
@@ -227,7 +227,8 @@ dependencies = ["httpx"]
 		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(python);
 
 		const log = readFileSync(logPath, "utf8");
-		expect(log).toContain(`venv ${venv} --python 3.11 --seed`);
+		expect(log).not.toContain(`venv ${venv} --python 3.11 --seed`);
+		expect(log).toContain(`--editable ${pythonSkill.packagePath}`);
 		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
 		expect(version.pythonSkills[0].pyprojectHash).toBe(pyprojectHash(pythonSkill.pyprojectPath));
 	});
@@ -262,7 +263,7 @@ dependencies = ["httpx"]
 		);
 
 		const retryLog = readFileSync(logPath, "utf8");
-		expect(retryLog.split("\n").filter((line) => line.startsWith(`venv ${venv} `))).toHaveLength(2);
+		expect(retryLog.split("\n").filter((line) => line.startsWith(`venv ${venv} `))).toHaveLength(1);
 		expect(
 			retryLog.split("\n").filter((line) => line.includes(`--editable ${brokenSkill.packagePath}`)),
 		).toHaveLength(2);

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -461,6 +461,7 @@ Content`,
 				baseDir: "/fake",
 				sourceInfo: createSyntheticSourceInfo("/fake/path", { source: "custom" }),
 				disableModelInvocation: false,
+				kind: "markdown",
 			};
 			const loader = new DefaultResourceLoader({
 				cwd,

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -82,6 +82,7 @@ This is a test skill.
 			baseDir: "/fake/path",
 			sourceInfo: createSyntheticSourceInfo("/fake/path/SKILL.md", { source: "sdk" }),
 			disableModelInvocation: false,
+			kind: "markdown" as const,
 		};
 
 		const resourceLoader: ResourceLoader = {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -2,7 +2,14 @@ import { homedir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
 import type { ResourceDiagnostic } from "../src/core/diagnostics.js";
-import { formatSkillsForPrompt, loadSkills, loadSkillsFromDir, type Skill } from "../src/core/skills.js";
+import {
+	formatSkillsForPrompt,
+	getPythonSkillRuntimeInfo,
+	loadSkills,
+	loadSkillsFromDir,
+	type Skill,
+	type SkillPythonMetadata,
+} from "../src/core/skills.js";
 import { createSyntheticSourceInfo } from "../src/core/source-info.js";
 
 const fixturesDir = resolve(__dirname, "fixtures/skills");
@@ -14,9 +21,10 @@ function createTestSkill(options: {
 	filePath: string;
 	baseDir: string;
 	disableModelInvocation?: boolean;
+	python?: SkillPythonMetadata;
 	source?: string;
 }): Skill {
-	return {
+	const base = {
 		name: options.name,
 		description: options.description,
 		filePath: options.filePath,
@@ -24,6 +32,16 @@ function createTestSkill(options: {
 		sourceInfo: createSyntheticSourceInfo(options.filePath, { source: options.source ?? "test" }),
 		disableModelInvocation: options.disableModelInvocation ?? false,
 	};
+	return options.python
+		? {
+				...base,
+				kind: "python",
+				python: options.python,
+			}
+		: {
+				...base,
+				kind: "markdown",
+			};
 }
 
 describe("skills", () => {
@@ -219,6 +237,49 @@ describe("skills", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].disableModelInvocation).toBe(false);
 		});
+
+		it("should load Python-backed skills from the same skill root", () => {
+			const skillDir = join(fixturesDir, "python-skill");
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: skillDir,
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0]).toMatchObject({
+				name: "python-skill",
+				kind: "python",
+				python: {
+					importName: "python_skill",
+					packagePath: skillDir,
+					pyprojectPath: join(skillDir, "pyproject.toml"),
+				},
+			});
+			expect(getPythonSkillRuntimeInfo(skills)).toEqual([
+				{
+					name: "python-skill",
+					importName: "python_skill",
+					packagePath: skillDir,
+					pyprojectPath: join(skillDir, "pyproject.toml"),
+				},
+			]);
+			expect(diagnostics).toHaveLength(0);
+		});
+
+		it("should warn and keep metadata-only skills when Python package files are missing", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "python-package-missing"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].kind).toBe("markdown");
+			expect(
+				diagnostics.some((d: ResourceDiagnostic) =>
+					d.message.includes("python skill package src/python_package_missing/__init__.py not found"),
+				),
+			).toBe(true);
+		});
 	});
 
 	describe("formatSkillsForPrompt", () => {
@@ -243,8 +304,30 @@ describe("skills", () => {
 			expect(result).toContain("</available_skills>");
 			expect(result).toContain("<skill>");
 			expect(result).toContain("<name>test-skill</name>");
+			expect(result).toContain("<type>markdown</type>");
 			expect(result).toContain("<description>A test skill.</description>");
 			expect(result).toContain("<location>/path/to/skill/SKILL.md</location>");
+		});
+
+		it("should include Python import metadata for Python-backed skills", () => {
+			const skills: Skill[] = [
+				createTestSkill({
+					name: "python-skill",
+					description: "A Python skill.",
+					filePath: "/path/to/skill/SKILL.md",
+					baseDir: "/path/to/skill",
+					python: {
+						importName: "python_skill",
+						packagePath: "/path/to/skill",
+						pyprojectPath: "/path/to/skill/pyproject.toml",
+					},
+				}),
+			];
+
+			const result = formatSkillsForPrompt(skills);
+
+			expect(result).toContain("<type>python</type>");
+			expect(result).toContain("<python_import>python_skill</python_import>");
 		});
 
 		it("should include intro text before XML", () => {
@@ -262,7 +345,8 @@ describe("skills", () => {
 			const introText = result.substring(0, xmlStart);
 
 			expect(introText).toContain("The following skills provide specialized instructions");
-			expect(introText).toContain("Use ipython to load a skill's file");
+			expect(introText).toContain("Use ipython to inspect a skill's file");
+			expect(introText).toContain("Skills with a python_import are pre-installed");
 		});
 
 		it("should escape XML special characters", () => {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -1,4 +1,5 @@
-import { homedir } from "os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
 import type { ResourceDiagnostic } from "../src/core/diagnostics.js";
@@ -42,6 +43,30 @@ function createTestSkill(options: {
 				...base,
 				kind: "markdown",
 			};
+}
+
+function writePythonSkill(root: string, name: string): void {
+	const skillDir = join(root, name);
+	const importName = name.replaceAll("-", "_");
+	mkdirSync(join(skillDir, "src", importName), { recursive: true });
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		`---
+name: ${name}
+description: Test skill ${name}
+---
+
+Use this skill for tests.
+`,
+	);
+	writeFileSync(
+		join(skillDir, "pyproject.toml"),
+		`[project]
+name = "${name}"
+version = "0.1.0"
+`,
+	);
+	writeFileSync(join(skillDir, "src", importName, "__init__.py"), "async def run():\n    return 'ok'\n");
 }
 
 describe("skills", () => {
@@ -346,7 +371,7 @@ describe("skills", () => {
 
 			expect(introText).toContain("The following skills provide specialized instructions");
 			expect(introText).toContain("Use ipython to inspect a skill's file");
-			expect(introText).toContain("Skills with a python_import are pre-installed");
+			expect(introText).toContain("Skills with a python_import are prepared");
 		});
 
 		it("should escape XML special characters", () => {
@@ -471,6 +496,32 @@ describe("skills", () => {
 				includeDefaults: true,
 			});
 			expect(withTilde.length).toBe(withoutTilde.length);
+		});
+
+		it("should warn when Python skills share an import name", () => {
+			const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-skills-"));
+			try {
+				writePythonSkill(tempDir, "web-search");
+				writePythonSkill(tempDir, "web_search");
+
+				const { skills, diagnostics } = loadSkills({
+					agentDir: emptyAgentDir,
+					cwd: emptyCwd,
+					skillPaths: [tempDir],
+					includeDefaults: false,
+				});
+
+				expect(skills.map((skill) => skill.name).sort()).toEqual(["web-search", "web_search"]);
+				expect(
+					diagnostics.some((d: ResourceDiagnostic) =>
+						d.message.includes(
+							'python import name "web_search" is shared by skills "web-search" and "web_search"',
+						),
+					),
+				).toBe(true);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -159,6 +159,7 @@ describe("AgentSession prompt characterization", () => {
 						description: "Test skill",
 						filePath: skillPath,
 						disableModelInvocation: false,
+						kind: "markdown" as const,
 						baseDir: tempDir,
 						sourceInfo: createSyntheticSourceInfo(skillPath, {
 							source: "local",

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -53,8 +53,9 @@ describe("buildRlmPrompt", () => {
 				"Working directory: /repo",
 				"Conversation log: /repo/.pi/sessions/session.jsonl",
 				"",
-				"Installed Python skills (pre-imported): `websearch`.",
-				"Each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+				"Configured Python skills for IPython: `websearch`.",
+				"When available, each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+				"If a Python skill is unavailable, calling it raises a RuntimeError with the import error.",
 				"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
 				"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
@@ -170,14 +171,14 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt).not.toContain("Installed Python skills");
+		expect(prompt).not.toContain("Configured Python skills for IPython");
 		expect(prompt).toContain("<available_skills>");
 		expect(prompt).toContain("<name>websearch</name>");
 		expect(prompt).toContain("<type>markdown</type>");
 		expect(prompt).toContain("<location>/skills/websearch/SKILL.md</location>");
 	});
 
-	test("Python skills are pre-imported and included in skill metadata", () => {
+	test("Python skills are configured for IPython and included in skill metadata", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: ["ipython"],
 			contextFiles: [],
@@ -185,7 +186,7 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt).toContain("Installed Python skills (pre-imported): `web_search`.");
+		expect(prompt).toContain("Configured Python skills for IPython: `web_search`.");
 		expect(prompt).toContain("<name>web-search</name>");
 		expect(prompt).toContain("<type>python</type>");
 		expect(prompt).toContain("<python_import>web_search</python_import>");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -17,6 +17,20 @@ function skill(name: string): Skill {
 			origin: "top-level",
 		},
 		disableModelInvocation: false,
+		kind: "markdown",
+	};
+}
+
+function pythonSkill(name: string, importName = name.replaceAll("-", "_")): Skill {
+	const base = skill(name);
+	return {
+		...base,
+		kind: "python",
+		python: {
+			importName,
+			packagePath: `/skills/${name}`,
+			pyprojectPath: `/skills/${name}/pyproject.toml`,
+		},
 	};
 }
 
@@ -39,9 +53,9 @@ describe("buildRlmPrompt", () => {
 				"Working directory: /repo",
 				"Conversation log: /repo/.pi/sessions/session.jsonl",
 				"",
-				"Installed skills (pre-imported): `websearch`.",
-				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
-				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
+				"Installed Python skills (pre-imported): `websearch`.",
+				"Each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+				"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
 				"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 				"",
@@ -148,7 +162,7 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("## AGENTS.md\n\nproject rules");
 	});
 
-	test("skills are included in rlm harness prompts", () => {
+	test("markdown skills are included in rlm harness prompts without Python pre-imports", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: ["ipython"],
 			contextFiles: [],
@@ -156,10 +170,25 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt).toContain("Installed skills (pre-imported): `websearch`.");
+		expect(prompt).not.toContain("Installed Python skills");
 		expect(prompt).toContain("<available_skills>");
 		expect(prompt).toContain("<name>websearch</name>");
+		expect(prompt).toContain("<type>markdown</type>");
 		expect(prompt).toContain("<location>/skills/websearch/SKILL.md</location>");
+	});
+
+	test("Python skills are pre-imported and included in skill metadata", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: ["ipython"],
+			contextFiles: [],
+			skills: [pythonSkill("web-search")],
+			cwd: "/repo",
+		});
+
+		expect(prompt).toContain("Installed Python skills (pre-imported): `web_search`.");
+		expect(prompt).toContain("<name>web-search</name>");
+		expect(prompt).toContain("<type>python</type>");
+		expect(prompt).toContain("<python_import>web_search</python_import>");
 	});
 
 	test("prompt guidelines are appended and deduplicated", () => {

--- a/prime-agent-runtime/pyproject.toml
+++ b/prime-agent-runtime/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
   "ipykernel",
   "nest-asyncio",
+  "tyro",
 ]
 
 [build-system]

--- a/prime-agent-runtime/src/rlm/skill.py
+++ b/prime-agent-runtime/src/rlm/skill.py
@@ -1,0 +1,30 @@
+"""Shared CLI helpers for Prime Agent Python skills."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+import tyro
+
+
+async def run_cli(func: Callable[..., Any], prog: str | None = None) -> None:
+    """Parse CLI arguments for a skill function and print a non-None result."""
+    result = tyro.cli(func, prog=prog)
+    if inspect.isawaitable(result):
+        result = await result
+    if result is not None:
+        print(result)
+
+
+def cli() -> None:
+    """Run `<skill>.run` for a console script named after the skill import."""
+    prog = Path(sys.argv[0]).stem
+    module = __import__(prog)
+    run = getattr(module, "run", None)
+    if not callable(run):
+        raise RuntimeError(f"{prog} does not expose a callable run()")
+    asyncio.run(run_cli(run, prog=prog))

--- a/prime-agent-runtime/src/rlm/skill.py
+++ b/prime-agent-runtime/src/rlm/skill.py
@@ -21,9 +21,16 @@ async def run_cli(func: Callable[..., Any], prog: str | None = None) -> None:
 
 
 def cli() -> None:
-    """Run `<skill>.run` for a console script named after the skill import."""
+    """Run `<skill>.run` for a console script named exactly after the skill import."""
     prog = Path(sys.argv[0]).stem
-    module = __import__(prog)
+    try:
+        module = __import__(prog)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Could not import Python skill module {prog!r}. "
+            "The console-script name must match the skill import name exactly; "
+            "use underscores instead of dashes."
+        ) from exc
     run = getattr(module, "run", None)
     if not callable(run):
         raise RuntimeError(f"{prog} does not expose a callable run()")


### PR DESCRIPTION
- added python-backed skills that load through the existing skills discovery flow.
- installed active python skills into the persistent ipython kernel and pre-imported callable modules.
- added prompt and bootstrap coverage for markdown metadata and python imports.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Python-backed skills to the IPython kernel bootstrap and system prompt
> - Skills in directories with a `pyproject.toml` and a `src/<import_name>/` package layout are now recognized as Python skills, installed editably into the persistent kernel venv, and exposed by import name in the IPython environment.
> - `buildRlmBootstrapCode` wraps each skill import in `try/except`: available skills exposing a `run()` function become async callables; unavailable ones become placeholders that raise `RuntimeError` with the import error.
> - `ensureKernelPython` now accepts a `pythonSkills` list, tracks installs in the version file (schema bumped 3→4, triggering a venv rebuild), and syncs skills incrementally when only the skill set changes.
> - The system prompt now advertises Python skills by import name and updates guidance to describe callable behavior and `RuntimeError` on unavailable skills.
> - A new `rlm.skill` CLI entrypoint uses `tyro` (added as a dependency) to let Python skills expose a `console_scripts` entry point via `rlm.skill:cli`.
> - Risk: schema version bump from 3 to 4 will force a rebuild of all existing kernel environments on next startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ce87f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes kernel bootstrap, editable venv installs, and IPython startup behavior; failures are degraded gracefully but can affect agent sessions and local Python environments.
> 
> **Overview**
> Adds **Python-backed skills**: directories with `SKILL.md`, `pyproject.toml`, and `src/<import_name>/__init__.py` are detected as `kind: "python"`, installed editably into the managed IPython kernel venv, and exposed to the agent by import name (with optional `tyro`-based CLI via `rlm.skill:cli`).
> 
> Kernel bootstrap moves to **schema 4**, tracks per-skill `pyproject` hashes, syncs skills without full venv rebuild when only skill metadata changes, and surfaces install/import failures as warnings plus unavailable stubs in IPython instead of failing the whole kernel.
> 
> Prompts and skill XML now include **`<type>`** and **`<python_import>`**; only Python skills are listed as pre-configured IPython imports. Docs/README/changelog are updated for Prime Agent paths and the new skill model.
> 
> Integration tests in `packages/ai` retarget GitHub Copilot cases from **`gpt-4o`** to **`gpt-5-mini`** and one OpenRouter case to **`google/gemini-2.5-flash`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce87f5e39d9a95cd3b2d3594e206b46593852d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->