### PR TITLE
show how to resume a session after exit

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -165,6 +165,7 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
+import { formatResumeHint } from "./resume-hint.js";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -4591,6 +4592,9 @@ export class InteractiveMode {
 		this.unregisterSignalHandlers();
 		this.clearCtrlCExitHint({ render: false });
 
+		// Fetch while the connection is still alive; exit must not fail on a stats error.
+		const sessionStats = await this.agentConnection.getSessionStats().catch(() => undefined);
+
 		// Drain any in-flight Kitty key release events before stopping.
 		// This prevents escape sequences from leaking to the parent shell over slow SSH.
 		await this.ui.terminal.drainInput(1000);
@@ -4600,6 +4604,10 @@ export class InteractiveMode {
 			await this.agentConnection.dispose();
 		} finally {
 			await this.options.onShutdown?.();
+		}
+		const resumeHint = formatResumeHint(sessionStats);
+		if (resumeHint) {
+			console.log(resumeHint);
 		}
 		process.exit(0);
 	}

--- a/packages/coding-agent/src/modes/interactive/resume-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/resume-hint.ts
@@ -2,6 +2,7 @@
  * Post-exit hint telling the user how to resume the session they just left.
  */
 
+import { existsSync } from "node:fs";
 import chalk from "chalk";
 import { APP_NAME } from "../../config.js";
 import type { SessionStats } from "../../core/session-stats.js";
@@ -17,5 +18,8 @@ export type ResumeHintStats = Pick<SessionStats, "sessionId" | "sessionFile" | "
  */
 export function formatResumeHint(stats: ResumeHintStats | undefined): string | undefined {
 	if (!stats?.sessionFile || stats.userMessages === 0) return undefined;
+	// Persistence is lazy: nothing is written until the first assistant message
+	// arrives, so exiting before then leaves no file to resume from.
+	if (!existsSync(stats.sessionFile)) return undefined;
 	return chalk.dim(`Resume this session with: ${APP_NAME} --session ${stats.sessionId}`);
 }

--- a/packages/coding-agent/src/modes/interactive/resume-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/resume-hint.ts
@@ -1,0 +1,21 @@
+/**
+ * Post-exit hint telling the user how to resume the session they just left.
+ */
+
+import chalk from "chalk";
+import { APP_NAME } from "../../config.js";
+import type { SessionStats } from "../../core/session-stats.js";
+
+export type ResumeHintStats = Pick<SessionStats, "sessionId" | "sessionFile" | "userMessages">;
+
+/**
+ * Format the resume hint printed to stdout after the TUI exits.
+ *
+ * Returns undefined when there is nothing to resume: ephemeral sessions
+ * (--no-session) have no session file, and sessions without any user
+ * messages may never have been flushed to disk.
+ */
+export function formatResumeHint(stats: ResumeHintStats | undefined): string | undefined {
+	if (!stats?.sessionFile || stats.userMessages === 0) return undefined;
+	return chalk.dim(`Resume this session with: ${APP_NAME} --session ${stats.sessionId}`);
+}

