### PR TITLE
feat(coding-agent): add Ctrl+C to interrupt streaming model and abort bash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Ctrl+C to interrupt the model while streaming and abort running bash commands, in addition to Escape.
+
 ### Fixed
 
 - Fixed child-agent navigation to show contextual keybinding hints and a visible focused tray marker.

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -65,7 +65,7 @@ declare module "@earendil-works/pi-tui" {
 export const KEYBINDINGS = {
 	...TUI_KEYBINDINGS,
 	"app.interrupt": { defaultKeys: "escape", description: "Cancel or abort" },
-	"app.clear": { defaultKeys: "ctrl+c", description: "Clear editor" },
+	"app.clear": { defaultKeys: "ctrl+c", description: "Abort streaming / clear editor" },
 	"app.exit": { defaultKeys: "ctrl+d", description: "Exit when editor is empty" },
 	"app.suspend": {
 		defaultKeys: process.platform === "win32" ? [] : "ctrl+z",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -773,7 +773,7 @@ export class InteractiveMode {
 			const verboseInstructions = this.options.verbose
 				? [
 						hint("app.interrupt", "to interrupt"),
-						hint("app.clear", "to clear"),
+						hint("app.clear", "to interrupt / clear"),
 						rawKeyHint(`${keyText("app.clear")} twice`, "to exit"),
 						hint("app.exit", "to exit (empty)"),
 						hint("app.suspend", "to suspend"),
@@ -3936,6 +3936,14 @@ export class InteractiveMode {
 	// =========================================================================
 
 	private handleCtrlC(): void {
+		if (this.session.isStreaming) {
+			this.restoreQueuedMessagesToEditor({ abort: true });
+			return;
+		}
+		if (this.session.isBashRunning) {
+			this.session.abortBash();
+			return;
+		}
 		const now = Date.now();
 		if (now - this.lastSigintTime < 500) {
 			void this.shutdown();
@@ -6380,7 +6388,7 @@ export class InteractiveMode {
 |-----|--------|
 | \`${tab}\` | Path completion / accept autocomplete |
 | \`${interrupt}\` | Cancel autocomplete / abort streaming |
-| \`${clear}\` | Clear editor (first) / exit (second) |
+| \`${clear}\` | Abort streaming / clear editor (first) / exit (second) |
 | \`${exit}\` | Exit (when editor is empty) |
 | \`${suspend}\` | Suspend to background |
 | \`${cycleThinkingLevel}\` | Cycle thinking level |


### PR DESCRIPTION
## Summary

Previously only `Escape` could interrupt the model while streaming or abort a running bash command. Now `Ctrl+C` also interrupts when the model is streaming or bash is running.

## Behavior

| State | Before | After |
|-------|--------|-------|
| Model streaming | Only Escape | **Ctrl+C** or Escape |
| Bash running | Only Escape | **Ctrl+C** or Escape |
| Neither | Ctrl+C clears editor (unchanged) | Ctrl+C clears editor (unchanged) |
| Double Ctrl+C | Exits (unchanged) | Exits (unchanged) |

## Changes

- `handleCtrlC()` now checks `session.isStreaming` and `session.isBashRunning` first, delegating to the same abort logic as Escape
- Updated `app.clear` keybinding description to "Abort streaming / clear editor"
- Updated verbose startup hint and help table to reflect the new behavior
- CHANGELOG entry added

## Not in scope

Ctrl+C does **not** cancel compaction or retry — those are handled by dynamically swapped Escape handlers and remain Escape-only. This is the minimal change for the most common interrupt scenarios.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ctrl+C to interrupt streaming model and abort running bash commands
> - `InteractiveMode.handleCtrlC` now checks `session.isStreaming` and `session.isBashRunning` before existing behavior, calling `restoreQueuedMessagesToEditor({ abort: true })` or `session.abortBash()` respectively.
> - Double-press within 500ms to exit and single-press to clear the editor remain unchanged.
> - Updates keybinding hint strings and help text to reflect the new Ctrl+C behavior alongside Escape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd5d707.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->