### PR TITLE
fix alternate alt arrow handling

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed alternate terminal encodings for `Alt+Arrow` keybindings, including `Alt+Up` for restoring queued messages ([ENG-3979](https://linear.app/primeintellect/issue/ENG-3979/queued-message-cant-be-edited-with-altup)).
+
 ## [0.0.4] - 2026-05-21
 
 ## [0.0.2] - 2026-05-20

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -314,6 +314,8 @@ const ARROW_CODEPOINTS = {
 	left: -4,
 } as const;
 
+type ArrowKeyName = keyof typeof ARROW_CODEPOINTS;
+
 const FUNCTIONAL_CODEPOINTS = {
 	delete: -10,
 	insert: -11,
@@ -481,6 +483,20 @@ const LEGACY_SEQUENCE_KEY_IDS: Record<string, KeyId> = {
 } as const;
 
 type LegacyModifierKey = keyof typeof LEGACY_SHIFT_SEQUENCES;
+
+const ALT_ARROW_SEQUENCES = {
+	up: ["\x1bp"],
+	down: ["\x1bn"],
+	right: ["\x1bf"],
+	left: ["\x1bb"],
+} as const satisfies Record<ArrowKeyName, readonly string[]>;
+
+const LEGACY_ALT_ARROW_SEQUENCES = {
+	up: ["\x1b[1;3A", "\x1b[1;9A", "\x1b[3A", "\x1bO3A", "\x1b\x1b[A", "\x1b\x1bOA"],
+	down: ["\x1b[1;3B", "\x1b[1;9B", "\x1b[3B", "\x1bO3B", "\x1b\x1b[B", "\x1b\x1bOB"],
+	right: ["\x1b[1;3C", "\x1b[1;9C", "\x1b[3C", "\x1bO3C", "\x1b\x1b[C", "\x1b\x1bOC", "\x1bF"],
+	left: ["\x1b[1;3D", "\x1b[1;9D", "\x1b[3D", "\x1bO3D", "\x1b\x1b[D", "\x1b\x1bOD", "\x1bB"],
+} as const satisfies Record<ArrowKeyName, readonly string[]>;
 
 const matchesLegacySequence = (data: string, sequences: readonly string[]): boolean => sequences.includes(data);
 
@@ -773,6 +789,37 @@ function matchesPrintableModifyOtherKeys(data: string, expectedKeycode: number, 
 	);
 }
 
+function parseAltArrowSequence(data: string): ArrowKeyName | undefined {
+	for (const key of Object.keys(ALT_ARROW_SEQUENCES) as ArrowKeyName[]) {
+		if (matchesLegacySequence(data, ALT_ARROW_SEQUENCES[key])) return key;
+	}
+
+	if (_kittyProtocolActive) return undefined;
+
+	for (const key of Object.keys(LEGACY_ALT_ARROW_SEQUENCES) as ArrowKeyName[]) {
+		if (matchesLegacySequence(data, LEGACY_ALT_ARROW_SEQUENCES[key])) return key;
+	}
+
+	return undefined;
+}
+
+function matchesArrowKey(data: string, key: ArrowKeyName, modifier: number): boolean {
+	const altArrow = parseAltArrowSequence(data);
+	if (altArrow !== undefined) {
+		return altArrow === key && modifier === MODIFIERS.alt;
+	}
+
+	if (modifier === 0) {
+		return (
+			matchesLegacySequence(data, LEGACY_KEY_SEQUENCES[key]) || matchesKittySequence(data, ARROW_CODEPOINTS[key], 0)
+		);
+	}
+	if (matchesLegacyModifierSequence(data, key, modifier)) {
+		return true;
+	}
+	return matchesKittySequence(data, ARROW_CODEPOINTS[key], modifier);
+}
+
 function formatKeyNameWithModifiers(keyName: string, modifier: number): string | undefined {
 	const mods: string[] = [];
 	const effectiveMod = modifier & ~LOCK_MASK;
@@ -1042,88 +1089,16 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 			return matchesKittySequence(data, FUNCTIONAL_CODEPOINTS.pageDown, modifier);
 
 		case "up":
-			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
-			}
-			if (modifier === 0) {
-				return (
-					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.up) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.up, 0)
-				);
-			}
-			if (matchesLegacyModifierSequence(data, "up", modifier)) {
-				return true;
-			}
-			return matchesKittySequence(data, ARROW_CODEPOINTS.up, modifier);
+			return matchesArrowKey(data, "up", modifier);
 
 		case "down":
