### PR TITLE
add 7-day minimum release age for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependency update PRs wait out the same 7-day cooldown that .npmrc's
+# min-release-age enforces locally. Security-advisory PRs are exempt
+# from cooldown by design, so CVE fixes still arrive promptly.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: uv
+    directory: /prime-agent-runtime
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Supply-chain cooldown: never resolve to package versions published
+# less than 7 days ago. Only affects version resolution (install/update of new
+# versions); already-locked versions and `npm ci` are unaffected.
+# Requires npm >= 11.10 to be enforced; older npm ignores this key.
+# Urgent security patch override: npm install --min-release-age=0 <pkg>
+min-release-age=7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@
 - Put issue-specific regressions under `packages/coding-agent/test/suite/regressions/` and name them `<issue-number>-<short-slug>.test.ts`.
 - NEVER commit unless user asks
 
+## Dependencies
+
+- A 7-day minimum release age applies to all dependency updates: `.npmrc` sets `min-release-age=7` and `.github/dependabot.yml` uses a matching `cooldown`. Never bypass it for routine updates.
+- Enforcement requires npm >= 11.10; older npm silently ignores the setting, so use a current npm when updating dependencies.
+- For an urgent security patch younger than 7 days, override explicitly: `npm install --min-release-age=0 <pkg>`.
+
 ## GitHub Workflow
 
 When creating issues:


### PR DESCRIPTION
- new dependency versions younger than 7 days are now refused at resolution time, closing the window where compromised fresh releases get adopted before detection.
- dependabot now waits the same 7-day cooldown before proposing version updates, while security-advisory prs remain exempt and arrive immediately.
- existing lockfile installs and ci are unaffected; an explicit per-install override exists for urgent patches and is documented in the agent rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy and tooling only; no runtime app logic. Main caveat is developers on npm &lt; 11.10 won't get local enforcement until they upgrade.
> 
> **Overview**
> Introduces a **7-day supply-chain cooldown** so newly published dependency versions are not adopted immediately.
> 
> **npm:** Adds `.npmrc` with `min-release-age=7`, blocking resolution to versions published in the last 7 days during install/update (npm ≥ 11.10; locked/`npm ci` unchanged). Urgent patches can use `npm install --min-release-age=0 <pkg>`.
> 
> **Automation:** Adds `.github/dependabot.yml` with weekly updates for npm (repo root, max 5 open PRs), uv (`prime-agent-runtime`), and GitHub Actions, each with a matching 7-day cooldown; security-advisory PRs stay exempt.
> 
> **Docs:** New **Dependencies** section in `AGENTS.md` states the policy and override for agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0cc42057ea2a988164c60ef4c14e74206d00833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 7-day minimum release age for dependency updates
> - Adds `min-release-age=7` to [.npmrc](https://github.com/PrimeIntellect-ai/prime-agent/pull/126/files#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35de) so npm skips package versions published within the last 7 days during resolution; `npm ci` and already-locked versions are unaffected. Requires npm >= 11.10 for enforcement.
> - Configures Dependabot in [dependabot.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/126/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) with a matching 7-day cooldown for npm, uv, and GitHub Actions updates, with weekly schedules and a 5 open PR limit for npm.
> - Documents the policy and override instructions (`npm install --min-release-age=0 <pkg>`) in [AGENTS.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/126/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0cc420.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->