### PR TITLE
show os-specific shortcut labels

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -5,10 +5,30 @@
 import { getKeybindings, type Keybinding, type KeyId } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
 
+function formatKeyPart(part: string, platform: NodeJS.Platform): string {
+	if (platform === "darwin") {
+		if (part === "ctrl") return "Cmd";
+		if (part === "alt") return "Option";
+	}
+	return part.charAt(0).toUpperCase() + part.slice(1);
+}
+
+export function formatKeyText(key: string, platform: NodeJS.Platform = process.platform): string {
+	return key
+		.split("/")
+		.map((binding) =>
+			binding
+				.split("+")
+				.map((part) => formatKeyPart(part, platform))
+				.join("+"),
+		)
+		.join("/");
+}
+
 function formatKeys(keys: KeyId[]): string {
 	if (keys.length === 0) return "";
-	if (keys.length === 1) return keys[0]!;
-	return keys.join("/");
+	if (keys.length === 1) return formatKeyText(keys[0]!);
+	return formatKeyText(keys.join("/"));
 }
 
 export function keyText(keybinding: Keybinding): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -130,7 +130,7 @@ import { ExtensionEditorComponent } from "./components/extension-editor.js";
 import { ExtensionInputComponent } from "./components/extension-input.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
 import { FooterComponent } from "./components/footer.js";
-import { keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
+import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
 import { type ModelSelectorAction, ModelSelectorComponent } from "./components/model-selector.js";
 import {
@@ -6353,7 +6353,7 @@ export class InteractiveMode {
 `;
 			for (const [key, shortcut] of shortcuts) {
 				const description = shortcut.description ?? shortcut.extensionPath;
-				const keyDisplay = key.replace(/\b\w/g, (c) => c.toUpperCase());
+				const keyDisplay = formatKeyText(key);
 				hotkeys += `| \`${keyDisplay}\` | ${description} |\n`;
 			}
 		}

--- a/packages/coding-agent/test/keybinding-hints.test.ts
+++ b/packages/coding-agent/test/keybinding-hints.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatKeyText } from "../src/modes/interactive/components/keybinding-hints.js";
+
+describe("keybinding hint formatting", () => {
+	it("uses macOS modifier names on darwin", () => {
+		expect(formatKeyText("ctrl+p", "darwin")).toBe("Cmd+P");
+		expect(formatKeyText("alt+enter", "darwin")).toBe("Option+Enter");
+		expect(formatKeyText("shift+ctrl+p/alt+up", "darwin")).toBe("Shift+Cmd+P/Option+Up");
+	});
+
+	it("keeps canonical modifier names on linux", () => {
+		expect(formatKeyText("ctrl+p", "linux")).toBe("Ctrl+P");
+		expect(formatKeyText("alt+enter", "linux")).toBe("Alt+Enter");
+		expect(formatKeyText("shift+ctrl+p/alt+up", "linux")).toBe("Shift+Ctrl+P/Alt+Up");
+	});
+
+	it("keeps canonical modifier names on Windows", () => {
+		expect(formatKeyText("ctrl+p", "win32")).toBe("Ctrl+P");
+		expect(formatKeyText("alt+enter", "win32")).toBe("Alt+Enter");
+		expect(formatKeyText("ctrl+backspace/pageUp", "win32")).toBe("Ctrl+Backspace/PageUp");
+	});
+});

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -66,7 +66,7 @@ describe("ModelSelectorComponent provider actions", () => {
 
 		const output = stripAnsi(selector.render(120).join("\n"));
 		expect(output).toContain("Choose a Prime model, or add another provider.");
-		expect(output).toContain("ctrl+x to add providers and access more models.");
+		expect(output).toContain("Ctrl+X to add providers and access more models.");
 		expect(output.indexOf("add provider")).toBeLessThan(output.indexOf("Search models"));
 		expect(output.match(/add provider/g)).toHaveLength(1);
 

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -53,7 +53,7 @@ describe("session selector rename", () => {
 		await flushPromises();
 
 		const output = selector.render(120).join("\n");
-		expect(output).toContain("ctrl+r");
+		expect(output).toContain("Ctrl+R");
 		expect(output).toContain("rename");
 	});
 
@@ -72,7 +72,7 @@ describe("session selector rename", () => {
 		await flushPromises();
 
 		const output = selector.render(120).join("\n");
-		expect(output).not.toContain("ctrl+r");
+		expect(output).not.toContain("Ctrl+R");
 		expect(output).not.toContain("rename");
 	});
 


### PR DESCRIPTION
- shortcut hints now render cmd and option on macos while keeping ctrl and alt elsewhere.
- hotkeys output uses the same formatter for built-in and extension shortcuts.
- added focused coverage for platform-specific key label formatting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to shortcut strings with focused unit tests; no input handling or auth logic touched.
> 
> **Overview**
> Interactive shortcut hints now use a shared **`formatKeyText`** helper so labels match the host OS: on macOS **`ctrl`** and **`alt`** render as **Cmd** and **Option**, while Linux and Windows keep **Ctrl** / **Alt** with consistent capitalization for multi-key chords and alternates (`/`).
> 
> **`keyText`** / **`keyHint`** route key IDs through this formatter, so splash hints, selectors, and similar UI no longer show raw lowercase IDs like `ctrl+r`. The **`/hotkeys`** extension shortcuts table uses the same helper instead of regex capitalization.
> 
> Vitest coverage was added for darwin, linux, and win32 formatting; existing selector tests were updated for **`Ctrl+X`** / **`Ctrl+R`** display strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f78fbd181f6c477bc3a57c3c5d001072fdb0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show OS-specific shortcut labels in keybinding hints
> - Adds `formatKeyText` in [keybinding-hints.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/89/files#diff-c352eb3ff4e96b143ad2486bd54abf1cd60ac214293033084fadbf3f55414397) to map modifier names to platform-specific display names (e.g. `ctrl` → `Cmd`, `alt` → `Option` on macOS; capitalized elsewhere).
> - Updates `formatKeys` and the keyboard shortcuts markdown builder in `InteractiveMode` to use `formatKeyText` instead of raw key IDs or regex capitalization.
> - Behavioral Change: keybinding hints now display `Cmd+P` on macOS and `Ctrl+P` on other platforms instead of raw lowercase strings like `ctrl+p`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35f78fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->