### PR TITLE
fix browser sign-in links in setup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the release installer to ask before bootstrapping the IPython kernel runtime during install, avoiding default first-run `uv` prompts inside the TUI.
+- Fixed browser sign-in links to show plain URLs when terminal hyperlinks are unsupported.
 
 ## [0.0.7] - 2026-06-01
 

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -3,6 +3,7 @@ import {
 	type Component,
 	Container,
 	type Focusable,
+	getCapabilities,
 	getKeybindings,
 	Spacer,
 	Text,
@@ -140,7 +141,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.addMutedText("The sign-in page should already be opening. If it did not open, use the link below.");
 		this.contentContainer.addChild(new Spacer(1));
 		this.addLabel("Sign-in link");
-		const linkedUrl = `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
+		const linkedUrl = getCapabilities().hyperlinks ? `\x1b]8;;${url}\x07${url}\x1b]8;;\x07` : url;
 		this.contentContainer.addChild(new Text(theme.fg("text", linkedUrl), 0, 0));
 
 		if (instructions) {

--- a/packages/coding-agent/test/login-dialog.test.ts
+++ b/packages/coding-agent/test/login-dialog.test.ts
@@ -1,6 +1,6 @@
-import { type TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { resetCapabilitiesCache, setCapabilities, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { LoginDialogComponent } from "../src/modes/interactive/components/login-dialog.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 import { PRIME_BUTTERFLY_LOGO } from "../src/themes/prime-logo.js";
@@ -28,6 +28,10 @@ describe("LoginDialogComponent", () => {
 		mocks.exec.mockClear();
 	});
 
+	afterEach(() => {
+		resetCapabilitiesCache();
+	});
+
 	it("renders browser login without legacy border chrome", () => {
 		const dialog = new LoginDialogComponent(createFakeTui(), "anthropic", () => {}, "Anthropic");
 
@@ -44,6 +48,31 @@ describe("LoginDialogComponent", () => {
 		expect(output).not.toContain("─");
 		expect(output).not.toContain("> ");
 		expect(mocks.exec).toHaveBeenCalledOnce();
+	});
+
+	it("renders sign-in URLs as OSC 8 hyperlinks when supported", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+		const dialog = new LoginDialogComponent(createFakeTui(), "anthropic", () => {}, "Anthropic");
+		const url = "https://example.com/oauth?client_id=test";
+
+		dialog.showAuth(url, "Complete login in your browser.");
+		const rawOutput = dialog.render(88).join("\n");
+
+		expect(rawOutput).toContain(`\x1b]8;;${url}\x07`);
+		expect(rawOutput).toContain("\x1b]8;;\x07");
+		expect(stripAnsi(rawOutput)).toContain(url);
+	});
+
+	it("renders plain sign-in URLs when OSC 8 hyperlinks are unsupported", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+		const dialog = new LoginDialogComponent(createFakeTui(), "anthropic", () => {}, "Anthropic");
+		const url = "https://example.com/oauth?client_id=test";
+
+		dialog.showAuth(url, "Complete login in your browser.");
+		const rawOutput = dialog.render(88).join("\n");
+
+		expect(rawOutput).not.toContain("\x1b]8;;");
+		expect(stripAnsi(rawOutput)).toContain(url);
 	});
 
 	it("renders verification codes as a distinct field", () => {


### PR DESCRIPTION
- browser sign-in links now respect terminal hyperlink support during setup.
- unsupported terminals show a plain url fallback instead of relying on osc 8 clickability.
- added login dialog coverage for both hyperlink and fallback rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI rendering change in the OAuth login dialog with no auth or credential logic changes.
> 
> **Overview**
> Browser sign-in URLs in the login dialog now follow terminal capability detection instead of always emitting OSC 8 hyperlink sequences.
> 
> **`showAuth`** uses `getCapabilities().hyperlinks` to wrap the sign-in URL in click-to-open OSC 8 markup only when the terminal reports support; otherwise users see a readable plain URL (still useful when auto-open fails). Tests cover both paths with `setCapabilities` / `resetCapabilitiesCache`, and the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9028e6da5aadcc15330b6ce590016d348463f7f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix browser sign-in links to show plain URLs when terminal hyperlinks are unsupported
> In [`login-dialog.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/90/files#diff-e6090ca397d340498bfdaf555c23c00e9e404e2e18adb1dc1dc4cebdb8707b00), the sign-in URL was always wrapped in OSC 8 hyperlink escape sequences regardless of terminal support. Now it calls `getCapabilities().hyperlinks` and only applies OSC 8 when the terminal reports support, otherwise rendering the plain URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9028e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->