### PR TITLE
add input prompt indicator

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -6,6 +6,7 @@ import type { AppKeybinding, KeybindingsManager } from "../../../core/keybinding
  */
 export class CustomEditor extends Editor {
 	private keybindings: KeybindingsManager;
+	private defaultPromptPrefix: string;
 	public actionHandlers: Map<AppKeybinding, () => void> = new Map();
 
 	// Special handlers that can be dynamically replaced
@@ -17,8 +18,43 @@ export class CustomEditor extends Editor {
 	public onExtensionShortcut?: (data: string) => boolean;
 
 	constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, options?: EditorOptions) {
-		super(tui, theme, options);
+		const promptPrefix = options?.promptPrefix ?? "> ";
+		super(tui, theme, { ...options, promptPrefix });
 		this.keybindings = keybindings;
+		this.defaultPromptPrefix = promptPrefix;
+	}
+
+	protected override getPromptPrefix(): string {
+		return this.getBashPromptInfo(this.getLines()[0] ?? "")?.promptPrefix ?? this.defaultPromptPrefix;
+	}
+
+	protected override formatPromptPrefix(prefix: string): string {
+		return prefix.startsWith("!") ? this.borderColor(prefix) : prefix;
+	}
+
+	protected override getHiddenTextPrefixLength(lineIndex: number, line: string): number {
+		if (lineIndex !== 0) {
+			return 0;
+		}
+		return this.getBashPromptInfo(line)?.hiddenTextPrefixLength ?? 0;
+	}
+
+	private getBashPromptInfo(line: string): { promptPrefix: string; hiddenTextPrefixLength: number } | undefined {
+		const trimmedLine = line.trimStart();
+		const leadingWhitespaceLength = line.length - trimmedLine.length;
+		if (trimmedLine.startsWith("!!")) {
+			return {
+				promptPrefix: "!! ",
+				hiddenTextPrefixLength: leadingWhitespaceLength + (trimmedLine.startsWith("!! ") ? 3 : 2),
+			};
+		}
+		if (trimmedLine.startsWith("!")) {
+			return {
+				promptPrefix: "! ",
+				hiddenTextPrefixLength: leadingWhitespaceLength + (trimmedLine.startsWith("! ") ? 2 : 1),
+			};
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4108,11 +4108,11 @@ export class InteractiveMode {
 	private updateEditorBorderColor(): void {
 		// Bash mode keeps a green accent. Otherwise the input surface stays neutral so the
 		// focus indicator doesn't fight the splash.
+		const editorTheme = getEditorTheme();
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
-			this.editor.backgroundColor = (str: string) => theme.bg("toolSuccessBg", str);
+			this.editor.backgroundColor = editorTheme.backgroundColor;
 		} else {
-			const editorTheme = getEditorTheme();
 			this.editor.borderColor = editorTheme.borderColor;
 			this.editor.backgroundColor = editorTheme.backgroundColor;
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1283,12 +1283,14 @@ export class Editor implements Component, Focusable {
 		this.historyIndex = -1; // Exit history browsing mode
 		this.lastAction = null;
 
-		if (this.state.cursorCol > 0) {
+		const line = this.state.lines[this.state.cursorLine] || "";
+		const lineStartCol = this.getLineHiddenTextPrefixLength(this.state.cursorLine, line);
+
+		if (this.state.cursorCol > lineStartCol) {
 			this.pushUndoSnapshot();
 
 			// Delete grapheme before cursor (handles emojis, combining characters, etc.)
-			const line = this.state.lines[this.state.cursorLine] || "";
-			const beforeCursor = line.slice(0, this.state.cursorCol);
+			const beforeCursor = line.slice(lineStartCol, this.state.cursorCol);
 
 			// Find the last grapheme in the text before cursor
 			const graphemes = [...this.segment(beforeCursor)];
@@ -1300,6 +1302,11 @@ export class Editor implements Component, Focusable {
 
 			this.state.lines[this.state.cursorLine] = before + after;
 			this.setCursorCol(this.state.cursorCol - graphemeLength);
+		} else if (lineStartCol > 0 && line.length === lineStartCol) {
+			this.pushUndoSnapshot();
+
+			this.state.lines[this.state.cursorLine] = "";
+			this.setCursorCol(0);
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -206,6 +206,7 @@ export interface EditorTheme {
 export interface EditorOptions {
 	paddingX?: number;
 	autocompleteMaxVisible?: number;
+	promptPrefix?: string;
 }
 
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
@@ -228,6 +229,7 @@ export class Editor implements Component, Focusable {
 	protected tui: TUI;
 	private theme: EditorTheme;
 	private paddingX: number = 0;
+	private promptPrefix: string = "";
 
 	// Store last render width for cursor navigation
 	private lastWidth: number = 80;
@@ -294,6 +296,7 @@ export class Editor implements Component, Focusable {
 		this.backgroundColor = theme.backgroundColor;
 		const paddingX = options.paddingX ?? 0;
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
+		this.promptPrefix = options.promptPrefix ?? "";
 		const maxVisible = options.autocompleteMaxVisible ?? 5;
 		this.autocompleteMaxVisible = Number.isFinite(maxVisible) ? Math.max(3, Math.min(20, Math.floor(maxVisible))) : 5;
 	}
@@ -330,6 +333,26 @@ export class Editor implements Component, Focusable {
 			this.autocompleteMaxVisible = newMaxVisible;
 			this.tui.requestRender();
 		}
+	}
+
+	protected getPromptPrefix(): string {
+		return this.promptPrefix;
+	}
+
+	protected formatPromptPrefix(prefix: string): string {
+		return prefix;
+	}
+
+	protected getHiddenTextPrefixLength(_lineIndex: number, _line: string): number {
+		return 0;
+	}
+
+	private getLineHiddenTextPrefixLength(lineIndex: number, line: string): number {
+		const hiddenLength = this.getHiddenTextPrefixLength(lineIndex, line);
+		if (!Number.isFinite(hiddenLength)) {
+			return 0;
+		}
+		return Math.max(0, Math.min(line.length, Math.floor(hiddenLength)));
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -425,10 +448,15 @@ export class Editor implements Component, Focusable {
 			? Math.min(Math.max(configuredPaddingX, 2), maxPadding)
 			: configuredPaddingX;
 		const contentWidth = Math.max(1, width - paddingX * 2);
+		const promptPrefixText = this.getPromptPrefix();
+		const promptPrefixWidth = Math.min(visibleWidth(promptPrefixText), Math.max(0, contentWidth - 1));
+		const inputWidth = Math.max(1, contentWidth - promptPrefixWidth);
+		const promptPrefix =
+			promptPrefixWidth > 0 ? this.formatPromptPrefix(truncateToWidth(promptPrefixText, promptPrefixWidth, "")) : "";
 
 		// Layout width: with padding the cursor can overflow into it,
 		// without padding we reserve 1 column for the cursor.
-		const layoutWidth = Math.max(1, contentWidth - (paddingX ? 0 : 1));
+		const layoutWidth = Math.max(1, inputWidth - (paddingX ? 0 : 1));
 
 		// Store for cursor navigation (must match wrapping width)
 		this.lastWidth = layoutWidth;
@@ -463,6 +491,9 @@ export class Editor implements Component, Focusable {
 		const result: string[] = [];
 		const leftPadding = " ".repeat(paddingX);
 		const rightPadding = leftPadding;
+		const promptPrefixInset = promptPrefixWidth > 0 ? Math.min(1, paddingX) : 0;
+		const promptLeadingPadding = " ".repeat(promptPrefixInset);
+		const promptTrailingPadding = " ".repeat(Math.max(0, paddingX - promptPrefixInset));
 		const cursorReset = useBackgroundSurface ? "\x1b[27m" : "\x1b[0m";
 		const renderSurfaceLine = (line: string): string => {
 			const padded = line + " ".repeat(Math.max(0, width - visibleWidth(line)));
@@ -519,18 +550,18 @@ export class Editor implements Component, Focusable {
 					displayText = before + marker + cursor;
 					lineVisibleWidth = lineVisibleWidth + 1;
 					// If cursor overflows content width into the padding, flag it
-					if (lineVisibleWidth > contentWidth && paddingX > 0) {
+					if (lineVisibleWidth > inputWidth && paddingX > 0) {
 						cursorInPadding = true;
 					}
 				}
 			}
 
 			// Calculate padding based on actual visible width
-			const padding = " ".repeat(Math.max(0, contentWidth - lineVisibleWidth));
+			const padding = " ".repeat(Math.max(0, inputWidth - lineVisibleWidth));
 			const lineRightPadding = cursorInPadding ? rightPadding.slice(1) : rightPadding;
 
 			// Render the line (no side borders, just horizontal lines above and below)
-			const contentLine = `${leftPadding}${displayText}${padding}${lineRightPadding}`;
+			const contentLine = `${promptLeadingPadding}${promptPrefix}${promptTrailingPadding}${displayText}${padding}${lineRightPadding}`;
 			result.push(useBackgroundSurface ? renderSurfaceLine(contentLine) : contentLine);
 		}
 
@@ -551,11 +582,12 @@ export class Editor implements Component, Focusable {
 
 		// Add autocomplete list if active
 		if (this.autocompleteState && this.autocompleteList) {
-			const autocompleteResult = this.autocompleteList.render(contentWidth);
+			const autocompleteResult = this.autocompleteList.render(inputWidth);
+			const promptPrefixPadding = " ".repeat(promptPrefixWidth);
 			for (const line of autocompleteResult) {
 				const lineWidth = visibleWidth(line);
-				const linePadding = " ".repeat(Math.max(0, contentWidth - lineWidth));
-				const contentLine = `${leftPadding}${line}${linePadding}${rightPadding}`;
+				const linePadding = " ".repeat(Math.max(0, inputWidth - lineWidth));
+				const contentLine = `${promptLeadingPadding}${promptPrefixPadding}${promptTrailingPadding}${line}${linePadding}${rightPadding}`;
 				result.push(useBackgroundSurface ? renderSurfaceLine(contentLine) : contentLine);
 			}
 		}
@@ -868,32 +900,43 @@ export class Editor implements Component, Focusable {
 		// Process each logical line
 		for (let i = 0; i < this.state.lines.length; i++) {
 			const line = this.state.lines[i] || "";
+			const hiddenPrefixLength = this.getLineHiddenTextPrefixLength(i, line);
+			const displayLine = line.slice(hiddenPrefixLength);
 			const isCurrentLine = i === this.state.cursorLine;
-			const lineVisibleWidth = visibleWidth(line);
+			const lineVisibleWidth = visibleWidth(displayLine);
+
+			if (displayLine.length === 0) {
+				layoutLines.push({
+					text: "",
+					hasCursor: isCurrentLine,
+					cursorPos: isCurrentLine ? 0 : undefined,
+				});
+				continue;
+			}
 
 			if (lineVisibleWidth <= contentWidth) {
 				// Line fits in one layout line
 				if (isCurrentLine) {
 					layoutLines.push({
-						text: line,
+						text: displayLine,
 						hasCursor: true,
-						cursorPos: this.state.cursorCol,
+						cursorPos: Math.max(0, this.state.cursorCol - hiddenPrefixLength),
 					});
 				} else {
 					layoutLines.push({
-						text: line,
+						text: displayLine,
 						hasCursor: false,
 					});
 				}
 			} else {
 				// Line needs wrapping - use word-aware wrapping
-				const chunks = wordWrapLine(line, contentWidth, [...this.segment(line)]);
+				const chunks = wordWrapLine(displayLine, contentWidth, [...this.segment(displayLine)]);
 
 				for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
 					const chunk = chunks[chunkIndex];
 					if (!chunk) continue;
 
-					const cursorPos = this.state.cursorCol;
+					const cursorPos = Math.max(0, this.state.cursorCol - hiddenPrefixLength);
 					const isLastChunk = chunkIndex === chunks.length - 1;
 
 					// Determine if cursor is in this chunk
@@ -1441,7 +1484,8 @@ export class Editor implements Component, Focusable {
 
 	private moveToLineStart(): void {
 		this.lastAction = null;
-		this.setCursorCol(0);
+		const currentLine = this.state.lines[this.state.cursorLine] || "";
+		this.setCursorCol(this.getLineHiddenTextPrefixLength(this.state.cursorLine, currentLine));
 	}
 
 	private moveToLineEnd(): void {
@@ -1454,18 +1498,20 @@ export class Editor implements Component, Focusable {
 		this.historyIndex = -1; // Exit history browsing mode
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
+		const lineStartCol = this.getLineHiddenTextPrefixLength(this.state.cursorLine, currentLine);
 
-		if (this.state.cursorCol > 0) {
+		if (this.state.cursorCol > lineStartCol) {
 			this.pushUndoSnapshot();
 
 			// Calculate text to be deleted and save to kill ring (backward deletion = prepend)
-			const deletedText = currentLine.slice(0, this.state.cursorCol);
+			const deletedText = currentLine.slice(lineStartCol, this.state.cursorCol);
 			this.killRing.push(deletedText, { prepend: true, accumulate: this.lastAction === "kill" });
 			this.lastAction = "kill";
 
 			// Delete from start of line up to cursor
-			this.state.lines[this.state.cursorLine] = currentLine.slice(this.state.cursorCol);
-			this.setCursorCol(0);
+			this.state.lines[this.state.cursorLine] =
+				currentLine.slice(0, lineStartCol) + currentLine.slice(this.state.cursorCol);
+			this.setCursorCol(lineStartCol);
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 
@@ -1666,19 +1712,21 @@ export class Editor implements Component, Focusable {
 
 		for (let i = 0; i < this.state.lines.length; i++) {
 			const line = this.state.lines[i] || "";
-			const lineVisWidth = visibleWidth(line);
-			if (line.length === 0) {
+			const hiddenPrefixLength = this.getLineHiddenTextPrefixLength(i, line);
+			const displayLine = line.slice(hiddenPrefixLength);
+			const lineVisWidth = visibleWidth(displayLine);
+			if (displayLine.length === 0) {
 				// Empty line still takes one visual line
-				visualLines.push({ logicalLine: i, startCol: 0, length: 0 });
+				visualLines.push({ logicalLine: i, startCol: hiddenPrefixLength, length: 0 });
 			} else if (lineVisWidth <= width) {
-				visualLines.push({ logicalLine: i, startCol: 0, length: line.length });
+				visualLines.push({ logicalLine: i, startCol: hiddenPrefixLength, length: displayLine.length });
 			} else {
 				// Line needs wrapping - use word-aware wrapping
-				const chunks = wordWrapLine(line, width, [...this.segment(line)]);
+				const chunks = wordWrapLine(displayLine, width, [...this.segment(displayLine)]);
 				for (const chunk of chunks) {
 					visualLines.push({
 						logicalLine: i,
-						startCol: chunk.startIndex,
+						startCol: hiddenPrefixLength + chunk.startIndex,
 						length: chunk.endIndex - chunk.startIndex,
 					});
 				}
@@ -1696,9 +1744,13 @@ export class Editor implements Component, Focusable {
 		line: number,
 		col: number,
 	): number {
+		const hiddenPrefixLength = this.getLineHiddenTextPrefixLength(line, this.state.lines[line] || "");
 		for (let i = 0; i < visualLines.length; i++) {
 			const vl = visualLines[i];
 			if (!vl || vl.logicalLine !== line) continue;
+			if (hiddenPrefixLength > 0 && col < hiddenPrefixLength && vl.startCol === hiddenPrefixLength) {
+				return i;
+			}
 			const offset = col - vl.startCol;
 			// Cursor is in this segment if it's within range. For the last
 			// segment of a logical line, cursor can be at length (end position)

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -522,7 +522,10 @@ export class Editor implements Component, Focusable {
 		// Emit hardware cursor marker only when focused and not showing autocomplete
 		const emitCursorMarker = this.focused && !this.autocompleteState;
 
-		for (const layoutLine of visibleLines) {
+		for (let visibleLineIndex = 0; visibleLineIndex < visibleLines.length; visibleLineIndex++) {
+			const layoutLine = visibleLines[visibleLineIndex]!;
+			const absoluteLineIndex = this.scrollOffset + visibleLineIndex;
+			const linePromptPrefix = absoluteLineIndex === 0 ? promptPrefix : " ".repeat(promptPrefixWidth);
 			let displayText = layoutLine.text;
 			let lineVisibleWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
@@ -561,7 +564,7 @@ export class Editor implements Component, Focusable {
 			const lineRightPadding = cursorInPadding ? rightPadding.slice(1) : rightPadding;
 
 			// Render the line (no side borders, just horizontal lines above and below)
-			const contentLine = `${promptLeadingPadding}${promptPrefix}${promptTrailingPadding}${displayText}${padding}${lineRightPadding}`;
+			const contentLine = `${promptLeadingPadding}${linePromptPrefix}${promptTrailingPadding}${displayText}${padding}${lineRightPadding}`;
 			result.push(useBackgroundSurface ? renderSurfaceLine(contentLine) : contentLine);
 		}
 
@@ -1786,6 +1789,7 @@ export class Editor implements Component, Focusable {
 
 		if (deltaCol !== 0) {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
+			const lineStartCol = this.getLineHiddenTextPrefixLength(this.state.cursorLine, currentLine);
 
 			if (deltaCol > 0) {
 				// Moving right - move by one grapheme (handles emojis, combining characters, etc.)
@@ -1807,11 +1811,12 @@ export class Editor implements Component, Focusable {
 				}
 			} else {
 				// Moving left - move by one grapheme (handles emojis, combining characters, etc.)
-				if (this.state.cursorCol > 0) {
-					const beforeCursor = currentLine.slice(0, this.state.cursorCol);
+				if (this.state.cursorCol > lineStartCol) {
+					const beforeCursor = currentLine.slice(lineStartCol, this.state.cursorCol);
 					const graphemes = [...this.segment(beforeCursor)];
 					const lastGrapheme = graphemes[graphemes.length - 1];
-					this.setCursorCol(this.state.cursorCol - (lastGrapheme ? lastGrapheme.segment.length : 1));
+					const previousCol = this.state.cursorCol - (lastGrapheme ? lastGrapheme.segment.length : 1);
+					this.setCursorCol(Math.max(lineStartCol, previousCol));
 				} else if (this.state.cursorLine > 0) {
 					// Wrap to end of previous logical line
 					this.state.cursorLine--;
@@ -1841,9 +1846,10 @@ export class Editor implements Component, Focusable {
 	private moveWordBackwards(): void {
 		this.lastAction = null;
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
+		const lineStartCol = this.getLineHiddenTextPrefixLength(this.state.cursorLine, currentLine);
 
 		// If at start of line, move to end of previous line
-		if (this.state.cursorCol === 0) {
+		if (this.state.cursorCol <= lineStartCol) {
 			if (this.state.cursorLine > 0) {
 				this.state.cursorLine--;
 				const prevLine = this.state.lines[this.state.cursorLine] || "";
@@ -1852,7 +1858,7 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
+		const textBeforeCursor = currentLine.slice(lineStartCol, this.state.cursorCol);
 		const graphemes = [...this.segment(textBeforeCursor)];
 		let newCol = this.state.cursorCol;
 
@@ -1892,7 +1898,7 @@ export class Editor implements Component, Focusable {
 			}
 		}
 
-		this.setCursorCol(newCol);
+		this.setCursorCol(Math.max(lineStartCol, newCol));
 	}
 
 	/**

--- a/packages/tui/test/editor-prompt-prefix.test.ts
+++ b/packages/tui/test/editor-prompt-prefix.test.ts
@@ -73,6 +73,17 @@ describe("Editor prompt prefix", () => {
 		assert.match(inputLine(editor), /^ > {2}hello/);
 	});
 
+	it("uses a blank prompt gutter on wrapped rows", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("abcdefghijklmnop");
+		const contentLines = editor.render(10).slice(1, -1).map(stripVTControlCharacters);
+
+		assert.match(contentLines[0] ?? "", /^> /);
+		assert.match(contentLines[1] ?? "", /^ {2}/);
+		assert.doesNotMatch(contentLines[1] ?? "", /^>/);
+	});
+
 	it("renders bash prefixes in the prompt gutter and hides them from input text", () => {
 		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
 
@@ -105,5 +116,31 @@ describe("Editor prompt prefix", () => {
 
 		assert.strictEqual(editor.getText(), "!xecho");
 		assert.match(inputLine(editor), /^! xecho/);
+	});
+
+	it("keeps left navigation out of hidden bash prefixes", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("!echo");
+		for (let i = 0; i < 10; i++) {
+			editor.handleInput("\x1b[D");
+		}
+		editor.handleInput("x");
+
+		assert.strictEqual(editor.getText(), "!xecho");
+		assert.match(inputLine(editor), /^! xecho/);
+	});
+
+	it("keeps word-left navigation out of hidden bash prefixes", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("! foo bar");
+		for (let i = 0; i < 4; i++) {
+			editor.handleInput("\x1b[1;5D");
+		}
+		editor.handleInput("x");
+
+		assert.strictEqual(editor.getText(), "! xfoo bar");
+		assert.match(inputLine(editor), /^! xfoo bar/);
 	});
 });

--- a/packages/tui/test/editor-prompt-prefix.test.ts
+++ b/packages/tui/test/editor-prompt-prefix.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { Editor } from "../src/components/editor.js";
+import { TUI } from "../src/tui.js";
+import { defaultEditorTheme } from "./test-themes.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+function createTestTUI(cols = 80, rows = 24): TUI {
+	return new TUI(new VirtualTerminal(cols, rows));
+}
+
+class BashPromptEditor extends Editor {
+	protected override getPromptPrefix(): string {
+		return this.getBashPromptInfo(this.getLines()[0] ?? "")?.promptPrefix ?? "> ";
+	}
+
+	protected override getHiddenTextPrefixLength(lineIndex: number, line: string): number {
+		if (lineIndex !== 0) {
+			return 0;
+		}
+		return this.getBashPromptInfo(line)?.hiddenTextPrefixLength ?? 0;
+	}
+
+	private getBashPromptInfo(line: string): { promptPrefix: string; hiddenTextPrefixLength: number } | undefined {
+		const trimmedLine = line.trimStart();
+		const leadingWhitespaceLength = line.length - trimmedLine.length;
+		if (trimmedLine.startsWith("!!")) {
+			return {
+				promptPrefix: "!! ",
+				hiddenTextPrefixLength: leadingWhitespaceLength + (trimmedLine.startsWith("!! ") ? 3 : 2),
+			};
+		}
+		if (trimmedLine.startsWith("!")) {
+			return {
+				promptPrefix: "! ",
+				hiddenTextPrefixLength: leadingWhitespaceLength + (trimmedLine.startsWith("! ") ? 2 : 1),
+			};
+		}
+		return undefined;
+	}
+}
+
+function inputLine(editor: Editor, width = 24): string {
+	return stripVTControlCharacters(editor.render(width)[1] ?? "");
+}
+
+describe("Editor prompt prefix", () => {
+	it("renders prompt prefixes in the default foreground", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("hello");
+
+		assert.match(editor.render(24)[1] ?? "", /^> /);
+	});
+
+	it("renders the default prompt prefix before regular input", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("hello");
+
+		assert.match(inputLine(editor), /^> hello/);
+	});
+
+	it("insets the prompt prefix one column into the surface padding", () => {
+		const editor = new BashPromptEditor(createTestTUI(), {
+			...defaultEditorTheme,
+			backgroundColor: (text) => text,
+		});
+
+		editor.setText("hello");
+
+		assert.match(inputLine(editor), /^ > {2}hello/);
+	});
+
+	it("renders bash prefixes in the prompt gutter and hides them from input text", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("!ls");
+		assert.match(inputLine(editor), /^! ls/);
+		assert.doesNotMatch(inputLine(editor), /^! !ls/);
+
+		editor.setText("! ls");
+		assert.match(inputLine(editor), /^! ls/);
+		assert.doesNotMatch(inputLine(editor), /^! {2}ls/);
+
+		editor.setText("!!pwd");
+		assert.match(inputLine(editor), /^!! pwd/);
+		assert.doesNotMatch(inputLine(editor), /^!! !!pwd/);
+
+		editor.setText("!! pwd");
+		assert.match(inputLine(editor), /^!! pwd/);
+		assert.doesNotMatch(inputLine(editor), /^!! {2}pwd/);
+
+		editor.setText("  !! pwd");
+		assert.match(inputLine(editor), /^!! pwd/);
+	});
+
+	it("treats the hidden prefix as the visual line start", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("!echo");
+		editor.handleInput("\x01");
+		editor.handleInput("x");
+
+		assert.strictEqual(editor.getText(), "!xecho");
+		assert.match(inputLine(editor), /^! xecho/);
+	});
+});

--- a/packages/tui/test/editor-prompt-prefix.test.ts
+++ b/packages/tui/test/editor-prompt-prefix.test.ts
@@ -143,4 +143,25 @@ describe("Editor prompt prefix", () => {
 		assert.strictEqual(editor.getText(), "! xfoo bar");
 		assert.match(inputLine(editor), /^! xfoo bar/);
 	});
+
+	it("keeps backspace at the visible command boundary from deleting hidden prefixes", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("!echo");
+		editor.handleInput("\x01");
+		editor.handleInput("\x7f");
+
+		assert.strictEqual(editor.getText(), "!echo");
+		assert.match(inputLine(editor), /^! echo/);
+	});
+
+	it("allows backspace to clear an empty bash marker", () => {
+		const editor = new BashPromptEditor(createTestTUI(), defaultEditorTheme);
+
+		editor.setText("!");
+		editor.handleInput("\x7f");
+
+		assert.strictEqual(editor.getText(), "");
+		assert.match(inputLine(editor), /^> /);
+	});
 });


### PR DESCRIPTION
- adds a visible prompt marker to the interactive input bar so the typing area is easier to find.
- switches the marker to ! or !! for bash commands while keeping the command prefix out of the visible input text.
- keeps bash mode highlighted without changing the input surface background.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only editor rendering and navigation changes with targeted tests; no auth, data, or API surface beyond optional editor options.
> 
> **Overview**
> Adds a **prompt gutter** to the TUI `Editor` so the first input line shows a configurable prefix (default `> `) and wrapped lines align with blank gutter space. The base editor gains `promptPrefix` in options plus overridable `getPromptPrefix`, `formatPromptPrefix`, and `getHiddenTextPrefixLength`, with layout, wrapping, and autocomplete width accounting for the gutter.
> 
> **`CustomEditor`** uses those hooks for bash-style `!` / `!!` markers: the gutter shows `! ` or `!! ` (styled via `borderColor`), while the leading `!` characters stay in buffer text but are **hidden from display** and protected from cursor/editing (line start, backspace, word-left, delete-to-start). Interactive mode **bash styling** now keeps the normal editor background instead of the green `toolSuccessBg` surface while still using the bash border color.
> 
> New tests in `editor-prompt-prefix.test.ts` cover rendering, wrapping, and navigation around hidden bash prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8ea3b676a9316585b2c9920a88a81905403794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prompt prefix gutter and bash-mode indicator to the TUI editor
> - Adds a `promptPrefix` option to the base [`Editor`](https://github.com/PrimeIntellect-ai/prime-agent/pull/91/files#diff-7b6fb102370899178db8d26e334f97123c72bc2127ed9a8d7b4952049b423d42), rendering a gutter (default `> `) before the first input line and indenting wrapped lines to match.
> - Introduces `getPromptPrefix`, `formatPromptPrefix`, and `getHiddenTextPrefixLength` protected hooks so subclasses can customize the gutter and hide leading marker characters from editable text.
> - [`CustomEditor`](https://github.com/PrimeIntellect-ai/prime-agent/pull/91/files#diff-d9bfbf3acb3425b8392c410c8136af3755b8cc08e825ed9312d29a2b15b82203) overrides these hooks to display `! ` or `!! ` as a colored bash-style gutter when input starts with those markers, hiding the raw marker from the editable area.
> - Cursor movement (Home, left-arrow, word-left, backspace, delete-to-line-start) is updated to treat the hidden prefix as a hard boundary that cannot be entered or deleted.
> - Behavioral Change: backspace on a line containing only `!`/`!!` clears the line entirely rather than merging with the previous line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae8ea3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->