### PR TITLE
add built-in skill-creator skill for authoring new skills

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added an `AgentConnection` client boundary with in-process and daemon adapters for interactive-mode decoupling.
 - Added daemon mode and CLI controls for starting on demand, creating, listing, attaching, detaching, killing, renaming, and prompting live sessions.
 - Added rich TUI attach for already-active daemon sessions via `--session <selector>` and live `daemon <selector>` shorthand.
+- Added a built-in `skill-creator` skill that teaches the agent to create new skills: markdown layout, frontmatter rules, placement and precedence, and the Python-backed skill contract (package layout, `run()` convention, optional CLI, kernel venv behavior) with a test-verified working template.
 - Added built-in skills shipped with prime-agent, starting with `prime-intellect`: ecosystem knowledge and prime CLI workflows for verifiers environments, evaluations, Hosted Training, sandboxes, inference, and compute. Built-in skills have the lowest precedence (user, project, and package skills with the same name win) and can be disabled with the `enableBuiltinSkills` setting or `--no-skills`.
 
 ### Changed

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -48,6 +48,7 @@ Disable discovery with `--no-skills` (explicit `--skill` paths still load).
 Prime Agent ships with built-in skills that teach the agent the Prime Intellect ecosystem:
 
 - `prime-intellect` - Prime Intellect products and workflows via the prime CLI: verifiers environments and the Environments Hub, evaluations (local and hosted), Hosted Training and prime-rl, sandboxes, tunnels, Prime Inference, GPU compute, and storage. Reference docs for each area load on demand from the skill's `references/` directory.
+- `skill-creator` - teaches the agent to create new skills: markdown skill layout, frontmatter rules, placement and precedence, and the full Python-backed skill contract (package layout, `run()` convention, optional CLI, kernel venv behavior) with a working template in `references/python-skills.md`.
 
 Built-in skills behave like any other skill but have the lowest precedence: a user, project, or package skill with the same name overrides the built-in one.
 

