### PR TITLE
bump release version to 0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.0.9",
+				"@earendil-works/pi-coding-agent": "^0.0.10",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5870,10 +5870,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.0.9",
+				"@earendil-works/pi-ai": "^0.0.10",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5900,7 +5900,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5942,13 +5942,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.0.9",
-				"@earendil-works/pi-ai": "^0.0.9",
-				"@earendil-works/pi-tui": "^0.0.9",
+				"@earendil-works/pi-agent-core": "^0.0.10",
+				"@earendil-works/pi-ai": "^0.0.10",
+				"@earendil-works/pi-tui": "^0.0.10",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6100,7 +6100,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.0.9",
+		"@earendil-works/pi-coding-agent": "^0.0.10",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.0.9",
+		"@earendil-works/pi-ai": "^0.0.10",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -41,9 +41,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.0.9",
-		"@earendil-works/pi-ai": "^0.0.9",
-		"@earendil-works/pi-tui": "^0.0.9",
+		"@earendil-works/pi-agent-core": "^0.0.10",
+		"@earendil-works/pi-ai": "^0.0.10",
+		"@earendil-works/pi-tui": "^0.0.10",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the published packages and root package from 0.0.9 to 0.0.10.
- syncs internal dependency ranges and lockfile metadata for the new version.
- verified the release prep with npm run check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no application or runtime code modifications.
> 
> **Overview**
> Bumps the monorepo release from **0.0.9** to **0.0.10** across the root `prime-agent` package and published workspaces `@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent`, and `pi-tui`.
> 
> Internal `^0.0.9` dependency ranges on those packages are updated to `^0.0.10`, and `package-lock.json` workspace version metadata is aligned with the new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057f634caf4966b8ae449dce3cea277f770356ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all packages to version 0.0.10
> Updates the version field from `0.0.9` to `0.0.10` across all packages in the monorepo and aligns internal dependency ranges to `^0.0.10`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 057f634.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->