### PR TITLE
ask before preparing ipython runtime

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ prime_agent_screen_drawn=0
 prime_agent_screen_last_cols=0
 prime_agent_screen_last_rows=0
 prime_agent_download_dir=
+prime_agent_bootstrap_kernel_on_install=0
 prime_agent_screen_title=
 prime_agent_screen_status=
 prime_agent_screen_detail=
@@ -89,6 +90,7 @@ main() {
 	tarball_url="$prime_agent_base_url/releases/v$version/$tarball_name"
 
 	confirm_install "$version" "$tarball_url"
+	confirm_kernel_runtime_setup
 
 	download_dir=$(create_temp_dir)
 	prime_agent_download_dir="$download_dir"
@@ -1418,18 +1420,69 @@ confirm_install() {
 	exit 0
 }
 
+confirm_kernel_runtime_setup() {
+	case "${PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL:-}" in
+		1)
+			prime_agent_bootstrap_kernel_on_install=1
+			return
+			;;
+		0)
+			prime_agent_bootstrap_kernel_on_install=0
+			return
+			;;
+	esac
+
+	if prime_agent_prompt_yes_no \
+		"Prepare IPython runtime now?" \
+		"Installs uv, Python 3.11, ipykernel, and Prime Agent runtime." \
+		"Prepare? [Y/n]"; then
+		prime_agent_bootstrap_kernel_on_install=1
+		return
+	else
+		prompt_status=$?
+	fi
+
+	if [ "$prompt_status" -eq 2 ]; then
+		printf 'No terminal detected; preparing the IPython runtime during install.\n'
+		prime_agent_bootstrap_kernel_on_install=1
+		return
+	fi
+
+	prime_agent_bootstrap_kernel_on_install=0
+	if [ "$prime_agent_screen_enabled" = 1 ]; then
+		prime_agent_screen "IPython setup skipped" "" "The runtime can be prepared on first ipython use." ""
+		sleep 0.4
+	else
+		printf '\nSkipping IPython runtime setup.\n'
+	fi
+}
+
 install_prime_agent_package() {
 	tarball_path="$1"
-	npm_install_details="Preparing global install.
+	if [ "$prime_agent_bootstrap_kernel_on_install" = 1 ]; then
+		npm_install_details="Preparing global install.
+Linking command binaries.
+Installing runtime packages.
+Preloading search tools.
+Preparing IPython kernel.
+Finalizing npm install."
+		prime_agent_run_quiet_with_animation_steps \
+			"Installing Prime Agent" \
+			"Installing Prime Agent" \
+			"$npm_install_details" \
+			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1 PRIME_AGENT_INSTALL_UV=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+	else
+		npm_install_details="Preparing global install.
 Linking command binaries.
 Installing runtime packages.
 Preloading search tools.
 Finalizing npm install."
-	prime_agent_run_quiet_with_animation_steps \
-		"Installing Prime Agent" \
-		"Installing Prime Agent" \
-		"$npm_install_details" \
-		env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+		prime_agent_run_quiet_with_animation_steps \
+			"Installing Prime Agent" \
+			"Installing Prime Agent" \
+			"$npm_install_details" \
+			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+	fi
 }
 
 main "$@"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the release installer to ask before bootstrapping the IPython kernel runtime during install, avoiding default first-run `uv` prompts inside the TUI.
+
 ## [0.0.7] - 2026-06-01
 
 ### Added

--- a/packages/coding-agent/src/postinstall.ts
+++ b/packages/coding-agent/src/postinstall.ts
@@ -8,6 +8,10 @@ if (!bootstrapKernel && !bootstrapTools) {
 	process.exit(0);
 }
 
+if (bootstrapKernel && process.env.PRIME_AGENT_INSTALL_UV === undefined) {
+	process.env.PRIME_AGENT_INSTALL_UV = "1";
+}
+
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }


### PR DESCRIPTION
- the installer now asks before preparing the ipython runtime during install.
- accepting the prompt enables kernel bootstrap and only installs uv when it is missing.
- skipping the prompt keeps the package install going and leaves runtime setup for first ipython use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer UX and optional postinstall env defaults only; no auth or core agent logic changes.
> 
> **Overview**
> The release **install.sh** now asks whether to **prepare the IPython runtime during install** (after the main install confirmation), instead of always kicking off kernel bootstrap as part of the default flow.
> 
> **`confirm_kernel_runtime_setup`** honors **`PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL`** when set to `1` or `0`; otherwise it shows a **[Y/n]** prompt. With no TTY it still prepares the runtime automatically. If the user declines, **`npm install -g`** only passes **`PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1`** and defers kernel setup to first **`ipython`** use.
> 
> When the user accepts (or forces bootstrap), install runs with **`PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1`** and **`PRIME_AGENT_INSTALL_UV=1`**, and the installer animation adds an IPython-kernel step.
> 
> **`postinstall.ts`** sets **`PRIME_AGENT_INSTALL_UV=1`** when kernel bootstrap is requested and that variable was not already set, so **`uv`** can be installed during postinstall without extra first-run prompts in the TUI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f4cd7d1fe3f0a87842bb69b4e1032b884218b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ask before bootstrapping the IPython kernel runtime during install
> - Adds a `confirm_kernel_runtime_setup` function to [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/77/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) that prompts the user whether to prepare the IPython runtime before installation begins.
> - Respects the `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL` env var (1 to force, 0 to skip); in non-interactive contexts, bootstrap is enabled automatically.
> - When bootstrap is enabled, npm install runs with `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1`, `PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1`, and `PRIME_AGENT_INSTALL_UV=1`; the progress animation also includes an IPython-specific step.
> - [postinstall.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/77/files#diff-7ad5f703362453158c7061179b9ff708182aa81ed8a09e12d5f5bfe9b3b0ac6b) defaults `PRIME_AGENT_INSTALL_UV` to `"1"` during postinstall when kernel bootstrap is requested and the var is not already set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3f4cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->