### PR TITLE
Updated system prompt to clarify bash persistence and tweak behavior slightly.

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -15,7 +15,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	const allowRecursion = options.allowRecursion ?? true;
 	const activeTools = options.activeTools ?? [];
 	const parts = [
-		"You are a coding agent. You solve tasks by writing and executing code, observing results, and iterating one step at a time.",
+		"You are a general purpose agent that uses code to solve tasks.",
+		"You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
 		"When you are done, stop calling tools and state your final answer.",
 		"A Python project's interpreter can be in `PATH`. If not use the appropriate `.venv`.",
 		"",
@@ -55,6 +56,10 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+			"",
+			"Each `!cmd` and each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. To persist state, either chain dependent steps inside one cell (e.g. `!cd build && make`, or a single `%%bash` block that sources then uses a venv), or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `!` and `%%bash` calls.",
+			"",
+			"Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, and shell-output captures via `out = !cmd` (a list of lines) all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.",
 			"",
 			`The kernel has these Python imports available: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}. Import them directly; no pip install needed.`,
 		);


### PR DESCRIPTION
Super minimal changes, one to the main static system prompt and one to the iPython add-on to talk a bit more about Python usage and clarify on the bash magic fn persistence issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes with no runtime logic; risk is limited to possible agent behavior shifts from new instructions.
> 
> **Overview**
> Refines the default **RLM system prompt** in `buildRlmPrompt` so agents get clearer role framing and IPython execution semantics.
> 
> The opening identity shifts from a narrow “coding agent” line to a **general-purpose agent** that uses code, with an explicit emphasis on **breaking work into sub-tasks** before iterating. When `ipython` is active, two new guidance blocks are added: one explains that **`!` / `%%bash` run in throw-away subshells** (so `cd`, `export`, etc. do not persist) and documents **kernel-level persistence** via `%cd`, `os.environ`, or chaining in one cell; the other states that **Python kernel state persists** across cells (variables, imports, `out = !cmd`) and that **tool calls are `await`able** like normal Python for composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00909d461179d6eaec74bd8f0a13c87dc0fb4d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update system prompt in `buildRlmPrompt` to clarify bash persistence and agent role
> - Changes the agent role description from 'coding agent' to 'general purpose agent that uses code to solve tasks' and adds guidance on breaking tasks into sub-tasks.
> - Adds IPython-specific instructions explaining that `!cmd` and `%%bash` cells run in subshells (shell state does not persist) and how to work around this via command chaining or `%cd`/environment variables at the kernel level.
> - Adds a paragraph clarifying that Python kernel state (variables, imports, helpers, captured shell output) does persist across cells, and that tool calls are awaitable with return values usable in subsequent logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00909d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->