### PR TITLE
render latex math as unicode in tui markdown

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -1201,6 +1201,8 @@ export function getMarkdownTheme(): MarkdownTheme {
 		italic: (text: string) => theme.italic(text),
 		underline: (text: string) => theme.underline(text),
 		strikethrough: (text: string) => chalk.strikethrough(text),
+		math: (text: string) => theme.fg("mdCode", text),
+		mathBlock: (text: string) => theme.fg("mdCodeBlock", text),
 		highlightCode: (code: string, lang?: string): string[] => {
 			// The highlighter loads lazily; until then render the block unhighlighted.
 			const highlighter = codeHighlighter;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,4 +1,5 @@
-import { Marked, type Token, Tokenizer, type Tokens } from "marked";
+import { Marked, type Token, Tokenizer, type TokenizerExtension, type Tokens } from "marked";
+import { latexToUnicode } from "../latex.js";
 import { getCapabilities, hyperlink, isImageLine } from "../terminal-image.js";
 import type { Component } from "../tui.js";
 import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.js";
@@ -22,10 +23,114 @@ class StrictStrikethroughTokenizer extends Tokenizer {
 	}
 }
 
+interface MathToken {
+	type: "blockMath" | "inlineMath";
+	raw: string;
+	/** Raw LaTeX source without the delimiters. */
+	text: string;
+}
+
+// Math tokens are captured by custom tokenizers (which marked tries before its
+// built-in ones) so LaTeX survives intact: otherwise \[ ... \] collapses to
+// [ ... ] via escape handling and underscores inside formulas turn into
+// emphasis. Unterminated delimiters never match, so partially streamed math
+// stays plain text until the closing delimiter arrives.
+// Leading indentation is tolerated (and consumed) because models often indent
+// display math by four or more spaces, which markdown would otherwise lex as
+// an indented code block. Block extensions run before the built-in code
+// tokenizer, so matching here keeps indented math out of that path.
+const BLOCK_MATH_REGEX = /^[ \t]*(?:\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\])[ \t]*(?:\n|$)/;
+
+// start() hooks run on every paragraph continuation (block) and every inline
+// position, so they use indexOf scans instead of regexes, and the tokenizers
+// bail on a first-character check before touching their regexes.
+function minIndex(a: number, b: number): number | undefined {
+	if (a === -1) {
+		return b === -1 ? undefined : b;
+	}
+	return b === -1 ? a : Math.min(a, b);
+}
+
+const blockMathExtension: TokenizerExtension = {
+	name: "blockMath",
+	level: "block",
+	// start() decides whether math can interrupt the paragraph being built, so
+	// only the current paragraph (up to the next blank line) needs scanning:
+	// math past it is caught at its own block boundary by the tokenizer.
+	start: (src: string) => {
+		const paragraphEnd = src.indexOf("\n\n");
+		const window = paragraphEnd === -1 ? src : src.slice(0, paragraphEnd);
+		return minIndex(window.indexOf("$$"), window.indexOf("\\["));
+	},
+	tokenizer(src: string): Tokens.Generic | undefined {
+		const first = src.charCodeAt(0);
+		if (first !== 0x24 /* $ */ && first !== 0x5c /* \ */ && first !== 0x20 /* space */ && first !== 0x09 /* tab */) {
+			return undefined;
+		}
+		const match = BLOCK_MATH_REGEX.exec(src);
+		if (!match) {
+			return undefined;
+		}
+		const token: MathToken = { type: "blockMath", raw: match[0], text: (match[1] ?? match[2]).trim() };
+		return token;
+	},
+};
+
+// $...$ uses the pandoc/GitHub rules to avoid matching prose dollar amounts:
+// the opening $ must be followed by a non-space, the closing $ preceded by a
+// non-space and not followed by a digit ("between $5 and $10" never matches).
+const INLINE_MATH_PATTERNS = [
+	/^\$\$([\s\S]+?)\$\$/, // display math used mid-paragraph
+	/^\\\[([\s\S]+?)\\\]/,
+	/^\\\(([\s\S]+?)\\\)/,
+	/^\$([^\s$](?:[^$\n]*[^\s$])?)\$(?!\d)/,
+];
+
+const inlineMathExtension: TokenizerExtension = {
+	name: "inlineMath",
+	level: "inline",
+	// Only "$" needs a start() hint: it is not an inline special character, so
+	// without one the text tokenizer would swallow it. "\(" and "\[" already
+	// terminate text runs (backslash starts an escape), and extensions are
+	// tried at that position anyway.
+	start: (src: string) => {
+		const index = src.indexOf("$");
+		return index === -1 ? undefined : index;
+	},
+	tokenizer(src: string): Tokens.Generic | undefined {
+		const first = src.charCodeAt(0);
+		if (first !== 0x24 /* $ */ && first !== 0x5c /* \ */) {
+			return undefined;
+		}
+		for (const pattern of INLINE_MATH_PATTERNS) {
+			const match = pattern.exec(src);
+			if (match) {
+				const token: MathToken = { type: "inlineMath", raw: match[0], text: match[1].trim() };
+				return token;
+			}
+		}
+		return undefined;
+	},
+};
+
 const markdownParser = new Marked();
 markdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),
 });
+
+// Registering extensions makes marked consult their start() hooks at every
+// block and inline position, which measurably slows lexing even when they
+// never match. Math-free text (the common case) therefore uses a parser
+// without them; pickMarkdownParser() gates on a cheap substring scan.
+const mathMarkdownParser = new Marked();
+mathMarkdownParser.setOptions({
+	tokenizer: new StrictStrikethroughTokenizer(),
+});
+mathMarkdownParser.use({ extensions: [blockMathExtension, inlineMathExtension] });
+
+function pickMarkdownParser(text: string): Marked {
+	return text.includes("$") || text.includes("\\(") || text.includes("\\[") ? mathMarkdownParser : markdownParser;
+}
 
 /**
  * Default text styling for markdown content.
@@ -68,6 +173,10 @@ export interface MarkdownTheme {
 	highlightCode?: (code: string, lang?: string) => string[];
 	/** Prefix applied to each rendered code block line (default: "  ") */
 	codeBlockIndent?: string;
