### PR TITLE
fix ipython kernel startup blocking input

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1642,13 +1642,7 @@ export class AgentSession {
 			return;
 		}
 		this._disposed = true;
-		for (const run of this._activeRlmChildRuns.values()) {
-			if (run.status === "running" || run.status === "queued") {
-				run.status = "cancelled";
-				run.error = "Parent session disposed";
-				run.abort();
-			}
-		}
+		this._cancelActiveRlmChildRuns("Parent session disposed");
 		this._pendingNextTurnMessages = [];
 		this._steeringMessages = [];
 		this._followUpMessages = [];
@@ -2306,6 +2300,7 @@ export class AgentSession {
 	 */
 	async abort(): Promise<void> {
 		this.abortRetry();
+		this._cancelActiveRlmChildRuns("Parent session aborted");
 		this._goalAbortInProgress = this._goalState.status === "active";
 		this.agent.abort();
 		try {
@@ -3453,6 +3448,16 @@ export class AgentSession {
 
 	private _assistantTurnCount(): number {
 		return this.agent.state.messages.filter((message) => message.role === "assistant").length;
+	}
+
+	private _cancelActiveRlmChildRuns(reason: string): void {
+		for (const run of this._activeRlmChildRuns.values()) {
+			if (run.status === "running" || run.status === "queued") {
+				run.status = "cancelled";
+				run.error = reason;
+				run.abort();
+			}
+		}
 	}
 
 	private _startRlmChildRun(prompt: string, kwargs: Record<string, unknown> = {}): RlmChildRun {

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -42,9 +42,11 @@ const BOOTSTRAP_LOCK_STALE_WITHOUT_PID_MS = 30_000;
 let inFlightEnsureKernelPython: { key: string; promise: Promise<string> } | null = null;
 
 export type KernelPythonSkill = PythonSkillRuntimeInfo;
+export type KernelBootstrapProgressHandler = (message: string) => void;
 
 export interface EnsureKernelPythonOptions {
 	pythonSkills?: readonly KernelPythonSkill[];
+	onProgress?: KernelBootstrapProgressHandler;
 }
 
 interface BootstrapPythonSkill {
@@ -234,6 +236,14 @@ async function missingPythonSkillImportLabels(
 	return missing;
 }
 
+function reportProgress(options: EnsureKernelPythonOptions, message: string): void {
+	if (options.onProgress) {
+		options.onProgress(message);
+		return;
+	}
+	process.stderr.write(`${message}\n`);
+}
+
 function bootstrapLockDir(venv: string): string {
 	return path.join(path.dirname(venv), `${path.basename(venv)}${BOOTSTRAP_LOCK_NAME}`);
 }
@@ -303,23 +313,25 @@ async function findExecutable(name: string): Promise<string | null> {
 	return null;
 }
 
-async function ensureUv(): Promise<string> {
+async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 	const fromPath = await findExecutable("uv");
 	if (fromPath) return fromPath;
 
 	const localUv = path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
 	if (await isExecutable(localUv)) return localUv;
 
-	if (process.env.PRIME_AGENT_INSTALL_UV !== "1" && !(await confirmUvInstall())) {
+	const shouldInstallUv =
+		process.env.PRIME_AGENT_INSTALL_UV === "1" || (!options.onProgress && (await confirmUvInstall()));
+	if (!shouldInstallUv) {
 		throw new Error(
 			`uv is required to set up the Python kernel. Install uv yourself: ${UV_INSTALL_COMMAND}, ` +
 				"or set PRIME_AGENT_INSTALL_UV=1 to let prime-agent run that installer.",
 		);
 	}
 
-	process.stderr.write("› installing uv (one-time)…\n");
+	reportProgress(options, "› installing uv (one-time)…");
 	try {
-		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: "inherit" });
+		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
 	} catch (error) {
 		throw new Error(
 			`couldn't install uv from astral.sh; install it yourself: ${UV_INSTALL_COMMAND}, then re-run prime-agent. ${errorMessage(error)}`,
@@ -453,9 +465,13 @@ async function resolveRuntimeRequirement(): Promise<string> {
 	return RUNTIME_REQUIREMENT;
 }
 
-async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPythonSkill[]): Promise<void> {
+async function bootstrapVenv(
+	venv: string,
+	pythonSkills: readonly BootstrapPythonSkill[],
+	options: EnsureKernelPythonOptions,
+): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
-	const uv = await ensureUv();
+	const uv = await ensureUv(options);
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
 
@@ -470,7 +486,7 @@ async function bootstrapVenv(venv: string, pythonSkills: readonly BootstrapPytho
 		runtimeRequirement,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
-	await syncPythonSkills(uv, venv, python, pythonSkills);
+	await syncPythonSkills(uv, venv, python, pythonSkills, options);
 }
 
 async function syncPythonSkills(
@@ -478,6 +494,7 @@ async function syncPythonSkills(
 	venv: string,
 	python: string,
 	pythonSkills: readonly BootstrapPythonSkill[],
+	options: EnsureKernelPythonOptions,
 ): Promise<void> {
 	const version = await readBootstrapVersion(venv);
 	const installedPythonSkills: BootstrapPythonSkill[] = [];
@@ -496,8 +513,9 @@ async function syncPythonSkills(
 			await run(uv, ["pip", "install", "--python", python, "--editable", skill.packagePath]);
 			installedPythonSkills.push(skill);
 		} catch (error) {
-			process.stderr.write(
-				`Warning: Python skill ${skill.importName} failed to install and will be unavailable: ${errorMessage(error)}\n`,
+			reportProgress(
+				options,
+				`Warning: Python skill ${skill.importName} failed to install and will be unavailable: ${errorMessage(error)}`,
 			);
 		}
 	}
@@ -551,8 +569,9 @@ async function ensureKernelPythonUncached(
 		if (missing.length === 0 && pythonSkills.length > 0) {
 			const missingPythonSkills = await missingPythonSkillImportLabels(python, options.pythonSkills ?? []);
 			if (missingPythonSkills.length > 0) {
-				process.stderr.write(
-					`Warning: Python skills unavailable in PRIME_AGENT_KERNEL_PYTHON and will be disabled: ${missingPythonSkills.join(", ")}\n`,
+				reportProgress(
+					options,
+					`Warning: Python skills unavailable in PRIME_AGENT_KERNEL_PYTHON and will be disabled: ${missingPythonSkills.join(", ")}`,
 				);
 			}
 		}
@@ -568,25 +587,25 @@ async function ensureKernelPythonUncached(
 	try {
 		if (await kernelReady(python, venv, pythonSkills)) return python;
 		if (await kernelBaseReady(python, venv)) {
-			await syncPythonSkills(await ensureUv(), venv, python, pythonSkills);
+			await syncPythonSkills(await ensureUv(options), venv, python, pythonSkills, options);
 			return python;
 		}
 
 		const hadVenv = existsSync(venv);
-		process.stderr.write("› setting up python kernel (one-time, ~30s)…\n");
+		reportProgress(options, "› setting up python kernel (one-time, ~30s)…");
 		if (hadVenv) {
-			process.stderr.write("rebuilding kernel venv\n");
+			reportProgress(options, "rebuilding kernel venv");
 			await rm(venv, { recursive: true, force: true });
 		}
 
-		await bootstrapVenv(venv, pythonSkills);
+		await bootstrapVenv(venv, pythonSkills, options);
 	} catch (error) {
 		throw formatBootstrapFailure(error);
 	} finally {
 		await releaseLock().catch(() => undefined);
 	}
 
-	process.stderr.write("✓ ready\n");
+	reportProgress(options, "✓ ready");
 	return python;
 }
 

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -9,7 +9,7 @@ import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
 import type { RlmRunHandler, RlmRunResult } from "../rlm-runtime.js";
-import { ensureKernelPython, type KernelPythonSkill } from "./bootstrap.js";
+import { ensureKernelPython, type KernelBootstrapProgressHandler, type KernelPythonSkill } from "./bootstrap.js";
 
 const DELIM = Buffer.from("<IDS|MSG>");
 const PROTOCOL_VERSION = "5.3";
@@ -30,6 +30,10 @@ export interface KernelManagerOptions {
 	pythonSkills?: readonly KernelPythonSkill[];
 	/** Default: "prime-agent". */
 	username?: string;
+}
+
+export interface KernelStartOptions {
+	onBootstrapProgress?: KernelBootstrapProgressHandler;
 }
 
 export interface ExecuteOptions {
@@ -321,21 +325,26 @@ export class KernelManager {
 		return this.options.sessionId;
 	}
 
-	async start(): Promise<void> {
+	async start(options: KernelStartOptions = {}): Promise<void> {
 		if (!this.startPromise) {
-			this.startPromise = this.doStart();
+			this.startPromise = this.doStart(options);
 		}
 		return this.startPromise;
 	}
 
-	private async doStart(): Promise<void> {
+	private async doStart(startOptions: KernelStartOptions): Promise<void> {
 		if (this.state !== "idle") return;
 		this.state = "starting";
 		installSignalHandlersOnce();
 
 		let python: string;
 		try {
-			python = this.options.python ?? (await ensureKernelPython({ pythonSkills: this.options.pythonSkills }));
+			python =
+				this.options.python ??
+				(await ensureKernelPython({
+					pythonSkills: this.options.pythonSkills,
+					onProgress: startOptions.onBootstrapProgress,
+				}));
 			this.options.python = python;
 		} catch (error) {
 			this.state = "idle";

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -2,6 +2,7 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
+import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
 import { KernelManager } from "../kernel/index.js";
 import type { RlmRunHandler } from "../rlm-runtime.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
@@ -120,7 +121,7 @@ export type IpythonToolInput = Static<typeof ipythonSchema>;
 
 export interface IpythonToolDetails {
 	durationMs?: number;
-	status?: "ok" | "error" | "aborted";
+	status?: "ok" | "error" | "aborted" | "starting";
 	errorEname?: string;
 }
 
@@ -147,7 +148,7 @@ export function createIpythonToolDefinition(
 		options.kernelManagerRef.current = undefined;
 	}
 
-	function getManager(): Promise<KernelManager> {
+	function getManager(onBootstrapProgress?: KernelBootstrapProgressHandler): Promise<KernelManager> {
 		if (!managerPromise) {
 			managerPromise = (async () => {
 				const m = new KernelManager({
@@ -158,7 +159,9 @@ export function createIpythonToolDefinition(
 					rlmRunHandler: options?.rlmRunHandler,
 					pythonSkills: options?.pythonSkills,
 				});
-				await m.start();
+				onBootstrapProgress?.("Starting IPython kernel...");
+				await m.start({ onBootstrapProgress });
+				onBootstrapProgress?.("Preparing IPython runtime...");
 				const bootstrap = await m.execute(buildRlmBootstrapCode(options?.pythonSkills));
 				if (bootstrap.status !== "ok") {
 					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
@@ -185,34 +188,50 @@ export function createIpythonToolDefinition(
 		// The kernel is single-threaded — pi must not run two ipython calls in parallel within a batch.
 		executionMode: "sequential",
 		parameters: ipythonSchema,
-		execute: async (_toolCallId, params, signal, onUpdate) => {
-			const m = await getManager();
-			const r = await m.execute(params.code, {
-				signal,
-				onStream: (chunk) => {
-					onUpdate?.({
-						content: [{ type: "text", text: chunk }],
-						details: { status: "ok" },
-					});
-				},
-			});
-
-			let text = r.stdout;
-			if (r.stderr) text += (text ? "\n" : "") + r.stderr;
-			if (r.result) text += (text ? "\n" : "") + r.result;
-			if (r.status === "error" && r.error) {
-				text += (text ? "\n" : "") + r.error.traceback.join("\n");
-			}
-
-			return {
-				content: [{ type: "text", text: text || "" }],
-				details: {
-					durationMs: r.durationMs,
-					status: r.status,
-					errorEname: r.error?.ename,
-				},
-				isError: r.status === "error" || r.status === "aborted",
+		execute: async (_toolCallId, params, signal, onUpdate, ctx) => {
+			let reportedStartupProgress = false;
+			const reportStartupProgress: KernelBootstrapProgressHandler = (message) => {
+				reportedStartupProgress = true;
+				ctx?.ui.setWorkingMessage(message);
+				onUpdate?.({
+					content: [{ type: "text", text: message }],
+					details: { status: "starting" },
+				});
 			};
+
+			try {
+				const m = await getManager(reportStartupProgress);
+				const r = await m.execute(params.code, {
+					signal,
+					onStream: (chunk) => {
+						onUpdate?.({
+							content: [{ type: "text", text: chunk }],
+							details: { status: "ok" },
+						});
+					},
+				});
+
+				let text = r.stdout;
+				if (r.stderr) text += (text ? "\n" : "") + r.stderr;
+				if (r.result) text += (text ? "\n" : "") + r.result;
+				if (r.status === "error" && r.error) {
+					text += (text ? "\n" : "") + r.error.traceback.join("\n");
+				}
+
+				return {
+					content: [{ type: "text", text: text || "" }],
+					details: {
+						durationMs: r.durationMs,
+						status: r.status,
+						errorEname: r.error?.ename,
+					},
+					isError: r.status === "error" || r.status === "aborted",
+				};
+			} finally {
+				if (reportedStartupProgress) {
+					ctx?.ui.setWorkingMessage();
+				}
+			}
 		},
 	};
 }

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -373,6 +373,40 @@ describe("AgentSession rlm recursion", () => {
 		await expect(runPromise).rejects.toThrow();
 	});
 
+	it("cancels active rlm children when the parent session is aborted", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const root = createSession({
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				if (text === "slow shard") {
+					childStarted = true;
+					void release.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+					});
+				}
+				return stream;
+			},
+		});
+
+		const runPromise = root.runRlmChild("slow shard");
+		await waitFor(() => childStarted);
+		const runs = (root as unknown as InspectableRlmSession)._activeRlmChildRuns;
+		expect(runs.size).toBe(1);
+		const run = [...runs.values()][0];
+
+		await root.abort();
+
+		expect(run.status).toBe("cancelled");
+		expect(run.error).toBe("Parent session aborted");
+		releaseChild();
+		await expect(runPromise).rejects.toThrow("Parent session aborted");
+	});
+
 	it("runs parallel rlm comm requests independently", async () => {
 		let active = 0;
 		let maxActive = 0;

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_RLM_EXTRA_IMPORT_NAMES,
 	DEFAULT_RLM_EXTRA_UV_ARGS,
@@ -183,6 +183,26 @@ describe("kernel bootstrap", () => {
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: [],
 		});
+	});
+
+	it("routes bootstrap progress through the provided callback", async () => {
+		installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const progress: string[] = [];
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		try {
+			await expect(ensureKernelPython({ onProgress: (message) => progress.push(message) })).resolves.toBe(
+				join(venv, "bin", "python"),
+			);
+		} finally {
+			stderrWrite.mockRestore();
+		}
+
+		expect(progress).toEqual(expect.arrayContaining(["› setting up python kernel (one-time, ~30s)…", "✓ ready"]));
+		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("setting up python kernel"));
+		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("ready"));
 	});
 
 	it("installs Python skills into the bootstrapped venv", async () => {


### PR DESCRIPTION
- cancels active rlm child runs when the parent session aborts so ipython cells stop cleanly.
- routes lazy kernel bootstrap progress through tool updates and the working loader instead of raw terminal output.
- adds regressions for parent abort cancellation and bootstrap progress routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session abort/dispose behavior for RLM child runs and alters first-time kernel bootstrap (uv prompts and stdio) when progress is routed to the UI.
> 
> **Overview**
> Fixes **IPython kernel first-use blocking** by surfacing lazy Python bootstrap in the interactive UI instead of only writing to the terminal, and tightens **parent abort** so nested RLM work stops with the session.
> 
> **Kernel bootstrap progress:** `ensureKernelPython` and `KernelManager.start` accept an optional `onProgress` callback. Bootstrap messages (venv setup, uv install, warnings, “ready”) go through that hook when provided; otherwise behavior stays on `stderr`. With a progress handler, interactive **uv** install prompts are skipped (install still allowed via `PRIME_AGENT_INSTALL_UV=1`), and the uv installer’s stdio is suppressed so output doesn’t fight the UI.
> 
> **ipython tool:** On first kernel startup, progress is pushed via **tool updates** (`details.status: "starting"`) and **`ctx.ui.setWorkingMessage`**, then cleared in a `finally` block after the manager is ready.
> 
> **RLM children:** Active child runs are cancelled on **`abort()`** as well as **`dispose()`**, via shared `_cancelActiveRlmChildRuns` with distinct error reasons (“Parent session aborted” vs disposed).
> 
> Tests cover abort-time child cancellation and callback-only bootstrap progress (no duplicate stderr for those lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e176189b480c67f8ef3c7ac16574436ca9c1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix IPython kernel startup blocking input by streaming progress during bootstrap
> - During first-time kernel bootstrap, the IPython tool now streams `'starting'` status updates and sets a working UI message, clearing it when startup completes.
> - Introduces an `onProgress` callback (`KernelBootstrapProgressHandler`) threaded through `ensureKernelPython`, `KernelManager.start`, and bootstrap helpers so progress messages can be delivered to callers instead of always writing to stderr.
> - When `onProgress` is provided, interactive UV install confirmation is skipped (requires `PRIME_AGENT_INSTALL_UV=1`) and subprocess output is suppressed.
> - `AgentSession.abort` now cancels any running or queued RLM child runs with the reason `'Parent session aborted'` via a new `_cancelActiveRlmChildRuns` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49e1761.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->