### PR TITLE
make error output less jarring

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Stopped showing changelog entries automatically on install, first launch, and update startup.
+- Fixed multi-line IPython, assistant, and child-agent errors to collapse internal tracebacks by default while preserving full details on expand.
 - Fixed child-agent navigation to show contextual keybinding hints and a visible focused tray marker.
 - Fixed the release installer to ask before bootstrapping the IPython kernel runtime during install, avoiding default first-run `uv` prompts inside the TUI.
 - Fixed browser sign-in links to show plain URLs when terminal hyperlinks are unsupported.

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -122,6 +122,14 @@ export interface IpythonToolDetails {
 	durationMs?: number;
 	status?: "ok" | "error" | "aborted" | "starting";
 	errorEname?: string;
+	stdout?: string;
+	stderr?: string;
+	result?: string;
+	error?: {
+		ename: string;
+		evalue: string;
+		traceback: string[];
+	};
 }
 
 export interface IpythonToolOptions {
@@ -220,6 +228,10 @@ export function createIpythonToolDefinition(
 						durationMs: r.durationMs,
 						status: r.status,
 						errorEname: r.error?.ename,
+						stdout: r.stdout,
+						stderr: r.stderr,
+						result: r.result,
+						error: r.error,
 					},
 					isError: r.status === "error" || r.status === "aborted",
 				};

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -185,7 +185,6 @@ export class AssistantMessageComponent extends Container {
 			text,
 			summary,
 			expanded: this.expanded,
-			collapseLabel: "error details collapsed",
 		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -7,6 +7,10 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+export interface AssistantMessageComponentOptions {
+	expanded?: boolean;
+}
+
 function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
 	const quiet = (text: string) => theme.fg("thinkingText", text);
 	return {
@@ -42,12 +46,14 @@ export class AssistantMessageComponent extends Container {
 		hideThinkingBlock = false,
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		hiddenThinkingLabel = "Thinking...",
+		options: AssistantMessageComponentOptions = {},
 	) {
 		super();
 
 		this.hideThinkingBlock = hideThinkingBlock;
 		this.markdownTheme = markdownTheme;
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
+		this.expanded = options.expanded ?? false;
 
 		// Container for text/thinking content
 		this.contentContainer = new Container();

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { type Component, Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
+import { CollapsibleErrorComponent, shouldCollapseErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -34,6 +35,7 @@ export class AssistantMessageComponent extends Container {
 	private hiddenThinkingLabel: string;
 	private lastMessage?: AssistantMessage;
 	private hasToolCalls = false;
+	private expanded = false;
 
 	constructor(
 		message?: AssistantMessage,
@@ -74,6 +76,15 @@ export class AssistantMessageComponent extends Container {
 		this.hiddenThinkingLabel = label;
 		if (this.lastMessage) {
 			this.updateContent(this.lastMessage);
+		}
+	}
+
+	setExpanded(expanded: boolean): void {
+		if (this.expanded !== expanded) {
+			this.expanded = expanded;
+			if (this.lastMessage) {
+				this.updateContent(this.lastMessage);
+			}
 		}
 	}
 
@@ -153,12 +164,28 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					this.contentContainer.addChild(new Spacer(1));
 				}
-				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
+				this.contentContainer.addChild(this.createErrorComponent(abortMessage));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";
 				this.contentContainer.addChild(new Spacer(1));
-				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0));
+				this.contentContainer.addChild(this.createErrorComponent(errorMsg, "Error"));
 			}
 		}
+	}
+
+	private createErrorComponent(message: string, prefix?: string): Component {
+		if (!shouldCollapseErrorDetails(message)) {
+			const text = prefix ? `${prefix}: ${message}` : message;
+			return new Text(theme.fg("error", text), 1, 0);
+		}
+
+		const text = prefix ? `${prefix}: ${message}` : message;
+		const summary = prefix ? `${prefix}: ${summarizeErrorDetails(message)}` : summarizeErrorDetails(message);
+		return new CollapsibleErrorComponent({
+			text,
+			summary,
+			expanded: this.expanded,
+			collapseLabel: "error details collapsed",
+		});
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -574,6 +574,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			this.options.getHideThinkingBlock?.() ?? false,
 			this.options.getMarkdownTheme?.(),
 			this.options.getHiddenThinkingLabel?.() ?? "Thinking...",
+			{ expanded: this.toolsExpanded },
 		);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -14,6 +14,7 @@ import {
 import type { ToolDefinition } from "../../../core/extensions/types.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
+import { CollapsibleErrorComponent, shouldCollapseErrorDetails } from "./collapsible-error.js";
 import { keyText } from "./keybinding-hints.js";
 import { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";
 import { UserMessageComponent } from "./user-message.js";
@@ -554,7 +555,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 					components.push(this.createToolComponent(entry));
 					break;
 				case "system":
-					components.push(new Text(theme.fg("error", entry.text), 1, 0));
+					components.push(this.createSystemComponent(entry));
 					break;
 			}
 		}
@@ -574,6 +575,17 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			this.options.getMarkdownTheme?.(),
 			this.options.getHiddenThinkingLabel?.() ?? "Thinking...",
 		);
