### PR TITLE
Tone down flashy green and purple in prime theme

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -9,20 +9,20 @@
 		"muted": "#a1a1aa",
 		"dim": "#71717a",
 		"grid": "#52525b",
-		"primary": "#7f5bd5",
-		"primarySoft": "#9162e6",
-		"success": "#84cc16",
+		"primary": "#7c6faf",
+		"primarySoft": "#8d7fc0",
+		"success": "#7da876",
 		"warning": "#f59e0b",
 		"error": "#ff2d55",
 		"info": "#38bdf8",
 		"infoDim": "#1f6f99",
 		"neutral": "#d4d4d8",
-		"stringMint": "#a3be8c",
+		"stringMint": "#8ba888",
 		"selectedBg": "#222226",
 		"userMsgBg": "#1a1a1f",
 		"customMsgBg": "#151518",
 		"toolPendingBg": "#101015",
-		"toolSuccessBg": "#0c1610",
+		"toolSuccessBg": "#0e1510",
 		"toolErrorBg": "#1a0d12"
 	},
 	"colors": {
@@ -37,7 +37,6 @@
 		"dim": "dim",
 		"text": "",
 		"thinkingText": "#8b8b94",
-
 		"selectedBg": "selectedBg",
 		"userMessageBg": "userMsgBg",
 		"userMessageText": "",
@@ -49,7 +48,6 @@
 		"toolErrorBg": "toolErrorBg",
 		"toolTitle": "",
 		"toolOutput": "muted",
-
 		"mdHeading": "primarySoft",
 		"mdLink": "info",
 		"mdLinkUrl": "dim",
@@ -60,11 +58,9 @@
 		"mdQuoteBorder": "grid",
 		"mdHr": "grid",
 		"mdListBullet": "muted",
-
 		"toolDiffAdded": "success",
 		"toolDiffRemoved": "error",
 		"toolDiffContext": "muted",
-
 		"syntaxComment": "muted",
 		"syntaxKeyword": "info",
 		"syntaxFunction": "info",
@@ -74,14 +70,12 @@
 		"syntaxType": "warning",
 		"syntaxOperator": "neutral",
 		"syntaxPunctuation": "neutral",
-
 		"thinkingOff": "fg",
 		"thinkingMinimal": "muted",
 		"thinkingLow": "info",
 		"thinkingMedium": "primarySoft",
 		"thinkingHigh": "primary",
 		"thinkingXhigh": "primary",
-
 		"bashMode": "success"
 	},
 	"export": {


### PR DESCRIPTION
## Summary

example 

<img width="3787" height="442" alt="image" src="https://github.com/user-attachments/assets/fd223eda-d7dd-44de-a8db-fd95b899b8f4" />


Tones down the flashy green and purple colors in the **prime** theme for a calmer, more comfortable look.

### Changes

| Var | Before | After |
|-----|--------|-------|
| `primary` | `#7f5bd5` (neon purple) | `#7c6faf` (dusty lavender) |
| `primarySoft` | `#9162e6` (bright purple) | `#8d7fc0` (muted lavender) |
| `success` | `#84cc16` (lime green) | `#7da876` (sage green) |
| `stringMint` | `#a3be8c` (mint green) | `#8ba888` (dusty sage) |
| `toolSuccessBg` | `#0c1610` | `#0e1510` (adjusted for new green undertone) |

These vars flow into accent, borders, headings, thinking levels, diff indicators, bash mode, code blocks, and syntax highlighting — all now use softer, less saturated tones.

### Affected package

`pkg:coding-agent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only theme token updates with no logic, API, or security impact.
> 
> **Overview**
> Softens the **prime** interactive theme palette by retuning five `vars` in `prime.json`: purple accents (`primary`, `primarySoft`), success/syntax greens (`success`, `stringMint`), and `toolSuccessBg` for the new green undertone. No structural or token-mapping changes—only hex values and minor whitespace cleanup—so anything that already references those vars (accents, borders, headings, thinking levels, diff added lines, bash mode, code blocks) picks up the calmer lavender/sage look automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fbda4cfb1a5c29f7c712d07b66f1da8fcd2b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tone down green and purple colors in the prime theme
> Updates color values for `primary`, `primarySoft`, `success`, `stringMint`, and `toolSuccessBg` in [prime.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/96/files#diff-8d3bf486be7ba9041562c78f0286ffa640e4daa1aca680e5d76aecfbe54e3a3f) to reduce visual intensity of the green and purple hues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11fbda4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->