### PR TITLE
fix subagent tool expansion keybinding

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -616,7 +616,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	private detailHintLine(width: number): string {
-		const expandAction = keyAction("app.tools.expand", this.toolsExpanded ? "collapse tools" : "expand tools");
+		const expandAction = keyAction("app.tools.expand", this.toolsExpanded ? "to collapse" : "to expand");
 		return hintLine(
 			[keyAction("tui.select.cancel", "back to subagents", { primaryOnly: true }), expandAction],
 			width,

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -100,6 +100,14 @@ interface DetailSections {
 	bodyLines: string[];
 }
 
+interface ExpandableComponent extends Component {
+	setExpanded(expanded: boolean): void;
+}
+
+function isExpandableComponent(component: Component): component is ExpandableComponent {
+	return "setExpanded" in component && typeof (component as { setExpanded?: unknown }).setExpanded === "function";
+}
+
 function flattenChildAgentNodes(nodes: readonly ChildAgentInspectorNode[]): FlatChildAgentNode[] {
 	const result: FlatChildAgentNode[] = [];
 	const walk = (items: readonly ChildAgentInspectorNode[], depth: number): void => {
@@ -433,17 +441,31 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	private node: ChildAgentInspectorNode | undefined;
 	private transcriptComponents: Component[] = [];
 	private readonly fallbackTui = { requestRender: () => {} } as TUI;
+	private toolsExpanded = false;
 
 	onCancel?: () => void;
+	onToggleToolsExpanded?: () => void;
 
 	constructor(
 		_getViewportHeight: () => number = () => 0,
 		private readonly options: ChildAgentDetailOptions = {},
-	) {}
+	) {
+		this.toolsExpanded = this.options.getToolsExpanded?.() ?? false;
+	}
 
 	setNode(node: ChildAgentInspectorNode | undefined): void {
 		this.node = node;
+		this.toolsExpanded = this.options.getToolsExpanded?.() ?? this.toolsExpanded;
 		this.rebuildTranscriptComponents();
+	}
+
+	setToolsExpanded(expanded: boolean): void {
+		this.toolsExpanded = expanded;
+		for (const component of this.transcriptComponents) {
+			if (isExpandableComponent(component)) {
+				component.setExpanded(expanded);
+			}
+		}
 	}
 
 	invalidate(): void {
@@ -466,6 +488,10 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 
 	handleInput(data: string): void {
 		const kb = getKeybindings();
+		if (kb.matches(data, "app.tools.expand")) {
+			this.onToggleToolsExpanded?.();
+			return;
+		}
 		if (kb.matches(data, "tui.select.cancel")) {
 			this.onCancel?.();
 		}
@@ -560,7 +586,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			this.options.ui ?? this.fallbackTui,
 			this.options.getCwd?.() ?? process.cwd(),
 		);
-		component.setExpanded(this.options.getToolsExpanded?.() ?? false);
+		component.setExpanded(this.toolsExpanded);
 		if (entry.executionStarted) {
 			component.markExecutionStarted();
 		}
@@ -590,7 +616,11 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	private detailHintLine(width: number): string {
-		return hintLine([keyAction("tui.select.cancel", "back to subagents", { primaryOnly: true })], width);
+		const expandAction = keyAction("app.tools.expand", this.toolsExpanded ? "collapse tools" : "expand tools");
+		return hintLine(
+			[keyAction("tui.select.cancel", "back to subagents", { primaryOnly: true }), expandAction],
+			width,
+		);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {

--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -19,7 +19,7 @@ function formatKeyPart(part: string, platform: NodeJS.Platform): string {
 		if (normalized === "ctrl") return "Cmd";
 		if (normalized === "alt") return "Option";
 	}
-	return normalized === "esc" ? normalized : normalized.charAt(0).toUpperCase() + normalized.slice(1);
+	return normalized.charAt(0).toUpperCase() + normalized.slice(1);
 }
 
 export function formatKeyText(key: string, platform: NodeJS.Platform = process.platform): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -545,6 +545,7 @@ export class InteractiveMode {
 			getHiddenThinkingLabel: () => this.hiddenThinkingLabel,
 		});
 		this.childAgentDetail.onCancel = () => this.showChildAgentList();
+		this.childAgentDetail.onToggleToolsExpanded = () => this.toggleToolOutputExpansion();
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
 		this.keybindings = KeybindingsManager.create();
@@ -4165,6 +4166,7 @@ export class InteractiveMode {
 				child.setExpanded(expanded);
 			}
 		}
+		this.childAgentDetail.setToolsExpanded(expanded);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -516,14 +516,16 @@ describe("truncatePathMiddle", () => {
 });
 
 describe("InteractiveMode.setToolsExpanded", () => {
-	test("applies expansion state to the active header and chat entries", () => {
+	test("applies expansion state to the active header, chat entries, and child agent detail", () => {
 		const header = { setExpanded: vi.fn() };
 		const chatChild = { setExpanded: vi.fn() };
+		const childAgentDetail = { setToolsExpanded: vi.fn() };
 		const fakeThis: any = {
 			toolOutputExpanded: false,
 			customHeader: undefined,
 			builtInHeader: header,
 			chatContainer: { children: [chatChild] },
+			childAgentDetail,
 			ui: { requestRender: vi.fn() },
 		};
 
@@ -532,6 +534,7 @@ describe("InteractiveMode.setToolsExpanded", () => {
 		expect(fakeThis.toolOutputExpanded).toBe(true);
 		expect(header.setExpanded).toHaveBeenCalledWith(true);
 		expect(chatChild.setExpanded).toHaveBeenCalledWith(true);
+		expect(childAgentDetail.setToolsExpanded).toHaveBeenCalledWith(true);
 		expect(fakeThis.ui.requestRender).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/keybinding-hints.test.ts
+++ b/packages/coding-agent/test/keybinding-hints.test.ts
@@ -20,8 +20,9 @@ describe("keybinding hint formatting", () => {
 		expect(formatKeyText("ctrl+backspace/pageUp", "win32")).toBe("Ctrl+Backspace/PageUp");
 	});
 
-	it("formats escape as esc", () => {
-		expect(formatKeyText("escape", "linux")).toBe("esc");
-		expect(formatKeyText("ctrl+escape", "linux")).toBe("Ctrl+esc");
+	it("formats escape as Esc", () => {
+		expect(formatKeyText("escape", "linux")).toBe("Esc");
+		expect(formatKeyText("esc", "linux")).toBe("Esc");
+		expect(formatKeyText("ctrl+escape", "linux")).toBe("Ctrl+Esc");
 	});
 });

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -1,8 +1,9 @@
 import type { AssistantMessage, Usage, UserMessage } from "@earendil-works/pi-ai";
-import { type Component, TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { type Component, setKeybindings, TUI, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test } from "vitest";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.js";
+import { KeybindingsManager } from "../src/core/keybindings.js";
 import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
 import {
 	ChildAgentDetailComponent,
@@ -83,6 +84,7 @@ async function renderInVirtualTerminal(component: Component, width = 100, height
 describe("marquee TUI components", () => {
 	beforeAll(() => {
 		initTheme("dark");
+		setKeybindings(new KeybindingsManager());
 	});
 
 	test("renders ipython cells with shell magic and collapsed traceback", async () => {
@@ -482,6 +484,52 @@ describe("marquee TUI components", () => {
 
 		const narrow = stripAnsi(component.render(24).join("\n"));
 		expect(narrow).toContain("inspect t…");
+	});
+
+	test("routes child agent detail tool expansion through app keybindings", () => {
+		setKeybindings(new KeybindingsManager({ "app.tools.expand": "ctrl+x" }));
+		try {
+			const detailComponent = new ChildAgentDetailComponent(() => 20);
+			let toggleCount = 0;
+			detailComponent.onToggleToolsExpanded = () => {
+				toggleCount += 1;
+			};
+			detailComponent.setNode({
+				id: "sub-a",
+				label: "inspect training logs",
+				status: "running",
+				sessionDir: "/tmp/session/sub-a",
+				transcript: [],
+				structuredTranscript: [
+					{
+						type: "tool",
+						role: "tool",
+						text: "bash: hi",
+						toolCallId: "tool-sub-a",
+						toolName: "bash",
+						args: { command: "echo hi" },
+						result: {
+							content: [{ type: "text", text: "hi" }],
+							isError: false,
+						},
+						isPartial: false,
+						executionStarted: true,
+						argsComplete: true,
+					},
+				],
+			});
+
+			const before = stripAnsi(detailComponent.render(80).join("\n"));
+			expect(before).toContain("Ctrl+X expand tools");
+			detailComponent.handleInput("\x18");
+
+			expect(toggleCount).toBe(1);
+			detailComponent.setToolsExpanded(true);
+			const after = stripAnsi(detailComponent.render(80).join("\n"));
+			expect(after).toContain("Ctrl+X collapse tools");
+		} finally {
+			setKeybindings(new KeybindingsManager());
+		}
 	});
 
 	test("keeps child agent summary visible when the right tray label is long", () => {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -436,7 +436,7 @@ describe("marquee TUI components", () => {
 		const wideList = stripAnsi(component.render(96).join("\n"));
 		expect(wideList).toContain("Up/Down move");
 		expect(wideList).toContain("Enter open");
-		expect(wideList).toContain("esc close");
+		expect(wideList).toContain("Esc close");
 		expect(wideList).not.toContain("ctrl+c close");
 		for (const line of component.render(96)) {
 			expect(visibleWidth(line)).toBe(96);
@@ -467,7 +467,7 @@ describe("marquee TUI components", () => {
 		expect(detail).toContain("reading shard metrics");
 		expect(detail).toContain("$ echo hi");
 		expect(detail).toContain("hi");
-		expect(detail).toContain("esc back to subagents");
+		expect(detail).toContain("Esc back to subagents");
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 		expect(detail).not.toContain("tool: bash");
@@ -572,7 +572,7 @@ describe("marquee TUI components", () => {
 		const first = stripAnsi(firstLines.join("\n"));
 		expect(first).toContain("fallback transcript row 01");
 		expect(first).toContain("fallback transcript row 12");
-		expect(first).toContain("esc back to subagents");
+		expect(first).toContain("Esc back to subagents");
 		expect(first).not.toContain("↑");
 		expect(first).not.toContain("↓");
 		expect(firstLines.length).toBeGreaterThan(6);

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -520,13 +520,13 @@ describe("marquee TUI components", () => {
 			});
 
 			const before = stripAnsi(detailComponent.render(80).join("\n"));
-			expect(before).toContain("Ctrl+X expand tools");
+			expect(before).toContain("Ctrl+X to expand");
 			detailComponent.handleInput("\x18");
 
 			expect(toggleCount).toBe(1);
 			detailComponent.setToolsExpanded(true);
 			const after = stripAnsi(detailComponent.render(80).join("\n"));
-			expect(after).toContain("Ctrl+X collapse tools");
+			expect(after).toContain("Ctrl+X to collapse");
 		} finally {
 			setKeybindings(new KeybindingsManager());
 		}


### PR DESCRIPTION
- child agent detail now routes tool expansion through the shared configurable keybinding.
- subagent transcript tools stay in sync with the main tool expansion state.
- added regression coverage for focused subagent detail handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only behavior for tool output expansion and hint formatting; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes subagent inspector tool expand/collapse** so it uses the same configurable `app.tools.expand` binding as the main chat, instead of being out of sync or unreachable from the child-agent detail view.
> 
> `ChildAgentDetailComponent` keeps a local `toolsExpanded` flag, handles `app.tools.expand` by calling `onToggleToolsExpanded`, and shows an expand/collapse hint on the detail footer. `InteractiveMode` routes that callback to `toggleToolOutputExpansion()` and propagates global expansion via `setToolsExpanded` on the detail panel and its transcript `ToolExecutionComponent` rows.
> 
> Key hint text now shows **Esc** (capitalized) for escape keys in formatted bindings; tests cover detail expansion routing and the updated hint strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5749bd14eb0f69a85ca3418044e81858db86a6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `app.tools.expand` keybinding in subagent tool panel of `ChildAgentDetailComponent`
> - `ChildAgentDetailComponent` now tracks a `toolsExpanded` state and responds to the `app.tools.expand` keybinding by calling `onToggleToolsExpanded`, which routes to the global toggle in `InteractiveMode`.
> - `setToolsExpanded` propagates expansion state to existing transcript subcomponents that implement `ExpandableComponent`, and `InteractiveMode.setToolsExpanded` now also syncs the child agent detail view.
> - An expand/collapse hint is rendered in the detail footer based on the current expansion state.
> - Fixes `Esc` key rendering in `formatKeyPart` — was lowercase `esc`, now correctly capitalized as `Esc`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5749bd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->