### PR TITLE
show subagents from daemon state and restore sessions on restart

### DIFF
--- a/packages/coding-agent/src/cli/daemon-list-format.ts
+++ b/packages/coding-agent/src/cli/daemon-list-format.ts
@@ -7,9 +7,10 @@ const LIST_STATUS_ORDER: Record<SessionStatus, number> = {
 	idle: 1,
 	tool: 2,
 	model: 3,
-	sleep: 4,
-	crash: 5,
-	hidden: 6,
+	active: 4,
+	sleep: 5,
+	crash: 6,
+	hidden: 7,
 };
 
 type ListRow = {
@@ -57,6 +58,7 @@ function formatListCell(row: ListRow, column: keyof ListRow, value: string): str
 		case "user":
 		case "idle":
 			return chalk.blue(value);
+		case "active":
 		case "sleep":
 		case "crash":
 		case "hidden":

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -381,7 +381,7 @@ function addAssistantUsage(total: Usage, usage: Usage): void {
 	total.cost.total += usage.cost.total;
 }
 
-function compactRlmText(text: string, maxLength = 160): string {
+export function compactRlmText(text: string, maxLength = 160): string {
 	const compact = text.replace(/\s+/g, " ").trim();
 	if (compact.length <= maxLength) {
 		return compact;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -119,7 +119,7 @@ export interface SessionInfoEntry extends SessionEntryBase {
 	name?: string;
 }
 
-export type SessionStateStatus = "sleep" | "crash" | "hidden";
+export type SessionStateStatus = "active" | "sleep" | "crash" | "hidden";
 
 export interface SessionState {
 	status: SessionStateStatus;
@@ -648,7 +648,7 @@ function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, sta
 }
 
 function isSessionStateStatus(value: unknown): value is SessionStateStatus {
-	return value === "sleep" || value === "crash" || value === "hidden";
+	return value === "active" || value === "sleep" || value === "crash" || value === "hidden";
 }
 
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -661,6 +661,9 @@ function mapDaemonSessionSnapshot(snapshot: DaemonSessionSnapshot, replay?: Daem
 	if (snapshot.parent) {
 		connectionSnapshot.parent = snapshot.parent;
 	}
+	if (snapshot.children) {
+		connectionSnapshot.children = snapshot.children;
+	}
 	if (replay) {
 		connectionSnapshot.replay = replay;
 	}

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -38,7 +38,7 @@ export type AgentConnectionQueueMode = "all" | "one-at-a-time";
 export type AgentConnectionModel = Model<Api>;
 export type AgentConnectionSavedSessionScope = "current" | "all";
 
-export type AgentConnectionSavedSessionStateStatus = "sleep" | "crash" | "hidden";
+export type AgentConnectionSavedSessionStateStatus = "active" | "sleep" | "crash" | "hidden";
 
 export type AgentConnectionSourceScope = "user" | "project" | "temporary";
 export type AgentConnectionSourceOrigin = "package" | "top-level";
@@ -221,6 +221,8 @@ export interface AgentConnectionSnapshot {
 	sessionContext?: AgentConnectionSessionContext;
 	sessionTree?: { tree: AgentConnectionSessionTreeNode[]; leafId: string | null };
 	parent?: AgentConnectionParentMetadata;
+	/** Live RLM child agents (including grandchildren) known to the host at snapshot time. */
+	children?: AgentConnectionRlmChildAgentSnapshot[];
 	lastEventSequence?: number;
 	replay?: AgentConnectionReplayInfo;
 }

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -11,6 +11,7 @@ import {
 import { APP_TITLE, VERSION } from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
+import { SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
 import type { DaemonCommand, DaemonResponse } from "../daemon/daemon-protocol.js";
@@ -707,6 +708,16 @@ class AgentsViewMode implements Component, Focusable {
 					if (!isUnknownActiveSessionError(error)) {
 						throw error;
 					}
+				}
+			}
+			if (pending.sessionFile) {
+				// The kill above normally persists sleep, but it can be skipped or
+				// hit an unknown session (e.g. the daemon died after listing). Make
+				// sure the file is not left marked active, or a restarted daemon
+				// would resurrect a deliberately deactivated agent.
+				const sessionManager = SessionManager.open(pending.sessionFile, this.options.config.sessionDir);
+				if (sessionManager.getSessionState()?.status === "active") {
+					sessionManager.appendSessionState({ status: "sleep" });
 				}
 			}
 			this.inactiveAgentIdentities.add(pending.identity);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -11,7 +11,6 @@ import {
 import { APP_TITLE, VERSION } from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
-import { loadEntriesFromFile, SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
 import type { DaemonCommand, DaemonResponse } from "../daemon/daemon-protocol.js";
@@ -44,7 +43,6 @@ const STATUS_MESSAGE_DURATION_MS = 4500;
 const SESSION_NAME_MAX_LENGTH = 80;
 const DEFAULT_PROMPT_PLACEHOLDER = "Describe a task for a new session";
 const REPLY_PROMPT_FALLBACK_PLACEHOLDER = "Write a reply to this agent";
-const NEEDS_INPUT_ROW_ICON = "◆";
 const COMPLETED_ROW_ICON = "✓";
 const WORKING_ICON_FRAMES = ["◇", "◈", "◆", "◈"] as const;
 const SELECTED_ROW_MARKER = "\0agents-view-selected-row\0";
@@ -711,11 +709,6 @@ class AgentsViewMode implements Component, Focusable {
 					}
 				}
 			}
-			if (pending.sessionFile) {
-				SessionManager.open(pending.sessionFile, this.options.config.sessionDir).appendSessionState({
-					status: "hidden",
-				});
-			}
 			this.inactiveAgentIdentities.add(pending.identity);
 			this.pendingDeleteAgent = undefined;
 			this.clearDeleteConfirmation({ render: false });
@@ -810,11 +803,7 @@ class AgentsViewMode implements Component, Focusable {
 			const data = requireDaemonData(response);
 			const sessions = expectSessionList(data);
 			const visibleSessions = sessions.filter((summary) =>
-				shouldShowAgentsViewSession(
-					summary,
-					this.getSavedSessionStatus(summary),
-					this.inactiveAgentIdentities.has(getSummaryIdentity(summary)),
-				),
+				shouldShowAgentsViewSession(summary, this.inactiveAgentIdentities.has(getSummaryIdentity(summary))),
 			);
 			this.rows = buildAgentsViewRows(this.withPendingDeleteSession(visibleSessions));
 			this.restoreSelection();
@@ -841,24 +830,6 @@ class AgentsViewMode implements Component, Focusable {
 			return pending.summary;
 		});
 		return replaced ? merged : [...merged, pending.summary];
-	}
-
-	private getSavedSessionStatus(summary: SessionSummary): SessionSummary["status"] | undefined {
-		if (!summary.sessionFile || summary.activeSessionId) {
-			return undefined;
-		}
-		try {
-			const entries = loadEntriesFromFile(summary.sessionFile);
-			for (let index = entries.length - 1; index >= 0; index--) {
-				const entry = entries[index];
-				if (entry.type === "session_state") {
-					return entry.state.status;
-				}
-			}
-		} catch {
-			return undefined;
-		}
-		return undefined;
 	}
 
 	private restoreSelection(): void {
@@ -943,7 +914,7 @@ class AgentsViewMode implements Component, Focusable {
 
 	private getAgentCountsText(): string {
 		const counts = countRowsBySection(this.rows);
-		return `${counts.needs_input} need input, ${counts.working} working, ${counts.completed} completed`;
+		return `${counts.working} working, ${counts.completed} completed`;
 	}
 
 	private renderSessionRows(width: number, maxRows: number): string[] {
@@ -952,7 +923,7 @@ class AgentsViewMode implements Component, Focusable {
 		}
 		if (this.rows.length === 0) {
 			return [
-				theme.bold(sectionTitle("needs_input")),
+				theme.bold(sectionTitle("working")),
 				theme.fg("dim", "  No agents yet. Describe a task below to start one."),
 			].slice(0, maxRows);
 		}
@@ -1087,10 +1058,8 @@ class AgentsViewMode implements Component, Focusable {
 
 	private getRowIcon(section: AgentsViewSection): string {
 		switch (section) {
-			case "needs_input":
-				return NEEDS_INPUT_ROW_ICON;
 			case "working":
-				return WORKING_ICON_FRAMES[this.workingIconFrame % WORKING_ICON_FRAMES.length] ?? NEEDS_INPUT_ROW_ICON;
+				return WORKING_ICON_FRAMES[this.workingIconFrame % WORKING_ICON_FRAMES.length] ?? WORKING_ICON_FRAMES[0];
 			case "completed":
 				return COMPLETED_ROW_ICON;
 			default: {
@@ -1102,8 +1071,6 @@ class AgentsViewMode implements Component, Focusable {
 
 	private formatRowIcon(section: AgentsViewSection, icon: string): string {
 		switch (section) {
-			case "needs_input":
-				return theme.fg("warning", icon);
 			case "working":
 				return theme.bold(icon);
 			case "completed":
@@ -1125,7 +1092,7 @@ type DisplayItem =
 
 function buildDisplayItems(rows: readonly AgentsViewRow[]): DisplayItem[] {
 	const items: DisplayItem[] = [];
-	const sections: AgentsViewSection[] = ["needs_input", "working", "completed"];
+	const sections: AgentsViewSection[] = ["working", "completed"];
 	for (const [index, section] of sections.entries()) {
 		if (index > 0) {
 			items.push({ type: "spacer" });
@@ -1152,7 +1119,6 @@ function getDisplayRowsForSection(rows: readonly AgentsViewRow[], section: Agent
 
 function countRowsBySection(rows: readonly AgentsViewRow[]): Record<AgentsViewSection, number> {
 	return {
-		needs_input: rows.filter((row) => row.section === "needs_input").length,
 		working: rows.filter((row) => row.section === "working").length,
 		completed: rows.filter((row) => row.section === "completed").length,
 	};

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -1,7 +1,7 @@
 import { basename } from "node:path";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
 
-export type AgentsViewSection = "needs_input" | "working" | "completed";
+export type AgentsViewSection = "working" | "completed";
 
 export interface AgentsViewRow {
 	section: AgentsViewSection;
@@ -21,27 +21,20 @@ export function classifyAgentsViewSession(summary: SessionSummary): AgentsViewSe
 	if (summary.status === "model" || summary.status === "tool") {
 		return "working";
 	}
-	if (summary.status === "user" || summary.messageCount === 0) {
-		return "needs_input";
-	}
 	return "completed";
 }
 
-export function shouldShowAgentsViewSession(
-	summary: SessionSummary,
-	savedStatus: SessionSummary["status"] | undefined = summary.status,
-	manuallyInactive = false,
-): boolean {
+// The agents view shows daemon-resident sessions only; saved (slept) sessions
+// stay out of the list until they are resumed back into the daemon.
+export function shouldShowAgentsViewSession(summary: SessionSummary, manuallyInactive = false): boolean {
 	if (manuallyInactive) {
 		return false;
 	}
-	return summary.activeSessionId !== undefined || savedStatus !== "hidden";
+	return summary.activeSessionId !== undefined;
 }
 
 export function sectionTitle(section: AgentsViewSection): string {
 	switch (section) {
-		case "needs_input":
-			return "Needs Input";
 		case "working":
 			return "Working";
 		case "completed":
@@ -173,12 +166,10 @@ function isSubagentSummary(summary: SessionSummary): boolean {
 
 function sectionRank(section: AgentsViewSection): number {
 	switch (section) {
-		case "needs_input":
-			return 0;
 		case "working":
-			return 1;
+			return 0;
 		case "completed":
-			return 2;
+			return 1;
 		default: {
 			const _exhaustive: never = section;
 			return _exhaustive;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -56,7 +56,7 @@ import {
 	isDaemonDialogExtensionUiRequest,
 	success,
 } from "./daemon-protocol.js";
-import { buildSessionList, summaryForActiveSession } from "./daemon-session-list.js";
+import { buildRlmChildSnapshots, buildSessionList, summaryForActiveSession } from "./daemon-session-list.js";
 import {
 	cleanupDaemonSocketPath,
 	defaultDaemonSocketPath,
@@ -196,6 +196,42 @@ class AgentDaemon {
 
 		this.registerSignalHandlers();
 		console.error(`Prime Agent daemon listening on ${this.socketPath}`);
+		void this.restoreActiveSessions();
+	}
+
+	/**
+	 * Reload sessions that were daemon-resident when the previous daemon
+	 * exited (clean shutdown or crash). Runs in the background after the
+	 * socket starts listening so startup latency is unaffected; clients see
+	 * restored sessions appear in list results as each one loads.
+	 */
+	private async restoreActiveSessions(): Promise<void> {
+		let saved: SessionInfo[];
+		try {
+			saved = await SessionManager.listAll(undefined, this.options.defaultSessionConfig.sessionDir);
+		} catch (error) {
+			console.error(
+				`Failed to scan sessions for restore: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return;
+		}
+		for (const info of saved) {
+			// Empty sessions carry no work worth restoring; leaving them out keeps
+			// abandoned create-and-quit sessions from resurrecting on every restart.
+			if (info.state?.status !== "active" || info.messageCount === 0) {
+				continue;
+			}
+			if (this.shuttingDown) {
+				return;
+			}
+			try {
+				await this.createRuntime({ type: "create", sessionPath: info.path });
+			} catch (error) {
+				console.error(
+					`Failed to restore session ${info.path}: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
 	}
 
 	private cleanupSocketPath(): void {
@@ -230,6 +266,16 @@ class AgentDaemon {
 		this.sessions.set(state.activeSessionId, state);
 		if (name) {
 			state.runtime.session.setSessionName(name);
+		}
+		if (runtime.metadata.kind !== "subagent") {
+			// Mark the session as daemon-resident so a restarted daemon can
+			// restore it. Closes for kill/completed/replaced flip this back to
+			// sleep; clean shutdowns leave it in place on purpose.
+			try {
+				runtime.session.sessionManager.appendSessionState({ status: "active" });
+			} catch {
+				// Marking is best-effort; the session still works unrestored.
+			}
 		}
 		return state;
 	}
@@ -957,6 +1003,7 @@ class AgentDaemon {
 						...(metadata.rlmChildId ? { childId: metadata.rlmChildId } : {}),
 					}
 				: undefined;
+		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
 		return {
 			activeSessionId: state.activeSessionId,
 			summary: summaryForActiveSession(state),
@@ -969,6 +1016,7 @@ class AgentDaemon {
 			},
 			lastEventSequence: state.lastEventSequence,
 			...(parent ? { parent } : {}),
+			...(children.length > 0 ? { children } : {}),
 		};
 	}
 
@@ -1018,10 +1066,12 @@ class AgentDaemon {
 		}
 		const cascadeError = await this.closeChildSessions(state, reason);
 		let persistError: unknown;
-		try {
-			state.runtime.session.sessionManager.appendSessionState({ status: "sleep" });
-		} catch (error) {
-			persistError = error;
+		if (reason !== "shutdown") {
+			try {
+				state.runtime.session.sessionManager.appendSessionState({ status: "sleep" });
+			} catch (error) {
+				persistError = error;
+			}
 		}
 		cancelPendingExtensionUiRequests(state);
 		if (reason === "killed" || reason === "shutdown" || reason === "replaced") {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -6,6 +6,7 @@ import type { DeleteSessionFileResult } from "../../core/session-file-actions.js
 import type {
 	AgentConnectionQueueMode,
 	AgentConnectionResourceSnapshot,
+	AgentConnectionRlmChildAgentSnapshot,
 	AgentConnectionSavedSessionScope,
 	AgentConnectionSavedSessionState,
 	AgentConnectionScopedModel,
@@ -121,6 +122,8 @@ export interface DaemonSessionSnapshot {
 		nodeId?: string;
 		childId?: string;
 	};
+	/** Live RLM child sessions (including grandchildren) hosted by the daemon under this session. */
+	children?: AgentConnectionRlmChildAgentSnapshot[];
 }
 
 export interface DaemonAttachResult {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -2,9 +2,15 @@ import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { compactRlmText } from "../../core/agent-session.js";
+import type { AgentSessionRuntimeMetadata } from "../../core/agent-session-runtime.js";
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.js";
 import type { SessionInfo } from "../../core/session-manager.js";
-import type { AgentConnectionSavedSessionStateStatus } from "../agent-connection/types.js";
+import type {
+	AgentConnectionRlmChildAgentSnapshot,
+	AgentConnectionRlmChildAgentTranscriptLine,
+	AgentConnectionSavedSessionStateStatus,
+} from "../agent-connection/types.js";
 import type { ActiveSessionState } from "./active-session-state.js";
 
 export type SessionStatus = "user" | "idle" | "tool" | "model" | AgentConnectionSavedSessionStateStatus;
@@ -133,6 +139,92 @@ export function summaryForInactiveSession(session: SessionInfo): SessionSummary 
 		firstMessage: session.firstMessage,
 		parentSessionPath: session.parentSessionPath,
 	};
+}
+
+/**
+ * Build snapshots for all RLM child sessions hosted by the daemon under the
+ * given session, including grandchildren. Mirrors the shape of live
+ * rlm_child_update events so attach clients can seed their subagent state
+ * from daemon memory instead of replaying the event stream.
+ */
+export function buildRlmChildSnapshots(
+	rootActiveSessionId: string,
+	activeSessions: readonly ActiveSessionState[],
+): AgentConnectionRlmChildAgentSnapshot[] {
+	const childrenByParent = new Map<string, ActiveSessionState[]>();
+	for (const candidate of activeSessions) {
+		const metadata = candidate.runtime.metadata;
+		if (metadata.kind !== "subagent" || !metadata.parentActiveSessionId) {
+			continue;
+		}
+		const siblings = childrenByParent.get(metadata.parentActiveSessionId) ?? [];
+		siblings.push(candidate);
+		childrenByParent.set(metadata.parentActiveSessionId, siblings);
+	}
+
+	const snapshots: AgentConnectionRlmChildAgentSnapshot[] = [];
+	const visit = (parentActiveSessionId: string, parentNodeId: string | undefined): void => {
+		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
+			const metadata = child.runtime.metadata;
+			snapshots.push(rlmChildSnapshotForActiveSession(child, metadata, parentNodeId));
+			// A child passes its own node id to its children as their parent id.
+			visit(child.activeSessionId, metadata.rlmChildId);
+		}
+	};
+	const root = activeSessions.find((candidate) => candidate.activeSessionId === rootActiveSessionId);
+	visit(rootActiveSessionId, root?.runtime.metadata.rlmChildId);
+	return snapshots;
+}
+
+function rlmChildSnapshotForActiveSession(
+	activeSession: ActiveSessionState,
+	metadata: AgentSessionRuntimeMetadata,
+	parentNodeId: string | undefined,
+): AgentConnectionRlmChildAgentSnapshot {
+	const session = activeSession.runtime.session;
+	const transcript: AgentConnectionRlmChildAgentTranscriptLine[] = [];
+	let answerPreview: string | undefined;
+	for (const message of session.messages) {
+		if (message.role !== "user" && message.role !== "assistant") {
+			continue;
+		}
+		const text = compactRlmText(readMessageText(message.content));
+		if (!text) {
+			continue;
+		}
+		transcript.push({ role: message.role, text });
+		if (message.role === "assistant") {
+			answerPreview = text;
+		}
+	}
+	return {
+		id: metadata.rlmChildId ?? activeSession.activeSessionId,
+		parentId: parentNodeId,
+		label: compactRlmText(metadata.prompt ?? "", 80) || "child agent",
+		status: session.isStreaming || session.pendingMessageCount > 0 ? "running" : "done",
+		answerPreview,
+		sessionDir: metadata.sessionDir ?? session.sessionManager.getSessionDir(),
+		transcript,
+	};
+}
+
+function readMessageText(content: unknown): string {
+	if (typeof content === "string") {
+		return content;
+	}
+	if (!Array.isArray(content)) {
+		return "";
+	}
+	return content
+		.filter(
+			(block): block is { type: "text"; text: string } =>
+				typeof block === "object" &&
+				block !== null &&
+				(block as { type?: unknown }).type === "text" &&
+				typeof (block as { text?: unknown }).text === "string",
+		)
+		.map((block) => block.text)
+		.join("\n");
 }
 
 function activeStatusForSession(activeSession: ActiveSessionState): SessionStatus {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3964,6 +3964,19 @@ export class InteractiveMode {
 		return `: ${truncateToWidth(detail, availableWidth)}`;
 	}
 
+	private seedChildAgentInspector(children: readonly AgentConnectionRlmChildAgentSnapshot[] | undefined): void {
+		if (!children?.length) {
+			return;
+		}
+		for (const child of children) {
+			// Live rlm_child_update events are richer than the snapshot; never
+			// clobber state that already arrived from the event stream.
+			if (!this.childAgentSnapshots.has(child.id)) {
+				this.updateChildAgentInspector(child);
+			}
+		}
+	}
+
 	private updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void {
 		this.childAgentSnapshots.set(child.id, child);
 		this.childAgentNodes = this.buildChildAgentInspectorNodes();
@@ -4433,6 +4446,7 @@ export class InteractiveMode {
 			this.initialConnectionSnapshotConsumed = true;
 			context = this.getSessionContextFromConnectionSnapshot(snapshot);
 			state = snapshot.state;
+			this.seedChildAgentInspector(snapshot.children);
 		}
 		this.applyConnectionStateSnapshot(state);
 		await this.renderSessionContext(context, {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -22,21 +22,21 @@ describe("agents view state", () => {
 	test("classifies active daemon sessions into coarse fleet sections", () => {
 		expect(classifyAgentsViewSession(makeSummary({ isStreaming: true, status: "model" }))).toBe("working");
 		expect(classifyAgentsViewSession(makeSummary({ pendingMessageCount: 1 }))).toBe("working");
-		expect(classifyAgentsViewSession(makeSummary({ status: "user", messageCount: 2 }))).toBe("needs_input");
-		expect(classifyAgentsViewSession(makeSummary({ status: "idle", messageCount: 0 }))).toBe("needs_input");
+		expect(classifyAgentsViewSession(makeSummary({ status: "tool" }))).toBe("working");
+		expect(classifyAgentsViewSession(makeSummary({ status: "user", messageCount: 2 }))).toBe("completed");
+		expect(classifyAgentsViewSession(makeSummary({ status: "idle", messageCount: 0 }))).toBe("completed");
 		expect(classifyAgentsViewSession(makeSummary({ status: "idle", messageCount: 4 }))).toBe("completed");
 	});
 
 	test("sorts rows by section and most recent modified time", () => {
 		const rows = buildAgentsViewRows([
 			makeSummary({ sessionName: "completed", status: "idle", messageCount: 2, modified: "2026-01-01T00:00:00Z" }),
-			makeSummary({ sessionName: "working", isStreaming: true, modified: "2026-01-01T00:00:00Z" }),
-			makeSummary({ sessionName: "older input", status: "user", modified: "2026-01-01T00:00:00Z" }),
-			makeSummary({ sessionName: "newer input", status: "user", modified: "2026-01-02T00:00:00Z" }),
+			makeSummary({ sessionName: "older working", isStreaming: true, modified: "2026-01-01T00:00:00Z" }),
+			makeSummary({ sessionName: "newer working", isStreaming: true, modified: "2026-01-02T00:00:00Z" }),
 		]);
 
-		expect(rows.map((row) => row.title)).toEqual(["newer input", "older input", "working", "completed"]);
-		expect(rows.map((row) => row.section)).toEqual(["needs_input", "needs_input", "working", "completed"]);
+		expect(rows.map((row) => row.title)).toEqual(["newer working", "older working", "completed"]);
+		expect(rows.map((row) => row.section)).toEqual(["working", "working", "completed"]);
 	});
 
 	test("summarizes subagents on their parent and omits subagent rows", () => {
@@ -157,17 +157,16 @@ describe("agents view state", () => {
 		expect(rows.map((row) => row.title)).toEqual(["Other"]);
 	});
 
-	test("hides inactive hidden sessions while keeping active sessions visible", () => {
+	test("shows daemon-resident sessions only", () => {
 		const inactiveHidden = makeSummary({ status: "hidden" });
-		const staleDaemonHidden = makeSummary({ status: "sleep" });
+		const inactiveSleep = makeSummary({ status: "sleep" });
 		delete inactiveHidden.activeSessionId;
-		delete staleDaemonHidden.activeSessionId;
+		delete inactiveSleep.activeSessionId;
 
 		expect(shouldShowAgentsViewSession(inactiveHidden)).toBe(false);
-		expect(shouldShowAgentsViewSession(staleDaemonHidden, "hidden")).toBe(false);
-		expect(shouldShowAgentsViewSession(inactiveHidden, undefined)).toBe(false);
-		expect(shouldShowAgentsViewSession(makeSummary({ status: "idle" }), undefined, true)).toBe(false);
-		expect(shouldShowAgentsViewSession(makeSummary({ status: "hidden", activeSessionId: "active-1" }))).toBe(true);
+		expect(shouldShowAgentsViewSession(inactiveSleep)).toBe(false);
+		expect(shouldShowAgentsViewSession(makeSummary({ status: "idle" }))).toBe(true);
+		expect(shouldShowAgentsViewSession(makeSummary({ status: "idle" }), true)).toBe(false);
 	});
 
 	test("does not override saved session cwd when reopening inactive agents", () => {

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import type { SessionInfo } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
-import { buildSessionList } from "../src/modes/daemon/daemon-session-list.js";
+import { buildRlmChildSnapshots, buildSessionList } from "../src/modes/daemon/daemon-session-list.js";
 
 describe("buildSessionList", () => {
 	it("derives active session statuses", () => {
@@ -90,6 +90,71 @@ describe("buildSessionList", () => {
 	});
 });
 
+describe("buildRlmChildSnapshots", () => {
+	it("collects children and grandchildren with event-compatible parent ids", () => {
+		const parent = makeState({ activeSessionId: "parent", sessionFile: "/tmp/parent.jsonl" });
+		const child = makeState({
+			activeSessionId: "child",
+			isStreaming: true,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: "parent",
+				rlmChildId: "sub-aaa",
+				rlmParentNodeId: "sub-aaa",
+				prompt: "Summarize   the repo\nlayout",
+				sessionDir: "/tmp/artifacts/sub-aaa",
+			},
+			messages: [
+				{ role: "user", content: "Summarize the repo layout" },
+				{ role: "assistant", content: [{ type: "text", text: "The repo is an npm workspace." }] },
+			] as AgentMessage[],
+		});
+		const grandchild = makeState({
+			activeSessionId: "grandchild",
+			metadata: {
+				kind: "subagent",
+				createdAt: 2,
+				parentActiveSessionId: "child",
+				rlmChildId: "sub-bbb",
+				rlmParentNodeId: "sub-bbb",
+				prompt: "Read the docs",
+				sessionDir: "/tmp/artifacts/sub-aaa/sub-bbb",
+			},
+		});
+		const unrelated = makeState({
+			activeSessionId: "unrelated-child",
+			metadata: {
+				kind: "subagent",
+				createdAt: 3,
+				parentActiveSessionId: "someone-else",
+				rlmChildId: "sub-ccc",
+			},
+		});
+
+		const snapshots = buildRlmChildSnapshots("parent", [parent, child, grandchild, unrelated]);
+
+		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.parentId, snapshot.status])).toEqual([
+			["sub-aaa", undefined, "running"],
+			["sub-bbb", "sub-aaa", "done"],
+		]);
+		expect(snapshots[0]).toMatchObject({
+			label: "Summarize the repo layout",
+			answerPreview: "The repo is an npm workspace.",
+			sessionDir: "/tmp/artifacts/sub-aaa",
+			transcript: [
+				{ role: "user", text: "Summarize the repo layout" },
+				{ role: "assistant", text: "The repo is an npm workspace." },
+			],
+		});
+	});
+
+	it("returns no snapshots for sessions without children", () => {
+		const solo = makeState({ activeSessionId: "solo" });
+		expect(buildRlmChildSnapshots("solo", [solo])).toEqual([]);
+	});
+});
+
 interface StateOptions {
 	activeSessionId: string;
 	sessionFile?: string;
@@ -97,6 +162,7 @@ interface StateOptions {
 	isStreaming?: boolean;
 	pendingToolCalls?: string[];
 	clients?: number;
+	messages?: AgentMessage[];
 	metadata?: {
 		kind: "top-level" | "subagent";
 		createdAt: number;
@@ -105,6 +171,8 @@ interface StateOptions {
 		parentSessionFile?: string;
 		rlmChildId?: string;
 		rlmParentNodeId?: string;
+		prompt?: string;
+		sessionDir?: string;
 	};
 }
 
@@ -131,8 +199,9 @@ function makeState(options: StateOptions): ActiveSessionState {
 				sessionName: `session ${options.activeSessionId}`,
 				sessionManager: {
 					getCwd: () => "/tmp/project",
+					getSessionDir: () => "/tmp/sessions",
 				},
-				messages: [] as AgentMessage[],
+				messages: options.messages ?? ([] as AgentMessage[]),
 				pendingMessageCount: 0,
 				state: {
 					streamingMessage: undefined,


### PR DESCRIPTION
- the subagent counter under the prompt bar was lost on reattach because it was rebuilt from streamed events only; attach snapshots now carry the live child agents straight from the daemon's session registry.
- the agents view now lists daemon-resident sessions only, split into working and completed; the needs input section and the hidden session state are gone.
- sessions are marked active while the daemon hosts them, so a restarted or crashed daemon reloads its previous fleet instead of coming back empty; killed sessions stay asleep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon session lifecycle and on-disk state (active vs sleep on shutdown/restore), which can affect which agents reappear after crashes or restarts if marking/deactivation paths miss edge cases.
> 
> **Overview**
> Adds a persisted **`active`** session state so top-level daemon sessions are marked on disk while hosted; after restart, **`restoreActiveSessions`** reloads non-empty `active` sessions in the background. Clean **`shutdown`** no longer overwrites that with **`sleep`** (kills and other closes still persist **`sleep`**).
> 
> Daemon attach snapshots now include live **RLM child agents** via **`buildRlmChildSnapshots`** (including grandchildren), wired through connection/daemon protocol **`children`**; interactive mode **seeds** the subagent inspector from that snapshot on attach so reattach does not lose the subagent tree.
> 
> The **agents view** drops the **Needs Input** section (idle/user sessions land in **completed**), lists only **daemon-resident** sessions (`activeSessionId`), and deactivation ensures files are not left **`active`** so a restart cannot resurrect killed agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d0a4eca6ef292b5e82ef8d99da757d04d3bb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show subagents in daemon state and restore active sessions on daemon restart
> - On daemon startup, sessions previously marked `active` are automatically restored via a new `restoreActiveSessions` method in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/119/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450).
> - Session snapshots now include a `children` array of subagent snapshots, built by the new `buildRlmChildSnapshots` utility in [daemon-session-list.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/119/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21).
> - The interactive mode pre-populates the child agent inspector from snapshot data on first attach, reducing reliance on event replay.
> - The agents view drops the `needs_input` section entirely; sessions previously classified there now fall into `completed`, and only daemon-resident sessions (those with an `activeSessionId`) are shown.
> - On shutdown, sessions retain their `active` status so they can be auto-restored; other close reasons write `sleep` instead.
> - Behavioral Change: saved/slept sessions no longer appear in the agents view until they are resumed into the daemon.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05d0a4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->