-			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
-			}
-			if (modifier === 0) {
-				return (
-					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.down) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.down, 0)
-				);
-			}
-			if (matchesLegacyModifierSequence(data, "down", modifier)) {
-				return true;
-			}
-			return matchesKittySequence(data, ARROW_CODEPOINTS.down, modifier);
+			return matchesArrowKey(data, "down", modifier);
 
 		case "left":
-			if (modifier === MODIFIERS.alt) {
-				return (
-					data === "\x1b[1;3D" ||
-					(!_kittyProtocolActive && data === "\x1bB") ||
-					data === "\x1bb" ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.alt)
-				);
-			}
-			if (modifier === MODIFIERS.ctrl) {
-				return (
-					data === "\x1b[1;5D" ||
-					matchesLegacyModifierSequence(data, "left", MODIFIERS.ctrl) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.ctrl)
-				);
-			}
-			if (modifier === 0) {
-				return (
-					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.left) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.left, 0)
-				);
-			}
-			if (matchesLegacyModifierSequence(data, "left", modifier)) {
-				return true;
-			}
-			return matchesKittySequence(data, ARROW_CODEPOINTS.left, modifier);
+			return matchesArrowKey(data, "left", modifier);
 
 		case "right":
-			if (modifier === MODIFIERS.alt) {
-				return (
-					data === "\x1b[1;3C" ||
-					(!_kittyProtocolActive && data === "\x1bF") ||
-					data === "\x1bf" ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.alt)
-				);
-			}
-			if (modifier === MODIFIERS.ctrl) {
-				return (
-					data === "\x1b[1;5C" ||
-					matchesLegacyModifierSequence(data, "right", MODIFIERS.ctrl) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.ctrl)
-				);
-			}
-			if (modifier === 0) {
-				return (
-					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.right) ||
-					matchesKittySequence(data, ARROW_CODEPOINTS.right, 0)
-				);
-			}
-			if (matchesLegacyModifierSequence(data, "right", modifier)) {
-				return true;
-			}
-			return matchesKittySequence(data, ARROW_CODEPOINTS.right, modifier);
+			return matchesArrowKey(data, "right", modifier);
 
 		case "f1":
 		case "f2":
