### PR TITLE
fix shell-quote audit critical via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5219,8 +5219,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"dev": true,
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -6284,16 +6285,6 @@
 		"packages/coding-agent/examples/extensions/sandbox/node_modules/lodash-es": {
 			"version": "4.18.1",
 			"license": "MIT"
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/shell-quote": {
-			"version": "1.8.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"packages/coding-agent/examples/extensions/sandbox/node_modules/zod": {
 			"version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"rimraf": "6.1.2",
 		"gaxios": {
 			"rimraf": "6.1.2"
-		}
+		},
+		"shell-quote": "^1.8.4"
 	}
 }


### PR DESCRIPTION
- npm audit flagged a critical in shell-quote (newline escaping in quote()), pulled in by concurrently and the sandbox example.
- concurrently pins the exact vulnerable version, and npm's only suggested fix was a breaking concurrently major bump that requires node 22.
- added a root override to the patched shell-quote release instead, so npm audit now reports zero vulnerabilities with no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version override only; no application logic changes, though transitive quoting behavior is patched at the library level.
> 
> **Overview**
> Addresses a **critical npm audit** finding in transitive **`shell-quote`** (newline escaping in `quote()`), used by **`concurrently`** and **`@anthropic-ai/sandbox-runtime`** in the sandbox example.
> 
> Adds a root **`npm` override** forcing **`shell-quote@^1.8.4`** instead of bumping **`concurrently`** to a major that needs Node 22. The lockfile now hoists **1.8.4** and drops the sandbox workspace’s duplicate **1.8.3** copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ea5138b80bfbc9809e8e1213e0d3fc377dacc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix critical `shell-quote` vulnerability via npm override
> Adds `shell-quote@^1.8.4` as a direct dependency in [package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/124/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to override the vulnerable transitive version flagged by `npm audit`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81ea513.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->