### PR TITLE
make subagents navigable in agents view and chat panel

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -187,7 +187,11 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 				modelFallbackMessage: opened.summary.modelFallbackMessage ?? options.modelFallbackMessage,
 				verbose: options.verbose,
 				returnToAgentsView: true,
-				initialSubagentNodeId: result.subagent?.rlmChildId,
+				// Matches the node id scheme used by snapshot child seeding
+				// (rlmChildId, falling back to the child's active session id).
+				initialSubagentNodeId: result.subagent
+					? (result.subagent.rlmChildId ?? result.subagent.activeSessionId)
+					: undefined,
 			});
 			await interactiveMode.run();
 		} catch (error) {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -32,6 +32,7 @@ import {
 	type AgentsViewRow,
 	type AgentsViewSection,
 	buildAgentsViewRows,
+	getAgentsViewSummaryIdentity as getSummaryIdentity,
 	sectionTitle,
 	shouldShowAgentsViewSession,
 } from "./agents-view-state.js";
@@ -62,7 +63,7 @@ export interface AgentsViewModeOptions {
 	verbose?: boolean;
 }
 
-type AgentsViewRunResult = { type: "exit" } | { type: "open"; summary: SessionSummary };
+type AgentsViewRunResult = { type: "exit" } | { type: "open"; summary: SessionSummary; subagent?: SessionSummary };
 type AgentsViewPersistentState = {
 	selectedRowIdentity?: string;
 	statusMessage?: string;
@@ -186,6 +187,7 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 				modelFallbackMessage: opened.summary.modelFallbackMessage ?? options.modelFallbackMessage,
 				verbose: options.verbose,
 				returnToAgentsView: true,
+				initialSubagentNodeId: result.subagent?.rlmChildId,
 			});
 			await interactiveMode.run();
 		} catch (error) {
@@ -212,6 +214,8 @@ class AgentsViewMode implements Component, Focusable {
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | undefined;
 	private workingIconFrame = 0;
 	private rows: AgentsViewRow[] = [];
+	private lastVisibleSummaries: SessionSummary[] = [];
+	private expandedSubagentParents = new Set<string>();
 	private selectedIndex = 0;
 	private selectedRowIdentity: string | undefined;
 	private selectedActiveSessionId: string | undefined;
@@ -493,12 +497,46 @@ class AgentsViewMode implements Component, Focusable {
 			: 0;
 		const nextPosition = Math.max(0, Math.min(selectableIndexes.length - 1, currentPosition + delta));
 		this.selectedIndex = selectableIndexes[nextPosition] ?? 0;
+		this.collapseSubagentListsOutsideSelection();
 		this.syncSelectedRowState();
 		this.clearDeleteConfirmation({ render: false });
 		if (this.replyActiveSessionId && this.replyActiveSessionId !== this.selectedActiveSessionId) {
 			this.setReplyTarget(undefined);
 		}
 		this.ui.requestRender();
+	}
+
+	/** Expanded subagent lists collapse back to their summary row once selection leaves them. */
+	private collapseSubagentListsOutsideSelection(): void {
+		if (this.expandedSubagentParents.size === 0) {
+			return;
+		}
+		const keep = new Set<string>();
+		let parentIdentity = this.rows[this.selectedIndex]?.parentIdentity;
+		while (parentIdentity !== undefined && !keep.has(parentIdentity)) {
+			keep.add(parentIdentity);
+			const target: string = parentIdentity;
+			parentIdentity = this.rows.find((row) => row.identity === target)?.parentIdentity;
+		}
+		const next = new Set([...this.expandedSubagentParents].filter((identity) => keep.has(identity)));
+		if (next.size === this.expandedSubagentParents.size) {
+			return;
+		}
+		this.expandedSubagentParents = next;
+		this.rebuildRows();
+	}
+
+	/** Rebuild rows from the last fetched summaries, keeping selection on the same row. */
+	private rebuildRows(): void {
+		const selectedIdentity = this.rows[this.selectedIndex]?.identity;
+		this.rows = buildAgentsViewRows(this.lastVisibleSummaries, this.expandedSubagentParents);
+		const index =
+			selectedIdentity === undefined ? -1 : this.rows.findIndex((row) => row.identity === selectedIdentity);
+		if (index >= 0) {
+			this.selectedIndex = index;
+		} else {
+			this.restoreSelection();
+		}
 	}
 
 	private async submit(value: string): Promise<void> {
@@ -524,6 +562,14 @@ class AgentsViewMode implements Component, Focusable {
 		if (!row?.selectable || this.isPendingDeleteRow(row)) {
 			return;
 		}
+		if (row.kind === "subagent-summary") {
+			this.expandSubagentList(row);
+			return;
+		}
+		if (row.kind === "subagent") {
+			this.openSelectedSubagent(row);
+			return;
+		}
 		if (!row.summary.activeSessionId && !row.summary.sessionFile) {
 			this.setStatusMessage("Cannot open agent without an active runtime or saved session file");
 			return;
@@ -531,9 +577,44 @@ class AgentsViewMode implements Component, Focusable {
 		this.finish({ type: "open", summary: row.summary });
 	}
 
+	private expandSubagentList(row: AgentsViewRow): void {
+		if (!row.parentIdentity) {
+			return;
+		}
+		this.expandedSubagentParents.add(row.parentIdentity);
+		this.rebuildRows();
+		const firstChild = this.rows.findIndex(
+			(candidate) => candidate.kind === "subagent" && candidate.parentIdentity === row.parentIdentity,
+		);
+		if (firstChild >= 0) {
+			this.selectedIndex = firstChild;
+		}
+		this.syncSelectedRowState();
+		this.ui.requestRender();
+	}
+
+	private openSelectedSubagent(row: AgentsViewRow): void {
+		// The whole subagent tree is inspected from the root agent's chat view,
+		// so nested subagents also resolve to their top-level ancestor.
+		let root = this.rows.find((candidate) => candidate.identity === row.parentIdentity);
+		while (root && root.kind !== "agent") {
+			const parentIdentity = root.parentIdentity;
+			root = this.rows.find((candidate) => candidate.identity === parentIdentity);
+		}
+		if (!root || !(root.summary.activeSessionId || root.summary.sessionFile)) {
+			this.setStatusMessage("Cannot open subagent without its parent agent");
+			return;
+		}
+		this.finish({ type: "open", summary: root.summary, subagent: row.summary });
+	}
+
 	private async toggleReplyTarget(): Promise<void> {
 		const selectedRow = this.rows[this.selectedIndex];
-		const activeSessionId = selectedRow?.summary.activeSessionId;
+		// Subagents are read-only; replying is reserved for top-level agents.
+		if (selectedRow?.kind !== "agent") {
+			return;
+		}
+		const activeSessionId = selectedRow.summary.activeSessionId;
 		if (!activeSessionId) {
 			return;
 		}
@@ -623,7 +704,7 @@ class AgentsViewMode implements Component, Focusable {
 
 	private async handleDeleteSelected(): Promise<void> {
 		const row = this.rows[this.selectedIndex];
-		if (!row?.selectable) {
+		if (row?.kind !== "agent" || !row.selectable) {
 			return;
 		}
 		const identity = getSummaryIdentity(row.summary);
@@ -816,7 +897,8 @@ class AgentsViewMode implements Component, Focusable {
 			const visibleSessions = sessions.filter((summary) =>
 				shouldShowAgentsViewSession(summary, this.inactiveAgentIdentities.has(getSummaryIdentity(summary))),
 			);
-			this.rows = buildAgentsViewRows(this.withPendingDeleteSession(visibleSessions));
+			this.lastVisibleSummaries = this.withPendingDeleteSession(visibleSessions);
+			this.rows = buildAgentsViewRows(this.lastVisibleSummaries, this.expandedSubagentParents);
 			this.restoreSelection();
 			this.ui.requestRender();
 		} catch (error) {
@@ -853,7 +935,7 @@ class AgentsViewMode implements Component, Focusable {
 		let index =
 			selectedIdentity === undefined
 				? -1
-				: this.rows.findIndex((row) => row.selectable && getSummaryIdentity(row.summary) === selectedIdentity);
+				: this.rows.findIndex((row) => row.selectable && row.identity === selectedIdentity);
 		const selectedId = this.selectedActiveSessionId;
 		if (index < 0) {
 			index =
@@ -871,11 +953,6 @@ class AgentsViewMode implements Component, Focusable {
 			this.selectedIndex = Math.min(this.selectedIndex, this.rows.length - 1);
 		}
 		this.syncSelectedRowState();
-	}
-
-	private getSelectedActiveSessionId(): string | undefined {
-		const row = this.rows[this.selectedIndex];
-		return row?.selectable ? (row.summary.activeSessionId ?? row.summary.id) : undefined;
 	}
 
 	private getSelectableRowIndexes(): number[] {
@@ -940,9 +1017,9 @@ class AgentsViewMode implements Component, Focusable {
 		}
 
 		const displayItems = buildDisplayItems(this.rows);
-		const selectedId = this.getSelectedActiveSessionId();
+		const selectedIdentity = this.rows[this.selectedIndex]?.identity;
 		const selectedDisplayIndex = displayItems.findIndex(
-			(item) => item.type === "row" && (item.row.summary.activeSessionId ?? item.row.summary.id) === selectedId,
+			(item) => item.type === "row" && item.row.identity === selectedIdentity,
 		);
 		const visibleRows = Math.min(maxRows, this.visibleListRows());
 		const start = Math.max(
@@ -969,9 +1046,6 @@ class AgentsViewMode implements Component, Focusable {
 			if (item.type === "empty") {
 				return theme.fg("dim", "  No agents");
 			}
-			if (item.type === "subagents") {
-				return this.renderSubagentSummary(item.count, width);
-			}
 			return this.renderRow(item.row, width);
 		});
 		if (showLeadingEllipsis) {
@@ -984,9 +1058,14 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private renderRow(row: AgentsViewRow, width: number): string {
-		const activeSessionId = row.summary.activeSessionId ?? row.summary.id;
-		const selected = row.selectable && activeSessionId === this.getSelectedActiveSessionId();
-		const pendingDelete = this.isPendingDeleteRow(row);
+		const selected = row.selectable && row.identity === this.rows[this.selectedIndex]?.identity;
+		if (row.kind === "subagent-summary") {
+			const indent = "  ".repeat(row.depth);
+			const label = theme.fg("dim", `▸ ${row.title}`);
+			const line = padLine(truncateToWidth(`${indent}${label}`, width, ""), width);
+			return selected ? `${SELECTED_ROW_MARKER}${line}` : line;
+		}
+		const pendingDelete = row.kind === "agent" && this.isPendingDeleteRow(row);
 		const rawIcon = this.getRowIcon(row.section);
 		const icon = this.formatRowIcon(row.section, rawIcon);
 		const indent = "  ".repeat(row.depth);
@@ -1002,11 +1081,6 @@ class AgentsViewMode implements Component, Focusable {
 		const base = `${indent}${cells[0]} ${cells[1]} ${cells[2]}`;
 		const line = padLine(truncateToWidth(base, width, ""), width);
 		return selected ? `${SELECTED_ROW_MARKER}${line}` : line;
-	}
-
-	private renderSubagentSummary(count: number, width: number): string {
-		const label = `  ${count} subagents running`;
-		return padLine(truncateToWidth(theme.fg("dim", label), width), width);
 	}
 
 	private finalizeRenderedLine(line: string, width: number): string {
@@ -1098,8 +1172,7 @@ type DisplayItem =
 	| { type: "spacer" }
 	| { type: "heading"; section: AgentsViewSection }
 	| { type: "empty"; section: AgentsViewSection }
-	| { type: "row"; row: AgentsViewRow }
-	| { type: "subagents"; count: number };
+	| { type: "row"; row: AgentsViewRow };
 
 function buildDisplayItems(rows: readonly AgentsViewRow[]): DisplayItem[] {
 	const items: DisplayItem[] = [];
@@ -1116,37 +1189,37 @@ function buildDisplayItems(rows: readonly AgentsViewRow[]): DisplayItem[] {
 		}
 		for (const row of sectionRows) {
 			items.push({ type: "row", row });
-			if (row.runningSubagentCount > 0) {
-				items.push({ type: "subagents", count: row.runningSubagentCount });
-			}
 		}
 	}
 	return items;
 }
 
+// Nested rows (subagent summaries and expanded subagents) always render in
+// their top-level agent's section block, regardless of their own section.
 function getDisplayRowsForSection(rows: readonly AgentsViewRow[], section: AgentsViewSection): AgentsViewRow[] {
-	return rows.filter((row) => row.depth === 0 && row.section === section);
+	const result: AgentsViewRow[] = [];
+	let include = false;
+	for (const row of rows) {
+		if (row.depth === 0) {
+			include = row.section === section;
+		}
+		if (include) {
+			result.push(row);
+		}
+	}
+	return result;
 }
 
 function countRowsBySection(rows: readonly AgentsViewRow[]): Record<AgentsViewSection, number> {
+	const agents = rows.filter((row) => row.kind === "agent");
 	return {
-		working: rows.filter((row) => row.section === "working").length,
-		completed: rows.filter((row) => row.section === "completed").length,
+		working: agents.filter((row) => row.section === "working").length,
+		completed: agents.filter((row) => row.section === "completed").length,
 	};
 }
 
 function getSelectedRowIdentity(row: AgentsViewRow | undefined): string | undefined {
-	return row ? getSummaryIdentity(row.summary) : undefined;
-}
-
-function getSummaryIdentity(summary: SessionSummary): string {
-	if (summary.sessionFile) {
-		return `file:${summary.sessionFile}`;
-	}
-	if (summary.activeSessionId) {
-		return `active:${summary.activeSessionId}`;
-	}
-	return `session:${summary.sessionId}`;
+	return row?.identity;
 }
 
 function isRunningSessionSummary(summary: SessionSummary): boolean {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1121,11 +1121,13 @@ class AgentsViewMode implements Component, Focusable {
 			const tone = this.statusMessage.startsWith("Failed") ? "error" : "muted";
 			return truncateToWidth(theme.fg(tone, this.statusMessage), width);
 		}
+		// Subagents are read-only: reply and stop/deactivate don't apply to them.
+		const selectedAgent = this.rows[this.selectedIndex]?.kind === "agent";
 		const hints = [
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open/send`,
-			`${keyText("app.agents.reply")} reply`,
-			`${keyText("app.agents.delete")} stop/deactivate`,
+			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
+			selectedAgent ? `${keyText("app.agents.delete")} stop/deactivate` : undefined,
 			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -504,7 +504,13 @@ class AgentsViewMode implements Component, Focusable {
 		this.collapseSubagentListsOutsideSelection();
 		this.syncSelectedRowState();
 		this.clearDeleteConfirmation({ render: false });
-		if (this.replyActiveSessionId && this.replyActiveSessionId !== this.selectedActiveSessionId) {
+		// Reply stays armed only while the selection sits on the agent row it
+		// targets; nested rows share the parent's session id but are read-only.
+		const selectedRow = this.rows[this.selectedIndex];
+		if (
+			this.replyActiveSessionId &&
+			(selectedRow?.kind !== "agent" || this.replyActiveSessionId !== this.selectedActiveSessionId)
+		) {
 			this.setReplyTarget(undefined);
 		}
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -116,8 +116,8 @@ export function buildAgentsViewRows(
 				child.parentIdentity = row.identity;
 				emit(child, depth + 1);
 			}
-		} else if (row.runningSubagentCount > 0) {
-			flattened.push(createSubagentSummaryRow(row, depth + 1));
+		} else {
+			flattened.push(createSubagentSummaryRow(row, children.length, depth + 1));
 		}
 	};
 	for (const root of roots.sort(compareAgentsViewRows)) {
@@ -128,18 +128,24 @@ export function buildAgentsViewRows(
 
 type MutableAgentsViewRow = AgentsViewRow;
 
-function createSubagentSummaryRow(parent: AgentsViewRow, depth: number): AgentsViewRow {
-	const count = parent.runningSubagentCount;
+function createSubagentSummaryRow(parent: AgentsViewRow, totalCount: number, depth: number): AgentsViewRow {
+	const running = parent.runningSubagentCount;
+	// Finished subagents stay reachable through the summary row even when
+	// nothing is running anymore.
+	const title =
+		running > 0
+			? `${running} ${running === 1 ? "subagent" : "subagents"} running`
+			: `${totalCount} ${totalCount === 1 ? "subagent" : "subagents"}`;
 	return {
 		kind: "subagent-summary",
 		section: parent.section,
 		summary: parent.summary,
-		title: `${count} ${count === 1 ? "subagent" : "subagents"} running`,
+		title,
 		subtitle: "",
 		statusLabel: "",
 		depth,
 		selectable: true,
-		runningSubagentCount: count,
+		runningSubagentCount: running,
 		identity: `subagents:${parent.identity}`,
 		parentIdentity: parent.identity,
 	};

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -3,7 +3,10 @@ import type { SessionSummary } from "../daemon/daemon-session-list.js";
 
 export type AgentsViewSection = "working" | "completed";
 
+export type AgentsViewRowKind = "agent" | "subagent-summary" | "subagent";
+
 export interface AgentsViewRow {
+	kind: AgentsViewRowKind;
 	section: AgentsViewSection;
 	summary: SessionSummary;
 	title: string;
@@ -12,6 +15,10 @@ export interface AgentsViewRow {
 	depth: number;
 	selectable: boolean;
 	runningSubagentCount: number;
+	/** Unique selection identity for this row. */
+	identity: string;
+	/** Identity of the agent row this row is nested under. */
+	parentIdentity?: string;
 }
 
 export function classifyAgentsViewSession(summary: SessionSummary): AgentsViewSection {
@@ -46,40 +53,96 @@ export function sectionTitle(section: AgentsViewSection): string {
 	}
 }
 
-export function buildAgentsViewRows(summaries: readonly SessionSummary[]): AgentsViewRow[] {
-	const rows = summaries.map(
+export function getAgentsViewSummaryIdentity(summary: SessionSummary): string {
+	if (summary.sessionFile) {
+		return `file:${summary.sessionFile}`;
+	}
+	if (summary.activeSessionId) {
+		return `active:${summary.activeSessionId}`;
+	}
+	return `session:${summary.sessionId}`;
+}
+
+export function buildAgentsViewRows(
+	summaries: readonly SessionSummary[],
+	expandedSubagentParents: ReadonlySet<string> = new Set(),
+): AgentsViewRow[] {
+	const baseRows = summaries.map(
 		(summary): MutableAgentsViewRow => ({
+			kind: isSubagentSummary(summary) ? "subagent" : "agent",
 			section: classifyAgentsViewSession(summary),
 			summary,
 			title: getSessionTitle(summary),
 			subtitle: getSessionSubtitle(summary),
 			statusLabel: getSessionStatusLabel(summary),
 			depth: 0,
-			selectable: !isSubagentSummary(summary),
+			selectable: true,
 			runningSubagentCount: 0,
-			children: [],
+			identity: getAgentsViewSummaryIdentity(summary),
 		}),
 	);
-	const rowsByKey = buildRowKeyMap(rows);
+	const rowsByKey = buildRowKeyMap(baseRows);
+	const childrenByParent = new Map<MutableAgentsViewRow, MutableAgentsViewRow[]>();
 	const nestedRows = new Set<MutableAgentsViewRow>();
 
-	for (const row of rows) {
-		if (!isSubagentSummary(row.summary)) {
+	for (const row of baseRows) {
+		if (row.kind !== "subagent") {
 			continue;
 		}
+		nestedRows.add(row);
 		const parent = findParentRow(row.summary, rowsByKey);
-		if (parent && parent !== row && row.section === "working") {
+		if (!parent || parent === row) {
+			continue;
+		}
+		if (row.section === "working") {
 			parent.runningSubagentCount += 1;
 		}
-		nestedRows.add(row);
+		const siblings = childrenByParent.get(parent) ?? [];
+		siblings.push(row);
+		childrenByParent.set(parent, siblings);
 	}
 
-	const roots = rows.filter((row) => !nestedRows.has(row));
-	return flattenRows(roots);
+	const roots = baseRows.filter((row) => !nestedRows.has(row));
+	const flattened: AgentsViewRow[] = [];
+	const emit = (row: MutableAgentsViewRow, depth: number): void => {
+		row.depth = depth;
+		flattened.push(row);
+		const children = childrenByParent.get(row) ?? [];
+		if (children.length === 0) {
+			return;
+		}
+		if (expandedSubagentParents.has(row.identity)) {
+			for (const child of children.sort(compareAgentsViewRows)) {
+				child.parentIdentity = row.identity;
+				emit(child, depth + 1);
+			}
+		} else if (row.runningSubagentCount > 0) {
+			flattened.push(createSubagentSummaryRow(row, depth + 1));
+		}
+	};
+	for (const root of roots.sort(compareAgentsViewRows)) {
+		emit(root, 0);
+	}
+	return flattened;
 }
 
-interface MutableAgentsViewRow extends AgentsViewRow {
-	children: MutableAgentsViewRow[];
+type MutableAgentsViewRow = AgentsViewRow;
+
+function createSubagentSummaryRow(parent: AgentsViewRow, depth: number): AgentsViewRow {
+	const count = parent.runningSubagentCount;
+	return {
+		kind: "subagent-summary",
+		section: parent.section,
+		summary: parent.summary,
+		title: `${count} ${count === 1 ? "subagent" : "subagents"} running`,
+		subtitle: "",
+		statusLabel: "",
+		depth,
+		selectable: true,
+		runningSubagentCount: count,
+		identity: `subagents:${parent.identity}`,
+		parentIdentity: parent.identity,
+	};
 }
 
 function compareAgentsViewRows(a: AgentsViewRow, b: AgentsViewRow): number {
@@ -92,29 +155,6 @@ function compareAgentsViewRows(a: AgentsViewRow, b: AgentsViewRow): number {
 		return modifiedDiff;
 	}
 	return a.title.localeCompare(b.title);
-}
-
-function flattenRows(rows: MutableAgentsViewRow[], depth = 0): AgentsViewRow[] {
-	const flattened: AgentsViewRow[] = [];
-	for (const row of rows.sort(compareAgentsViewRows)) {
-		row.depth = depth;
-		flattened.push(toAgentsViewRow(row));
-		flattened.push(...flattenRows(row.children, depth + 1));
-	}
-	return flattened;
-}
-
-function toAgentsViewRow(row: MutableAgentsViewRow): AgentsViewRow {
-	return {
-		section: row.section,
-		summary: row.summary,
-		title: row.title,
-		subtitle: row.subtitle,
-		statusLabel: row.statusLabel,
-		depth: row.depth,
-		selectable: row.selectable,
-		runningSubagentCount: row.runningSubagentCount,
-	};
 }
 
 function buildRowKeyMap(rows: readonly MutableAgentsViewRow[]): Map<string, MutableAgentsViewRow> {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -110,7 +110,9 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		streamingMessage: session.state.streamingMessage,
 		created: savedSession?.created.toISOString(),
 		modified,
-		firstMessage: savedSession?.firstMessage,
+		// Subagent sessions live in artifact dirs that the saved-session scan
+		// never sees; their spawn prompt is the most identifying title we have.
+		firstMessage: savedSession?.firstMessage ?? (metadata.prompt ? compactRlmText(metadata.prompt, 120) : undefined),
 		parentActiveSessionId: metadata.parentActiveSessionId,
 		parentSessionId: metadata.parentSessionId,
 		parentSessionPath: savedSession?.parentSessionPath ?? metadata.parentSessionFile,

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -153,6 +153,69 @@ function hintLine(hints: ReadonlyArray<string | undefined>, width: number): stri
 	return truncateToWidth(joinHints(hints), width, "");
 }
 
+// Subagent list entries mirror the agents view row format: icon, title, right-aligned time.
+function childAgentStatusIcon(status: ChildAgentStatus): string {
+	switch (status) {
+		case "queued":
+			return "◇";
+		case "running":
+			return "◆";
+		case "done":
+			return "✓";
+		case "error":
+		case "cancelled":
+			return "✗";
+		default: {
+			const _exhaustive: never = status;
+			return _exhaustive;
+		}
+	}
+}
+
+function formatChildAgentStatusIcon(status: ChildAgentStatus, icon: string): string {
+	switch (status) {
+		case "queued":
+			return theme.fg("dim", icon);
+		case "running":
+			return theme.bold(icon);
+		case "done":
+			return theme.fg("success", icon);
+		case "error":
+			return theme.fg("error", icon);
+		case "cancelled":
+			return theme.fg("warning", icon);
+		default: {
+			const _exhaustive: never = status;
+			return _exhaustive;
+		}
+	}
+}
+
+function formatChildAgentDuration(durationMs: number | undefined): string {
+	if (durationMs === undefined) {
+		return "";
+	}
+	const seconds = Math.max(0, Math.floor(durationMs / 1000));
+	if (seconds < 60) {
+		return `${seconds}s`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) {
+		return `${minutes}m`;
+	}
+	return `${Math.floor(minutes / 60)}h`;
+}
+
+function padTableCell(value: string, width: number): string {
+	const truncated = truncateToWidth(value, width, "");
+	return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
+}
+
+function padRightTableCell(value: string, width: number): string {
+	const truncated = truncateToWidth(value, width, "");
+	return " ".repeat(Math.max(0, width - visibleWidth(truncated))) + truncated;
+}
+
 export class ChildAgentSummaryComponent implements Component, Focusable {
 	focused = false;
 	private readonly paddingX = 1;
@@ -314,7 +377,7 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			return;
 		}
 
-		if (kb.matches(data, "tui.select.cancel")) {
+		if (kb.matches(data, "app.agents.back")) {
 			this.onCancel?.();
 			return;
 		}
@@ -369,8 +432,13 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 
 	private renderListEntry(entry: FlatChildAgentNode, width: number): string {
 		const indent = " ".repeat(Math.min(6, entry.depth * 2));
-		const line = `  ${indent}${this.statusLabel(entry.node.status)} ${theme.fg("dim", "·")} ${theme.fg("muted", entry.node.label)}`;
-		return this.truncate(line, width, "…");
+		const rawIcon = childAgentStatusIcon(entry.node.status);
+		const icon = formatChildAgentStatusIcon(entry.node.status, rawIcon);
+		const timeWidth = 6;
+		const titleWidth = Math.max(0, width - visibleWidth(indent) - visibleWidth(rawIcon) - timeWidth - 2);
+		const titleCell = padTableCell(entry.node.label, titleWidth);
+		const timeCell = padRightTableCell(formatChildAgentDuration(entry.node.durationMs), timeWidth);
+		return this.truncate(`${indent}${icon} ${titleCell} ${timeCell}`, width, "");
 	}
 	private flatten(): FlatChildAgentNode[] {
 		return flattenChildAgentNodes(this.nodes);
@@ -402,25 +470,10 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			[
 				combinedKeyAction(["tui.select.up", "tui.select.down"], "move"),
 				keyAction("tui.select.confirm", "open"),
-				keyAction("tui.select.cancel", "close", { primaryOnly: true }),
+				keyAction("app.agents.back", "back to chat", { primaryOnly: true }),
 			],
 			width,
 		);
-	}
-
-	private statusLabel(status: ChildAgentStatus): string {
-		switch (status) {
-			case "queued":
-				return theme.fg("muted", "queued");
-			case "running":
-				return theme.fg("accent", "running");
-			case "done":
-				return theme.fg("success", "done");
-			case "error":
-				return theme.fg("error", "error");
-			case "cancelled":
-				return theme.fg("warning", "cancelled");
-		}
 	}
 
 	private panelLine(line: string, width: number, selected: boolean): string {
@@ -492,7 +545,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			this.onToggleToolsExpanded?.();
 			return;
 		}
-		if (kb.matches(data, "tui.select.cancel")) {
+		if (kb.matches(data, "app.agents.back")) {
 			this.onCancel?.();
 		}
 	}
@@ -628,10 +681,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 
 	private detailHintLine(width: number): string {
 		const expandAction = keyAction("app.tools.expand", this.toolsExpanded ? "to collapse" : "to expand");
-		return hintLine(
-			[keyAction("tui.select.cancel", "back to subagents", { primaryOnly: true }), expandAction],
-			width,
-		);
+		return hintLine([keyAction("app.agents.back", "back to subagents", { primaryOnly: true }), expandAction], width);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -479,6 +479,8 @@ export interface InteractiveModeOptions {
 	onShutdown?: () => void | Promise<void>;
 	/** Allow returning from a full session to the agents view without stopping the daemon-owned agent. */
 	returnToAgentsView?: boolean;
+	/** Open the read-only detail view for this subagent node right after startup. */
+	initialSubagentNodeId?: string;
 }
 
 export type InteractiveModeRunResult = "agents_view";
@@ -929,6 +931,12 @@ export class InteractiveMode {
 
 		// Render initial messages AFTER showing loaded resources
 		await this.renderInitialMessages();
+
+		// Jump straight into a subagent's read-only detail view when the agents
+		// view opened this session targeting one of its subagents.
+		if (this.options.initialSubagentNodeId) {
+			this.openChildAgentDetail(this.options.initialSubagentNodeId);
+		}
 
 		// Set up theme file watcher
 		onThemeChange(() => {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -934,8 +934,11 @@ export class InteractiveMode {
 
 		// Jump straight into a subagent's read-only detail view when the agents
 		// view opened this session targeting one of its subagents.
-		if (this.options.initialSubagentNodeId) {
-			this.openChildAgentDetail(this.options.initialSubagentNodeId);
+		if (this.options.initialSubagentNodeId && !this.openChildAgentDetail(this.options.initialSubagentNodeId)) {
+			// The subagent can finish and get released between the agents view
+			// listing it and this session attaching; say so instead of silently
+			// landing in the parent chat.
+			this.showStatus("Subagent already finished; showing its parent session");
 		}
 
 		// Set up theme file watcher
@@ -4136,10 +4139,10 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private openChildAgentDetail(nodeId: string): void {
+	private openChildAgentDetail(nodeId: string): boolean {
 		const node = this.findChildAgentInspectorNode(nodeId);
 		if (!node) {
-			return;
+			return false;
 		}
 		this.childAgentPanelMode = "detail";
 		this.childAgentDetailNodeId = nodeId;
@@ -4150,6 +4153,7 @@ export class InteractiveMode {
 		this.mainViewContainer.addChild(this.childAgentDetail);
 		this.ui.setFocus(this.childAgentDetail);
 		this.ui.requestRender();
+		return true;
 	}
 
 	private focusChildAgentInspector(): void {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -91,10 +91,64 @@ describe("agents view state", () => {
 			}),
 		]);
 
-		expect(rows.map((row) => row.title)).toEqual(["Parent", "Other"]);
-		expect(rows.map((row) => row.runningSubagentCount)).toEqual([2, 0]);
-		expect(rows.map((row) => row.depth)).toEqual([0, 0]);
-		expect(rows.map((row) => row.selectable)).toEqual([true, true]);
+		expect(rows.map((row) => [row.title, row.kind])).toEqual([
+			["Parent", "agent"],
+			["2 subagents running", "subagent-summary"],
+			["Other", "agent"],
+		]);
+		expect(rows.map((row) => row.runningSubagentCount)).toEqual([2, 2, 0]);
+		expect(rows.map((row) => row.depth)).toEqual([0, 1, 0]);
+		expect(rows.map((row) => row.selectable)).toEqual([true, true, true]);
+		expect(rows[1]?.parentIdentity).toBe(rows[0]?.identity);
+		expect(rows[1]?.identity).not.toBe(rows[0]?.identity);
+	});
+
+	test("expands subagent rows for expanded parents and collapses otherwise", () => {
+		const summaries = [
+			makeSummary({
+				id: "child-active",
+				activeSessionId: "child-active",
+				sessionId: "child-session",
+				sessionFile: "/tmp/child.jsonl",
+				sessionName: "Child",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "parent-active",
+				isStreaming: true,
+				status: "model",
+			}),
+			makeSummary({
+				id: "completed-child-active",
+				activeSessionId: "completed-child-active",
+				sessionId: "completed-child-session",
+				sessionFile: "/tmp/completed-child.jsonl",
+				sessionName: "Completed child",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "parent-active",
+				status: "idle",
+				messageCount: 2,
+			}),
+			makeSummary({
+				id: "parent-active",
+				activeSessionId: "parent-active",
+				sessionId: "parent-session",
+				sessionFile: "/tmp/parent.jsonl",
+				sessionName: "Parent",
+				isStreaming: true,
+				status: "tool",
+			}),
+		];
+
+		const collapsed = buildAgentsViewRows(summaries);
+		expect(collapsed.map((row) => row.kind)).toEqual(["agent", "subagent-summary"]);
+
+		const parentIdentity = collapsed[0]?.identity;
+		const expanded = buildAgentsViewRows(summaries, new Set([parentIdentity ?? ""]));
+		expect(expanded.map((row) => [row.title, row.kind, row.depth])).toEqual([
+			["Parent", "agent", 0],
+			["Child", "subagent", 1],
+			["Completed child", "subagent", 1],
+		]);
+		expect(expanded.slice(1).every((row) => row.selectable && row.parentIdentity === parentIdentity)).toBe(true);
 	});
 
 	test("treats parent-linked summaries without runtimeKind as subagents", () => {
@@ -127,8 +181,11 @@ describe("agents view state", () => {
 			}),
 		]);
 
-		expect(rows.map((row) => row.title)).toEqual(["Parent"]);
-		expect(rows.map((row) => row.runningSubagentCount)).toEqual([1]);
+		expect(rows.map((row) => [row.title, row.kind])).toEqual([
+			["Parent", "agent"],
+			["1 subagent running", "subagent-summary"],
+		]);
+		expect(rows[0]?.runningSubagentCount).toBe(1);
 	});
 
 	test("omits subagents when their parent is not visible", () => {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -140,6 +140,7 @@ describe("agents view state", () => {
 
 		const collapsed = buildAgentsViewRows(summaries);
 		expect(collapsed.map((row) => row.kind)).toEqual(["agent", "subagent-summary"]);
+		expect(collapsed[1]?.title).toBe("1 subagent running");
 
 		const parentIdentity = collapsed[0]?.identity;
 		const expanded = buildAgentsViewRows(summaries, new Set([parentIdentity ?? ""]));
@@ -149,6 +150,37 @@ describe("agents view state", () => {
 			["Completed child", "subagent", 1],
 		]);
 		expect(expanded.slice(1).every((row) => row.selectable && row.parentIdentity === parentIdentity)).toBe(true);
+	});
+
+	test("keeps finished subagents reachable via the summary row", () => {
+		const rows = buildAgentsViewRows([
+			makeSummary({
+				id: "done-child",
+				activeSessionId: "done-child",
+				sessionId: "done-child-session",
+				sessionFile: "/tmp/done-child.jsonl",
+				sessionName: "Done child",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "parent-active",
+				status: "idle",
+				messageCount: 2,
+			}),
+			makeSummary({
+				id: "parent-active",
+				activeSessionId: "parent-active",
+				sessionId: "parent-session",
+				sessionFile: "/tmp/parent.jsonl",
+				sessionName: "Parent",
+				status: "idle",
+				messageCount: 4,
+			}),
+		]);
+
+		expect(rows.map((row) => [row.title, row.kind])).toEqual([
+			["Parent", "agent"],
+			["1 subagent", "subagent-summary"],
+		]);
+		expect(rows[1]?.selectable).toBe(true);
 	});
 
 	test("treats parent-linked summaries without runtimeKind as subagents", () => {

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -73,6 +73,7 @@ describe("buildSessionList", () => {
 						parentSessionFile: "/tmp/parent.jsonl",
 						rlmChildId: "rlm-child",
 						rlmParentNodeId: "rlm-child",
+						prompt: "Audit the   retry\nlogic for races",
 					},
 				}),
 			],
@@ -86,6 +87,8 @@ describe("buildSessionList", () => {
 			parentSessionPath: "/tmp/parent.jsonl",
 			rlmChildId: "rlm-child",
 			rlmParentNodeId: "rlm-child",
+			// The spawn prompt doubles as the subagent's display title.
+			firstMessage: "Audit the retry logic for races",
 		});
 	});
 });

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -571,15 +571,15 @@ describe("marquee TUI components", () => {
 		expect(compact).toContain("─");
 		expect(visibleWidth(component.render(42)[0] ?? "")).toBe(42);
 		expect(compact).toContain("1 running · 2 total");
-		expect(compact).toContain("running · inspect training logs");
-		expect(compact).toContain("done · check shard 2");
+		expect(compact).toContain("◆ inspect training logs");
+		expect(compact).toContain("✓ check shard 2");
 		expect(compact).not.toContain("└─");
 		expect(compact).not.toContain("├─");
 		expect(compact).not.toContain("assistant: reading shard metrics");
 		const wideList = stripAnsi(component.render(96).join("\n"));
 		expect(wideList).toContain("↑/↓ move");
 		expect(wideList).toContain("Enter open");
-		expect(wideList).toContain("Esc close");
+		expect(wideList).toContain("← back to chat");
 		expect(wideList).not.toContain("ctrl+c close");
 		for (const line of component.render(96)) {
 			expect(visibleWidth(line)).toBe(96);
@@ -588,7 +588,7 @@ describe("marquee TUI components", () => {
 		component.focused = true;
 		const focused = stripAnsi(component.render(42).join("\n"));
 		expect(focused).not.toContain("▌");
-		expect(focused).toContain("running · inspect training logs");
+		expect(focused).toContain("◆ inspect training logs");
 		expect(focused).not.toContain("assistant: reading shard metrics");
 
 		let openedNodeId: string | undefined;
@@ -610,7 +610,7 @@ describe("marquee TUI components", () => {
 		expect(detail).toContain("reading shard metrics");
 		expect(detail).toContain("$ echo hi");
 		expect(detail).toContain("hi");
-		expect(detail).toContain("Esc back to subagents");
+		expect(detail).toContain("← back to subagents");
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 		expect(detail).not.toContain("tool: bash");
@@ -618,7 +618,7 @@ describe("marquee TUI components", () => {
 		component.handleInput("\x1b");
 		const returned = stripAnsi(component.render(42).join("\n"));
 		expect(returned).not.toContain("▌");
-		expect(returned).toContain("running · inspect training logs");
+		expect(returned).toContain("◆ inspect training logs");
 		expect(returned).not.toContain("assistant: reading shard metrics");
 
 		for (const line of component.render(42)) {
@@ -626,7 +626,7 @@ describe("marquee TUI components", () => {
 		}
 
 		const narrow = stripAnsi(component.render(24).join("\n"));
-		expect(narrow).toContain("inspect t…");
+		expect(narrow).toContain("◆ inspect train");
 	});
 
 	test("collapses multiline child agent system errors in detail view", () => {
@@ -783,7 +783,7 @@ describe("marquee TUI components", () => {
 		const first = stripAnsi(firstLines.join("\n"));
 		expect(first).toContain("fallback transcript row 01");
 		expect(first).toContain("fallback transcript row 12");
-		expect(first).toContain("Esc back to subagents");
+		expect(first).toContain("← back to subagents");
 		expect(first).not.toContain("↑");
 		expect(first).not.toContain("↓");
 		expect(firstLines.length).toBeGreaterThan(6);


### PR DESCRIPTION
- the subagents summary row under a parent agent is now selectable and indented; enter expands it into one nested row per subagent, and moving the selection out of the list collapses it again.
- enter on a subagent opens its read-only detail view inside the parent's chat session, so subagents stay inspectable but not promptable.
- the in-chat subagent panel now uses left arrow to go back instead of esc, and its list rows match the agents view style with status icons and durations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI navigation and display changes in agents view and child-agent inspector; no auth, persistence, or daemon protocol changes beyond subagent title fallback.
> 
> **Overview**
> **Agents view** now treats subagents as a navigable tree instead of hiding them or showing a static “N subagents running” line. Parents get a selectable **subagent-summary** row (collapsed by default); **Enter** expands it to per-subagent rows, and moving selection away collapses again. **Enter** on a subagent opens the **parent** session in interactive mode with an optional `subagent` payload and `initialSubagentNodeId` so the read-only child detail opens immediately. Row **identity** / **parentIdentity** and `expandedSubagentParents` keep selection stable across refreshes; reply, stop/delete, and footer hints apply only to top-level **agent** rows.
> 
> **Session list** fills `firstMessage` for subagents from spawn **prompt** when there is no saved session scan.
> 
> **In-chat subagent panel** list rows match agents-view styling (status icons, duration column); back navigation uses **`app.agents.back`** instead of Esc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3969b6450b0a8da46c67d6afebf0eebbdfc551b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make subagents navigable in the agents view and chat panel
> - Adds expandable subagent rows under each agent in the agents view: collapsed parents show a summary row (running count or total); selecting it expands inline subagent entries.
> - Selecting a subagent row opens the parent agent's chat session and navigates directly to that subagent's detail panel via `initialSubagentNodeId`.
> - Reply, delete, and stop actions are gated to top-level agent rows only; subagent rows are read-only.
> - Reworks child agent inspector list entries to show a status icon (`◆`/`✓`), fixed-width title, and right-aligned duration instead of text labels; back keybinding changed to `app.agents.back`.
> - Subagent summaries now derive a title from their spawn prompt when no saved session title is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3969b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->