### PR TITLE
surface missing ripgrep warnings cleanly

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -48,7 +48,7 @@ import {
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
-import { ensureTool, formatMissingRipgrepMessage } from "../utils/tools-manager.js";
+import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../utils/tools-manager.js";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.js";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
 import {
@@ -3729,7 +3729,7 @@ export class AgentSession {
 		const task = (async (): Promise<RlmRunResult> => {
 			try {
 				if (!(await ensureTool("rg", true))) {
-					throw new Error(formatMissingRipgrepMessage());
+					throw new Error(MISSING_RIPGREP_MESSAGE);
 				}
 				await child.prompt(prompt, { expandPromptTemplates: false, source: "extension" });
 				await child.agent.waitForIdle();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -48,6 +48,7 @@ import {
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
+import { ensureTool, formatMissingRipgrepMessage } from "../utils/tools-manager.js";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.js";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
 import {
@@ -3727,6 +3728,9 @@ export class AgentSession {
 
 		const task = (async (): Promise<RlmRunResult> => {
 			try {
+				if (!(await ensureTool("rg", true))) {
+					throw new Error(formatMissingRipgrepMessage());
+				}
 				await child.prompt(prompt, { expandPromptTemplates: false, source: "extension" });
 				await child.agent.waitForIdle();
 				if (run.status === "cancelled") {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -325,6 +325,10 @@ export class KernelManager {
 		return this.options.sessionId;
 	}
 
+	private appendKernelDiagnostic(message: string): void {
+		this.kernelStderr += `[kernel] ${message.endsWith("\n") ? message : `${message}\n`}`;
+	}
+
 	async start(options: KernelStartOptions = {}): Promise<void> {
 		if (!this.startPromise) {
 			this.startPromise = this.doStart(options);
@@ -364,12 +368,11 @@ export class KernelManager {
 		kernel.stderr?.on("data", (buf: Buffer) => {
 			const s = buf.toString();
 			this.kernelStderr += s;
-			process.stderr.write(`[kernel] ${s}`);
 		});
 
 		kernel.on("error", (err) => {
 			if (this.kernel !== kernel) return;
-			console.error(`[kernel] spawn error: ${err.message}`);
+			this.appendKernelDiagnostic(`spawn error: ${err.message}`);
 			this.state = "shutdown";
 			liveKernels.delete(this);
 		});
@@ -377,7 +380,7 @@ export class KernelManager {
 		kernel.on("exit", (code, signal) => {
 			if (this.kernel !== kernel) return;
 			if (this.state !== "shutdown") {
-				console.error(`[kernel] unexpected exit code=${code} signal=${signal}`);
+				this.appendKernelDiagnostic(`unexpected exit code=${code} signal=${signal}`);
 			}
 			this.state = "shutdown";
 			liveKernels.delete(this);
@@ -595,7 +598,7 @@ export class KernelManager {
 			}
 		} catch (error) {
 			if ((this.state as string) !== "shutdown") {
-				console.error(`[kernel] iopub pump failed: ${errorMessage(error)}`);
+				this.appendKernelDiagnostic(`iopub pump failed: ${errorMessage(error)}`);
 				this.rejectActiveExecution(new Error(`Kernel IOPub channel failed: ${errorMessage(error)}`));
 			}
 		} finally {
@@ -731,17 +734,17 @@ export class KernelManager {
 				try {
 					await this.sendCommMessage(commId, { status: "ok", ...result });
 				} catch (replyError) {
-					console.error(
-						`[kernel] failed to send rlm.run ok reply for comm ${commId}: ${errorMessage(replyError)}`,
+					this.appendKernelDiagnostic(
+						`failed to send rlm.run ok reply for comm ${commId}: ${errorMessage(replyError)}`,
 					);
 				}
 			} catch (error) {
-				console.error(`[kernel] rlm.run failed for comm ${commId}: ${errorMessage(error)}`);
+				this.appendKernelDiagnostic(`rlm.run failed for comm ${commId}: ${errorMessage(error)}`);
 				try {
 					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
 				} catch (replyError) {
-					console.error(
-						`[kernel] failed to send rlm.run error reply for comm ${commId}: ${errorMessage(replyError)}`,
+					this.appendKernelDiagnostic(
+						`failed to send rlm.run error reply for comm ${commId}: ${errorMessage(replyError)}`,
 					);
 				}
 			}
@@ -824,7 +827,9 @@ export class KernelManager {
 			globalThis.clearTimeout(timeout);
 		}
 		if (result === "timeout") {
-			console.error(`[kernel] timed out waiting ${timeoutMs}ms for ${tasks.length} rlm.run task(s) during dispose`);
+			this.appendKernelDiagnostic(
+				`timed out waiting ${timeoutMs}ms for ${tasks.length} rlm.run task(s) during dispose`,
+			);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -104,7 +104,7 @@ import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipb
 import { parseGitUrl } from "../../utils/git.js";
 import { getCwdRelativePath } from "../../utils/paths.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
-import { ensureTool } from "../../utils/tools-manager.js";
+import { ensureTool, formatMissingRipgrepMessage } from "../../utils/tools-manager.js";
 import { checkForNewPiVersion } from "../../utils/version-check.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
@@ -759,8 +759,11 @@ export class InteractiveMode {
 
 		// Ensure fd and rg are available (downloads if missing, adds to PATH via getBinDir)
 		// fd powers autocomplete, and rg is available for shell commands.
-		const [fdPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
+		const [fdPath, rgPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
 		this.fdPath = fdPath;
+		if (!rgPath) {
+			this.showWarning(formatMissingRipgrepMessage());
+		}
 
 		// Add header container as first child
 		this.ui.addChild(this.headerContainer);
@@ -4251,7 +4254,7 @@ export class InteractiveMode {
 
 	showWarning(warningMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+		this.chatContainer.addChild(new Text(theme.fg("warning", `⚠ ${warningMessage}`), 1, 0));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -104,7 +104,7 @@ import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipb
 import { parseGitUrl } from "../../utils/git.js";
 import { getCwdRelativePath } from "../../utils/paths.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
-import { ensureTool, formatMissingRipgrepMessage } from "../../utils/tools-manager.js";
+import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../../utils/tools-manager.js";
 import { checkForNewPiVersion } from "../../utils/version-check.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
@@ -762,7 +762,7 @@ export class InteractiveMode {
 		const [fdPath, rgPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
 		this.fdPath = fdPath;
 		if (!rgPath) {
-			this.showWarning(formatMissingRipgrepMessage());
+			this.showWarning(MISSING_RIPGREP_MESSAGE);
 		}
 
 		// Add header container as first child

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -244,9 +244,8 @@ const TERMUX_PACKAGES: Record<string, string> = {
 	rg: "ripgrep",
 };
 
-export function formatMissingRipgrepMessage(): string {
-	return "ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
-}
+export const MISSING_RIPGREP_MESSAGE =
+	"ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
 
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -244,6 +244,10 @@ const TERMUX_PACKAGES: Record<string, string> = {
 	rg: "ripgrep",
 };
 
+export function formatMissingRipgrepMessage(): string {
+	return "ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
+}
+
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable
 export async function ensureTool(tool: "fd" | "rg", silent: boolean = true): Promise<string | undefined> {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -19,7 +19,20 @@ import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
+import { formatMissingRipgrepMessage } from "../src/utils/tools-manager.js";
 import { createTestResourceLoader } from "./utilities.js";
+
+const toolsManagerMock = vi.hoisted(() => ({
+	ensureTool: vi.fn(async (): Promise<string | undefined> => "rg"),
+}));
+
+vi.mock("../src/utils/tools-manager.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/utils/tools-manager.js")>();
+	return {
+		...actual,
+		ensureTool: toolsManagerMock.ensureTool,
+	};
+});
 
 const model = getModel("anthropic", "claude-sonnet-4-5")!;
 
@@ -194,6 +207,8 @@ describe("AgentSession rlm recursion", () => {
 	afterEach(() => {
 		session?.dispose();
 		session = undefined;
+		toolsManagerMock.ensureTool.mockReset();
+		toolsManagerMock.ensureTool.mockResolvedValue("rg");
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -264,6 +279,25 @@ describe("AgentSession rlm recursion", () => {
 				expect.objectContaining({ type: "message", role: "assistant", text: "child answer: summarize shard 1" }),
 			]),
 		);
+	});
+
+	it("surfaces missing ripgrep as one child-agent error before model work starts", async () => {
+		toolsManagerMock.ensureTool.mockResolvedValueOnce(undefined);
+		const streamFn = vi.fn((_model, context: Context) => streamAnswer(`child answer: ${userText(context)}`));
+		const root = createSession({ streamFn });
+		const childUpdates: Array<{ status: string; transcript: readonly { role: string; text: string }[] }> = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") {
+				childUpdates.push(event.child);
+			}
+		});
+
+		await expect(root.runRlmChild("summarize shard 1")).rejects.toThrow(formatMissingRipgrepMessage());
+
+		expect(toolsManagerMock.ensureTool).toHaveBeenCalledWith("rg", true);
+		expect(streamFn).not.toHaveBeenCalled();
+		const errorUpdate = [...childUpdates].reverse().find((update) => update.status === "error");
+		expect(errorUpdate?.transcript).toContainEqual({ role: "system", text: formatMissingRipgrepMessage() });
 	});
 
 	it("adds child usage to the parent session aggregate", async () => {
@@ -622,7 +656,7 @@ print(_result.answer)
 		}
 	});
 
-	it("waits for in-flight rlm comm work during dispose and logs failures", async () => {
+	it("waits for in-flight rlm comm work during dispose and buffers failures", async () => {
 		let started = false;
 		let handlerSettled = false;
 		let released = false;
@@ -646,7 +680,7 @@ print(_result.answer)
 				}
 			},
 		});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
 		try {
 			const kernel = manager as unknown as KernelCommTestApi;
@@ -667,15 +701,14 @@ print(_result.answer)
 			await expectSettlesWithin(trackedDispose, 1000);
 			expect(handlerSettled).toBe(true);
 
-			const logLines = errorSpy.mock.calls.map((call) => call.map(String).join(" "));
-			expect(logLines.some((line) => line.includes("[kernel] rlm.run failed for comm comm-dispose"))).toBe(true);
-			expect(
-				logLines.some((line) => line.includes("[kernel] failed to send rlm.run error reply for comm comm-dispose")),
-			).toBe(true);
+			const kernelStderr = (manager as unknown as { kernelStderr: string }).kernelStderr;
+			expect(kernelStderr).toContain("[kernel] rlm.run failed for comm comm-dispose");
+			expect(kernelStderr).toContain("[kernel] failed to send rlm.run error reply for comm comm-dispose");
+			expect(stderrSpy).not.toHaveBeenCalled();
 		} finally {
 			releaseChild();
 			await manager.dispose();
-			errorSpy.mockRestore();
+			stderrSpy.mockRestore();
 		}
 	});
 });

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -19,7 +19,7 @@ import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
-import { formatMissingRipgrepMessage } from "../src/utils/tools-manager.js";
+import { MISSING_RIPGREP_MESSAGE } from "../src/utils/tools-manager.js";
 import { createTestResourceLoader } from "./utilities.js";
 
 const toolsManagerMock = vi.hoisted(() => ({
@@ -292,12 +292,12 @@ describe("AgentSession rlm recursion", () => {
 			}
 		});
 
-		await expect(root.runRlmChild("summarize shard 1")).rejects.toThrow(formatMissingRipgrepMessage());
+		await expect(root.runRlmChild("summarize shard 1")).rejects.toThrow(MISSING_RIPGREP_MESSAGE);
 
 		expect(toolsManagerMock.ensureTool).toHaveBeenCalledWith("rg", true);
 		expect(streamFn).not.toHaveBeenCalled();
 		const errorUpdate = [...childUpdates].reverse().find((update) => update.status === "error");
-		expect(errorUpdate?.transcript).toContainEqual({ role: "system", text: formatMissingRipgrepMessage() });
+		expect(errorUpdate?.transcript).toContainEqual({ role: "system", text: MISSING_RIPGREP_MESSAGE });
 	});
 
 	it("adds child usage to the parent session aggregate", async () => {


### PR DESCRIPTION
- missing ripgrep now appears as one yellow warning instead of raw kernel stderr.
- child-agent runs stop before model work when ripgrep is unavailable and surface one clean error.
- kernel diagnostics are buffered instead of being written directly to stderr.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX and preflight checks around optional `rg` plus logging redirection; no auth or data-path changes.
> 
> **Overview**
> Introduces a shared **`MISSING_RIPGREP_MESSAGE`** in `tools-manager` and uses it when **`rg`** is unavailable.
> 
> **Interactive startup** still ensures `fd` and `rg`, but if ripgrep cannot be resolved it shows a single in-chat warning via `showWarning` (now prefixed with **`⚠`** instead of `Warning:`).
> 
> **RLM child runs** call `ensureTool("rg", true)` before any child `prompt` / model work; failure throws that message and records a system line on the child transcript without invoking the stream.
> 
> **Kernel diagnostics** no longer hit `process.stderr` or `console.error` for `[kernel]` lines—spawn/exit, IOPub pump, RLM comm reply failures, and dispose timeouts are appended to an internal **`kernelStderr`** buffer (raw kernel stderr from the child process is still accumulated there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee85938de6b7076d7bb0f09f06d4711c4be4ce10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface missing ripgrep warnings to users in interactive mode and fail early in agent sessions
> - In [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/103/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316), checks for `rg` availability on init and shows a `⚠` warning via `showWarning` if ripgrep is missing.
> - In [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/103/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae), `runRlmChild` now calls `ensureTool("rg")` before starting child model work and throws `MISSING_RIPGREP_MESSAGE` if unavailable.
> - In [kernel/index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/103/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac), kernel lifecycle errors, IOPub pump failures, and dispose-time diagnostics are buffered into `kernelStderr` instead of being written to `process.stderr` or `console.error`.
> - Behavioral Change: kernel diagnostics no longer appear in process stderr; they are only accessible via `KernelManager.kernelStderr`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee85938.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->