### PR TITLE
restore bash shortcuts in interactive mode via agent connection

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -649,6 +649,7 @@ export class AgentSession {
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
+	private _userBashRunning = false;
 	private _pendingBashMessages: BashExecutionMessage[] = [];
 
 	// Extension system
@@ -4129,7 +4130,18 @@ export class AgentSession {
 		if (this.isBashRunning) {
 			throw new Error("A bash command is already running");
 		}
-		const excludeFromContext = options?.excludeFromContext ?? false;
+		// Claim the bash slot synchronously: isBashRunning is otherwise false until
+		// executeBash installs its abort controller, which would let a second command
+		// slip through during the user_bash extension dispatch below.
+		this._userBashRunning = true;
+		try {
+			await this.runUserBashLocked(command, options?.excludeFromContext ?? false);
+		} finally {
+			this._userBashRunning = false;
+		}
+	}
+
+	private async runUserBashLocked(command: string, excludeFromContext: boolean): Promise<void> {
 		const eventResult = await this._extensionRunner.emitUserBash({
 			type: "user_bash",
 			command,
@@ -4217,7 +4229,7 @@ export class AgentSession {
 
 	/** Whether a bash command is currently running */
 	get isBashRunning(): boolean {
-		return this._bashAbortController !== undefined;
+		return this._bashAbortController !== undefined || this._userBashRunning;
 	}
 
 	/** Whether there are pending bash messages waiting to be flushed */

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -222,7 +222,18 @@ export type AgentSessionEvent =
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
 	| { type: "rlm_child_update"; child: RlmChildAgentSnapshot }
-	| { type: "goal_update"; goal: GoalState };
+	| { type: "goal_update"; goal: GoalState }
+	| { type: "bash_start"; command: string; excludeFromContext: boolean }
+	| { type: "bash_output"; chunk: string }
+	| {
+			type: "bash_end";
+			exitCode: number | undefined;
+			cancelled: boolean;
+			truncated: boolean;
+			fullOutputPath?: string;
+			/** Set when execution failed before producing a result (e.g. spawn failure) */
+			errorMessage?: string;
+	  };
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -4102,6 +4113,68 @@ export class AgentSession {
 			return result;
 		} finally {
 			this._bashAbortController = undefined;
+		}
+	}
+
+	/**
+	 * Run a user-initiated bash command (! / !! prefix), emitting bash_start,
+	 * bash_output, and bash_end session events so any attached client can render
+	 * streaming output. Extensions can intercept execution via the user_bash event.
+	 * Execution failures are reported through bash_end rather than a rejected promise;
+	 * only the already-running guard and extension dispatch errors reject.
+	 * @param command The bash command to execute
+	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
+	 */
+	async runUserBash(command: string, options?: { excludeFromContext?: boolean }): Promise<void> {
+		if (this.isBashRunning) {
+			throw new Error("A bash command is already running");
+		}
+		const excludeFromContext = options?.excludeFromContext ?? false;
+		const eventResult = await this._extensionRunner.emitUserBash({
+			type: "user_bash",
+			command,
+			excludeFromContext,
+			cwd: this.sessionManager.getCwd(),
+		});
+
+		this._emit({ type: "bash_start", command, excludeFromContext });
+		try {
+			// If an extension returned a full result, surface it without executing
+			if (eventResult?.result) {
+				const result = eventResult.result;
+				if (result.output) {
+					this._emit({ type: "bash_output", chunk: result.output });
+				}
+				this.recordBashResult(command, result, { excludeFromContext });
+				this._emit({
+					type: "bash_end",
+					exitCode: result.exitCode,
+					cancelled: result.cancelled,
+					truncated: result.truncated,
+					fullOutputPath: result.fullOutputPath,
+				});
+				return;
+			}
+
+			const result = await this.executeBash(command, (chunk) => this._emit({ type: "bash_output", chunk }), {
+				excludeFromContext,
+				operations: eventResult?.operations,
+			});
+			this._emit({
+				type: "bash_end",
+				exitCode: result.exitCode,
+				cancelled: result.cancelled,
+				truncated: result.truncated,
+				fullOutputPath: result.fullOutputPath,
+			});
+		} catch (error) {
+			this._emit({
+				type: "bash_end",
+				exitCode: undefined,
+				cancelled: false,
+				truncated: false,
+				errorMessage: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -238,6 +238,15 @@ export type AgentSessionEvent =
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
+/** Payload of the bash_end event for a user-initiated bash command */
+type UserBashEndDetails = {
+	exitCode: number | undefined;
+	cancelled: boolean;
+	truncated: boolean;
+	fullOutputPath?: string;
+	errorMessage?: string;
+};
+
 /** Thrown when compaction is skipped for a benign reason (surfaced as a warning, not an error) */
 export class CompactionSkippedError extends Error {}
 
@@ -650,6 +659,7 @@ export class AgentSession {
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
 	private _userBashRunning = false;
+	private _userBashAbortRequested = false;
 	private _pendingBashMessages: BashExecutionMessage[] = [];
 
 	// Extension system
@@ -4134,14 +4144,19 @@ export class AgentSession {
 		// executeBash installs its abort controller, which would let a second command
 		// slip through during the user_bash extension dispatch below.
 		this._userBashRunning = true;
+		this._userBashAbortRequested = false;
+		let end: UserBashEndDetails;
 		try {
-			await this.runUserBashLocked(command, options?.excludeFromContext ?? false);
+			end = await this.runUserBashLocked(command, options?.excludeFromContext ?? false);
 		} finally {
 			this._userBashRunning = false;
 		}
+		// Emitted after the slot is released so clients never observe a bash_end
+		// while the session still rejects new commands as already running.
+		this._emit({ type: "bash_end", ...end });
 	}
 
-	private async runUserBashLocked(command: string, excludeFromContext: boolean): Promise<void> {
+	private async runUserBashLocked(command: string, excludeFromContext: boolean): Promise<UserBashEndDetails> {
 		const eventResult = await this._extensionRunner.emitUserBash({
 			type: "user_bash",
 			command,
@@ -4158,35 +4173,42 @@ export class AgentSession {
 					this._emit({ type: "bash_output", chunk: result.output });
 				}
 				this.recordBashResult(command, result, { excludeFromContext });
-				this._emit({
-					type: "bash_end",
+				return {
 					exitCode: result.exitCode,
 					cancelled: result.cancelled,
 					truncated: result.truncated,
 					fullOutputPath: result.fullOutputPath,
-				});
-				return;
+				};
+			}
+
+			// An abort that arrived before the process spawned (during extension
+			// dispatch) has no abort controller to act on; honor it here instead.
+			if (this._userBashAbortRequested) {
+				this.recordBashResult(
+					command,
+					{ output: "", exitCode: undefined, cancelled: true, truncated: false },
+					{ excludeFromContext },
+				);
+				return { exitCode: undefined, cancelled: true, truncated: false };
 			}
 
 			const result = await this.executeBash(command, (chunk) => this._emit({ type: "bash_output", chunk }), {
 				excludeFromContext,
 				operations: eventResult?.operations,
 			});
-			this._emit({
-				type: "bash_end",
+			return {
 				exitCode: result.exitCode,
 				cancelled: result.cancelled,
 				truncated: result.truncated,
 				fullOutputPath: result.fullOutputPath,
-			});
+			};
 		} catch (error) {
-			this._emit({
-				type: "bash_end",
+			return {
 				exitCode: undefined,
 				cancelled: false,
 				truncated: false,
 				errorMessage: error instanceof Error ? error.message : String(error),
-			});
+			};
 		}
 	}
 
@@ -4224,6 +4246,11 @@ export class AgentSession {
 	 * Cancel running bash command.
 	 */
 	abortBash(): void {
+		// A user bash command may not have spawned yet (extension dispatch in
+		// progress); flag the request so runUserBash cancels before executing.
+		if (this._userBashRunning && this._bashAbortController === undefined) {
+			this._userBashAbortRequested = true;
+		}
 		this._bashAbortController?.abort();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4203,11 +4203,19 @@ export class AgentSession {
 				fullOutputPath: result.fullOutputPath,
 			};
 		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			// Persist the failure like every other outcome so replayed transcripts
+			// and the LLM context reflect that the command did not run.
+			this.recordBashResult(
+				command,
+				{ output: `bash failed: ${errorMessage}`, exitCode: undefined, cancelled: false, truncated: false },
+				{ excludeFromContext },
+			);
 			return {
 				exitCode: undefined,
 				cancelled: false,
 				truncated: false,
-				errorMessage: error instanceof Error ? error.message : String(error),
+				errorMessage,
 			};
 		}
 	}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -391,7 +391,14 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async abortBash(): Promise<void> {
-		await this.requestOk({ type: "abort_bash", activeSessionId: this.activeSessionId });
+		try {
+			await this.requestOk({ type: "abort_bash", activeSessionId: this.activeSessionId });
+		} catch (error) {
+			if (isUnknownDaemonCommandError(error, "abort_bash")) {
+				throw new Error("the daemon is running an older build; restart the daemon and try again");
+			}
+			throw error;
+		}
 	}
 
 	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -22,6 +22,7 @@ import type {
 	AgentConnectionBeforeSessionInvalidateListener,
 	AgentConnectionEvent,
 	AgentConnectionEventListener,
+	AgentConnectionExecuteBashOptions,
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionForkOptions,
 	AgentConnectionModel,
@@ -371,6 +372,26 @@ export class DaemonAgentConnection implements AgentConnection {
 
 	async waitForIdle(): Promise<void> {
 		await this.requestOk({ type: "wait_for_idle", activeSessionId: this.activeSessionId });
+	}
+
+	async executeBash(command: string, options?: AgentConnectionExecuteBashOptions): Promise<void> {
+		try {
+			await this.requestOk({
+				type: "execute_bash",
+				activeSessionId: this.activeSessionId,
+				command,
+				excludeFromContext: options?.excludeFromContext,
+			});
+		} catch (error) {
+			if (isUnknownDaemonCommandError(error, "execute_bash")) {
+				throw new Error("the daemon is running an older build; restart the daemon and try again");
+			}
+			throw error;
+		}
+	}
+
+	async abortBash(): Promise<void> {
+		await this.requestOk({ type: "abort_bash", activeSessionId: this.activeSessionId });
 	}
 
 	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -18,6 +18,7 @@ import type {
 	AgentConnectionBeforeSessionInvalidateListener,
 	AgentConnectionEvent,
 	AgentConnectionEventListener,
+	AgentConnectionExecuteBashOptions,
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionForkOptions,
 	AgentConnectionModel,
@@ -189,6 +190,14 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async waitForIdle(): Promise<void> {
 		await this.session.agent.waitForIdle();
+	}
+
+	async executeBash(command: string, options?: AgentConnectionExecuteBashOptions): Promise<void> {
+		await this.session.runUserBash(command, options);
+	}
+
+	async abortBash(): Promise<void> {
+		this.session.abortBash();
 	}
 
 	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -27,6 +27,7 @@ export function createAgentConnectionState(
 		availableThinkingLevels: session.getAvailableThinkingLevels(),
 		isStreaming: session.isStreaming,
 		isCompacting: session.isCompacting,
+		isBashRunning: session.isBashRunning,
 		retryAttempt: session.retryAttempt,
 		steeringMode: session.steeringMode,
 		followUpMode: session.followUpMode,

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -246,6 +246,7 @@ export interface AgentConnectionState {
 	availableThinkingLevels: ThinkingLevel[];
 	isStreaming: boolean;
 	isCompacting: boolean;
+	isBashRunning: boolean;
 	retryAttempt: number;
 	steeringMode: AgentConnectionQueueMode;
 	followUpMode: AgentConnectionQueueMode;
@@ -348,6 +349,10 @@ export interface AgentConnectionToolDefinition {
 export interface AgentConnectionPromptOptions {
 	images?: ImageContent[];
 	streamingBehavior?: "steer" | "followUp";
+}
+
+export interface AgentConnectionExecuteBashOptions {
+	excludeFromContext?: boolean;
 }
 
 export interface AgentConnectionNewSessionOptions {
@@ -473,7 +478,18 @@ export type AgentConnectionSessionEvent =
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
 	| { type: "rlm_child_update"; child: AgentConnectionRlmChildAgentSnapshot }
-	| { type: "goal_update"; goal: GoalState };
+	| { type: "goal_update"; goal: GoalState }
+	| { type: "bash_start"; command: string; excludeFromContext: boolean }
+	| { type: "bash_output"; chunk: string }
+	| {
+			type: "bash_end";
+			exitCode: number | undefined;
+			cancelled: boolean;
+			truncated: boolean;
+			fullOutputPath?: string;
+			/** Set when execution failed before producing a result (e.g. spawn failure) */
+			errorMessage?: string;
+	  };
 
 export type AgentConnectionEvent =
 	| { type: "session_event"; event: AgentConnectionSessionEvent }
@@ -515,6 +531,14 @@ export interface AgentConnection {
 	abort(): Promise<void>;
 	cancelRlmChild(childId: string): Promise<boolean>;
 	waitForIdle(): Promise<void>;
+
+	/**
+	 * Run a user-initiated bash command (! / !! prefix). Resolution timing is
+	 * adapter-specific; rendering must be driven by the bash_start/bash_output/
+	 * bash_end session events, which reach every attached client.
+	 */
+	executeBash(command: string, options?: AgentConnectionExecuteBashOptions): Promise<void>;
+	abortBash(): Promise<void>;
 
 	setModel(provider: string, modelId: string): Promise<AgentConnectionModel>;
 	cycleModel(direction?: "forward" | "backward"): Promise<AgentConnectionModelCycleResult | undefined>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -86,6 +86,8 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"steer",
 	"follow_up",
 	"abort",
+	"execute_bash",
+	"abort_bash",
 	"cancel_rlm_child",
 	"wait_for_idle",
 	"get_state",
@@ -672,6 +674,30 @@ class AgentDaemon {
 				const state = this.getSessionState(command.activeSessionId);
 				await state.runtime.session.abort();
 				return success(command.id, "abort");
+			}
+
+			case "execute_bash": {
+				const state = this.getSessionState(command.activeSessionId);
+				if (state.runtime.session.isBashRunning) {
+					throw new Error("A bash command is already running");
+				}
+				// Respond before completion (bash can outlive the client request
+				// timeout); output and completion stream via bash_* session events.
+				void state.runtime.session
+					.runUserBash(command.command, { excludeFromContext: command.excludeFromContext })
+					.catch((error) => {
+						this.broadcastToSession(
+							state,
+							failure(undefined, "execute_bash", error, serializeDaemonError(error)),
+						);
+					});
+				return success(command.id, "execute_bash");
+			}
+
+			case "abort_bash": {
+				const state = this.getSessionState(command.activeSessionId);
+				state.runtime.session.abortBash();
+				return success(command.id, "abort_bash");
 			}
 
 			case "cancel_rlm_child": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -173,6 +173,14 @@ export type DaemonCommand =
 	| { id?: string; type: "steer"; activeSessionId: string; message: string; images?: ImageContent[] }
 	| { id?: string; type: "follow_up"; activeSessionId: string; message: string; images?: ImageContent[] }
 	| { id?: string; type: "abort"; activeSessionId: string }
+	| {
+			id?: string;
+			type: "execute_bash";
+			activeSessionId: string;
+			command: string;
+			excludeFromContext?: boolean;
+	  }
+	| { id?: string; type: "abort_bash"; activeSessionId: string }
 	| { id?: string; type: "cancel_rlm_child"; activeSessionId: string; childId: string }
 	| { id?: string; type: "wait_for_idle"; activeSessionId: string }
 	| { id?: string; type: "get_state"; activeSessionId: string }

--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -23,6 +23,7 @@ export class BashExecutionComponent extends Container {
 	private outputLines: string[] = [];
 	private status: "running" | "complete" | "cancelled" | "error" = "running";
 	private exitCode: number | undefined = undefined;
+	private errorMessage: string | undefined = undefined;
 	private loader: Loader;
 	private truncationResult?: TruncationResult;
 	private fullOutputPath?: string;
@@ -116,6 +117,14 @@ export class BashExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	/** Mark the execution as failed before producing a result (e.g. spawn failure). */
+	setFailed(message: string): void {
+		this.errorMessage = message;
+		this.status = "error";
+		this.loader.stop();
+		this.updateDisplay();
+	}
+
 	private updateDisplay(): void {
 		// Apply truncation for LLM context limits (same limits as bash tool)
 		const fullOutput = this.outputLines.join("\n");
@@ -187,7 +196,12 @@ export class BashExecutionComponent extends Container {
 			if (this.status === "cancelled") {
 				statusParts.push(theme.fg("warning", "(cancelled)"));
 			} else if (this.status === "error") {
-				statusParts.push(theme.fg("error", `(exit ${this.exitCode})`));
+				statusParts.push(
+					theme.fg(
+						"error",
+						this.errorMessage !== undefined ? `(failed: ${this.errorMessage})` : `(exit ${this.exitCode})`,
+					),
+				);
 			}
 
 			// Add truncation warning (context truncation, not preview truncation)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3586,15 +3586,18 @@ export class InteractiveMode {
 
 			case "bash_end":
 				if (this.activeBashComponent) {
-					this.activeBashComponent.setComplete(
-						event.exitCode,
-						event.cancelled,
-						event.truncated ? ({ truncated: true } as TruncationResult) : undefined,
-						event.fullOutputPath,
-					);
+					if (event.errorMessage) {
+						this.activeBashComponent.setFailed(event.errorMessage);
+					} else {
+						this.activeBashComponent.setComplete(
+							event.exitCode,
+							event.cancelled,
+							event.truncated ? ({ truncated: true } as TruncationResult) : undefined,
+							event.fullOutputPath,
+						);
+					}
 					this.activeBashComponent = undefined;
-				}
-				if (event.errorMessage) {
+				} else if (event.errorMessage) {
 					this.showError(`Bash command failed: ${event.errorMessage}`);
 				}
 				this.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -476,6 +476,10 @@ export class InteractiveMode {
 	private streamingComponent: AssistantMessageComponent | undefined = undefined;
 	private streamingMessage: AssistantMessage | undefined = undefined;
 
+	// User bash execution tracking (! / !! prefix), driven by bash_* session events
+	private activeBashComponent: BashExecutionComponent | undefined = undefined;
+	private pendingBashComponents: BashExecutionComponent[] = [];
+
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 	private pendingToolCreations = new Set<string>();
@@ -1977,6 +1981,12 @@ export class InteractiveMode {
 			case "goal_update":
 				this.patchConnectionState({ goal: event.goal });
 				break;
+			case "bash_start":
+				this.patchConnectionState({ isBashRunning: true });
+				break;
+			case "bash_end":
+				this.patchConnectionState({ isBashRunning: false });
+				break;
 		}
 	}
 
@@ -2002,6 +2012,10 @@ export class InteractiveMode {
 
 	private isAgentCompacting(): boolean {
 		return this.connectionState?.isCompacting ?? false;
+	}
+
+	private isBashRunning(): boolean {
+		return this.connectionState?.isBashRunning ?? false;
 	}
 
 	private getRetryAttempt(): number {
@@ -2063,6 +2077,8 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
+		this.activeBashComponent = undefined;
+		this.pendingBashComponents = [];
 		this.activityTracker.reset();
 		this.resetPendingToolState();
 		this.resetChildAgentInspector();
@@ -3239,11 +3255,26 @@ export class InteractiveMode {
 				return;
 			}
 
-			// Legacy bash shortcuts are intentionally not transported through AgentConnection.
+			// Handle bash command (! for normal, !! for excluded from context)
 			if (text.startsWith("!")) {
-				this.showWarning("Bash commands are not available in interactive mode. Use IPython for shell commands.");
-				this.editor.setText("");
-				return;
+				const isExcluded = text.startsWith("!!");
+				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
+				if (command) {
+					if (this.isBashRunning()) {
+						this.showWarning(
+							`A bash command is already running. Press ${keyText("app.clear")} to cancel it first.`,
+						);
+						return;
+					}
+					this.editor.addToHistory?.(text);
+					this.editor.setText("");
+					try {
+						await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
+					} catch (error) {
+						this.showError(error instanceof Error ? error.message : String(error));
+					}
+					return;
+				}
 			}
 
 			// Queue input during compaction (extension commands execute immediately)
@@ -3268,6 +3299,10 @@ export class InteractiveMode {
 				this.ui.requestRender();
 				return;
 			}
+
+			// Normal message submission
+			// First, move any pending bash components to chat
+			this.flushPendingBashComponents();
 
 			if (this.onInputCallback) {
 				this.onInputCallback(text);
@@ -3523,6 +3558,42 @@ export class InteractiveMode {
 			case "thinking_level_changed":
 				this.footer.invalidate();
 				this.updateEditorBorderColor();
+				break;
+
+			case "bash_start": {
+				const component = new BashExecutionComponent(event.command, this.ui, event.excludeFromContext);
+				if (this.isAgentStreaming()) {
+					this.pendingMessagesContainer.addChild(component);
+					this.pendingBashComponents.push(component);
+				} else {
+					this.chatContainer.addChild(component);
+				}
+				this.activeBashComponent = component;
+				this.ui.requestRender();
+				break;
+			}
+
+			case "bash_output":
+				if (this.activeBashComponent) {
+					this.activeBashComponent.appendOutput(event.chunk);
+					this.ui.requestRender();
+				}
+				break;
+
+			case "bash_end":
+				if (this.activeBashComponent) {
+					this.activeBashComponent.setComplete(
+						event.exitCode,
+						event.cancelled,
+						event.truncated ? ({ truncated: true } as TruncationResult) : undefined,
+						event.fullOutputPath,
+					);
+					this.activeBashComponent = undefined;
+				}
+				if (event.errorMessage) {
+					this.showError(`Bash command failed: ${event.errorMessage}`);
+				}
+				this.ui.requestRender();
 				break;
 
 			case "message_start":
@@ -4530,6 +4601,10 @@ export class InteractiveMode {
 			});
 			return;
 		}
+		if (this.isBashRunning()) {
+			void this.agentConnection.abortBash();
+			return;
+		}
 	}
 
 	private showCtrlCExitHint(): void {
@@ -4979,6 +5054,15 @@ export class InteractiveMode {
 			const hintText = theme.fg("dim", `↳ ${dequeueHint} to edit all queued messages`);
 			this.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
+	}
+
+	/** Move pending bash components from pending area to chat */
+	private flushPendingBashComponents(): void {
+		for (const component of this.pendingBashComponents) {
+			this.pendingMessagesContainer.removeChild(component);
+			this.chatContainer.addChild(component);
+		}
+		this.pendingBashComponents = [];
 	}
 
 	private async restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): Promise<number> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3268,9 +3268,13 @@ export class InteractiveMode {
 					}
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
+					// Optimistic: bash_start only fires after extension dispatch, and the
+					// clear key must already route to abortBash in that window.
+					this.patchConnectionState({ isBashRunning: true });
 					try {
 						await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
 					} catch (error) {
+						this.patchConnectionState({ isBashRunning: false });
 						this.showError(error instanceof Error ? error.message : String(error));
 					}
 					return;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -480,6 +480,9 @@ export class InteractiveMode {
 	private activeBashComponent: BashExecutionComponent | undefined = undefined;
 	private pendingBashComponents: BashExecutionComponent[] = [];
 
+	// Serializes session event handling; see subscribeToAgent
+	private sessionEventQueue: Promise<void> = Promise.resolve();
+
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 	private pendingToolCreations = new Set<string>();
@@ -3322,7 +3325,12 @@ export class InteractiveMode {
 		this.unsubscribe = this.agentConnection.subscribe(async (event) => {
 			try {
 				if (event.type === "session_event") {
-					await this.handleEvent(event.event);
+					// Connection adapters dispatch without awaiting, so a handler that
+					// suspends would let later events overtake it; queue session events
+					// to keep paired events like bash_start/bash_end in emission order.
+					const run = this.sessionEventQueue.then(() => this.handleEvent(event.event));
+					this.sessionEventQueue = run.catch(() => {});
+					await run;
 				} else if (event.type === "session_replaced") {
 					this.resetExtensionUI();
 					this.applyConnectionStateSnapshot(event.state);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2077,6 +2077,9 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
+		// The discarded component's loader interval keeps firing otherwise; no
+		// bash_end will reach it once the reference is dropped.
+		this.activeBashComponent?.setComplete(undefined, true);
 		this.activeBashComponent = undefined;
 		this.pendingBashComponents = [];
 		this.activityTracker.reset();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3718,6 +3718,7 @@ export class InteractiveMode {
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
 				}
+				this.flushPendingBashComponents();
 				this.resetPendingToolState();
 
 				await this.checkShutdownRequested();
@@ -4595,14 +4596,16 @@ export class InteractiveMode {
 			void this.agentConnection.abortBranchSummary();
 			return;
 		}
+		// Bash outranks the agent stream: the already-running warning tells the user
+		// this key cancels the bash command, and the stream stays one press away.
+		if (this.isBashRunning()) {
+			void this.agentConnection.abortBash();
+			return;
+		}
 		if (this.isAgentStreaming()) {
 			void this.restoreQueuedMessagesToEditor({ abort: true }).catch((error) => {
 				this.showError(error instanceof Error ? error.message : String(error));
 			});
-			return;
-		}
-		if (this.isBashRunning()) {
-			void this.agentConnection.abortBash();
 			return;
 		}
 	}
@@ -5039,6 +5042,11 @@ export class InteractiveMode {
 
 	private updatePendingMessagesDisplay(): void {
 		this.pendingMessagesContainer.clear();
+		// Keep in-flight bash output visible across queue refreshes; clear() detaches
+		// the components but they stay tracked in pendingBashComponents until flushed.
+		for (const component of this.pendingBashComponents) {
+			this.pendingMessagesContainer.addChild(component);
+		}
 		const { steering: steeringMessages, followUp: followUpMessages } = this.getAllQueuedMessages();
 		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
 			this.pendingMessagesContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3281,7 +3281,14 @@ export class InteractiveMode {
 				try {
 					await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
 				} catch (error) {
-					this.patchConnectionState({ isBashRunning: false });
+					// Re-sync rather than assume idle: the rejection may mean another
+					// client's bash run already holds the slot.
+					try {
+						const state = await this.agentConnection.getState();
+						this.patchConnectionState({ isBashRunning: state.isBashRunning });
+					} catch {
+						this.patchConnectionState({ isBashRunning: false });
+					}
 					this.showError(error instanceof Error ? error.message : String(error));
 				}
 				return;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3262,26 +3262,26 @@ export class InteractiveMode {
 			if (text.startsWith("!")) {
 				const isExcluded = text.startsWith("!!");
 				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
-				if (command) {
-					if (this.isBashRunning()) {
-						this.showWarning(
-							`A bash command is already running. Press ${keyText("app.clear")} to cancel it first.`,
-						);
-						return;
-					}
-					this.editor.addToHistory?.(text);
-					this.editor.setText("");
-					// Optimistic: bash_start only fires after extension dispatch, and the
-					// clear key must already route to abortBash in that window.
-					this.patchConnectionState({ isBashRunning: true });
-					try {
-						await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
-					} catch (error) {
-						this.patchConnectionState({ isBashRunning: false });
-						this.showError(error instanceof Error ? error.message : String(error));
-					}
+				if (!command) {
+					// Bare ! / !! is bash mode with nothing to run; don't send it as a prompt
 					return;
 				}
+				if (this.isBashRunning()) {
+					this.showWarning(`A bash command is already running. Press ${keyText("app.clear")} to cancel it first.`);
+					return;
+				}
+				this.editor.addToHistory?.(text);
+				this.editor.setText("");
+				// Optimistic: bash_start only fires after extension dispatch, and the
+				// clear key must already route to abortBash in that window.
+				this.patchConnectionState({ isBashRunning: true });
+				try {
+					await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
+				} catch (error) {
+					this.patchConnectionState({ isBashRunning: false });
+					this.showError(error instanceof Error ? error.message : String(error));
+				}
+				return;
 			}
 
 			// Queue input during compaction (extension commands execute immediately)

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -219,6 +219,18 @@ class FakeDaemonClient {
 					success: true,
 					data: { cancelled: command.childId === "child-1" },
 				};
+			case "execute_bash":
+				if (command.command === "stale-daemon") {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: "Unknown daemon command: execute_bash",
+					};
+				}
+				return { type: "response", command: command.type, success: true };
+			case "abort_bash":
+				return { type: "response", command: command.type, success: true };
 			case "delete_saved_session":
 				return {
 					type: "response",
@@ -303,6 +315,7 @@ function createConnectionState(activeSessionId: string, sessionId: string): Agen
 		availableThinkingLevels: ["minimal", "low", "medium", "high", "xhigh"],
 		isStreaming: false,
 		isCompacting: false,
+		isBashRunning: false,
 		retryAttempt: 0,
 		steeringMode: "all",
 		followUpMode: "one-at-a-time",
@@ -727,6 +740,29 @@ describe("DaemonAgentConnection", () => {
 		// A daemon from a build that predates the command reports a restart hint
 		// instead of the raw protocol error.
 		await expect(connection.cancelRlmChild("stale-daemon")).rejects.toThrow(
+			"the daemon is running an older build; restart the daemon and try again",
+		);
+	});
+
+	it("sends bash commands through the daemon protocol", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		await connection.attach();
+
+		await connection.executeBash("echo hi", { excludeFromContext: true });
+		await connection.abortBash();
+
+		expect(fakeClient.requests[1]).toMatchObject({
+			type: "execute_bash",
+			activeSessionId: "active-1",
+			command: "echo hi",
+			excludeFromContext: true,
+		});
+		expect(fakeClient.requests[2]).toMatchObject({ type: "abort_bash", activeSessionId: "active-1" });
+
+		// A daemon from a build that predates the command reports a restart hint
+		// instead of the raw protocol error.
+		await expect(connection.executeBash("stale-daemon")).rejects.toThrow(
 			"the daemon is running an older build; restart the daemon and try again",
 		);
 	});

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -23,6 +23,7 @@ class FakeDaemonClient {
 	readonly requests: DaemonCommand[] = [];
 	attachResultFactory: ((command: Extract<DaemonCommand, { type: "attach" }>) => DaemonAttachResult) | undefined;
 	closeCount = 0;
+	abortBashUnknownCommand = false;
 	private readonly messageListeners = new Set<DaemonClientMessageListener>();
 	private readonly closeListeners = new Set<DaemonClientCloseListener>();
 
@@ -230,6 +231,14 @@ class FakeDaemonClient {
 				}
 				return { type: "response", command: command.type, success: true };
 			case "abort_bash":
+				if (this.abortBashUnknownCommand) {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: "Unknown daemon command: abort_bash",
+					};
+				}
 				return { type: "response", command: command.type, success: true };
 			case "delete_saved_session":
 				return {
@@ -763,6 +772,10 @@ describe("DaemonAgentConnection", () => {
 		// A daemon from a build that predates the command reports a restart hint
 		// instead of the raw protocol error.
 		await expect(connection.executeBash("stale-daemon")).rejects.toThrow(
+			"the daemon is running an older build; restart the daemon and try again",
+		);
+		fakeClient.abortBashUnknownCommand = true;
+		await expect(connection.abortBash()).rejects.toThrow(
 			"the daemon is running an older build; restart the daemon and try again",
 		);
 	});

--- a/packages/coding-agent/test/bash-execution-width.test.ts
+++ b/packages/coding-agent/test/bash-execution-width.test.ts
@@ -77,4 +77,18 @@ describe("BashExecutionComponent width handling (#2569)", () => {
 			expect(w, `Line ${i} visibleWidth=${w} > 60`).toBeLessThanOrEqual(60);
 		}
 	});
+
+	it("renders an inline failure state via setFailed", () => {
+		const { stub } = createTuiStub(120);
+		const component = new BashExecutionComponent("boom", stub);
+
+		component.setFailed("spawn failure");
+
+		const rendered = component
+			.render(120)
+			.map((line) => line.replace(/\[[0-9;]*m/g, ""))
+			.join("\n");
+		expect(rendered).toContain("failed: spawn failure");
+		expect(rendered).not.toContain("Running...");
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -244,6 +244,46 @@ describe("InteractiveMode submit handling", () => {
 	});
 });
 
+describe("InteractiveMode pending bash components", () => {
+	const bashComponent = () => ({ render: () => [], invalidate: () => {} });
+
+	test("keeps pending bash components visible across queue refreshes", () => {
+		const pendingMessagesContainer = new Container();
+		const component = bashComponent();
+		const fakeThis = {
+			pendingMessagesContainer,
+			pendingBashComponents: [component],
+			getAllQueuedMessages: () => ({ steering: [], followUp: [] }),
+		} as unknown as InteractiveMode;
+
+		(
+			InteractiveMode.prototype as unknown as { updatePendingMessagesDisplay(this: unknown): void }
+		).updatePendingMessagesDisplay.call(fakeThis);
+
+		expect(pendingMessagesContainer.children).toContain(component);
+	});
+
+	test("flushes pending bash components from the pending area to chat", () => {
+		const pendingMessagesContainer = new Container();
+		const chatContainer = new Container();
+		const component = bashComponent();
+		pendingMessagesContainer.addChild(component);
+		const fakeThis = {
+			pendingMessagesContainer,
+			chatContainer,
+			pendingBashComponents: [component],
+		} as unknown as InteractiveMode;
+
+		(
+			InteractiveMode.prototype as unknown as { flushPendingBashComponents(this: unknown): void }
+		).flushPendingBashComponents.call(fakeThis);
+
+		expect(pendingMessagesContainer.children).not.toContain(component);
+		expect(chatContainer.children).toContain(component);
+		expect((fakeThis as unknown as { pendingBashComponents: unknown[] }).pendingBashComponents).toHaveLength(0);
+	});
+});
+
 describe("InteractiveMode connection events", () => {
 	test("clears extension UI when a connection-backed session is replaced", async () => {
 		type SessionReplacedEvent = { type: "session_replaced"; state: AgentConnectionState; messages: [] };

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -221,6 +221,16 @@ describe("InteractiveMode submit handling", () => {
 		expect(fakeThis.agentConnection.prompt).not.toHaveBeenCalled();
 	});
 
+	test("ignores bare ! and !! input instead of prompting the agent", async () => {
+		const fakeThis = createSubmitHandlerHarness();
+
+		await fakeThis.defaultEditor.onSubmit?.("!");
+		await fakeThis.defaultEditor.onSubmit?.("!!");
+
+		expect(fakeThis.agentConnection.executeBash).not.toHaveBeenCalled();
+		expect(fakeThis.agentConnection.prompt).not.toHaveBeenCalled();
+	});
+
 	test("warns instead of executing when a bash command is already running", async () => {
 		const fakeThis = createSubmitHandlerHarness({ isBashRunning: () => true });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -178,6 +178,7 @@ type SubmitHandlerHarness = {
 	agentConnection: {
 		prompt: (message: string) => Promise<void>;
 		executeBash: (command: string, options?: { excludeFromContext?: boolean }) => Promise<void>;
+		getState: () => Promise<{ isBashRunning: boolean }>;
 	};
 };
 
@@ -189,7 +190,11 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 		showError: vi.fn(),
 		isBashRunning: () => false,
 		patchConnectionState: vi.fn(),
-		agentConnection: { prompt: vi.fn(async () => {}), executeBash: vi.fn(async () => {}) },
+		agentConnection: {
+			prompt: vi.fn(async () => {}),
+			executeBash: vi.fn(async () => {}),
+			getState: vi.fn(async () => ({ isBashRunning: false })),
+		},
 		...overrides,
 	};
 	(
@@ -248,12 +253,31 @@ describe("InteractiveMode submit handling", () => {
 				executeBash: vi.fn(async () => {
 					throw new Error("the daemon is running an older build; restart the daemon and try again");
 				}),
+				getState: vi.fn(async () => ({ isBashRunning: false })),
 			},
 		});
 
 		await fakeThis.defaultEditor.onSubmit?.("!pwd");
 
 		expect(fakeThis.showError).toHaveBeenCalledWith(expect.stringContaining("older build"));
+		expect(fakeThis.patchConnectionState).toHaveBeenLastCalledWith({ isBashRunning: false });
+	});
+
+	test("re-syncs the bash flag from connection state when executeBash is rejected", async () => {
+		const fakeThis = createSubmitHandlerHarness({
+			agentConnection: {
+				prompt: vi.fn(async () => {}),
+				executeBash: vi.fn(async () => {
+					throw new Error("A bash command is already running");
+				}),
+				// Another attached client holds the bash slot
+				getState: vi.fn(async () => ({ isBashRunning: true })),
+			},
+		});
+
+		await fakeThis.defaultEditor.onSubmit?.("!pwd");
+
+		expect(fakeThis.patchConnectionState).toHaveBeenLastCalledWith({ isBashRunning: true });
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -300,6 +300,39 @@ describe("InteractiveMode pending bash components", () => {
 		expect((fakeThis as unknown as { pendingBashComponents: unknown[] }).pendingBashComponents).toHaveLength(0);
 	});
 
+	test("handles session events in emission order even when a handler suspends", async () => {
+		type ConnectionListener = (event: { type: string; event: { type: string } }) => Promise<void>;
+		let listener: ConnectionListener | undefined;
+		const order: string[] = [];
+		const fakeThis = {
+			agentConnection: {
+				subscribe: (l: ConnectionListener) => {
+					listener = l;
+					return () => {};
+				},
+			},
+			sessionEventQueue: Promise.resolve(),
+			showError: vi.fn(),
+			handleEvent: async (event: { type: string }) => {
+				order.push(`start:${event.type}`);
+				if (event.type === "bash_start") {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+				}
+				order.push(`end:${event.type}`);
+			},
+		} as unknown as InteractiveMode;
+
+		(InteractiveMode.prototype as unknown as { subscribeToAgent(this: unknown): void }).subscribeToAgent.call(
+			fakeThis,
+		);
+
+		const first = listener?.({ type: "session_event", event: { type: "bash_start" } });
+		const second = listener?.({ type: "session_event", event: { type: "bash_end" } });
+		await Promise.all([first, second]);
+
+		expect(order).toEqual(["start:bash_start", "end:bash_start", "start:bash_end", "end:bash_end"]);
+	});
+
 	test("stops an orphaned bash loader when session render state resets", () => {
 		const tuiStub = {
 			terminal: { columns: 120, rows: 24 },

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -173,6 +173,7 @@ type SubmitHandlerHarness = {
 	showWarning: (message: string) => void;
 	showError: (message: string) => void;
 	isBashRunning: () => boolean;
+	patchConnectionState: (patch: Record<string, unknown>) => void;
 	agentConnection: {
 		prompt: (message: string) => Promise<void>;
 		executeBash: (command: string, options?: { excludeFromContext?: boolean }) => Promise<void>;
@@ -186,6 +187,7 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 		showWarning: vi.fn(),
 		showError: vi.fn(),
 		isBashRunning: () => false,
+		patchConnectionState: vi.fn(),
 		agentConnection: { prompt: vi.fn(async () => {}), executeBash: vi.fn(async () => {}) },
 		...overrides,
 	};

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -22,6 +22,7 @@ import type {
 	AgentConnectionState,
 } from "../src/modes/agent-connection/types.js";
 import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
+import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
 import type { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
 import { formatSplashCwd, InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -247,6 +248,10 @@ describe("InteractiveMode submit handling", () => {
 });
 
 describe("InteractiveMode pending bash components", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
 	const bashComponent = () => ({ render: () => [], invalidate: () => {} });
 
 	test("keeps pending bash components visible across queue refreshes", () => {
@@ -283,6 +288,39 @@ describe("InteractiveMode pending bash components", () => {
 		expect(pendingMessagesContainer.children).not.toContain(component);
 		expect(chatContainer.children).toContain(component);
 		expect((fakeThis as unknown as { pendingBashComponents: unknown[] }).pendingBashComponents).toHaveLength(0);
+	});
+
+	test("stops an orphaned bash loader when session render state resets", () => {
+		const tuiStub = {
+			terminal: { columns: 120, rows: 24 },
+			requestRender: () => {},
+		} as unknown as ConstructorParameters<typeof BashExecutionComponent>[1];
+		const component = new BashExecutionComponent("sleep 99", tuiStub);
+		const loader = (component as unknown as { loader: { intervalId: unknown } }).loader;
+		expect(loader.intervalId).not.toBeNull();
+
+		const fakeThis = {
+			chatContainer: new Container(),
+			pendingMessagesContainer: new Container(),
+			compactionQueuedMessages: [],
+			streamingComponent: undefined,
+			streamingMessage: undefined,
+			activeBashComponent: component,
+			pendingBashComponents: [component],
+			activityTracker: { reset: vi.fn() },
+			resetPendingToolState: vi.fn(),
+			resetChildAgentInspector: vi.fn(),
+			setGoalAnnouncementBaseline: vi.fn(),
+			syncGoalTray: vi.fn(),
+			getGoalState: () => emptyGoalState(),
+		} as unknown as InteractiveMode;
+
+		(
+			InteractiveMode.prototype as unknown as { resetCurrentSessionRenderState(this: unknown): void }
+		).resetCurrentSessionRenderState.call(fakeThis);
+
+		expect(loader.intervalId).toBeNull();
+		expect((fakeThis as unknown as { activeBashComponent: unknown }).activeBashComponent).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -54,6 +54,7 @@ function createConnectionState(overrides: Partial<AgentConnectionState> = {}): A
 		availableThinkingLevels: ["minimal", "low", "medium", "high", "xhigh"],
 		isStreaming: false,
 		isCompacting: false,
+		isBashRunning: false,
 		retryAttempt: 0,
 		steeringMode: "all",
 		followUpMode: "all",
@@ -168,33 +169,78 @@ describe("InteractiveMode.showStatus", () => {
 
 type SubmitHandlerHarness = {
 	defaultEditor: { onSubmit?: (text: string) => Promise<void> };
-	editor: { setText: (text: string) => void };
+	editor: { setText: (text: string) => void; addToHistory?: (text: string) => void };
 	showWarning: (message: string) => void;
-	agentConnection: { prompt: (message: string) => Promise<void> };
+	showError: (message: string) => void;
+	isBashRunning: () => boolean;
+	agentConnection: {
+		prompt: (message: string) => Promise<void>;
+		executeBash: (command: string, options?: { excludeFromContext?: boolean }) => Promise<void>;
+	};
 };
 
-describe("InteractiveMode submit handling", () => {
-	test("rejects legacy bash shortcuts before reaching the agent connection", async () => {
-		const fakeThis: SubmitHandlerHarness = {
-			defaultEditor: {},
-			editor: { setText: vi.fn() },
-			showWarning: vi.fn(),
-			agentConnection: { prompt: vi.fn(async () => {}) },
-		};
+function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {}): SubmitHandlerHarness {
+	const fakeThis: SubmitHandlerHarness = {
+		defaultEditor: {},
+		editor: { setText: vi.fn(), addToHistory: vi.fn() },
+		showWarning: vi.fn(),
+		showError: vi.fn(),
+		isBashRunning: () => false,
+		agentConnection: { prompt: vi.fn(async () => {}), executeBash: vi.fn(async () => {}) },
+		...overrides,
+	};
+	(
+		InteractiveMode.prototype as unknown as {
+			setupEditorSubmitHandler(this: SubmitHandlerHarness): void;
+		}
+	).setupEditorSubmitHandler.call(fakeThis);
+	return fakeThis;
+}
 
-		(
-			InteractiveMode.prototype as unknown as {
-				setupEditorSubmitHandler(this: SubmitHandlerHarness): void;
-			}
-		).setupEditorSubmitHandler.call(fakeThis);
+describe("InteractiveMode submit handling", () => {
+	test("routes ! shortcuts to executeBash on the agent connection", async () => {
+		const fakeThis = createSubmitHandlerHarness();
 
 		await fakeThis.defaultEditor.onSubmit?.("!pwd");
 
-		expect(fakeThis.showWarning).toHaveBeenCalledWith(
-			"Bash commands are not available in interactive mode. Use IPython for shell commands.",
-		);
+		expect(fakeThis.agentConnection.executeBash).toHaveBeenCalledWith("pwd", { excludeFromContext: false });
+		expect(fakeThis.editor.addToHistory).toHaveBeenCalledWith("!pwd");
 		expect(fakeThis.editor.setText).toHaveBeenCalledWith("");
 		expect(fakeThis.agentConnection.prompt).not.toHaveBeenCalled();
+	});
+
+	test("routes !! shortcuts to executeBash with excludeFromContext", async () => {
+		const fakeThis = createSubmitHandlerHarness();
+
+		await fakeThis.defaultEditor.onSubmit?.("!!git status");
+
+		expect(fakeThis.agentConnection.executeBash).toHaveBeenCalledWith("git status", { excludeFromContext: true });
+		expect(fakeThis.agentConnection.prompt).not.toHaveBeenCalled();
+	});
+
+	test("warns instead of executing when a bash command is already running", async () => {
+		const fakeThis = createSubmitHandlerHarness({ isBashRunning: () => true });
+
+		await fakeThis.defaultEditor.onSubmit?.("!pwd");
+
+		expect(fakeThis.showWarning).toHaveBeenCalledWith(expect.stringContaining("A bash command is already running"));
+		expect(fakeThis.agentConnection.executeBash).not.toHaveBeenCalled();
+		expect(fakeThis.editor.setText).not.toHaveBeenCalled();
+	});
+
+	test("surfaces executeBash transport failures via showError", async () => {
+		const fakeThis = createSubmitHandlerHarness({
+			agentConnection: {
+				prompt: vi.fn(async () => {}),
+				executeBash: vi.fn(async () => {
+					throw new Error("the daemon is running an older build; restart the daemon and try again");
+				}),
+			},
+		});
+
+		await fakeThis.defaultEditor.onSubmit?.("!pwd");
+
+		expect(fakeThis.showError).toHaveBeenCalledWith(expect.stringContaining("older build"));
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-streaming.test.ts
+++ b/packages/coding-agent/test/interactive-mode-streaming.test.ts
@@ -62,6 +62,8 @@ function createFakeInteractiveModeThis(): HandleEventThis {
 		hiddenThinkingLabel: "Thinking...",
 		streamingComponent: undefined,
 		streamingMessage: undefined,
+		pendingMessagesContainer: new Container(),
+		pendingBashComponents: [],
 		pendingTools: new Map<string, ToolExecutionComponent>(),
 		updateConnectionStateFromEvent: vi.fn(),
 		getMarkdownThemeWithSettings: () => getMarkdownTheme(),

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -287,6 +287,47 @@ describe("AgentSession bash and persistence characterization", () => {
 		expect(events[0]?.errorMessage).toBe("spawn failure");
 	});
 
+	it("cancels runUserBash when abortBash arrives before execution starts", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const events: Array<{ type: string; cancelled?: boolean }> = [];
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "bash_output" || event.type === "bash_end") {
+				events.push(event);
+			}
+		});
+
+		// Abort lands during the user_bash extension dispatch, before any process spawns
+		const run = harness.session.runUserBash("echo should-not-run");
+		harness.session.abortBash();
+		await run;
+		unsubscribe();
+
+		expect(events).toEqual([{ type: "bash_end", exitCode: undefined, cancelled: true, truncated: false }]);
+		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
+		expect(lastMessage?.role).toBe("bashExecution");
+		if (lastMessage?.role === "bashExecution") {
+			expect(lastMessage.cancelled).toBe(true);
+			expect(lastMessage.output).toBe("");
+		}
+	});
+
+	it("releases the bash slot before bash_end reaches subscribers", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let runningAtBashEnd: boolean | undefined;
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "bash_end") {
+				runningAtBashEnd = harness.session.isBashRunning;
+			}
+		});
+
+		await harness.session.runUserBash("echo done");
+		unsubscribe();
+
+		expect(runningAtBashEnd).toBe(false);
+	});
+
 	it("rejects a second runUserBash issued before the first starts executing", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -285,6 +285,13 @@ describe("AgentSession bash and persistence characterization", () => {
 
 		expect(events).toHaveLength(1);
 		expect(events[0]?.errorMessage).toBe("spawn failure");
+
+		// The failure is persisted like every other outcome
+		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
+		expect(lastMessage?.role).toBe("bashExecution");
+		if (lastMessage?.role === "bashExecution") {
+			expect(lastMessage.output).toContain("spawn failure");
+		}
 	});
 
 	it("cancels runUserBash when abortBash arrives before execution starts", async () => {

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -239,4 +239,70 @@ describe("AgentSession bash and persistence characterization", () => {
 		expect(result.output).toContain("hello from custom ops");
 		expect(harness.session.messages[harness.session.messages.length - 1]?.role).toBe("bashExecution");
 	});
+
+	it("emits bash lifecycle events and records the result for runUserBash", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const events: Array<{ type: string }> = [];
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "bash_start" || event.type === "bash_output" || event.type === "bash_end") {
+				events.push(event);
+			}
+		});
+
+		await harness.session.runUserBash("echo lifecycle", { excludeFromContext: true });
+		unsubscribe();
+
+		expect(events[0]).toMatchObject({ type: "bash_start", command: "echo lifecycle", excludeFromContext: true });
+		expect(events.some((event) => event.type === "bash_output")).toBe(true);
+		expect(events[events.length - 1]).toMatchObject({ type: "bash_end", exitCode: 0, cancelled: false });
+
+		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
+		expect(lastMessage?.role).toBe("bashExecution");
+		if (lastMessage?.role === "bashExecution") {
+			expect(lastMessage.output).toContain("lifecycle");
+			expect(lastMessage.excludeFromContext).toBe(true);
+		}
+	});
+
+	it("reports runUserBash execution failures through bash_end instead of rejecting", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const events: Array<{ type: string; errorMessage?: string }> = [];
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "bash_end") {
+				events.push(event);
+			}
+		});
+
+		const executeBashSpy = harness.session.executeBash.bind(harness.session);
+		harness.session.executeBash = async () => {
+			throw new Error("spawn failure");
+		};
+		await harness.session.runUserBash("echo unreachable");
+		harness.session.executeBash = executeBashSpy;
+		unsubscribe();
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.errorMessage).toBe("spawn failure");
+	});
+
+	it("rejects runUserBash while another bash command is running", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let releaseExec: (() => void) | undefined;
+		const operations: BashOperations = {
+			exec: async () => {
+				await new Promise<void>((resolve) => {
+					releaseExec = resolve;
+				});
+				return { exitCode: 0 };
+			},
+		};
+
+		const first = harness.session.executeBash("blocked", undefined, { operations });
+		await expect(harness.session.runUserBash("echo nope")).rejects.toThrow("already running");
+		releaseExec?.();
+		await first;
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -287,6 +287,20 @@ describe("AgentSession bash and persistence characterization", () => {
 		expect(events[0]?.errorMessage).toBe("spawn failure");
 	});
 
+	it("rejects a second runUserBash issued before the first starts executing", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		// Same-tick overlap: the guard must trip before the first command reaches
+		// executeBash, i.e. during the async user_bash extension dispatch.
+		const first = harness.session.runUserBash("echo first");
+		await expect(harness.session.runUserBash("echo second")).rejects.toThrow("already running");
+		await first;
+
+		const bashMessages = harness.session.messages.filter((message) => message.role === "bashExecution");
+		expect(bashMessages).toHaveLength(1);
+	});
+
 	it("rejects runUserBash while another bash command is running", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);


### PR DESCRIPTION
- the ! and !! bash shortcuts stopped working when the tui moved behind the agent connection boundary, leaving a hardcoded warning instead.
- bash execution now lives in the session and emits start/output/end events, so both in-process and daemon-attached clients render streaming output and can abort.
- restores the previous tui behavior (history, pending placement while streaming, ctrl+c abort) and rejects stale daemons with a restart hint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell execution, session event ordering, and daemon protocol compatibility; mistakes could affect concurrent runs, multi-client state, or older daemon attachments.
> 
> **Overview**
> Restores **`!` / `!!` shell shortcuts** in interactive mode after the TUI moved behind `AgentConnection`, replacing the previous hardcoded “not available” warning.
> 
> **Session layer:** `runUserBash` drives user-initiated runs with **`bash_start` / `bash_output` / `bash_end`** events, optional `user_bash` extension interception, pre-spawn abort handling, and outcomes recorded in session history. **`isBashRunning`** now covers the gap before a process spawns so concurrent commands are rejected reliably; **`bash_end`** is emitted only after the bash slot is released.
> 
> **Connection & daemon:** `AgentConnection` gains **`executeBash` / `abortBash`** and **`isBashRunning`** in connection state; the daemon adds **`execute_bash` / `abort_bash`** (ack before completion, streaming via session events) with a restart hint for older daemons.
> 
> **Interactive UI:** Editor routes shortcuts to **`executeBash`**, renders streaming **`BashExecutionComponent`** output (pending area while the agent streams), serializes session events to preserve **`bash_start`/`bash_end`** order, and prioritizes **clear/ctrl+c** to abort bash before aborting the agent stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732278af80df0dc63e43d414dedf5e19051d77ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bash shortcut execution via `!` and `!!` prefixes in interactive agent mode
> - Adds `!<cmd>` and `!!<cmd>` input prefixes in interactive mode to run user-initiated bash commands inline, with `!!` excluding output from agent context.
> - Extends `AgentConnection`, `InProcessAgentConnection`, and `DaemonAgentConnection` with `executeBash` and `abortBash` methods; the daemon protocol gains matching `execute_bash` and `abort_bash` commands.
> - Bash lifecycle is tracked via new `bash_start`, `bash_output`, and `bash_end` session events, rendered in the chat UI using `BashExecutionComponent` including inline failure messages.
> - The interrupt key (Ctrl-C) now cancels an active bash command before aborting the agent stream.
> - Behavioral Change: `isBashRunning` now returns `true` earlier in the lifecycle (pre-spawn), and bash failures are reported via `bash_end` events rather than promise rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 732278a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->