@@ -1249,6 +1224,9 @@ function formatParsedKey(codepoint: number, modifier: number, baseLayoutKey?: nu
 }
 
 export function parseKey(data: string): string | undefined {
+	const altArrow = parseAltArrowSequence(data);
+	if (altArrow) return `alt+${altArrow}`;
+
 	const kitty = parseKittySequence(data);
 	if (kitty) {
 		return formatParsedKey(kitty.codepoint, kitty.modifier, kitty.baseLayoutKey);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -90,12 +90,15 @@ describe("matchesKey", () => {
 			setKittyProtocolActive(true);
 			assert.strictEqual(matchesKey("\x1b[107;9u", "super+k"), true);
 			assert.strictEqual(matchesKey("\x1b[13;9u", "super+enter"), true);
+			assert.strictEqual(matchesKey("\x1b[1;9A", "super+up"), true);
 			assert.strictEqual(matchesKey("\x1b[107;13u", Key.ctrlSuper("k")), true);
 			assert.strictEqual(matchesKey("\x1b[107;13u", "ctrl+super+k"), true);
 			assert.strictEqual(matchesKey("\x1b[107;14u", "ctrl+shift+super+k"), true);
 			assert.strictEqual(matchesKey("\x1b[107;13u", "super+k"), false);
+			assert.strictEqual(matchesKey("\x1b[1;9A", "alt+up"), false);
 			assert.strictEqual(parseKey("\x1b[107;9u"), "super+k");
 			assert.strictEqual(parseKey("\x1b[13;9u"), "super+enter");
+			assert.strictEqual(parseKey("\x1b[1;9A"), "super+up");
 			assert.strictEqual(parseKey("\x1b[107;13u"), "ctrl+super+k");
 			assert.strictEqual(parseKey("\x1b[107;14u"), "shift+ctrl+super+k");
 			setKittyProtocolActive(false);
@@ -483,6 +486,47 @@ describe("matchesKey", () => {
 			assert.strictEqual(matchesKey("\x1bp", "up"), false);
 		});
 
+		it("should match alternate legacy alt+arrow encodings", () => {
+			setKittyProtocolActive(false);
+			const cases = [
+				["\x1bp", "alt+up"],
+				["\x1bn", "alt+down"],
+				["\x1bf", "alt+right"],
+				["\x1bb", "alt+left"],
+				["\x1b[1;3A", "alt+up"],
+				["\x1b[1;3B", "alt+down"],
+				["\x1b[1;3C", "alt+right"],
+				["\x1b[1;3D", "alt+left"],
+				["\x1b[1;9A", "alt+up"],
+				["\x1b[1;9B", "alt+down"],
+				["\x1b[1;9C", "alt+right"],
+				["\x1b[1;9D", "alt+left"],
+				["\x1b[3A", "alt+up"],
+				["\x1b[3B", "alt+down"],
+				["\x1b[3C", "alt+right"],
+				["\x1b[3D", "alt+left"],
+				["\x1bO3A", "alt+up"],
+				["\x1bO3B", "alt+down"],
+				["\x1bO3C", "alt+right"],
+				["\x1bO3D", "alt+left"],
+				["\x1b\x1b[A", "alt+up"],
+				["\x1b\x1b[B", "alt+down"],
+				["\x1b\x1b[C", "alt+right"],
+				["\x1b\x1b[D", "alt+left"],
+				["\x1b\x1bOA", "alt+up"],
+				["\x1b\x1bOB", "alt+down"],
+				["\x1b\x1bOC", "alt+right"],
+				["\x1b\x1bOD", "alt+left"],
+			] as const;
+
+			for (const [sequence, key] of cases) {
+				assert.strictEqual(matchesKey(sequence, key), true, key);
+				assert.strictEqual(parseKey(sequence), key, key);
+			}
+
+			assert.strictEqual(matchesKey("\x1b[1;9A", "super+up"), false);
+		});
+
 		it("should match rxvt modifier sequences", () => {
 			assert.strictEqual(matchesKey("\x1b[a", "shift+up"), true);
 			assert.strictEqual(matchesKey("\x1bOa", "ctrl+up"), true);
@@ -605,6 +649,8 @@ describe("parseKey", () => {
 			assert.strictEqual(parseKey("\x1b[E"), "clear");
 			assert.strictEqual(parseKey("\x1b[2^"), "ctrl+insert");
 			assert.strictEqual(parseKey("\x1bp"), "alt+up");
+			assert.strictEqual(parseKey("\x1b[1;9A"), "alt+up");
+			assert.strictEqual(parseKey("\x1b\x1b[A"), "alt+up");
 		});
 
 		it("should parse double bracket pageUp", () => {


### PR DESCRIPTION
- alternate terminal encodings for alt+arrow now resolve through the shared keybinding matcher.
- alt+up restores queued messages again in terminals that emit meta-style arrow sequences.
- added key parser regressions while preserving kitty super+arrow handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to TUI input parsing in `keys.ts` with broad regression tests; behavior change is limited to recognizing more Alt+Arrow sequences while preserving Kitty super+arrow handling.
> 
> **Overview**
> **Fixes `Alt+Arrow` keybindings** (including **Alt+Up** for restoring queued messages) when terminals emit non-standard escape sequences instead of the simple meta forms (`\x1bp`, etc.).
> 
> `matchesKey` / `parseKey` now route arrow handling through shared **`parseAltArrowSequence`** and **`matchesArrowKey`**, with tables for **CSI-style** (`\x1b[1;3A`, `\x1b[3A`, `\x1bO3A`, double-ESC prefixes, etc.) and **rxvt-style** `\x1bB` / `\x1bF` left/right. **`parseKey` resolves alt-arrows before Kitty CSI parsing** so ambiguous sequences like `\x1b[1;9A` map to **`alt+up`** rather than **`super+up`**. Legacy alt-arrow CSI variants are skipped when the **Kitty protocol** is active so **`super+arrow`** Kitty bindings stay correct.
> 
> Changelog and regression tests cover the new encodings and the alt vs super distinction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b3efddb30782e06b79c88985ecbd0baa1810c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Alt+Arrow key handling for alternate terminal encodings
> - Adds `parseAltArrowSequence` and `matchesArrowKey` helpers in [keys.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/99/files#diff-c4967c48e0748404d8098865b5c26f3cde0386f443cdc0876af23a893ce7774a) to centralize alt+arrow detection across multiple legacy encodings (e.g. `ESC[1;3X`, `ESC[1;9X`, `O3X`, `ESC B/F`).
> - When Kitty protocol is active, legacy alt-arrow sequences are not claimed, preserving correct Kitty/super-modifier interpretation (e.g. `ESC[1;9A` returns `super+up`, not `alt+up`).
> - `matchesKey` for arrow keys now delegates to the new helpers instead of inline ad-hoc logic.
> - Behavioral Change: `ESC B` and `ESC F` are no longer treated as `alt+left`/`alt+right` when Kitty protocol is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47b3efd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->