### PR TITLE
add ability to kill running subagents

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -324,6 +324,8 @@ interface RlmChildRun {
 	abort: () => void;
 	/** Child session, once its runtime exists. Used to cancel nested child runs. */
 	session?: AgentSession;
+	/** Re-emits the run's rlm_child_update snapshot with its current status. */
+	emitUpdate?: () => void;
 }
 
 // ============================================================================
@@ -3538,6 +3540,10 @@ export class AgentSession {
 		run.status = "cancelled";
 		run.error = reason;
 		run.abort();
+		// Surface the cancellation immediately; the run's own terminal update is
+		// delayed indefinitely when the child is stuck mid-stream, which is
+		// exactly when users reach for the kill.
+		run.emitUpdate?.();
 		return true;
 	}
 
@@ -3618,6 +3624,7 @@ export class AgentSession {
 				},
 			});
 		};
+		run.emitUpdate = emitChildUpdate;
 		const recordAssistantMessage = (message: AssistantMessage) => {
 			const text = compactRlmText(readAssistantText(message));
 			const thinking = compactRlmText(readAssistantThinking(message));

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3541,6 +3541,11 @@ export class AgentSession {
 		return true;
 	}
 
+	/** Status of a direct RLM child run, while the run is still tracked. */
+	getRlmChildRunStatus(childId: string): RlmChildAgentStatus | undefined {
+		return this._activeRlmChildRuns.get(childId)?.status;
+	}
+
 	/**
 	 * Cancel a single RLM child run by id, searching nested child sessions.
 	 *

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -322,6 +322,8 @@ interface RlmChildRun {
 	error?: string;
 	task?: Promise<RlmInternalRunResult>;
 	abort: () => void;
+	/** Child session, once its runtime exists. Used to cancel nested child runs. */
+	session?: AgentSession;
 }
 
 // ============================================================================
@@ -3525,12 +3527,37 @@ export class AgentSession {
 
 	private _cancelActiveRlmChildRuns(reason: string): void {
 		for (const run of this._activeRlmChildRuns.values()) {
-			if (run.status === "running" || run.status === "queued") {
-				run.status = "cancelled";
-				run.error = reason;
-				run.abort();
+			this._cancelRlmChildRun(run, reason);
+		}
+	}
+
+	private _cancelRlmChildRun(run: RlmChildRun, reason: string): boolean {
+		if (run.status !== "running" && run.status !== "queued") {
+			return false;
+		}
+		run.status = "cancelled";
+		run.error = reason;
+		run.abort();
+		return true;
+	}
+
+	/**
+	 * Cancel a single RLM child run by id, searching nested child sessions.
+	 *
+	 * @returns true when a running or queued run was cancelled; false when the
+	 * id is unknown or the run already finished.
+	 */
+	cancelRlmChildRun(childId: string, reason = "Cancelled by user"): boolean {
+		const run = this._activeRlmChildRuns.get(childId);
+		if (run) {
+			return this._cancelRlmChildRun(run, reason);
+		}
+		for (const candidate of this._activeRlmChildRuns.values()) {
+			if (candidate.session?.cancelRlmChildRun(childId, reason)) {
+				return true;
 			}
 		}
+		return false;
 	}
 
 	private _startRlmChildRun(prompt: string, kwargs: Record<string, unknown> = {}): RlmChildRun {
@@ -3678,6 +3705,7 @@ export class AgentSession {
 				}
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
+				run.session = child;
 				run.abort = () => {
 					void child.abort();
 				};
@@ -3822,6 +3850,7 @@ export class AgentSession {
 					await this._releaseRlmSubagentRuntime(childRuntime, subagentOptions);
 				}
 				run.abort = noopRlmChildAbort;
+				run.session = undefined;
 				this._activeRlmChildRuns.delete(run.id);
 			}
 		})();

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -6,14 +6,15 @@ import type { DeleteSessionFileResult } from "../../core/session-file-actions.js
 import type { SessionStats } from "../../core/session-stats.js";
 import type { DaemonClient } from "../daemon/daemon-client.js";
 import { deserializeDaemonError } from "../daemon/daemon-errors.js";
