### PR TITLE
add /clear alias for /new

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -143,7 +143,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |
-| `/new` | Start a new session |
+| `/new`, `/clear` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session info (file, ID, messages) |
 | `/usage` | Show token, cost, and context usage |

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -36,6 +36,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "login", description: "Configure provider authentication" },
 	{ name: "logout", description: "Remove provider authentication" },
 	{ name: "new", description: "Start a new session" },
+	{ name: "clear", description: "Start a new session (alias for /new)" },
 	{
 		name: "compact",
 		description: "Compact the session context; optional instructions focus the summary",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3197,7 +3197,7 @@ export class InteractiveMode {
 				await this.showOAuthSelector("logout");
 				return;
 			}
-			if (text === "/new") {
+			if (text === "/new" || text === "/clear") {
 				this.editor.setText("");
 				await this.handleClearCommand();
 				return;

--- a/packages/coding-agent/test/agents-view-commands.test.ts
+++ b/packages/coding-agent/test/agents-view-commands.test.ts
@@ -38,7 +38,7 @@ describe("classifyAgentsViewCommand", () => {
 	});
 
 	test("other built-ins are session-only", () => {
-		for (const name of ["compact", "fork", "settings", "resume", "new", "export"]) {
+		for (const name of ["compact", "fork", "settings", "resume", "new", "clear", "export"]) {
 			expect(classifyAgentsViewCommand(name)).toBe("session-only");
 		}
 	});


### PR DESCRIPTION
- users coming from other agent clis expect /clear, but only /new existed for starting a fresh session.
- registered /clear as a built-in alongside /new so autocomplete, extension conflict warnings, and the agents view all pick it up automatically.
- both commands route to the same session reset handler, and the readme command table now lists the alias.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX alias with no new behavior beyond existing session reset; limited to slash-command registration and routing.
> 
> **Overview**
> Adds **`/clear`** as a built-in slash command alias for **`/new`**, so users can start a fresh session with either name.
> 
> The alias is registered in `BUILTIN_SLASH_COMMANDS` (autocomplete, extension conflict checks, and agents-view classification treat it like other built-ins). Interactive mode dispatches **`/clear`** to the same **`handleClearCommand`** path as **`/new`**. The README command table documents **`/new`, `/clear`** together, and agents-view tests expect **`clear`** to be session-only like **`new`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c5466da59e418aea3aef91dd0cb86527eede3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/clear` as an alias for `/new` in interactive mode
> Typing `/clear` in the interactive editor now starts a new session, identical to `/new`. The command is registered in `BUILTIN_SLASH_COMMANDS` and documented in the README.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0c5466.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->