### PR TITLE
Update system prompt to match rlm_harness (at least on prefix)

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -14,7 +14,7 @@ const IPYTHON_CONTROL_PROMPT = [
 	"",
 	"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 	"",
-	"When running shell commands from IPython, use `%%bash` cells. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
+	"When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
 	"",
 	'Project import checks are target-environment checks. If the user asks whether the current project, package, or repository imports from Python, do not run `import <project>` directly in IPython. Use a `%%bash` cell with the target environment, such as `uv run python -c "import <package>"`, `.venv/bin/python -c "import <package>"`, or the documented project command.',
 	"",
@@ -54,6 +54,11 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		skillLines.push(
 			"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 		);
+		if (installedSkills.includes("edit")) {
+			skillLines.push(
+				"For targeted existing-file edits, prefer the pre-imported async `edit` skill from IPython: `old = '''...'''; new = '''...'''; await edit(path=\"pkg/file.py\", old_str=old, new_str=new)`. Use exact old/new strings; if the text contains triple double quotes, use triple single-quoted variables or build `old`/`new` from inspected file slices.",
+			);
+		}
 	}
 	if (skillLines.length > 0) {
 		parts.push("", ...skillLines);

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -62,7 +62,7 @@ describe("buildRlmPrompt", () => {
 				"",
 				"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 				"",
-				"When running shell commands from IPython, use `%%bash` cells. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
+				"When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
 				"",
 				'Project import checks are target-environment checks. If the user asks whether the current project, package, or repository imports from Python, do not run `import <project>` directly in IPython. Use a `%%bash` cell with the target environment, such as `uv run python -c "import <package>"`, `.venv/bin/python -c "import <package>"`, or the documented project command.',
 				"",
@@ -88,6 +88,40 @@ describe("buildRlmPrompt", () => {
 		});
 
 		expect(prompt).not.toContain("IPython is the agent's long-lived notebook");
+	});
+
+	test("documents the %%bash first-line rule when ipython is active", () => {
+		const prompt = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(prompt).toContain("it must be the first line of the code cell");
+	});
+
+	test("includes the edit skill guidance only when the edit skill is installed", () => {
+		const withEdit = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["edit"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(withEdit).toContain('await edit(path="pkg/file.py", old_str=old, new_str=new)');
+		expect(withEdit).toContain("triple double quotes");
+
+		const withoutEdit = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["websearch"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(withoutEdit).not.toContain("await edit(path=");
 	});
 });
 


### PR DESCRIPTION
Update w.r.t. the recent tweaks to the `rlm-harness` prompt: https://github.com/PrimeIntellect-ai/rlm-harness/commit/1d7831a6d2c95a89ec94f4193408130ca13d0822#diff-2a691ccfd4bf07c781afa9c920667945391bd3211c8407080ee1ae35b1d909d0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only and test changes; no runtime agent or tool behavior is modified.
> 
> **Overview**
> Aligns the coding agent **RLM system prompt** (`buildRlmPrompt`) with recent **rlm-harness** IPython guidance.
> 
> The IPython section now states that **`%%bash` must be the first line** of a code cell (no leading comments, blank lines, imports, or Python before it). When **`edit`** is among configured Python skills, the prompt adds guidance to prefer **`await edit(path=..., old_str=..., new_str=...)`** for targeted file edits, including how to handle triple-quoted strings.
> 
> **Tests** update the full prompt fixture and add coverage that the `%%bash` rule appears with IPython active and that edit guidance is included only when the edit skill is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e3727093b74d34a1c37b6b2dd0a482bbaed9df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update system prompt to require `%%bash` on first cell line and add `edit` skill guidance
> - Updates `IPYTHON_CONTROL_PROMPT` in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/161/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) to state that `%%bash` must appear on the very first line of a code cell, with no preceding comments, spaces, or statements.
> - When `edit` is listed in `installedSkills`, `buildRlmPrompt` now appends usage guidance for the pre-imported async `edit` skill, including an example with old/new triple-quoted strings and advice for embedded triple double quotes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5e3727.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->