### PR TITLE
fix slash commands in the main agents view

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
@@ -1,0 +1,63 @@
+/**
+ * Slash command support for the agents view.
+ *
+ * The agents view is session-less, so only a small whitelist of global
+ * built-in commands runs here. Other built-in names are swallowed with a
+ * pointer to open an agent instead of spawning a junk agent, while unknown
+ * "/..." text passes through untouched — prompt templates, skills, and
+ * extension commands are expanded by the daemon-side session.
+ */
+
+import { BUILTIN_SLASH_COMMANDS, type BuiltinSlashCommand } from "../../core/slash-commands.js";
+
+const AGENTS_VIEW_COMMAND_NAMES = ["login", "logout", "model", "quit"] as const;
+
+export type AgentsViewCommandName = (typeof AGENTS_VIEW_COMMAND_NAMES)[number];
+
+/** Descriptions that differ from the in-session built-in. */
+const AGENTS_VIEW_COMMAND_DESCRIPTIONS: Partial<Record<AgentsViewCommandName, string>> = {
+	model: "Select the model for new agents",
+};
+
+export const AGENTS_VIEW_SLASH_COMMANDS: readonly BuiltinSlashCommand[] = AGENTS_VIEW_COMMAND_NAMES.map((name) => {
+	const builtin = BUILTIN_SLASH_COMMANDS.find((command) => command.name === name);
+	if (!builtin) {
+		throw new Error(`Agents view command '/${name}' is not a built-in slash command`);
+	}
+	return { ...builtin, description: AGENTS_VIEW_COMMAND_DESCRIPTIONS[name] ?? builtin.description };
+});
+
+export interface ParsedSlashCommand {
+	name: string;
+	args: string;
+}
+
+export function parseSlashCommand(text: string): ParsedSlashCommand | undefined {
+	if (!text.startsWith("/")) {
+		return undefined;
+	}
+	const spaceIndex = text.indexOf(" ");
+	const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	if (!name) {
+		return undefined;
+	}
+	return { name, args: spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim() };
+}
+
+export type AgentsViewCommandKind =
+	/** Whitelisted built-in that runs directly in the agents view. */
+	| "agents-view"
+	/** Built-in that only works inside an open agent session. */
+	| "session-only"
+	/** Not a built-in; passes through to the daemon session untouched. */
+	| "unknown";
+
+export function classifyAgentsViewCommand(name: string): AgentsViewCommandKind {
+	if ((AGENTS_VIEW_COMMAND_NAMES as readonly string[]).includes(name)) {
+		return "agents-view";
+	}
+	if (BUILTIN_SLASH_COMMANDS.some((command) => command.name === name)) {
+		return "session-only";
+	}
+	return "unknown";
+}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -14,6 +14,7 @@ import {
 import { APP_TITLE, VERSION } from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
+import { findExactModelReferenceMatch } from "../../core/model-resolver.js";
 import { SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
@@ -631,9 +632,23 @@ class AgentsViewMode implements Component, Focusable {
 			case "logout":
 				await this.createAuthFlows().runLogout();
 				return;
-			case "model":
-				await this.showModelSelector(command.args || undefined);
+			case "model": {
+				const searchTerm = command.args || undefined;
+				if (searchTerm) {
+					// Mirror the in-session /model behavior: an exact provider/id or
+					// unique model id reference applies directly without the picker.
+					const match = findExactModelReferenceMatch(
+						searchTerm,
+						this.options.uiServices.modelRegistry.getAvailable(),
+					);
+					if (match) {
+						this.applyDefaultModel(match);
+						return;
+					}
+				}
+				await this.showModelSelector(searchTerm);
 				return;
+			}
 			case "quit":
 				this.finish({ type: "exit" });
 				return;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1,7 +1,10 @@
-import type { ImageContent } from "@earendil-works/pi-ai";
+import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
+import type { AutocompleteItem, OverlayHandle, SlashCommand } from "@earendil-works/pi-tui";
 import {
+	CombinedAutocompleteProvider,
 	type Component,
 	type Focusable,
+	fuzzyFilter,
 	ProcessTerminal,
 	setKeybindings,
 	TUI,
@@ -16,8 +19,11 @@ import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connecti
 import { DaemonClient } from "../daemon/daemon-client.js";
 import { type DaemonCommand, type DaemonResponse, isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
+import { ProviderAuthFlows } from "../interactive/auth-flows.js";
+import { showFullPaneOverlay } from "../interactive/components/centered-overlay.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
+import { ModelSelectorComponent } from "../interactive/components/model-selector.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
 import type { InteractiveModeUiServices } from "../interactive/interactive-mode-services.js";
 import {
@@ -28,6 +34,13 @@ import {
 	stopThemeWatcher,
 	theme,
 } from "../interactive/theme/theme.js";
+import {
+	AGENTS_VIEW_SLASH_COMMANDS,
+	type AgentsViewCommandName,
+	classifyAgentsViewCommand,
+	type ParsedSlashCommand,
+	parseSlashCommand,
+} from "./agents-view-commands.js";
 import {
 	type AgentsViewRow,
 	type AgentsViewSection,
@@ -259,6 +272,7 @@ class AgentsViewMode implements Component, Focusable {
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
 		this.editor.focused = true;
+		this.editor.setAutocompleteProvider(this.createAutocompleteProvider());
 		this.editor.getHeaderLine = () => this.renderReplyHeaderLine();
 		this.editor.onSubmit = (value) => {
 			void this.submit(value);
@@ -573,12 +587,143 @@ class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 
+		// Only built-in interactive commands are intercepted here; unknown "/..."
+		// text still reaches the daemon session, which expands prompt templates,
+		// skills, and extension commands.
+		const command = parseSlashCommand(text);
+		if (command) {
+			const kind = classifyAgentsViewCommand(command.name);
+			if (kind === "agents-view") {
+				this.editor.setText("");
+				await this.runSlashCommand(command);
+				return;
+			}
+			if (kind === "session-only") {
+				this.editor.setText("");
+				this.setStatusMessage(
+					`/${command.name} is only available inside an agent session — press ${keyText("tui.select.confirm")} on an agent to open it`,
+				);
+				return;
+			}
+		}
+
 		this.editor.setText("");
 		if (this.replyActiveSessionId) {
 			await this.sendReply(this.replyActiveSessionId, text);
 			return;
 		}
 		await this.createAgentForPrompt(text);
+	}
+
+	private async runSlashCommand(command: ParsedSlashCommand): Promise<void> {
+		switch (command.name as AgentsViewCommandName) {
+			case "login":
+				await this.createAuthFlows().runLogin();
+				return;
+			case "logout":
+				await this.createAuthFlows().runLogout();
+				return;
+			case "model":
+				await this.showModelSelector(command.args || undefined);
+				return;
+			case "quit":
+				this.finish({ type: "exit" });
+				return;
+			default: {
+				const _exhaustive: never = command.name as never;
+				return _exhaustive;
+			}
+		}
+	}
+
+	private createAuthFlows(): ProviderAuthFlows {
+		const modelRegistry = this.options.uiServices.modelRegistry;
+		return new ProviderAuthFlows({
+			ui: this.ui,
+			modelRegistry,
+			showStatus: (message) => this.setStatusMessage(message),
+			showError: (message) => this.setStatusMessage(message),
+			getAvailableModels: async () => modelRegistry.getAvailable(),
+		});
+	}
+
+	private showModelSelector(initialSearchInput?: string): Promise<void> {
+		const modelRegistry = this.options.uiServices.modelRegistry;
+		const availableModels = modelRegistry.getAvailable();
+		if (availableModels.length === 0) {
+			this.setStatusMessage("No models available. Add credentials with /login.");
+			return Promise.resolve();
+		}
+		return new Promise((resolve) => {
+			let handle: OverlayHandle | undefined;
+			const close = () => {
+				handle?.hide();
+				this.ui.requestRender();
+			};
+			const selector = new ModelSelectorComponent(
+				this.ui,
+				this.getDefaultModelForNewAgents(),
+				modelRegistry,
+				[],
+				(model) => {
+					close();
+					this.applyDefaultModel(model);
+					resolve();
+				},
+				() => {
+					close();
+					resolve();
+				},
+				initialSearchInput,
+				{ availableModels, getRows: () => this.ui.terminal.rows },
+			);
+			handle = showFullPaneOverlay(this.ui, selector, 96);
+		});
+	}
+
+	private getDefaultModelForNewAgents(): Model<Api> | undefined {
+		const settings = this.options.uiServices.settingsManager;
+		const provider = settings.getDefaultProvider();
+		const modelId = settings.getDefaultModel();
+		return provider && modelId ? this.options.uiServices.modelRegistry.find(provider, modelId) : undefined;
+	}
+
+	private applyDefaultModel(model: Model<Api>): void {
+		this.options.uiServices.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// New agents are created from this shared config; pin the model explicitly
+		// so the daemon does not fall back to its own settings snapshot.
+		this.options.config.provider = model.provider;
+		this.options.config.model = model.id;
+		this.options.startupModelId = model.id;
+		this.setStatusMessage(`Model for new agents: ${model.id}`);
+	}
+
+	private createAutocompleteProvider(): CombinedAutocompleteProvider {
+		const commands: SlashCommand[] = AGENTS_VIEW_SLASH_COMMANDS.map((command) => ({
+			name: command.name,
+			description: command.description,
+			...(command.argumentHint ? { argumentHint: command.argumentHint } : {}),
+		}));
+		const modelCommand = commands.find((command) => command.name === "model");
+		if (modelCommand) {
+			modelCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null => {
+				const models = this.options.uiServices.modelRegistry.getAvailable();
+				if (models.length === 0) {
+					return null;
+				}
+				const items = models.map((model) => ({
+					id: model.id,
+					provider: model.provider,
+					label: `${model.provider}/${model.id}`,
+				}));
+				const filtered = fuzzyFilter(items, prefix, (item) => `${item.id} ${item.provider}`);
+				if (filtered.length === 0) {
+					return null;
+				}
+				return filtered.map((item) => ({ value: item.label, label: item.id, description: item.provider }));
+			};
+		}
+		return new CombinedAutocompleteProvider(commands, this.options.uiServices.getInitialCwd(), null);
 	}
 
 	private openSelected(): void {
@@ -1218,6 +1363,7 @@ class AgentsViewMode implements Component, Focusable {
 		const hints = [
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open/send`,
+			"/ commands",
 			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
 			selectedAgent ? `${keyText("app.agents.delete")} stop/deactivate` : undefined,
 			selectedSubagent ? `${keyText("app.agents.delete")} stop` : undefined,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -20,7 +20,7 @@ import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connecti
 import { DaemonClient } from "../daemon/daemon-client.js";
 import { type DaemonCommand, type DaemonResponse, isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
-import { ProviderAuthFlows } from "../interactive/auth-flows.js";
+import { getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "../interactive/auth-flows.js";
 import { showFullPaneOverlay } from "../interactive/components/centered-overlay.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
@@ -259,6 +259,7 @@ class AgentsViewMode implements Component, Focusable {
 	private statusMessage: string | undefined;
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
 	private stopped = false;
+	private anthropicSubscriptionWarningShown = false;
 
 	constructor(
 		private readonly options: AgentsViewModeOptions,
@@ -667,7 +668,25 @@ class AgentsViewMode implements Component, Focusable {
 			showStatus: (message) => this.setStatusMessage(message),
 			showError: (message) => this.setStatusMessage(message),
 			getAvailableModels: async () => modelRegistry.getAvailable(),
+			onLoginCompleted: () => {
+				void this.maybeWarnAboutAnthropicSubscriptionAuth(this.getDefaultModelForNewAgents());
+			},
 		});
+	}
+
+	private async maybeWarnAboutAnthropicSubscriptionAuth(model: Model<Api> | undefined): Promise<void> {
+		if (this.options.uiServices.settingsManager.getWarnings().anthropicExtraUsage === false) {
+			return;
+		}
+		if (this.anthropicSubscriptionWarningShown) {
+			return;
+		}
+		const warning = await getAnthropicSubscriptionAuthWarning(this.options.uiServices.modelRegistry, model);
+		if (!warning) {
+			return;
+		}
+		this.anthropicSubscriptionWarningShown = true;
+		this.setStatusMessage(warning);
 	}
 
 	private showModelSelector(initialSearchInput?: string): Promise<void> {
@@ -719,6 +738,7 @@ class AgentsViewMode implements Component, Focusable {
 		this.options.config.model = model.id;
 		this.options.startupModelId = model.id;
 		this.setStatusMessage(`Model for new agents: ${model.id}`);
+		void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 	}
 
 	private createAutocompleteProvider(): CombinedAutocompleteProvider {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -257,6 +257,7 @@ class AgentsViewMode implements Component, Focusable {
 	private pendingKillSubagent: PendingKillSubagent | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
+	private statusMessageTone: "muted" | "error" = "muted";
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
 	private stopped = false;
 	private anthropicSubscriptionWarningShown = false;
@@ -500,13 +501,18 @@ class AgentsViewMode implements Component, Focusable {
 		return this.deleteConfirmExpiresAt > Date.now();
 	}
 
-	private setStatusMessage(message: string | undefined, options: { render?: boolean } = {}): void {
+	private setStatusMessage(
+		message: string | undefined,
+		options: { render?: boolean; tone?: "muted" | "error" } = {},
+	): void {
 		const statusLine = message === undefined ? undefined : formatAgentsViewStatusLine(message);
 		if (this.statusMessageTimer) {
 			clearTimeout(this.statusMessageTimer);
 			this.statusMessageTimer = undefined;
 		}
 		this.statusMessage = statusLine;
+		// Errors come both from explicit tones and from formatError-style messages.
+		this.statusMessageTone = options.tone ?? (statusLine?.startsWith("Failed") ? "error" : "muted");
 		if (statusLine) {
 			this.statusMessageTimer = setTimeout(() => {
 				this.statusMessageTimer = undefined;
@@ -666,7 +672,7 @@ class AgentsViewMode implements Component, Focusable {
 			ui: this.ui,
 			modelRegistry,
 			showStatus: (message) => this.setStatusMessage(message),
-			showError: (message) => this.setStatusMessage(message),
+			showError: (message) => this.setStatusMessage(message, { tone: "error" }),
 			getAvailableModels: async () => modelRegistry.getAvailable(),
 			onLoginCompleted: () => {
 				void this.maybeWarnAboutAnthropicSubscriptionAuth(this.getDefaultModelForNewAgents());
@@ -1401,8 +1407,7 @@ class AgentsViewMode implements Component, Focusable {
 			return truncateToWidth(theme.fg("muted", hint), width);
 		}
 		if (this.statusMessage) {
-			const tone = this.statusMessage.startsWith("Failed") ? "error" : "muted";
-			return truncateToWidth(theme.fg(tone, this.statusMessage), width);
+			return truncateToWidth(theme.fg(this.statusMessageTone, this.statusMessage), width);
 		}
 		// Replying is reserved for top-level agents; subagents can be stopped.
 		const selectedRow = this.rows[this.selectedIndex];

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -257,7 +257,8 @@ class AgentsViewMode implements Component, Focusable {
 	private pendingKillSubagent: PendingKillSubagent | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
-	private statusMessageTone: "muted" | "error" = "muted";
+	private statusMessageTone: "muted" | "error" | "warning" = "muted";
+	private statusMessageSticky = false;
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
 	private stopped = false;
 	private anthropicSubscriptionWarningShown = false;
@@ -350,6 +351,7 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	handleInput(data: string): void {
+		this.clearStickyStatusMessage();
 		if (this.keybindings.matches(data, "app.clear")) {
 			this.handleCtrlC();
 			return;
@@ -503,7 +505,7 @@ class AgentsViewMode implements Component, Focusable {
 
 	private setStatusMessage(
 		message: string | undefined,
-		options: { render?: boolean; tone?: "muted" | "error" } = {},
+		options: { render?: boolean; tone?: "muted" | "error" | "warning"; sticky?: boolean } = {},
 	): void {
 		const statusLine = message === undefined ? undefined : formatAgentsViewStatusLine(message);
 		if (this.statusMessageTimer) {
@@ -513,7 +515,9 @@ class AgentsViewMode implements Component, Focusable {
 		this.statusMessage = statusLine;
 		// Errors come both from explicit tones and from formatError-style messages.
 		this.statusMessageTone = options.tone ?? (statusLine?.startsWith("Failed") ? "error" : "muted");
-		if (statusLine) {
+		// Sticky messages stay up until the next keypress instead of a timer.
+		this.statusMessageSticky = options.sticky === true && statusLine !== undefined;
+		if (statusLine && !this.statusMessageSticky) {
 			this.statusMessageTimer = setTimeout(() => {
 				this.statusMessageTimer = undefined;
 				if (this.statusMessage === statusLine) {
@@ -526,6 +530,16 @@ class AgentsViewMode implements Component, Focusable {
 		if (options.render !== false) {
 			this.ui.requestRender();
 		}
+	}
+
+	/** Sticky messages (e.g. billing warnings) stay until the user acknowledges them with any keypress. */
+	private clearStickyStatusMessage(): void {
+		if (!this.statusMessageSticky) {
+			return;
+		}
+		this.statusMessageSticky = false;
+		this.statusMessage = undefined;
+		this.ui.requestRender();
 	}
 
 	private moveSelection(delta: number): void {
@@ -692,7 +706,7 @@ class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		this.anthropicSubscriptionWarningShown = true;
-		this.setStatusMessage(warning);
+		this.setStatusMessage(warning, { tone: "warning", sticky: true });
 	}
 
 	private showModelSelector(initialSearchInput?: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/auth-flows.ts
+++ b/packages/coding-agent/src/modes/interactive/auth-flows.ts
@@ -1,0 +1,682 @@
+/**
+ * Provider authentication flows (login/logout dialogs and selectors).
+ *
+ * Extracted from InteractiveMode so any TUI surface that owns a `TUI` and a
+ * `ModelRegistry` (interactive sessions, the agents view) can run the same
+ * auth UI. Host-specific side effects (footer refresh, billing warnings) hang
+ * off the small host interface instead of the flows themselves.
+ */
+
+import * as path from "node:path";
+import { getProviders, type OAuthProviderId, type OAuthSelectPrompt } from "@earendil-works/pi-ai";
+import type { OverlayHandle, TUI } from "@earendil-works/pi-tui";
+import { getAuthPath, getDocsPath } from "../../config.js";
+import type { ModelRegistry } from "../../core/model-registry.js";
+import {
+	checkPrimeInferenceAccess,
+	fetchPrimeTeams,
+	loadPrimeCliConfig,
+	loginPrimeInference,
+	PRIME_INFERENCE_PROVIDER_ID,
+	PRIME_INFERENCE_PROVIDER_NAME,
+	type PrimeTeam,
+} from "../../core/prime-inference-auth.js";
+import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-names.js";
+import { showFullPaneOverlay } from "./components/centered-overlay.js";
+import { ExtensionSelectorComponent } from "./components/extension-selector.js";
+import { LoginDialogComponent } from "./components/login-dialog.js";
+import {
+	type AuthSelectorProvider,
+	compareAuthSelectorProviders,
+	OAuthSelectorComponent,
+} from "./components/oauth-selector.js";
+import { PrimeTeamSelectorComponent } from "./components/prime-team-selector.js";
+import { theme } from "./theme/theme.js";
+
+export type AuthenticationResult =
+	| {
+			status: "success";
+			providerId: string;
+			providerName: string;
+			authType: "oauth" | "api_key";
+	  }
+	| { status: "cancelled" }
+	| { status: "failed" };
+
+export const BEDROCK_PROVIDER_ID = "amazon-bedrock";
+
+const BUILT_IN_MODEL_PROVIDERS = new Set<string>(getProviders());
+
+export function isApiKeyLoginProvider(
+	providerId: string,
+	oauthProviderIds: ReadonlySet<string>,
+	builtInProviderIds: ReadonlySet<string> = BUILT_IN_MODEL_PROVIDERS,
+): boolean {
+	if (BUILT_IN_PROVIDER_DISPLAY_NAMES[providerId]) {
+		return true;
+	}
+	if (builtInProviderIds.has(providerId)) {
+		return false;
+	}
+	return !oauthProviderIds.has(providerId);
+}
+
+export interface ProviderAuthFlowsHost {
+	readonly ui: TUI;
+	readonly modelRegistry: ModelRegistry;
+	showStatus(message: string): void;
+	showError(message: string): void;
+	/** Models currently visible to the host; used to detect providers configured via external credentials. */
+	getAvailableModels(): Promise<ReadonlyArray<{ provider: string }>>;
+	/** Invoked after stored credentials change so the host can refresh dependent UI. */
+	onAuthChanged?(): void | Promise<void>;
+	/** Invoked after a successful login (e.g. to surface billing warnings). */
+	onLoginCompleted?(): void;
+}
+
+export class ProviderAuthFlows {
+	constructor(private readonly host: ProviderAuthFlowsHost) {}
+
+	/** Runs the provider selector followed by the matching login dialog. */
+	runLogin(authType?: "oauth" | "api_key"): Promise<AuthenticationResult> {
+		const providerOptions = this.getLoginProviderOptions(authType);
+		if (providerOptions.length === 0) {
+			this.host.showStatus(
+				authType === "oauth"
+					? "No subscription providers available."
+					: authType === "api_key"
+						? "No API key providers available."
+						: "No providers available.",
+			);
+			return Promise.resolve({ status: "failed" });
+		}
+
+		return new Promise((resolve) => {
+			let handle: OverlayHandle | undefined;
+			const close = () => {
+				handle?.hide();
+				this.host.ui.requestRender();
+			};
+			const selector = new OAuthSelectorComponent(
+				"login",
+				this.host.modelRegistry.authStorage,
+				providerOptions,
+				async (providerOption: AuthSelectorProvider) => {
+					close();
+
+					if (providerOption.authType === "oauth") {
+						resolve(await this.showLoginDialog(providerOption.id, providerOption.name));
+					} else if (providerOption.id === PRIME_INFERENCE_PROVIDER_ID) {
+						resolve(await this.runPrimeInferenceLogin());
+					} else if (providerOption.id === BEDROCK_PROVIDER_ID) {
+						resolve(await this.showBedrockSetupDialog(providerOption.id, providerOption.name));
+					} else {
+						resolve(await this.showApiKeyLoginDialog(providerOption.id, providerOption.name));
+					}
+				},
+				() => {
+					close();
+					resolve({ status: "cancelled" });
+				},
+				(providerId) => this.host.modelRegistry.getProviderAuthStatus(providerId),
+				{ getRows: () => this.host.ui.terminal.rows },
+			);
+			handle = showFullPaneOverlay(this.host.ui, selector, 78);
+		});
+	}
+
+	/** Shows the stored-credential selector and removes the chosen credential. */
+	runLogout(): Promise<void> {
+		const providerOptions = this.getLogoutProviderOptions();
+		if (providerOptions.length === 0) {
+			this.host.showStatus(
+				"No stored credentials to remove. /logout only removes credentials saved by /login; environment variables and models.json config are unchanged.",
+			);
+			return Promise.resolve();
+		}
+
+		return new Promise((resolve) => {
+			let handle: OverlayHandle | undefined;
+			const close = () => {
+				handle?.hide();
+				this.host.ui.requestRender();
+			};
+			const selector = new OAuthSelectorComponent(
+				"logout",
+				this.host.modelRegistry.authStorage,
+				providerOptions,
+				async (providerOption: AuthSelectorProvider) => {
+					close();
+
+					try {
+						this.host.modelRegistry.authStorage.logout(providerOption.id);
+						this.host.modelRegistry.refresh();
+						await this.host.onAuthChanged?.();
+						const message =
+							providerOption.authType === "oauth"
+								? `Logged out of ${providerOption.name}`
+								: `Removed stored API key for ${providerOption.name}. Environment variables and models.json config are unchanged.`;
+						this.host.showStatus(message);
+					} catch (error: unknown) {
+						this.host.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+					}
+					resolve();
+				},
+				() => {
+					close();
+					resolve();
+				},
+				undefined,
+				{ getRows: () => this.host.ui.terminal.rows },
+			);
+			handle = showFullPaneOverlay(this.host.ui, selector, 78);
+		});
+	}
+
+	private getLoginProviderOptions(authType?: "oauth" | "api_key"): AuthSelectorProvider[] {
+		const authStorage = this.host.modelRegistry.authStorage;
+		const oauthProviders = authStorage.getOAuthProviders();
+		const oauthProviderIds = new Set(oauthProviders.map((provider) => provider.id));
+		const options: AuthSelectorProvider[] = oauthProviders.map((provider) => ({
+			id: provider.id,
+			name: provider.name,
+			authType: "oauth",
+		}));
+
+		const modelProviders = new Set(this.host.modelRegistry.getAll().map((model) => model.provider));
+		for (const providerId of modelProviders) {
+			if (!isApiKeyLoginProvider(providerId, oauthProviderIds)) {
+				continue;
+			}
+			options.push({
+				id: providerId,
+				name: this.host.modelRegistry.getProviderDisplayName(providerId),
+				authType: "api_key",
+			});
+		}
+
+		const filteredOptions = authType ? options.filter((option) => option.authType === authType) : options;
+		return filteredOptions.sort(compareAuthSelectorProviders);
+	}
+
+	private getLogoutProviderOptions(): AuthSelectorProvider[] {
+		const authStorage = this.host.modelRegistry.authStorage;
+		const options: AuthSelectorProvider[] = [];
+
+		for (const providerId of authStorage.list()) {
+			const credential = authStorage.get(providerId);
+			if (!credential) {
+				continue;
+			}
+			options.push({
+				id: providerId,
+				name: this.host.modelRegistry.getProviderDisplayName(providerId),
+				authType: credential.type,
+			});
+		}
+
+		return options.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	private async completeProviderAuthentication(
+		providerId: string,
+		providerName: string,
+		authType: "oauth" | "api_key",
+		statusSuffix?: string,
+	): Promise<AuthenticationResult> {
+		this.host.modelRegistry.refresh();
+
+		const actionLabel = authType === "oauth" ? `Logged in to ${providerName}` : `Saved API key for ${providerName}`;
+		await this.host.onAuthChanged?.();
+		this.host.showStatus(
+			`${actionLabel}. Credentials saved to ${getAuthPath()}${statusSuffix ? `. ${statusSuffix}` : ""}`,
+		);
+		this.host.onLoginCompleted?.();
+		return {
+			status: "success",
+			providerId,
+			providerName,
+			authType,
+		};
+	}
+
+	private async completeExternalProviderSetup(
+		providerId: string,
+		providerName: string,
+	): Promise<AuthenticationResult> {
+		this.host.modelRegistry.refresh();
+		await this.host.onAuthChanged?.();
+		this.host.showStatus(`${providerName} uses external credentials. Select a model after configuring them.`);
+		return {
+			status: "success",
+			providerId,
+			providerName,
+			authType: "api_key",
+		};
+	}
+
+	private async hasAvailableProviderModels(providerId: string): Promise<boolean> {
+		const models = await this.host.getAvailableModels();
+		return models.some((model) => model.provider === providerId);
+	}
+
+	private async showBedrockSetupDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
+		const dialog = new LoginDialogComponent(
+			this.host.ui,
+			providerId,
+			() => {
+				// Completion handled below.
+			},
+			providerName,
+			"Amazon Bedrock setup",
+		);
+		const handle = showFullPaneOverlay(this.host.ui, dialog, 88);
+		const closeDialog = () => {
+			handle.hide();
+			this.host.ui.requestRender();
+		};
+
+		try {
+			await dialog.showContinueInfo([
+				theme.fg("text", "Amazon Bedrock uses AWS credentials instead of a single API key."),
+				theme.fg("text", "Configure an AWS profile, IAM keys, bearer token, or role-based credentials."),
+				theme.fg("muted", "See:"),
+				theme.fg("accent", `  ${path.join(getDocsPath(), "providers.md")}`),
+			]);
+			closeDialog();
+			if (!(await this.hasAvailableProviderModels(providerId))) {
+				this.host.showStatus(`${providerName} credentials were not detected. Configure them, then reopen /model.`);
+				return { status: "cancelled" };
+			}
+			return await this.completeExternalProviderSetup(providerId, providerName);
+		} catch (error: unknown) {
+			closeDialog();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Login cancelled") {
+				this.host.showError(`Failed to set up ${providerName}: ${errorMsg}`);
+				return { status: "failed" };
+			}
+			return { status: "cancelled" };
+		}
+	}
+
+	private showPrimeTeamSelector(
+		teams: PrimeTeam[],
+		currentTeamId: string | undefined,
+	): Promise<PrimeTeam | null | undefined> {
+		return new Promise((resolve) => {
+			let handle: OverlayHandle | undefined;
+			const close = () => {
+				handle?.hide();
+				this.host.ui.requestRender();
+			};
+			const selector = new PrimeTeamSelectorComponent(
+				teams,
+				currentTeamId,
+				(team) => {
+					close();
+					resolve(team);
+				},
+				() => {
+					close();
+					resolve(undefined);
+				},
+				{ getRows: () => this.host.ui.terminal.rows },
+			);
+			handle = showFullPaneOverlay(this.host.ui, selector, 78);
+		});
+	}
+
+	private getPrimeInferenceDefaultTeamStatus(): string {
+		const storedTeam = this.host.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
+		if (storedTeam) {
+			return `Using team "${storedTeam.name}".`;
+		}
+		if (storedTeam === null) {
+			return "Using personal account.";
+		}
+		let config: ReturnType<typeof loadPrimeCliConfig>;
+		try {
+			config = loadPrimeCliConfig();
+		} catch {
+			return "Using personal account.";
+		}
+		if (config.teamIdFromEnv) {
+			return "Using team from PRIME_TEAM_ID.";
+		}
+		if (config.teamName) {
+			return `Using team "${config.teamName}".`;
+		}
+		if (config.teamId) {
+			return "Using Prime CLI team.";
+		}
+		return "Using personal account.";
+	}
+
+	private async selectPrimeInferenceTeam(apiKey: string, dialog: LoginDialogComponent): Promise<string | undefined> {
+		try {
+			const config = loadPrimeCliConfig();
+			if (config.teamIdFromEnv) {
+				this.host.modelRegistry.authStorage.reload();
+				return "Using team from PRIME_TEAM_ID.";
+			}
+
+			dialog.showProgress("Loading Prime teams...");
+			const teams = await fetchPrimeTeams(apiKey, config.baseUrl, { signal: dialog.signal });
+			if (dialog.signal.aborted) {
+				return this.getPrimeInferenceDefaultTeamStatus();
+			}
+			if (teams.length === 0) {
+				this.host.modelRegistry.authStorage.setPrimeInferenceTeamSelection(null);
+				return "Using personal account.";
+			}
+
+			const storedTeam = this.host.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
+			const currentTeamId = storedTeam === null ? undefined : (storedTeam?.teamId ?? config.teamId);
+			const selectedTeam = await this.showPrimeTeamSelector(teams, currentTeamId);
+			if (selectedTeam !== undefined) {
+				this.host.modelRegistry.authStorage.setPrimeInferenceTeamSelection(selectedTeam);
+			}
+			return selectedTeam
+				? `Using team "${selectedTeam.name}".`
+				: selectedTeam === null
+					? "Using personal account."
+					: this.getPrimeInferenceDefaultTeamStatus();
+		} catch {
+			this.host.modelRegistry.authStorage.reload();
+			return this.getPrimeInferenceDefaultTeamStatus();
+		}
+	}
+
+	private async completePrimeInferenceLogin(
+		apiKey: string,
+		dialog: LoginDialogComponent,
+		closeDialog: () => void,
+	): Promise<AuthenticationResult> {
+		const previousPrimeCredential = this.host.modelRegistry.authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
+		const previousPrimeTeam =
+			previousPrimeCredential?.type === "api_key" ? previousPrimeCredential.primeTeam : undefined;
+		this.host.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
+			type: "api_key",
+			key: apiKey,
+			...(previousPrimeTeam !== undefined ? { primeTeam: previousPrimeTeam } : {}),
+		});
+		const teamStatus = await this.selectPrimeInferenceTeam(apiKey, dialog);
+
+		closeDialog();
+		return await this.completeProviderAuthentication(
+			PRIME_INFERENCE_PROVIDER_ID,
+			PRIME_INFERENCE_PROVIDER_NAME,
+			"api_key",
+			teamStatus,
+		);
+	}
+
+	async runPrimeInferenceLogin(): Promise<AuthenticationResult> {
+		const dialog = new LoginDialogComponent(
+			this.host.ui,
+			PRIME_INFERENCE_PROVIDER_ID,
+			(_success, _message) => {
+				// Completion handled below.
+			},
+			PRIME_INFERENCE_PROVIDER_NAME,
+		);
+
+		const handle = showFullPaneOverlay(this.host.ui, dialog, 88);
+
+		const closeDialog = () => {
+			handle.hide();
+			this.host.ui.requestRender();
+		};
+
+		// The browser challenge gets its own controller so a manually pasted key
+		// can stop the polling without tearing down the dialog.
+		const browserAbort = new AbortController();
+		const onDialogAbort = () => browserAbort.abort();
+		dialog.signal.addEventListener("abort", onDialogAbort, { once: true });
+
+		let manualInputArmed = false;
+		let resolveManualKey: (entry: { apiKey: string; source: "manual" }) => void = () => {};
+		const manualKeyEntry = new Promise<{ apiKey: string; source: "manual" }>((resolve) => {
+			resolveManualKey = resolve;
+		});
+		const armManualInput = (prompt: string): void => {
+			manualInputArmed = true;
+			void (async () => {
+				let value = (await dialog.showManualInput(prompt)).trim();
+				while (!value) {
+					value = (await dialog.waitForInput()).trim();
+				}
+				resolveManualKey({ apiKey: value, source: "manual" });
+			})().catch(() => {
+				// Cancellation surfaces through the dialog signal.
+			});
+		};
+
+		try {
+			const browserLogin = loginPrimeInference({
+				onAuth: (info) => {
+					dialog.showAuth(info.url, info.instructions);
+					armManualInput("Complete the sign-in in your browser, or paste an API key below:");
+				},
+				onProgress: (message) => {
+					dialog.showProgress(message);
+				},
+				signal: browserAbort.signal,
+			});
+			// When the browser challenge cannot start or breaks down, keep the dialog
+			// open and fall back to plain API key entry instead of failing outright.
+			const browserLoginOrFallback = browserLogin.catch((error: unknown) => {
+				if (browserAbort.signal.aborted) {
+					throw error;
+				}
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				dialog.showProgress(`Browser sign-in unavailable (${errorMsg}).`);
+				if (!manualInputArmed) {
+					armManualInput("Paste a Prime API key below:");
+				}
+				return manualKeyEntry;
+			});
+			// Once the browser flow has settled into manual fallback, nothing above
+			// rejects on cancel anymore, so the dialog signal must end the race too.
+			const dialogCancelled = new Promise<never>((_, reject) => {
+				dialog.signal.addEventListener("abort", () => reject(new Error("Login cancelled")), { once: true });
+			});
+			// Promise.race observes the rejections below, but keep dedicated handlers
+			// so neither an aborted browser flow nor a cancelled dialog can surface
+			// as an unhandled rejection.
+			browserLoginOrFallback.catch(() => {});
+			dialogCancelled.catch(() => {});
+
+			const result = await Promise.race([browserLoginOrFallback, manualKeyEntry, dialogCancelled]);
+			if (dialog.signal.aborted) {
+				closeDialog();
+				return { status: "cancelled" };
+			}
+
+			if (result.source === "manual") {
+				browserAbort.abort();
+				dialog.showProgress("Checking Prime Inference access...");
+				const config = loadPrimeCliConfig();
+				const access = await checkPrimeInferenceAccess(result.apiKey, config.baseUrl, { signal: dialog.signal });
+				if (dialog.signal.aborted) {
+					closeDialog();
+					return { status: "cancelled" };
+				}
+				if (!access.ok) {
+					const status = access.status === undefined ? "" : `HTTP ${access.status}: `;
+					throw new Error(`Prime API key does not have Prime Inference access (${status}${access.message})`);
+				}
+			}
+
+			return await this.completePrimeInferenceLogin(result.apiKey, dialog, closeDialog);
+		} catch (error: unknown) {
+			closeDialog();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (!dialog.signal.aborted && errorMsg !== "Login cancelled") {
+				this.host.showError(`Failed to login to ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
+				return { status: "failed" };
+			}
+			return { status: "cancelled" };
+		} finally {
+			dialog.signal.removeEventListener("abort", onDialogAbort);
+		}
+	}
+
+	private async showApiKeyLoginDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
+		const dialog = new LoginDialogComponent(
+			this.host.ui,
+			providerId,
+			(_success, _message) => {
+				// Completion handled below
+			},
+			providerName,
+		);
+
+		const handle = showFullPaneOverlay(this.host.ui, dialog, 88);
+
+		const closeDialog = () => {
+			handle.hide();
+			this.host.ui.requestRender();
+		};
+
+		try {
+			const apiKey = (await dialog.showPrompt("Enter API key:")).trim();
+			if (!apiKey) {
+				throw new Error("API key cannot be empty.");
+			}
+
+			this.host.modelRegistry.authStorage.set(providerId, { type: "api_key", key: apiKey });
+
+			closeDialog();
+			return await this.completeProviderAuthentication(providerId, providerName, "api_key");
+		} catch (error: unknown) {
+			closeDialog();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Login cancelled") {
+				this.host.showError(`Failed to save API key for ${providerName}: ${errorMsg}`);
+				return { status: "failed" };
+			}
+			return { status: "cancelled" };
+		}
+	}
+
+	private showOAuthLoginSelect(dialogHandle: OverlayHandle, prompt: OAuthSelectPrompt): Promise<string | undefined> {
+		return new Promise((resolve) => {
+			dialogHandle.setHidden(true);
+			let selectorHandle: OverlayHandle | undefined;
+			const restoreDialog = () => {
+				selectorHandle?.hide();
+				dialogHandle.setHidden(false);
+				dialogHandle.focus();
+				this.host.ui.requestRender();
+			};
+			const labels = prompt.options.map((option) => option.label);
+			const selector = new ExtensionSelectorComponent(
+				prompt.message,
+				labels,
+				(optionLabel) => {
+					restoreDialog();
+					resolve(prompt.options.find((option) => option.label === optionLabel)?.id);
+				},
+				() => {
+					restoreDialog();
+					resolve(undefined);
+				},
+				{ getRows: () => this.host.ui.terminal.rows },
+			);
+			selectorHandle = showFullPaneOverlay(this.host.ui, selector, 76);
+		});
+	}
+
+	private async showLoginDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
+		const providerInfo = this.host.modelRegistry.authStorage
+			.getOAuthProviders()
+			.find((provider) => provider.id === providerId);
+
+		// Providers that use callback servers (can paste redirect URL)
+		const usesCallbackServer = providerInfo?.usesCallbackServer ?? false;
+
+		// Create login dialog component
+		const dialog = new LoginDialogComponent(
+			this.host.ui,
+			providerId,
+			(_success, _message) => {
+				// Completion handled below
+			},
+			providerName,
+		);
+
+		const dialogHandle = showFullPaneOverlay(this.host.ui, dialog, 88);
+
+		// Promise for manual code input (racing with callback server)
+		let manualCodeResolve: ((code: string) => void) | undefined;
+		let manualCodeReject: ((err: Error) => void) | undefined;
+		const manualCodePromise = new Promise<string>((resolve, reject) => {
+			manualCodeResolve = resolve;
+			manualCodeReject = reject;
+		});
+
+		// Close dialog overlay helper.
+		const closeDialog = () => {
+			dialogHandle.hide();
+			this.host.ui.requestRender();
+		};
+
+		try {
+			await this.host.modelRegistry.authStorage.login(providerId as OAuthProviderId, {
+				onAuth: (info: { url: string; instructions?: string }) => {
+					dialog.showAuth(info.url, info.instructions);
+
+					if (usesCallbackServer) {
+						// Show input for manual paste, racing with callback
+						dialog
+							.showManualInput("Paste redirect URL below, or complete login in browser:")
+							.then((value) => {
+								if (value && manualCodeResolve) {
+									manualCodeResolve(value);
+									manualCodeResolve = undefined;
+								}
+							})
+							.catch(() => {
+								if (manualCodeReject) {
+									manualCodeReject(new Error("Login cancelled"));
+									manualCodeReject = undefined;
+								}
+							});
+					} else if (providerId === "github-copilot") {
+						// GitHub Copilot polls after onAuth
+						dialog.showWaiting("Waiting for browser authentication...");
+					}
+					// For Anthropic: onPrompt is called immediately after
+				},
+
+				onPrompt: async (prompt: { message: string; placeholder?: string }) => {
+					return dialog.showPrompt(prompt.message, prompt.placeholder);
+				},
+
+				onProgress: (message: string) => {
+					dialog.showProgress(message);
+				},
+
+				onSelect: (prompt: OAuthSelectPrompt) => this.showOAuthLoginSelect(dialogHandle, prompt),
+
+				onManualCodeInput: () => manualCodePromise,
+
+				signal: dialog.signal,
+			});
+
+			// Success
+			closeDialog();
+			return await this.completeProviderAuthentication(providerId, providerName, "oauth");
+		} catch (error: unknown) {
+			closeDialog();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Login cancelled") {
+				this.host.showError(`Failed to login to ${providerName}: ${errorMsg}`);
+				return { status: "failed" };
+			}
+			return { status: "cancelled" };
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/auth-flows.ts
+++ b/packages/coding-agent/src/modes/interactive/auth-flows.ts
@@ -45,6 +45,38 @@ export type AuthenticationResult =
 
 export const BEDROCK_PROVIDER_ID = "amazon-bedrock";
 
+export const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
+	"Anthropic subscription auth is active. Third-party harness usage draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
+
+function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
+	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
+}
+
+/** Returns the extra-usage warning when the given model would run on Anthropic subscription auth. */
+export async function getAnthropicSubscriptionAuthWarning(
+	modelRegistry: ModelRegistry,
+	model: { provider: string } | undefined,
+): Promise<string | undefined> {
+	if (!model || model.provider !== "anthropic") {
+		return undefined;
+	}
+
+	const storedCredential = modelRegistry.authStorage.get("anthropic");
+	if (storedCredential?.type === "oauth") {
+		return ANTHROPIC_SUBSCRIPTION_AUTH_WARNING;
+	}
+
+	try {
+		const apiKey = await modelRegistry.getApiKeyForProvider(model.provider);
+		if (isAnthropicSubscriptionAuthKey(apiKey)) {
+			return ANTHROPIC_SUBSCRIPTION_AUTH_WARNING;
+		}
+	} catch {
+		// Ignore auth lookup failures for warning-only checks.
+	}
+	return undefined;
+}
+
 const BUILT_IN_MODEL_PROVIDERS = new Set<string>(getProviders());
 
 export function isApiKeyLoginProvider(

--- a/packages/coding-agent/src/modes/interactive/components/centered-overlay.ts
+++ b/packages/coding-agent/src/modes/interactive/components/centered-overlay.ts
@@ -1,4 +1,12 @@
-import { type Component, type Focusable, isFocusable, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	type Focusable,
+	isFocusable,
+	type OverlayHandle,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 
 interface CenteredOverlayOptions {
 	getRows: () => number;
@@ -12,6 +20,22 @@ interface InputHandler {
 
 function hasInputHandler(component: Component): component is Component & InputHandler {
 	return typeof (component as { handleInput?: unknown }).handleInput === "function";
+}
+
+/** Shows a component as a full-pane centered overlay on the given TUI. */
+export function showFullPaneOverlay(ui: TUI, component: Component, maxContentWidth = 80): OverlayHandle {
+	return ui.showOverlay(
+		new CenteredOverlayComponent(component, {
+			getRows: () => ui.terminal.rows,
+			maxContentWidth,
+		}),
+		{
+			width: "100%",
+			maxHeight: "100%",
+			row: 0,
+			col: 0,
+		},
+	);
 }
 
 export class CenteredOverlayComponent implements Component, Focusable {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -57,7 +57,6 @@ import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.j
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
-import { PRIME_INFERENCE_PROVIDER_ID } from "../../core/prime-inference-auth.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8,17 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import {
-	type Api,
-	type AssistantMessage,
-	getProviders,
-	type ImageContent,
-	type Message,
-	type Model,
-	type OAuthProviderId,
-	type OAuthSelectPrompt,
-	type ToolCall,
-} from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, ImageContent, Message, Model, ToolCall } from "@earendil-works/pi-ai";
 import type {
 	AutocompleteItem,
 	AutocompleteProvider,
@@ -49,15 +39,7 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { spawn, spawnSync } from "child_process";
-import {
-	APP_TITLE,
-	getAgentDir,
-	getAuthPath,
-	getDebugLogPath,
-	getDocsPath,
-	getShareViewerUrl,
-	VERSION,
-} from "../../config.js";
+import { APP_TITLE, getAgentDir, getDebugLogPath, getShareViewerUrl, VERSION } from "../../config.js";
 import { formatNoModelsAvailableMessage } from "../../core/auth-guidance.js";
 import type {
 	AutocompleteProviderFactory,
@@ -75,16 +57,7 @@ import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.j
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
-import {
-	checkPrimeInferenceAccess,
-	fetchPrimeTeams,
-	loadPrimeCliConfig,
-	loginPrimeInference,
-	PRIME_INFERENCE_PROVIDER_ID,
-	PRIME_INFERENCE_PROVIDER_NAME,
-	type PrimeTeam,
-} from "../../core/prime-inference-auth.js";
-import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-names.js";
+import { PRIME_INFERENCE_PROVIDER_ID } from "../../core/prime-inference-auth.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
@@ -118,12 +91,13 @@ import type {
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
 import { AGENT_ACTIVITY_LABELS, AgentActivityTracker, formatTokenCount } from "./agent-activity.js";
+import { type AuthenticationResult, ProviderAuthFlows } from "./auth-flows.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
 import { BorderedLoader } from "./components/bordered-loader.js";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.js";
-import { CenteredOverlayComponent } from "./components/centered-overlay.js";
+import { showFullPaneOverlay } from "./components/centered-overlay.js";
 import {
 	ChildAgentDetailComponent,
 	ChildAgentInspectorComponent,
@@ -144,15 +118,8 @@ import { ExtensionInputComponent } from "./components/extension-input.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
 import { FooterComponent } from "./components/footer.js";
 import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
-import { LoginDialogComponent } from "./components/login-dialog.js";
 import { type ModelSelectorAction, ModelSelectorComponent } from "./components/model-selector.js";
-import {
-	type AuthSelectorProvider,
-	compareAuthSelectorProviders,
-	OAuthSelectorComponent,
-} from "./components/oauth-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
-import { PrimeTeamSelectorComponent } from "./components/prime-team-selector.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
@@ -344,16 +311,6 @@ type GoalAnnouncementSnapshot = {
 	lastError?: string;
 };
 
-type AuthenticationResult =
-	| {
-			status: "success";
-			providerId: string;
-			providerName: string;
-			authType: "oauth" | "api_key";
-	  }
-	| { status: "cancelled" }
-	| { status: "failed" };
-
 type ModelSelectionResult = { status: "selected" } | { status: "cancelled" } | { status: "action"; actionId: string };
 
 type ModelFallbackWarningAction = "show" | "suppress" | "wait";
@@ -377,24 +334,6 @@ const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 
 function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
 	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
-}
-
-const BEDROCK_PROVIDER_ID = "amazon-bedrock";
-
-const BUILT_IN_MODEL_PROVIDERS = new Set<string>(getProviders());
-
-export function isApiKeyLoginProvider(
-	providerId: string,
-	oauthProviderIds: ReadonlySet<string>,
-	builtInProviderIds: ReadonlySet<string> = BUILT_IN_MODEL_PROVIDERS,
-): boolean {
-	if (BUILT_IN_PROVIDER_DISPLAY_NAMES[providerId]) {
-		return true;
-	}
-	if (builtInProviderIds.has(providerId)) {
-		return false;
-	}
-	return !oauthProviderIds.has(providerId);
 }
 
 function getPayloadString(payload: Record<string, unknown>, key: string): string | undefined {
@@ -5186,18 +5125,7 @@ export class InteractiveMode {
 	}
 
 	private showFullPaneOverlay(component: Component, maxContentWidth = 80): OverlayHandle {
-		return this.ui.showOverlay(
-			new CenteredOverlayComponent(component, {
-				getRows: () => this.ui.terminal.rows,
-				maxContentWidth,
-			}),
-			{
-				width: "100%",
-				maxHeight: "100%",
-				row: 0,
-				col: 0,
-			},
-		);
+		return showFullPaneOverlay(this.ui, component, maxContentWidth);
 	}
 
 	private async showSettingsSelector(): Promise<void> {
@@ -5974,51 +5902,6 @@ export class InteractiveMode {
 		}
 	}
 
-	private getLoginProviderOptions(authType?: "oauth" | "api_key"): AuthSelectorProvider[] {
-		const authStorage = this.modelRegistry.authStorage;
-		const oauthProviders = authStorage.getOAuthProviders();
-		const oauthProviderIds = new Set(oauthProviders.map((provider) => provider.id));
-		const options: AuthSelectorProvider[] = oauthProviders.map((provider) => ({
-			id: provider.id,
-			name: provider.name,
-			authType: "oauth",
-		}));
-
-		const modelProviders = new Set(this.modelRegistry.getAll().map((model) => model.provider));
-		for (const providerId of modelProviders) {
-			if (!isApiKeyLoginProvider(providerId, oauthProviderIds)) {
-				continue;
-			}
-			options.push({
-				id: providerId,
-				name: this.modelRegistry.getProviderDisplayName(providerId),
-				authType: "api_key",
-			});
-		}
-
-		const filteredOptions = authType ? options.filter((option) => option.authType === authType) : options;
-		return filteredOptions.sort(compareAuthSelectorProviders);
-	}
-
-	private getLogoutProviderOptions(): AuthSelectorProvider[] {
-		const authStorage = this.modelRegistry.authStorage;
-		const options: AuthSelectorProvider[] = [];
-
-		for (const providerId of authStorage.list()) {
-			const credential = authStorage.get(providerId);
-			if (!credential) {
-				continue;
-			}
-			options.push({
-				id: providerId,
-				name: this.modelRegistry.getProviderDisplayName(providerId),
-				authType: credential.type,
-			});
-		}
-
-		return options.sort((a, b) => a.name.localeCompare(b.name));
-	}
-
 	private showOnboardingPrimeLogin(): Promise<AuthenticationResult> {
 		return new Promise((resolve) => {
 			let settled = false;
@@ -6039,7 +5922,7 @@ export class InteractiveMode {
 			selector = new PrimeOnboardingSplashComponent(
 				() => {
 					close();
-					void this.showPrimeInferenceLoginDialog().then(settle);
+					void this.createAuthFlows().runPrimeInferenceLogin().then(settle);
 				},
 				() => {
 					close();
@@ -6100,51 +5983,26 @@ export class InteractiveMode {
 		});
 	}
 
-	private showLoginProviderSelector(authType?: "oauth" | "api_key"): Promise<AuthenticationResult> {
-		const providerOptions = this.getLoginProviderOptions(authType);
-		if (providerOptions.length === 0) {
-			this.showStatus(
-				authType === "oauth"
-					? "No subscription providers available."
-					: authType === "api_key"
-						? "No API key providers available."
-						: "No providers available.",
-			);
-			return Promise.resolve({ status: "failed" });
-		}
-
-		return new Promise((resolve) => {
-			let handle: OverlayHandle | undefined;
-			const close = () => {
-				handle?.hide();
-				this.ui.requestRender();
-			};
-			const selector = new OAuthSelectorComponent(
-				"login",
-				this.modelRegistry.authStorage,
-				providerOptions,
-				async (providerOption: AuthSelectorProvider) => {
-					close();
-
-					if (providerOption.authType === "oauth") {
-						resolve(await this.showLoginDialog(providerOption.id, providerOption.name));
-					} else if (providerOption.id === PRIME_INFERENCE_PROVIDER_ID) {
-						resolve(await this.showPrimeInferenceLoginDialog());
-					} else if (providerOption.id === BEDROCK_PROVIDER_ID) {
-						resolve(await this.showBedrockSetupDialog(providerOption.id, providerOption.name));
-					} else {
-						resolve(await this.showApiKeyLoginDialog(providerOption.id, providerOption.name));
-					}
-				},
-				() => {
-					close();
-					resolve({ status: "cancelled" });
-				},
-				(providerId) => this.modelRegistry.getProviderAuthStatus(providerId),
-				{ getRows: () => this.ui.terminal.rows },
-			);
-			handle = this.showFullPaneOverlay(selector, 78);
+	private createAuthFlows(): ProviderAuthFlows {
+		return new ProviderAuthFlows({
+			ui: this.ui,
+			modelRegistry: this.modelRegistry,
+			showStatus: (message) => this.showStatus(message),
+			showError: (message) => this.showError(message),
+			getAvailableModels: () => this.getConnectionAvailableModels(),
+			onAuthChanged: async () => {
+				await this.updateAvailableProviderCount();
+				this.footer.invalidate();
+				this.updateEditorBorderColor();
+			},
+			onLoginCompleted: () => {
+				void this.maybeWarnAboutAnthropicSubscriptionAuth();
+			},
 		});
+	}
+
+	private showLoginProviderSelector(authType?: "oauth" | "api_key"): Promise<AuthenticationResult> {
+		return this.createAuthFlows().runLogin(authType);
 	}
 
 	private async showOAuthSelector(mode: "login" | "logout"): Promise<void> {
@@ -6156,510 +6014,7 @@ export class InteractiveMode {
 			return;
 		}
 
-		const providerOptions = this.getLogoutProviderOptions();
-		if (providerOptions.length === 0) {
-			this.showStatus(
-				"No stored credentials to remove. /logout only removes credentials saved by /login; environment variables and models.json config are unchanged.",
-			);
-			return;
-		}
-
-		this.showSelector((done) => {
-			const selector = new OAuthSelectorComponent(
-				mode,
-				this.modelRegistry.authStorage,
-				providerOptions,
-				async (providerOption: AuthSelectorProvider) => {
-					done();
-
-					try {
-						this.modelRegistry.authStorage.logout(providerOption.id);
-						this.modelRegistry.refresh();
-						await this.updateAvailableProviderCount();
-						const message =
-							providerOption.authType === "oauth"
-								? `Logged out of ${providerOption.name}`
-								: `Removed stored API key for ${providerOption.name}. Environment variables and models.json config are unchanged.`;
-						this.showStatus(message);
-					} catch (error: unknown) {
-						this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
-					}
-				},
-				() => {
-					done();
-					this.ui.requestRender();
-				},
-				undefined,
-				{ getRows: () => this.ui.terminal.rows },
-			);
-			return { component: selector, focus: selector };
-		});
-	}
-
-	private async completeProviderAuthentication(
-		providerId: string,
-		providerName: string,
-		authType: "oauth" | "api_key",
-		statusSuffix?: string,
-	): Promise<AuthenticationResult> {
-		this.modelRegistry.refresh();
-
-		const actionLabel = authType === "oauth" ? `Logged in to ${providerName}` : `Saved API key for ${providerName}`;
-		await this.updateAvailableProviderCount();
-		this.footer.invalidate();
-		this.updateEditorBorderColor();
-		this.showStatus(
-			`${actionLabel}. Credentials saved to ${getAuthPath()}${statusSuffix ? `. ${statusSuffix}` : ""}`,
-		);
-		void this.maybeWarnAboutAnthropicSubscriptionAuth();
-		return {
-			status: "success",
-			providerId,
-			providerName,
-			authType,
-		};
-	}
-
-	private async completeExternalProviderSetup(
-		providerId: string,
-		providerName: string,
-	): Promise<AuthenticationResult> {
-		this.modelRegistry.refresh();
-		await this.updateAvailableProviderCount();
-		this.footer.invalidate();
-		this.updateEditorBorderColor();
-		this.showStatus(`${providerName} uses external credentials. Select a model after configuring them.`);
-		return {
-			status: "success",
-			providerId,
-			providerName,
-			authType: "api_key",
-		};
-	}
-
-	private async hasAvailableProviderModels(providerId: string): Promise<boolean> {
-		const models = await this.getConnectionAvailableModels();
-		return models.some((model) => model.provider === providerId);
-	}
-
-	private async showBedrockSetupDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
-		const dialog = new LoginDialogComponent(
-			this.ui,
-			providerId,
-			() => {
-				// Completion handled below.
-			},
-			providerName,
-			"Amazon Bedrock setup",
-		);
-		const handle = this.showFullPaneOverlay(dialog, 88);
-		const closeDialog = () => {
-			handle.hide();
-			this.ui.requestRender();
-		};
-
-		try {
-			await dialog.showContinueInfo([
-				theme.fg("text", "Amazon Bedrock uses AWS credentials instead of a single API key."),
-				theme.fg("text", "Configure an AWS profile, IAM keys, bearer token, or role-based credentials."),
-				theme.fg("muted", "See:"),
-				theme.fg("accent", `  ${path.join(getDocsPath(), "providers.md")}`),
-			]);
-			closeDialog();
-			if (!(await this.hasAvailableProviderModels(providerId))) {
-				this.showStatus(`${providerName} credentials were not detected. Configure them, then reopen /model.`);
-				return { status: "cancelled" };
-			}
-			return await this.completeExternalProviderSetup(providerId, providerName);
-		} catch (error: unknown) {
-			closeDialog();
-			const errorMsg = error instanceof Error ? error.message : String(error);
-			if (errorMsg !== "Login cancelled") {
-				this.showError(`Failed to set up ${providerName}: ${errorMsg}`);
-				return { status: "failed" };
-			}
-			return { status: "cancelled" };
-		}
-	}
-
-	private showPrimeTeamSelector(
-		teams: PrimeTeam[],
-		currentTeamId: string | undefined,
-	): Promise<PrimeTeam | null | undefined> {
-		return new Promise((resolve) => {
-			let handle: OverlayHandle | undefined;
-			const close = () => {
-				handle?.hide();
-				this.ui.requestRender();
-			};
-			const selector = new PrimeTeamSelectorComponent(
-				teams,
-				currentTeamId,
-				(team) => {
-					close();
-					resolve(team);
-				},
-				() => {
-					close();
-					resolve(undefined);
-				},
-				{ getRows: () => this.ui.terminal.rows },
-			);
-			handle = this.showFullPaneOverlay(selector, 78);
-		});
-	}
-
-	private getPrimeInferenceDefaultTeamStatus(): string {
-		const storedTeam = this.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
-		if (storedTeam) {
-			return `Using team "${storedTeam.name}".`;
-		}
-		if (storedTeam === null) {
-			return "Using personal account.";
-		}
-		let config: ReturnType<typeof loadPrimeCliConfig>;
-		try {
-			config = loadPrimeCliConfig();
-		} catch {
-			return "Using personal account.";
-		}
-		if (config.teamIdFromEnv) {
-			return "Using team from PRIME_TEAM_ID.";
-		}
-		if (config.teamName) {
-			return `Using team "${config.teamName}".`;
-		}
-		if (config.teamId) {
-			return "Using Prime CLI team.";
-		}
-		return "Using personal account.";
-	}
-
-	private async selectPrimeInferenceTeam(apiKey: string, dialog: LoginDialogComponent): Promise<string | undefined> {
-		try {
-			const config = loadPrimeCliConfig();
-			if (config.teamIdFromEnv) {
-				this.modelRegistry.authStorage.reload();
-				return "Using team from PRIME_TEAM_ID.";
-			}
-
-			dialog.showProgress("Loading Prime teams...");
-			const teams = await fetchPrimeTeams(apiKey, config.baseUrl, { signal: dialog.signal });
-			if (dialog.signal.aborted) {
-				return this.getPrimeInferenceDefaultTeamStatus();
-			}
-			if (teams.length === 0) {
-				this.modelRegistry.authStorage.setPrimeInferenceTeamSelection(null);
-				return "Using personal account.";
-			}
-
-			const storedTeam = this.modelRegistry.authStorage.getPrimeInferenceTeamSelection();
-			const currentTeamId = storedTeam === null ? undefined : (storedTeam?.teamId ?? config.teamId);
-			const selectedTeam = await this.showPrimeTeamSelector(teams, currentTeamId);
-			if (selectedTeam !== undefined) {
-				this.modelRegistry.authStorage.setPrimeInferenceTeamSelection(selectedTeam);
-			}
-			return selectedTeam
-				? `Using team "${selectedTeam.name}".`
-				: selectedTeam === null
-					? "Using personal account."
-					: this.getPrimeInferenceDefaultTeamStatus();
-		} catch {
-			this.modelRegistry.authStorage.reload();
-			return this.getPrimeInferenceDefaultTeamStatus();
-		}
-	}
-
-	private async completePrimeInferenceLogin(
-		apiKey: string,
-		dialog: LoginDialogComponent,
-		closeDialog: () => void,
-	): Promise<AuthenticationResult> {
-		const previousPrimeCredential = this.modelRegistry.authStorage.get(PRIME_INFERENCE_PROVIDER_ID);
-		const previousPrimeTeam =
-			previousPrimeCredential?.type === "api_key" ? previousPrimeCredential.primeTeam : undefined;
-		this.modelRegistry.authStorage.set(PRIME_INFERENCE_PROVIDER_ID, {
-			type: "api_key",
-			key: apiKey,
-			...(previousPrimeTeam !== undefined ? { primeTeam: previousPrimeTeam } : {}),
-		});
-		const teamStatus = await this.selectPrimeInferenceTeam(apiKey, dialog);
-
-		closeDialog();
-		return await this.completeProviderAuthentication(
-			PRIME_INFERENCE_PROVIDER_ID,
-			PRIME_INFERENCE_PROVIDER_NAME,
-			"api_key",
-			teamStatus,
-		);
-	}
-
-	private async showPrimeInferenceLoginDialog(): Promise<AuthenticationResult> {
-		const dialog = new LoginDialogComponent(
-			this.ui,
-			PRIME_INFERENCE_PROVIDER_ID,
-			(_success, _message) => {
-				// Completion handled below.
-			},
-			PRIME_INFERENCE_PROVIDER_NAME,
-		);
-
-		const handle = this.showFullPaneOverlay(dialog, 88);
-
-		const closeDialog = () => {
-			handle.hide();
-			this.ui.requestRender();
-		};
-
-		// The browser challenge gets its own controller so a manually pasted key
-		// can stop the polling without tearing down the dialog.
-		const browserAbort = new AbortController();
-		const onDialogAbort = () => browserAbort.abort();
-		dialog.signal.addEventListener("abort", onDialogAbort, { once: true });
-
-		let manualInputArmed = false;
-		let resolveManualKey: (entry: { apiKey: string; source: "manual" }) => void = () => {};
-		const manualKeyEntry = new Promise<{ apiKey: string; source: "manual" }>((resolve) => {
-			resolveManualKey = resolve;
-		});
-		const armManualInput = (prompt: string): void => {
-			manualInputArmed = true;
-			void (async () => {
-				let value = (await dialog.showManualInput(prompt)).trim();
-				while (!value) {
-					value = (await dialog.waitForInput()).trim();
-				}
-				resolveManualKey({ apiKey: value, source: "manual" });
-			})().catch(() => {
-				// Cancellation surfaces through the dialog signal.
-			});
-		};
-
-		try {
-			const browserLogin = loginPrimeInference({
-				onAuth: (info) => {
-					dialog.showAuth(info.url, info.instructions);
-					armManualInput("Complete the sign-in in your browser, or paste an API key below:");
-				},
-				onProgress: (message) => {
-					dialog.showProgress(message);
-				},
-				signal: browserAbort.signal,
-			});
-			// When the browser challenge cannot start or breaks down, keep the dialog
-			// open and fall back to plain API key entry instead of failing outright.
-			const browserLoginOrFallback = browserLogin.catch((error: unknown) => {
-				if (browserAbort.signal.aborted) {
-					throw error;
-				}
-				const errorMsg = error instanceof Error ? error.message : String(error);
-				dialog.showProgress(`Browser sign-in unavailable (${errorMsg}).`);
-				if (!manualInputArmed) {
-					armManualInput("Paste a Prime API key below:");
-				}
-				return manualKeyEntry;
-			});
-			// Once the browser flow has settled into manual fallback, nothing above
-			// rejects on cancel anymore, so the dialog signal must end the race too.
-			const dialogCancelled = new Promise<never>((_, reject) => {
-				dialog.signal.addEventListener("abort", () => reject(new Error("Login cancelled")), { once: true });
-			});
-			// Promise.race observes the rejections below, but keep dedicated handlers
-			// so neither an aborted browser flow nor a cancelled dialog can surface
-			// as an unhandled rejection.
-			browserLoginOrFallback.catch(() => {});
-			dialogCancelled.catch(() => {});
-
-			const result = await Promise.race([browserLoginOrFallback, manualKeyEntry, dialogCancelled]);
-			if (dialog.signal.aborted) {
-				closeDialog();
-				return { status: "cancelled" };
-			}
-
-			if (result.source === "manual") {
-				browserAbort.abort();
-				dialog.showProgress("Checking Prime Inference access...");
-				const config = loadPrimeCliConfig();
-				const access = await checkPrimeInferenceAccess(result.apiKey, config.baseUrl, { signal: dialog.signal });
-				if (dialog.signal.aborted) {
-					closeDialog();
-					return { status: "cancelled" };
-				}
-				if (!access.ok) {
-					const status = access.status === undefined ? "" : `HTTP ${access.status}: `;
-					throw new Error(`Prime API key does not have Prime Inference access (${status}${access.message})`);
-				}
-			}
-
-			return await this.completePrimeInferenceLogin(result.apiKey, dialog, closeDialog);
-		} catch (error: unknown) {
-			closeDialog();
-			const errorMsg = error instanceof Error ? error.message : String(error);
-			if (!dialog.signal.aborted && errorMsg !== "Login cancelled") {
-				this.showError(`Failed to login to ${PRIME_INFERENCE_PROVIDER_NAME}: ${errorMsg}`);
-				return { status: "failed" };
-			}
-			return { status: "cancelled" };
-		} finally {
-			dialog.signal.removeEventListener("abort", onDialogAbort);
-		}
-	}
-
-	private async showApiKeyLoginDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
-		const dialog = new LoginDialogComponent(
-			this.ui,
-			providerId,
-			(_success, _message) => {
-				// Completion handled below
-			},
-			providerName,
-		);
-
-		const handle = this.showFullPaneOverlay(dialog, 88);
-
-		const closeDialog = () => {
-			handle.hide();
-			this.ui.requestRender();
-		};
-
-		try {
-			const apiKey = (await dialog.showPrompt("Enter API key:")).trim();
-			if (!apiKey) {
-				throw new Error("API key cannot be empty.");
-			}
-
-			this.modelRegistry.authStorage.set(providerId, { type: "api_key", key: apiKey });
-
-			closeDialog();
-			return await this.completeProviderAuthentication(providerId, providerName, "api_key");
-		} catch (error: unknown) {
-			closeDialog();
-			const errorMsg = error instanceof Error ? error.message : String(error);
-			if (errorMsg !== "Login cancelled") {
-				this.showError(`Failed to save API key for ${providerName}: ${errorMsg}`);
-				return { status: "failed" };
-			}
-			return { status: "cancelled" };
-		}
-	}
-
-	private showOAuthLoginSelect(dialogHandle: OverlayHandle, prompt: OAuthSelectPrompt): Promise<string | undefined> {
-		return new Promise((resolve) => {
-			dialogHandle.setHidden(true);
-			let selectorHandle: OverlayHandle | undefined;
-			const restoreDialog = () => {
-				selectorHandle?.hide();
-				dialogHandle.setHidden(false);
-				dialogHandle.focus();
-				this.ui.requestRender();
-			};
-			const labels = prompt.options.map((option) => option.label);
-			const selector = new ExtensionSelectorComponent(
-				prompt.message,
-				labels,
-				(optionLabel) => {
-					restoreDialog();
-					resolve(prompt.options.find((option) => option.label === optionLabel)?.id);
-				},
-				() => {
-					restoreDialog();
-					resolve(undefined);
-				},
-				{ getRows: () => this.ui.terminal.rows },
-			);
-			selectorHandle = this.showFullPaneOverlay(selector, 76);
-		});
-	}
-
-	private async showLoginDialog(providerId: string, providerName: string): Promise<AuthenticationResult> {
-		const providerInfo = this.modelRegistry.authStorage
-			.getOAuthProviders()
-			.find((provider) => provider.id === providerId);
-
-		// Providers that use callback servers (can paste redirect URL)
-		const usesCallbackServer = providerInfo?.usesCallbackServer ?? false;
-
-		// Create login dialog component
-		const dialog = new LoginDialogComponent(
-			this.ui,
-			providerId,
-			(_success, _message) => {
-				// Completion handled below
-			},
-			providerName,
-		);
-
-		const dialogHandle = this.showFullPaneOverlay(dialog, 88);
-
-		// Promise for manual code input (racing with callback server)
-		let manualCodeResolve: ((code: string) => void) | undefined;
-		let manualCodeReject: ((err: Error) => void) | undefined;
-		const manualCodePromise = new Promise<string>((resolve, reject) => {
-			manualCodeResolve = resolve;
-			manualCodeReject = reject;
-		});
-
-		// Close dialog overlay helper.
-		const closeDialog = () => {
-			dialogHandle.hide();
-			this.ui.requestRender();
-		};
-
-		try {
-			await this.modelRegistry.authStorage.login(providerId as OAuthProviderId, {
-				onAuth: (info: { url: string; instructions?: string }) => {
-					dialog.showAuth(info.url, info.instructions);
-
-					if (usesCallbackServer) {
-						// Show input for manual paste, racing with callback
-						dialog
-							.showManualInput("Paste redirect URL below, or complete login in browser:")
-							.then((value) => {
-								if (value && manualCodeResolve) {
-									manualCodeResolve(value);
-									manualCodeResolve = undefined;
-								}
-							})
-							.catch(() => {
-								if (manualCodeReject) {
-									manualCodeReject(new Error("Login cancelled"));
-									manualCodeReject = undefined;
-								}
-							});
-					} else if (providerId === "github-copilot") {
-						// GitHub Copilot polls after onAuth
-						dialog.showWaiting("Waiting for browser authentication...");
-					}
-					// For Anthropic: onPrompt is called immediately after
-				},
-
-				onPrompt: async (prompt: { message: string; placeholder?: string }) => {
-					return dialog.showPrompt(prompt.message, prompt.placeholder);
-				},
-
-				onProgress: (message: string) => {
-					dialog.showProgress(message);
-				},
-
-				onSelect: (prompt: OAuthSelectPrompt) => this.showOAuthLoginSelect(dialogHandle, prompt),
-
-				onManualCodeInput: () => manualCodePromise,
-
-				signal: dialog.signal,
-			});
-
-			// Success
-			closeDialog();
-			return await this.completeProviderAuthentication(providerId, providerName, "oauth");
-		} catch (error: unknown) {
-			closeDialog();
-			const errorMsg = error instanceof Error ? error.message : String(error);
-			if (errorMsg !== "Login cancelled") {
-				this.showError(`Failed to login to ${providerName}: ${errorMsg}`);
-				return { status: "failed" };
-			}
-			return { status: "cancelled" };
-		}
+		await this.createAuthFlows().runLogout();
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -90,7 +90,7 @@ import type {
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
 import { AGENT_ACTIVITY_LABELS, AgentActivityTracker, formatTokenCount } from "./agent-activity.js";
-import { type AuthenticationResult, ProviderAuthFlows } from "./auth-flows.js";
+import { type AuthenticationResult, getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "./auth-flows.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -332,13 +332,6 @@ function isDeadTerminalError(error: unknown): boolean {
 	}
 	const code = (error as NodeJS.ErrnoException).code;
 	return code !== undefined && DEAD_TERMINAL_ERROR_CODES.has(code);
-}
-
-const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
-	"Anthropic subscription auth is active. Third-party harness usage draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
-
-function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
-	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
 }
 
 function getPayloadString(payload: Record<string, unknown>, key: string): string | undefined {
@@ -5398,27 +5391,12 @@ export class InteractiveMode {
 		if (this.anthropicSubscriptionWarningShown) {
 			return;
 		}
-		if (!model || model.provider !== "anthropic") {
+		const warning = await getAnthropicSubscriptionAuthWarning(this.modelRegistry, model);
+		if (!warning) {
 			return;
 		}
-
-		const storedCredential = this.modelRegistry.authStorage.get("anthropic");
-		if (storedCredential?.type === "oauth") {
-			this.anthropicSubscriptionWarningShown = true;
-			this.showWarning(ANTHROPIC_SUBSCRIPTION_AUTH_WARNING);
-			return;
-		}
-
-		try {
-			const apiKey = await this.modelRegistry.getApiKeyForProvider(model.provider);
-			if (!isAnthropicSubscriptionAuthKey(apiKey)) {
-				return;
-			}
-			this.anthropicSubscriptionWarningShown = true;
-			this.showWarning(ANTHROPIC_SUBSCRIPTION_AUTH_WARNING);
-		} catch {
-			// Ignore auth lookup failures for warning-only checks.
-		}
+		this.anthropicSubscriptionWarningShown = true;
+		this.showWarning(warning);
 	}
 
 	private showModelSelector(initialSearchInput?: string): void {

--- a/packages/coding-agent/test/agents-view-commands.test.ts
+++ b/packages/coding-agent/test/agents-view-commands.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.js";
+import {
+	AGENTS_VIEW_SLASH_COMMANDS,
+	classifyAgentsViewCommand,
+	parseSlashCommand,
+} from "../src/modes/agents-view/agents-view-commands.js";
+
+describe("parseSlashCommand", () => {
+	test("parses a bare command", () => {
+		expect(parseSlashCommand("/login")).toEqual({ name: "login", args: "" });
+	});
+
+	test("parses a command with arguments", () => {
+		expect(parseSlashCommand("/model opus anthropic")).toEqual({ name: "model", args: "opus anthropic" });
+	});
+
+	test("trims argument whitespace", () => {
+		expect(parseSlashCommand("/compact  focus on the bug ")).toEqual({ name: "compact", args: "focus on the bug" });
+	});
+
+	test("returns undefined for non-command text", () => {
+		expect(parseSlashCommand("fix the bug")).toBeUndefined();
+		expect(parseSlashCommand("")).toBeUndefined();
+	});
+
+	test("returns undefined for a lone slash", () => {
+		expect(parseSlashCommand("/")).toBeUndefined();
+		expect(parseSlashCommand("/ leading space")).toBeUndefined();
+	});
+});
+
+describe("classifyAgentsViewCommand", () => {
+	test("whitelisted global commands run in the agents view", () => {
+		for (const name of ["login", "logout", "model", "quit"]) {
+			expect(classifyAgentsViewCommand(name)).toBe("agents-view");
+		}
+	});
+
+	test("other built-ins are session-only", () => {
+		for (const name of ["compact", "fork", "settings", "resume", "new", "export"]) {
+			expect(classifyAgentsViewCommand(name)).toBe("session-only");
+		}
+	});
+
+	test("non-built-ins pass through for daemon-side expansion", () => {
+		expect(classifyAgentsViewCommand("skill:create-pr")).toBe("unknown");
+		expect(classifyAgentsViewCommand("my-template")).toBe("unknown");
+	});
+});
+
+describe("AGENTS_VIEW_SLASH_COMMANDS", () => {
+	test("every whitelisted command is a built-in with a description", () => {
+		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => command.name));
+		for (const command of AGENTS_VIEW_SLASH_COMMANDS) {
+			expect(builtinNames.has(command.name)).toBe(true);
+			expect(command.description.length).toBeGreaterThan(0);
+		}
+	});
+
+	test("classification agrees with the command list", () => {
+		for (const command of AGENTS_VIEW_SLASH_COMMANDS) {
+			expect(classifyAgentsViewCommand(command.name)).toBe("agents-view");
+		}
+	});
+});

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -4,11 +4,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../src/core/provider-display-names.js";
+import { isApiKeyLoginProvider } from "../src/modes/interactive/auth-flows.js";
 import {
 	compareAuthSelectorProviders,
 	OAuthSelectorComponent,
 } from "../src/modes/interactive/components/oauth-selector.js";
-import { isApiKeyLoginProvider } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
- typing a slash command in the agents view used to spawn a junk agent with the command as its prompt; now /login, /logout, /model, and /quit work directly in the view, with autocomplete.
- other built-in commands show a hint to open an agent instead, while unknown slash text still passes through so prompt templates and skills keep working.
- the provider login/logout flows moved out of interactive mode into a shared class so both views reuse the same auth ui; /model in the agents view picks the model new agents start with.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential storage/login flows and default model config for new agents; behavior is largely moved/refactored rather than rewritten, with new unit tests for command classification.
> 
> **Overview**
> Fixes the **session-less agents view** so slash input no longer spawns junk agents when users type built-in commands.
> 
> **Slash handling:** A new `agents-view-commands` module parses `/…` input and classifies commands as **agents-view** (`/login`, `/logout`, `/model`, `/quit`), **session-only** (other built-ins get a hint to open an agent), or **unknown** (unchanged text still goes to the daemon for templates/skills). `AgentsViewMode` intercepts whitelisted commands in `submit`, runs them via `runSlashCommand`, wires editor autocomplete (including fuzzy `/model` args), and adds sticky warning/error status tones.
> 
> **Shared auth UI:** Provider login/logout (OAuth, API key, Prime, Bedrock) moves from `InteractiveMode` into **`ProviderAuthFlows`** in `auth-flows.ts`, with `showFullPaneOverlay` extracted for reuse. Interactive mode delegates to the same class; the agents view uses it for `/login`/`/logout` and surfaces Anthropic subscription billing warnings after model changes.
> 
> **`/model` in agents view** sets the default model for **new** agents (settings + pinned `config`), mirroring in-session exact-reference matching when args are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95c9d943582dc23b67b79f6306a77fee9c1d5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slash commands in the agents view with autocomplete and auth flows
> - Adds slash command support (`/login`, `/logout`, `/model`, `/quit`) to the agents view, parsing input and routing whitelisted commands to direct handlers while showing guidance for session-only commands.
> - Introduces [`agents-view-commands.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/149/files#diff-8db3d56d05f5f34691c9c890a11fceb4fd84db7e01c686172b2f6af3473c5e60) with a whitelist, parser, and classifier for agents-view slash commands.
> - Extracts a reusable `ProviderAuthFlows` class in [`auth-flows.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/149/files#diff-f2484207f87351603fae4d33f2407db0f62fa1c1d2b19166e2e32547e1a62915) covering login/logout for all providers (OAuth, API key, Prime, Bedrock); `InteractiveMode` is refactored to delegate to it.
> - Adds inline autocomplete for slash command names and `/model` argument completions using fuzzy search over available models.
> - Adds sticky status messages with tone variants (muted/error/warning) and an Anthropic subscription auth warning in the agents view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b95c9d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->