### PR TITLE
handle multiline agent errors without breaking the agents view input

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -97,6 +97,13 @@ export function createAgentsViewResumeConfig(config: AgentSessionRuntimeConfig):
 	return resumeConfig;
 }
 
+// Status messages render in a single-row hint slot below the editor; embedded
+// newlines would make that row taller than the layout accounts for and overlap
+// the input, so flatten all whitespace runs to single spaces.
+export function formatAgentsViewStatusLine(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
 export function createAgentsViewReplyHeadline(text: string | undefined): string | undefined {
 	return text
 		?.split("\n")
@@ -478,15 +485,16 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private setStatusMessage(message: string | undefined, options: { render?: boolean } = {}): void {
+		const statusLine = message === undefined ? undefined : formatAgentsViewStatusLine(message);
 		if (this.statusMessageTimer) {
 			clearTimeout(this.statusMessageTimer);
 			this.statusMessageTimer = undefined;
 		}
-		this.statusMessage = message;
-		if (message) {
+		this.statusMessage = statusLine;
+		if (statusLine) {
 			this.statusMessageTimer = setTimeout(() => {
 				this.statusMessageTimer = undefined;
-				if (this.statusMessage === message) {
+				if (this.statusMessage === statusLine) {
 					this.statusMessage = undefined;
 					this.ui.requestRender();
 				}
@@ -1173,7 +1181,12 @@ class AgentsViewMode implements Component, Focusable {
 
 	private finalizeRenderedLine(line: string, width: number): string {
 		const selected = line.startsWith(SELECTED_ROW_MARKER);
-		const content = selected ? line.slice(SELECTED_ROW_MARKER.length) : line;
+		let content = selected ? line.slice(SELECTED_ROW_MARKER.length) : line;
+		// Each rendered line must occupy exactly one terminal row; a stray
+		// newline would shift every line below it and overlap the editor.
+		if (content.includes("\n") || content.includes("\r")) {
+			content = content.replace(/[\r\n]+/g, " ");
+		}
 		const padded = padLine(truncateToWidth(content, width), width);
 		return selected ? theme.bg("selectedBg", padded) : padded;
 	}
@@ -1415,7 +1428,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function formatError(prefix: string, error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);
-	return `${prefix}: ${message}`;
+	return formatAgentsViewStatusLine(`${prefix}: ${message}`);
 }
 
 function padLine(line: string, width: number): string {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -7,6 +7,7 @@ import {
 	createAgentsViewResumeConfig,
 	createAgentsViewSessionName,
 	formatAgentsViewRelativeTime,
+	formatAgentsViewStatusLine,
 	resolveAgentsViewSessionUiServices,
 } from "../src/modes/agents-view/agents-view-mode.js";
 import {
@@ -290,6 +291,17 @@ describe("agents view state", () => {
 		expect(formatAgentsViewRelativeTime("2025-12-30T12:00:00Z", now)).toBe("3d");
 		expect(formatAgentsViewRelativeTime(undefined, now)).toBe("");
 		expect(formatAgentsViewRelativeTime("not a timestamp", now)).toBe("");
+	});
+
+	test("flattens multiline status messages so they fit the single-row hint slot", () => {
+		expect(formatAgentsViewStatusLine("Failed to send reply: connection lost\nat Socket.emit\nat process")).toBe(
+			"Failed to send reply: connection lost at Socket.emit at process",
+		);
+		expect(formatAgentsViewStatusLine('Failed:\r\n\t{\r\n\t"error": "boom"\r\n}')).toBe(
+			'Failed: { "error": "boom" }',
+		);
+		expect(formatAgentsViewStatusLine("  already   flat  ")).toBe("already flat");
+		expect(formatAgentsViewStatusLine("\n \r\n ")).toBe("");
 	});
 
 	test("caps generated session names at the configured limit", () => {


### PR DESCRIPTION
- multiline error messages shown in the agents view status slot occupied extra terminal rows, overlapping the text input and corrupting the layout.
- status messages are now flattened to a single line at the point they are set, and long ones truncate with an ellipsis as before.
- the final render pass also strips any stray newlines from every row, so the one-row-per-line layout invariant can no longer break.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI-only sanitization in agents view with no auth, data, or daemon protocol changes.
> 
> **Overview**
> Fixes agents view terminal layout when **status or error text contains newlines** (e.g. stack traces or JSON), which previously grew the hint row and overlapped the input.
> 
> Adds **`formatAgentsViewStatusLine`** to collapse all whitespace runs to a single line; **`setStatusMessage`** and **`formatError`** route messages through it before display. **`finalizeRenderedLine`** also replaces any `\r`/`\n` in every rendered row so the one-line-per-row invariant cannot break from other content.
> 
> Unit tests cover multiline and mixed-whitespace status formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07031b84e0f614776dfacd6d3c54b8504ce5d7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multiline agent errors breaking the agents view input line
> - Adds `formatAgentsViewStatusLine` in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/146/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10) to collapse any whitespace (newlines, tabs, multiple spaces) into a single space and trim the result.
> - `setStatusMessage` now normalizes input through this utility before storing or scheduling auto-clear timers; purely-whitespace messages no longer set a timer.
> - `finalizeRenderedLine` replaces any stray CR/LF in rendered list rows with spaces, preventing layout shifts from multi-row wrapping.
> - `formatError` wraps its output through the same utility so error strings are always single-line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07031b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->