### PR TITLE
release 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.0.8",
+				"@earendil-works/pi-coding-agent": "^0.0.9",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5870,10 +5870,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.0.8",
+				"@earendil-works/pi-ai": "^0.0.9",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5900,7 +5900,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5942,13 +5942,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.0.8",
-				"@earendil-works/pi-ai": "^0.0.8",
-				"@earendil-works/pi-tui": "^0.0.8",
+				"@earendil-works/pi-agent-core": "^0.0.9",
+				"@earendil-works/pi-ai": "^0.0.9",
+				"@earendil-works/pi-tui": "^0.0.9",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6100,7 +6100,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.0.8",
+		"@earendil-works/pi-coding-agent": "^0.0.9",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.0.8",
+		"@earendil-works/pi-ai": "^0.0.9",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -41,9 +41,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.0.8",
-		"@earendil-works/pi-ai": "^0.0.8",
-		"@earendil-works/pi-tui": "^0.0.8",
+		"@earendil-works/pi-agent-core": "^0.0.9",
+		"@earendil-works/pi-ai": "^0.0.9",
+		"@earendil-works/pi-tui": "^0.0.9",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps published package versions and internal ranges to 0.0.9.
- refreshes the lockfile for the release branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no runtime, auth, or logic changes in the diff.
> 
> **Overview**
> **Release 0.0.9** — lockstep version bump across the `prime-agent` monorepo with no application source changes in this diff.
> 
> Root `package.json`, workspace packages (`@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`), and internal `^0.0.9` dependency ranges move from **0.0.8** to **0.0.9**. `package-lock.json` is updated so resolved workspace versions and the root dependency on `@earendil-works/pi-coding-agent` match the new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887b55efbf6a5b02a95f86fd9abd0a91d2b6e1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.0.9 across all packages
> Bumps the version field from 0.0.8 to 0.0.9 in all workspace packages ([package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/84/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [packages/ai](https://github.com/PrimeIntellect-ai/prime-agent/pull/84/files#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2df), [packages/tui](https://github.com/PrimeIntellect-ai/prime-agent/pull/84/files#diff-a8d45caab701ce8207cd9a7e7579e5f26ddd9b0a9faa7744cabbdf9d51dfbbc7), [packages/agent](https://github.com/PrimeIntellect-ai/prime-agent/pull/84/files#diff-f0f4adde46deb8e106c88cfb5dbf48155b8261ff0d73ada3429381a40e9bb3ba), [packages/coding-agent](https://github.com/PrimeIntellect-ai/prime-agent/pull/84/files#diff-8539bf3a7fb8b77848c0018f167f04fac756a980228bd467182af459cd8c5674)) and updates all internal `@earendil-works/*` dependency ranges to `^0.0.9`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 887b55e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->