### PR TITLE
prewarm the ipython kernel for main agent sessions

### DIFF
--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -56,6 +56,7 @@ export interface AgentSessionCreationOptions {
 	rlmSessionDir?: string;
 	rlmParentNodeId?: string;
 	subagentRuntimeHost?: SubagentRuntimeHost;
+	prewarmIpythonKernel?: boolean;
 }
 
 /**
@@ -216,5 +217,6 @@ export async function createAgentSessionFromServices(
 		rlmParentNodeId: options.rlmParentNodeId,
 		subagentRuntimeHost: options.subagentRuntimeHost,
 		sessionStartEvent: options.sessionStartEvent,
+		prewarmIpythonKernel: options.prewarmIpythonKernel,
 	});
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -106,7 +106,6 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import type { KernelManager } from "./kernel/index.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -134,6 +133,7 @@ import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
+import { IpythonKernelProvisioner } from "./tools/ipython.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
 import { cloneUsage, emptyUsage } from "./usage.js";
 
@@ -270,6 +270,13 @@ export interface AgentSessionConfig {
 	rlmParentNodeId?: string;
 	/** Host responsible for creating RLM subagent runtimes. */
 	subagentRuntimeHost?: SubagentRuntimeHost;
+	/**
+	 * Boot the IPython kernel in the background as soon as the session is created,
+	 * so the first ipython tool call doesn't pay the kernel cold start.
+	 *
+	 * Only applies to main agents (rlmDepth 0); subagent kernels stay lazy. Default: false.
+	 */
+	prewarmIpythonKernel?: boolean;
 }
 
 export interface ExtensionBindings {
@@ -644,7 +651,8 @@ export class AgentSession {
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
 	private _disposed = false;
-	private _ipythonKernelManagerRef: { current?: KernelManager } = {};
+	private _ipythonKernelProvisioner?: IpythonKernelProvisioner;
+	private readonly _prewarmIpythonKernel: boolean;
 	private _rlmDepth: number;
 	private _rlmMaxDepth: number;
 	private _rlmSessionDir?: string;
@@ -683,6 +691,7 @@ export class AgentSession {
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
 		this._rlmDepth = config.rlmDepth ?? parseDepth(process.env.RLM_DEPTH, 0, "RLM_DEPTH");
 		this._rlmMaxDepth = config.rlmMaxDepth ?? parseDepth(process.env.RLM_MAX_DEPTH, 1, "RLM_MAX_DEPTH");
+		this._prewarmIpythonKernel = (config.prewarmIpythonKernel ?? false) && this._rlmDepth === 0;
 		this._rlmSessionDir = config.rlmSessionDir;
 		this._rlmParentNodeId = config.rlmParentNodeId;
 		this._subagentRuntimeHost = config.subagentRuntimeHost;
@@ -2474,7 +2483,7 @@ export class AgentSession {
 	}
 
 	private async _restartIpythonKernelAfterCompaction(): Promise<void> {
-		await this._ipythonKernelManagerRef.current?.restart();
+		await this._ipythonKernelProvisioner?.restart();
 	}
 
 	// =========================================================================
@@ -3249,23 +3258,29 @@ export class AgentSession {
 		const shellCommandPrefix = this.settingsManager.getShellCommandPrefix();
 		const shellPath = this.settingsManager.getShellPath();
 		const pythonSkills = getPythonSkillRuntimeInfo(this._resourceLoader.getSkills().skills);
-		const configuredBaseToolDefinitions = this._baseToolsOverride
-			? Object.fromEntries(
-					Object.entries(this._baseToolsOverride).map(([name, tool]) => [
-						name,
-						createToolDefinitionFromAgentTool(tool),
-					]),
-				)
-			: createAllToolDefinitions(this._cwd, {
-					ipython: {
-						kernelManagerRef: this._ipythonKernelManagerRef,
-						env: this._rlmKernelEnv(),
-						sessionId: this.sessionId,
-						rlmRunHandler: ({ prompt, kwargs }) => this.runRlmChild(prompt, kwargs),
-						pythonSkills,
-					},
-					bash: { commandPrefix: shellCommandPrefix, shellPath },
-				});
+		let configuredBaseToolDefinitions: Record<string, ToolDefinition>;
+		if (this._baseToolsOverride) {
+			configuredBaseToolDefinitions = Object.fromEntries(
+				Object.entries(this._baseToolsOverride).map(([name, tool]) => [
+					name,
+					createToolDefinitionFromAgentTool(tool),
+				]),
+			);
+		} else {
+			// Rebuilding (e.g. /reload) replaces the provisioner; drop the previous
+			// kernel so the session never holds two live kernels.
+			void this._ipythonKernelProvisioner?.dispose();
+			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
+				env: this._rlmKernelEnv(),
+				sessionId: this.sessionId,
+				rlmRunHandler: ({ prompt, kwargs }) => this.runRlmChild(prompt, kwargs),
+				pythonSkills,
+			});
+			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {
+				ipython: { provisioner: this._ipythonKernelProvisioner },
+				bash: { commandPrefix: shellCommandPrefix, shellPath },
+			});
+		}
 		const goalToolDefinitions = this._includeGoalTools
 			? createGoalToolDefinitions({
 					getGoalState: () => this.goalState,
@@ -3314,6 +3329,10 @@ export class AgentSession {
 			activeToolNames: [...new Set(baseActiveToolNames)],
 			includeAllExtensionTools: options.includeAllExtensionTools,
 		});
+
+		if (this._prewarmIpythonKernel && this.getActiveToolNames().includes("ipython")) {
+			this._ipythonKernelProvisioner?.prewarm();
+		}
 	}
 
 	async reload(): Promise<void> {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -340,6 +340,9 @@ export class KernelManager {
 		if (this.state !== "idle") return;
 		this.state = "starting";
 		installSignalHandlersOnce();
+		// Tracked from the moment startup begins so session cleanup and signal
+		// handlers can dispose a kernel that is still booting.
+		liveKernels.add(this);
 
 		let python: string;
 		try {
@@ -351,8 +354,13 @@ export class KernelManager {
 				}));
 			this.options.python = python;
 		} catch (error) {
-			this.state = "idle";
+			liveKernels.delete(this);
+			if ((this.state as string) !== "shutdown") this.state = "idle";
 			throw error;
+		}
+
+		if ((this.state as string) === "shutdown") {
+			throw new Error("Kernel was disposed during startup");
 		}
 
 		const { path: connectionPath, tempDir } = makeConnection();
@@ -418,7 +426,6 @@ export class KernelManager {
 			throw e;
 		}
 
-		liveKernels.add(this);
 		this.state = "running";
 	}
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -362,6 +362,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		rlmParentNodeId: options.rlmParentNodeId,
 		subagentRuntimeHost: options.subagentRuntimeHost,
 		sessionStartEvent: options.sessionStartEvent,
