### PR TITLE
add child-agent keybinding hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed child-agent navigation to show contextual keybinding hints and a visible focused tray marker.
 - Fixed the release installer to ask before bootstrapping the IPython kernel runtime during install, avoiding default first-run `uv` prompts inside the TUI.
 
 ## [0.0.7] - 2026-06-01

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -6,6 +6,24 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
+	const quiet = (text: string) => theme.fg("thinkingText", text);
+	return {
+		...baseTheme,
+		heading: quiet,
+		link: quiet,
+		linkUrl: quiet,
+		code: quiet,
+		codeBlock: quiet,
+		codeBlockBorder: quiet,
+		quote: quiet,
+		quoteBorder: quiet,
+		hr: quiet,
+		listBullet: quiet,
+		highlightCode: (code: string) => code.split("\n").map((line) => quiet(line)),
+	};
+}
+
 /**
  * Component that renders a complete assistant message
  */
@@ -107,11 +125,10 @@ export class AssistantMessageComponent extends Container {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				} else {
-					// Thinking traces in thinkingText color, italic
+					// Thinking traces keep Markdown structure but stay visually quiet.
 					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+						new Markdown(content.thinking.trim(), 1, 0, getThinkingMarkdownTheme(this.markdownTheme), {
 							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
 						}),
 					);
 					if (hasVisibleContentAfter) {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -3,6 +3,7 @@ import {
 	type Component,
 	type Focusable,
 	getKeybindings,
+	type Keybinding,
 	type MarkdownTheme,
 	Text,
 	type TUI,
@@ -13,6 +14,7 @@ import {
 import type { ToolDefinition } from "../../../core/extensions/types.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
+import { keyText } from "./keybinding-hints.js";
 import { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";
 import { UserMessageComponent } from "./user-message.js";
 
@@ -118,6 +120,27 @@ function pluralize(count: number, singular: string, plural = `${singular}s`): st
 	return count === 1 ? singular : plural;
 }
 
+function keyAction(keybinding: Keybinding, description: string): string | undefined {
+	const keys = keyText(keybinding).trim();
+	return keys ? `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}` : undefined;
+}
+
+function combinedKeyAction(keybindings: readonly Keybinding[], description: string): string | undefined {
+	const keys = keybindings
+		.map((keybinding) => keyText(keybinding).trim())
+		.filter((key) => key.length > 0)
+		.join("/");
+	return keys ? `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}` : undefined;
+}
+
+function joinHints(hints: ReadonlyArray<string | undefined>): string {
+	return hints.filter((hint) => hint !== undefined).join(theme.fg("dim", " · "));
+}
+
+function hintLine(hints: ReadonlyArray<string | undefined>, width: number): string {
+	return truncateToWidth(joinHints(hints), width, "");
+}
+
 export class ChildAgentSummaryComponent implements Component, Focusable {
 	focused = false;
 	private readonly paddingX = 1;
@@ -163,7 +186,8 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const location = !override && locationLabel ? theme.fg("muted", locationLabel) : "";
 		const context = contextLabel ? theme.fg("muted", contextLabel) : "";
 		const subagents = !override && flat.length > 0 ? this.subagentSummary(flat, this.focused) : "";
-		const leftSegments = [override, location, subagents].filter((segment) => segment.length > 0);
+		const summaryHint = !override && this.focused && flat.length > 0 ? this.summaryHint() : "";
+		const leftSegments = [override, location, subagents, summaryHint].filter((segment) => segment.length > 0);
 		if (leftSegments.length === 0 && !context) {
 			return [];
 		}
@@ -220,7 +244,14 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 				? `${running} ${pluralize(running, "subagent")} running`
 				: `${flat.length} ${pluralize(flat.length, "subagent")}`;
 		const rendered = theme.bold(summary);
-		return selected ? theme.bg("selectedBg", rendered) : rendered;
+		if (!selected) {
+			return rendered;
+		}
+		return theme.bg("selectedBg", `${theme.fg("accent", "▌")} ${rendered}`);
+	}
+
+	private summaryHint(): string {
+		return joinHints([keyAction("tui.select.confirm", "open"), keyAction("tui.select.cancel", "editor")]);
 	}
 }
 
@@ -304,23 +335,23 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		const running = countRunning(flat);
 		const targetHeight = Math.max(0, this.getViewportHeight());
 		const lines: InspectorLine[] = [{ text: this.headerLine(running, flat.length, contentWidth), selected: false }];
-		const availableRows = targetHeight > 0 ? Math.max(0, targetHeight - 2) : flat.length;
-		if (availableRows === 0) {
-			return lines;
-		}
+		const availableRows = targetHeight > 0 ? Math.max(0, targetHeight - 3) : flat.length;
 
 		const selectedIndex = Math.max(
 			0,
 			flat.findIndex((entry) => entry.node.id === this.selectedId),
 		);
 		const start = Math.max(0, Math.min(selectedIndex - Math.floor(availableRows / 2), flat.length - availableRows));
-		for (const entry of flat.slice(start, start + availableRows)) {
-			const selected = this.focused && entry.node.id === this.selectedId;
-			lines.push({ text: this.renderListEntry(entry, contentWidth, selected), selected });
+		if (availableRows > 0) {
+			for (const entry of flat.slice(start, start + availableRows)) {
+				const selected = this.focused && entry.node.id === this.selectedId;
+				lines.push({ text: this.renderListEntry(entry, contentWidth, selected), selected });
+			}
 		}
-		while (targetHeight > 0 && lines.length < targetHeight - 1) {
+		while (targetHeight > 0 && lines.length < targetHeight - 2) {
 			lines.push({ text: "", selected: false });
 		}
+		lines.push({ text: this.listHintLine(contentWidth), selected: false });
 		return lines;
 	}
 
@@ -353,6 +384,17 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			running > 0 ? theme.fg("muted", `${running} running · ${total} total`) : theme.fg("muted", `${total} total`);
 		const gap = " ".repeat(Math.max(1, width - visibleWidth(left) - visibleWidth(right)));
 		return this.truncate(`${left}${gap}${right}`, width);
+	}
+
+	private listHintLine(width: number): string {
+		return hintLine(
+			[
+				combinedKeyAction(["tui.select.up", "tui.select.down"], "move"),
+				keyAction("tui.select.confirm", "open"),
+				keyAction("tui.select.cancel", "close"),
+			],
+			width,
+		);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {
@@ -411,7 +453,12 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	render(width: number): string[] {
 		const safeWidth = Math.max(1, width);
 		const sections = this.renderDetail(safeWidth);
-		return [...sections.headerLines, ...sections.bodyLines];
+		return [
+			...sections.headerLines,
+			...sections.bodyLines,
+			this.panelLine(theme.fg("borderMuted", "─".repeat(safeWidth)), safeWidth),
+			this.panelLine(this.detailHintLine(safeWidth), safeWidth),
+		];
 	}
 
 	handleInput(data: string): void {
@@ -537,6 +584,10 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 		const plainWidth = visibleWidth(text);
 		const rule = "─".repeat(Math.max(1, width - plainWidth - 1));
 		return this.truncate(`${text} ${theme.fg("borderMuted", rule)}`, width);
+	}
+
+	private detailHintLine(width: number): string {
+		return hintLine([keyAction("tui.select.cancel", "back to subagents")], width);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -120,8 +120,12 @@ function pluralize(count: number, singular: string, plural = `${singular}s`): st
 	return count === 1 ? singular : plural;
 }
 
-function keyAction(keybinding: Keybinding, description: string): string | undefined {
-	const keys = keyText(keybinding).trim();
+interface KeyActionOptions {
+	primaryOnly?: boolean;
+}
+
+function keyAction(keybinding: Keybinding, description: string, options: KeyActionOptions = {}): string | undefined {
+	const keys = keyText(keybinding, options).trim();
 	return keys ? `${theme.fg("dim", keys)}${theme.fg("muted", ` ${description}`)}` : undefined;
 }
 
@@ -247,11 +251,11 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		if (!selected) {
 			return rendered;
 		}
-		return theme.bg("selectedBg", `${theme.fg("accent", "▌")} ${rendered}`);
+		return theme.bg("selectedBg", rendered);
 	}
 
 	private summaryHint(): string {
-		return joinHints([keyAction("tui.select.confirm", "open"), keyAction("tui.select.cancel", "editor")]);
+		return joinHints([keyAction("tui.select.confirm", "open")]);
 	}
 }
 
@@ -345,7 +349,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		if (availableRows > 0) {
 			for (const entry of flat.slice(start, start + availableRows)) {
 				const selected = this.focused && entry.node.id === this.selectedId;
-				lines.push({ text: this.renderListEntry(entry, contentWidth, selected), selected });
+				lines.push({ text: this.renderListEntry(entry, contentWidth), selected });
 			}
 		}
 		while (targetHeight > 0 && lines.length < targetHeight - 2) {
@@ -355,10 +359,9 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		return lines;
 	}
 
-	private renderListEntry(entry: FlatChildAgentNode, width: number, selected: boolean): string {
-		const selector = selected ? theme.fg("accent", "▌") : " ";
+	private renderListEntry(entry: FlatChildAgentNode, width: number): string {
 		const indent = " ".repeat(Math.min(6, entry.depth * 2));
-		const line = `${selector} ${indent}${this.statusLabel(entry.node.status)} ${theme.fg("dim", "·")} ${theme.fg("muted", entry.node.label)}`;
+		const line = `  ${indent}${this.statusLabel(entry.node.status)} ${theme.fg("dim", "·")} ${theme.fg("muted", entry.node.label)}`;
 		return this.truncate(line, width, "…");
 	}
 	private flatten(): FlatChildAgentNode[] {
@@ -391,7 +394,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			[
 				combinedKeyAction(["tui.select.up", "tui.select.down"], "move"),
 				keyAction("tui.select.confirm", "open"),
-				keyAction("tui.select.cancel", "close"),
+				keyAction("tui.select.cancel", "close", { primaryOnly: true }),
 			],
 			width,
 		);
@@ -587,7 +590,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	private detailHintLine(width: number): string {
-		return hintLine([keyAction("tui.select.cancel", "back to subagents")], width);
+		return hintLine([keyAction("tui.select.cancel", "back to subagents", { primaryOnly: true })], width);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {

--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -5,20 +5,29 @@
 import { getKeybindings, type Keybinding, type KeyId } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
 
-function formatKeys(keys: KeyId[]): string {
-	if (keys.length === 0) return "";
-	if (keys.length === 1) return keys[0]!;
-	return keys.join("/");
+export interface KeyTextOptions {
+	primaryOnly?: boolean;
 }
 
-export function keyText(keybinding: Keybinding): string {
-	return formatKeys(getKeybindings().getKeys(keybinding));
+function formatKey(key: KeyId | string): string {
+	return key === "escape" ? "esc" : key;
 }
 
-export function keyHint(keybinding: Keybinding, description: string): string {
-	return theme.fg("dim", keyText(keybinding)) + theme.fg("muted", ` ${description}`);
+function formatKeys(keys: KeyId[], options: KeyTextOptions = {}): string {
+	const displayKeys = (options.primaryOnly ? keys.slice(0, 1) : keys).map((key) => formatKey(key));
+	if (displayKeys.length === 0) return "";
+	if (displayKeys.length === 1) return displayKeys[0]!;
+	return displayKeys.join("/");
+}
+
+export function keyText(keybinding: Keybinding, options: KeyTextOptions = {}): string {
+	return formatKeys(getKeybindings().getKeys(keybinding), options);
+}
+
+export function keyHint(keybinding: Keybinding, description: string, options: KeyTextOptions = {}): string {
+	return theme.fg("dim", keyText(keybinding, options)) + theme.fg("muted", ` ${description}`);
 }
 
 export function rawKeyHint(key: string, description: string): string {
-	return theme.fg("dim", key) + theme.fg("muted", ` ${description}`);
+	return theme.fg("dim", formatKey(key)) + theme.fg("muted", ` ${description}`);
 }

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -258,8 +258,8 @@ export class SettingsSelectorComponent extends Container {
 			},
 			{
 				id: "double-escape-action",
-				label: "Double-escape action",
-				description: "Action when pressing Escape twice with empty editor",
+				label: "Double-esc action",
+				description: "Action when pressing esc twice with empty editor",
 				currentValue: config.doubleEscapeAction,
 				values: ["tree", "fork", "none"],
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6233,7 +6233,7 @@ export class InteractiveMode {
 			.map((k) =>
 				k
 					.split("+")
-					.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+					.map((part) => (part === "esc" ? part : part.charAt(0).toUpperCase() + part.slice(1)))
 					.join("+"),
 			)
 			.join("/");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -785,6 +785,7 @@ export class InteractiveMode {
 						hint("app.model.select", "to select model"),
 						hint("app.tools.expand", "to expand tools"),
 						hint("app.thinking.toggle", "to expand thinking"),
+						hint("app.subagents.focus", "to inspect subagents"),
 						hint("app.editor.external", "for external editor"),
 						rawKeyHint("/", "for commands"),
 						rawKeyHint("!", "to run bash"),
@@ -6289,6 +6290,7 @@ export class InteractiveMode {
 		const selectModel = this.getAppKeyDisplay("app.model.select");
 		const expandTools = this.getAppKeyDisplay("app.tools.expand");
 		const toggleThinking = this.getAppKeyDisplay("app.thinking.toggle");
+		const focusSubagents = this.getAppKeyDisplay("app.subagents.focus");
 		const externalEditor = this.getAppKeyDisplay("app.editor.external");
 		const cycleModelBackward = this.getAppKeyDisplay("app.model.cycleBackward");
 		const followUp = this.getAppKeyDisplay("app.message.followUp");
@@ -6333,6 +6335,7 @@ export class InteractiveMode {
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |
 | \`${toggleThinking}\` | Toggle thinking block visibility |
+| \`${focusSubagents}\` | Open subagent inspector |
 | \`${externalEditor}\` | Edit message in external editor |
 | \`${followUp}\` | Queue follow-up message |
 | \`${dequeue}\` | Restore queued messages |

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -167,10 +167,11 @@ export type ThemeBg =
 type ColorMode = "truecolor" | "256color";
 
 const ADAPTIVE_LIGHT_BG_ACCENT: Rgb = { r: 0, g: 95, b: 135 };
-const DARK_EDITOR_SURFACE_ALPHA = 0.06;
-const LIGHT_EDITOR_SURFACE_ALPHA = 0.04;
+const SURFACE_MIN_LUMINANCE_DELTA = 12;
+const SURFACE_CONTRAST_ALPHA = 0.08;
 const BLACK: Rgb = { r: 0, g: 0, b: 0 };
 const WHITE: Rgb = { r: 255, g: 255, b: 255 };
+const CUBE_VALUES = [0, 95, 135, 175, 215, 255] as const;
 
 // ============================================================================
 // Color Utilities
@@ -215,6 +216,57 @@ function hexToRgb(hex: string): { r: number; g: number; b: number } {
 		throw new Error(`Invalid hex color: ${hex}`);
 	}
 	return { r, g, b };
+}
+
+function ansi256ToRgb(index: number): Rgb | undefined {
+	if (index < 0 || index > 255) {
+		return undefined;
+	}
+	if (index < 16) {
+		const basicColors: Rgb[] = [
+			{ r: 0, g: 0, b: 0 },
+			{ r: 128, g: 0, b: 0 },
+			{ r: 0, g: 128, b: 0 },
+			{ r: 128, g: 128, b: 0 },
+			{ r: 0, g: 0, b: 128 },
+			{ r: 128, g: 0, b: 128 },
+			{ r: 0, g: 128, b: 128 },
+			{ r: 192, g: 192, b: 192 },
+			{ r: 128, g: 128, b: 128 },
+			{ r: 255, g: 0, b: 0 },
+			{ r: 0, g: 255, b: 0 },
+			{ r: 255, g: 255, b: 0 },
+			{ r: 0, g: 0, b: 255 },
+			{ r: 255, g: 0, b: 255 },
+			{ r: 0, g: 255, b: 255 },
+			{ r: 255, g: 255, b: 255 },
+		];
+		return basicColors[index];
+	}
+	if (index >= 232) {
+		const value = 8 + (index - 232) * 10;
+		return { r: value, g: value, b: value };
+	}
+	const cubeIndex = index - 16;
+	return {
+		r: CUBE_VALUES[Math.floor(cubeIndex / 36)]!,
+		g: CUBE_VALUES[Math.floor((cubeIndex % 36) / 6)]!,
+		b: CUBE_VALUES[cubeIndex % 6]!,
+	};
+}
+
+function colorValueToRgb(value: string | number | undefined): Rgb | undefined {
+	if (typeof value === "number") {
+		return ansi256ToRgb(value);
+	}
+	if (!value || !value.startsWith("#")) {
+		return undefined;
+	}
+	return hexToRgb(value);
+}
+
+function luminance(rgb: Rgb): number {
+	return 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b;
 }
 
 function hexTo256(hex: string): number {
@@ -290,6 +342,7 @@ export class Theme {
 	sourceInfo?: SourceInfo;
 	private fgColors: Map<ThemeColor, string>;
 	private bgColors: Map<ThemeBg, string>;
+	private bgColorValues: Map<ThemeBg, string | number>;
 	private mode: ColorMode;
 
 	constructor(
@@ -310,6 +363,7 @@ export class Theme {
 		for (const [key, value] of Object.entries(bgColors) as [ThemeBg, string | number][]) {
 			this.bgColors.set(key, bgAnsi(value, mode));
 		}
+		this.bgColorValues = new Map(Object.entries(bgColors) as [ThemeBg, string | number][]);
 	}
 
 	fg(color: ThemeColor, text: string): string {
@@ -325,23 +379,32 @@ export class Theme {
 	}
 
 	getEditorBackgroundColor(): ((str: string) => string) | undefined {
-		const terminalBg = getDefaultTerminalColors()?.background;
-		if (!terminalBg) {
-			return undefined;
-		}
-
-		const top = isLightColor(terminalBg) ? BLACK : WHITE;
-		const alpha = isLightColor(terminalBg) ? LIGHT_EDITOR_SURFACE_ALPHA : DARK_EDITOR_SURFACE_ALPHA;
-		const color = bestAnsiColor(blendColor(top, terminalBg, alpha), this.mode);
-		if (color === "") {
-			return undefined;
-		}
-		const ansi = bgAnsi(color, this.mode);
-		return (str: string) => `${ansi}${str}\x1b[49m`;
+		return this.surfaceBackgroundColor("userMessageBg");
 	}
 
 	getUserMessageBackgroundColor(): (str: string) => string {
-		return (str: string) => this.getEditorBackgroundColor()?.(str) ?? str;
+		return this.surfaceBackgroundColor("userMessageBg");
+	}
+
+	private surfaceBackgroundColor(color: ThemeBg): (str: string) => string {
+		const terminalBg = getDefaultTerminalColors()?.background;
+		const surfaceRgb = colorValueToRgb(this.bgColorValues.get(color));
+		if (!terminalBg || !surfaceRgb) {
+			return (str: string) => this.bg(color, str);
+		}
+
+		const delta = Math.abs(luminance(surfaceRgb) - luminance(terminalBg));
+		if (delta >= SURFACE_MIN_LUMINANCE_DELTA) {
+			return (str: string) => this.bg(color, str);
+		}
+
+		const top = isLightColor(terminalBg) ? BLACK : WHITE;
+		const adjustedColor = bestAnsiColor(blendColor(top, surfaceRgb, SURFACE_CONTRAST_ALPHA), this.mode);
+		if (adjustedColor === "") {
+			return (str: string) => this.bg(color, str);
+		}
+		const ansi = bgAnsi(adjustedColor, this.mode);
+		return (str: string) => `${ansi}${str}\x1b[49m`;
 	}
 
 	getAdaptiveAccentColor(): (str: string) => string {
@@ -1119,7 +1182,7 @@ export function getSelectListTheme(): SelectListTheme {
 
 export function getEditorTheme(): EditorTheme {
 	return {
-		borderColor: theme.getAdaptiveAccentColor(),
+		borderColor: (text: string) => theme.fg("borderMuted", text),
 		backgroundColor: theme.getEditorBackgroundColor(),
 		selectList: getSelectListTheme(),
 	};

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -3,6 +3,7 @@ import { type Component, TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test } from "vitest";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.js";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
 import {
 	ChildAgentDetailComponent,
 	ChildAgentInspectorComponent,
@@ -313,6 +314,22 @@ describe("marquee TUI components", () => {
 		expect(expanded).toContain("assistant: no anomaly found in this shard");
 	});
 
+	test("renders assistant thinking as quiet text without background styling", () => {
+		const component = new AssistantMessageComponent(
+			createAssistantMessage("answer", "Check **bold** and `code` first.\n```ts\nconst value = 1;\n```"),
+		);
+
+		const rendered = component.render(80).join("\n");
+		const plain = stripAnsi(rendered);
+
+		expect(plain).toContain("Check bold and code first.");
+		expect(plain).not.toContain("**bold**");
+		expect(plain).not.toContain("`code`");
+		expect(plain).not.toContain("```ts");
+		expect(plain).toContain("const value = 1;");
+		expect(rendered).not.toMatch(/\x1b\[(?:4\d|10\d|48;)/);
+	});
+
 	test("renders child agent summary and bounded inspector list", () => {
 		const summary = new ChildAgentSummaryComponent(
 			() => "agents-sidebar",
@@ -383,10 +400,11 @@ describe("marquee TUI components", () => {
 		expect(focusedSummary).toContain("agents-sidebar");
 		expect(focusedSummary).toContain("37% context left");
 		expect(focusedSummary).toContain("1 subagent running");
-		expect(focusedSummary).toContain("▌");
+		expect(focusedSummary).not.toContain("▌");
 		const focusedSummaryWide = stripAnsi(summary.render(96).join("\n"));
 		expect(focusedSummaryWide).toContain("enter open");
-		expect(focusedSummaryWide).toContain("escape/ctrl+c editor");
+		expect(focusedSummaryWide).not.toContain("editor");
+		expect(focusedSummaryWide).not.toContain("ctrl+c");
 		const summaryRow = summary.render(60).at(-1) ?? "";
 		expect(visibleWidth(summaryRow)).toBe(60);
 		expect(stripAnsi(summaryRow).endsWith("37% context left")).toBe(true);
@@ -416,14 +434,16 @@ describe("marquee TUI components", () => {
 		const wideList = stripAnsi(component.render(96).join("\n"));
 		expect(wideList).toContain("up/down move");
 		expect(wideList).toContain("enter open");
-		expect(wideList).toContain("escape/ctrl+c close");
+		expect(wideList).toContain("esc close");
+		expect(wideList).not.toContain("ctrl+c close");
 		for (const line of component.render(96)) {
 			expect(visibleWidth(line)).toBe(96);
 		}
 
 		component.focused = true;
 		const focused = stripAnsi(component.render(42).join("\n"));
-		expect(focused).toContain("▌ running · inspect training logs");
+		expect(focused).not.toContain("▌");
+		expect(focused).toContain("running · inspect training logs");
 		expect(focused).not.toContain("assistant: reading shard metrics");
 
 		let openedNodeId: string | undefined;
@@ -445,14 +465,15 @@ describe("marquee TUI components", () => {
 		expect(detail).toContain("reading shard metrics");
 		expect(detail).toContain("$ echo hi");
 		expect(detail).toContain("hi");
-		expect(detail).toContain("escape/ctrl+c back to subagents");
+		expect(detail).toContain("esc back to subagents");
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 		expect(detail).not.toContain("tool: bash");
 
 		component.handleInput("\x1b");
 		const returned = stripAnsi(component.render(42).join("\n"));
-		expect(returned).toContain("▌ running · inspect training logs");
+		expect(returned).not.toContain("▌");
+		expect(returned).toContain("running · inspect training logs");
 		expect(returned).not.toContain("assistant: reading shard metrics");
 
 		for (const line of component.render(42)) {
@@ -503,7 +524,7 @@ describe("marquee TUI components", () => {
 		const first = stripAnsi(firstLines.join("\n"));
 		expect(first).toContain("fallback transcript row 01");
 		expect(first).toContain("fallback transcript row 12");
-		expect(first).toContain("escape/ctrl+c back to subagents");
+		expect(first).toContain("esc back to subagents");
 		expect(first).not.toContain("↑");
 		expect(first).not.toContain("↓");
 		expect(firstLines.length).toBeGreaterThan(6);

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -383,7 +383,10 @@ describe("marquee TUI components", () => {
 		expect(focusedSummary).toContain("agents-sidebar");
 		expect(focusedSummary).toContain("37% context left");
 		expect(focusedSummary).toContain("1 subagent running");
-		expect(focusedSummary).not.toContain("▌");
+		expect(focusedSummary).toContain("▌");
+		const focusedSummaryWide = stripAnsi(summary.render(96).join("\n"));
+		expect(focusedSummaryWide).toContain("enter open");
+		expect(focusedSummaryWide).toContain("escape/ctrl+c editor");
 		const summaryRow = summary.render(60).at(-1) ?? "";
 		expect(visibleWidth(summaryRow)).toBe(60);
 		expect(stripAnsi(summaryRow).endsWith("37% context left")).toBe(true);
@@ -410,6 +413,10 @@ describe("marquee TUI components", () => {
 		expect(compact).not.toContain("└─");
 		expect(compact).not.toContain("├─");
 		expect(compact).not.toContain("assistant: reading shard metrics");
+		const wideList = stripAnsi(component.render(96).join("\n"));
+		expect(wideList).toContain("up/down move");
+		expect(wideList).toContain("enter open");
+		expect(wideList).toContain("escape/ctrl+c close");
 		for (const line of component.render(96)) {
 			expect(visibleWidth(line)).toBe(96);
 		}
@@ -438,6 +445,7 @@ describe("marquee TUI components", () => {
 		expect(detail).toContain("reading shard metrics");
 		expect(detail).toContain("$ echo hi");
 		expect(detail).toContain("hi");
+		expect(detail).toContain("escape/ctrl+c back to subagents");
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 		expect(detail).not.toContain("tool: bash");
@@ -495,6 +503,7 @@ describe("marquee TUI components", () => {
 		const first = stripAnsi(firstLines.join("\n"));
 		expect(first).toContain("fallback transcript row 01");
 		expect(first).toContain("fallback transcript row 12");
+		expect(first).toContain("escape/ctrl+c back to subagents");
 		expect(first).not.toContain("↑");
 		expect(first).not.toContain("↓");
 		expect(firstLines.length).toBeGreaterThan(6);

--- a/packages/coding-agent/test/theme-adaptive.test.ts
+++ b/packages/coding-agent/test/theme-adaptive.test.ts
@@ -2,9 +2,6 @@ import { clearDefaultTerminalColors, setDefaultTerminalColors } from "@earendil-
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getEditorTheme, initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
-const BOLD_CYAN = "\x1b[36m\x1b[1mx\x1b[22m\x1b[39m";
-const BOLD_DARK_CYAN_TRUECOLOR = "\x1b[38;2;0;95;135m\x1b[1mx\x1b[22m\x1b[39m";
-
 describe("adaptive TUI theme colors", () => {
 	let previousColorTerm: string | undefined;
 	let previousColorFgBg: string | undefined;
@@ -32,14 +29,14 @@ describe("adaptive TUI theme colors", () => {
 		}
 	});
 
-	it("uses no editor background fill when the terminal background is unknown", () => {
+	it("uses theme colors for editor chrome when the terminal background is unknown", () => {
 		const editorTheme = getEditorTheme();
 
-		expect(editorTheme.backgroundColor).toBeUndefined();
-		expect(editorTheme.borderColor("x")).toBe(BOLD_CYAN);
+		expect(editorTheme.backgroundColor?.("x")).toBe(theme.bg("userMessageBg", "x"));
+		expect(editorTheme.borderColor("x")).toBe(theme.fg("borderMuted", "x"));
 	});
 
-	it("lightens dark terminal backgrounds for the editor input surface", () => {
+	it("keeps theme editor chrome on dark terminal backgrounds", () => {
 		setDefaultTerminalColors({
 			foreground: { r: 255, g: 255, b: 255 },
 			background: { r: 0, g: 0, b: 0 },
@@ -47,11 +44,24 @@ describe("adaptive TUI theme colors", () => {
 
 		const editorTheme = getEditorTheme();
 
-		expect(editorTheme.backgroundColor?.("x")).toBe("\x1b[48;2;15;15;15mx\x1b[49m");
-		expect(editorTheme.borderColor("x")).toBe(BOLD_CYAN);
+		expect(editorTheme.backgroundColor?.("x")).toBe(theme.bg("userMessageBg", "x"));
+		expect(editorTheme.borderColor("x")).toBe(theme.fg("borderMuted", "x"));
 	});
 
-	it("darkens light terminal backgrounds and uses a darker cyan accent", () => {
+	it("nudges the editor surface when it matches the terminal background", () => {
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 26, g: 26, b: 31 },
+		});
+
+		const editorTheme = getEditorTheme();
+
+		expect(editorTheme.backgroundColor?.("x")).not.toBe(theme.bg("userMessageBg", "x"));
+		expect(editorTheme.backgroundColor?.("x")).toMatch(/\x1b\[48;2;\d+;\d+;\d+mx\x1b\[49m/);
+		expect(editorTheme.borderColor("x")).toBe(theme.fg("borderMuted", "x"));
+	});
+
+	it("keeps theme editor chrome on light terminal backgrounds", () => {
 		setDefaultTerminalColors({
 			foreground: { r: 0, g: 0, b: 0 },
 			background: { r: 255, g: 255, b: 255 },
@@ -59,8 +69,8 @@ describe("adaptive TUI theme colors", () => {
 
 		const editorTheme = getEditorTheme();
 
-		expect(editorTheme.backgroundColor?.("x")).toBe("\x1b[48;2;245;245;245mx\x1b[49m");
-		expect(editorTheme.borderColor("x")).toBe(BOLD_DARK_CYAN_TRUECOLOR);
+		expect(editorTheme.backgroundColor?.("x")).toBe(theme.bg("userMessageBg", "x"));
+		expect(editorTheme.borderColor("x")).toBe(theme.fg("borderMuted", "x"));
 	});
 
 	it("uses COLORFGBG for automatic default theme selection when OSC colors are unavailable", () => {

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -32,14 +32,14 @@ describe("UserMessageComponent", () => {
 		expect(lines[2].endsWith(BG_RESET)).toBe(true);
 	});
 
-	test("does not use a hardcoded message background when terminal background is unknown", () => {
+	test("uses the themed message background when terminal background is unknown", () => {
 		clearDefaultTerminalColors();
 		initTheme("dark");
 
 		const component = new UserMessageComponent("hello");
 		const lines = component.render(20);
 
-		expect(lines[0].endsWith(BG_RESET)).toBe(false);
-		expect(lines[2].endsWith(BG_RESET)).toBe(false);
+		expect(lines[0].endsWith(BG_RESET)).toBe(true);
+		expect(lines[2].endsWith(BG_RESET)).toBe(true);
 	});
 });


### PR DESCRIPTION
- added contextual keybinding hints for opening, closing, and navigating child-agent views.
- made the focused child-agent tray state visible without relying only on background color.
- updated the shortcut reference and component coverage for the new guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and hint copy only; no auth, networking, or agent execution logic changes.
> 
> **Overview**
> Improves **child-agent** navigation with contextual shortcut footers (move/open/close on the list, **esc** back on detail, **Enter open** on the focused summary tray) and documents **`app.subagents.focus`** in the editor hints and hotkeys help. List selection drops the `▌` glyph in favor of full-row **`selectedBg`** highlighting plus hint text.
> 
> **Keybinding hints** now support **`primaryOnly`** (e.g. show **esc** without alternate bindings) and display **escape** as **esc** across settings copy and warnings.
> 
> **Thinking** blocks render through a quiet **Markdown** theme (structure preserved, muted styling) instead of forced italics.
> 
> **Theme/editor chrome**: borders use **`borderMuted`**; editor and user-message surfaces use theme **`userMessageBg`**, with a luminance-based blend only when the surface would match the terminal background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb12b1007f0e557ed23c072de63791d06e42348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keybinding hints to child-agent inspector views
> - Adds contextual keybinding hints to the child-agent summary, list, and detail panels: summary shows an open hint when focused, list shows move/open/close hints at the bottom, and detail shows a back hint.
> - Adds `primaryOnly` support to keybinding hint helpers and normalizes `escape` display to lowercase `esc` across all hint rendering.
> - Adjusts list row rendering to remove the leading selector glyph; selection is indicated by row highlighting instead.
> - Adds adaptive surface background color logic in `Theme` that nudges surface colors only when luminance is too close to the terminal background, affecting editor and user message backgrounds.
> - Updates the interactive mode footer to include a subagent inspector hint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cb12b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->