### PR TITLE
Update RLM system prompt to match rlm_harness

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -5,6 +5,7 @@ import type { KnownProvider } from "./types.js";
 
 // NEVER convert to top-level runtime imports - breaks browser/Vite builds (web-ui)
 let _existsSync: typeof existsSync | null = null;
+let _readFileSync: typeof readFileSync | null = null;
 let _homedir: typeof homedir | null = null;
 let _join: typeof join | null = null;
 
@@ -19,6 +20,7 @@ const NODE_PATH_SPECIFIER = "node:" + "path";
 if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
 	dynamicImport(NODE_FS_SPECIFIER).then((m) => {
 		_existsSync = (m as { existsSync: typeof existsSync }).existsSync;
+		_readFileSync = (m as { readFileSync: typeof readFileSync }).readFileSync;
 	});
 	dynamicImport(NODE_OS_SPECIFIER).then((m) => {
 		_homedir = (m as { homedir: typeof homedir }).homedir;
@@ -208,5 +210,23 @@ export function getEnvApiKey(provider: string): string | undefined {
 		}
 	}
 
+	return undefined;
+}
+
+// PRIME_TEAM_ID env var, falling back to team_id in ~/.prime/config.json.
+export function getPrimeTeamId(): string | undefined {
+	const fromEnv = process.env.PRIME_TEAM_ID || getProcEnv("PRIME_TEAM_ID");
+	if (fromEnv?.trim()) return fromEnv.trim();
+
+	if (!_existsSync || !_readFileSync || !_homedir || !_join) return undefined;
+	const configPath = _join(_homedir(), ".prime", "config.json");
+	if (!_existsSync(configPath)) return undefined;
+	try {
+		const parsed = JSON.parse(_readFileSync(configPath, "utf-8")) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			const teamId = (parsed as Record<string, unknown>).team_id;
+			if (typeof teamId === "string" && teamId.trim()) return teamId.trim();
+		}
+	} catch {}
 	return undefined;
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -10,7 +10,7 @@ import type {
 	ChatCompletionSystemMessageParam,
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
-import { getEnvApiKey } from "../env-api-keys.js";
+import { getEnvApiKey, getPrimeTeamId } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
 	AssistantMessage,
@@ -460,6 +460,11 @@ function createClient(
 			hasImages,
 		});
 		Object.assign(headers, copilotHeaders);
+	}
+
+	if (model.provider === "prime-inference") {
+		const teamId = getPrimeTeamId();
+		if (teamId) headers["X-Prime-Team-ID"] = teamId;
 	}
 
 	if (sessionId && compat.sendSessionAffinityHeaders) {

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -34,6 +34,11 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		skillLines.push(
 			"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 		);
+		if (installedSkills.includes("edit")) {
+			skillLines.push(
+				"For targeted existing-file edits, prefer the pre-imported async `edit` skill from IPython: `old = '''...'''; new = '''...'''; await edit(path=\"pkg/file.py\", old_str=old, new_str=new)`. Use exact old/new strings; if the text contains triple double quotes, use triple single-quoted variables or build `old`/`new` from inspected file slices.",
+			);
+		}
 	}
 	if (skillLines.length > 0) {
 		parts.push("", ...skillLines);
@@ -51,7 +56,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	if (activeTools.includes("ipython")) {
 		parts.push(
 			"",
-			"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+			"Use `ipython` for both Python and shell work. When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 		);
 	}
 

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -42,11 +42,45 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
-				"Use `ipython` for both Python and shell work. For repository shell commands, prefer IPython shell syntax: `!rg ...`, `!npm run check`, or `%%bash` for multi-line scripts. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
+				"Use `ipython` for both Python and shell work. When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context. Do not wrap ordinary shell commands in Python subprocesses unless you need Python-level processing.",
 				"",
 				"Call at most one built-in tool per turn.",
 			].join("\n"),
 		);
+	});
+
+	test("documents the %%bash first-line rule when ipython is active", () => {
+		const prompt = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(prompt).toContain("it must be the first line of the code cell");
+	});
+
+	test("includes the edit skill guidance only when the edit skill is installed", () => {
+		const withEdit = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["edit"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(withEdit).toContain('await edit(path="pkg/file.py", old_str=old, new_str=new)');
+		expect(withEdit).toContain("triple double quotes");
+
+		const withoutEdit = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["websearch"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(withoutEdit).not.toContain("await edit(path=");
 	});
 
 	test("only documents ipython shell prefixes when ipython is active", () => {
@@ -91,7 +125,8 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");
 		expect(prompt).toContain("Use `ipython` for both Python and shell work");
-		expect(prompt).toContain("prefer IPython shell syntax");
+		expect(prompt).toContain("use `%%bash` cells");
+		expect(prompt).toContain("Avoid `!cmd` shell escapes for project commands");
 		expect(prompt).toContain("Do not wrap ordinary shell commands in Python subprocesses");
 		expect(prompt).toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are prompt text, optional HTTP headers for one provider, and tests—no auth or data-path changes beyond reading local Prime config when present.
> 
> **Overview**
> **RLM system prompt** is updated to match `rlm_harness`: IPython shell work now steers agents toward **`%%bash` cells** (must be the first line of the cell, with no preamble) and away from **`!cmd` escapes** for project commands. When the **`edit`** skill is installed, the prompt adds targeted guidance for `await edit(...)` with exact `old_str`/`new_str` and quoting tips.
> 
> **Prime Inference** requests now optionally include **`X-Prime-Team-ID`**: a new **`getPrimeTeamId()`** resolves `PRIME_TEAM_ID` (including Bun `/proc` env fallback) or **`team_id`** from **`~/.prime/config.json`**, using the same lazy Node `fs` loading pattern as other env helpers.
> 
> Tests cover the **`%%bash`** rule, conditional **edit** copy, and updated harness expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe9c09806d90506ff747e9450d160c7821c2618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update RLM system prompt to match rlm_harness with `%%bash` and edit-skill guidance
> - Updates `buildRlmPrompt` in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/160/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) to replace `!cmd` shell escape guidance with `%%bash` cell guidance, and conditionally adds edit-skill usage instructions when the `edit` skill is installed.
> - Adds `getPrimeTeamId` to [env-api-keys.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/160/files#diff-2348feed8ded6af482a24473231ace3a3ccc5ad8705195b9391ba0d50cfae913), which resolves a team ID from `PRIME_TEAM_ID` env var or `~/.prime/config.json`.
> - Injects `X-Prime-Team-ID` header into outgoing requests for `prime-inference` models in [openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/160/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fe9c09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->