+	/** Inline math, e.g. $x_i$ (default: `code`) */
+	math?: (text: string) => string;
+	/** Display math block lines, e.g. $$...$$ (default: `codeBlock`) */
+	mathBlock?: (text: string) => string;
 }
 
 interface InlineStyleContext {
@@ -147,7 +256,7 @@ export class Markdown implements Component {
 		const normalizedText = this.text.replace(/\t/g, "   ");
 
 		// Parse markdown to HTML-like tokens
-		const tokens = markdownParser.lexer(normalizedText);
+		const tokens = pickMarkdownParser(normalizedText).lexer(normalizedText);
 
 		// Reference-link definitions make a block's rendering depend on other
 		// blocks, so per-block caching is disabled when any are present.
@@ -363,6 +472,14 @@ export class Markdown implements Component {
 				break;
 			}
 
+			case "blockMath": {
+				lines.push(...this.renderMathBlock(token as unknown as MathToken));
+				if (nextTokenType && nextTokenType !== "space") {
+					lines.push(""); // Add spacing after math blocks (unless space token follows)
+				}
+				break;
+			}
+
 			case "list": {
 				const listLines = this.renderList(token as any, 0, styleContext);
 				lines.push(...listLines);
@@ -495,6 +612,13 @@ export class Markdown implements Component {
 				case "codespan":
 					result += this.theme.code(token.text) + stylePrefix;
 					break;
+
+				case "inlineMath": {
+					const mathStyle = this.theme.math ?? this.theme.code;
+					const converted = latexToUnicode((token as unknown as MathToken).text).replace(/\s*\n\s*/g, " ");
+					result += mathStyle(converted) + stylePrefix;
+					break;
+				}
 
 				case "link": {
 					const linkText = this.renderInlineTokens(token.tokens || [], resolvedStyleContext);
@@ -632,6 +756,9 @@ export class Markdown implements Component {
 			} else if (token.type === "code") {
 				// Code block in list item
 				lines.push(...this.renderCodeBlock(token));
+			} else if (token.type === "blockMath") {
+				// Display math in list item
+				lines.push(...this.renderMathBlock(token as unknown as MathToken));
 			} else {
 				// Other token types - try to render as inline
 				const text = this.renderInlineTokens([token], styleContext);
@@ -657,6 +784,17 @@ export class Markdown implements Component {
 		const codeLines = renderedCodeLines.length > 0 ? renderedCodeLines : [this.theme.codeBlock("")];
 
 		return codeLines.map((codeLine) => `${indent}${codeLine}`);
+	}
+
+	/** Render display math: converted to Unicode, indented like a code block. */
+	private renderMathBlock(token: MathToken): string[] {
+		const indent = this.theme.codeBlockIndent ?? "  ";
+		const style = this.theme.mathBlock ?? this.theme.codeBlock;
+		const mathLines = latexToUnicode(token.text)
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+		return mathLines.map((line) => indent + style(line));
 	}
 
 	/**

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -30,20 +30,13 @@ interface MathToken {
 	text: string;
 }
 
-// Math tokens are captured by custom tokenizers (which marked tries before its
-// built-in ones) so LaTeX survives intact: otherwise \[ ... \] collapses to
-// [ ... ] via escape handling and underscores inside formulas turn into
-// emphasis. Unterminated delimiters never match, so partially streamed math
-// stays plain text until the closing delimiter arrives.
-// Leading indentation is tolerated (and consumed) because models often indent
-// display math by four or more spaces, which markdown would otherwise lex as
-// an indented code block. Block extensions run before the built-in code
-// tokenizer, so matching here keeps indented math out of that path.
+// Math must tokenize before marked's escape/emphasis handling, or \[ collapses
+// to [ and underscores inside formulas become italics. Unterminated delimiters
+// never match, so partially streamed math stays plain text until the closing
+// delimiter arrives. Leading indentation is consumed because models often
+// indent display math, which would otherwise lex as an indented code block.
 const BLOCK_MATH_REGEX = /^[ \t]*(?:\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\])[ \t]*(?:\n|$)/;
 
-// start() hooks run on every paragraph continuation (block) and every inline
-// position, so they use indexOf scans instead of regexes, and the tokenizers
-// bail on a first-character check before touching their regexes.
 function minIndex(a: number, b: number): number | undefined {
 	if (a === -1) {
 		return b === -1 ? undefined : b;
@@ -54,9 +47,8 @@ function minIndex(a: number, b: number): number | undefined {
 const blockMathExtension: TokenizerExtension = {
 	name: "blockMath",
 	level: "block",
-	// start() decides whether math can interrupt the paragraph being built, so
-	// only the current paragraph (up to the next blank line) needs scanning:
-	// math past it is caught at its own block boundary by the tokenizer.
+	// start() runs on every paragraph continuation; scanning only the current
+	// paragraph keeps it cheap, and later math is caught at its block boundary.
 	start: (src: string) => {
 		const paragraphEnd = src.indexOf("\n\n");
 		const window = paragraphEnd === -1 ? src : src.slice(0, paragraphEnd);
@@ -89,10 +81,8 @@ const INLINE_MATH_PATTERNS = [
 const inlineMathExtension: TokenizerExtension = {
 	name: "inlineMath",
 	level: "inline",
-	// Only "$" needs a start() hint: it is not an inline special character, so
-	// without one the text tokenizer would swallow it. "\(" and "\[" already
-	// terminate text runs (backslash starts an escape), and extensions are
-	// tried at that position anyway.
+	// Only "$" needs a start() hint: backslashes already terminate text runs,
+	// but the text tokenizer would swallow a bare "$" without one.
 	start: (src: string) => {
 		const index = src.indexOf("$");
 		return index === -1 ? undefined : index;
@@ -118,10 +108,8 @@ markdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),
 });
 
-// Registering extensions makes marked consult their start() hooks at every
-// block and inline position, which measurably slows lexing even when they
-// never match. Math-free text (the common case) therefore uses a parser
-// without them; pickMarkdownParser() gates on a cheap substring scan.
+// Registered extensions measurably slow marked's lexing even when they never
+// match, so math-free text (the common case) uses a parser without them.
 const mathMarkdownParser = new Marked();
 mathMarkdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -57,6 +57,8 @@ export {
 	parseKey,
 	setKittyProtocolActive,
 } from "./keys.js";
+// LaTeX math to Unicode conversion
+export { latexToUnicode } from "./latex.js";
 // Render caching
 export { VersionedRenderCache } from "./render-cache.js";
 // Input buffering for batch splitting

--- a/packages/tui/src/latex.ts
+++ b/packages/tui/src/latex.ts
@@ -510,22 +510,11 @@ const ALPHABETS: Record<string, AlphabetStyle> = {
 	},
 };
 
-/** Commands whose single group argument renders as plain text. */
-const PLAIN_TEXT_COMMANDS = new Set([
-	"text",
-	"textrm",
-	"textit",
-	"textsf",
-	"texttt",
-	"mbox",
-	"hbox",
-	"mathrm",
-	"mathit",
-	"mathsf",
-	"mathtt",
-	"mathnormal",
-	"operatorname",
-]);
+/** Text-mode commands: their argument is literal text, so ^ and _ stay as-is. */
+const TEXT_COMMANDS = new Set(["text", "textrm", "textit", "textsf", "texttt", "mbox", "hbox"]);
+
+/** Math-mode font commands rendered unstyled; scripts inside still apply. */
+const MATH_FONT_COMMANDS = new Set(["mathrm", "mathit", "mathsf", "mathtt", "mathnormal", "operatorname"]);
 
 /** Size/style commands that take no argument and render as nothing. */
 const IGNORED_COMMANDS = new Set([
@@ -590,7 +579,7 @@ function mapScript(text: string, table: Record<string, string>): string | undefi
 
 /** True when a fraction/sqrt operand reads unambiguously without parentheses. */
 function isSimpleOperand(text: string): boolean {
-	return [...text].length === 1 || /^[\p{L}\p{N}]+$/u.test(text);
+	return [...text].length === 1 || /^[\p{L}\p{N}\p{M}]+$/u.test(text);
 }
 
 function parenthesize(text: string): string {
@@ -600,6 +589,7 @@ function parenthesize(text: string): string {
 class LatexParser {
 	private readonly src: string;
 	private pos = 0;
+	private textMode = false;
 
 	constructor(src: string) {
 		this.src = src;
@@ -617,7 +607,7 @@ class LatexParser {
 			if (ch === "}") {
 				break;
 			}
-			if (ch === "^" || ch === "_") {
+			if ((ch === "^" || ch === "_") && !this.textMode) {
 				this.pos++;
 				result += this.parseScript(ch === "^" ? SUPERSCRIPTS : SUBSCRIPTS, ch);
 				continue;
@@ -736,7 +726,14 @@ class LatexParser {
 			}
 			return "";
 		}
-		if (PLAIN_TEXT_COMMANDS.has(name)) {
+		if (TEXT_COMMANDS.has(name)) {
+			const wasTextMode = this.textMode;
+			this.textMode = true;
+			const content = this.parseArgument();
+			this.textMode = wasTextMode;
+			return content;
+		}
+		if (MATH_FONT_COMMANDS.has(name)) {
 			return this.parseArgument();
 		}
 		const alphabet = ALPHABETS[name];

--- a/packages/tui/src/latex.ts
+++ b/packages/tui/src/latex.ts
@@ -1,0 +1,848 @@
+/**
+ * Best-effort LaTeX math to Unicode plain text conversion for terminal display.
+ *
+ * The goal is readable math in a monospace grid, not faithful typesetting:
+ * symbols map to their Unicode equivalents (\sum → ∑, \alpha → α), scripts use
+ * Unicode sub/superscript characters when every character is available
+ * (x_{t-k} → xₜ₋ₖ) and stay in TeX notation otherwise (x_\theta → x_θ), and
+ * structural commands degrade to linear notation (\frac{a}{b} → a/b).
+ * Unknown commands keep their name with the backslash dropped, so output is
+ * never worse than the raw source.
+ */
+
+const SYMBOLS: Record<string, string> = {
+	// Greek lowercase
+	alpha: "α",
+	beta: "β",
+	gamma: "γ",
+	delta: "δ",
+	epsilon: "ε",
+	varepsilon: "ε",
+	zeta: "ζ",
+	eta: "η",
+	theta: "θ",
+	vartheta: "ϑ",
+	iota: "ι",
+	kappa: "κ",
+	lambda: "λ",
+	mu: "μ",
+	nu: "ν",
+	xi: "ξ",
+	pi: "π",
+	varpi: "ϖ",
+	rho: "ρ",
+	varrho: "ϱ",
+	sigma: "σ",
+	varsigma: "ς",
+	tau: "τ",
+	upsilon: "υ",
+	phi: "ϕ",
+	varphi: "φ",
+	chi: "χ",
+	psi: "ψ",
+	omega: "ω",
+	// Greek uppercase
+	Gamma: "Γ",
+	Delta: "Δ",
+	Theta: "Θ",
+	Lambda: "Λ",
+	Xi: "Ξ",
+	Pi: "Π",
+	Sigma: "Σ",
+	Upsilon: "Υ",
+	Phi: "Φ",
+	Psi: "Ψ",
+	Omega: "Ω",
+	// Big operators
+	sum: "∑",
+	prod: "∏",
+	coprod: "∐",
+	int: "∫",
+	iint: "∬",
+	iiint: "∭",
+	oint: "∮",
+	bigcup: "⋃",
+	bigcap: "⋂",
+	bigoplus: "⨁",
+	bigotimes: "⨂",
+	bigodot: "⨀",
+	bigvee: "⋁",
+	bigwedge: "⋀",
+	bigsqcup: "⨆",
+	// Binary operators
+	pm: "±",
+	mp: "∓",
+	times: "×",
+	div: "÷",
+	cdot: "·",
+	ast: "∗",
+	star: "⋆",
+	circ: "∘",
+	bullet: "•",
+	oplus: "⊕",
+	ominus: "⊖",
+	otimes: "⊗",
+	oslash: "⊘",
+	odot: "⊙",
+	wedge: "∧",
+	land: "∧",
+	vee: "∨",
+	lor: "∨",
+	cap: "∩",
+	cup: "∪",
+	setminus: "∖",
+	sqcap: "⊓",
+	sqcup: "⊔",
+	uplus: "⊎",
+	dagger: "†",
+	ddagger: "‡",
+	// Relations
+	leq: "≤",
+	le: "≤",
+	geq: "≥",
+	ge: "≥",
+	neq: "≠",
+	ne: "≠",
+	equiv: "≡",
+	sim: "∼",
+	simeq: "≃",
+	approx: "≈",
+	cong: "≅",
+	propto: "∝",
+	ll: "≪",
+	gg: "≫",
+	subset: "⊂",
+	supset: "⊃",
+	subseteq: "⊆",
+	supseteq: "⊇",
+	sqsubseteq: "⊑",
+	sqsupseteq: "⊒",
+	in: "∈",
+	ni: "∋",
+	notin: "∉",
+	models: "⊨",
+	vdash: "⊢",
+	dashv: "⊣",
+	perp: "⊥",
+	parallel: "∥",
+	mid: "∣",
+	asymp: "≍",
+	doteq: "≐",
+	prec: "≺",
+	succ: "≻",
+	preceq: "⪯",
+	succeq: "⪰",
+	triangleq: "≜",
+	coloneqq: "≔",
+	coloneq: "≔",
+	// Arrows
+	to: "→",
+	rightarrow: "→",
+	leftarrow: "←",
+	gets: "←",
+	leftrightarrow: "↔",
+	Rightarrow: "⇒",
+	Leftarrow: "⇐",
+	Leftrightarrow: "⇔",
+	iff: "⇔",
+	implies: "⇒",
+	impliedby: "⇐",
+	mapsto: "↦",
+	longrightarrow: "⟶",
+	longleftarrow: "⟵",
+	Longrightarrow: "⟹",
+	Longleftarrow: "⟸",
+	longmapsto: "⟼",
+	uparrow: "↑",
+	downarrow: "↓",
+	updownarrow: "↕",
+	Uparrow: "⇑",
+	Downarrow: "⇓",
+	hookrightarrow: "↪",
+	hookleftarrow: "↩",
+	rightharpoonup: "⇀",
+	leftharpoonup: "↼",
+	rightrightarrows: "⇉",
+	rightleftarrows: "⇄",
+	leadsto: "⇝",
+	nearrow: "↗",
+	searrow: "↘",
+	nwarrow: "↖",
+	swarrow: "↙",
+	// Misc
+	infty: "∞",
+	partial: "∂",
+	nabla: "∇",
+	forall: "∀",
+	exists: "∃",
+	nexists: "∄",
+	emptyset: "∅",
+	varnothing: "∅",
+	neg: "¬",
+	lnot: "¬",
+	angle: "∠",
+	triangle: "△",
+	square: "□",
+	Box: "□",
+	blacksquare: "■",
+	diamond: "⋄",
+	Diamond: "◇",
+	aleph: "ℵ",
+	hbar: "ℏ",
+	ell: "ℓ",
+	Re: "ℜ",
+	Im: "ℑ",
+	wp: "℘",
+	top: "⊤",
+	bot: "⊥",
+	flat: "♭",
+	sharp: "♯",
+	natural: "♮",
+	checkmark: "✓",
+	degree: "°",
+	prime: "′",
+	therefore: "∴",
+	because: "∵",
+	// Dots
+	dots: "…",
+	ldots: "…",
+	dotsc: "…",
+	dotso: "…",
+	cdots: "⋯",
+	dotsb: "⋯",
+	vdots: "⋮",
+	ddots: "⋱",
+	// Delimiters
+	langle: "⟨",
+	rangle: "⟩",
+	lceil: "⌈",
+	rceil: "⌉",
+	lfloor: "⌊",
+	rfloor: "⌋",
+	lvert: "|",
+	rvert: "|",
+	vert: "|",
+	lVert: "‖",
+	rVert: "‖",
+	Vert: "‖",
+};
+
+/** Operator names render as plain words (\log → log). */
+const OPERATOR_NAMES = new Set([
+	"log",
+	"ln",
+	"lg",
+	"exp",
+	"sin",
+	"cos",
+	"tan",
+	"cot",
+	"sec",
+	"csc",
+	"arcsin",
+	"arccos",
+	"arctan",
+	"sinh",
+	"cosh",
+	"tanh",
+	"coth",
+	"min",
+	"max",
+	"argmin",
+	"argmax",
+	"arg",
+	"sup",
+	"inf",
+	"lim",
+	"limsup",
+	"liminf",
+	"det",
+	"dim",
+	"ker",
+	"deg",
+	"gcd",
+	"hom",
+	"Pr",
+	"tr",
+	"Tr",
+	"rank",
+	"diag",
+	"sgn",
+	"softmax",
+	"mod",
+	"bmod",
+]);
+
+/** Single-character escapes (\{ → {) and spacing commands. */
+const ESCAPES: Record<string, string> = {
+	"{": "{",
+	"}": "}",
+	"%": "%",
+	$: "$",
+	"&": "&",
+	"#": "#",
+	_: "_",
+	"|": "‖",
+	"\\": "\n",
+	" ": " ",
+	",": " ",
+	";": " ",
+	":": " ",
+	"!": "",
+};
+
+const SPACING_COMMANDS: Record<string, string> = {
+	quad: "  ",
+	qquad: "    ",
+	thinspace: " ",
+	enspace: " ",
+	medspace: " ",
+	thickspace: " ",
+};
+
+/** Accent commands → combining character appended to each character. */
+const ACCENTS: Record<string, string> = {
+	hat: "̂",
+	widehat: "̂",
+	bar: "̄",
+	overline: "̅",
+	underline: "̲",
+	vec: "⃗",
+	tilde: "̃",
+	widetilde: "̃",
+	dot: "̇",
+	ddot: "̈",
+	breve: "̆",
+	check: "̌",
+	acute: "́",
+	grave: "̀",
+	mathring: "̊",
+};
+
+const SUPERSCRIPTS: Record<string, string> = {
+	"0": "⁰",
+	"1": "¹",
+	"2": "²",
+	"3": "³",
+	"4": "⁴",
+	"5": "⁵",
+	"6": "⁶",
+	"7": "⁷",
+	"8": "⁸",
+	"9": "⁹",
+	"+": "⁺",
+	"-": "⁻",
+	"−": "⁻",
+	"=": "⁼",
+	"(": "⁽",
+	")": "⁾",
+	"*": "*",
+	a: "ᵃ",
+	b: "ᵇ",
+	c: "ᶜ",
+	d: "ᵈ",
+	e: "ᵉ",
+	f: "ᶠ",
+	g: "ᵍ",
+	h: "ʰ",
+	i: "ⁱ",
+	j: "ʲ",
+	k: "ᵏ",
+	l: "ˡ",
+	m: "ᵐ",
+	n: "ⁿ",
+	o: "ᵒ",
+	p: "ᵖ",
+	r: "ʳ",
+	s: "ˢ",
+	t: "ᵗ",
+	u: "ᵘ",
+	v: "ᵛ",
+	w: "ʷ",
+	x: "ˣ",
+	y: "ʸ",
+	z: "ᶻ",
+	A: "ᴬ",
+	B: "ᴮ",
+	D: "ᴰ",
+	E: "ᴱ",
+	G: "ᴳ",
+	H: "ᴴ",
+	I: "ᴵ",
+	J: "ᴶ",
+	K: "ᴷ",
+	L: "ᴸ",
+	M: "ᴹ",
+	N: "ᴺ",
+	O: "ᴼ",
+	P: "ᴾ",
+	R: "ᴿ",
+	T: "ᵀ",
+	U: "ᵁ",
+	V: "ⱽ",
+	W: "ᵂ",
+	β: "ᵝ",
+	γ: "ᵞ",
+	δ: "ᵟ",
+	θ: "ᶿ",
+	ϕ: "ᵠ",
+	φ: "ᵠ",
+	χ: "ᵡ",
+};
+
+const SUBSCRIPTS: Record<string, string> = {
+	"0": "₀",
+	"1": "₁",
+	"2": "₂",
+	"3": "₃",
+	"4": "₄",
+	"5": "₅",
+	"6": "₆",
+	"7": "₇",
+	"8": "₈",
+	"9": "₉",
+	"+": "₊",
+	"-": "₋",
+	"−": "₋",
+	"=": "₌",
+	"(": "₍",
+	")": "₎",
+	a: "ₐ",
+	e: "ₑ",
+	h: "ₕ",
+	i: "ᵢ",
+	j: "ⱼ",
+	k: "ₖ",
+	l: "ₗ",
+	m: "ₘ",
+	n: "ₙ",
+	o: "ₒ",
+	p: "ₚ",
+	r: "ᵣ",
+	s: "ₛ",
+	t: "ₜ",
+	u: "ᵤ",
+	v: "ᵥ",
+	x: "ₓ",
+	β: "ᵦ",
+	γ: "ᵧ",
+	ρ: "ᵨ",
+	ϕ: "ᵩ",
+	φ: "ᵩ",
+	χ: "ᵪ",
+};
+
+const COMMON_FRACTIONS: Record<string, string> = {
+	"1/2": "½",
+	"1/3": "⅓",
+	"2/3": "⅔",
+	"1/4": "¼",
+	"3/4": "¾",
+	"1/5": "⅕",
+	"2/5": "⅖",
+	"3/5": "⅗",
+	"4/5": "⅘",
+	"1/6": "⅙",
+	"5/6": "⅚",
+	"1/8": "⅛",
+};
+
+interface AlphabetStyle {
+	/** Code point of the styled "A" in the Mathematical Alphanumeric block. */
+	upper?: number;
+	/** Code point of the styled "a". */
+	lower?: number;
+	/** Code point of the styled "0". */
+	digit?: number;
+	/** Letters whose styled forms predate the block and live elsewhere in the BMP. */
+	exceptions?: Record<string, string>;
+}
+
+const ALPHABETS: Record<string, AlphabetStyle> = {
+	mathbb: {
+		upper: 0x1d538,
+		lower: 0x1d552,
+		digit: 0x1d7d8,
+		exceptions: { C: "ℂ", H: "ℍ", N: "ℕ", P: "ℙ", Q: "ℚ", R: "ℝ", Z: "ℤ" },
+	},
+	mathbf: { upper: 0x1d400, lower: 0x1d41a, digit: 0x1d7ce },
+	boldsymbol: { upper: 0x1d400, lower: 0x1d41a, digit: 0x1d7ce },
+	bm: { upper: 0x1d400, lower: 0x1d41a, digit: 0x1d7ce },
+	textbf: { upper: 0x1d400, lower: 0x1d41a, digit: 0x1d7ce },
+	mathcal: {
+		upper: 0x1d49c,
+		lower: 0x1d4b6,
+		exceptions: {
+			B: "ℬ",
+			E: "ℰ",
+			F: "ℱ",
+			H: "ℋ",
+			I: "ℐ",
+			L: "ℒ",
+			M: "ℳ",
+			R: "ℛ",
+			e: "ℯ",
+			g: "ℊ",
+			o: "ℴ",
+		},
+	},
+	mathscr: {
+		upper: 0x1d49c,
+		lower: 0x1d4b6,
+		exceptions: {
+			B: "ℬ",
+			E: "ℰ",
+			F: "ℱ",
+			H: "ℋ",
+			I: "ℐ",
+			L: "ℒ",
+			M: "ℳ",
+			R: "ℛ",
+			e: "ℯ",
+			g: "ℊ",
+			o: "ℴ",
+		},
+	},
+	mathfrak: {
+		upper: 0x1d504,
+		lower: 0x1d51e,
+		exceptions: { C: "ℭ", H: "ℌ", I: "ℑ", R: "ℜ", Z: "ℨ" },
+	},
+};
+
+/** Commands whose single group argument renders as plain text. */
+const PLAIN_TEXT_COMMANDS = new Set([
+	"text",
+	"textrm",
+	"textit",
+	"textsf",
+	"texttt",
+	"mbox",
+	"hbox",
+	"mathrm",
+	"mathit",
+	"mathsf",
+	"mathtt",
+	"mathnormal",
+	"operatorname",
+]);
+
+/** Size/style commands that take no argument and render as nothing. */
+const IGNORED_COMMANDS = new Set([
+	"left",
+	"right",
+	"big",
+	"Big",
+	"bigg",
+	"Bigg",
+	"bigl",
+	"bigr",
+	"bigm",
+	"Bigl",
+	"Bigr",
+	"Bigm",
+	"biggl",
+	"biggr",
+	"Biggl",
+	"Biggr",
+	"displaystyle",
+	"textstyle",
+	"scriptstyle",
+	"limits",
+	"nolimits",
+	"middle",
+	"allowbreak",
+	"nonumber",
+	"notag",
+]);
+
+function styleAlphabet(text: string, style: AlphabetStyle): string {
+	let result = "";
+	for (const ch of text) {
+		const exception = style.exceptions?.[ch];
+		if (exception) {
+			result += exception;
+		} else if (ch >= "A" && ch <= "Z" && style.upper !== undefined) {
+			result += String.fromCodePoint(style.upper + ch.charCodeAt(0) - 0x41);
+		} else if (ch >= "a" && ch <= "z" && style.lower !== undefined) {
+			result += String.fromCodePoint(style.lower + ch.charCodeAt(0) - 0x61);
+		} else if (ch >= "0" && ch <= "9" && style.digit !== undefined) {
+			result += String.fromCodePoint(style.digit + ch.charCodeAt(0) - 0x30);
+		} else {
+			result += ch;
+		}
+	}
+	return result;
+}
+
+/** Map every character through a sub/superscript table, or return undefined if any character is missing. */
+function mapScript(text: string, table: Record<string, string>): string | undefined {
+	let result = "";
+	for (const ch of text) {
+		const mapped = table[ch];
+		if (mapped === undefined) {
+			return undefined;
+		}
+		result += mapped;
+	}
+	return result;
+}
+
+/** True when a fraction/sqrt operand reads unambiguously without parentheses. */
+function isSimpleOperand(text: string): boolean {
+	return [...text].length === 1 || /^[\p{L}\p{N}]+$/u.test(text);
+}
+
+function parenthesize(text: string): string {
+	return isSimpleOperand(text) ? text : `(${text})`;
+}
+
+class LatexParser {
+	private readonly src: string;
+	private pos = 0;
+
+	constructor(src: string) {
+		this.src = src;
+	}
+
+	parse(): string {
+		return this.parseSequence();
+	}
+
+	/** Render atoms (with attached scripts) until a closing brace or end of input. */
+	private parseSequence(): string {
+		let result = "";
+		while (this.pos < this.src.length) {
+			const ch = this.src[this.pos];
+			if (ch === "}") {
+				break;
+			}
+			if (ch === "^" || ch === "_") {
+				this.pos++;
+				result += this.parseScript(ch === "^" ? SUPERSCRIPTS : SUBSCRIPTS, ch);
+				continue;
+			}
+			if (ch === "&") {
+				// Alignment marker (aligned/cases/matrix environments): becomes a
+				// separating space unless one is already there.
+				this.pos++;
+				if (!/\s$/.test(result)) {
+					result += " ";
+				}
+				continue;
+			}
+			result += this.parseAtom() ?? "";
+		}
+		return result;
+	}
+
+	/** Render the next atom: a group, a command, or a single character. */
+	private parseAtom(): string | undefined {
+		if (this.pos >= this.src.length) {
+			return undefined;
+		}
+		const ch = this.src[this.pos];
+		if (ch === "{") {
+			return this.parseGroup();
+		}
+		if (ch === "\\") {
+			return this.parseCommand();
+		}
+		this.pos++;
+		return ch;
+	}
+
+	/** Consume "{...}" and render its contents. Assumes "{" at the current position. */
+	private parseGroup(): string {
+		this.pos++; // consume "{"
+		const content = this.parseSequence();
+		if (this.src[this.pos] === "}") {
+			this.pos++;
+		}
+		return content;
+	}
+
+	/** Consume "[...]" and render its contents, or return undefined when absent. */
+	private parseOptionalBracket(): string | undefined {
+		if (this.src[this.pos] !== "[") {
+			return undefined;
+		}
+		const end = this.src.indexOf("]", this.pos + 1);
+		if (end === -1) {
+			return undefined;
+		}
+		const content = new LatexParser(this.src.slice(this.pos + 1, end)).parse();
+		this.pos = end + 1;
+		return content;
+	}
+
+	/** Render the next required argument: a braced group, or a single atom (TeX allows \frac12). */
+	private parseArgument(): string {
+		while (this.pos < this.src.length && /\s/.test(this.src[this.pos])) {
+			this.pos++;
+		}
+		if (this.src[this.pos] === "{") {
+			return this.parseGroup();
+		}
+		return this.parseAtom() ?? "";
+	}
+
+	/** Render a ^ or _ script. The operator character itself is already consumed. */
+	private parseScript(table: Record<string, string>, operator: string): string {
+		const content = this.parseArgument();
+		const mapped = mapScript(content, table);
+		if (mapped !== undefined) {
+			return mapped;
+		}
+		// Not all characters have sub/superscript forms; keep TeX notation, which
+		// stays lossless and readable (x_θ, x_{best}).
+		return [...content].length === 1 ? `${operator}${content}` : `${operator}{${content}}`;
+	}
+
+	/** Render a command. Assumes "\" at the current position. */
+	private parseCommand(): string {
+		this.pos++; // consume "\"
+		if (this.pos >= this.src.length) {
+			return "";
+		}
+
+		const ch = this.src[this.pos];
+		if (!/[a-zA-Z]/.test(ch)) {
+			this.pos++;
+			return ESCAPES[ch] ?? ch;
+		}
+
+		let name = "";
+		while (this.pos < this.src.length && /[a-zA-Z]/.test(this.src[this.pos])) {
+			name += this.src[this.pos];
+			this.pos++;
+		}
+		if (this.src[this.pos] === "*") {
+			this.pos++; // operatorname*, section* etc.
+		}
+
+		const symbol = SYMBOLS[name];
+		if (symbol !== undefined) {
+			return symbol;
+		}
+		if (OPERATOR_NAMES.has(name)) {
+			return name;
+		}
+		const spacing = SPACING_COMMANDS[name];
+		if (spacing !== undefined) {
+			return spacing;
+		}
+		if (IGNORED_COMMANDS.has(name)) {
+			if (name === "left" || name === "right") {
+				return this.parseDelimiter();
+			}
+			return "";
+		}
+		if (PLAIN_TEXT_COMMANDS.has(name)) {
+			return this.parseArgument();
+		}
+		const alphabet = ALPHABETS[name];
+		if (alphabet !== undefined) {
+			return styleAlphabet(this.parseArgument(), alphabet);
+		}
+		const accent = ACCENTS[name];
+		if (accent !== undefined) {
+			const content = this.parseArgument();
+			return [...content].map((c) => (/\s/.test(c) ? c : c + accent)).join("");
+		}
+		switch (name) {
+			case "frac":
+			case "dfrac":
+			case "tfrac":
+			case "cfrac": {
+				const numerator = this.parseArgument();
+				const denominator = this.parseArgument();
+				const common = COMMON_FRACTIONS[`${numerator}/${denominator}`];
+				if (common !== undefined) {
+					return common;
+				}
+				return `${parenthesize(numerator)}/${parenthesize(denominator)}`;
+			}
+			case "binom": {
+				const top = this.parseArgument();
+				const bottom = this.parseArgument();
+				return `C(${top},${bottom})`;
+			}
+			case "sqrt": {
+				const index = this.parseOptionalBracket();
+				const radicand = this.parseArgument();
+				const operand = isSimpleOperand(radicand) ? radicand : `(${radicand})`;
+				if (index === undefined) {
+					return `√${operand}`;
+				}
+				if (index === "3") {
+					return `∛${operand}`;
+				}
+				if (index === "4") {
+					return `∜${operand}`;
+				}
+				return `${mapScript(index, SUPERSCRIPTS) ?? `^${index}`}√${operand}`;
+			}
+			case "not": {
+				const negated = this.parseAtom() ?? "";
+				return `${negated}̸`;
+			}
+			case "begin":
+			case "end": {
+				this.parseArgument(); // environment name
+				return "";
+			}
+			case "stackrel":
+			case "overset": {
+				const above = this.parseArgument();
+				const base = this.parseArgument();
+				const mapped = mapScript(above, SUPERSCRIPTS);
+				return mapped !== undefined ? base + mapped : `${base}^{${above}}`;
+			}
+			case "underset": {
+				const below = this.parseArgument();
+				const base = this.parseArgument();
+				const mapped = mapScript(below, SUBSCRIPTS);
+				return mapped !== undefined ? base + mapped : `${base}_{${below}}`;
+			}
+			default:
+				// Unknown command: drop the backslash, keep the name.
+				return name;
+		}
+	}
+
+	/** Render the delimiter following \left or \right ("." means invisible). */
+	private parseDelimiter(): string {
+		while (this.pos < this.src.length && /\s/.test(this.src[this.pos])) {
+			this.pos++;
+		}
+		const ch = this.src[this.pos];
+		if (ch === undefined) {
+			return "";
+		}
+		if (ch === ".") {
+			this.pos++;
+			return "";
+		}
+		if (ch === "\\") {
+			return this.parseCommand();
+		}
+		this.pos++;
+		return ch;
+	}
+}
+
+/**
+ * Convert LaTeX math source to Unicode plain text.
+ *
+ * Newlines in the source are preserved and "\\" becomes a newline, so
+ * multi-line display math (aligned environments) renders on multiple lines.
+ * Runs of spaces collapse to one — TeX treats source whitespace as
+ * insignificant, and spacing commands otherwise leave double gaps.
+ */
+export function latexToUnicode(tex: string): string {
+	return new LatexParser(tex)
+		.parse()
+		.replace(/[^\S\n]{2,}/g, " ")
+		.replace(/\n\s*\n/g, "\n");
+}

--- a/packages/tui/src/latex.ts
+++ b/packages/tui/src/latex.ts
@@ -623,8 +623,7 @@ class LatexParser {
 				continue;
 			}
 			if (ch === "&") {
-				// Alignment marker (aligned/cases/matrix environments): becomes a
-				// separating space unless one is already there.
+				// Alignment marker: becomes a separating space unless one is there.
 				this.pos++;
 				if (!/\s$/.test(result)) {
 					result += " ";
@@ -694,8 +693,7 @@ class LatexParser {
 		if (mapped !== undefined) {
 			return mapped;
 		}
-		// Not all characters have sub/superscript forms; keep TeX notation, which
-		// stays lossless and readable (x_θ, x_{best}).
+		// No Unicode form for every character: keep lossless TeX notation (x_θ).
 		return [...content].length === 1 ? `${operator}${content}` : `${operator}{${content}}`;
 	}
 

--- a/packages/tui/test/markdown-latex.test.ts
+++ b/packages/tui/test/markdown-latex.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Markdown } from "../src/components/markdown.js";
+import { latexToUnicode } from "../src/latex.js";
+import { defaultMarkdownTheme } from "./test-themes.js";
+
+function stripAnsi(line: string): string {
+	return line.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderPlain(text: string, width = 80): string[] {
+	const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
+	return markdown.render(width).map(stripAnsi);
+}
+
+describe("latexToUnicode", () => {
+	it("converts symbols, big operators, and scripts", () => {
+		assert.strictEqual(latexToUnicode("y_t = \\sum_{k=0}^{W-1} w_k \\odot x_{t-k}"), "yₜ = ∑ₖ₌₀ᵂ⁻¹ wₖ ⊙ xₜ₋ₖ");
+	});
+
+	it("converts greek letters and relations", () => {
+		assert.strictEqual(latexToUnicode("\\alpha \\leq \\beta \\implies \\gamma \\to \\infty"), "α ≤ β ⇒ γ → ∞");
+	});
+
+	it("renders operator names as plain words", () => {
+		assert.strictEqual(latexToUnicode("O(n \\log n)"), "O(n log n)");
+		assert.strictEqual(latexToUnicode("\\max_i f(x_i)"), "maxᵢ f(xᵢ)");
+	});
+
+	it("renders fractions linearly with parentheses only when needed", () => {
+		assert.strictEqual(latexToUnicode("\\frac{a}{b}"), "a/b");
+		assert.strictEqual(latexToUnicode("\\frac{x+1}{2}"), "(x+1)/2");
+		assert.strictEqual(latexToUnicode("\\frac{1}{2} m v^2"), "½ m v²");
+	});
+
+	it("renders square roots", () => {
+		assert.strictEqual(latexToUnicode("\\sqrt{x}"), "√x");
+		assert.strictEqual(latexToUnicode("\\sqrt{x^2+1}"), "√(x²+1)");
+		assert.strictEqual(latexToUnicode("\\sqrt[3]{8}"), "∛8");
+	});
+
+	it("unwraps text commands and styles alphabets", () => {
+		assert.strictEqual(latexToUnicode("\\text{softmax}(QK^T / \\sqrt{d_k})"), "softmax(QKᵀ / √dₖ)");
+		assert.strictEqual(latexToUnicode("\\mathbb{R}^d"), "ℝᵈ");
+		assert.strictEqual(latexToUnicode("\\mathcal{L}"), "ℒ");
+		assert.strictEqual(latexToUnicode("\\mathbf{W} x"), "𝐖 x");
+	});
+
+	it("applies accents as combining characters", () => {
+		assert.strictEqual(latexToUnicode("\\hat{y}"), "ŷ");
+		assert.strictEqual(latexToUnicode("\\vec{x}"), "x⃗");
+	});
+
+	it("keeps TeX notation for scripts without Unicode forms", () => {
+		assert.strictEqual(latexToUnicode("\\nabla_\\theta J(\\theta)"), "∇_θ J(θ)");
+		assert.strictEqual(latexToUnicode("x_{best}"), "x_{best}");
+	});
+
+	it("drops sizing commands and keeps delimiters", () => {
+		assert.strictEqual(latexToUnicode("\\left( \\frac{1}{N} \\sum_{i=1}^N x_i \\right)"), "( 1/N ∑ᵢ₌₁ᴺ xᵢ )");
+	});
+
+	it("turns aligned environments into multiple lines", () => {
+		assert.strictEqual(
+			latexToUnicode("\\begin{aligned} a &= b + c \\\\ d &= e \\end{aligned}").trim(),
+			"a = b + c \n d = e",
+		);
+	});
+
+	it("degrades unknown commands to their name", () => {
+		assert.strictEqual(latexToUnicode("\\foobar x"), "foobar x");
+	});
+
+	it("handles escaped braces", () => {
+		assert.strictEqual(latexToUnicode("x \\in \\{1, \\dots, K\\}"), "x ∈ {1, …, K}");
+	});
+
+	it("collapses insignificant whitespace from spacing commands", () => {
+		assert.strictEqual(latexToUnicode("\\int_0^1 x^2 \\, dx = \\frac{1}{3}"), "∫₀¹ x² dx = ⅓");
+	});
+
+	it("renders matrix environments as rows", () => {
+		assert.strictEqual(latexToUnicode("\\begin{pmatrix}\n1 & 2 \\\\\n3 & 4\n\\end{pmatrix}").trim(), "1 2 \n3 4");
+	});
+});
+
+describe("Markdown math rendering", () => {
+	it("renders \\[ ... \\] display math as a Unicode block", () => {
+		const lines = renderPlain("Intro:\n\n\\[\ny_t = \\sum_{k=0}^{W-1} w_k \\odot x_{t-k}\n\\]\n\nAfter.");
+		assert.ok(lines.some((line) => line.includes("yₜ = ∑ₖ₌₀ᵂ⁻¹ wₖ ⊙ xₜ₋ₖ")));
+		assert.ok(!lines.some((line) => line.includes("\\sum")));
+		assert.ok(lines.some((line) => line.includes("After.")));
+	});
+
+	it("renders $$ ... $$ display math as a Unicode block", () => {
+		const lines = renderPlain("$$\nE = mc^2\n$$");
+		assert.ok(lines.some((line) => line.includes("E = mc²")));
+	});
+
+	it("renders inline \\( ... \\) math", () => {
+		const lines = renderPlain("where the weights \\(w_k\\) are shared");
+		assert.ok(lines.some((line) => line.includes("where the weights wₖ are shared")));
+	});
+
+	it("renders inline $ ... $ math", () => {
+		const lines = renderPlain("the value $x_i \\cdot y$ grows");
+		assert.ok(lines.some((line) => line.includes("the value xᵢ · y grows")));
+	});
+
+	it("keeps underscores inside math out of emphasis", () => {
+		// Without math support, marked would turn _k ... x_ into an em token.
+		const lines = renderPlain("\\[ a_k = b_k + x_k \\]");
+		assert.ok(lines.some((line) => line.includes("aₖ = bₖ + xₖ")));
+	});
+
+	it("does not treat dollar amounts as math", () => {
+		const lines = renderPlain("between $5 and $10 total");
+		assert.ok(lines.some((line) => line.includes("between $5 and $10 total")));
+	});
+
+	it("does not match a closing dollar followed by a digit", () => {
+		const lines = renderPlain("prices $5,$10 listed");
+		assert.ok(lines.some((line) => line.includes("prices $5,$10 listed")));
+	});
+
+	it("leaves unterminated display math as plain text while streaming", () => {
+		const lines = renderPlain("$$\ny_t = \\sum");
+		assert.ok(lines.some((line) => line.includes("$$")));
+	});
+
+	it("renders math inside list items", () => {
+		const lines = renderPlain("- gradient \\(\\nabla_\\theta J\\) step");
+		assert.ok(lines.some((line) => line.includes("- gradient ∇_θ J step")));
+	});
+
+	it("renders display math blocks inside list items", () => {
+		const lines = renderPlain(
+			"1. The sum:\n\n   \\[\n   \\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}\n   \\]\n\n2. Next item",
+		);
+		assert.ok(lines.some((line) => line.includes("∑ₖ₌₁ⁿ k = (n(n+1))/2")));
+		assert.ok(!lines.some((line) => line.includes("\\sum")));
+		assert.ok(lines.some((line) => line.includes("2. Next item")));
+	});
+
+	it("renders $$ display math inside list items", () => {
+		const lines = renderPlain("- item:\n\n  $$\n  E = mc^2\n  $$");
+		assert.ok(lines.some((line) => line.includes("E = mc²")));
+	});
+
+	it("renders display math indented four spaces instead of treating it as code", () => {
+		// Models often indent display math; 4-space indents would otherwise lex
+		// as an indented code block and show raw TeX verbatim.
+		const lines = renderPlain("Math:\n\n    \\[\n    E = mc^2\n    \\]\n\n    $$\n    a^2 + b^2 = c^2\n    $$");
+		assert.ok(lines.some((line) => line.includes("E = mc²")));
+		assert.ok(lines.some((line) => line.includes("a² + b² = c²")));
+		assert.ok(!lines.some((line) => line.includes("\\[")));
+	});
+
+	it("still lexes indented code that is not math as a code block", () => {
+		const lines = renderPlain("Code:\n\n    const x = 1;\n    return x;");
+		assert.ok(lines.some((line) => line.includes("const x = 1;")));
+	});
+
+	it("leaves LaTeX inside fenced code blocks untouched", () => {
+		const lines = renderPlain("```latex\n\\[\nE = mc^2\n\\]\n```");
+		assert.ok(lines.some((line) => line.includes("\\[")));
+		assert.ok(lines.some((line) => line.includes("E = mc^2")));
+		assert.ok(!lines.some((line) => line.includes("E = mc²")));
+	});
+
+	it("leaves math delimiters inside inline code spans untouched", () => {
+		const lines = renderPlain("run `echo $PATH$HOME` and `$x_i$` now");
+		assert.ok(lines.some((line) => line.includes("echo $PATH$HOME")));
+		assert.ok(lines.some((line) => line.includes("$x_i$")));
+	});
+
+	it("joins multi-line inline math with spaces", () => {
+		const lines = renderPlain("a \\(x +\ny\\) b");
+		assert.ok(lines.some((line) => line.includes("a x + y b")));
+	});
+
+	it("falls back to code/codeBlock theme styles", () => {
+		const markdown = new Markdown("$$x + y$$", 0, 0, defaultMarkdownTheme);
+		const lines = markdown.render(80);
+		// defaultMarkdownTheme has no math entries; block math falls back to
+		// codeBlock (green in the test theme).
+		const mathLine = lines.find((line) => stripAnsi(line).includes("x + y"));
+		assert.ok(mathLine);
+		assert.ok(mathLine.includes("\x1b[32m"));
+	});
+
+	it("produces identical output for streamed and fresh renders", () => {
+		const part1 = "Some intro text.\n\n$$\ny_t = \\sum_{k=0}^{W-1} w_k\n$$\n\n";
+		const part2 = "And inline \\(x_i\\) afterwards.";
+		const streamed = new Markdown(part1, 0, 0, defaultMarkdownTheme);
+		streamed.render(80);
+		streamed.setText(part1 + part2);
+		const streamedLines = streamed.render(80);
+		const freshLines = new Markdown(part1 + part2, 0, 0, defaultMarkdownTheme).render(80);
+		assert.deepStrictEqual(streamedLines, freshLines);
+	});
+});

--- a/packages/tui/test/markdown-latex.test.ts
+++ b/packages/tui/test/markdown-latex.test.ts
@@ -82,6 +82,17 @@ describe("latexToUnicode", () => {
 	it("renders matrix environments as rows", () => {
 		assert.strictEqual(latexToUnicode("\\begin{pmatrix}\n1 & 2 \\\\\n3 & 4\n\\end{pmatrix}").trim(), "1 2 \n3 4");
 	});
+
+	it("treats accented characters as simple fraction operands", () => {
+		assert.strictEqual(latexToUnicode("\\frac{\\hat{x}}{2}"), "x̂/2");
+	});
+
+	it("keeps underscores literal inside text-mode commands", () => {
+		assert.strictEqual(latexToUnicode("\\text{x_i}"), "x_i");
+		assert.strictEqual(latexToUnicode("\\text{learning_rate} = 0.1"), "learning_rate = 0.1");
+		// Math-mode font commands still apply scripts, as TeX does.
+		assert.strictEqual(latexToUnicode("\\mathrm{x_i}"), "xᵢ");
+	});
 });
 
 describe("Markdown math rendering", () => {
@@ -94,6 +105,12 @@ describe("Markdown math rendering", () => {
 
 	it("renders $$ ... $$ display math as a Unicode block", () => {
 		const lines = renderPlain("$$\nE = mc^2\n$$");
+		assert.ok(lines.some((line) => line.includes("E = mc²")));
+	});
+
+	it("renders display math with CRLF line endings", () => {
+		// marked normalizes \r\n before tokenizers run; pin that assumption.
+		const lines = renderPlain("\\[\r\nE = mc^2\r\n\\]\r\n");
 		assert.ok(lines.some((line) => line.includes("E = mc²")));
 	});
 


### PR DESCRIPTION
- math in assistant responses showed as raw tex with underscores mangled into italics, making papers hard to read.
- display and inline math ($$, \[..\], \(..\), $..$) now convert to unicode at render time, including indented math and math inside list items, with currency and code blocks left alone.
- math-free text keeps the exact lexing fast path so streaming render cost is unchanged for the common case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only markdown/TUI rendering with broad test coverage; conversion is intentionally lossy but does not affect security or persisted data.
> 
> **Overview**
> **TUI markdown** now recognizes LaTeX math delimiters (`$$`, `\[...\]`, `\(...\)`, `$...$`) and renders them as **Unicode plain text** instead of raw TeX, so underscores and backslashes are no longer parsed as markdown emphasis.
> 
> A new **`latexToUnicode`** helper converts common math (symbols, fractions, scripts, matrices, etc.) for monospace terminals; unknown commands degrade gracefully. The **`marked`** lexer gains `blockMath` / `inlineMath` extensions (including indented display math and list items), with a **math-free fast path** when the text has no `$`, `\(`, or `\[`. **Currency** (`$5`) and **fenced/inline code** stay untouched; incomplete delimiters stay plain text while streaming.
> 
> The coding-agent **markdown theme** adds optional **`math`** / **`mathBlock`** styling (defaulting to code colors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163dbb495b25c35da7f8477a17efe586a6257219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render LaTeX math as Unicode in the TUI markdown component
> - Adds a new [`latexToUnicode`](https://github.com/PrimeIntellect-ai/prime-agent/pull/125/files#diff-84a5015399f280fe21f4d155eca307b0627598f062655c25151575de4eff1847) converter that maps a wide subset of LaTeX math constructs (symbols, scripts, fractions, roots, accents, environments) to Unicode plain text suitable for terminal display.
> - Adds `blockMathExtension` and `inlineMathExtension` marked tokenizer extensions in [`markdown.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/125/files#diff-fb3e9420feec95597c74a1977e938d99f40ca5bc9757095a0a048ab3486018be) that recognize `$$...$$`, `\[...\]`, and `$...$` delimiters, preventing misinterpretation as emphasis or code blocks.
> - The markdown renderer selects a math-enabled parser only when the input contains likely math delimiters, keeping overhead low for non-math content.
> - Extends `MarkdownTheme` with optional `math` and `mathBlock` style hooks, falling back to `code` and `codeBlock` respectively.
> - Behavioral Change: underscores inside math expressions no longer produce emphasis, and display math with common leading indentation is no longer classified as a code block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 163dbb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
