### PR TITLE
show reply context header in agents view prompt bar

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -92,9 +92,11 @@ export function createAgentsViewResumeConfig(config: AgentSessionRuntimeConfig):
 	return resumeConfig;
 }
 
-export function createAgentsViewReplyPlaceholder(text: string | undefined): string {
-	const normalized = text?.replace(/\s+/g, " ").trim();
-	return normalized ? `Reply to: ${normalized}` : REPLY_PROMPT_FALLBACK_PLACEHOLDER;
+export function createAgentsViewReplyHeadline(text: string | undefined): string | undefined {
+	return text
+		?.split("\n")
+		.map((line) => line.replace(/\s+/g, " ").trim())
+		.find((line) => line.length > 0);
 }
 
 async function openAgentsViewSession(
@@ -215,6 +217,9 @@ class AgentsViewMode implements Component, Focusable {
 	private selectedRowIdentity: string | undefined;
 	private selectedActiveSessionId: string | undefined;
 	private replyActiveSessionId: string | undefined;
+	private replyLastAssistantText: string | undefined;
+	private replyLastAssistantTextLoading = false;
+	private replyHeaderTime = "";
 	private pendingDeleteAgent: PendingDeleteAgent | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
@@ -241,6 +246,7 @@ class AgentsViewMode implements Component, Focusable {
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
 		this.editor.focused = true;
+		this.editor.getHeaderLine = () => this.renderReplyHeaderLine();
 		this.editor.onSubmit = (value) => {
 			void this.submit(value);
 		};
@@ -539,24 +545,50 @@ class AgentsViewMode implements Component, Focusable {
 			this.setReplyTarget(undefined);
 			return;
 		}
-		this.setReplyTarget(activeSessionId, REPLY_PROMPT_FALLBACK_PLACEHOLDER);
+		this.setReplyTarget(activeSessionId);
+		this.replyLastAssistantTextLoading = true;
 		try {
 			const latestAssistantText = await this.getLastAssistantText(activeSessionId);
 			if (this.replyActiveSessionId === activeSessionId) {
-				this.editor.setPlaceholder(createAgentsViewReplyPlaceholder(latestAssistantText));
+				this.replyLastAssistantText = latestAssistantText;
+				this.replyLastAssistantTextLoading = false;
 				this.ui.requestRender();
 			}
 		} catch (error) {
 			if (this.replyActiveSessionId === activeSessionId) {
+				this.replyLastAssistantTextLoading = false;
 				this.setStatusMessage(formatError("Failed to load latest response", error));
 			}
 		}
 	}
 
-	private setReplyTarget(activeSessionId: string | undefined, placeholder?: string): void {
+	private setReplyTarget(activeSessionId: string | undefined): void {
 		this.replyActiveSessionId = activeSessionId;
-		this.editor.setPlaceholder(activeSessionId ? placeholder : DEFAULT_PROMPT_PLACEHOLDER);
+		this.replyLastAssistantText = undefined;
+		this.replyLastAssistantTextLoading = false;
+		// Captured once on entry so the header does not count up while reply mode stays open.
+		this.replyHeaderTime = activeSessionId ? this.getReplyHeaderTime(activeSessionId) : "";
+		this.editor.setPlaceholder(activeSessionId ? REPLY_PROMPT_FALLBACK_PLACEHOLDER : DEFAULT_PROMPT_PLACEHOLDER);
 		this.ui.requestRender();
+	}
+
+	private getReplyHeaderTime(activeSessionId: string): string {
+		const summary = this.findSummaryByActiveSessionId(activeSessionId);
+		return formatAgentsViewRelativeTime(summary?.modified ?? summary?.created);
+	}
+
+	private findSummaryByActiveSessionId(activeSessionId: string): SessionSummary | undefined {
+		return this.rows.find((row) => (row.summary.activeSessionId ?? row.summary.id) === activeSessionId)?.summary;
+	}
+
+	private renderReplyHeaderLine(): string | undefined {
+		if (!this.replyActiveSessionId) {
+			return undefined;
+		}
+		const headline =
+			createAgentsViewReplyHeadline(this.replyLastAssistantText) ??
+			theme.fg("dim", this.replyLastAssistantTextLoading ? "Loading last response..." : "No response yet");
+		return this.replyHeaderTime ? `${theme.fg("warning", this.replyHeaderTime)} ${headline}` : headline;
 	}
 
 	private async getLastAssistantText(activeSessionId: string): Promise<string | undefined> {
@@ -578,10 +610,7 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private async sendReply(activeSessionId: string, text: string): Promise<void> {
-		const row = this.rows.find(
-			(candidate) => (candidate.summary.activeSessionId ?? candidate.summary.id) === activeSessionId,
-		);
-		const behavior = row?.summary.isStreaming ? "followUp" : undefined;
+		const behavior = this.findSummaryByActiveSessionId(activeSessionId)?.isStreaming ? "followUp" : undefined;
 		this.setStatusMessage("Sending reply...");
 		try {
 			await this.sendPrompt(activeSessionId, text, undefined, behavior);
@@ -621,7 +650,7 @@ class AgentsViewMode implements Component, Focusable {
 				stopped: false,
 			};
 			this.setStatusMessage(undefined, { render: false });
-			this.replyActiveSessionId = undefined;
+			this.setReplyTarget(undefined);
 			this.showDeleteConfirmation();
 			return;
 		}
@@ -634,7 +663,7 @@ class AgentsViewMode implements Component, Focusable {
 				stopped: false,
 			};
 			this.setStatusMessage(undefined, { render: false });
-			this.replyActiveSessionId = undefined;
+			this.setReplyTarget(undefined);
 			this.showDeleteConfirmation();
 			return;
 		}
@@ -653,7 +682,7 @@ class AgentsViewMode implements Component, Focusable {
 				stopped: true,
 			};
 			this.selectedActiveSessionId = activeSessionId;
-			this.replyActiveSessionId = undefined;
+			this.setReplyTarget(undefined);
 			this.setStatusMessage(undefined, { render: false });
 			this.showDeleteConfirmation();
 			await this.refreshSessions();
@@ -1171,11 +1200,15 @@ function formatRightTableCell(value: string, width: number): string {
 }
 
 function formatSessionDuration(summary: SessionSummary): string {
-	const timestamp = parseSessionTimestamp(summary.created ?? summary.modified);
+	return formatAgentsViewRelativeTime(summary.created ?? summary.modified);
+}
+
+export function formatAgentsViewRelativeTime(value: string | undefined, now: number = Date.now()): string {
+	const timestamp = parseSessionTimestamp(value);
 	if (!timestamp) {
 		return "";
 	}
-	const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+	const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
 	if (seconds < 60) {
 		return `${seconds}s`;
 	}

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -30,6 +30,8 @@ export class CustomEditor extends Editor {
 	public onPasteImage?: () => void;
 	public onMoveBelowPrompt?: () => boolean;
 	public onAgentsBack?: () => boolean;
+	/** When set, the returned line is rendered inside the top of the editor box. */
+	public getHeaderLine?: () => string | undefined;
 	/** Handler for extension-registered shortcuts. Returns true if handled. */
 	public onExtensionShortcut?: (data: string) => boolean;
 
@@ -84,11 +86,20 @@ export class CustomEditor extends Editor {
 	}
 
 	override render(width: number): string[] {
-		const lines = super.render(width);
-		if (!this.placeholder || this.getText().length > 0 || lines.length < 2) {
-			return lines;
+		let lines = super.render(width);
+		if (this.placeholder && this.getText().length === 0 && lines.length >= 2) {
+			lines = [lines[0]!, this.renderPlaceholderLine(width), ...lines.slice(2)];
 		}
-		return [lines[0]!, this.renderPlaceholderLine(width), ...lines.slice(2)];
+		const headerLine = this.getHeaderLine?.();
+		if (headerLine !== undefined && lines.length >= 2) {
+			lines = [
+				lines[0]!,
+				this.renderHeaderContentLine(headerLine, width),
+				this.renderHeaderContentLine("", width),
+				...lines.slice(1),
+			];
+		}
+		return lines;
 	}
 
 	setPlaceholder(placeholder: string | undefined): void {
@@ -164,13 +175,33 @@ export class CustomEditor extends Editor {
 		super.handleInput(data);
 	}
 
-	private renderPlaceholderLine(width: number): string {
+	private getEffectivePaddingX(width: number): number {
 		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
-		const useBackgroundSurface = this.backgroundColor !== undefined;
 		const configuredPaddingX = Math.min(this.configuredPaddingX, maxPadding);
-		const paddingX = useBackgroundSurface
+		return this.backgroundColor !== undefined
 			? Math.min(Math.max(configuredPaddingX, 2), maxPadding)
 			: configuredPaddingX;
+	}
+
+	private renderHeaderContentLine(content: string, width: number): string {
+		const paddingX = this.getEffectivePaddingX(width);
+		const contentWidth = Math.max(1, width - paddingX * 2);
+		const line = `${" ".repeat(paddingX)}${truncateToWidth(content, contentWidth)}`;
+		const padded = line + " ".repeat(Math.max(0, width - visibleWidth(line)));
+		const backgroundColor = this.backgroundColor;
+		if (!backgroundColor) {
+			return padded;
+		}
+		// Truncation may inject full ANSI resets; wrap each segment so the
+		// background survives past them instead of falling back to the terminal's.
+		return padded
+			.split("\x1b[0m")
+			.map((segment) => backgroundColor(segment))
+			.join("\x1b[0m");
+	}
+
+	private renderPlaceholderLine(width: number): string {
+		const paddingX = this.getEffectivePaddingX(width);
 		const contentWidth = Math.max(1, width - paddingX * 2);
 		const promptPrefixText = this.getPromptPrefix();
 		const promptPrefixWidth = Math.min(visibleWidth(promptPrefixText), Math.max(0, contentWidth - 1));

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -3,9 +3,10 @@ import type { AgentSessionRuntimeConfig } from "../src/core/agent-session-config
 import type { ModelRegistry } from "../src/core/model-registry.js";
 import type { SettingsManager } from "../src/core/settings-manager.js";
 import {
-	createAgentsViewReplyPlaceholder,
+	createAgentsViewReplyHeadline,
 	createAgentsViewResumeConfig,
 	createAgentsViewSessionName,
+	formatAgentsViewRelativeTime,
 	resolveAgentsViewSessionUiServices,
 } from "../src/modes/agents-view/agents-view-mode.js";
 import {
@@ -186,9 +187,21 @@ describe("agents view state", () => {
 		expect(config.cwd).toBe("/tmp/dashboard");
 	});
 
-	test("uses latest assistant text as reply placeholder", () => {
-		expect(createAgentsViewReplyPlaceholder("  Done.\nNext step?  ")).toBe("Reply to: Done. Next step?");
-		expect(createAgentsViewReplyPlaceholder(undefined)).toBe("Write a reply to this agent");
+	test("derives the reply headline from the first line of the latest assistant text", () => {
+		expect(createAgentsViewReplyHeadline("  Done.\nNext step?  ")).toBe("Done.");
+		expect(createAgentsViewReplyHeadline("\n\n  spread   over \nlines")).toBe("spread over");
+		expect(createAgentsViewReplyHeadline("   \n  ")).toBeUndefined();
+		expect(createAgentsViewReplyHeadline(undefined)).toBeUndefined();
+	});
+
+	test("formats relative timestamps for the reply header", () => {
+		const now = Date.parse("2026-01-02T12:00:00Z");
+		expect(formatAgentsViewRelativeTime("2026-01-02T11:59:30Z", now)).toBe("30s");
+		expect(formatAgentsViewRelativeTime("2026-01-02T11:15:00Z", now)).toBe("45m");
+		expect(formatAgentsViewRelativeTime("2026-01-02T06:00:00Z", now)).toBe("6h");
+		expect(formatAgentsViewRelativeTime("2025-12-30T12:00:00Z", now)).toBe("3d");
+		expect(formatAgentsViewRelativeTime(undefined, now)).toBe("");
+		expect(formatAgentsViewRelativeTime("not a timestamp", now)).toBe("");
 	});
 
 	test("caps generated session names at the configured limit", () => {

--- a/packages/coding-agent/test/custom-editor.test.ts
+++ b/packages/coding-agent/test/custom-editor.test.ts
@@ -67,4 +67,51 @@ describe("CustomEditor", () => {
 		expect(handler).toHaveBeenCalledTimes(1);
 		expect(editor.getText()).toBe("/");
 	});
+
+	it("renders a header line and blank spacer inside the top of the editor box", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const withoutHeader = editor.render(40);
+
+		editor.getHeaderLine = () => "6h last agent response";
+		const lines = editor.render(40);
+
+		expect(lines.length).toBe(withoutHeader.length + 2);
+		expect(lines[0]).toBe(withoutHeader[0]);
+		expect(lines[1]).toContain("6h last agent response");
+		expect(lines[2]!.trim()).toBe("");
+		expect(lines.slice(3)).toEqual(withoutHeader.slice(1));
+	});
+
+	it("truncates the header line to the editor width", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		editor.getHeaderLine = () => "x".repeat(100);
+		const lines = editor.render(40);
+
+		expect(lines[1]).toContain("x".repeat(37));
+		expect(lines[1]).not.toContain("x".repeat(38));
+		expect(lines[1]).toContain("...");
+	});
+
+	it("keeps the surface background across truncation resets in the header line", () => {
+		const backgroundColor = (text: string) => `<bg>${text}</bg>`;
+		const editor = new CustomEditor(fakeTui, { ...editorTheme, backgroundColor }, new KeybindingsManager());
+		editor.getHeaderLine = () => "x".repeat(100);
+		const lines = editor.render(40);
+
+		const segments = lines[1]!.split("\x1b[0m");
+		expect(segments.length).toBeGreaterThan(1);
+		for (const segment of segments) {
+			expect(segment.startsWith("<bg>")).toBe(true);
+			expect(segment.endsWith("</bg>")).toBe(true);
+		}
+	});
+
+	it("renders no header when the callback returns undefined", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const withoutCallback = editor.render(40);
+
+		editor.getHeaderLine = () => undefined;
+
+		expect(editor.render(40)).toEqual(withoutCallback);
+	});
 });


### PR DESCRIPTION
- hitting space to reply to an agent in the agents view gave no visual indication, so the prompt bar now expands with a header showing the first line of the agent's last response and a relative timestamp, like claude code's session picker.
- the timestamp is captured once when reply mode is entered so it doesn't count up while typing, and truncated header text keeps the prompt bar background instead of falling back to the terminal's.
- the last response no longer gets stuffed into the input placeholder, and deleting the reply target now fully resets reply state.