+		prewarmIpythonKernel: options.prewarmIpythonKernel,
 	});
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -21,6 +21,7 @@ export { withFileMutationQueue } from "./file-mutation-queue.js";
 export {
 	createIpythonTool,
 	createIpythonToolDefinition,
+	IpythonKernelProvisioner,
 	type IpythonToolDetails,
 	type IpythonToolInput,
 	type IpythonToolOptions,

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -141,47 +141,134 @@ export interface IpythonToolOptions {
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
+	/** Shared provisioner owning the kernel lifecycle. When provided, the remaining options are ignored. */
+	provisioner?: IpythonKernelProvisioner;
+}
+
+/**
+ * Owns the lazy create+start+runtime-bootstrap of one session's IPython kernel.
+ *
+ * Concurrent ensure() calls await the same in-flight startup, a failed startup
+ * clears the memo so the next call retries fresh, and progress listeners can
+ * attach mid-flight (a tool call racing a background prewarm()).
+ */
+export class IpythonKernelProvisioner {
+	private managerPromise?: Promise<KernelManager>;
+	private startedManager?: KernelManager;
+	private readonly startupListeners = new Set<KernelBootstrapProgressHandler>();
+	private lastStartupMessage?: string;
+
+	constructor(
+		private readonly cwd: string,
+		private readonly options?: Omit<IpythonToolOptions, "provisioner">,
+	) {
+		if (options?.kernelManagerRef) {
+			options.kernelManagerRef.current = undefined;
+		}
+	}
+
+	/** The kernel manager, once a startup has completed successfully. */
+	get manager(): KernelManager | undefined {
+		return this.startedManager;
+	}
+
+	/** Start the kernel in the background. Failures are swallowed here and surface on the next ensure(). */
+	prewarm(): void {
+		void this.ensure().catch(() => {});
+	}
+
+	/** Restart the kernel if one is running (e.g. after compaction). */
+	async restart(): Promise<void> {
+		await this.startedManager?.restart();
+	}
+
+	/** Dispose the kernel owned by this provisioner, including one still starting up. */
+	async dispose(): Promise<void> {
+		const pending = this.managerPromise;
+		this.managerPromise = undefined;
+		this.startedManager = undefined;
+		if (!pending) return;
+		try {
+			const m = await pending;
+			await m.dispose();
+		} catch {
+			// a failed startup already cleaned up after itself
+		}
+	}
+
+	ensure(onProgress?: KernelBootstrapProgressHandler): Promise<KernelManager> {
+		if (onProgress && !this.startedManager) {
+			this.startupListeners.add(onProgress);
+			// Joining an in-flight startup: replay the current stage.
+			if (this.managerPromise && this.lastStartupMessage) {
+				onProgress(this.lastStartupMessage);
+			}
+		}
+		if (!this.managerPromise) {
+			const startup = this.startKernel();
+			this.managerPromise = startup;
+			startup.then(
+				(m) => {
+					if (this.managerPromise === startup) {
+						this.startedManager = m;
+					}
+					this.settleStartup();
+				},
+				() => {
+					// Clear the memo so the next ensure() retries instead of
+					// rethrowing a cached rejection forever.
+					if (this.managerPromise === startup) {
+						this.managerPromise = undefined;
+					}
+					this.settleStartup();
+				},
+			);
+		}
+		return this.managerPromise;
+	}
+
+	private settleStartup(): void {
+		this.startupListeners.clear();
+		this.lastStartupMessage = undefined;
+	}
+
+	private emitStartupProgress(message: string): void {
+		this.lastStartupMessage = message;
+		for (const listener of [...this.startupListeners]) {
+			listener(message);
+		}
+	}
+
+	private async startKernel(): Promise<KernelManager> {
+		const m = new KernelManager({
+			python: this.options?.python,
+			cwd: this.cwd,
+			env: this.options?.env,
+			sessionId: this.options?.sessionId,
+			rlmRunHandler: this.options?.rlmRunHandler,
+			pythonSkills: this.options?.pythonSkills,
+		});
+		this.emitStartupProgress("Starting IPython kernel...");
+		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
+		this.emitStartupProgress("Preparing IPython runtime...");
+		const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
+		if (bootstrap.status !== "ok") {
+			const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+			void m.dispose();
+			throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+		}
+		if (this.options?.kernelManagerRef) {
+			this.options.kernelManagerRef.current = m;
+		}
+		return m;
+	}
 }
 
 export function createIpythonToolDefinition(
 	cwd: string,
 	options?: IpythonToolOptions,
 ): ToolDefinition<typeof ipythonSchema, IpythonToolDetails> {
-	// Memoize the entire create+start so concurrent first calls all await the
-	// same in-flight startup instead of creating two managers or skipping the
-	// not-yet-finished start().
-	let managerPromise: Promise<KernelManager> | undefined;
-	if (options?.kernelManagerRef) {
-		options.kernelManagerRef.current = undefined;
-	}
-
-	function getManager(onBootstrapProgress?: KernelBootstrapProgressHandler): Promise<KernelManager> {
-		if (!managerPromise) {
-			managerPromise = (async () => {
-				const m = new KernelManager({
-					python: options?.python,
-					cwd,
-					env: options?.env,
-					sessionId: options?.sessionId,
-					rlmRunHandler: options?.rlmRunHandler,
-					pythonSkills: options?.pythonSkills,
-				});
-				onBootstrapProgress?.("Starting IPython kernel...");
-				await m.start({ onBootstrapProgress });
-				onBootstrapProgress?.("Preparing IPython runtime...");
-				const bootstrap = await m.execute(buildRlmBootstrapCode(options?.pythonSkills));
-				if (bootstrap.status !== "ok") {
-					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
-					throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
-				}
-				if (options?.kernelManagerRef) {
-					options.kernelManagerRef.current = m;
-				}
-				return m;
-			})();
-		}
-		return managerPromise;
-	}
+	const provisioner = options?.provisioner ?? new IpythonKernelProvisioner(cwd, options);
 
 	return {
 		name: "ipython",
@@ -204,7 +291,7 @@ export function createIpythonToolDefinition(
 			};
 
 			try {
-				const m = await getManager(reportStartupProgress);
+				const m = await provisioner.ensure(reportStartupProgress);
 				const r = await m.execute(params.code, {
 					signal,
 					onStream: (chunk) => {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -250,6 +250,7 @@ export {
 	type EditToolInput,
 	type EditToolOptions,
 	formatSize,
+	IpythonKernelProvisioner,
 	type IpythonToolDetails,
 	type IpythonToolInput,
 	type IpythonToolOptions,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1085,6 +1085,9 @@ export async function main(args: string[], options?: MainOptions) {
 			rlmSessionDir: runtimeSessionOptions?.rlmSessionDir,
 			rlmParentNodeId: runtimeSessionOptions?.rlmParentNodeId,
 			subagentRuntimeHost: runtimeSessionOptions?.subagentRuntimeHost,
+			// Main agents boot their kernel in the background at session creation;
+			// subagent sessions (rlmDepth > 0) keep the lazy first-call start.
+			prewarmIpythonKernel: true,
 		});
 		const cliThinkingOverride = config.thinking !== undefined || prepared.cliThinkingFromModel;
 		if (created.session.model && cliThinkingOverride) {

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -1,0 +1,130 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanupSessionResources } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+let tempDir = "";
+
+function writeFakePython(opts: { sleepSeconds?: number } = {}): { python: string; countRuns: () => number } {
+	const python = join(tempDir, "python");
+	const countFile = join(tempDir, "runs");
+	writeFileSync(
+		python,
+		[
+			"#!/bin/sh",
+			`echo run >> "${countFile}"`,
+			...(opts.sleepSeconds ? [`sleep ${opts.sleepSeconds}`] : []),
+			"exit 42",
+			"",
+		].join("\n"),
+	);
+	chmodSync(python, 0o755);
+	const countRuns = () => {
+		try {
+			return readFileSync(countFile, "utf8").split("\n").filter(Boolean).length;
+		} catch {
+			return 0;
+		}
+	};
+	return { python, countRuns };
+}
+
+describe("IpythonKernelProvisioner", () => {
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-provisioner-"));
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("memoizes concurrent ensure() calls into one startup", async () => {
+		const { python, countRuns } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		const [a, b] = await Promise.allSettled([provisioner.ensure(), provisioner.ensure()]);
+		expect(a.status).toBe("rejected");
+		expect(b.status).toBe("rejected");
+		expect(countRuns()).toBe(1);
+	});
+
+	it("retries after a failed startup instead of caching the rejection", async () => {
+		const { python, countRuns } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		await expect(provisioner.ensure()).rejects.toThrow(/Kernel exited before resolving ports/);
+		await expect(provisioner.ensure()).rejects.toThrow(/Kernel exited before resolving ports/);
+		expect(countRuns()).toBe(2);
+	});
+
+	it("prewarm() swallows the failure and the next ensure() starts fresh", async () => {
+		const { python, countRuns } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		provisioner.prewarm();
+		expect(provisioner.manager).toBeUndefined();
+
+		// Once the prewarm startup settles, ensure() must launch a second attempt.
+		await vi.waitFor(async () => {
+			await expect(provisioner.ensure()).rejects.toThrow();
+			expect(countRuns()).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	it("replays the current startup stage to listeners attaching mid-flight", async () => {
+		const { python } = writeFakePython({ sleepSeconds: 1 });
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		provisioner.prewarm();
+		const messages: string[] = [];
+		const joined = provisioner.ensure((message) => messages.push(message));
+		expect(messages).toContain("Starting IPython kernel...");
+		await expect(joined).rejects.toThrow();
+	});
+
+	it("dispose() settles a startup that is still in flight", async () => {
+		const { python } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		provisioner.prewarm();
+		await provisioner.dispose();
+		expect(provisioner.manager).toBeUndefined();
+	});
+});
+
+describe("KernelManager session cleanup during startup", () => {
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-kernel-cleanup-"));
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("disposes a kernel that is still booting when its session is cleaned up", async () => {
+		const python = join(tempDir, "python");
+		// Never writes connection ports - stays in the booting phase until killed.
+		writeFileSync(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
+		chmodSync(python, 0o755);
+		const sessionId = `provisioner-test-${Date.now()}`;
+		const manager = new KernelManager({ python, cwd: tempDir, sessionId });
+
+		try {
+			const startup = manager.start();
+			cleanupSessionResources(sessionId);
+			await expect(startup).rejects.toThrow(/Kernel exited before resolving ports|disposed during startup/);
+			expect(manager.isRunning).toBe(false);
+		} finally {
+			await manager.dispose();
+		}
+	});
+});


### PR DESCRIPTION
- ipython kernels took 4-5 seconds to boot on the first tool call, blocking the agent behind a "setting up ipython kernel" spinner.
- main agent sessions now boot their kernel in the background at creation, so the first call is typically instant; subagent kernels stay lazy and prime agent cold start is unaffected.
- extracting the kernel startup into a provisioner also fixes a cached startup failure that permanently broke ipython for a session, and a kernel process leak when a session was killed mid-boot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess/kernel lifecycle, session reload, and compaction restarts; behavior changes are mostly additive but incorrect cleanup could still leak or double-start kernels.
> 
> **Overview**
> Main agent sessions can **prewarm the IPython kernel in the background** at creation (`prewarmIpythonKernel`, enabled from the CLI for `rlmDepth === 0`) so the first `ipython` tool call usually skips the cold-start wait; subagents stay lazy.
> 
> Kernel lifecycle moves into **`IpythonKernelProvisioner`**: shared memoized startup, **retries after failed boot** instead of caching a permanent rejection, **`prewarm()`** with swallowed background errors, **dispose** of in-flight startups, and progress replay for callers racing prewarm. `AgentSession` owns one provisioner per runtime build and disposes the old kernel on reload.
> 
> **`KernelManager`** registers kernels in `liveKernels` as soon as boot begins so session cleanup can tear down processes still starting, avoiding leaks when a session ends mid-boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b5052016a688705e0f70b1f18bdca2103ecfbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prewarm the IPython kernel for main agent sessions at startup
> - Introduces `IpythonKernelProvisioner` in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/143/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d), a concurrency-safe class that owns IPython kernel lifecycle: lazy startup, progress replay to late listeners, retry after failure, restart, prewarm, and disposal.
> - CLI main agent sessions now pass `prewarmIpythonKernel: true` in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/143/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586), triggering background kernel startup during session creation; subagent sessions remain lazy.
> - Fixes a bug in `KernelManager.doStart` where kernels were not added to `liveKernels` until fully started, preventing cleanup of kernels that were still booting.
> - Behavioral Change: concurrent IPython tool invocations now share a single kernel startup and its progress stream rather than racing independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6b5052.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->