### PR TITLE
fix api key login selection

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -39,14 +39,14 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	private mode: "login" | "logout";
 	private authStorage: AuthStorage;
 	private getAuthStatus: (providerId: string) => AuthStatus;
-	private onSelectCallback: (providerId: string) => void;
+	private onSelectCallback: (provider: AuthSelectorProvider) => void;
 	private onCancelCallback: () => void;
 
 	constructor(
 		mode: "login" | "logout",
 		authStorage: AuthStorage,
 		providers: AuthSelectorProvider[],
-		onSelect: (providerId: string) => void,
+		onSelect: (provider: AuthSelectorProvider) => void,
 		onCancel: () => void,
 		getAuthStatus?: (providerId: string) => AuthStatus,
 	) {
@@ -70,7 +70,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		this.searchInput.onSubmit = () => {
 			const selectedProvider = this.filteredProviders[this.selectedIndex];
 			if (selectedProvider) {
-				this.onSelectCallback(selectedProvider.id);
+				this.onSelectCallback(selectedProvider);
 			}
 		};
 		panel.addChild(this.searchInput);
@@ -202,7 +202,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedProvider = this.filteredProviders[this.selectedIndex];
 			if (selectedProvider) {
-				this.onSelectCallback(selectedProvider.id);
+				this.onSelectCallback(selectedProvider);
 			}
 		}
 		// Escape or Ctrl+C

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -82,6 +82,7 @@ import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
 import {
+	checkPrimeInferenceAccess,
 	fetchPrimeTeams,
 	loadPrimeCliConfig,
 	loginPrimeInference,
@@ -5328,19 +5329,13 @@ export class InteractiveMode {
 				"login",
 				this.session.modelRegistry.authStorage,
 				providerOptions,
-				async (providerId: string) => {
+				async (providerOption: AuthSelectorProvider) => {
 					close();
-
-					const providerOption = providerOptions.find((provider) => provider.id === providerId);
-					if (!providerOption) {
-						resolve({ status: "failed" });
-						return;
-					}
 
 					if (providerOption.authType === "oauth") {
 						resolve(await this.showLoginDialog(providerOption.id, providerOption.name));
 					} else if (providerOption.id === PRIME_INFERENCE_PROVIDER_ID) {
-						resolve(await this.showPrimeInferenceLoginDialog());
+						resolve(await this.showPrimeInferenceApiKeyLoginDialog());
 					} else if (providerOption.id === BEDROCK_PROVIDER_ID) {
 						resolve(await this.showBedrockSetupDialog(providerOption.id, providerOption.name));
 					} else {
@@ -5379,13 +5374,8 @@ export class InteractiveMode {
 				mode,
 				this.session.modelRegistry.authStorage,
 				providerOptions,
-				async (providerId: string) => {
+				async (providerOption: AuthSelectorProvider) => {
 					done();
-
-					const providerOption = providerOptions.find((provider) => provider.id === providerId);
-					if (!providerOption) {
-						return;
-					}
 
 					try {
 						this.session.modelRegistry.authStorage.logout(providerOption.id);
@@ -5638,6 +5628,69 @@ export class InteractiveMode {
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			if (errorMsg !== "Login cancelled") {
 				this.showError(`Failed to login to ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
+				return { status: "failed" };
+			}
+			return { status: "cancelled" };
+		}
+	}
+
+	private async showPrimeInferenceApiKeyLoginDialog(): Promise<AuthenticationResult> {
+		const dialog = new LoginDialogComponent(
+			this.ui,
+			PRIME_INFERENCE_PROVIDER_ID,
+			(_success, _message) => {
+				// Completion handled below
+			},
+			PRIME_INFERENCE_PROVIDER_NAME,
+		);
+
+		const handle = this.showFullPaneOverlay(dialog, 88);
+
+		const closeDialog = () => {
+			handle.hide();
+			this.ui.requestRender();
+		};
+
+		try {
+			const apiKey = (await dialog.showPrompt("Enter API key:")).trim();
+			if (!apiKey) {
+				throw new Error("API key cannot be empty.");
+			}
+
+			dialog.showProgress("Checking Prime Inference access...");
+			const config = loadPrimeCliConfig();
+			const access = await checkPrimeInferenceAccess(apiKey, config.baseUrl, { signal: dialog.signal });
+			if (dialog.signal.aborted) {
+				closeDialog();
+				return { status: "cancelled" };
+			}
+			if (!access.ok) {
+				const status = access.status === undefined ? "" : `HTTP ${access.status}: `;
+				throw new Error(`Prime API key does not have Prime Inference access (${status}${access.message})`);
+			}
+
+			const previousPrimeCredential = this.session.modelRegistry.authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
+			const previousPrimeTeam =
+				previousPrimeCredential?.type === "api_key" ? previousPrimeCredential.primeTeam : undefined;
+			this.session.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
+				type: "api_key",
+				key: apiKey,
+				...(previousPrimeTeam !== undefined ? { primeTeam: previousPrimeTeam } : {}),
+			});
+			const teamStatus = await this.selectPrimeInferenceTeam(apiKey, dialog);
+
+			closeDialog();
+			return await this.completeProviderAuthentication(
+				PRIME_INFERENCE_PROVIDER_ID,
+				PRIME_INFERENCE_PROVIDER_NAME,
+				"api_key",
+				teamStatus,
+			);
+		} catch (error: unknown) {
+			closeDialog();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Login cancelled") {
+				this.showError(`Failed to save API key for ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
 				return { status: "failed" };
 			}
 			return { status: "cancelled" };

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -59,6 +59,28 @@ describe("OAuthSelectorComponent", () => {
 		]);
 	});
 
+	it("preserves auth type when selecting duplicate provider ids", () => {
+		const authStorage = AuthStorage.inMemory();
+		const selections: string[] = [];
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[
+				{ id: "anthropic", name: "Anthropic", authType: "oauth" },
+				{ id: "anthropic", name: "Anthropic", authType: "api_key" },
+			],
+			(provider) => {
+				selections.push(`${provider.id}:${provider.authType}`);
+			},
+			() => {},
+		);
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\r");
+
+		expect(selections).toEqual(["anthropic:api_key"]);
+	});
+
 	it("shows configured providers before unconfigured providers", () => {
 		process.env.OPENAI_API_KEY = "test-openai-key";
 		const authStorage = AuthStorage.inMemory();


### PR DESCRIPTION
- api key selections now keep their auth type instead of falling back to the matching subscription row.
- prime inference api key login now prompts for a key and validates access without browser auth.
- added a regression for duplicate provider ids in the auth selector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive credential login paths and how Prime Inference keys are validated and stored; scope is limited to the TUI auth selector, not core model routing.
> 
> **Overview**
> Fixes **auth provider selection** when the same provider appears twice (subscription vs API key): `OAuthSelectorComponent` now passes the full `AuthSelectorProvider` (including `authType`) instead of only `id`, so login/logout no longer re-resolve the row with `find()` and pick the wrong auth path.
> 
> For **Prime Inference** from `/login` and the provider picker, the **api key** row now opens a dedicated flow that prompts for a key, runs `checkPrimeInferenceAccess`, then saves credentials and team selection—instead of always using browser OAuth. Onboarding still uses the existing browser login dialog.
> 
> Adds a regression test that selecting the API key row for duplicate `anthropic` ids records `anthropic:api_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719562d27edb88df248c38d87dd04df3eaa53b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix API key login flow for Prime Inference provider selection
> - `OAuthSelectorComponent` now emits the full `AuthSelectorProvider` object on selection instead of just the provider id, preserving `authType` when multiple providers share the same id.
> - The login selector's `onSelect` handler now routes Prime Inference selections to a new `showPrimeInferenceApiKeyLoginDialog()` method instead of the OAuth flow.
> - `showPrimeInferenceApiKeyLoginDialog()` prompts for an API key, validates it via `checkPrimeInferenceAccess`, preserves any previously saved `primeTeam`, then proceeds to team selection and completes authentication.
> - A new test verifies that selecting a provider with a duplicate id emits the correct `authType`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 719562d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->