### PR TITLE
fix confusing thinking and tool block formatting in the transcript

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Fixed confusing transcript formatting around thinking blocks and tool calls: ipython cells and default-shell tools (bash and extension tools) now share one panel style with a subtle neutral background instead of a status-colored box or a left rail, and tool status headers name the tool (`python · done · 7ms`, `bash · running`) so they no longer read as floating labels for the preceding thinking block. Themes gain a required `toolPanelBg` color for the panel background.
 - Fixed `prime-agent` to detect a daemon left running by a previous version after self-update: the daemon now reports its app version on connect, and idle stale daemons are restarted automatically (daemons with active sessions are left running with a warning).
 - Fixed Agents View listing daemon-owned subagents as top-level selectable agents instead of nested child rows.
 - Fixed Agents View opening saved or stale sessions by creating a daemon runtime from the saved session file before attaching.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1970,9 +1970,9 @@ export default function (pi: ExtensionAPI) {
 
 Tools can provide `renderCall` and `renderResult` for custom TUI display. See [tui.md](tui.md) for the full component API and [tool-execution.ts](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/modes/interactive/components/tool-execution.ts) for how tool rows are composed.
 
-By default, tool output is wrapped in a `Box` that handles padding and background. A defined `renderCall` or `renderResult` must return a `Component`. If a slot renderer is not defined, `tool-execution.ts` uses fallback rendering for that slot.
+By default, tool output is wrapped in a tool panel: a `label · status` header line (e.g. `my_tool · running`) followed by the slot components, every line indented and drawn on the `toolPanelBg` background so the block reads as one unit. A defined `renderCall` or `renderResult` must return a `Component`. If a slot renderer is not defined, `tool-execution.ts` uses fallback rendering for that slot.
 
-Set `renderShell: "self"` when the tool should render its own shell instead of using the default `Box`. This is useful for tools that need complete control over framing or background behavior, for example large previews that must stay visually stable after the tool settles.
+Set `renderShell: "self"` when the tool should render its own shell instead of the default tool panel. This is useful for tools that need complete control over framing or background behavior, for example large previews that must stay visually stable after the tool settles.
 
 ```typescript
 pi.registerTool({
@@ -2083,12 +2083,12 @@ Custom editors and `ctx.ui.custom()` components receive `keybindings: Keybinding
 - Read `context.args` in `renderResult` instead of copying args into `context.state`.
 - Use `context.state` only for data that must be shared across call and result slots.
 - Reuse `context.lastComponent` when the same component instance can be updated in place.
-- Use `renderShell: "self"` only when the default boxed shell gets in the way. In self-shell mode the tool is responsible for its own framing, padding, and background.
+- Use `renderShell: "self"` only when the default tool panel shell gets in the way. In self-shell mode the tool is responsible for its own framing, padding, and background.
 
 #### Fallback
 
 If a slot renderer is not defined or throws:
-- `renderCall`: Shows the tool name
+- `renderCall`: The panel header already names the tool; self-shell tools show the bold tool name
 - `renderResult`: Shows raw text from `content`
 
 ## Custom UI

--- a/packages/coding-agent/docs/themes.md
+++ b/packages/coding-agent/docs/themes.md
@@ -79,6 +79,7 @@ vim ~/.pi/agent/themes/my-theme.json
     "toolPendingBg": "#1e1e2e",
     "toolSuccessBg": "#1e2e1e",
     "toolErrorBg": "#2e1e1e",
+    "toolPanelBg": "#2d2d38",
     "toolTitle": "primary",
     "toolOutput": "",
     "mdHeading": "#ffaa00",
@@ -163,7 +164,7 @@ Every theme must define all 51 color tokens. There are no optional colors.
 | `text` | Default text (usually `""`) |
 | `thinkingText` | Thinking block text |
 
-### Backgrounds & Content (11 colors)
+### Backgrounds & Content (12 colors)
 
 | Token | Purpose |
 |-------|---------|
@@ -176,6 +177,7 @@ Every theme must define all 51 color tokens. There are no optional colors.
 | `toolPendingBg` | Tool box (pending) |
 | `toolSuccessBg` | Tool box (success) |
 | `toolErrorBg` | Tool box (error) |
+| `toolPanelBg` | Tool panel background |
 | `toolTitle` | Tool title |
 | `toolOutput` | Tool output text |
 

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -420,7 +420,7 @@ renderResult(result, options, theme, context) {
 
 **Background colors** (`theme.bg(color, text)`):
 
-`selectedBg`, `userMessageBg`, `customMessageBg`, `toolPendingBg`, `toolSuccessBg`, `toolErrorBg`
+`selectedBg`, `userMessageBg`, `customMessageBg`, `toolPendingBg`, `toolSuccessBg`, `toolErrorBg`, `toolPanelBg`
 
 **For Markdown**, use `getMarkdownTheme()`:
 

--- a/packages/coding-agent/examples/extensions/dynamic-resources/dynamic.json
+++ b/packages/coding-agent/examples/extensions/dynamic-resources/dynamic.json
@@ -39,6 +39,7 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolPanelBg": "#262630",
 		"toolTitle": "",
 		"toolOutput": "gray",
 		"mdHeading": "#f0c674",

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -48,6 +48,7 @@ export {
 export { ThemeSelectorComponent } from "./theme-selector.js";
 export { ThinkingSelectorComponent } from "./thinking-selector.js";
 export { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";
+export { TOOL_PANEL_PADDING_X, ToolPanel, toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 export { TreeSelectorComponent } from "./tree-selector.js";
 export { UserMessageComponent } from "./user-message.js";
 export { UserMessageSelectorComponent } from "./user-message-selector.js";

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -1,13 +1,8 @@
-import {
-	type Component,
-	truncateToWidth,
-	VersionedRenderCache,
-	visibleWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import { type Component, VersionedRenderCache, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
 import { keyHint } from "./keybinding-hints.js";
+import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
 export interface IPythonCellContentBlock {
 	type: string;
@@ -162,7 +157,6 @@ function formatIpythonErrorSummary(error: IpythonErrorDetails): string {
 }
 
 export class IPythonCellComponent implements Component {
-	private readonly paddingX = 2;
 	private readonly renderCache = new VersionedRenderCache();
 	private state: IPythonCellState;
 	private stateVersion = 0;
@@ -198,16 +192,19 @@ export class IPythonCellComponent implements Component {
 			return `${theme.fg("muted", label)} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
 		};
 
-		lines.push(this.panelLine(this.header(details), safeWidth));
+		lines.push(toolPanelLine(this.header(details), safeWidth));
 		const hasCode = this.renderCode(lines, safeWidth, withExpandHint);
 		this.renderOutput(lines, safeWidth, details, hasCode, withExpandHint);
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
 
 	private header(details: IpythonDetails): string {
+		// Name the cell so the status reads as part of this tool call instead of
+		// a floating label between the surrounding blocks.
+		const isBashCell = CELL_MAGIC_PATTERN.test(this.state.code.split("\n")[0] ?? "");
 		const status = this.status(details);
 		const duration = formatDuration(details.durationMs);
-		const parts = [status.label];
+		const parts = [theme.fg("muted", isBashCell ? "bash" : "python"), status.label];
 		if (duration) {
 			parts.push(theme.fg("muted", duration));
 		}
@@ -410,24 +407,15 @@ export class IPythonCellComponent implements Component {
 	}
 
 	private addWrapped(lines: string[], prefix: string, text: string, width: number): void {
-		const contentWidth = Math.max(1, width - this.paddingX * 2);
-		const available = Math.max(1, contentWidth - visibleWidth(prefix));
+		const available = Math.max(1, toolPanelContentWidth(width) - visibleWidth(prefix));
 		const wrapped = wrapTextWithAnsi(text, available);
 		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
 			const linePrefix = index === 0 ? prefix : " ".repeat(visibleWidth(prefix));
-			lines.push(this.panelLine(linePrefix + line, width));
+			lines.push(toolPanelLine(linePrefix + line, width));
 		}
 	}
 
 	private addBlank(lines: string[], width: number): void {
-		lines.push(this.panelLine("", width));
-	}
-
-	private panelLine(line: string, width: number): string {
-		const contentWidth = Math.max(1, width - this.paddingX * 2);
-		const truncated = truncateToWidth(line, contentWidth, "");
-		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
-		const rail = theme.bg("customMessageBg", " ");
-		return `${rail}${" ".repeat(this.paddingX - 1)}${paddedContent}${" ".repeat(this.paddingX)}`;
+		lines.push(toolPanelLine("", width));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { Box, type Component, Container, getCapabilities, Image, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import { type Component, Container, getCapabilities, Image, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDefinition, ToolRenderContext, ToolRenderResultOptions } from "../../../core/extensions/types.js";
 import { createAllToolDefinitions, type ToolName } from "../../../core/tools/index.js";
 import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/render-utils.js";
@@ -7,6 +7,7 @@ import { convertToPng } from "../../../utils/image-convert.js";
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
 import { type Theme, theme } from "../theme/theme.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
+import { ToolPanel } from "./tool-panel.js";
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
@@ -26,8 +27,7 @@ export interface ToolExecutionRendererDefinition {
 export type ToolExecutionDefinition = AgentConnectionToolDefinition & Partial<ToolExecutionRendererDefinition>;
 
 export class ToolExecutionComponent extends Container {
-	private contentBox: Box;
-	private contentText: Text;
+	private contentPanel: ToolPanel;
 	private selfRenderContainer: Container;
 	private callRendererComponent?: Component;
 	private resultRendererComponent?: Component;
@@ -78,17 +78,17 @@ export class ToolExecutionComponent extends Container {
 
 		this.addChild(new Spacer(1));
 
-		// Always create all shell variants. contentBox is used for default renderer-based composition.
-		// selfRenderContainer is used when the tool renders its own framing.
-		// contentText is reserved for generic fallback rendering when no tool definition exists.
-		this.contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
-		this.contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		// Always create both shell variants. contentPanel is the tool panel used
+		// for default renderer-based composition (and the generic fallback when no
+		// tool definition exists). selfRenderContainer is used when the tool
+		// renders its own framing.
+		this.contentPanel = new ToolPanel();
 		this.selfRenderContainer = new Container();
 
-		if (this.hasRendererDefinition()) {
-			this.addChild(this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox);
+		if (this.hasRendererDefinition() && this.getRenderShell() === "self") {
+			this.addChild(this.selfRenderContainer);
 		} else {
-			this.addChild(this.contentText);
+			this.addChild(this.contentPanel);
 		}
 
 		this.updateDisplay();
@@ -249,20 +249,10 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private updateDisplay(): void {
-		const bgFn = this.isPartial
-			? (text: string) => theme.bg("toolPendingBg", text)
-			: this.result?.isError
-				? (text: string) => theme.bg("toolErrorBg", text)
-				: (text: string) => theme.bg("toolSuccessBg", text);
-
 		let hasContent = false;
 		this.hideComponent = false;
-		if (this.hasRendererDefinition()) {
-			const renderContainer = this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox;
-			if (renderContainer instanceof Box) {
-				renderContainer.setBgFn(bgFn);
-			}
-			renderContainer.clear();
+		if (this.hasRendererDefinition() && this.getRenderShell() === "self") {
+			this.selfRenderContainer.clear();
 
 			if (this.shouldUseIpythonRenderer()) {
 				const state = {
@@ -281,59 +271,24 @@ export class ToolExecutionComponent extends Container {
 				} else {
 					this.ipythonCellComponent.update(state);
 				}
-				renderContainer.addChild(this.ipythonCellComponent);
+				this.selfRenderContainer.addChild(this.ipythonCellComponent);
 				hasContent = true;
 			} else {
-				const callRenderer = this.getCallRenderer();
-				if (!callRenderer) {
-					renderContainer.addChild(this.createCallFallback());
-					hasContent = true;
-				} else {
-					try {
-						const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
-						this.callRendererComponent = component;
-						renderContainer.addChild(component);
-						hasContent = true;
-					} catch {
-						this.callRendererComponent = undefined;
-						renderContainer.addChild(this.createCallFallback());
-						hasContent = true;
-					}
-				}
-
-				if (this.result) {
-					const resultRenderer = this.getResultRenderer();
-					if (!resultRenderer) {
-						const component = this.createResultFallback();
-						if (component) {
-							renderContainer.addChild(component);
-							hasContent = true;
-						}
-					} else {
-						try {
-							const component = resultRenderer(
-								{ content: this.result.content as any, details: this.result.details },
-								{ expanded: this.expanded, isPartial: this.isPartial },
-								theme,
-								this.getRenderContext(this.resultRendererComponent),
-							);
-							this.resultRendererComponent = component;
-							renderContainer.addChild(component);
-							hasContent = true;
-						} catch {
-							this.resultRendererComponent = undefined;
-							const component = this.createResultFallback();
-							if (component) {
-								renderContainer.addChild(component);
-								hasContent = true;
-							}
-						}
-					}
-				}
+				hasContent = this.mountRenderers(this.selfRenderContainer, true);
 			}
 		} else {
-			this.contentText.setCustomBgFn(bgFn);
-			this.contentText.setText(this.formatToolExecution());
+			// Default shell: tool panel with a `label · status` header so the block
+			// is self-identifying. The header replaces the bold-tool-name fallback.
+			this.contentPanel.setHeader(this.panelHeader());
+			this.contentPanel.clear();
+			if (this.hasRendererDefinition()) {
+				this.mountRenderers(this.contentPanel, false);
+			} else {
+				const fallbackText = this.formatToolExecution();
+				if (fallbackText) {
+					this.contentPanel.addChild(new Text(fallbackText, 0, 0));
+				}
+			}
 			hasContent = true;
 		}
 
@@ -377,20 +332,100 @@ export class ToolExecutionComponent extends Container {
 		}
 	}
 
+	/**
+	 * Mount the call/result renderer components into the given shell container.
+	 * `useFallbacks` keeps the bold-tool-name call fallback for self-rendering
+	 * tools; the default panel shell already names the tool in its header.
+	 */
+	private mountRenderers(container: Container | ToolPanel, useFallbacks: boolean): boolean {
+		let hasContent = false;
+
+		const callRenderer = this.getCallRenderer();
+		if (!callRenderer) {
+			if (useFallbacks) {
+				container.addChild(this.createCallFallback());
+				hasContent = true;
+			}
+		} else {
+			try {
+				const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
+				this.callRendererComponent = component;
+				container.addChild(component);
+				hasContent = true;
+			} catch {
+				this.callRendererComponent = undefined;
+				if (useFallbacks) {
+					container.addChild(this.createCallFallback());
+					hasContent = true;
+				}
+			}
+		}
+
+		if (this.result) {
+			const resultRenderer = this.getResultRenderer();
+			if (!resultRenderer) {
+				const component = this.createResultFallback();
+				if (component) {
+					container.addChild(component);
+					hasContent = true;
+				}
+			} else {
+				try {
+					const component = resultRenderer(
+						{ content: this.result.content as any, details: this.result.details },
+						{ expanded: this.expanded, isPartial: this.isPartial },
+						theme,
+						this.getRenderContext(this.resultRendererComponent),
+					);
+					this.resultRendererComponent = component;
+					container.addChild(component);
+					hasContent = true;
+				} catch {
+					this.resultRendererComponent = undefined;
+					const component = this.createResultFallback();
+					if (component) {
+						container.addChild(component);
+						hasContent = true;
+					}
+				}
+			}
+		}
+
+		return hasContent;
+	}
+
+	private panelHeader(): string {
+		const label = this.toolDefinition?.label ?? this.builtInToolDefinition?.label ?? this.toolName;
+		return `${theme.fg("muted", label)}${theme.fg("dim", " · ")}${this.panelStatus()}`;
+	}
+
+	private panelStatus(): string {
+		if (this.result && !this.isPartial) {
+			return this.result.isError ? theme.fg("error", "error") : theme.fg("success", "done");
+		}
+		if (this.result?.isError) {
+			return theme.fg("error", "error");
+		}
+		if (this.executionStarted) {
+			return theme.fg("bashMode", "running");
+		}
+		return theme.fg("muted", "queued");
+	}
+
 	private getTextOutput(): string {
 		return getRenderedTextOutput(this.result, this.showImages);
 	}
 
 	private formatToolExecution(): string {
-		let text = theme.fg("toolTitle", theme.bold(this.toolName));
+		const parts: string[] = [];
 		const content = JSON.stringify(this.args, null, 2);
 		if (content) {
-			text += `\n\n${content}`;
+			parts.push(content);
 		}
 		const output = this.getTextOutput();
 		if (output) {
-			text += `\n${output}`;
+			parts.push(output);
 		}
-		return text;
+		return parts.join("\n\n");
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tool-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-panel.ts
@@ -1,0 +1,93 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+
+export const TOOL_PANEL_PADDING_X = 2;
+
+export function toolPanelContentWidth(width: number): number {
+	return Math.max(1, width - TOOL_PANEL_PADDING_X * 2);
+}
+
+/**
+ * Format a single tool panel line: content indented by the panel padding and
+ * padded to the full width, on the subtle panel background that groups the
+ * block.
+ */
+export function toolPanelLine(line: string, width: number): string {
+	const contentWidth = toolPanelContentWidth(width);
+	const truncated = truncateToWidth(line, contentWidth, "");
+	const padding = " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
+	const sidePad = " ".repeat(TOOL_PANEL_PADDING_X);
+	return theme.bg("toolPanelBg", `${sidePad}${truncated}${padding}${sidePad}`);
+}
+
+/**
+ * Panel shell for tool executions: a status header line followed by the
+ * tool's own call/result components, every line on the panel background so
+ * the whole block reads as one unit. Children render at the reduced content
+ * width; lines that still overflow are truncated, matching ipython cell
+ * behavior.
+ */
+export class ToolPanel implements Component {
+	private children: Component[] = [];
+	private header = "";
+	private cache?: {
+		width: number;
+		header: string;
+		bgSample: string;
+		childLines: string[];
+		lines: string[];
+	};
+
+	setHeader(header: string): void {
+		this.header = header;
+	}
+
+	addChild(component: Component): void {
+		this.children.push(component);
+		this.cache = undefined;
+	}
+
+	clear(): void {
+		this.children = [];
+		this.cache = undefined;
+	}
+
+	invalidate(): void {
+		this.cache = undefined;
+		for (const child of this.children) {
+			child.invalidate?.();
+		}
+	}
+
+	render(width: number): string[] {
+		const childLines: string[] = [];
+		for (const child of this.children) {
+			childLines.push(...child.render(toolPanelContentWidth(width)));
+		}
+
+		// The background sample detects theme changes that don't go through
+		// invalidate().
+		const bgSample = theme.bg("toolPanelBg", " ");
+		const cache = this.cache;
+		if (
+			cache &&
+			cache.width === width &&
+			cache.header === this.header &&
+			cache.bgSample === bgSample &&
+			cache.childLines.length === childLines.length &&
+			cache.childLines.every((line, i) => line === childLines[i])
+		) {
+			return cache.lines;
+		}
+
+		const lines: string[] = [toolPanelLine(this.header, width)];
+		if (childLines.length > 0) {
+			lines.push(toolPanelLine("", width));
+			for (const line of childLines) {
+				lines.push(toolPanelLine(line, width));
+			}
+		}
+		this.cache = { width, header: this.header, bgSample, childLines, lines };
+		return lines;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -40,6 +40,7 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolPanelBg": "#262630",
 		"toolTitle": "",
 		"toolOutput": "gray",
 

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -39,6 +39,7 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolPanelBg": "#ededf2",
 		"toolTitle": "",
 		"toolOutput": "mediumGray",
 

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -46,6 +46,7 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolPanelBg": "surface",
 		"toolTitle": "",
 		"toolOutput": "muted",
 		"mdHeading": "primarySoft",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -55,6 +55,7 @@
 				"toolPendingBg",
 				"toolSuccessBg",
 				"toolErrorBg",
+				"toolPanelBg",
 				"toolTitle",
 				"toolOutput",
 				"mdHeading",
@@ -167,6 +168,10 @@
 				"toolErrorBg": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Tool execution box (error state)"
+				},
+				"toolPanelBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Tool panel background (ipython cells and tool executions)"
 				},
 				"toolTitle": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -48,7 +48,7 @@ const ThemeJsonSchema = Type.Object({
 		dim: ColorValueSchema,
 		text: ColorValueSchema,
 		thinkingText: ColorValueSchema,
-		// Backgrounds & Content Text (11 colors)
+		// Backgrounds & Content Text (12 colors)
 		selectedBg: ColorValueSchema,
 		userMessageBg: ColorValueSchema,
 		userMessageText: ColorValueSchema,
@@ -58,6 +58,7 @@ const ThemeJsonSchema = Type.Object({
 		toolPendingBg: ColorValueSchema,
 		toolSuccessBg: ColorValueSchema,
 		toolErrorBg: ColorValueSchema,
+		toolPanelBg: ColorValueSchema,
 		toolTitle: ColorValueSchema,
 		toolOutput: ColorValueSchema,
 		// Markdown (10 colors)
@@ -173,7 +174,8 @@ export type ThemeBg =
 	| "customMessageBg"
 	| "toolPendingBg"
 	| "toolSuccessBg"
-	| "toolErrorBg";
+	| "toolErrorBg"
+	| "toolPanelBg";
 
 type ColorMode = "truecolor" | "256color";
 
@@ -666,6 +668,7 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 		"toolPendingBg",
 		"toolSuccessBg",
 		"toolErrorBg",
+		"toolPanelBg",
 	]);
 	for (const [key, value] of Object.entries(resolvedColors)) {
 		if (bgColorKeys.has(key)) {

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -106,7 +106,7 @@ describe("marquee TUI components", () => {
 		const component = new IPythonCellComponent(state);
 
 		const collapsed = await renderInVirtualTerminal(component);
-		expect(collapsed).toContain("error · 1.2s");
+		expect(collapsed).toContain("bash · error · 1.2s");
 		expect(collapsed).not.toContain("ipython");
 		expect(collapsed).toContain("%%bash");
 		expect(collapsed).toContain("hi");
@@ -809,12 +809,13 @@ describe("marquee TUI components", () => {
 
 		const rawOutput = component.render(100).join("\n");
 		expect(rawOutput).toMatch(/\x1b\[48;(?:2|5);/);
-		const railLine = component.render(100).find((line) => line.includes("\x1b[48;")) ?? "";
-		const backgroundResetIndex = railLine.indexOf("\x1b[49m");
-		expect(backgroundResetIndex).toBeGreaterThan(0);
-		expect(backgroundResetIndex).toBeLessThan(32);
+		// The panel background spans the full line with the content padded inside.
+		const panelLine = component.render(100).find((line) => line.includes("\x1b[48;")) ?? "";
+		expect(panelLine.startsWith("\x1b[48;")).toBe(true);
+		expect(panelLine.endsWith("\x1b[49m")).toBe(true);
+		expect(visibleWidth(panelLine)).toBe(100);
 		const output = stripAnsi(rawOutput);
-		expect(output).toContain("done · 12ms");
+		expect(output).toContain("python · done · 12ms");
 		expect(output).not.toContain("ipython");
 		expect(output).toContain("print(55)");
 		expect(output).toContain("55");

--- a/packages/coding-agent/test/test-theme-colors.ts
+++ b/packages/coding-agent/test/test-theme-colors.ts
@@ -225,6 +225,7 @@ function cmdTheme(themeName: string): void {
 	console.log("toolPendingBg:", theme.bg("toolPendingBg", " Sample "));
 	console.log("toolSuccessBg:", theme.bg("toolSuccessBg", " Sample "));
 	console.log("toolErrorBg:", theme.bg("toolErrorBg", " Sample "));
+	console.log("toolPanelBg:", theme.bg("toolPanelBg", " Sample "));
 	console.log();
 }
 

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -274,6 +274,56 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("arg:bar");
 	});
 
+	test("renders default-shell tools in a rail panel with a labeled status header", () => {
+		const component = new ToolExecutionComponent(
+			"bash",
+			"tool-7",
+			{ command: "echo hello" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(stripAnsi(component.render(100).join("\n"))).toContain("bash · queued");
+
+		component.markExecutionStarted();
+		expect(stripAnsi(component.render(100).join("\n"))).toContain("bash · running");
+
+		component.updateResult({ content: [{ type: "text", text: "hello" }], details: undefined, isError: false }, false);
+		const lines = component.render(100);
+		const rendered = stripAnsi(lines.join("\n"));
+		expect(rendered).toContain("bash · done");
+		expect(rendered).toContain("$ echo hello");
+		expect(rendered).toContain("hello");
+
+		// Panel lines carry the neutral panel background across the full width.
+		const panelLines = lines.filter((line) => line.includes("\x1b[48;"));
+		expect(panelLines.length).toBeGreaterThan(0);
+		for (const line of panelLines) {
+			expect(line.startsWith("\x1b[48;")).toBe(true);
+			expect(line.endsWith("\x1b[49m")).toBe(true);
+		}
+	});
+
+	test("shows the error status in the rail panel header", () => {
+		const component = new ToolExecutionComponent(
+			"bash",
+			"tool-8",
+			{ command: "false" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.markExecutionStarted();
+		component.updateResult(
+			{ content: [{ type: "text", text: "Command exited with code 1" }], details: undefined, isError: true },
+			false,
+		);
+		const rendered = stripAnsi(component.render(100).join("\n"));
+		expect(rendered).toContain("bash · error");
+	});
+
 	test("falls back when custom renderers are absent", () => {
 		const toolDefinition: ToolDefinition = {
 			...createBaseToolDefinition(),


### PR DESCRIPTION
- tool calls used to render as full-width status-colored boxes for some tools and nothing for ipython cells, which read as broken formatting next to thinking text.
- all tools now share one panel style: a subtle neutral background with a header naming the tool and its status, like python · done · 7ms.
- the running and done labels previously floated between blocks and could read as a status for the preceding thinking; they now sit inside their tool's panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom themes must add `toolPanelBg` or validation fails; otherwise this is interactive TUI presentation only with no runtime or security impact.
> 
> **Overview**
> Unifies **tool and IPython cell** transcript rendering so blocks no longer look disconnected from adjacent thinking text.
> 
> **`ToolPanel`** replaces the old status-colored `Box` shell for default tools: every line uses a neutral **`toolPanelBg`** background, with a **`label · status`** header (`bash · running`, `python · done · 7ms`, etc.) so status no longer reads as belonging to the preceding thinking block. **`IPythonCellComponent`** drops the left-rail styling and shares the same panel line helpers; cell headers now prefix **`python`** or **`bash`** (for `%%bash` cells) before status and duration.
> 
> Themes must define the new required **`toolPanelBg`** token (built-in dark/light/prime and schema/docs updated). Extension docs describe the default tool panel shell vs `renderShell: "self"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f9f881285c5e7c122f72cacf7b1d5a7fedb2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix confusing thinking and tool block formatting in the transcript
> - Introduces a new `ToolPanel` component in [tool-panel.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/137/files#diff-7d06b6f5e65ca1e31620219e3ee1612c8e33756a858e130924540253c457654d) that renders a labeled header (`label · status`) and child content on a neutral `toolPanelBg` background with consistent padding.
> - Reworks `ToolExecutionComponent` to use `ToolPanel` for default-shell tools; status transitions (queued/running/done/error) are reflected in the header, replacing the previous Box/Text background shell.
> - Updates `IPythonCellComponent` to use the same `ToolPanel` with a `bash` or `python` label derived from the cell magic, removing its local panel rendering logic.
> - Adds `toolPanelBg` as a required theme token to all built-in themes (dark, light, prime) and the theme schema.
> - Behavioral Change: tool executions no longer show a bold tool title in fallback content since the panel header names the tool; self-rendering tools (`renderShell: 'self'`) are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00f9f88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->