+	}
+
+	private createSystemComponent(entry: ChildAgentSystemTranscriptEntry): Component {
+		if (!shouldCollapseErrorDetails(entry.text)) {
+			return new Text(theme.fg("error", entry.text), 1, 0);
+		}
+		return new CollapsibleErrorComponent({
+			text: entry.text,
+			expanded: this.toolsExpanded,
+			collapseLabel: "error details collapsed",
+		});
 	}
 
 	private createToolComponent(entry: ChildAgentToolTranscriptEntry): Component {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -584,7 +584,6 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 		return new CollapsibleErrorComponent({
 			text: entry.text,
 			expanded: this.toolsExpanded,
-			collapseLabel: "error details collapsed",
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -15,19 +15,60 @@ export function normalizeErrorDetails(text: string): string {
 	return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd();
 }
 
-export function summarizeErrorDetails(text: string): string {
-	const normalized = normalizeErrorDetails(text);
-	const lines = normalized
+interface ErrorDetailLine {
+	raw: string;
+	trimmed: string;
+}
+
+function errorDetailLines(text: string): ErrorDetailLine[] {
+	return normalizeErrorDetails(text)
 		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0);
+		.map((raw) => ({ raw, trimmed: raw.trim() }))
+		.filter((line) => line.trimmed.length > 0);
+}
+
+function startsStackContext(line: ErrorDetailLine): boolean {
+	if (line.trimmed.startsWith("Traceback ")) {
+		return true;
+	}
+	if (line.trimmed.startsWith("File ") && line.trimmed.includes(", line ")) {
+		return true;
+	}
+	if (line.trimmed.startsWith("Cell In[") && line.trimmed.includes(", line ")) {
+		return true;
+	}
+	if (line.trimmed.startsWith("---->")) {
+		return true;
+	}
+	return false;
+}
+
+function isStackContextLine(line: ErrorDetailLine): boolean {
+	if (startsStackContext(line)) {
+		return true;
+	}
+	return line.raw.startsWith(" ") || line.raw.startsWith("\t");
+}
+
+function summarizeStackContext(lines: readonly ErrorDetailLine[]): string | undefined {
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index];
+		if (line && !isStackContextLine(line)) {
+			return line.trimmed;
+		}
+	}
+	return undefined;
+}
+
+export function summarizeErrorDetails(text: string): string {
+	const lines = errorDetailLines(text);
 	if (lines.length === 0) {
 		return "Error";
 	}
-	if (lines[0]?.startsWith("Traceback ")) {
-		return lines.at(-1) ?? "Error";
+	if (lines.length > 1 && startsStackContext(lines[0]!)) {
+		return summarizeStackContext(lines) ?? "Error";
 	}
-	return lines[0] ?? "Error";
+	return lines[0]?.trimmed ?? "Error";
 }
 
 export function shouldCollapseErrorDetails(text: string): boolean {

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -57,16 +57,9 @@ export class CollapsibleErrorComponent implements Component {
 		}
 
 		const summary = normalizeErrorDetails(this.options.summary ?? summarizeErrorDetails(text));
-		const lines = this.renderText(summary, width);
 		const label = this.options.collapseLabel ?? "error details collapsed";
-		lines.push(
-			...this.renderText(
-				`${label} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`,
-				width,
-				"muted",
-			),
-		);
-		return lines;
+		const inlineHint = `${summary} ${theme.fg("dim", "·")} ${label} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
+		return this.renderText(inlineHint, width, "muted");
 	}
 
 	private renderText(text: string, width: number, color: "error" | "muted" = "error"): string[] {

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -1,0 +1,88 @@
+import { type Component, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { theme } from "../theme/theme.js";
+import { keyHint } from "./keybinding-hints.js";
+
+export interface CollapsibleErrorOptions {
+	text: string;
+	summary?: string;
+	expanded?: boolean;
+	collapseLabel?: string;
+	forceCollapse?: boolean;
+	paddingX?: number;
+}
+
+export function normalizeErrorDetails(text: string): string {
+	return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd();
+}
+
+export function summarizeErrorDetails(text: string): string {
+	const normalized = normalizeErrorDetails(text);
+	return (
+		normalized
+			.split("\n")
+			.map((line) => line.trim())
+			.find((line) => line.length > 0) ?? "Error"
+	);
+}
+
+export function shouldCollapseErrorDetails(text: string): boolean {
+	return normalizeErrorDetails(text).split("\n").length > 1;
+}
+
+export class CollapsibleErrorComponent implements Component {
+	private expanded: boolean;
+
+	constructor(private readonly options: CollapsibleErrorOptions) {
+		this.expanded = options.expanded ?? false;
+	}
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+	}
+
+	invalidate(): void {
+		// Render output is derived from constructor options and expansion state.
+	}
+
+	render(width: number): string[] {
+		const text = normalizeErrorDetails(this.options.text);
+		if (!text) {
+			return [];
+		}
+
+		const collapsible = this.options.forceCollapse ?? shouldCollapseErrorDetails(text);
+		if (!collapsible || this.expanded) {
+			return this.renderText(text, width);
+		}
+
+		const summary = normalizeErrorDetails(this.options.summary ?? summarizeErrorDetails(text));
+		const lines = this.renderText(summary, width);
+		const label = this.options.collapseLabel ?? "error details collapsed";
+		lines.push(
+			...this.renderText(
+				`${label} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`,
+				width,
+				"muted",
+			),
+		);
+		return lines;
+	}
+
+	private renderText(text: string, width: number, color: "error" | "muted" = "error"): string[] {
+		const safeWidth = Math.max(1, width);
+		const paddingX = this.options.paddingX ?? 1;
+		const contentWidth = Math.max(1, safeWidth - paddingX);
+		const prefix = " ".repeat(paddingX);
+		const lines: string[] = [];
+		for (const rawLine of text.split("\n")) {
+			const styled = theme.fg(color, rawLine || " ");
+			const wrapped = wrapTextWithAnsi(styled, contentWidth);
+			for (const line of wrapped.length > 0 ? wrapped : [""]) {
+				const padded = `${prefix}${line}`;
+				lines.push(truncateToWidth(padded, safeWidth, ""));
+			}
+		}
+		return lines.map((line) => line + " ".repeat(Math.max(0, safeWidth - visibleWidth(line))));
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -7,7 +7,6 @@ export interface CollapsibleErrorOptions {
 	text: string;
 	summary?: string;
 	expanded?: boolean;
-	collapseLabel?: string;
 	forceCollapse?: boolean;
 	paddingX?: number;
 }
@@ -18,12 +17,17 @@ export function normalizeErrorDetails(text: string): string {
 
 export function summarizeErrorDetails(text: string): string {
 	const normalized = normalizeErrorDetails(text);
-	return (
-		normalized
-			.split("\n")
-			.map((line) => line.trim())
-			.find((line) => line.length > 0) ?? "Error"
-	);
+	const lines = normalized
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	if (lines.length === 0) {
+		return "Error";
+	}
+	if (lines[0]?.startsWith("Traceback ")) {
+		return lines.at(-1) ?? "Error";
+	}
+	return lines[0] ?? "Error";
 }
 
 export function shouldCollapseErrorDetails(text: string): boolean {
@@ -57,8 +61,7 @@ export class CollapsibleErrorComponent implements Component {
 		}
 
 		const summary = normalizeErrorDetails(this.options.summary ?? summarizeErrorDetails(text));
-		const label = this.options.collapseLabel ?? "error details collapsed";
-		const inlineHint = `${summary} ${theme.fg("dim", "·")} ${label} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
+		const inlineHint = `${summary} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
 		return this.renderText(inlineHint, width, "muted");
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -50,7 +50,7 @@ interface TracebackParts {
 	preview: string;
 }
 
-type CellBackground = "toolPendingBg";
+type CellBackground = "toolPendingBg" | "toolSuccessBg" | "toolErrorBg";
 type ExpandHintFormatter = (label: string) => string;
 
 const MAGIC_LINE_PATTERN = /^\s*!/;
@@ -359,24 +359,14 @@ export class IPythonCellComponent implements Component {
 					details.error.traceback.join("\n") || formatIpythonErrorSummary(details.error),
 				);
 			} else {
-				this.addWrapped(
-					lines,
-					"",
-					`${theme.fg("muted", formatIpythonErrorSummary(details.error))} ${theme.fg("dim", "·")} ${withExpandHint("traceback collapsed")}`,
-					width,
-				);
+				this.addWrapped(lines, "", withExpandHint(formatIpythonErrorSummary(details.error)), width);
 			}
 		} else if (traceback) {
 			startOutput();
 			if (this.state.expanded) {
 				this.renderTraceback(lines, width, traceback.traceback);
 			} else {
-				this.addWrapped(
-					lines,
-					"",
-					`${theme.fg("muted", traceback.preview)} ${theme.fg("dim", "·")} ${withExpandHint("traceback collapsed")}`,
-					width,
-				);
+				this.addWrapped(lines, "", withExpandHint(traceback.preview), width);
 			}
 		}
 
@@ -437,14 +427,14 @@ export class IPythonCellComponent implements Component {
 		const truncated = truncateToWidth(line, contentWidth, "");
 		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
 		const padded = `${" ".repeat(this.paddingX)}${paddedContent}${" ".repeat(this.paddingX)}`;
-		const background = this.background();
-		return background ? theme.bg(background, padded) : padded;
+		return theme.bg(this.background(), padded);
 	}
 
-	private background(): CellBackground | undefined {
+	private background(): CellBackground {
 		if (this.state.isPartial || !this.state.executionStarted) {
 			return "toolPendingBg";
 		}
-		return undefined;
+		const details = readDetails(this.state.details);
+		return this.state.isError || details.status === "error" ? "toolErrorBg" : "toolSuccessBg";
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -50,7 +50,7 @@ interface TracebackParts {
 	preview: string;
 }
 
-type CellBackground = "customMessageBg" | "toolPendingBg" | "toolErrorBg";
+type CellBackground = "toolPendingBg";
 type ExpandHintFormatter = (label: string) => string;
 
 const MAGIC_LINE_PATTERN = /^\s*!/;
@@ -162,7 +162,10 @@ function formatIpythonErrorSummary(error: IpythonErrorDetails): string {
 		.map((line) => line.trim())
 		.filter((line) => line.length > 0)
 		.join(" ");
-	return value ? `${error.ename}: ${value}` : error.ename;
+	if (!value) {
+		return error.ename;
+	}
+	return visibleWidth(value) <= 48 ? `${error.ename}: ${value}` : error.ename;
 }
 
 export class IPythonCellComponent implements Component {
@@ -356,16 +359,24 @@ export class IPythonCellComponent implements Component {
 					details.error.traceback.join("\n") || formatIpythonErrorSummary(details.error),
 				);
 			} else {
-				this.addWrapped(lines, "", theme.fg("error", formatIpythonErrorSummary(details.error)), width);
-				this.addWrapped(lines, "", withExpandHint("traceback collapsed"), width);
+				this.addWrapped(
+					lines,
+					"",
+					`${theme.fg("muted", formatIpythonErrorSummary(details.error))} ${theme.fg("dim", "·")} ${withExpandHint("traceback collapsed")}`,
+					width,
+				);
 			}
 		} else if (traceback) {
 			startOutput();
 			if (this.state.expanded) {
 				this.renderTraceback(lines, width, traceback.traceback);
 			} else {
-				this.addWrapped(lines, "", theme.fg("error", traceback.preview), width);
-				this.addWrapped(lines, "", withExpandHint("traceback collapsed"), width);
+				this.addWrapped(
+					lines,
+					"",
+					`${theme.fg("muted", traceback.preview)} ${theme.fg("dim", "·")} ${withExpandHint("traceback collapsed")}`,
+					width,
+				);
 			}
 		}
 
@@ -385,7 +396,7 @@ export class IPythonCellComponent implements Component {
 		label: "out" | "err",
 		withExpandHint: ExpandHintFormatter,
 	): void {
-		const color = label === "err" ? "error" : "toolOutput";
+		const color = label === "err" ? "muted" : "toolOutput";
 		const allLines = text.split("\n");
 		const expanded = this.state.expanded ?? false;
 		const showCollapsed = !expanded && allLines.length > OUTPUT_PREVIEW_LINES;
@@ -403,7 +414,7 @@ export class IPythonCellComponent implements Component {
 
 	private renderTraceback(lines: string[], width: number, traceback: string): void {
 		for (const line of traceback.split("\n")) {
-			this.addWrapped(lines, "", theme.fg("error", line || " "), width);
+			this.addWrapped(lines, "", theme.fg("muted", line || " "), width);
 		}
 	}
 
@@ -426,16 +437,14 @@ export class IPythonCellComponent implements Component {
 		const truncated = truncateToWidth(line, contentWidth, "");
 		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
 		const padded = `${" ".repeat(this.paddingX)}${paddedContent}${" ".repeat(this.paddingX)}`;
-		return theme.bg(this.background(), padded);
+		const background = this.background();
+		return background ? theme.bg(background, padded) : padded;
 	}
 
-	private background(): CellBackground {
-		if (this.state.isError || readDetails(this.state.details).status === "error") {
-			return "toolErrorBg";
-		}
+	private background(): CellBackground | undefined {
 		if (this.state.isPartial || !this.state.executionStarted) {
 			return "toolPendingBg";
 		}
-		return "customMessageBg";
+		return undefined;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -5,8 +5,8 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import stripAnsi from "strip-ansi";
 import { highlightCode, theme } from "../theme/theme.js";
+import { normalizeErrorDetails } from "./collapsible-error.js";
 import { keyHint } from "./keybinding-hints.js";
 
 export interface IPythonCellContentBlock {
@@ -32,6 +32,16 @@ interface IpythonDetails {
 	durationMs?: number;
 	status?: string;
 	errorEname?: string;
+	stdout?: string;
+	stderr?: string;
+	result?: string;
+	error?: IpythonErrorDetails;
+}
+
+interface IpythonErrorDetails {
+	ename: string;
+	evalue: string;
+	traceback: readonly string[];
 }
 
 interface TracebackParts {
@@ -62,15 +72,33 @@ function readDetails(details: unknown): IpythonDetails {
 		return {};
 	}
 	const record = details as Record<string, unknown>;
+	const error = readErrorDetails(record.error);
 	return {
 		durationMs: typeof record.durationMs === "number" ? record.durationMs : undefined,
 		status: typeof record.status === "string" ? record.status : undefined,
-		errorEname: typeof record.errorEname === "string" ? record.errorEname : undefined,
+		errorEname: error?.ename ?? (typeof record.errorEname === "string" ? record.errorEname : undefined),
+		stdout: typeof record.stdout === "string" ? record.stdout : undefined,
+		stderr: typeof record.stderr === "string" ? record.stderr : undefined,
+		result: typeof record.result === "string" ? record.result : undefined,
+		error,
 	};
 }
 
-function normalizeText(text: string): string {
-	return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+function readErrorDetails(value: unknown): IpythonErrorDetails | undefined {
+	if (!value || typeof value !== "object") {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	if (typeof record.ename !== "string") {
+		return undefined;
+	}
+	return {
+		ename: record.ename,
+		evalue: typeof record.evalue === "string" ? record.evalue : "",
+		traceback: Array.isArray(record.traceback)
+			? record.traceback.filter((line): line is string => typeof line === "string")
+			: [],
+	};
 }
 
 function formatDuration(durationMs: number | undefined): string | undefined {
@@ -102,7 +130,7 @@ function textFromBlocks(blocks: readonly IPythonCellContentBlock[] | undefined):
 }
 
 function splitTraceback(text: string, errorName: string | undefined): TracebackParts | undefined {
-	const normalized = normalizeText(text);
+	const normalized = normalizeErrorDetails(text);
 	if (!normalized.trim()) {
 		return undefined;
 	}
@@ -111,11 +139,6 @@ function splitTraceback(text: string, errorName: string | undefined): TracebackP
 	let tracebackIndex = lines.findIndex((line) => line.includes("Traceback (most recent call last):"));
 	if (tracebackIndex < 0 && errorName) {
 		tracebackIndex = lines.findIndex((line) => line.trim().startsWith(`${errorName}:`));
-	}
-	if (tracebackIndex < 0) {
-		tracebackIndex = lines.findIndex((line) =>
-			/^[A-Za-z_][\w.]*?(Error|Exception|Interrupt|Exit)\b/.test(line.trim()),
-		);
 	}
 	if (tracebackIndex < 0) {
 		return undefined;
@@ -131,6 +154,15 @@ function splitTraceback(text: string, errorName: string | undefined): TracebackP
 		errorName ??
 		"error";
 	return { output, traceback, preview };
+}
+
+function formatIpythonErrorSummary(error: IpythonErrorDetails): string {
+	const value = normalizeErrorDetails(error.evalue)
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.join(" ");
+	return value ? `${error.ename}: ${value}` : error.ename;
 }
 
 export class IPythonCellComponent implements Component {
@@ -250,9 +282,17 @@ export class IPythonCellComponent implements Component {
 		const blocks = this.state.content ?? [];
 		const text = textFromBlocks(blocks);
 		const imageCount = blocks.filter(isImageBlock).length;
+		const hasStructuredOutput =
+			details.stdout !== undefined ||
+			details.stderr !== undefined ||
+			details.result !== undefined ||
+			details.error !== undefined;
 		const traceback =
-			this.state.isError || details.status === "error" ? splitTraceback(text, details.errorEname) : undefined;
+			!hasStructuredOutput && (this.state.isError || details.status === "error")
+				? splitTraceback(text, details.errorEname)
+				: undefined;
 		let outputStarted = false;
+		let renderedTextOutput = false;
 
 		const startOutput = (): void => {
 			if (outputStarted) {
@@ -264,21 +304,62 @@ export class IPythonCellComponent implements Component {
 			}
 		};
 
-		if (traceback?.output) {
+		if (hasStructuredOutput) {
+			if (details.stdout?.trim()) {
+				startOutput();
+				renderedTextOutput = true;
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.stdout), "out", withExpandHint);
+			}
+			if (details.stderr?.trim()) {
+				startOutput();
+				renderedTextOutput = true;
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.stderr), "err", withExpandHint);
+			}
+			if (details.result?.trim()) {
+				startOutput();
+				renderedTextOutput = true;
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.result), "out", withExpandHint);
+			}
+		} else if (traceback?.output) {
 			startOutput();
+			renderedTextOutput = true;
 			this.renderOutputText(lines, width, traceback.output, "out", withExpandHint);
 		} else if (text.trim()) {
 			startOutput();
-			this.renderOutputText(lines, width, normalizeText(text), this.state.isError ? "err" : "out", withExpandHint);
-		} else if (this.state.isPartial || (this.state.executionStarted && !this.state.argsComplete)) {
+			renderedTextOutput = true;
+			this.renderOutputText(
+				lines,
+				width,
+				normalizeErrorDetails(text),
+				this.state.isError ? "err" : "out",
+				withExpandHint,
+			);
+		}
+
+		if (!renderedTextOutput && this.state.isPartial) {
 			startOutput();
 			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
-		} else if (this.state.executionStarted && imageCount === 0) {
+		} else if (!renderedTextOutput && this.state.executionStarted && !this.state.argsComplete) {
+			startOutput();
+			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
+		} else if (!renderedTextOutput && !details.error && this.state.executionStarted && imageCount === 0) {
 			startOutput();
 			this.addWrapped(lines, "", theme.fg("muted", "no output"), width);
 		}
 
-		if (traceback) {
+		if (details.error) {
+			startOutput();
+			if (this.state.expanded) {
+				this.renderTraceback(
+					lines,
+					width,
+					details.error.traceback.join("\n") || formatIpythonErrorSummary(details.error),
+				);
+			} else {
+				this.addWrapped(lines, "", theme.fg("error", formatIpythonErrorSummary(details.error)), width);
+				this.addWrapped(lines, "", withExpandHint("traceback collapsed"), width);
+			}
+		} else if (traceback) {
 			startOutput();
 			if (this.state.expanded) {
 				this.renderTraceback(lines, width, traceback.traceback);

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -6,7 +6,7 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { highlightCode, theme } from "../theme/theme.js";
-import { normalizeErrorDetails } from "./collapsible-error.js";
+import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
 import { keyHint } from "./keybinding-hints.js";
 
 export interface IPythonCellContentBlock {
@@ -50,7 +50,6 @@ interface TracebackParts {
 	preview: string;
 }
 
-type CellBackground = "toolPendingBg" | "toolSuccessBg" | "toolErrorBg";
 type ExpandHintFormatter = (label: string) => string;
 
 const MAGIC_LINE_PATTERN = /^\s*!/;
@@ -146,23 +145,17 @@ function splitTraceback(text: string, errorName: string | undefined): TracebackP
 
 	const output = lines.slice(0, tracebackIndex).join("\n").trimEnd();
 	const traceback = lines.slice(tracebackIndex).join("\n").trim();
-	const preview =
-		traceback
-			.split("\n")
-			.filter((line) => line.trim().length > 0)
-			.at(-1) ??
-		errorName ??
-		"error";
-	return { output, traceback, preview };
+	const preview = summarizeErrorDetails(traceback);
+	return { output, traceback, preview: preview === "Error" && errorName ? errorName : preview };
 }
 
 function formatIpythonErrorSummary(error: IpythonErrorDetails): string {
-	const value = normalizeErrorDetails(error.evalue)
-		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0)
-		.join(" ");
-	if (!value) {
+	const normalizedValue = normalizeErrorDetails(error.evalue);
+	if (!normalizedValue.trim()) {
+		return error.ename;
+	}
+	const value = summarizeErrorDetails(normalizedValue);
+	if (value === "Error") {
 		return error.ename;
 	}
 	return visibleWidth(value) <= 48 ? `${error.ename}: ${value}` : error.ename;
@@ -323,10 +316,12 @@ export class IPythonCellComponent implements Component {
 				renderedTextOutput = true;
 				this.renderOutputText(lines, width, normalizeErrorDetails(details.result), "out", withExpandHint);
 			}
-		} else if (traceback?.output) {
-			startOutput();
-			renderedTextOutput = true;
-			this.renderOutputText(lines, width, traceback.output, "out", withExpandHint);
+		} else if (traceback) {
+			if (traceback.output) {
+				startOutput();
+				renderedTextOutput = true;
+				this.renderOutputText(lines, width, traceback.output, "out", withExpandHint);
+			}
 		} else if (text.trim()) {
 			startOutput();
 			renderedTextOutput = true;
@@ -426,15 +421,7 @@ export class IPythonCellComponent implements Component {
 		const contentWidth = Math.max(1, width - this.paddingX * 2);
 		const truncated = truncateToWidth(line, contentWidth, "");
 		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
-		const padded = `${" ".repeat(this.paddingX)}${paddedContent}${" ".repeat(this.paddingX)}`;
-		return theme.bg(this.background(), padded);
-	}
-
-	private background(): CellBackground {
-		if (this.state.isPartial || !this.state.executionStarted) {
-			return "toolPendingBg";
-		}
-		const details = readDetails(this.state.details);
-		return this.state.isError || details.status === "error" ? "toolErrorBg" : "toolSuccessBg";
+		const rail = theme.bg("customMessageBg", " ");
+		return `${rail}${" ".repeat(this.paddingX - 1)}${paddedContent}${" ".repeat(this.paddingX)}`;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -340,7 +340,13 @@ export class IPythonCellComponent implements Component {
 		} else if (!renderedTextOutput && this.state.executionStarted && !this.state.argsComplete) {
 			startOutput();
 			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
-		} else if (!renderedTextOutput && !details.error && this.state.executionStarted && imageCount === 0) {
+		} else if (
+			!renderedTextOutput &&
+			!traceback &&
+			!details.error &&
+			this.state.executionStarted &&
+			imageCount === 0
+		) {
 			startOutput();
 			this.addWrapped(lines, "", theme.fg("muted", "no output"), width);
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2989,6 +2989,7 @@ export class InteractiveMode {
 						this.hideThinkingBlock,
 						this.getMarkdownThemeWithSettings(),
 						this.hiddenThinkingLabel,
+						{ expanded: this.toolOutputExpanded },
 					);
 					this.streamingMessage = event.message;
 					this.chatContainer.addChild(this.streamingComponent);
@@ -3710,6 +3711,7 @@ export class InteractiveMode {
 					this.hideThinkingBlock,
 					this.getMarkdownThemeWithSettings(),
 					this.hiddenThinkingLabel,
+					{ expanded: this.toolOutputExpanded },
 				);
 				this.chatContainer.addChild(assistantComponent);
 				break;

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -13,7 +13,7 @@
 		"primarySoft": "#8d7fc0",
 		"success": "#7da876",
 		"warning": "#f59e0b",
-		"error": "#ff2d55",
+		"error": "#d06f82",
 		"info": "#38bdf8",
 		"infoDim": "#1f6f99",
 		"neutral": "#d4d4d8",

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -244,8 +244,7 @@ const TERMUX_PACKAGES: Record<string, string> = {
 	rg: "ripgrep",
 };
 
-export const MISSING_RIPGREP_MESSAGE =
-	"ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
+export const MISSING_RIPGREP_MESSAGE = "ripgrep (rg) is missing; search and sub-agents may fail until it is installed.";
 
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
+import stripAnsi from "strip-ansi";
 import { describe, expect, test } from "vitest";
 import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -53,5 +54,25 @@ describe("AssistantMessageComponent", () => {
 		expect(rendered.includes(OSC133_ZONE_START)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_END)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_FINAL)).toBe(false);
+	});
+
+	test("honors initial expansion for multiline assistant errors", () => {
+		initTheme("dark");
+
+		const message = {
+			...createAssistantMessage([]),
+			stopReason: "error" as const,
+			errorMessage: [
+				"Provider request failed",
+				"Traceback (most recent call last):",
+				'  File "/tmp/internal.py", line 12, in run',
+				"RuntimeError: backend crashed",
+			].join("\n"),
+		};
+		const component = new AssistantMessageComponent(message, false, undefined, "Thinking...", { expanded: true });
+		const rendered = stripAnsi(component.render(100).join("\n"));
+
+		expect(rendered).toContain("/tmp/internal.py");
+		expect(rendered).not.toContain("Ctrl+O to expand");
 	});
 });

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -172,6 +172,33 @@ describe("marquee TUI components", () => {
 		expect(expanded).toContain("Cell In[15]");
 	});
 
+	test("keeps ipython stack frame locations out of collapsed traceback previews", () => {
+		const state: IPythonCellState = {
+			code: "run_job()",
+			content: [
+				{
+					type: "text",
+					text: [
+						"Traceback (most recent call last):",
+						'  File "/tmp/internal.py", line 12, in run',
+						"    run_job()",
+					].join("\n"),
+				},
+			],
+			details: { status: "error", errorEname: "RuntimeError" },
+			isError: true,
+			expanded: false,
+			executionStarted: true,
+			argsComplete: true,
+		};
+		const component = new IPythonCellComponent(state);
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("RuntimeError · Ctrl+O to expand");
+		expect(collapsed).not.toContain("/tmp/internal.py");
+		expect(collapsed).not.toContain("line 12");
+	});
+
 	test("caches ipython cell renders until state, width, or invalidation changes", () => {
 		const state: IPythonCellState = {
 			code: "value = 1\nprint(value)",
@@ -421,6 +448,18 @@ describe("marquee TUI components", () => {
 		expect(tracebackFirstCollapsed).toContain("Error: RuntimeError: backend crashed");
 		expect(tracebackFirstCollapsed).not.toContain("Traceback (most recent call last):");
 		expect(tracebackFirstCollapsed).not.toContain("/tmp/internal.py");
+
+		const frameFirstMessage: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [],
+			stopReason: "error",
+			errorMessage: ['  File "/tmp/internal.py", line 12, in run', "RuntimeError: backend crashed"].join("\n"),
+		};
+		const frameFirstComponent = new AssistantMessageComponent(frameFirstMessage);
+		const frameFirstCollapsed = stripAnsi(frameFirstComponent.render(100).join("\n"));
+		expect(frameFirstCollapsed).toContain("Error: RuntimeError: backend crashed");
+		expect(frameFirstCollapsed).not.toContain("/tmp/internal.py");
+		expect(frameFirstCollapsed).not.toContain("line 12");
 
 		const shortMessage: AssistantMessage = {
 			...createAssistantMessage(""),
@@ -729,6 +768,10 @@ describe("marquee TUI components", () => {
 
 		const rawOutput = component.render(100).join("\n");
 		expect(rawOutput).toMatch(/\x1b\[48;(?:2|5);/);
+		const railLine = component.render(100).find((line) => line.includes("\x1b[48;")) ?? "";
+		const backgroundResetIndex = railLine.indexOf("\x1b[49m");
+		expect(backgroundResetIndex).toBeGreaterThan(0);
+		expect(backgroundResetIndex).toBeLessThan(32);
 		const output = stripAnsi(rawOutput);
 		expect(output).toContain("done · 12ms");
 		expect(output).not.toContain("ipython");

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -111,7 +111,8 @@ describe("marquee TUI components", () => {
 		expect(collapsed).toContain("%%bash");
 		expect(collapsed).toContain("hi");
 		expect(collapsed).toContain("ValueError: bad");
-		expect(collapsed).toContain("traceback collapsed");
+		expect(collapsed).toContain("Ctrl+O to expand");
+		expect(collapsed).not.toContain("traceback collapsed");
 		expect(collapsed).not.toContain('File "<stdin>"');
 
 		component.update({ ...state, expanded: true });
@@ -159,9 +160,9 @@ describe("marquee TUI components", () => {
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
 		expect(collapsed).toContain("cat: /tmp/missing-file: No such file or directory");
-		expect(collapsed).toContain("CalledProcessError · traceback collapsed");
+		expect(collapsed).toContain("CalledProcessError · Ctrl+O to expand");
 		expect(collapsed).not.toContain("returned non-zero exit status 1.");
-		expect(collapsed).toContain("traceback collapsed");
+		expect(collapsed).not.toContain("traceback collapsed");
 		expect(collapsed).not.toContain("get_ipython().run_cell_magic");
 		expect(collapsed).not.toContain("Cell In[15]");
 
@@ -306,7 +307,8 @@ describe("marquee TUI components", () => {
 
 		const collapsed = component.render(80);
 		const collapsedText = stripAnsi(collapsed.join("\n"));
-		expect(collapsedText).toContain("traceback collapsed");
+		expect(collapsedText).toContain("Ctrl+O to expand");
+		expect(collapsedText).not.toContain("traceback collapsed");
 		expect(collapsedText).not.toContain('File "<stdin>"');
 
 		component.update({ ...state, expanded: true });
@@ -396,12 +398,29 @@ describe("marquee TUI components", () => {
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
 		expect(collapsed).toContain("Error: Provider request failed");
-		expect(collapsed).toContain("error details collapsed");
+		expect(collapsed).toContain("Ctrl+O to expand");
+		expect(collapsed).not.toContain("error details collapsed");
 		expect(collapsed).not.toContain("/tmp/internal.py");
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(100).join("\n"));
 		expect(expanded).toContain("/tmp/internal.py");
+
+		const tracebackFirstMessage: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [],
+			stopReason: "error",
+			errorMessage: [
+				"Traceback (most recent call last):",
+				'  File "/tmp/internal.py", line 12, in run',
+				"RuntimeError: backend crashed",
+			].join("\n"),
+		};
+		const tracebackFirstComponent = new AssistantMessageComponent(tracebackFirstMessage);
+		const tracebackFirstCollapsed = stripAnsi(tracebackFirstComponent.render(100).join("\n"));
+		expect(tracebackFirstCollapsed).toContain("Error: RuntimeError: backend crashed");
+		expect(tracebackFirstCollapsed).not.toContain("Traceback (most recent call last):");
+		expect(tracebackFirstCollapsed).not.toContain("/tmp/internal.py");
 
 		const shortMessage: AssistantMessage = {
 			...createAssistantMessage(""),
@@ -413,6 +432,7 @@ describe("marquee TUI components", () => {
 		const short = stripAnsi(shortComponent.render(100).join("\n"));
 		expect(short).toContain("Error: provider failure");
 		expect(short).not.toContain("error details collapsed");
+		expect(short).not.toContain("Ctrl+O to expand");
 	});
 
 	test("renders child agent summary and bounded inspector list", () => {
@@ -588,7 +608,8 @@ describe("marquee TUI components", () => {
 
 		const collapsed = stripAnsi(detailComponent.render(100).join("\n"));
 		expect(collapsed).toContain("ChildProcessError: child exited with status 1");
-		expect(collapsed).toContain("error details collapsed");
+		expect(collapsed).toContain("Ctrl+O to expand");
+		expect(collapsed).not.toContain("error details collapsed");
 		expect(collapsed).not.toContain("/tmp/rlm_harness/internal.py");
 
 		detailComponent.setToolsExpanded(true);
@@ -706,7 +727,9 @@ describe("marquee TUI components", () => {
 			isError: false,
 		});
 
-		const output = stripAnsi(component.render(100).join("\n"));
+		const rawOutput = component.render(100).join("\n");
+		expect(rawOutput).toMatch(/\x1b\[48;(?:2|5);/);
+		const output = stripAnsi(rawOutput);
 		expect(output).toContain("done · 12ms");
 		expect(output).not.toContain("ipython");
 		expect(output).toContain("print(55)");

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -159,9 +159,8 @@ describe("marquee TUI components", () => {
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
 		expect(collapsed).toContain("cat: /tmp/missing-file: No such file or directory");
-		expect(collapsed).toContain(
-			"CalledProcessError: Command 'cat /tmp/missing-file' returned non-zero exit status 1.",
-		);
+		expect(collapsed).toContain("CalledProcessError · traceback collapsed");
+		expect(collapsed).not.toContain("returned non-zero exit status 1.");
 		expect(collapsed).toContain("traceback collapsed");
 		expect(collapsed).not.toContain("get_ipython().run_cell_magic");
 		expect(collapsed).not.toContain("Cell In[15]");

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -656,6 +656,46 @@ describe("marquee TUI components", () => {
 		expect(expanded).toContain("/tmp/rlm_harness/internal.py");
 	});
 
+	test("keeps child agent assistant errors expanded after transcript rebuilds", () => {
+		const detailComponent = new ChildAgentDetailComponent(() => 20);
+		detailComponent.setToolsExpanded(true);
+		const assistantError: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [],
+			stopReason: "error",
+			errorMessage: [
+				"Provider request failed",
+				"Traceback (most recent call last):",
+				'  File "/tmp/internal.py", line 12, in run',
+				"RuntimeError: backend crashed",
+			].join("\n"),
+		};
+		detailComponent.setNode({
+			id: "sub-assistant-error",
+			label: "inspect failure",
+			status: "error",
+			sessionDir: "/tmp/session/sub-assistant-error",
+			transcript: [],
+			structuredTranscript: [
+				{
+					type: "message",
+					role: "assistant",
+					text: assistantError.errorMessage ?? "",
+					message: assistantError,
+				},
+			],
+		});
+
+		const expanded = stripAnsi(detailComponent.render(100).join("\n"));
+		expect(expanded).toContain("/tmp/internal.py");
+		expect(expanded).not.toContain("Ctrl+O to expand");
+
+		detailComponent.invalidate();
+		const afterInvalidate = stripAnsi(detailComponent.render(100).join("\n"));
+		expect(afterInvalidate).toContain("/tmp/internal.py");
+		expect(afterInvalidate).not.toContain("Ctrl+O to expand");
+	});
+
 	test("routes child agent detail tool expansion through app keybindings", () => {
 		setKeybindings(new KeybindingsManager({ "app.tools.expand": "ctrl+x" }));
 		try {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -195,6 +195,7 @@ describe("marquee TUI components", () => {
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
 		expect(collapsed).toContain("RuntimeError · Ctrl+O to expand");
+		expect(collapsed).not.toContain("no output");
 		expect(collapsed).not.toContain("/tmp/internal.py");
 		expect(collapsed).not.toContain("line 12");
 	});

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -124,6 +124,54 @@ describe("marquee TUI components", () => {
 		}
 	});
 
+	test("renders structured ipython bash errors with traceback details collapsed", async () => {
+		const traceback = [
+			"Traceback (most recent call last):",
+			"  Cell In[15], line 1",
+			"----> 1 get_ipython().run_cell_magic('bash', '', 'cat /tmp/missing-file\\n')",
+			"CalledProcessError: Command 'cat /tmp/missing-file' returned non-zero exit status 1.",
+		];
+		const state: IPythonCellState = {
+			code: "%%bash\ncat /tmp/missing-file",
+			content: [
+				{
+					type: "text",
+					text: ["cat: /tmp/missing-file: No such file or directory", ...traceback].join("\n"),
+				},
+			],
+			details: {
+				status: "error",
+				durationMs: 29,
+				stdout: "",
+				stderr: "cat: /tmp/missing-file: No such file or directory\n",
+				error: {
+					ename: "CalledProcessError",
+					evalue: "Command 'cat /tmp/missing-file' returned non-zero exit status 1.",
+					traceback,
+				},
+			},
+			isError: true,
+			expanded: false,
+			executionStarted: true,
+			argsComplete: true,
+		};
+		const component = new IPythonCellComponent(state);
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("cat: /tmp/missing-file: No such file or directory");
+		expect(collapsed).toContain(
+			"CalledProcessError: Command 'cat /tmp/missing-file' returned non-zero exit status 1.",
+		);
+		expect(collapsed).toContain("traceback collapsed");
+		expect(collapsed).not.toContain("get_ipython().run_cell_magic");
+		expect(collapsed).not.toContain("Cell In[15]");
+
+		component.update({ ...state, expanded: true });
+		const expanded = stripAnsi(component.render(100).join("\n"));
+		expect(expanded).toContain("get_ipython().run_cell_magic");
+		expect(expanded).toContain("Cell In[15]");
+	});
+
 	test("caches ipython cell renders until state, width, or invalidation changes", () => {
 		const state: IPythonCellState = {
 			code: "value = 1\nprint(value)",
@@ -332,6 +380,42 @@ describe("marquee TUI components", () => {
 		expect(rendered).not.toMatch(/\x1b\[(?:4\d|10\d|48;)/);
 	});
 
+	test("collapses multiline assistant errors without changing short errors", () => {
+		const multilineError = [
+			"Provider request failed",
+			"Traceback (most recent call last):",
+			'  File "/tmp/internal.py", line 12, in run',
+			"RuntimeError: backend crashed",
+		].join("\n");
+		const message: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [],
+			stopReason: "error",
+			errorMessage: multilineError,
+		};
+		const component = new AssistantMessageComponent(message);
+
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("Error: Provider request failed");
+		expect(collapsed).toContain("error details collapsed");
+		expect(collapsed).not.toContain("/tmp/internal.py");
+
+		component.setExpanded(true);
+		const expanded = stripAnsi(component.render(100).join("\n"));
+		expect(expanded).toContain("/tmp/internal.py");
+
+		const shortMessage: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [],
+			stopReason: "error",
+			errorMessage: "provider failure",
+		};
+		const shortComponent = new AssistantMessageComponent(shortMessage);
+		const short = stripAnsi(shortComponent.render(100).join("\n"));
+		expect(short).toContain("Error: provider failure");
+		expect(short).not.toContain("error details collapsed");
+	});
+
 	test("renders child agent summary and bounded inspector list", () => {
 		const summary = new ChildAgentSummaryComponent(
 			() => "agents-sidebar",
@@ -484,6 +568,33 @@ describe("marquee TUI components", () => {
 
 		const narrow = stripAnsi(component.render(24).join("\n"));
 		expect(narrow).toContain("inspect t…");
+	});
+
+	test("collapses multiline child agent system errors in detail view", () => {
+		const detailComponent = new ChildAgentDetailComponent(() => 20);
+		const errorText = [
+			"ChildProcessError: child exited with status 1",
+			"Traceback (most recent call last):",
+			'  File "/tmp/rlm_harness/internal.py", line 10, in run',
+			"ChildProcessError: child exited with status 1",
+		].join("\n");
+		detailComponent.setNode({
+			id: "sub-error",
+			label: "inspect failure",
+			status: "error",
+			sessionDir: "/tmp/session/sub-error",
+			transcript: [],
+			structuredTranscript: [{ type: "system", role: "system", text: errorText }],
+		});
+
+		const collapsed = stripAnsi(detailComponent.render(100).join("\n"));
+		expect(collapsed).toContain("ChildProcessError: child exited with status 1");
+		expect(collapsed).toContain("error details collapsed");
+		expect(collapsed).not.toContain("/tmp/rlm_harness/internal.py");
+
+		detailComponent.setToolsExpanded(true);
+		const expanded = stripAnsi(detailComponent.render(100).join("\n"));
+		expect(expanded).toContain("/tmp/rlm_harness/internal.py");
 	});
 
 	test("routes child agent detail tool expansion through app keybindings", () => {


### PR DESCRIPTION
- multi-line ipython, assistant, and child-agent errors now show concise summaries by default.
- full traceback details remain available through the existing expand control.
- added focused tui regressions for bash failures and child-agent error detail views.

collapsed:
<img width="743" height="509" alt="image" src="https://github.com/user-attachments/assets/a76821a8-9ba9-4220-81d1-76fd788c8cfa" />

expanded:
<img width="744" height="641" alt="image" src="https://github.com/user-attachments/assets/5f45db4a-4375-414e-b5f0-66de5e41f940" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and IPython tool metadata only; no auth, persistence, or execution semantics changes beyond richer error details for rendering.
> 
> **Overview**
> **Multi-line errors in the interactive TUI now default to a one-line summary** with the existing expand keybinding (`app.tools.expand` / Ctrl+O) to show full tracebacks. A new `CollapsibleErrorComponent` handles stack-aware summarization (traceback frames, IPython cells, etc.) and is wired into **assistant** abort/error messages, **child-agent** system and assistant transcript lines, and **IPython** failure output.
> 
> **IPython** tool results now carry structured `stdout`, `stderr`, `result`, and `error` in `IpythonToolDetails`, and the cell renderer shows those channels separately instead of only parsing combined text. Collapsed failures show a short exception label plus the expand hint; expanded mode shows full tracebacks in muted styling. Cell chrome shifts from a full error/pending background block to a **left rail**, and the Prime theme **error** color is softened.
> 
> Assistant and child-agent views respect the global **tool output expanded** toggle so expansion stays consistent across the session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277c444e8af395aed88eb99589b9462cc6cacaed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse multi-line error output by default in IPython cells, assistant messages, and child agent views
> - Adds a `CollapsibleErrorComponent` in [collapsible-error.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/109/files#diff-1a63c618c28bae29c8c8de27a2a65dfc5bc438af1ae277d6c344bf08d926cdd7) that shows a one-line error summary with an expand hint; full details appear on expand.
> - IPython cells in [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/109/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) now parse structured `stdout`, `stderr`, `result`, and `traceback` from tool details and render tracebacks collapsed by default.
> - Assistant error messages and child agent system errors route through the same collapsible logic, respecting the global `toolOutputExpanded` setting for initial state.
> - Error color in the Prime theme changes from `#ff2d55` to `#d06f82` for a less jarring appearance.
> - Behavioral Change: multi-line errors that previously displayed inline now show collapsed by default across all three views.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 277c444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->