--- a/packages/coding-agent/skills/skill-creator/SKILL.md
+++ b/packages/coding-agent/skills/skill-creator/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: skill-creator
+description: Create, validate, and install Prime Agent skills - both markdown skills and Python-backed skills callable from the IPython kernel. Use when the user asks to create a skill, turn a workflow, script, or prompt into a reusable skill, add a Python skill the agent can call, or asks how to write a SKILL.md and where skills live.
+---
+
+# Skill Creator
+
+A skill is a directory with a `SKILL.md` file (YAML frontmatter + markdown instructions). At startup Prime Agent reads only each skill's name and description into the system prompt; the full file loads on demand when a task matches. Prime Agent follows the [Agent Skills standard](https://agentskills.io/specification) and extends it with Python-backed skills.
+
+| Kind | What it is | When to use |
+|---|---|---|
+| markdown | `SKILL.md` plus optional scripts, references, and assets | Workflows, CLI recipes, domain knowledge, multi-step instructions |
+| python | A markdown skill that also ships a Python package installed into the agent's persistent IPython kernel | Capabilities that are naturally one Python call: API wrappers, fetchers, converters, computations |
+
+Before writing a Python-backed skill, read [references/python-skills.md](references/python-skills.md) for the package contract.
+
+## Creating a Skill
+
+1. **Pick the kind.** Default to markdown. Go Python only when the agent should *call* the capability (`await my_skill(...)`) instead of following instructions.
+2. **Pick the location.** Ask the user when it is not obvious from context:
+   - Project skill, shared via the repo: `.prime/agent/skills/<name>/`
+   - Personal global skill: `~/.prime/agent/skills/<name>/`
+   - Shipped with an npm package: a `skills/` directory in the package, or `pi.skills` paths in its `package.json`
+3. **Scaffold and write** the directory using the layout and frontmatter rules below.
+4. **Verify** the skill loads (see Verification).
+
+On a name collision the first skill found wins. Precedence: explicit `--skill` paths and `skills` settings entries, then project, then global, then package, then built-in skills.
+
+## Layout
+
+```
+my-skill/
+├── SKILL.md              # Required: frontmatter + instructions
+├── scripts/              # Optional helper scripts the instructions reference
+├── references/           # Optional detailed docs, loaded only when needed
+└── assets/               # Optional templates and data files
+```
+
+Everything except `SKILL.md` is freeform. Reference files with paths relative to the skill directory; the agent resolves them against the directory containing `SKILL.md`.
+
+## Frontmatter
+
+```markdown
+---
+name: my-skill
+description: What this skill does and when to use it. Be specific.
+---
+```
+
+| Field | Required | Rules |
+|---|---|---|
+| `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens. No leading/trailing/consecutive hyphens. Must match the parent directory name. |
+| `description` | Yes | Max 1024 chars. A skill with a missing or empty description is **silently not loaded**. |
+| `disable-model-invocation` | No | `true` hides the skill from the system prompt; only explicit `/skill:<name>` invokes it. |
+| `license` | No | License name or reference to a bundled file. |
+| `compatibility` | No | Max 500 chars. Environment requirements. |
+| `metadata` | No | Arbitrary key-value mapping. |
+| `allowed-tools` | No | Space-delimited pre-approved tools (experimental). |
+
+Unknown fields are ignored. Name violations produce warnings but the skill still loads.
+
+### Write the description for routing
+
+The description is the only thing the model sees before deciding to load the skill. State what the skill does *and* the trigger conditions ("Use when ..."), naming the concrete tasks, tools, and phrases a request would contain.
+
+Good: `Extracts text and tables from PDF files, fills PDF forms, and merges PDFs. Use when working with PDF documents.`
+Poor: `Helps with PDFs.`
+
+### Write the body for progressive disclosure
+
+Keep `SKILL.md` short: the decision flow, the common commands, the contract. Push exhaustive detail (API schemas, full option lists, long examples) into `references/*.md` and link them, so they only enter context when actually needed. State setup steps (installs, env vars, credentials) explicitly and early.
+
+## Verification
+
+After writing the skill:
+
+1. Re-read the frontmatter and check every rule in the table above, especially that `name` matches the directory name and the description is non-empty.
+2. In an interactive session, `/reload` picks up new skills without a restart; other sessions pick them up on start. Loading problems (bad name, missing description, name collisions) surface as warnings — ask the user to check, or check diagnostics yourself if you can.
+3. A loaded skill is also invocable as `/skill:<name>`, which the user can try directly.
+
+For Python-backed skills, also run the checks in [references/python-skills.md](references/python-skills.md).

--- a/packages/coding-agent/skills/skill-creator/references/python-skills.md
+++ b/packages/coding-agent/skills/skill-creator/references/python-skills.md
@@ -1,0 +1,133 @@
+# Python-Backed Skills
+
+A Python-backed skill is a regular markdown skill that also ships a Python package. Prime Agent installs the package editable into the kernel venv (`~/.prime/agent/kernel-venv` by default, `PRIME_AGENT_KERNEL_VENV` to override) and exposes it in the persistent IPython kernel, so the agent can call it directly instead of shelling out.
+
+## Detection Contract
+
+All of these must hold or the skill silently degrades to a markdown-only skill (with a load warning):
+
+- `SKILL.md` exists as usual.
+- `pyproject.toml` exists at the skill root — its presence is what marks the skill as Python-backed.
+- The import name is the skill name with hyphens converted to underscores, and it must be a valid Python identifier.
+- `src/<import_name>/__init__.py` exists (src layout, exact directory name).
+
+For a skill named `word-count`, the kernel exposes `word_count`.
+
+## Minimal Template
+
+```
+word-count/
+├── SKILL.md
+├── pyproject.toml
+└── src/
+    └── word_count/
+        └── __init__.py
+```
+
+**`SKILL.md`**
+
+```markdown
+---
+name: word-count
+description: Count word frequencies in text and return the most common words. Use when the user asks for word counts or frequency analysis of a text snippet.
+---
+
+# Word Count
+
+Call directly from the kernel:
+
+    await word_count("some text to analyze", top=3)
+
+Or from a shell cell:
+
+    !word_count "some text to analyze" --top 3
+```
+
+**`pyproject.toml`**
+
+```toml
+[project]
+name = "word-count"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+word_count = "rlm.skill:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/word_count"]
+```
+
+**`src/word_count/__init__.py`**
+
+```python
+from collections import Counter
+
+
+async def run(text: str, top: int = 5) -> str:
+    """Count words in text and return the most common ones."""
+    counts = Counter(text.lower().split())
+    return "\n".join(f"{word}: {count}" for word, count in counts.most_common(top))
+```
+
+The `[tool.hatch.build.targets.wheel]` section is required with hatchling whenever the project name differs from the package directory name (it always does for hyphenated skill names).
+
+## The run() Convention
+
+If `src/<import_name>/__init__.py` defines `run()`, the kernel wraps the module so the module itself is an async callable:
+
+```python
+await word_count("text")        # same as word_count.run("text")
+await word_count.run("text")
+help(word_count)                # shows run()'s docstring and signature
+```
+
+- `run()` may be sync or async; the wrapper awaits awaitable results.
+- The signature and docstring of `run()` are copied onto the module, so write a real docstring and typed keyword arguments with defaults — they are the skill's API documentation *and* its CLI.
+- Without `run()`, the module is still imported and exposed by name, just not callable.
+- Import failures do not break the kernel: the name is bound to a placeholder that raises a `RuntimeError` containing the import error when called.
+
+## Optional CLI Command
+
+The `[project.scripts]` entry pointing at `rlm.skill:cli` gives the skill a shell command. Rules:
+
+- The script name must **exactly** match the Python import name, underscores included (`word_count`, not `word-count`).
+- `rlm.skill:cli` imports `<script_name>.run` and parses argv against its signature with `tyro`, awaits async results, and prints non-`None` return values.
+- `rlm` and `tyro` are already present in the kernel venv. Do **not** declare `prime-agent-runtime` as a dependency: it is bundled with Prime Agent, not published on PyPI, so declaring it breaks installs outside the kernel venv. The CLI entry point only works where the runtime is installed, i.e. inside the kernel venv.
+
+The agent can then use either form:
+
+```python
+await word_count("prime agent", top=3)
+```
+
+```bash
+!word_count "prime agent" --top 3
+```
+
+Omit `[project.scripts]` when a CLI is not needed.
+
+## Dependencies and the Kernel Venv
+
+- Declare every third-party package `run()` imports in `dependencies` — `pyproject.toml` is the source of truth. The one exception is `prime-agent-runtime` (see above).
+- These are already in the kernel venv, so depending on them is free: `requests`, `httpx`, `pyyaml`, `tomli`, `python-dotenv`, `pandas`, `numpy`, `scipy`, `beautifulsoup4`, `lxml`, `pydantic`, `tyro`.
+- The install is editable and keyed on a hash of `pyproject.toml`: editing Python source takes effect on the next kernel start with no reinstall; editing `pyproject.toml` triggers a reinstall automatically.
+- If the user sets `PRIME_AGENT_KERNEL_PYTHON`, Prime Agent installs nothing — skills whose imports are missing there are disabled with a warning.
+
+A Python skill runs inside the agent's kernel, so it can itself spawn recursive sub-agents with `import rlm` and `await rlm.run("subtask")` — useful for skills that delegate open-ended work.
+
+## Verifying a Python Skill
+
+1. Check the contract: skill name maps to a valid identifier, `src/<import_name>/__init__.py` exists, hatchling wheel packages list matches.
+2. Test `run()` standalone from the skill directory, without the kernel:
+
+   ```bash
+   cd <skill-dir> && uv run python -c "import asyncio, word_count; print(asyncio.run(word_count.run('a b a', top=1)))"
+   ```
+
+3. In a fresh agent session (the kernel installs skills at startup), confirm `help(<import_name>)` shows the docstring and `await <import_name>(...)` works. If it raises `RuntimeError`, the message contains the underlying import error.

--- a/packages/coding-agent/test/builtin-skills.test.ts
+++ b/packages/coding-agent/test/builtin-skills.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBundledSkillsDir } from "../src/config.js";
 import { DefaultPackageManager } from "../src/core/package-manager.js";
@@ -160,6 +160,31 @@ describe("builtin skills", () => {
 			expect(diagnostics).toEqual([]);
 			expect(skills.length).toBeGreaterThan(0);
 			expect(skills.map((s) => s.name)).toContain("prime-intellect");
+			expect(skills.map((s) => s.name)).toContain("skill-creator");
+		});
+
+		it("loads the skill-creator python template as a valid python skill", () => {
+			const referencePath = join(getBundledSkillsDir(), "skill-creator", "references", "python-skills.md");
+			const reference = readFileSync(referencePath, "utf-8");
+			const section = reference.match(/## Minimal Template([\s\S]*?)\n## /)?.[1];
+			expect(section).toBeDefined();
+
+			const files = [...(section as string).matchAll(/\*\*`([^`]+)`\*\*\s*\n+```[a-z]*\n([\s\S]*?)\n```/g)];
+			expect(files.map((m) => m[1])).toEqual(["SKILL.md", "pyproject.toml", "src/word_count/__init__.py"]);
+
+			const templateRoot = join(tempDir, "template-skills");
+			for (const [, relPath, content] of files) {
+				const filePath = join(templateRoot, "word-count", relPath);
+				mkdirSync(dirname(filePath), { recursive: true });
+				writeFileSync(filePath, content);
+			}
+
+			const { skills, diagnostics } = loadSkillsFromDir({ dir: templateRoot, source: "test" });
+			expect(diagnostics).toEqual([]);
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("word-count");
+			expect(skills[0].kind).toBe("python");
+			expect(skills[0].kind === "python" && skills[0].python.importName).toBe("word_count");
 		});
 	});
 });


### PR DESCRIPTION
- ships a skill-creator built-in so the agent knows how to write its own skills instead of improvising the format from training data.
- covers markdown skill layout, frontmatter rules, placement and precedence, plus the python skill contract with a working word-count template in an on-demand reference.
- a test extracts the template from the reference markdown and runs it through the skill loader, so the docs cannot drift from the implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and bundled skill content only; no changes to skill loading or agent runtime behavior beyond an additional built-in skill entry.
> 
> **Overview**
> Adds a new built-in **`skill-creator`** skill so the agent can author skills from shipped guidance instead of guessing format from training data.
> 
> The skill’s **`SKILL.md`** covers markdown vs Python-backed skills, layout, frontmatter, placement/precedence, routing descriptions, and verification; **`references/python-skills.md`** documents the Python contract (`pyproject.toml`, `run()`, optional `rlm.skill:cli`, kernel venv) with a copy-paste **word-count** minimal template. **CHANGELOG** and **`docs/skills.md`** list the built-in alongside `prime-intellect`.
> 
> **Tests** assert bundled skills include `skill-creator` with no diagnostics, and parse the template out of the reference markdown into a temp tree so **`loadSkillsFromDir`** must classify it as a valid `python` skill—keeping docs aligned with the loader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db12d60fa7d5895b6d816ddfb1195a8156c22dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add built-in `skill-creator` skill for authoring new agent skills
> - Adds a new built-in skill at [`skills/skill-creator/SKILL.md`](https://github.com/PrimeIntellect-ai/prime-agent/pull/122/files#diff-175dc0fe28a63405415116fdfa1914a6f8d8801724229509faddce92830ce3b3) that guides the agent in creating both markdown and Python-backed skills, covering frontmatter, layout, placement, and verification steps.
> - Adds [`references/python-skills.md`](https://github.com/PrimeIntellect-ai/prime-agent/pull/122/files#diff-56b1910c37de83605114e055c0e25e5428ed4b792726140aa5dd9ae9f22a44fc) as a reference document detailing the Python skill contract (detection rules, minimal template, `run()` convention, dependency handling).
> - Extends the test suite to assert `skill-creator` is present among bundled skills and to verify that the documented Python template parses into a valid detected skill with the expected name and import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0db12d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->