### PR TITLE
fall back to manual api key entry when prime browser login fails

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6354,37 +6354,60 @@ export class InteractiveMode {
 		const onDialogAbort = () => browserAbort.abort();
 		dialog.signal.addEventListener("abort", onDialogAbort, { once: true });
 
-		let resolveManualKey: (apiKey: string) => void = () => {};
+		let manualInputArmed = false;
+		let resolveManualKey: (entry: { apiKey: string; source: "manual" }) => void = () => {};
 		const manualKeyEntry = new Promise<{ apiKey: string; source: "manual" }>((resolve) => {
-			resolveManualKey = (apiKey) => resolve({ apiKey, source: "manual" });
+			resolveManualKey = resolve;
 		});
+		const armManualInput = (prompt: string): void => {
+			manualInputArmed = true;
+			void (async () => {
+				let value = (await dialog.showManualInput(prompt)).trim();
+				while (!value) {
+					value = (await dialog.waitForInput()).trim();
+				}
+				resolveManualKey({ apiKey: value, source: "manual" });
+			})().catch(() => {
+				// Cancellation surfaces through the dialog signal.
+			});
+		};
 
 		try {
 			const browserLogin = loginPrimeInference({
 				onAuth: (info) => {
 					dialog.showAuth(info.url, info.instructions);
-					void (async () => {
-						let value = (
-							await dialog.showManualInput("Complete the sign-in in your browser, or paste an API key below:")
-						).trim();
-						while (!value) {
-							value = (await dialog.waitForInput()).trim();
-						}
-						resolveManualKey(value);
-					})().catch(() => {
-						// Cancellation surfaces through the dialog signal.
-					});
+					armManualInput("Complete the sign-in in your browser, or paste an API key below:");
 				},
 				onProgress: (message) => {
 					dialog.showProgress(message);
 				},
 				signal: browserAbort.signal,
 			});
-			// Promise.race observes the rejection below, but keep a dedicated handler
-			// so an aborted browser flow can never surface as an unhandled rejection.
-			browserLogin.catch(() => {});
+			// When the browser challenge cannot start or breaks down, keep the dialog
+			// open and fall back to plain API key entry instead of failing outright.
+			const browserLoginOrFallback = browserLogin.catch((error: unknown) => {
+				if (browserAbort.signal.aborted) {
+					throw error;
+				}
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				dialog.showProgress(`Browser sign-in unavailable (${errorMsg}).`);
+				if (!manualInputArmed) {
+					armManualInput("Paste a Prime API key below:");
+				}
+				return manualKeyEntry;
+			});
+			// Once the browser flow has settled into manual fallback, nothing above
+			// rejects on cancel anymore, so the dialog signal must end the race too.
+			const dialogCancelled = new Promise<never>((_, reject) => {
+				dialog.signal.addEventListener("abort", () => reject(new Error("Login cancelled")), { once: true });
+			});
+			// Promise.race observes the rejections below, but keep dedicated handlers
+			// so neither an aborted browser flow nor a cancelled dialog can surface
+			// as an unhandled rejection.
+			browserLoginOrFallback.catch(() => {});
+			dialogCancelled.catch(() => {});
 
-			const result = await Promise.race([browserLogin, manualKeyEntry]);
+			const result = await Promise.race([browserLoginOrFallback, manualKeyEntry, dialogCancelled]);
 			if (dialog.signal.aborted) {
 				closeDialog();
 				return { status: "cancelled" };
@@ -6409,7 +6432,7 @@ export class InteractiveMode {
 		} catch (error: unknown) {
 			closeDialog();
 			const errorMsg = error instanceof Error ? error.message : String(error);
-			if (errorMsg !== "Login cancelled") {
+			if (!dialog.signal.aborted && errorMsg !== "Login cancelled") {
 				this.showError(`Failed to login to ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
 				return { status: "failed" };
 			}


### PR DESCRIPTION
- follow-up to the prime inference login pr: if the browser challenge could not start, the dialog closed with an error before offering manual key entry.
- the dialog now stays open on browser flow failures, shows why, and falls back to the paste-an-api-key input.
- cancelling with esc or ctrl+c now ends the dialog in every state, including after the browser flow has already failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive login UX only in the Prime Inference dialog; no changes to credential storage or API auth logic beyond existing manual-key validation.
> 
> **Overview**
> Prime Inference login no longer closes the dialog when the browser sign-in challenge fails to start or errors out. Instead it shows a progress message explaining the failure and **falls back to manual API key entry** (reusing the same paste-key flow as during browser auth).
> 
> Manual key input is refactored into `armManualInput` with a guard so fallback does not double-arm prompts. The login race now includes **`dialogCancelled`** so Esc/Ctrl+C reliably ends the flow even after browser failure, and errors are suppressed when the dialog was already aborted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5b8a22ab6daa2b5bf957b79aa9021092b7a8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to manual API key entry when Prime browser login fails
> - When the browser sign-in flow fails to start or rejects, the login dialog stays open and prompts the user to paste an API key manually instead of failing outright.
> - Extracts a reusable `armManualInput(prompt)` helper in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/144/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) that loops until non-empty input is provided.
> - Adds a `dialogCancelled` promise to the `Promise.race` so cancelling the dialog reliably terminates the login flow.
> - Errors are no longer surfaced when the dialog has already been aborted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b5b8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->