### PR TITLE
show models after onboarding login when sessions run in the daemon

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -369,6 +369,10 @@ export class ModelRegistry {
 		this.modelRequestHeaders.clear();
 		this.loadError = undefined;
 
+		// Credentials may have been written by another process (e.g. the UI
+		// process saving a login while the session lives in the daemon).
+		this.authStorage.reload();
+
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
 		resetApiProviders();
 		resetOAuthProviders();

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1121,6 +1121,28 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("auth refresh across processes", () => {
+		test("refresh() picks up credentials written by another process", () => {
+			const savedEnvKey = process.env.PRIME_API_KEY;
+			delete process.env.PRIME_API_KEY;
+			try {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+				expect(registry.getAvailable().some((m) => m.provider === "prime-inference")).toBe(false);
+
+				// Simulate the UI process saving a login while this registry lives in the daemon.
+				const otherProcessAuth = AuthStorage.create(join(tempDir, "auth.json"));
+				otherProcessAuth.set("prime-inference", { type: "api_key", key: "test-key" });
+
+				registry.refresh();
+				expect(registry.getAvailable().some((m) => m.provider === "prime-inference")).toBe(true);
+			} finally {
+				if (savedEnvKey !== undefined) {
+					process.env.PRIME_API_KEY = savedEnvKey;
+				}
+			}
+		});
+	});
+
 	describe("API key resolution", () => {
 		/** Create provider config with custom apiKey */
 		function providerWithApiKey(apiKey: string) {


### PR DESCRIPTION
- logging in with prime inference during onboarding saved credentials in the ui process, but the daemon serving the model list never reloaded auth from disk, so the model popup came up empty.
- the model registry now reloads auth storage from disk on refresh, so credentials written by another process are picked up.
- added a regression test covering two processes sharing one auth file, and verified the full onboarding flow end to end in an isolated tui.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to refresh ordering; affects model availability when auth changes on disk, with a focused regression test.
> 
> **Overview**
> Fixes **empty model lists after onboarding login** when the session runs in a **daemon** while login runs in the **UI process**. Credentials were persisted to `auth.json`, but the daemon’s `ModelRegistry` only reloaded `models.json` on `refresh()` and kept a **stale in-memory** `AuthStorage`, so `getAvailable()` still hid providers like **prime-inference**.
> 
> `ModelRegistry.refresh()` now calls **`authStorage.reload()`** before resetting API/OAuth providers and reloading models, so disk-written credentials from another process are visible on the next refresh.
> 
> A regression test simulates a second `AuthStorage` writing to the shared `auth.json` and asserts `refresh()` exposes **prime-inference** models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4732996fabf3ae50c4cc13ec8038f44ec41a9595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reload credentials in `ModelRegistry.refresh` so models appear after daemon login
> When sessions run in a daemon, credentials written by an external process (e.g. onboarding login) were not picked up because `ModelRegistry.refresh()` never re-read from `AuthStorage`. Adding `this.authStorage.reload()` at the start of `refresh()` ensures providers and models are resolved against the latest credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4732996.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->