### PR TITLE
make popup menus responsive

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
@@ -4,14 +4,19 @@
  */
 
 import { Container, getKeybindings, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
 import { CountdownTimer } from "./countdown-timer.js";
 import { keyHint, rawKeyHint } from "./keybinding-hints.js";
-import { MenuList, MenuPanel, MenuRow } from "./menu-panel.js";
+import { getMenuListLayout, MenuList, MenuPanel, MenuRow, type MenuViewportProvider } from "./menu-panel.js";
 
 export interface ExtensionSelectorOptions {
 	tui?: TUI;
 	timeout?: number;
+	getRows?: () => number;
 }
+
+const PREFERRED_VISIBLE_OPTIONS = 8;
+const OPTION_LIST_RESERVED_ROWS = 7;
 
 export class ExtensionSelectorComponent extends Container {
 	private options: string[];
@@ -22,6 +27,13 @@ export class ExtensionSelectorComponent extends Container {
 	private baseTitle: string;
 	private countdown: CountdownTimer | undefined;
 	private panel: MenuPanel;
+	private listLayout = getMenuListLayout({
+		preferredVisibleItems: PREFERRED_VISIBLE_OPTIONS,
+		reservedRows: OPTION_LIST_RESERVED_ROWS,
+		comfortableItemRows: 2,
+		compactItemRows: 1,
+	});
+	private readonly viewport: MenuViewportProvider;
 
 	constructor(
 		title: string,
@@ -36,6 +48,8 @@ export class ExtensionSelectorComponent extends Container {
 		this.onSelectCallback = onSelect;
 		this.onCancelCallback = onCancel;
 		this.baseTitle = title;
+		const tui = opts?.tui;
+		this.viewport = { getRows: opts?.getRows ?? (tui ? () => tui.terminal.rows : undefined) };
 
 		this.panel = new MenuPanel({
 			title,
@@ -51,7 +65,7 @@ export class ExtensionSelectorComponent extends Container {
 			);
 		}
 
-		this.listContainer = new MenuList();
+		this.listContainer = new MenuList({ compact: () => this.listLayout.compact });
 		this.panel.addChild(this.listContainer);
 		this.panel.addChild(new Spacer(1));
 		this.panel.addChild(
@@ -69,15 +83,39 @@ export class ExtensionSelectorComponent extends Container {
 		this.updateList();
 	}
 
+	override render(width: number): string[] {
+		const previousLayout = this.listLayout;
+		this.updateLayout();
+		if (
+			this.listLayout.compact !== previousLayout.compact ||
+			this.listLayout.visibleItems !== previousLayout.visibleItems
+		) {
+			this.updateList();
+		}
+		return super.render(width);
+	}
+
 	private updateList(): void {
+		this.updateLayout();
 		this.listContainer.clear();
-		for (let i = 0; i < this.options.length; i++) {
+		const maxVisible = this.listLayout.visibleItems;
+		const startIndex = Math.max(
+			0,
+			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.options.length - maxVisible),
+		);
+		const endIndex = Math.min(startIndex + maxVisible, this.options.length);
+		for (let i = startIndex; i < endIndex; i++) {
 			const isSelected = i === this.selectedIndex;
 			this.listContainer.addChild(
 				new MenuRow({
 					primary: this.options[i] ?? "",
 					selected: isSelected,
 				}),
+			);
+		}
+		if (startIndex > 0 || endIndex < this.options.length) {
+			this.listContainer.addChild(
+				new Text(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.options.length})`), 0, 0),
 			);
 		}
 	}
@@ -100,5 +138,15 @@ export class ExtensionSelectorComponent extends Container {
 
 	dispose(): void {
 		this.countdown?.dispose();
+	}
+
+	private updateLayout(): void {
+		this.listLayout = getMenuListLayout({
+			getRows: this.viewport.getRows,
+			preferredVisibleItems: PREFERRED_VISIBLE_OPTIONS,
+			reservedRows: OPTION_LIST_RESERVED_ROWS,
+			comfortableItemRows: 2,
+			compactItemRows: 1,
+		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
@@ -16,7 +16,8 @@ export interface ExtensionSelectorOptions {
 }
 
 const PREFERRED_VISIBLE_OPTIONS = 8;
-const OPTION_LIST_RESERVED_ROWS = 7;
+const OPTION_LIST_RESERVED_ROWS = 6;
+const OPTION_SCROLL_INDICATOR_ROWS = 1;
 
 export class ExtensionSelectorComponent extends Container {
 	private options: string[];
@@ -144,9 +145,11 @@ export class ExtensionSelectorComponent extends Container {
 		this.listLayout = getMenuListLayout({
 			getRows: this.viewport.getRows,
 			preferredVisibleItems: PREFERRED_VISIBLE_OPTIONS,
+			totalItems: this.options.length,
 			reservedRows: OPTION_LIST_RESERVED_ROWS,
 			comfortableItemRows: 2,
 			compactItemRows: 1,
+			scrollIndicatorRows: OPTION_SCROLL_INDICATOR_ROWS,
 		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -13,6 +13,29 @@ interface MenuPanelOptions {
 	subtitle?: string;
 }
 
+export interface MenuViewportProvider {
+	getRows?: () => number;
+}
+
+interface MenuListOptions {
+	compact?: boolean | (() => boolean);
+}
+
+interface MenuListLayoutOptions extends MenuViewportProvider {
+	preferredVisibleItems: number;
+	minVisibleItems?: number;
+	reservedRows: number;
+	comfortableItemRows: number;
+	compactItemRows?: number;
+	comfortableListPaddingRows?: number;
+	compactListPaddingRows?: number;
+}
+
+export interface MenuListLayout {
+	compact: boolean;
+	visibleItems: number;
+}
+
 const PANEL_PADDING_X = 2;
 const PANEL_PADDING_Y = 1;
 const FIELD_PADDING_X = 2;
@@ -25,6 +48,87 @@ interface FullWidthMenuComponent {
 
 function fillsMenuPanel(component: Component): component is Component & FullWidthMenuComponent {
 	return (component as { fillsMenuPanel?: unknown }).fillsMenuPanel === true;
+}
+
+function getViewportRows(getRows: (() => number) | undefined): number | undefined {
+	const rows = getRows?.();
+	if (rows === undefined || !Number.isFinite(rows) || rows <= 0) {
+		return undefined;
+	}
+	return Math.floor(rows);
+}
+
+function visibleItemCount(
+	rows: number,
+	options: {
+		preferredVisibleItems: number;
+		minVisibleItems: number;
+		reservedRows: number;
+		itemRows: number;
+		listPaddingRows: number;
+	},
+): number {
+	const capacityRows = Math.max(0, rows - options.reservedRows - options.listPaddingRows);
+	const itemCapacity = Math.floor(capacityRows / options.itemRows);
+	return Math.max(options.minVisibleItems, Math.min(options.preferredVisibleItems, itemCapacity));
+}
+
+function listRowsUsed(options: {
+	reservedRows: number;
+	listPaddingRows: number;
+	visibleItems: number;
+	itemRows: number;
+}) {
+	return options.reservedRows + options.listPaddingRows + options.visibleItems * options.itemRows;
+}
+
+export function getMenuListLayout(options: MenuListLayoutOptions): MenuListLayout {
+	const minVisibleItems = options.minVisibleItems ?? 1;
+	const preferredVisibleItems = Math.max(minVisibleItems, options.preferredVisibleItems);
+	const rows = getViewportRows(options.getRows);
+	if (rows === undefined) {
+		return { compact: false, visibleItems: preferredVisibleItems };
+	}
+
+	const comfortableVisibleItems = visibleItemCount(rows, {
+		preferredVisibleItems,
+		minVisibleItems,
+		reservedRows: options.reservedRows,
+		itemRows: Math.max(1, options.comfortableItemRows),
+		listPaddingRows: options.comfortableListPaddingRows ?? 1,
+	});
+	if (options.compactItemRows === undefined) {
+		return { compact: false, visibleItems: comfortableVisibleItems };
+	}
+
+	const comfortableItemRows = Math.max(1, options.comfortableItemRows);
+	const compactItemRows = Math.max(1, options.compactItemRows);
+	const comfortableListPaddingRows = options.comfortableListPaddingRows ?? 1;
+	const compactListPaddingRows = options.compactListPaddingRows ?? 0;
+	const compactVisibleItems = visibleItemCount(rows, {
+		preferredVisibleItems,
+		minVisibleItems,
+		reservedRows: options.reservedRows,
+		itemRows: compactItemRows,
+		listPaddingRows: compactListPaddingRows,
+	});
+	const comfortableFits =
+		listRowsUsed({
+			reservedRows: options.reservedRows,
+			listPaddingRows: comfortableListPaddingRows,
+			visibleItems: comfortableVisibleItems,
+			itemRows: comfortableItemRows,
+		}) <= rows;
+	const compactFits =
+		listRowsUsed({
+			reservedRows: options.reservedRows,
+			listPaddingRows: compactListPaddingRows,
+			visibleItems: compactVisibleItems,
+			itemRows: compactItemRows,
+		}) <= rows;
+	return compactVisibleItems > comfortableVisibleItems || (!comfortableFits && compactFits)
+		? { compact: true, visibleItems: compactVisibleItems }
+		: { compact: false, visibleItems: comfortableVisibleItems };
 }
 
 function surfaceLine(text: string, width: number, paddingX = PANEL_PADDING_X): string {
@@ -209,11 +313,20 @@ export class MenuRow implements Component, FullWidthMenuComponent {
 export class MenuList extends Container implements FullWidthMenuComponent {
 	readonly fillsMenuPanel = true;
 
+	constructor(private readonly options: MenuListOptions = {}) {
+		super();
+	}
+
 	override render(width: number): string[] {
 		const lines: string[] = [];
+		const compact = this.isCompact();
 		for (let index = 0; index < this.children.length; index++) {
 			const child = this.children[index];
 			if (child instanceof MenuRow) {
+				if (compact) {
+					lines.push(...child.renderContent(width));
+					continue;
+				}
 				const previousChild = this.children[index - 1];
 				const nextChild = this.children[index + 1];
 				const previousRow = previousChild instanceof MenuRow ? previousChild : undefined;
@@ -233,5 +346,10 @@ export class MenuList extends Container implements FullWidthMenuComponent {
 			}
 		}
 		return lines;
+	}
+
+	private isCompact(): boolean {
+		const compact = this.options.compact;
+		return typeof compact === "function" ? compact() : compact === true;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -24,9 +24,11 @@ interface MenuListOptions {
 interface MenuListLayoutOptions extends MenuViewportProvider {
 	preferredVisibleItems: number;
 	minVisibleItems?: number;
+	totalItems?: number;
 	reservedRows: number;
 	comfortableItemRows: number;
 	compactItemRows?: number;
+	scrollIndicatorRows?: number;
 	comfortableListPaddingRows?: number;
 	compactListPaddingRows?: number;
 }
@@ -66,9 +68,10 @@ function visibleItemCount(
 		reservedRows: number;
 		itemRows: number;
 		listPaddingRows: number;
+		extraRows: number;
 	},
 ): number {
-	const capacityRows = Math.max(0, rows - options.reservedRows - options.listPaddingRows);
+	const capacityRows = Math.max(0, rows - options.reservedRows - options.listPaddingRows - options.extraRows);
 	const itemCapacity = Math.floor(capacityRows / options.itemRows);
 	return Math.max(options.minVisibleItems, Math.min(options.preferredVisibleItems, itemCapacity));
 }
@@ -78,8 +81,68 @@ function listRowsUsed(options: {
 	listPaddingRows: number;
 	visibleItems: number;
 	itemRows: number;
-}) {
-	return options.reservedRows + options.listPaddingRows + options.visibleItems * options.itemRows;
+	extraRows: number;
+}): number {
+	return options.reservedRows + options.listPaddingRows + options.extraRows + options.visibleItems * options.itemRows;
+}
+
+function scrollIndicatorRows(options: {
+	totalItems: number | undefined;
+	visibleItems: number;
+	scrollIndicatorRows: number;
+}): number {
+	if (options.totalItems === undefined || options.scrollIndicatorRows <= 0) {
+		return 0;
+	}
+	return options.totalItems > options.visibleItems ? options.scrollIndicatorRows : 0;
+}
+
+function getLayoutCandidate(
+	rows: number,
+	options: MenuListLayoutOptions,
+	itemRows: number,
+	listPaddingRows: number,
+	compact: boolean,
+): MenuListLayout & { rowsUsed: number; fits: boolean } {
+	const minVisibleItems = options.minVisibleItems ?? 1;
+	const preferredVisibleItems = Math.max(minVisibleItems, options.preferredVisibleItems);
+	const visibleItemsWithoutScroll = visibleItemCount(rows, {
+		preferredVisibleItems,
+		minVisibleItems,
+		reservedRows: options.reservedRows,
+		itemRows,
+		listPaddingRows,
+		extraRows: 0,
+	});
+	const extraRows = scrollIndicatorRows({
+		totalItems: options.totalItems,
+		visibleItems: visibleItemsWithoutScroll,
+		scrollIndicatorRows: options.scrollIndicatorRows ?? 0,
+	});
+	const visibleItems =
+		extraRows > 0
+			? visibleItemCount(rows, {
+					preferredVisibleItems,
+					minVisibleItems,
+					reservedRows: options.reservedRows,
+					itemRows,
+					listPaddingRows,
+					extraRows,
+				})
+			: visibleItemsWithoutScroll;
+	const rowsUsed = listRowsUsed({
+		reservedRows: options.reservedRows,
+		listPaddingRows,
+		visibleItems,
+		itemRows,
+		extraRows,
+	});
+	return {
+		compact,
+		visibleItems,
+		rowsUsed,
+		fits: rowsUsed <= rows,
+	};
 }
 
 export function getMenuListLayout(options: MenuListLayoutOptions): MenuListLayout {
@@ -90,45 +153,33 @@ export function getMenuListLayout(options: MenuListLayoutOptions): MenuListLayou
 		return { compact: false, visibleItems: preferredVisibleItems };
 	}
 
-	const comfortableVisibleItems = visibleItemCount(rows, {
-		preferredVisibleItems,
-		minVisibleItems,
-		reservedRows: options.reservedRows,
-		itemRows: Math.max(1, options.comfortableItemRows),
-		listPaddingRows: options.comfortableListPaddingRows ?? 1,
-	});
+	const comfortableLayout = getLayoutCandidate(
+		rows,
+		options,
+		Math.max(1, options.comfortableItemRows),
+		options.comfortableListPaddingRows ?? 1,
+		false,
+	);
 	if (options.compactItemRows === undefined) {
-		return { compact: false, visibleItems: comfortableVisibleItems };
+		return { compact: false, visibleItems: comfortableLayout.visibleItems };
 	}
 
-	const comfortableItemRows = Math.max(1, options.comfortableItemRows);
-	const compactItemRows = Math.max(1, options.compactItemRows);
-	const comfortableListPaddingRows = options.comfortableListPaddingRows ?? 1;
-	const compactListPaddingRows = options.compactListPaddingRows ?? 0;
-	const compactVisibleItems = visibleItemCount(rows, {
-		preferredVisibleItems,
-		minVisibleItems,
-		reservedRows: options.reservedRows,
-		itemRows: compactItemRows,
-		listPaddingRows: compactListPaddingRows,
-	});
-	const comfortableFits =
-		listRowsUsed({
-			reservedRows: options.reservedRows,
-			listPaddingRows: comfortableListPaddingRows,
-			visibleItems: comfortableVisibleItems,
-			itemRows: comfortableItemRows,
-		}) <= rows;
-	const compactFits =
-		listRowsUsed({
-			reservedRows: options.reservedRows,
-			listPaddingRows: compactListPaddingRows,
-			visibleItems: compactVisibleItems,
-			itemRows: compactItemRows,
-		}) <= rows;
-	return compactVisibleItems > comfortableVisibleItems || (!comfortableFits && compactFits)
-		? { compact: true, visibleItems: compactVisibleItems }
-		: { compact: false, visibleItems: comfortableVisibleItems };
+	const compactLayout = getLayoutCandidate(
+		rows,
+		options,
+		Math.max(1, options.compactItemRows),
+		options.compactListPaddingRows ?? 0,
+		true,
+	);
+	if (compactLayout.fits && (!comfortableLayout.fits || compactLayout.visibleItems > comfortableLayout.visibleItems)) {
+		return { compact: true, visibleItems: compactLayout.visibleItems };
+	}
+	if (comfortableLayout.fits) {
+		return { compact: false, visibleItems: comfortableLayout.visibleItems };
+	}
+	return compactLayout.rowsUsed <= comfortableLayout.rowsUsed
+		? { compact: true, visibleItems: compactLayout.visibleItems }
+		: { compact: false, visibleItems: comfortableLayout.visibleItems };
 }
 
 function surfaceLine(text: string, width: number, paddingX = PANEL_PADDING_X): string {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -42,7 +42,6 @@ type ModelScope = "all" | "scoped";
 const PREFERRED_VISIBLE_MODELS = 10;
 const MODEL_LIST_RESERVED_ROWS = {
 	base: 8,
-	help: 2,
 	detail: 2,
 };
 const MODEL_HELP_MIN_ROWS = 12;
@@ -394,20 +393,24 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private updateResponsiveLayout(): void {
 		const showHeaderHelp = this.shouldShowHeaderHelp();
+		let headerHelpRows = 0;
 		this.headerHelpContainer.clear();
 		if (showHeaderHelp) {
 			if (this.scopeText && this.scopeHintText) {
 				this.headerHelpContainer.addChild(this.scopeText);
 				this.headerHelpContainer.addChild(this.scopeHintText);
+				headerHelpRows += 2;
 			} else if (this.warningText) {
 				this.headerHelpContainer.addChild(this.warningText);
+				headerHelpRows += 1;
 			}
 			this.headerHelpContainer.addChild(new Spacer(1));
+			headerHelpRows += 1;
 		}
 
 		const reservedRows =
 			MODEL_LIST_RESERVED_ROWS.base +
-			(showHeaderHelp ? MODEL_LIST_RESERVED_ROWS.help : 0) +
+			headerHelpRows +
 			(this.shouldShowSelectedDetails() ? MODEL_LIST_RESERVED_ROWS.detail : 0);
 		this.listLayout = getMenuListLayout({
 			getRows: this.viewport.getRows,
@@ -418,6 +421,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		});
 		this.responsiveLayoutKey = [
 			showHeaderHelp ? "help" : "no-help",
+			headerHelpRows,
 			this.shouldShowSelectedDetails() ? "detail" : "no-detail",
 			this.listLayout.compact ? "compact" : "comfortable",
 			this.listLayout.visibleItems,

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -41,9 +41,10 @@ type ModelScope = "all" | "scoped";
 
 const PREFERRED_VISIBLE_MODELS = 10;
 const MODEL_LIST_RESERVED_ROWS = {
-	base: 8,
+	base: 7,
 	detail: 2,
 };
+const MODEL_SCROLL_INDICATOR_ROWS = 1;
 const MODEL_HELP_MIN_ROWS = 12;
 const MODEL_DETAIL_MIN_ROWS = 14;
 
@@ -415,9 +416,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.listLayout = getMenuListLayout({
 			getRows: this.viewport.getRows,
 			preferredVisibleItems: PREFERRED_VISIBLE_MODELS,
+			totalItems: this.filteredModels.length,
 			reservedRows,
 			comfortableItemRows: 3,
 			compactItemRows: 2,
+			scrollIndicatorRows: MODEL_SCROLL_INDICATOR_ROWS,
 		});
 		this.responsiveLayoutKey = [
 			showHeaderHelp ? "help" : "no-help",

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -4,7 +4,14 @@ import type { ModelRegistry } from "../../../core/model-registry.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
 import { theme } from "../theme/theme.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
-import { MenuList, MenuPanel, MenuRow, MenuSearchInput } from "./menu-panel.js";
+import {
+	getMenuListLayout,
+	MenuList,
+	MenuPanel,
+	MenuRow,
+	MenuSearchInput,
+	type MenuViewportProvider,
+} from "./menu-panel.js";
 
 interface ModelItem {
 	provider: string;
@@ -27,9 +34,19 @@ interface ModelSelectorOptions {
 	actions?: ReadonlyArray<ModelSelectorAction>;
 	onAction?: (actionId: string) => void;
 	subtitle?: string;
+	getRows?: () => number;
 }
 
 type ModelScope = "all" | "scoped";
+
+const PREFERRED_VISIBLE_MODELS = 10;
+const MODEL_LIST_RESERVED_ROWS = {
+	base: 8,
+	help: 2,
+	detail: 2,
+};
+const MODEL_HELP_MIN_ROWS = 12;
+const MODEL_DETAIL_MIN_ROWS = 14;
 
 /**
  * Component that renders a model selector with search
@@ -65,6 +82,17 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private scope: ModelScope = "all";
 	private scopeText?: Text;
 	private scopeHintText?: Text;
+	private panel: MenuPanel;
+	private headerHelpContainer: Container;
+	private warningText?: Text;
+	private listLayout = getMenuListLayout({
+		preferredVisibleItems: PREFERRED_VISIBLE_MODELS,
+		reservedRows: MODEL_LIST_RESERVED_ROWS.base,
+		comfortableItemRows: 3,
+		compactItemRows: 2,
+	});
+	private responsiveLayoutKey = "";
+	private readonly viewport: MenuViewportProvider;
 
 	constructor(
 		tui: TUI,
@@ -89,27 +117,27 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.onCancelCallback = onCancel;
 		this.actions = options.actions ?? [];
 		this.onActionCallback = options.onAction;
+		this.viewport = { getRows: options.getRows };
 
-		const panel = new MenuPanel({
+		this.panel = new MenuPanel({
 			title: "Models",
 			subtitle: options.subtitle ?? "Available from configured providers.",
 		});
-		this.addChild(panel);
+		this.addChild(this.panel);
 
 		// Add hint about model filtering
 		if (scopedModels.length > 0) {
 			this.scopeText = new Text(this.getScopeText(), 0, 0);
-			panel.addChild(this.scopeText);
 			this.scopeHintText = new Text(this.getScopeHintText(), 0, 0);
-			panel.addChild(this.scopeHintText);
 		} else {
 			const hintText =
 				this.actions.length > 0
 					? `Only showing models from configured providers. ${keyText("app.provider.add")} to add providers and access more models.`
 					: "Only showing models from configured providers. Use /login to add providers and see more models.";
-			panel.addChild(new Text(theme.fg("warning", hintText), 0, 0));
+			this.warningText = new Text(theme.fg("warning", hintText), 0, 0);
 		}
-		panel.addChild(new Spacer(1));
+		this.headerHelpContainer = new Container();
+		this.panel.addChild(this.headerHelpContainer);
 
 		// Create search input
 		this.searchInput = new MenuSearchInput("Search models");
@@ -119,13 +147,14 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.searchInput.onSubmit = () => {
 			this.handleConfirm();
 		};
-		panel.addChild(this.searchInput);
+		this.panel.addChild(this.searchInput);
 
-		panel.addChild(new Spacer(1));
+		this.panel.addChild(new Spacer(1));
 
 		// Create list container
-		this.listContainer = new MenuList();
-		panel.addChild(this.listContainer);
+		this.listContainer = new MenuList({ compact: () => this.listLayout.compact });
+		this.panel.addChild(this.listContainer);
+		this.updateResponsiveLayout();
 
 		// Load models and do initial render
 		this.loadModels().then(() => {
@@ -232,10 +261,20 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.updateList();
 	}
 
+	override render(width: number): string[] {
+		const previousLayoutKey = this.responsiveLayoutKey;
+		this.updateResponsiveLayout();
+		if (this.responsiveLayoutKey !== previousLayoutKey) {
+			this.updateList();
+		}
+		return super.render(width);
+	}
+
 	private updateList(): void {
+		this.updateResponsiveLayout();
 		this.listContainer.clear();
 
-		const maxVisible = 10;
+		const maxVisible = this.listLayout.visibleItems;
 		const selectedModelIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 		const startIndex = Math.max(
 			0,
@@ -278,7 +317,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.listContainer.addChild(new Text(theme.fg("muted", "No matching models"), 0, 0));
 		} else {
 			const selected = this.filteredModels[this.selectedIndex];
-			if (selected) {
+			if (selected && this.shouldShowSelectedDetails()) {
 				this.listContainer.addChild(new Spacer(1));
 				this.listContainer.addChild(new Text(theme.fg("muted", selected.model.name), 0, 0));
 			}
@@ -351,5 +390,50 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	getSearchInput(): MenuSearchInput {
 		return this.searchInput;
+	}
+
+	private updateResponsiveLayout(): void {
+		const showHeaderHelp = this.shouldShowHeaderHelp();
+		this.headerHelpContainer.clear();
+		if (showHeaderHelp) {
+			if (this.scopeText && this.scopeHintText) {
+				this.headerHelpContainer.addChild(this.scopeText);
+				this.headerHelpContainer.addChild(this.scopeHintText);
+			} else if (this.warningText) {
+				this.headerHelpContainer.addChild(this.warningText);
+			}
+			this.headerHelpContainer.addChild(new Spacer(1));
+		}
+
+		const reservedRows =
+			MODEL_LIST_RESERVED_ROWS.base +
+			(showHeaderHelp ? MODEL_LIST_RESERVED_ROWS.help : 0) +
+			(this.shouldShowSelectedDetails() ? MODEL_LIST_RESERVED_ROWS.detail : 0);
+		this.listLayout = getMenuListLayout({
+			getRows: this.viewport.getRows,
+			preferredVisibleItems: PREFERRED_VISIBLE_MODELS,
+			reservedRows,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+		});
+		this.responsiveLayoutKey = [
+			showHeaderHelp ? "help" : "no-help",
+			this.shouldShowSelectedDetails() ? "detail" : "no-detail",
+			this.listLayout.compact ? "compact" : "comfortable",
+			this.listLayout.visibleItems,
+		].join(":");
+	}
+
+	private shouldShowHeaderHelp(): boolean {
+		return this.hasRows(MODEL_HELP_MIN_ROWS);
+	}
+
+	private shouldShowSelectedDetails(): boolean {
+		return this.hasRows(MODEL_DETAIL_MIN_ROWS);
+	}
+
+	private hasRows(minRows: number): boolean {
+		const rows = this.viewport.getRows?.();
+		return rows === undefined || !Number.isFinite(rows) || rows >= minRows;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -1,7 +1,14 @@
 import { Container, type Focusable, fuzzyFilter, getKeybindings, Spacer, TruncatedText } from "@earendil-works/pi-tui";
 import type { AuthStatus, AuthStorage } from "../../../core/auth-storage.js";
 import { theme } from "../theme/theme.js";
-import { MenuList, MenuPanel, MenuRow, MenuSearchInput } from "./menu-panel.js";
+import {
+	getMenuListLayout,
+	MenuList,
+	MenuPanel,
+	MenuRow,
+	MenuSearchInput,
+	type MenuViewportProvider,
+} from "./menu-panel.js";
 
 export type AuthSelectorProvider = {
 	id: string;
@@ -15,6 +22,9 @@ export function compareAuthSelectorProviders(a: AuthSelectorProvider, b: AuthSel
 	}
 	return a.name.localeCompare(b.name);
 }
+
+const PREFERRED_VISIBLE_PROVIDERS = 8;
+const PROVIDER_LIST_RESERVED_ROWS = 8;
 
 /**
  * Component that renders an auth provider selector
@@ -41,6 +51,13 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	private getAuthStatus: (providerId: string) => AuthStatus;
 	private onSelectCallback: (provider: AuthSelectorProvider) => void;
 	private onCancelCallback: () => void;
+	private listLayout = getMenuListLayout({
+		preferredVisibleItems: PREFERRED_VISIBLE_PROVIDERS,
+		reservedRows: PROVIDER_LIST_RESERVED_ROWS,
+		comfortableItemRows: 3,
+		compactItemRows: 2,
+	});
+	private readonly viewport: MenuViewportProvider;
 
 	constructor(
 		mode: "login" | "logout",
@@ -49,12 +66,14 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		onSelect: (provider: AuthSelectorProvider) => void,
 		onCancel: () => void,
 		getAuthStatus?: (providerId: string) => AuthStatus,
+		viewport: MenuViewportProvider = {},
 	) {
 		super();
 
 		this.mode = mode;
 		this.authStorage = authStorage;
 		this.getAuthStatus = getAuthStatus ?? ((providerId) => this.authStorage.getAuthStatus(providerId));
+		this.viewport = viewport;
 		this.allProviders = this.sortProviders(providers);
 		this.filteredProviders = this.allProviders;
 		this.onSelectCallback = onSelect;
@@ -77,7 +96,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		panel.addChild(new Spacer(1));
 
 		// Create list container
-		this.listContainer = new MenuList();
+		this.listContainer = new MenuList({ compact: () => this.listLayout.compact });
 		panel.addChild(this.listContainer);
 
 		// Initial render
@@ -113,10 +132,23 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		return this.getAuthStatus(provider.id).source !== undefined;
 	}
 
+	override render(width: number): string[] {
+		const previousLayout = this.listLayout;
+		this.updateLayout();
+		if (
+			this.listLayout.compact !== previousLayout.compact ||
+			this.listLayout.visibleItems !== previousLayout.visibleItems
+		) {
+			this.updateList();
+		}
+		return super.render(width);
+	}
+
 	private updateList(): void {
+		this.updateLayout();
 		this.listContainer.clear();
 
-		const maxVisible = 8;
+		const maxVisible = this.listLayout.visibleItems;
 		const startIndex = Math.max(
 			0,
 			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredProviders.length - maxVisible),
@@ -214,5 +246,15 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 			this.searchInput.handleInput(keyData);
 			this.filterProviders(this.searchInput.getValue());
 		}
+	}
+
+	private updateLayout(): void {
+		this.listLayout = getMenuListLayout({
+			getRows: this.viewport.getRows,
+			preferredVisibleItems: PREFERRED_VISIBLE_PROVIDERS,
+			reservedRows: PROVIDER_LIST_RESERVED_ROWS,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -24,7 +24,8 @@ export function compareAuthSelectorProviders(a: AuthSelectorProvider, b: AuthSel
 }
 
 const PREFERRED_VISIBLE_PROVIDERS = 8;
-const PROVIDER_LIST_RESERVED_ROWS = 8;
+const PROVIDER_LIST_RESERVED_ROWS = 7;
+const PROVIDER_SCROLL_INDICATOR_ROWS = 1;
 
 /**
  * Component that renders an auth provider selector
@@ -252,9 +253,11 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		this.listLayout = getMenuListLayout({
 			getRows: this.viewport.getRows,
 			preferredVisibleItems: PREFERRED_VISIBLE_PROVIDERS,
+			totalItems: this.filteredProviders.length,
 			reservedRows: PROVIDER_LIST_RESERVED_ROWS,
 			comfortableItemRows: 3,
 			compactItemRows: 2,
+			scrollIndicatorRows: PROVIDER_SCROLL_INDICATOR_ROWS,
 		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
@@ -1,12 +1,22 @@
 import { Container, type Focusable, fuzzyFilter, getKeybindings, Spacer, TruncatedText } from "@earendil-works/pi-tui";
 import type { PrimeTeam } from "../../../core/prime-inference-auth.js";
 import { theme } from "../theme/theme.js";
-import { MenuList, MenuPanel, MenuRow, MenuSearchInput } from "./menu-panel.js";
+import {
+	getMenuListLayout,
+	MenuList,
+	MenuPanel,
+	MenuRow,
+	MenuSearchInput,
+	type MenuViewportProvider,
+} from "./menu-panel.js";
 
 type PrimeTeamOption = {
 	type: "personal" | "team";
 	team: PrimeTeam | null;
 };
+
+const PREFERRED_VISIBLE_TEAMS = 8;
+const TEAM_LIST_RESERVED_ROWS = 8;
 
 export class PrimeTeamSelectorComponent extends Container implements Focusable {
 	private readonly searchInput: MenuSearchInput;
@@ -15,12 +25,19 @@ export class PrimeTeamSelectorComponent extends Container implements Focusable {
 	private filteredOptions: PrimeTeamOption[];
 	private selectedIndex = 0;
 	private _focused = false;
+	private listLayout = getMenuListLayout({
+		preferredVisibleItems: PREFERRED_VISIBLE_TEAMS,
+		reservedRows: TEAM_LIST_RESERVED_ROWS,
+		comfortableItemRows: 3,
+		compactItemRows: 2,
+	});
 
 	constructor(
 		teams: PrimeTeam[],
 		private readonly currentTeamId: string | undefined,
 		private readonly onSelect: (team: PrimeTeam | null) => void,
 		private readonly onCancel: () => void,
+		private readonly viewport: MenuViewportProvider = {},
 	) {
 		super();
 
@@ -43,7 +60,7 @@ export class PrimeTeamSelectorComponent extends Container implements Focusable {
 		panel.addChild(this.searchInput);
 		panel.addChild(new Spacer(1));
 
-		this.listContainer = new MenuList();
+		this.listContainer = new MenuList({ compact: () => this.listLayout.compact });
 		panel.addChild(this.listContainer);
 		this.filterOptions("");
 	}
@@ -73,10 +90,23 @@ export class PrimeTeamSelectorComponent extends Container implements Focusable {
 		return team ? `${team.name} ${team.slug ?? ""} ${team.role ?? ""} ${team.teamId}` : "";
 	}
 
+	override render(width: number): string[] {
+		const previousLayout = this.listLayout;
+		this.updateLayout();
+		if (
+			this.listLayout.compact !== previousLayout.compact ||
+			this.listLayout.visibleItems !== previousLayout.visibleItems
+		) {
+			this.updateList();
+		}
+		return super.render(width);
+	}
+
 	private updateList(): void {
+		this.updateLayout();
 		this.listContainer.clear();
 
-		const maxVisible = 8;
+		const maxVisible = this.listLayout.visibleItems;
 		const startIndex = Math.max(
 			0,
 			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredOptions.length - maxVisible),
@@ -151,5 +181,15 @@ export class PrimeTeamSelectorComponent extends Container implements Focusable {
 			this.searchInput.handleInput(keyData);
 			this.filterOptions(this.searchInput.getValue());
 		}
+	}
+
+	private updateLayout(): void {
+		this.listLayout = getMenuListLayout({
+			getRows: this.viewport.getRows,
+			preferredVisibleItems: PREFERRED_VISIBLE_TEAMS,
+			reservedRows: TEAM_LIST_RESERVED_ROWS,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/prime-team-selector.ts
@@ -16,7 +16,8 @@ type PrimeTeamOption = {
 };
 
 const PREFERRED_VISIBLE_TEAMS = 8;
-const TEAM_LIST_RESERVED_ROWS = 8;
+const TEAM_LIST_RESERVED_ROWS = 7;
+const TEAM_SCROLL_INDICATOR_ROWS = 1;
 
 export class PrimeTeamSelectorComponent extends Container implements Focusable {
 	private readonly searchInput: MenuSearchInput;
@@ -187,9 +188,11 @@ export class PrimeTeamSelectorComponent extends Container implements Focusable {
 		this.listLayout = getMenuListLayout({
 			getRows: this.viewport.getRows,
 			preferredVisibleItems: PREFERRED_VISIBLE_TEAMS,
+			totalItems: this.filteredOptions.length,
 			reservedRows: TEAM_LIST_RESERVED_ROWS,
 			comfortableItemRows: 3,
 			compactItemRows: 2,
+			scrollIndicatorRows: TEAM_SCROLL_INDICATOR_ROWS,
 		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4803,6 +4803,7 @@ export class InteractiveMode {
 						settle({ status: "action", actionId });
 					},
 					subtitle: options?.subtitle,
+					getRows: () => this.ui.terminal.rows,
 				},
 			);
 			handle = this.showFullPaneOverlay(selector, 96);
@@ -5311,6 +5312,7 @@ export class InteractiveMode {
 					resolve({ status: "cancelled" });
 				},
 				(providerId) => this.session.modelRegistry.getProviderAuthStatus(providerId),
+				{ getRows: () => this.ui.terminal.rows },
 			);
 			handle = this.showFullPaneOverlay(selector, 78);
 		});
@@ -5358,6 +5360,8 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
+				undefined,
+				{ getRows: () => this.ui.terminal.rows },
 			);
 			return { component: selector, focus: selector };
 		});
@@ -5470,6 +5474,7 @@ export class InteractiveMode {
 					close();
 					resolve(undefined);
 				},
+				{ getRows: () => this.ui.terminal.rows },
 			);
 			handle = this.showFullPaneOverlay(selector, 78);
 		});
@@ -5721,6 +5726,7 @@ export class InteractiveMode {
 					restoreDialog();
 					resolve(undefined);
 				},
+				{ getRows: () => this.ui.terminal.rows },
 			);
 			selectorHandle = this.showFullPaneOverlay(selector, 76);
 		});

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -244,8 +244,7 @@ const TERMUX_PACKAGES: Record<string, string> = {
 	rg: "ripgrep",
 };
 
-export const MISSING_RIPGREP_MESSAGE =
-	"ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
+export const MISSING_RIPGREP_MESSAGE = "ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
 
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable

--- a/packages/coding-agent/test/menu-panel.test.ts
+++ b/packages/coding-agent/test/menu-panel.test.ts
@@ -1,7 +1,13 @@
 import { type Component, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, it } from "vitest";
-import { MenuList, MenuPanel, MenuRow, MenuSearchInput } from "../src/modes/interactive/components/menu-panel.js";
+import {
+	getMenuListLayout,
+	MenuList,
+	MenuPanel,
+	MenuRow,
+	MenuSearchInput,
+} from "../src/modes/interactive/components/menu-panel.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 class StaticComponent implements Component {
@@ -100,6 +106,48 @@ describe("MenuPanel", () => {
 		expect(selectedIndex).toBeGreaterThan(0);
 		expect(output[selectedIndex - 1]?.trim()).toBe("");
 		expect(output[selectedIndex - 2]?.trim()).not.toBe("");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBe(40);
+		}
+	});
+
+	it("uses compact list layout when the comfortable layout would overflow", () => {
+		const layout = getMenuListLayout({
+			getRows: () => 24,
+			preferredVisibleItems: 8,
+			reservedRows: 8,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+		});
+
+		expect(layout).toEqual({ compact: true, visibleItems: 8 });
+	});
+
+	it("renders compact rows without vertical padding", () => {
+		const list = new MenuList({ compact: true });
+		list.addChild(
+			new MenuRow({
+				primary: "first",
+				secondary: "provider",
+				selected: true,
+			}),
+		);
+		list.addChild(
+			new MenuRow({
+				primary: "second",
+				secondary: "provider",
+				selected: false,
+			}),
+		);
+
+		const lines = list.render(40);
+		const output = lines.map((line) => stripAnsi(line));
+
+		expect(lines).toHaveLength(4);
+		expect(output[0]).toContain("first");
+		expect(output[1]).toContain("provider");
+		expect(output[2]).toContain("second");
+		expect(output[3]).toContain("provider");
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBe(40);
 		}

--- a/packages/coding-agent/test/menu-panel.test.ts
+++ b/packages/coding-agent/test/menu-panel.test.ts
@@ -123,6 +123,32 @@ describe("MenuPanel", () => {
 		expect(layout).toEqual({ compact: true, visibleItems: 8 });
 	});
 
+	it("reserves scroll indicator rows when sizing visible items", () => {
+		const layout = getMenuListLayout({
+			getRows: () => 16,
+			preferredVisibleItems: 10,
+			totalItems: 12,
+			reservedRows: 12,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+			scrollIndicatorRows: 1,
+		});
+
+		expect(layout).toEqual({ compact: true, visibleItems: 1 });
+	});
+
+	it("uses compact layout when neither layout can fully fit", () => {
+		const layout = getMenuListLayout({
+			getRows: () => 5,
+			preferredVisibleItems: 3,
+			reservedRows: 4,
+			comfortableItemRows: 3,
+			compactItemRows: 2,
+		});
+
+		expect(layout).toEqual({ compact: true, visibleItems: 1 });
+	});
+
 	it("renders compact rows without vertical padding", () => {
 		const list = new MenuList({ compact: true });
 		list.addChild(

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -111,4 +111,44 @@ describe("ModelSelectorComponent provider actions", () => {
 		expect(output).toContain("faux-2");
 		expect(output).toContain("(2/12)");
 	});
+
+	it("keeps scoped model help within a short terminal viewport", async () => {
+		const harness = await createHarness({
+			models: Array.from({ length: 12 }, (_, index) => ({
+				id: `faux-${index + 1}`,
+				name: `Faux Model ${index + 1}`,
+				reasoning: true,
+			})),
+		});
+		harnesses.push(harness);
+		const scopedModels = Array.from({ length: 12 }, (_, index) => {
+			const model = harness.getModel(`faux-${index + 1}`);
+			if (!model) {
+				throw new Error(`Missing model faux-${index + 1}`);
+			}
+			return { model };
+		});
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel("faux-1"),
+			harness.settingsManager,
+			harness.session.modelRegistry,
+			scopedModels,
+			() => {},
+			() => {},
+			undefined,
+			{ getRows: () => 16 },
+		);
+
+		await waitForAsyncRender();
+
+		const lines = selector.render(120);
+		const output = stripAnsi(lines.join("\n"));
+
+		expect(lines.length).toBeLessThanOrEqual(16);
+		expect(output).toContain("Scope: ");
+		expect(output).toContain("(all/scoped)");
+		expect(output).toContain("(1/12)");
+	});
 });

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -77,4 +77,38 @@ describe("ModelSelectorComponent provider actions", () => {
 
 		expect(selectedAction).toBe("add_provider");
 	});
+
+	it("keeps the model menu within a short terminal viewport", async () => {
+		const harness = await createHarness({
+			models: Array.from({ length: 12 }, (_, index) => ({
+				id: `faux-${index + 1}`,
+				name: `Faux Model ${index + 1}`,
+				reasoning: true,
+			})),
+		});
+		harnesses.push(harness);
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel("faux-1"),
+			harness.settingsManager,
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{ getRows: () => 12 },
+		);
+
+		await waitForAsyncRender();
+
+		expect(selector.render(120)).toHaveLength(12);
+
+		selector.handleInput("\x1b[B");
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(selector.render(120)).toHaveLength(12);
+		expect(output).toContain("faux-2");
+		expect(output).toContain("(2/12)");
+	});
 });

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -196,4 +196,32 @@ describe("OAuthSelectorComponent", () => {
 		expect(output).toContain("command in models.json");
 		expect(output).not.toContain("unconfigured");
 	});
+
+	it("keeps the provider menu within a short terminal viewport", () => {
+		const authStorage = AuthStorage.inMemory();
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			Array.from({ length: 12 }, (_, index) => ({
+				id: `provider-${index + 1}`,
+				name: `Provider ${index + 1}`,
+				authType: "api_key" as const,
+			})),
+			() => {},
+			() => {},
+			() => ({ configured: false }),
+			{ getRows: () => 12 },
+		);
+
+		expect(selector.render(80)).toHaveLength(12);
+
+		for (let i = 0; i < 5; i++) {
+			selector.handleInput("\x1b[B");
+		}
+		const output = stripAnsi(selector.render(80).join("\n"));
+
+		expect(selector.render(80)).toHaveLength(12);
+		expect(output).toContain("Provider 3");
+		expect(output).toContain("(6/12)");
+	});
 });


### PR DESCRIPTION
- popup selectors now size their visible items from terminal height and switch to compact rows on short screens.
- provider, model, team, and extension menus stay scrollable instead of being clipped by overlays.
- added regressions for short terminal rendering in shared menu and selector tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and layout only; behavior is covered by new tests with no auth or data-path changes.
> 
> **Overview**
> Popup TUI selectors now adapt to **terminal height** instead of using fixed visible-item caps.
> 
> **Shared layout:** `getMenuListLayout` in `menu-panel.ts` computes **compact vs comfortable** row density, **how many list items fit**, and accounts for **scroll-indicator** rows when lists overflow. `MenuList` can render rows in **compact** mode (content only, no vertical padding between rows).
> 
> **Selectors:** Model, OAuth/provider, Prime team, and extension menus take an optional **`getRows`** viewport, recompute layout on **`render`** (resize), window the list around the selection, and show a muted **`(i/n)`** position when not all items are visible. The **model** selector additionally moves scope/warning help into a **`headerHelpContainer`** and **drops** header help and selected-model detail when the viewport is below row thresholds.
> 
> **Wiring:** `interactive-mode.ts` passes **`() => this.ui.terminal.rows`** into overlay selectors (models, login/logout providers, Prime team, extension prompts).
> 
> **Tests:** New coverage for `getMenuListLayout`, compact `MenuList` rendering, and short-viewport behavior for model and OAuth selectors. Trivial formatting-only change to `MISSING_RIPGREP_MESSAGE` in `tools-manager.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46c7b5a17c82a83ec7648a52f87046eb32c059e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make popup menus responsive to terminal viewport size
> - Adds `getMenuListLayout` in [menu-panel.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/106/files#diff-22f82f8366fad943dc6e7f231f4645c864e17b89b5228a1453cc21e1a57a329c) to compute visible item count and compact vs. comfortable row density based on available terminal rows.
> - Updates all selector components ([model-selector](https://github.com/PrimeIntellect-ai/prime-agent/pull/106/files#diff-0eea64beefbee1061fdf18121e74d8a9344b3ee1d5942193697b874e5db4c63b), [oauth-selector](https://github.com/PrimeIntellect-ai/prime-agent/pull/106/files#diff-6770bbf1881aae4d394abfb02cbab2cbd4e910a6dfa0145782fb6a68a467e415), [extension-selector](https://github.com/PrimeIntellect-ai/prime-agent/pull/106/files#diff-57a0e50605f5246c8e85caa31da3e4d3256dbd06ba897d1621618f04c4817e9f), [prime-team-selector](https://github.com/PrimeIntellect-ai/prime-agent/pull/106/files#diff-1c9680260e45ee5bcd060a8f77f1c5bb1d73982755f160caa13cb10c0a2509d4)) to accept a viewport provider and paginate their lists to fit the terminal height.
> - When the comfortable layout would overflow, compact mode (no vertical padding on rows) is chosen automatically; a `(current/total)` indicator is appended when the list is scrollable.
> - The model selector additionally hides help text and selected model details when there are insufficient rows.
> - Behavioral Change: menus now render a subset of items on short terminals instead of overflowing the viewport.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a46c7b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->