-import type {
-	DaemonAttachResult,
-	DaemonCommand,
-	DaemonDeleteSavedSessionResult,
-	DaemonOutbound,
-	DaemonReplayInfo,
-	DaemonSavedSessionInfo,
-	DaemonSessionSnapshot,
+import {
+	type DaemonAttachResult,
+	type DaemonCommand,
+	type DaemonDeleteSavedSessionResult,
+	type DaemonOutbound,
+	type DaemonReplayInfo,
+	type DaemonSavedSessionInfo,
+	type DaemonSessionSnapshot,
+	isUnknownDaemonCommandError,
 } from "../daemon/daemon-protocol.js";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
 import type {
@@ -353,12 +354,19 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async cancelRlmChild(childId: string): Promise<boolean> {
-		const result = await this.requestData<{ cancelled: boolean }>({
-			type: "cancel_rlm_child",
-			activeSessionId: this.activeSessionId,
-			childId,
-		});
-		return result.cancelled;
+		try {
+			const result = await this.requestData<{ cancelled: boolean }>({
+				type: "cancel_rlm_child",
+				activeSessionId: this.activeSessionId,
+				childId,
+			});
+			return result.cancelled;
+		} catch (error) {
+			if (isUnknownDaemonCommandError(error, "cancel_rlm_child")) {
+				throw new Error("the daemon is running an older build; restart the daemon and try again");
+			}
+			throw error;
+		}
 	}
 
 	async waitForIdle(): Promise<void> {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -352,6 +352,15 @@ export class DaemonAgentConnection implements AgentConnection {
 		await this.requestOk({ type: "abort", activeSessionId: this.activeSessionId });
 	}
 
+	async cancelRlmChild(childId: string): Promise<boolean> {
+		const result = await this.requestData<{ cancelled: boolean }>({
+			type: "cancel_rlm_child",
+			activeSessionId: this.activeSessionId,
+			childId,
+		});
+		return result.cancelled;
+	}
+
 	async waitForIdle(): Promise<void> {
 		await this.requestOk({ type: "wait_for_idle", activeSessionId: this.activeSessionId });
 	}

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -183,6 +183,10 @@ export class InProcessAgentConnection implements AgentConnection {
 		await this.session.abort();
 	}
 
+	async cancelRlmChild(childId: string): Promise<boolean> {
+		return this.session.cancelRlmChildRun(childId);
+	}
+
 	async waitForIdle(): Promise<void> {
 		await this.session.agent.waitForIdle();
 	}

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -510,6 +510,7 @@ export interface AgentConnection {
 	steer(message: string, images?: ImageContent[]): Promise<void>;
 	followUp(message: string, images?: ImageContent[]): Promise<void>;
 	abort(): Promise<void>;
+	cancelRlmChild(childId: string): Promise<boolean>;
 	waitForIdle(): Promise<void>;
 
 	setModel(provider: string, modelId: string): Promise<AgentConnectionModel>;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -759,10 +759,11 @@ class AgentsViewMode implements Component, Focusable {
 		await this.stopAgentForDeletion(row);
 	}
 
+	// Subagent rows only stay visible while the daemon hosts their session, and
+	// the daemon releases a child session as soon as its run settles, so any
+	// visible subagent is part of an active run regardless of its idle/streaming
+	// status. A kill that races completion reports "already finished".
 	private async handleKillSubagentSelected(row: AgentsViewRow): Promise<void> {
-		if (!isRunningSessionSummary(row.summary)) {
-			return;
-		}
 		const identity = getSummaryIdentity(row.summary);
 		if (this.pendingKillSubagent?.identity === identity && this.isDeleteConfirmationVisible()) {
 			const pending = this.pendingKillSubagent;
@@ -1210,16 +1211,16 @@ class AgentsViewMode implements Component, Focusable {
 			const tone = this.statusMessage.startsWith("Failed") ? "error" : "muted";
 			return truncateToWidth(theme.fg(tone, this.statusMessage), width);
 		}
-		// Replying is reserved for top-level agents; running subagents can be stopped.
+		// Replying is reserved for top-level agents; subagents can be stopped.
 		const selectedRow = this.rows[this.selectedIndex];
 		const selectedAgent = selectedRow?.kind === "agent";
-		const selectedRunningSubagent = selectedRow?.kind === "subagent" && isRunningSessionSummary(selectedRow.summary);
+		const selectedSubagent = selectedRow?.kind === "subagent";
 		const hints = [
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open/send`,
 			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
 			selectedAgent ? `${keyText("app.agents.delete")} stop/deactivate` : undefined,
-			selectedRunningSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
+			selectedSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
 			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -14,7 +14,7 @@ import { KeybindingsManager } from "../../core/keybindings.js";
 import { SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
-import type { DaemonCommand, DaemonResponse } from "../daemon/daemon-protocol.js";
+import { type DaemonCommand, type DaemonResponse, isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
@@ -77,6 +77,11 @@ type PendingDeleteAgent = {
 	sessionFile?: string;
 	summary: SessionSummary;
 	stopped: boolean;
+};
+type PendingKillSubagent = {
+	identity: string;
+	rootActiveSessionId: string;
+	childId: string;
 };
 
 export async function resolveAgentsViewSessionUiServices(
@@ -228,6 +233,7 @@ class AgentsViewMode implements Component, Focusable {
 	private replyLastAssistantTextLoading = false;
 	private replyHeaderTime = "";
 	private pendingDeleteAgent: PendingDeleteAgent | undefined;
+	private pendingKillSubagent: PendingKillSubagent | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
@@ -453,6 +459,7 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private clearDeleteConfirmation(options: { render?: boolean } = {}): void {
+		this.pendingKillSubagent = undefined;
 		if (!this.deleteConfirmTimer && this.deleteConfirmExpiresAt === 0) {
 			return;
 		}
@@ -611,18 +618,25 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private openSelectedSubagent(row: AgentsViewRow): void {
-		// The whole subagent tree is inspected from the root agent's chat view,
-		// so nested subagents also resolve to their top-level ancestor.
-		let root = this.rows.find((candidate) => candidate.identity === row.parentIdentity);
-		while (root && root.kind !== "agent") {
-			const parentIdentity = root.parentIdentity;
-			root = this.rows.find((candidate) => candidate.identity === parentIdentity);
-		}
+		const root = this.findSubagentRootRow(row);
 		if (!root || !(root.summary.activeSessionId || root.summary.sessionFile)) {
 			this.setStatusMessage("Cannot open subagent without its parent agent");
 			return;
 		}
 		this.finish({ type: "open", summary: root.summary, subagent: row.summary });
+	}
+
+	/**
+	 * The whole subagent tree belongs to the root agent's session, so nested
+	 * subagents also resolve to their top-level ancestor.
+	 */
+	private findSubagentRootRow(row: AgentsViewRow): AgentsViewRow | undefined {
+		let root = this.rows.find((candidate) => candidate.identity === row.parentIdentity);
+		while (root && root.kind !== "agent") {
+			const parentIdentity = root.parentIdentity;
+			root = this.rows.find((candidate) => candidate.identity === parentIdentity);
+		}
+		return root;
 	}
 
 	private async toggleReplyTarget(): Promise<void> {
@@ -721,9 +735,18 @@ class AgentsViewMode implements Component, Focusable {
 
 	private async handleDeleteSelected(): Promise<void> {
 		const row = this.rows[this.selectedIndex];
-		if (row?.kind !== "agent" || !row.selectable) {
+		if (!row?.selectable) {
 			return;
 		}
+		if (row.kind === "subagent") {
+			this.pendingDeleteAgent = undefined;
+			await this.handleKillSubagentSelected(row);
+			return;
+		}
+		if (row.kind !== "agent") {
+			return;
+		}
+		this.pendingKillSubagent = undefined;
 		const identity = getSummaryIdentity(row.summary);
 		if (this.pendingDeleteAgent?.identity === identity) {
 			if (this.isDeleteConfirmationVisible()) {
@@ -734,6 +757,48 @@ class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		await this.stopAgentForDeletion(row);
+	}
+
+	private async handleKillSubagentSelected(row: AgentsViewRow): Promise<void> {
+		if (!isRunningSessionSummary(row.summary)) {
+			return;
+		}
+		const identity = getSummaryIdentity(row.summary);
+		if (this.pendingKillSubagent?.identity === identity && this.isDeleteConfirmationVisible()) {
+			const pending = this.pendingKillSubagent;
+			this.clearDeleteConfirmation({ render: false });
+			await this.killSubagent(pending);
+			return;
+		}
+		const childId = row.summary.rlmChildId;
+		const rootActiveSessionId = this.findSubagentRootRow(row)?.summary.activeSessionId;
+		if (!childId || !rootActiveSessionId) {
+			this.setStatusMessage("Cannot stop subagent without its parent agent");
+			return;
+		}
+		this.pendingKillSubagent = { identity, rootActiveSessionId, childId };
+		this.showDeleteConfirmation();
+	}
+
+	private async killSubagent(pending: PendingKillSubagent): Promise<void> {
+		this.setStatusMessage("Stopping subagent...");
+		try {
+			const response = await this.requireClient().request({
+				type: "cancel_rlm_child",
+				activeSessionId: pending.rootActiveSessionId,
+				childId: pending.childId,
+			});
+			const data = requireDaemonData(response);
+			const cancelled = isRecord(data) && data.cancelled === true;
+			this.setStatusMessage(cancelled ? "Subagent stopped" : "Subagent already finished", { render: false });
+			await this.refreshSessions();
+		} catch (error) {
+			this.setStatusMessage(
+				isUnknownDaemonCommandError(error, "cancel_rlm_child")
+					? "Failed to stop subagent: the daemon is running an older build; restart the daemon and try again"
+					: formatError("Failed to stop subagent", error),
+			);
+		}
 	}
 
 	private async stopAgentForDeletion(row: AgentsViewRow): Promise<void> {
@@ -1083,16 +1148,21 @@ class AgentsViewMode implements Component, Focusable {
 			return selected ? `${SELECTED_ROW_MARKER}${line}` : line;
 		}
 		const pendingDelete = row.kind === "agent" && this.isPendingDeleteRow(row);
+		const pendingKill = row.kind === "subagent" && this.isPendingKillSubagentRow(row);
 		const rawIcon = this.getRowIcon(row.section);
 		const icon = this.formatRowIcon(row.section, rawIcon);
 		const indent = "  ".repeat(row.depth);
 		const timeWidth = 10;
 		const titleWidth = Math.max(0, width - visibleWidth(indent) - visibleWidth(rawIcon) - timeWidth - 2);
-		const title = pendingDelete ? this.getPendingDeleteTitle() : row.title;
+		const title = pendingDelete
+			? this.getPendingDeleteTitle()
+			: pendingKill
+				? `${keyText("app.agents.delete")} again to stop`
+				: row.title;
 		const titleCell = formatTableCell(title, titleWidth);
 		const cells = [
 			icon,
-			pendingDelete ? theme.fg("error", titleCell) : titleCell,
+			pendingDelete || pendingKill ? theme.fg("error", titleCell) : titleCell,
 			formatRightTableCell(formatSessionDuration(row.summary), timeWidth),
 		];
 		const base = `${indent}${cells[0]} ${cells[1]} ${cells[2]}`;
@@ -1110,6 +1180,12 @@ class AgentsViewMode implements Component, Focusable {
 	private isPendingDeleteRow(row: AgentsViewRow): boolean {
 		return (
 			getSummaryIdentity(row.summary) === this.pendingDeleteAgent?.identity && this.isDeleteConfirmationVisible()
+		);
+	}
+
+	private isPendingKillSubagentRow(row: AgentsViewRow): boolean {
+		return (
+			getSummaryIdentity(row.summary) === this.pendingKillSubagent?.identity && this.isDeleteConfirmationVisible()
 		);
 	}
 
@@ -1134,13 +1210,16 @@ class AgentsViewMode implements Component, Focusable {
 			const tone = this.statusMessage.startsWith("Failed") ? "error" : "muted";
 			return truncateToWidth(theme.fg(tone, this.statusMessage), width);
 		}
-		// Subagents are read-only: reply and stop/deactivate don't apply to them.
-		const selectedAgent = this.rows[this.selectedIndex]?.kind === "agent";
+		// Replying is reserved for top-level agents; running subagents can be stopped.
+		const selectedRow = this.rows[this.selectedIndex];
+		const selectedAgent = selectedRow?.kind === "agent";
+		const selectedRunningSubagent = selectedRow?.kind === "subagent" && isRunningSessionSummary(selectedRow.summary);
 		const hints = [
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open/send`,
 			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
 			selectedAgent ? `${keyText("app.agents.delete")} stop/deactivate` : undefined,
+			selectedRunningSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
 			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -86,6 +86,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"steer",
 	"follow_up",
 	"abort",
+	"cancel_rlm_child",
 	"wait_for_idle",
 	"get_state",
 	"get_connection_state",
@@ -671,6 +672,12 @@ class AgentDaemon {
 				const state = this.getSessionState(command.activeSessionId);
 				await state.runtime.session.abort();
 				return success(command.id, "abort");
+			}
+
+			case "cancel_rlm_child": {
+				const state = this.getSessionState(command.activeSessionId);
+				const cancelled = state.runtime.session.cancelRlmChildRun(command.childId);
+				return success(command.id, "cancel_rlm_child", { cancelled });
 			}
 
 			case "wait_for_idle": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -257,6 +257,14 @@ export function isDaemonDialogExtensionUiRequest(method: string): boolean {
 	return method === "select" || method === "confirm" || method === "input" || method === "editor";
 }
 
+/**
+ * True when a daemon rejected a command it does not know, i.e. the daemon
+ * process was started from a build that predates the command.
+ */
+export function isUnknownDaemonCommandError(error: unknown, command: DaemonCommand["type"]): boolean {
+	return error instanceof Error && error.message.includes(`Unknown daemon command: ${command}`);
+}
+
 export interface DaemonRequestProgress {
 	id?: string;
 	type: "session_list_progress";

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -173,6 +173,7 @@ export type DaemonCommand =
 	| { id?: string; type: "steer"; activeSessionId: string; message: string; images?: ImageContent[] }
 	| { id?: string; type: "follow_up"; activeSessionId: string; message: string; images?: ImageContent[] }
 	| { id?: string; type: "abort"; activeSessionId: string }
+	| { id?: string; type: "cancel_rlm_child"; activeSessionId: string; childId: string }
 	| { id?: string; type: "wait_for_idle"; activeSessionId: string }
 	| { id?: string; type: "get_state"; activeSessionId: string }
 	| { id?: string; type: "get_connection_state"; activeSessionId: string }

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -165,16 +165,16 @@ export function buildRlmChildSnapshots(
 	}
 
 	const snapshots: AgentConnectionRlmChildAgentSnapshot[] = [];
-	const visit = (parentActiveSessionId: string, parentNodeId: string | undefined): void => {
+	const visit = (parent: ActiveSessionState | undefined, parentActiveSessionId: string): void => {
+		const parentNodeId = parent?.runtime.metadata.rlmChildId;
 		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
-			const metadata = child.runtime.metadata;
-			snapshots.push(rlmChildSnapshotForActiveSession(child, metadata, parentNodeId));
+			snapshots.push(rlmChildSnapshotForActiveSession(child, child.runtime.metadata, parentNodeId, parent));
 			// A child passes its own node id to its children as their parent id.
-			visit(child.activeSessionId, metadata.rlmChildId);
+			visit(child, child.activeSessionId);
 		}
 	};
 	const root = activeSessions.find((candidate) => candidate.activeSessionId === rootActiveSessionId);
-	visit(rootActiveSessionId, root?.runtime.metadata.rlmChildId);
+	visit(root, rootActiveSessionId);
 	return snapshots;
 }
 
@@ -182,6 +182,7 @@ function rlmChildSnapshotForActiveSession(
 	activeSession: ActiveSessionState,
 	metadata: AgentSessionRuntimeMetadata,
 	parentNodeId: string | undefined,
+	parent: ActiveSessionState | undefined,
 ): AgentConnectionRlmChildAgentSnapshot {
 	const session = activeSession.runtime.session;
 	const transcript: AgentConnectionRlmChildAgentTranscriptLine[] = [];
@@ -199,11 +200,18 @@ function rlmChildSnapshotForActiveSession(
 			answerPreview = text;
 		}
 	}
+	// The parent session's run tracker is the source of truth for child status;
+	// a daemon-hosted child whose agent is momentarily idle is still part of an
+	// active run. The streaming heuristic only covers parents the daemon does
+	// not host (e.g. children attributed to a session created by an older build).
+	const runStatus = metadata.rlmChildId
+		? parent?.runtime.session.getRlmChildRunStatus(metadata.rlmChildId)
+		: undefined;
 	return {
 		id: metadata.rlmChildId ?? activeSession.activeSessionId,
 		parentId: parentNodeId,
 		label: compactRlmText(metadata.prompt ?? "", 80) || "child agent",
-		status: session.isStreaming || session.pendingMessageCount > 0 ? "running" : "done",
+		status: runStatus ?? (session.isStreaming || session.pendingMessageCount > 0 ? "running" : "done"),
 		answerPreview,
 		sessionDir: metadata.sessionDir ?? session.sessionManager.getSessionDir(),
 		transcript,

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -392,6 +392,11 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			return;
 		}
 
+		// Any input other than the kill key disarms the pending confirmation,
+		// matching the agents view delete flow.
+		if (!kb.matches(data, "app.agents.delete")) {
+			this.clearKillConfirmation({ render: false });
+		}
 		if (kb.matches(data, "app.agents.back")) {
 			this.onCancel?.();
 			return;
@@ -471,7 +476,6 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		if (flat.length === 0) {
 			return;
 		}
-		this.clearKillConfirmation({ render: false });
 		const current = Math.max(
 			0,
 			flat.findIndex((entry) => entry.node.id === this.selectedId),
@@ -628,6 +632,11 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 
 	handleInput(data: string): void {
 		const kb = getKeybindings();
+		// Any input other than the kill key disarms the pending confirmation,
+		// matching the agents view delete flow.
+		if (!kb.matches(data, "app.agents.delete")) {
+			this.clearKillConfirmation({ render: false });
+		}
 		if (kb.matches(data, "app.tools.expand")) {
 			this.onToggleToolsExpanded?.();
 			return;

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -153,6 +153,13 @@ function hintLine(hints: ReadonlyArray<string | undefined>, width: number): stri
 	return truncateToWidth(joinHints(hints), width, "");
 }
 
+// Matches the agents view delete confirmation window.
+const KILL_CONFIRM_DURATION_MS = 2000;
+
+function isKillableChildAgentStatus(status: ChildAgentStatus): boolean {
+	return status === "running" || status === "queued";
+}
+
 // Subagent list entries mirror the agents view row format: icon, title, right-aligned time.
 function childAgentStatusIcon(status: ChildAgentStatus): string {
 	switch (status) {
@@ -335,17 +342,25 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 	private readonly paddingX = 1;
 	private nodes: readonly ChildAgentInspectorNode[] = [];
 	private selectedId: string | undefined;
+	private pendingKillId: string | undefined;
+	private killConfirmExpiresAt = 0;
+	private killConfirmTimer: ReturnType<typeof setTimeout> | undefined;
 
 	onCancel?: () => void;
 	onOpenDetail?: (nodeId: string) => void;
+	onKill?: (nodeId: string) => void;
 
-	constructor(private readonly getViewportHeight: () => number = () => 0) {}
+	constructor(
+		private readonly getViewportHeight: () => number = () => 0,
+		private readonly requestRender: () => void = () => {},
+	) {}
 
 	setNodes(nodes: readonly ChildAgentInspectorNode[]): void {
 		this.nodes = nodes;
 		const flat = this.flatten();
 		if (flat.length === 0) {
 			this.selectedId = undefined;
+			this.clearKillConfirmation({ render: false });
 			return;
 		}
 		if (!this.selectedId || !flat.some((entry) => entry.node.id === this.selectedId)) {
@@ -385,6 +400,10 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 			if (this.selectedId) {
 				this.onOpenDetail?.(this.selectedId);
 			}
+			return;
+		}
+		if (kb.matches(data, "app.agents.delete")) {
+			this.handleKillKey();
 			return;
 		}
 		if (kb.matches(data, "tui.select.up")) {
@@ -436,9 +455,12 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		const icon = formatChildAgentStatusIcon(entry.node.status, rawIcon);
 		const timeWidth = 6;
 		const titleWidth = Math.max(0, width - visibleWidth(indent) - visibleWidth(rawIcon) - timeWidth - 2);
-		const titleCell = padTableCell(entry.node.label, titleWidth);
+		const pendingKill = this.isPendingKillNode(entry.node);
+		const title = pendingKill ? `${keyText("app.agents.delete").trim()} again to stop` : entry.node.label;
+		const titleCell = padTableCell(title, titleWidth);
 		const timeCell = padRightTableCell(formatChildAgentDuration(entry.node.durationMs), timeWidth);
-		return this.truncate(`${indent}${icon} ${titleCell} ${timeCell}`, width, "");
+		const renderedTitleCell = pendingKill ? theme.fg("error", titleCell) : titleCell;
+		return this.truncate(`${indent}${icon} ${renderedTitleCell} ${timeCell}`, width, "");
 	}
 	private flatten(): FlatChildAgentNode[] {
 		return flattenChildAgentNodes(this.nodes);
@@ -449,12 +471,68 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 		if (flat.length === 0) {
 			return;
 		}
+		this.clearKillConfirmation({ render: false });
 		const current = Math.max(
 			0,
 			flat.findIndex((entry) => entry.node.id === this.selectedId),
 		);
 		const next = (current + delta + flat.length) % flat.length;
 		this.selectedId = flat[next]?.node.id;
+	}
+
+	private handleKillKey(): void {
+		const selected = this.flatten().find((entry) => entry.node.id === this.selectedId)?.node;
+		if (!selected || !isKillableChildAgentStatus(selected.status)) {
+			this.clearKillConfirmation({ render: false });
+			return;
+		}
+		if (this.pendingKillId === selected.id && this.isKillConfirmationVisible()) {
+			this.clearKillConfirmation({ render: false });
+			this.onKill?.(selected.id);
+			return;
+		}
+		this.showKillConfirmation(selected.id);
+	}
+
+	private isPendingKillNode(node: ChildAgentInspectorNode): boolean {
+		return (
+			node.id === this.pendingKillId && isKillableChildAgentStatus(node.status) && this.isKillConfirmationVisible()
+		);
+	}
+
+	private showKillConfirmation(nodeId: string): void {
+		if (this.killConfirmTimer) {
+			clearTimeout(this.killConfirmTimer);
+		}
+		this.pendingKillId = nodeId;
+		this.killConfirmExpiresAt = Date.now() + KILL_CONFIRM_DURATION_MS;
+		this.killConfirmTimer = setTimeout(() => {
+			this.killConfirmTimer = undefined;
+			this.pendingKillId = undefined;
+			this.killConfirmExpiresAt = 0;
+			this.requestRender();
+		}, KILL_CONFIRM_DURATION_MS);
+		this.killConfirmTimer.unref?.();
+		this.requestRender();
+	}
+
+	private clearKillConfirmation(options: { render?: boolean } = {}): void {
+		if (!this.killConfirmTimer && this.killConfirmExpiresAt === 0) {
+			return;
+		}
+		if (this.killConfirmTimer) {
+			clearTimeout(this.killConfirmTimer);
+			this.killConfirmTimer = undefined;
+		}
+		this.pendingKillId = undefined;
+		this.killConfirmExpiresAt = 0;
+		if (options.render !== false) {
+			this.requestRender();
+		}
+	}
+
+	private isKillConfirmationVisible(): boolean {
+		return this.killConfirmExpiresAt > Date.now();
 	}
 
 	private headerLine(running: number, total: number, width: number): string {
@@ -466,10 +544,13 @@ export class ChildAgentInspectorComponent implements Component, Focusable {
 	}
 
 	private listHintLine(width: number): string {
+		const selected = this.flatten().find((entry) => entry.node.id === this.selectedId)?.node;
+		const killable = selected !== undefined && isKillableChildAgentStatus(selected.status);
 		return hintLine(
 			[
 				combinedKeyAction(["tui.select.up", "tui.select.down"], "move"),
 				keyAction("tui.select.confirm", "open"),
+				killable ? keyAction("app.agents.delete", "stop", { primaryOnly: true }) : undefined,
 				keyAction("app.agents.back", "back to chat", { primaryOnly: true }),
 			],
 			width,
@@ -495,9 +576,12 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	private transcriptComponents: Component[] = [];
 	private readonly fallbackTui = { requestRender: () => {} } as TUI;
 	private toolsExpanded = false;
+	private killConfirmExpiresAt = 0;
+	private killConfirmTimer: ReturnType<typeof setTimeout> | undefined;
 
 	onCancel?: () => void;
 	onToggleToolsExpanded?: () => void;
+	onKill?: (nodeId: string) => void;
 
 	constructor(
 		_getViewportHeight: () => number = () => 0,
@@ -507,6 +591,9 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	setNode(node: ChildAgentInspectorNode | undefined): void {
+		if (node?.id !== this.node?.id) {
+			this.clearKillConfirmation({ render: false });
+		}
 		this.node = node;
 		this.toolsExpanded = this.options.getToolsExpanded?.() ?? this.toolsExpanded;
 		this.rebuildTranscriptComponents();
@@ -545,9 +632,63 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			this.onToggleToolsExpanded?.();
 			return;
 		}
+		if (kb.matches(data, "app.agents.delete")) {
+			this.handleKillKey();
+			return;
+		}
 		if (kb.matches(data, "app.agents.back")) {
 			this.onCancel?.();
 		}
+	}
+
+	private handleKillKey(): void {
+		const node = this.node;
+		if (!node || !isKillableChildAgentStatus(node.status)) {
+			this.clearKillConfirmation({ render: false });
+			return;
+		}
+		if (this.isKillConfirmationVisible()) {
+			this.clearKillConfirmation({ render: false });
+			this.onKill?.(node.id);
+			return;
+		}
+		this.showKillConfirmation();
+	}
+
+	private showKillConfirmation(): void {
+		if (this.killConfirmTimer) {
+			clearTimeout(this.killConfirmTimer);
+		}
+		this.killConfirmExpiresAt = Date.now() + KILL_CONFIRM_DURATION_MS;
+		this.killConfirmTimer = setTimeout(() => {
+			this.killConfirmTimer = undefined;
+			this.killConfirmExpiresAt = 0;
+			this.requestRender();
+		}, KILL_CONFIRM_DURATION_MS);
+		this.killConfirmTimer.unref?.();
+		this.requestRender();
+	}
+
+	private clearKillConfirmation(options: { render?: boolean } = {}): void {
+		if (!this.killConfirmTimer && this.killConfirmExpiresAt === 0) {
+			return;
+		}
+		if (this.killConfirmTimer) {
+			clearTimeout(this.killConfirmTimer);
+			this.killConfirmTimer = undefined;
+		}
+		this.killConfirmExpiresAt = 0;
+		if (options.render !== false) {
+			this.requestRender();
+		}
+	}
+
+	private isKillConfirmationVisible(): boolean {
+		return this.killConfirmExpiresAt > Date.now();
+	}
+
+	private requestRender(): void {
+		(this.options.ui ?? this.fallbackTui).requestRender();
 	}
 
 	private renderDetail(width: number): DetailSections {
@@ -681,7 +822,16 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 
 	private detailHintLine(width: number): string {
 		const expandAction = keyAction("app.tools.expand", this.toolsExpanded ? "to collapse" : "to expand");
-		return hintLine([keyAction("app.agents.back", "back to subagents", { primaryOnly: true }), expandAction], width);
+		const killable = this.node !== undefined && isKillableChildAgentStatus(this.node.status);
+		const stopAction = !killable
+			? undefined
+			: this.isKillConfirmationVisible()
+				? theme.fg("error", `${keyText("app.agents.delete", { primaryOnly: true }).trim()} again to stop`)
+				: keyAction("app.agents.delete", "stop", { primaryOnly: true });
+		return hintLine(
+			[keyAction("app.agents.back", "back to subagents", { primaryOnly: true }), expandAction, stopAction],
+			width,
+		);
 	}
 
 	private statusLabel(status: ChildAgentStatus): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -117,7 +117,6 @@ import type {
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
-import { isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -4149,11 +4148,7 @@ export class InteractiveMode {
 				this.showError("Subagent already finished");
 			}
 		} catch (error) {
-			this.showError(
-				isUnknownDaemonCommandError(error, "cancel_rlm_child")
-					? "Failed to stop subagent: the daemon is running an older build; restart the daemon and try again"
-					: `Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			this.showError(`Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`);
 		}
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -117,6 +117,7 @@ import type {
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
+import { isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -4124,7 +4125,11 @@ export class InteractiveMode {
 				this.showError("Subagent already finished");
 			}
 		} catch (error) {
-			this.showError(`Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`);
+			this.showError(
+				isUnknownDaemonCommandError(error, "cancel_rlm_child")
+					? "Failed to stop subagent: the daemon is running an older build; restart the daemon and try again"
+					: `Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -645,9 +645,13 @@ export class InteractiveMode {
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
-		this.childAgentInspector = new ChildAgentInspectorComponent(() => this.getChildAgentPanelRows());
+		this.childAgentInspector = new ChildAgentInspectorComponent(
+			() => this.getChildAgentPanelRows(),
+			() => this.ui.requestRender(),
+		);
 		this.childAgentInspector.onCancel = () => this.closeChildAgentPanel();
 		this.childAgentInspector.onOpenDetail = (nodeId) => this.openChildAgentDetail(nodeId);
+		this.childAgentInspector.onKill = (nodeId) => void this.killChildAgent(nodeId);
 		this.childAgentDetail = new ChildAgentDetailComponent(() => this.getChildAgentPanelRows(), {
 			ui: this.ui,
 			getCwd: () => this.getCurrentCwd(),
@@ -663,6 +667,7 @@ export class InteractiveMode {
 		});
 		this.childAgentDetail.onCancel = () => this.showChildAgentList();
 		this.childAgentDetail.onToggleToolsExpanded = () => this.toggleToolOutputExpansion();
+		this.childAgentDetail.onKill = (nodeId) => void this.killChildAgent(nodeId);
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
 		this.keybindings = KeybindingsManager.create();
@@ -4110,6 +4115,18 @@ export class InteractiveMode {
 			return;
 		}
 		this.showChildAgentList();
+	}
+
+	private async killChildAgent(nodeId: string): Promise<void> {
+		try {
+			const cancelled = await this.agentConnection.cancelRlmChild(nodeId);
+			if (!cancelled) {
+				this.showError("Subagent already finished");
+			}
+		} catch (error) {
+			this.showError(`Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		this.ui.requestRender();
 	}
 
 	private showChildAgentList(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3985,14 +3985,38 @@ export class InteractiveMode {
 	}
 
 	private updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void {
-		this.childAgentSnapshots.set(child.id, child);
+		// Cancelled subagents were deliberately stopped; drop them from the
+		// viewer instead of keeping a dead row around.
+		if (child.status === "cancelled") {
+			this.removeChildAgentSnapshot(child.id);
+		} else {
+			this.childAgentSnapshots.set(child.id, child);
+		}
 		this.childAgentNodes = this.buildChildAgentInspectorNodes();
 		this.childAgentSummary.setNodes(this.childAgentNodes);
 		this.childAgentInspector.setNodes(this.childAgentNodes);
 		if (this.childAgentDetailNodeId) {
-			this.childAgentDetail.setNode(this.findChildAgentInspectorNode(this.childAgentDetailNodeId));
+			const detailNode = this.findChildAgentInspectorNode(this.childAgentDetailNodeId);
+			if (!detailNode && this.childAgentPanelMode === "detail") {
+				this.showChildAgentList();
+				return;
+			}
+			this.childAgentDetail.setNode(detailNode);
+		}
+		if (this.childAgentPanelMode === "list" && this.childAgentNodes.length === 0) {
+			this.closeChildAgentPanel();
+			return;
 		}
 		this.ui.requestRender();
+	}
+
+	private removeChildAgentSnapshot(id: string): void {
+		this.childAgentSnapshots.delete(id);
+		for (const child of [...this.childAgentSnapshots.values()]) {
+			if (child.parentId === id) {
+				this.removeChildAgentSnapshot(child.id);
+			}
+		}
 	}
 
 	private restoreMainAgentView(): void {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -204,6 +204,13 @@ class FakeDaemonClient {
 			case "extension_ui_response":
 			case "detach":
 				return { type: "response", command: command.type, success: true };
+			case "cancel_rlm_child":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: { cancelled: command.childId === "child-1" },
+				};
 			case "delete_saved_session":
 				return {
 					type: "response",
@@ -692,6 +699,21 @@ describe("DaemonAgentConnection", () => {
 			type: "set_scoped_models",
 			activeSessionId: "active-1",
 			scopedModels: [{ model, thinkingLevel: "high" }],
+		});
+	});
+
+	it("cancels rlm child runs through the daemon protocol", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		await connection.attach();
+
+		await expect(connection.cancelRlmChild("child-1")).resolves.toBe(true);
+		await expect(connection.cancelRlmChild("finished-child")).resolves.toBe(false);
+
+		expect(fakeClient.requests[1]).toMatchObject({
+			type: "cancel_rlm_child",
+			activeSessionId: "active-1",
+			childId: "child-1",
 		});
 	});
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -205,6 +205,14 @@ class FakeDaemonClient {
 			case "detach":
 				return { type: "response", command: command.type, success: true };
 			case "cancel_rlm_child":
+				if (command.childId === "stale-daemon") {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: "Unknown daemon command: cancel_rlm_child",
+					};
+				}
 				return {
 					type: "response",
 					command: command.type,
@@ -715,6 +723,12 @@ describe("DaemonAgentConnection", () => {
 			activeSessionId: "active-1",
 			childId: "child-1",
 		});
+
+		// A daemon from a build that predates the command reports a restart hint
+		// instead of the raw protocol error.
+		await expect(connection.cancelRlmChild("stale-daemon")).rejects.toThrow(
+			"the daemon is running an older build; restart the daemon and try again",
+		);
 	});
 
 	it("loads resource snapshots through the daemon protocol", async () => {

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -100,6 +100,7 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 		scopedModels: [],
 		getActiveToolNames: () => ["ipython"],
 		getContextUsage: () => undefined,
+		cancelRlmChildRun: (childId: string) => childId === "child-1",
 		getToolDefinition: (toolName: string) => ({
 			name: toolName,
 			label: toolName,
@@ -153,6 +154,15 @@ describe("InProcessAgentConnection", () => {
 		expect(definition).not.toHaveProperty("execute");
 		expect(definition).not.toHaveProperty("renderCall");
 		expect(definition).not.toHaveProperty("renderResult");
+	});
+
+	it("cancels rlm child runs through the session", async () => {
+		const session = createFakeSession("rlm", []);
+		const runtime = new FakeRuntime(session.session);
+		const connection = new InProcessAgentConnection(asRuntime(runtime));
+
+		await expect(connection.cancelRlmChild("child-1")).resolves.toBe(true);
+		await expect(connection.cancelRlmChild("finished-child")).resolves.toBe(false);
 	});
 
 	it("loads session context through the connection boundary", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -104,6 +104,7 @@ interface InspectableRlmRun {
 	abort: () => void;
 	status: string;
 	error?: string;
+	session?: AgentSession;
 }
 
 interface InspectableRlmSession {
@@ -440,6 +441,114 @@ describe("AgentSession rlm recursion", () => {
 		expect(run.error).toBe("Parent session aborted");
 		releaseChild();
 		await expect(runPromise).rejects.toThrow("Parent session aborted");
+	});
+
+	it("cancels a single rlm child run by id and reports unknown ids", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const root = createSession({
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				if (text === "slow shard") {
+					childStarted = true;
+					void release.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+					});
+				}
+				return stream;
+			},
+		});
+		const childStatuses: string[] = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") {
+				childStatuses.push(event.child.status);
+			}
+		});
+
+		const runPromise = root.runRlmChild("slow shard");
+		await waitFor(() => childStarted);
+		const runs = (root as unknown as InspectableRlmSession)._activeRlmChildRuns;
+		expect(runs.size).toBe(1);
+		const childId = [...runs.keys()][0];
+		if (!childId) {
+			throw new Error("Missing child run id");
+		}
+		const run = runs.get(childId);
+
+		expect(root.cancelRlmChildRun("unknown-child")).toBe(false);
+		expect(run?.status).toBe("running");
+
+		expect(root.cancelRlmChildRun(childId)).toBe(true);
+		expect(run?.status).toBe("cancelled");
+		expect(run?.error).toBe("Cancelled by user");
+		releaseChild();
+		await expect(runPromise).rejects.toThrow("Cancelled by user");
+		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");
+
+		// The run has finished; a second cancel finds nothing to stop.
+		expect(root.cancelRlmChildRun(childId)).toBe(false);
+	});
+
+	it("cancels nested rlm child runs through the root session", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let releaseNested: () => void = () => {};
+		const nestedRelease = new Promise<void>((resolve) => {
+			releaseNested = resolve;
+		});
+		let childStarted = false;
+		let nestedStarted = false;
+		const root = createSession({
+			maxDepth: 2,
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				if (text === "slow shard") {
+					childStarted = true;
+					void release.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+					});
+				} else if (text === "nested shard") {
+					nestedStarted = true;
+					void nestedRelease.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+					});
+				}
+				return stream;
+			},
+		});
+
+		const runPromise = root.runRlmChild("slow shard");
+		await waitFor(() => childStarted);
+		const rootRuns = (root as unknown as InspectableRlmSession)._activeRlmChildRuns;
+		const rootRun = [...rootRuns.values()][0];
+		if (!rootRun?.session) {
+			throw new Error("Missing child session on root run");
+		}
+
+		const childSession = rootRun.session;
+		const nestedPromise = childSession.runRlmChild("nested shard");
+		await waitFor(() => nestedStarted);
+		const nestedRuns = (childSession as unknown as InspectableRlmSession)._activeRlmChildRuns;
+		expect(nestedRuns.size).toBe(1);
+		const nestedId = [...nestedRuns.keys()][0];
+		if (!nestedId) {
+			throw new Error("Missing nested run id");
+		}
+
+		expect(root.cancelRlmChildRun(nestedId)).toBe(true);
+		releaseNested();
+		await expect(nestedPromise).rejects.toThrow("Cancelled by user");
+		expect(rootRun.status).toBe("running");
+
+		releaseChild();
+		await expect(runPromise).resolves.toMatchObject({ answer: "child answer: slow shard" });
 	});
 
 	it("runs parallel rlm comm requests independently", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -485,6 +485,9 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.cancelRlmChildRun(childId)).toBe(true);
 		expect(run?.status).toBe("cancelled");
 		expect(run?.error).toBe("Cancelled by user");
+		// The cancelled update is pushed at cancel time, before the (possibly
+		// stuck) child unwinds; viewers must not keep showing a running child.
+		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");
 		releaseChild();
 		await expect(runPromise).rejects.toThrow("Cancelled by user");
 		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -152,6 +152,33 @@ describe("buildRlmChildSnapshots", () => {
 		});
 	});
 
+	it("prefers the parent's run status over the streaming heuristic", () => {
+		// An idle child session is still part of an active run; only the parent's
+		// run tracker knows that.
+		const parent = makeState({
+			activeSessionId: "parent",
+			sessionFile: "/tmp/parent.jsonl",
+			childRunStatuses: { "sub-aaa": "running" },
+		});
+		const idleChild = makeState({
+			activeSessionId: "child",
+			isStreaming: false,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: "parent",
+				rlmChildId: "sub-aaa",
+				rlmParentNodeId: "sub-aaa",
+				prompt: "Slow task",
+				sessionDir: "/tmp/artifacts/sub-aaa",
+			},
+		});
+
+		const snapshots = buildRlmChildSnapshots("parent", [parent, idleChild]);
+
+		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
+	});
+
 	it("returns no snapshots for sessions without children", () => {
 		const solo = makeState({ activeSessionId: "solo" });
 		expect(buildRlmChildSnapshots("solo", [solo])).toEqual([]);
@@ -166,6 +193,7 @@ interface StateOptions {
 	pendingToolCalls?: string[];
 	clients?: number;
 	messages?: AgentMessage[];
+	childRunStatuses?: Record<string, "queued" | "running" | "done" | "error" | "cancelled">;
 	metadata?: {
 		kind: "top-level" | "subagent";
 		createdAt: number;
@@ -205,6 +233,7 @@ function makeState(options: StateOptions): ActiveSessionState {
 					getSessionDir: () => "/tmp/sessions",
 				},
 				messages: options.messages ?? ([] as AgentMessage[]),
+				getRlmChildRunStatus: (childId: string) => options.childRunStatuses?.[childId],
 				pendingMessageCount: 0,
 				state: {
 					streamingMessage: undefined,


### PR DESCRIPTION
- subagents could get stuck running with no way to stop them; ctrl+x now cancels the selected subagent in the subagent viewer and the agents view.
- uses the same keybinding and two-tap confirmation pattern as the agents view deactivate flow, in the list, transcript, and agents view rows.
- cancellation is plumbed through the agent connection and a new daemon command, so it also works for nested subagents; a stale daemon now reports that it needs a restart instead of a raw protocol error.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ability to kill running subagents from interactive and agents-view UI
> - Adds a `cancelRlmChildRun` method to `AgentSession` that cancels a specific child run by id, including nested runs, and immediately emits a terminal update snapshot.
> - Extends the daemon protocol with a `cancel_rlm_child` command and wires it through `DaemonAgentConnection` and `InProcessAgentConnection` via a new `cancelRlmChild` method on the `AgentConnection` interface.
> - Adds a two-press confirmation kill flow to both the agents-view ([agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/140/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10)) and interactive inspector ([child-agent-inspector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/140/files#diff-c6e80ba5fe28e36eaaf2f0d66307dec3db0481b56d24b214c31d2530d49517a1)), with visual feedback and keyboard hints.
> - Fixes child snapshot status derivation in [daemon-session-list.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/140/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21) to use the parent session's run tracker instead of the streaming heuristic, preventing idle-but-running subagents from appearing as done.
> - Cancelled subagents are removed from the interactive viewer, which auto-navigates when the focused node disappears.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 844d81d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RLM child lifecycle, daemon protocol, and nested session abort paths; mis-cancellation could stop the wrong child, but scope is limited to explicit user kill and returns boolean for races with natural completion.
> 
> **Overview**
> Adds a way to **stop individual RLM subagents** that are running or queued, including **nested** children, without aborting the whole parent session.
> 
> **Core:** `AgentSession` gains `cancelRlmChildRun` / `getRlmChildRunStatus`, refactors bulk cancel through `_cancelRlmChildRun`, keeps a child `session` on each run for recursive lookup, and **re-emits `rlm_child_update` immediately** on cancel so stuck streams still show `cancelled` in the UI.
> 
> **Plumbing:** `AgentConnection.cancelRlmChild` is implemented for in-process and daemon clients; the daemon adds **`cancel_rlm_child`** and **`isUnknownDaemonCommandError`** so older daemons get a restart hint.
> 
> **UI:** Agents view routes delete on subagent rows to a two-tap kill (root session + `rlmChildId`). The child agent inspector/detail panels use the same delete-key confirmation and call `cancelRlmChild`. Cancelled children are **removed** from the inspector; empty lists close the panel. Session list snapshots prefer the **parent run tracker** for subagent status over idle/streaming heuristics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844d81d6b1ddce6bf17864c9fe8b47e2fc4b575d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->