--- a/packages/coding-agent/test/resume-hint.test.ts
+++ b/packages/coding-agent/test/resume-hint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { APP_NAME } from "../src/config.js";
+import { formatResumeHint } from "../src/modes/interactive/resume-hint.js";
+
+const SESSION_ID = "0196c2e4-7f01-7abc-8def-0123456789ab";
+
+describe("formatResumeHint", () => {
+	test("returns hint with --session and the session id for a persisted session", () => {
+		const hint = formatResumeHint({
+			sessionId: SESSION_ID,
+			sessionFile: `/home/user/.prime/agent/sessions/${SESSION_ID}.jsonl`,
+			userMessages: 3,
+		});
+		expect(hint).toBeDefined();
+		expect(hint).toContain(`${APP_NAME} --session ${SESSION_ID}`);
+	});
+
+	test("returns undefined for an in-memory session", () => {
+		const hint = formatResumeHint({
+			sessionId: SESSION_ID,
+			sessionFile: undefined,
+			userMessages: 3,
+		});
+		expect(hint).toBeUndefined();
+	});
+
+	test("returns undefined when the session has no user messages", () => {
+		const hint = formatResumeHint({
+			sessionId: SESSION_ID,
+			sessionFile: `/home/user/.prime/agent/sessions/${SESSION_ID}.jsonl`,
+			userMessages: 0,
+		});
+		expect(hint).toBeUndefined();
+	});
+
+	test("returns undefined when stats are unavailable", () => {
+		expect(formatResumeHint(undefined)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/resume-hint.test.ts
+++ b/packages/coding-agent/test/resume-hint.test.ts
@@ -1,14 +1,25 @@
-import { describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
 import { APP_NAME } from "../src/config.js";
 import { formatResumeHint } from "../src/modes/interactive/resume-hint.js";
 
 const SESSION_ID = "0196c2e4-7f01-7abc-8def-0123456789ab";
 
+const sessionDir = mkdtempSync(join(tmpdir(), "resume-hint-test-"));
+const existingSessionFile = join(sessionDir, `${SESSION_ID}.jsonl`);
+writeFileSync(existingSessionFile, `{"type":"session","id":"${SESSION_ID}"}\n`);
+
+afterAll(() => {
+	rmSync(sessionDir, { recursive: true, force: true });
+});
+
 describe("formatResumeHint", () => {
 	test("returns hint with --session and the session id for a persisted session", () => {
 		const hint = formatResumeHint({
 			sessionId: SESSION_ID,
-			sessionFile: `/home/user/.prime/agent/sessions/${SESSION_ID}.jsonl`,
+			sessionFile: existingSessionFile,
 			userMessages: 3,
 		});
 		expect(hint).toBeDefined();
@@ -27,8 +38,17 @@ describe("formatResumeHint", () => {
 	test("returns undefined when the session has no user messages", () => {
 		const hint = formatResumeHint({
 			sessionId: SESSION_ID,
-			sessionFile: `/home/user/.prime/agent/sessions/${SESSION_ID}.jsonl`,
+			sessionFile: existingSessionFile,
 			userMessages: 0,
+		});
+		expect(hint).toBeUndefined();
+	});
+
+	test("returns undefined when the session file was never flushed to disk", () => {
+		const hint = formatResumeHint({
+			sessionId: SESSION_ID,
+			sessionFile: join(sessionDir, "never-written.jsonl"),
+			userMessages: 1,
 		});
 		expect(hint).toBeUndefined();
 	});


### PR DESCRIPTION
- exiting an interactive session previously gave no indication that it could be resumed, even though the cli fully supports it.
- the agent now prints a dim hint with the exact resume command after the tui tears down, using the current session id so it stays correct after mid-run session switches.
- the hint is skipped for ephemeral sessions and sessions without any user messages, since there is nothing to resume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX addition on the shutdown path only; stats fetch errors are swallowed and hint logic is gated on safe persistence checks.
> 
> **Overview**
> After the interactive TUI tears down on **normal shutdown**, the agent prints a dim stdout line with the exact **`--session <id>`** resume command for the active session.
> 
> **`formatResumeHint`** centralizes when to show it: skip ephemeral sessions (no `sessionFile`), sessions with zero user messages, or when the session file was never flushed to disk (`existsSync`). Stats are fetched via **`getSessionStats()`** before connection disposal; fetch failures are ignored so exit still succeeds.
> 
> Unit tests cover persisted sessions and each skip condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08b0c46ec9556b661c8c1a170ec433bbdd4b51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show a session resume hint on exit in interactive mode
> - On shutdown, `InteractiveMode` calls `getSessionStats()` and passes the result to the new `formatResumeHint` utility in [resume-hint.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/139/files#diff-9ecdaa0dbb08e8ce8f0cd9bcffdc1bc94934b4e5039e1ca6a8b7ee8a42af1029).
> - `formatResumeHint` returns a dimmed hint string (`Resume this session with: <APP_NAME> --session <sessionId>`) only when a session file exists on disk and at least one user message was sent; otherwise returns `undefined`.
> - Errors fetching session stats are silently swallowed, suppressing the hint rather than crashing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d08b0c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->