### PR TITLE
show agent activity and live token count in the working loader

### DIFF
--- a/packages/coding-agent/src/modes/interactive/agent-activity.ts
+++ b/packages/coding-agent/src/modes/interactive/agent-activity.ts
@@ -119,7 +119,7 @@ export class AgentActivityTracker {
 		return this.completedTokens + Math.max(this.streamingUsageTokens, this.estimatedStreamingTokens());
 	}
 
-	private reset(): void {
+	reset(): void {
 		this.activity = "waiting";
 		this.completedTokens = 0;
 		this.streamingUsageTokens = 0;

--- a/packages/coding-agent/src/modes/interactive/agent-activity.ts
+++ b/packages/coding-agent/src/modes/interactive/agent-activity.ts
@@ -1,0 +1,143 @@
+import type { AgentConnectionSessionEvent } from "../agent-connection/index.js";
+
+export type AgentActivity = "waiting" | "thinking" | "writing" | "writing-code" | "executing";
+
+export interface AgentActivityStatus {
+	activity: AgentActivity;
+	/** "down" while receiving model output, "up" while sending (request in flight or tool executing). */
+	direction: "down" | "up";
+	/** Output tokens accumulated since the user's last message. */
+	tokens: number;
+}
+
+export const AGENT_ACTIVITY_LABELS: Record<AgentActivity, string> = {
+	waiting: "Waiting",
+	thinking: "Thinking",
+	writing: "Writing",
+	"writing-code": "Writing code",
+	executing: "Executing",
+};
+
+/** Fallback estimate for providers that only report usage when the message completes. */
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+
+/**
+ * Derives what the agent is doing right now (and how many output tokens it has
+ * produced since the user's last message) from the session event stream, so the
+ * working loader can show more than a static "Working...".
+ */
+export class AgentActivityTracker {
+	private activity: AgentActivity = "waiting";
+	private completedTokens = 0;
+	private streamingUsageTokens = 0;
+	private streamingChars = 0;
+	private runningToolCount = 0;
+	// Providers like Anthropic only report usage at the start and end of a message, so the
+	// live count leans on the character estimate in between. Keeping the reported value
+	// monotonic prevents it from dipping when authoritative usage arrives at message end.
+	private reportedTokens = 0;
+
+	handleEvent(event: AgentConnectionSessionEvent): void {
+		switch (event.type) {
+			case "agent_start":
+				this.activity = "waiting";
+				this.runningToolCount = 0;
+				break;
+
+			case "message_start":
+				if (event.message.role === "user") {
+					this.reset();
+				} else if (event.message.role === "assistant") {
+					this.activity = "waiting";
+					this.streamingUsageTokens = 0;
+					this.streamingChars = 0;
+				}
+				break;
+
+			case "message_update": {
+				if (event.message.role !== "assistant") break;
+				const streamEvent = event.assistantMessageEvent;
+				switch (streamEvent.type) {
+					case "thinking_start":
+					case "thinking_delta":
+						this.activity = "thinking";
+						break;
+					case "text_start":
+					case "text_delta":
+						this.activity = "writing";
+						break;
+					case "toolcall_start":
+					case "toolcall_delta":
+						this.activity = "writing-code";
+						break;
+					default:
+						break;
+				}
+				if ("delta" in streamEvent) {
+					this.streamingChars += streamEvent.delta.length;
+				}
+				this.streamingUsageTokens = event.message.usage.output;
+				break;
+			}
+
+			case "message_end":
+				if (event.message.role !== "assistant") break;
+				this.completedTokens +=
+					event.message.usage.output > 0 ? event.message.usage.output : this.estimatedStreamingTokens();
+				this.streamingUsageTokens = 0;
+				this.streamingChars = 0;
+				this.activity = "waiting";
+				break;
+
+			case "tool_execution_start":
+				this.runningToolCount++;
+				this.activity = "executing";
+				break;
+
+			case "tool_execution_end":
+				this.runningToolCount = Math.max(0, this.runningToolCount - 1);
+				if (this.runningToolCount === 0) {
+					this.activity = "waiting";
+				}
+				break;
+
+			default:
+				break;
+		}
+		this.reportedTokens = Math.max(this.reportedTokens, this.currentTokens());
+	}
+
+	getStatus(): AgentActivityStatus {
+		return {
+			activity: this.activity,
+			direction: this.activity === "waiting" || this.activity === "executing" ? "up" : "down",
+			tokens: this.reportedTokens,
+		};
+	}
+
+	private currentTokens(): number {
+		return this.completedTokens + Math.max(this.streamingUsageTokens, this.estimatedStreamingTokens());
+	}
+
+	private reset(): void {
+		this.activity = "waiting";
+		this.completedTokens = 0;
+		this.streamingUsageTokens = 0;
+		this.streamingChars = 0;
+		this.runningToolCount = 0;
+		this.reportedTokens = 0;
+	}
+
+	private estimatedStreamingTokens(): number {
+		return Math.round(this.streamingChars / CHARS_PER_TOKEN_ESTIMATE);
+	}
+}
+
+// Same tiers as the token formatter in the pre-fork footer (removed in #21).
+export function formatTokenCount(count: number): string {
+	if (count < 1000) return count.toString();
+	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+	if (count < 1000000) return `${Math.round(count / 1000)}k`;
+	if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
+	return `${Math.round(count / 1000000)}M`;
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2125,6 +2125,7 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
+		this.activityTracker.reset();
 		this.resetPendingToolState();
 		this.resetChildAgentInspector();
 		this.setGoalAnnouncementBaseline(this.getGoalState());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -117,6 +117,7 @@ import type {
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
+import { AGENT_ACTIVITY_LABELS, AgentActivityTracker, formatTokenCount } from "./agent-activity.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -519,7 +520,7 @@ export class InteractiveMode {
 	private workingIndicatorOptions: LoaderIndicatorOptions | undefined = undefined;
 	private workingStartedAt: number | undefined = undefined;
 	private workingTimer: NodeJS.Timeout | undefined = undefined;
-	private readonly defaultWorkingMessage = "Working...";
+	private readonly activityTracker = new AgentActivityTracker();
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
 
@@ -2327,11 +2328,23 @@ export class InteractiveMode {
 	}
 
 	private getWorkingLoaderMessage(): string {
-		const message = this.workingMessage ?? this.defaultWorkingMessage;
-		if (this.workingStartedAt === undefined) {
-			return message;
+		const elapsed =
+			this.workingStartedAt === undefined
+				? undefined
+				: this.formatWorkingElapsed(Date.now() - this.workingStartedAt);
+		if (this.workingMessage !== undefined) {
+			// Extensions and tool bootstrap own the message; keep the plain "<message> <elapsed>" form.
+			return elapsed === undefined ? this.workingMessage : `${this.workingMessage} ${elapsed}`;
 		}
-		return `${message} ${this.formatWorkingElapsed(Date.now() - this.workingStartedAt)}`;
+		const status = this.activityTracker.getStatus();
+		const parts = [AGENT_ACTIVITY_LABELS[status.activity]];
+		if (elapsed !== undefined) {
+			parts.push(elapsed);
+		}
+		if (status.tokens > 0) {
+			parts.push(`${status.direction === "down" ? "↓" : "↑"} ${formatTokenCount(status.tokens)} tokens`);
+		}
+		return parts.join(" · ");
 	}
 
 	private createWorkingLoader(): Loader {
@@ -3529,6 +3542,8 @@ export class InteractiveMode {
 
 		this.footer.invalidate();
 		this.updateConnectionStateFromEvent(event);
+		this.activityTracker.handleEvent(event);
+		this.updateWorkingLoaderMessage();
 
 		switch (event.type) {
 			case "agent_start":
@@ -3606,10 +3621,14 @@ export class InteractiveMode {
 					let errorMessage: string | undefined;
 					if (this.streamingMessage.stopReason === "aborted") {
 						const retryAttempt = this.getRetryAttempt();
+						const elapsedSuffix =
+							this.workingStartedAt === undefined
+								? ""
+								: ` · ${this.formatWorkingElapsed(Date.now() - this.workingStartedAt)}`;
 						errorMessage =
 							retryAttempt > 0
-								? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-								: "Operation aborted";
+								? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}${elapsedSuffix}`
+								: `Operation aborted${elapsedSuffix}`;
 						this.streamingMessage.errorMessage = errorMessage;
 					}
 					this.ensureAssistantStreamingComponent(event.message).updateContent(this.streamingMessage);
@@ -4413,7 +4432,9 @@ export class InteractiveMode {
 								errorMessage =
 									retryAttempt > 0
 										? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-										: "Operation aborted";
+										: message.errorMessage && message.errorMessage !== "Request was aborted"
+											? message.errorMessage
+											: "Operation aborted";
 							} else {
 								errorMessage = message.errorMessage || "Error";
 							}

--- a/packages/coding-agent/test/agent-activity.test.ts
+++ b/packages/coding-agent/test/agent-activity.test.ts
@@ -1,0 +1,178 @@
+import type { AssistantMessage, AssistantMessageEvent, UserMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { AgentActivityTracker, formatTokenCount } from "../src/modes/interactive/agent-activity.js";
+
+function createAssistantMessage(outputTokens = 0): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: outputTokens,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: outputTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function createUserMessage(): UserMessage {
+	return { role: "user", content: "hello", timestamp: 0 };
+}
+
+function update(message: AssistantMessage, assistantMessageEvent: AssistantMessageEvent) {
+	return { type: "message_update" as const, message, assistantMessageEvent };
+}
+
+describe("AgentActivityTracker", () => {
+	test("starts waiting with no tokens", () => {
+		const tracker = new AgentActivityTracker();
+		expect(tracker.getStatus()).toEqual({ activity: "waiting", direction: "up", tokens: 0 });
+	});
+
+	test("derives activity from streaming delta types", () => {
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage();
+		tracker.handleEvent({ type: "agent_start" });
+		tracker.handleEvent({ type: "message_start", message });
+
+		tracker.handleEvent(update(message, { type: "thinking_delta", contentIndex: 0, delta: "hmm", partial: message }));
+		expect(tracker.getStatus().activity).toBe("thinking");
+		expect(tracker.getStatus().direction).toBe("down");
+
+		tracker.handleEvent(update(message, { type: "text_delta", contentIndex: 1, delta: "hi", partial: message }));
+		expect(tracker.getStatus().activity).toBe("writing");
+
+		tracker.handleEvent(update(message, { type: "toolcall_start", contentIndex: 2, partial: message }));
+		expect(tracker.getStatus().activity).toBe("writing-code");
+		expect(tracker.getStatus().direction).toBe("down");
+	});
+
+	test("uses streamed usage tokens when the provider reports them", () => {
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage(1234);
+		tracker.handleEvent({ type: "message_start", message });
+		tracker.handleEvent(update(message, { type: "text_delta", contentIndex: 0, delta: "hi", partial: message }));
+		expect(tracker.getStatus().tokens).toBe(1234);
+	});
+
+	test("falls back to a character estimate when usage is not streamed", () => {
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage(0);
+		tracker.handleEvent({ type: "message_start", message });
+		tracker.handleEvent(
+			update(message, { type: "text_delta", contentIndex: 0, delta: "a".repeat(40), partial: message }),
+		);
+		expect(tracker.getStatus().tokens).toBe(10);
+	});
+
+	test("updates live from the character estimate when streamed usage is stale", () => {
+		// Anthropic reports usage at message start (~1 token) and then again only at the end.
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage(1);
+		tracker.handleEvent({ type: "message_start", message });
+		tracker.handleEvent(
+			update(message, { type: "text_delta", contentIndex: 0, delta: "a".repeat(400), partial: message }),
+		);
+		expect(tracker.getStatus().tokens).toBe(100);
+	});
+
+	test("never decreases when authoritative usage arrives at message end", () => {
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage(0);
+		tracker.handleEvent({ type: "message_start", message });
+		tracker.handleEvent(
+			update(message, { type: "text_delta", contentIndex: 0, delta: "a".repeat(400), partial: message }),
+		);
+		expect(tracker.getStatus().tokens).toBe(100);
+		tracker.handleEvent({ type: "message_end", message: createAssistantMessage(80) });
+		expect(tracker.getStatus().tokens).toBe(100);
+	});
+
+	test("accumulates tokens across turns and flips direction while executing tools", () => {
+		const tracker = new AgentActivityTracker();
+		const first = createAssistantMessage(500);
+		tracker.handleEvent({ type: "message_start", message: first });
+		tracker.handleEvent(update(first, { type: "toolcall_delta", contentIndex: 0, delta: "code", partial: first }));
+		tracker.handleEvent({ type: "message_end", message: first });
+		expect(tracker.getStatus()).toEqual({ activity: "waiting", direction: "up", tokens: 500 });
+
+		tracker.handleEvent({ type: "tool_execution_start", toolCallId: "t1", toolName: "ipython", args: {} });
+		expect(tracker.getStatus()).toEqual({ activity: "executing", direction: "up", tokens: 500 });
+
+		tracker.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "t1",
+			toolName: "ipython",
+			result: {},
+			isError: false,
+		});
+		expect(tracker.getStatus().activity).toBe("waiting");
+
+		const second = createAssistantMessage(250);
+		tracker.handleEvent({ type: "message_start", message: second });
+		tracker.handleEvent(update(second, { type: "text_delta", contentIndex: 0, delta: "done", partial: second }));
+		expect(tracker.getStatus().tokens).toBe(750);
+	});
+
+	test("stays executing while a parallel tool call is still running", () => {
+		const tracker = new AgentActivityTracker();
+		tracker.handleEvent({ type: "tool_execution_start", toolCallId: "t1", toolName: "ipython", args: {} });
+		tracker.handleEvent({ type: "tool_execution_start", toolCallId: "t2", toolName: "ipython", args: {} });
+		tracker.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "t1",
+			toolName: "ipython",
+			result: {},
+			isError: false,
+		});
+		expect(tracker.getStatus().activity).toBe("executing");
+		tracker.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "t2",
+			toolName: "ipython",
+			result: {},
+			isError: false,
+		});
+		expect(tracker.getStatus().activity).toBe("waiting");
+	});
+
+	test("resets token count on the next user message", () => {
+		const tracker = new AgentActivityTracker();
+		const message = createAssistantMessage(500);
+		tracker.handleEvent({ type: "message_start", message });
+		tracker.handleEvent({ type: "message_end", message });
+		expect(tracker.getStatus().tokens).toBe(500);
+
+		tracker.handleEvent({ type: "message_start", message: createUserMessage() });
+		expect(tracker.getStatus()).toEqual({ activity: "waiting", direction: "up", tokens: 0 });
+	});
+});
+
+describe("formatTokenCount", () => {
+	test("formats counts below 1k as-is", () => {
+		expect(formatTokenCount(0)).toBe("0");
+		expect(formatTokenCount(999)).toBe("999");
+	});
+
+	test("formats small thousands with one decimal", () => {
+		expect(formatTokenCount(1000)).toBe("1.0k");
+		expect(formatTokenCount(9940)).toBe("9.9k");
+	});
+
+	test("drops the decimal at 10k and above", () => {
+		expect(formatTokenCount(12340)).toBe("12k");
+		expect(formatTokenCount(250400)).toBe("250k");
+	});
+
+	test("formats millions", () => {
+		expect(formatTokenCount(1500000)).toBe("1.5M");
+		expect(formatTokenCount(12000000)).toBe("12M");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 
 describe("InteractiveMode compaction events", () => {
@@ -7,6 +8,8 @@ describe("InteractiveMode compaction events", () => {
 			isInitialized: true,
 			footer: { invalidate: vi.fn() },
 			updateConnectionStateFromEvent: vi.fn(),
+			activityTracker: new AgentActivityTracker(),
+			updateWorkingLoaderMessage: vi.fn(),
 			autoCompactionLoader: undefined,
 			defaultEditor: {},
 			statusContainer: { clear: vi.fn() },

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -21,6 +21,7 @@ import type {
 	AgentConnectionSourceInfo,
 	AgentConnectionState,
 } from "../src/modes/agent-connection/types.js";
+import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import type { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
 import { formatSplashCwd, InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -361,6 +362,7 @@ describe("InteractiveMode tool event rendering", () => {
 			init: vi.fn(async () => {}),
 			footer: { invalidate: vi.fn() },
 			updateConnectionStateFromEvent: vi.fn(),
+			activityTracker: new AgentActivityTracker(),
 			streamingComponent: { updateContent: vi.fn() },
 			streamingMessage: undefined,
 			chatContainer: new Container(),
@@ -378,38 +380,40 @@ describe("InteractiveMode tool event rendering", () => {
 			ui: { requestRender: vi.fn() },
 			getCurrentCwd: () => "/tmp/project",
 		});
-		const event = {
-			type: "message_update",
-			message: {
-				role: "assistant",
-				content: [
-					{
-						type: "toolCall",
-						id: "tool-1",
-						name: "ipython",
-						arguments: { code: "print(1)" },
-					},
-				],
-				api: "anthropic-messages",
-				provider: "anthropic",
-				model: "claude-sonnet-4-5",
-				usage: {
+		const message = {
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "tool-1",
+					name: "ipython",
+					arguments: { code: "print(1)" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: {
 					input: 0,
 					output: 0,
 					cacheRead: 0,
 					cacheWrite: 0,
-					totalTokens: 0,
-					cost: {
-						input: 0,
-						output: 0,
-						cacheRead: 0,
-						cacheWrite: 0,
-						total: 0,
-					},
+					total: 0,
 				},
-				stopReason: "stop",
-				timestamp: 1,
 			},
+			stopReason: "stop",
+			timestamp: 1,
+		};
+		const event = {
+			type: "message_update",
+			message,
+			assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, partial: message },
 		} as unknown as AgentConnectionSessionEvent;
 		const handleEvent = (
 			InteractiveMode.prototype as unknown as {

--- a/packages/coding-agent/test/interactive-mode-streaming.test.ts
+++ b/packages/coding-agent/test/interactive-mode-streaming.test.ts
@@ -3,6 +3,7 @@ import { Container, type MarkdownTheme, type TUI } from "@earendil-works/pi-tui"
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import type { AgentConnectionSessionEvent } from "../src/modes/agent-connection/index.js";
+import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import type { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
 import type { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
@@ -54,6 +55,7 @@ function createFakeInteractiveModeThis(): HandleEventThis {
 		isInitialized: true,
 		settingsManager: { getShowTerminalProgress: () => false },
 		footer: { invalidate: vi.fn() },
+		activityTracker: new AgentActivityTracker(),
 		ui: { requestRender: vi.fn() } as unknown as TUI,
 		chatContainer: new Container(),
 		hideThinkingBlock: false,

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -7,6 +7,7 @@ import type {
 	AgentConnectionSessionContext,
 	AgentConnectionSessionEvent,
 } from "../../../src/modes/agent-connection/index.js";
+import { AgentActivityTracker } from "../../../src/modes/interactive/agent-activity.js";
 import type { ToolExecutionComponent } from "../../../src/modes/interactive/components/tool-execution.js";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
@@ -43,6 +44,8 @@ type RenderSessionContextThis = {
 	};
 	toolOutputExpanded: boolean;
 	isInitialized: boolean;
+	activityTracker: AgentActivityTracker;
+	updateWorkingLoaderMessage(): void;
 	updateEditorBorderColor(): void;
 	updateConnectionStateFromEvent(event: AgentConnectionSessionEvent): void;
 	getCurrentCwd(): string;
@@ -83,6 +86,8 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		},
 		toolOutputExpanded: false,
 		isInitialized: true,
+		activityTracker: new AgentActivityTracker(),
+		updateWorkingLoaderMessage: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
 		updateConnectionStateFromEvent: vi.fn(),
 		getCurrentCwd: () => process.cwd(),


### PR DESCRIPTION
- the working loader showed a static "Working..." for entire runs, making long or stuck requests indistinguishable from healthy ones.
- it now derives a live verb (waiting, thinking, writing, writing code, executing) from the session event stream, plus elapsed time and a token count since the last user message with an up/down arrow for send vs receive.
- the count updates per streamed delta with a character-based estimate between the sparse provider usage reports, and aborted runs now show their elapsed time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interactive-mode status text and display logic, covered by new unit tests with no auth, data, or API contract changes.
> 
> **Overview**
> Replaces the static **Working...** loader with a live status derived from session events via a new **`AgentActivityTracker`**.
> 
> When extensions do not override the message, the loader shows an activity label (Waiting, Thinking, Writing, Writing code, Executing), elapsed time, and—when non-zero—a directional token tally (`↓` while streaming model output, `↑` while waiting or running tools). Output tokens since the last user message use streamed usage when available and a ~4 chars/token estimate in between; the displayed count stays monotonic so late provider usage does not make it drop. The tracker resets on new user messages and keeps **Executing** until parallel tools all finish.
> 
> **`InteractiveMode`** feeds every session event into the tracker and refreshes the loader text; aborted runs append elapsed time to abort messages, and historical tool rows prefer a stored abort error over a generic label when rebuilding chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52f76c0648978bb08b0a096667a438ca67e6822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show agent activity label and live token count in the working loader
> - Adds `AgentActivityTracker` in [agent-activity.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/141/files#diff-e1868c25e6f2887704e4c407fdc71b482ecf15ce587f44f17cc7a11ec5b1b891) to derive real-time activity state (`waiting`, `thinking`, `writing`, `writing-code`, `executing`) and a monotonically increasing output token count from session events.
> - Rewrites `getWorkingLoaderMessage` in `InteractiveMode` to display a contextual activity label, elapsed time, and a live token count with a directional arrow (↓ while receiving model output, ↑ during tool execution) instead of a static 'Working...' message.
> - Adds `formatTokenCount` to render token counts as compact strings (e.g. `1.2k`, `3M`), falling back to a chars-per-token estimate when streamed usage is unavailable.
> - Aborted/error messages now append elapsed time and prefer the specific `errorMessage` field when available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f52f76c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->