### PR TITLE
fix onboarding flow opening agents view first

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -64,6 +64,7 @@ import {
 	type SessionSummary,
 } from "./modes/index.js";
 import { ExtensionSelectorComponent } from "./modes/interactive/components/extension-selector.js";
+import { shouldRunOnboarding } from "./modes/interactive/onboarding.js";
 import { initTheme, preloadCodeHighlighter, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
 import { isLocalPath } from "./utils/paths.js";
@@ -156,6 +157,7 @@ export function shouldUseDaemonInteractive(options: InteractiveDaemonStartupDeci
 
 export interface AgentsViewStartupDecision {
 	useDaemonInteractive: boolean;
+	needsOnboarding: boolean;
 	session?: string;
 	resume?: boolean;
 	continue?: boolean;
@@ -163,7 +165,17 @@ export interface AgentsViewStartupDecision {
 }
 
 export function shouldOpenAgentsViewForDaemonInteractive(options: AgentsViewStartupDecision): boolean {
-	return options.useDaemonInteractive && !options.session && !options.resume && !options.continue && !options.fork;
+	return (
+		options.useDaemonInteractive &&
+		// Onboarding lives in InteractiveMode, so a first run must take the
+		// direct session path; the agents view would otherwise require creating
+		// an agent before the onboarding splash ever renders.
+		!options.needsOnboarding &&
+		!options.session &&
+		!options.resume &&
+		!options.continue &&
+		!options.fork
+	);
 }
 
 export interface DaemonInteractiveSessionManagerDecision {
@@ -1198,6 +1210,11 @@ export async function main(args: string[], options?: MainOptions) {
 		if (
 			shouldOpenAgentsViewForDaemonInteractive({
 				useDaemonInteractive,
+				needsOnboarding: shouldRunOnboarding({
+					settingsManager,
+					modelRegistry: services.modelRegistry,
+					model: startupModel.model,
+				}),
 				session: parsed.session,
 				resume: parsed.resume,
 				continue: parsed.continue,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -166,6 +166,12 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
+import {
+	isOnboardingModelReady,
+	type OnboardingStartupState,
+	shouldRunOnboarding,
+	shouldRunPrimeCliOnboardingSplash,
+} from "./onboarding.js";
 import { formatResumeHint } from "./resume-hint.js";
 import {
 	getAvailableThemes,
@@ -1132,29 +1138,24 @@ export class InteractiveMode {
 		return "show";
 	}
 
+	private getOnboardingState(): OnboardingStartupState {
+		return {
+			settingsManager: this.settingsManager,
+			modelRegistry: this.modelRegistry,
+			model: this.getCurrentModel(),
+		};
+	}
+
 	private shouldRunOnboarding(): boolean {
-		this.modelRegistry.refresh();
-		if (this.shouldRunPrimeCliOnboardingSplash()) {
-			return true;
-		}
-		return !this.isCurrentModelReady();
+		return shouldRunOnboarding(this.getOnboardingState());
 	}
 
 	private shouldRunPrimeCliOnboardingSplash(): boolean {
-		if (this.settingsManager.getOnboardingCompleted()) {
-			return false;
-		}
-		const model = this.getCurrentModel();
-		if (!model || model.provider !== PRIME_INFERENCE_PROVIDER_ID) {
-			return false;
-		}
-		const authStatus = this.modelRegistry.getProviderAuthStatus(PRIME_INFERENCE_PROVIDER_ID);
-		return authStatus.source === "prime_cli";
+		return shouldRunPrimeCliOnboardingSplash(this.getOnboardingState());
 	}
 
 	private isCurrentModelReady(): boolean {
-		const model = this.getCurrentModel();
-		return model !== undefined && this.modelRegistry.hasConfiguredAuth(model);
+		return isOnboardingModelReady(this.getOnboardingState());
 	}
 
 	private completeOnboarding(): void {

--- a/packages/coding-agent/src/modes/interactive/onboarding.ts
+++ b/packages/coding-agent/src/modes/interactive/onboarding.ts
@@ -1,0 +1,42 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { AuthStatus } from "../../core/auth-storage.js";
+import { PRIME_INFERENCE_PROVIDER_ID } from "../../core/prime-inference-auth.js";
+
+export interface OnboardingSettingsReader {
+	getOnboardingCompleted(): boolean;
+}
+
+export interface OnboardingModelRegistryReader {
+	refresh(): void;
+	hasConfiguredAuth(model: Model<Api>): boolean;
+	getProviderAuthStatus(provider: string): AuthStatus;
+}
+
+export interface OnboardingStartupState {
+	settingsManager: OnboardingSettingsReader;
+	modelRegistry: OnboardingModelRegistryReader;
+	model: Model<Api> | undefined;
+}
+
+export function shouldRunPrimeCliOnboardingSplash(state: OnboardingStartupState): boolean {
+	if (state.settingsManager.getOnboardingCompleted()) {
+		return false;
+	}
+	if (!state.model || state.model.provider !== PRIME_INFERENCE_PROVIDER_ID) {
+		return false;
+	}
+	const authStatus = state.modelRegistry.getProviderAuthStatus(PRIME_INFERENCE_PROVIDER_ID);
+	return authStatus.source === "prime_cli";
+}
+
+export function isOnboardingModelReady(state: OnboardingStartupState): boolean {
+	return state.model !== undefined && state.modelRegistry.hasConfiguredAuth(state.model);
+}
+
+export function shouldRunOnboarding(state: OnboardingStartupState): boolean {
+	state.modelRegistry.refresh();
+	if (shouldRunPrimeCliOnboardingSplash(state)) {
+		return true;
+	}
+	return !isOnboardingModelReady(state);
+}

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -67,16 +67,18 @@ describe("daemon-backed interactive session manager routing", () => {
 		expect(
 			shouldOpenAgentsViewForDaemonInteractive({
 				useDaemonInteractive: true,
+				needsOnboarding: false,
 			}),
 		).toBe(true);
 	});
 
 	const directAttachCases: Array<[string, Parameters<typeof shouldOpenAgentsViewForDaemonInteractive>[0]]> = [
-		["non-daemon interactive path", { useDaemonInteractive: false }],
-		["explicit session", { useDaemonInteractive: true, session: "active-1" }],
-		["resume picker", { useDaemonInteractive: true, resume: true }],
-		["continue recent", { useDaemonInteractive: true, continue: true }],
-		["fork", { useDaemonInteractive: true, fork: "source-session-id" }],
+		["non-daemon interactive path", { useDaemonInteractive: false, needsOnboarding: false }],
+		["pending onboarding", { useDaemonInteractive: true, needsOnboarding: true }],
+		["explicit session", { useDaemonInteractive: true, needsOnboarding: false, session: "active-1" }],
+		["resume picker", { useDaemonInteractive: true, needsOnboarding: false, resume: true }],
+		["continue recent", { useDaemonInteractive: true, needsOnboarding: false, continue: true }],
+		["fork", { useDaemonInteractive: true, needsOnboarding: false, fork: "source-session-id" }],
 	];
 
 	test.each(directAttachCases)("does not open agents view for %s", (_label, decision) => {

--- a/packages/coding-agent/test/onboarding-startup.test.ts
+++ b/packages/coding-agent/test/onboarding-startup.test.ts
@@ -1,0 +1,82 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import type { AuthStatus } from "../src/core/auth-storage.js";
+import { PRIME_INFERENCE_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
+import {
+	type OnboardingStartupState,
+	shouldRunOnboarding,
+	shouldRunPrimeCliOnboardingSplash,
+} from "../src/modes/interactive/onboarding.js";
+
+function makeModel(provider: string): Model<Api> {
+	return { id: "test-model", provider } as Model<Api>;
+}
+
+function makeState(overrides: {
+	onboardingCompleted: boolean;
+	model: Model<Api> | undefined;
+	modelHasAuth?: boolean;
+	primeAuthSource?: AuthStatus["source"];
+}): OnboardingStartupState {
+	return {
+		settingsManager: {
+			getOnboardingCompleted: () => overrides.onboardingCompleted,
+		},
+		modelRegistry: {
+			refresh: () => {},
+			hasConfiguredAuth: () => overrides.modelHasAuth ?? false,
+			getProviderAuthStatus: () => ({
+				configured: overrides.primeAuthSource !== undefined,
+				source: overrides.primeAuthSource,
+			}),
+		},
+		model: overrides.model,
+	};
+}
+
+describe("startup onboarding decision", () => {
+	test("runs onboarding on first launch with Prime CLI auth", () => {
+		const state = makeState({
+			onboardingCompleted: false,
+			model: makeModel(PRIME_INFERENCE_PROVIDER_ID),
+			modelHasAuth: true,
+			primeAuthSource: "prime_cli",
+		});
+		expect(shouldRunPrimeCliOnboardingSplash(state)).toBe(true);
+		expect(shouldRunOnboarding(state)).toBe(true);
+	});
+
+	test("runs onboarding when no model is available", () => {
+		expect(shouldRunOnboarding(makeState({ onboardingCompleted: true, model: undefined }))).toBe(true);
+	});
+
+	test("runs onboarding when the current model has no configured auth", () => {
+		expect(
+			shouldRunOnboarding(
+				makeState({ onboardingCompleted: true, model: makeModel("anthropic"), modelHasAuth: false }),
+			),
+		).toBe(true);
+	});
+
+	test("skips onboarding once completed with a ready model", () => {
+		const state = makeState({
+			onboardingCompleted: true,
+			model: makeModel(PRIME_INFERENCE_PROVIDER_ID),
+			modelHasAuth: true,
+			primeAuthSource: "prime_cli",
+		});
+		expect(shouldRunPrimeCliOnboardingSplash(state)).toBe(false);
+		expect(shouldRunOnboarding(state)).toBe(false);
+	});
+
+	test("skips the Prime CLI splash for non-Prime providers with ready auth", () => {
+		const state = makeState({
+			onboardingCompleted: false,
+			model: makeModel("anthropic"),
+			modelHasAuth: true,
+			primeAuthSource: "stored",
+		});
+		expect(shouldRunPrimeCliOnboardingSplash(state)).toBe(false);
+		expect(shouldRunOnboarding(state)).toBe(false);
+	});
+});


### PR DESCRIPTION
- a fresh install landed in the agents view and only showed the onboarding splash after the user manually created an agent session.
- the startup router now checks whether onboarding is pending and routes first runs through the direct session path, so the splash renders immediately and the agents view opens on later launches.
- the needs-onboarding check is extracted into a shared module used by both the router and interactive mode, with unit tests for the routing and predicate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup routing and refactored onboarding predicates only; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes first-launch UX where daemon-backed interactive startup opened the **agents view** before onboarding could run, so users had to create an agent session before seeing the splash.
> 
> **Startup routing** now passes a `needsOnboarding` flag into `shouldOpenAgentsViewForDaemonInteractive`. When onboarding is pending, the CLI skips the agents view and uses the direct `InteractiveMode` path so the splash can render immediately; the agents view remains the default on later launches when onboarding is not needed.
> 
> **Shared onboarding logic** is moved into `onboarding.ts` (`shouldRunOnboarding`, Prime CLI splash checks, model-readiness). `InteractiveMode` calls that module instead of duplicating predicates, and `main.ts` uses the same check for routing.
> 
> Tests cover the new routing case (`needsOnboarding: true`) and the extracted onboarding decision functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47129c7d9562344e27aa9f99735cf0419fd07117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding flow to prevent agents view from opening when onboarding is pending
> - Extracts onboarding decision logic from `InteractiveMode` into standalone utility functions (`shouldRunOnboarding`, `shouldRunPrimeCliOnboardingSplash`, `isOnboardingModelReady`) in [onboarding.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/147/files#diff-94630b93bec3361f307df403ea0e39c533837d08044fa62819352a85457782cd).
> - Updates `shouldOpenAgentsViewForDaemonInteractive` in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/147/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586) to return `false` when `needsOnboarding` is true, so the agents view is bypassed when onboarding is required.
> - At startup, `main` now computes `needsOnboarding` using the extracted utility and includes it in the agents view routing decision.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47129c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->