### PR TITLE
feat(coding-agent): add slash command aliases

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -15,9 +15,26 @@ export interface BuiltinSlashCommand {
 	description: string;
 	/** Shown in autocomplete before the description, e.g. "[instructions]" */
 	argumentHint?: string;
+	/** Hidden names that resolve to this command without being shown as commands. */
+	aliases?: readonly string[];
 }
 
-export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
+export interface ParsedSlashCommand {
+	name: string;
+	args: string;
+}
+
+export interface ResolvedSlashCommand extends ParsedSlashCommand {
+	originalName: string;
+	isAlias: boolean;
+}
+
+interface BuiltinSlashCommandAlias {
+	name: string;
+	aliasFor: string;
+}
+
+const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
@@ -28,7 +45,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info" },
 	{ name: "context", description: "Show token, cost, and context usage for agent and sub-agents" },
-	{ name: "usage", description: "Show token, cost, and context usage (alias for /context)" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
 	{ name: "fork", description: "Create a new fork from a previous user message" },
@@ -37,7 +53,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "login", description: "Configure provider authentication" },
 	{ name: "logout", description: "Remove provider authentication" },
 	{ name: "new", description: "Start a new session" },
-	{ name: "clear", description: "Start a new session (alias for /new)" },
 	{
 		name: "compact",
 		description: "Compact the session context; optional instructions focus the summary",
@@ -49,3 +64,66 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
 ];
+
+const BUILTIN_SLASH_COMMAND_ALIASES: ReadonlyArray<BuiltinSlashCommandAlias> = [
+	{ name: "clear", aliasFor: "new" },
+	{ name: "usage", aliasFor: "context" },
+];
+
+function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {
+	const canonicalByName = new Map(CANONICAL_BUILTIN_SLASH_COMMANDS.map((command) => [command.name, command]));
+	const aliasesByTarget = new Map<string, string[]>();
+	for (const alias of BUILTIN_SLASH_COMMAND_ALIASES) {
+		const target = canonicalByName.get(alias.aliasFor);
+		if (!target) {
+			throw new Error(`Slash command alias '/${alias.name}' targets unknown command '/${alias.aliasFor}'`);
+		}
+		const targetAliases = aliasesByTarget.get(alias.aliasFor);
+		if (targetAliases) {
+			targetAliases.push(alias.name);
+		} else {
+			aliasesByTarget.set(alias.aliasFor, [alias.name]);
+		}
+	}
+	return CANONICAL_BUILTIN_SLASH_COMMANDS.map((command) => ({
+		...command,
+		...(aliasesByTarget.has(command.name) ? { aliases: aliasesByTarget.get(command.name) } : {}),
+	}));
+}
+
+export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = buildBuiltinSlashCommands();
+
+const BUILTIN_SLASH_COMMAND_BY_NAME = new Map(BUILTIN_SLASH_COMMANDS.map((command) => [command.name, command]));
+const BUILTIN_SLASH_COMMAND_ALIAS_TO_NAME = new Map(
+	BUILTIN_SLASH_COMMANDS.flatMap((command) => command.aliases?.map((alias) => [alias, command.name] as const) ?? []),
+);
+
+export function parseSlashCommand(text: string): ParsedSlashCommand | undefined {
+	if (!text.startsWith("/")) {
+		return undefined;
+	}
+	const spaceIndex = text.indexOf(" ");
+	const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	if (!name) {
+		return undefined;
+	}
+	return { name, args: spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim() };
+}
+
+export function resolveBuiltinSlashCommandName(name: string): string {
+	return BUILTIN_SLASH_COMMAND_ALIAS_TO_NAME.get(name) ?? name;
+}
+
+export function isBuiltinSlashCommandName(name: string): boolean {
+	return BUILTIN_SLASH_COMMAND_BY_NAME.has(name) || BUILTIN_SLASH_COMMAND_ALIAS_TO_NAME.has(name);
+}
+
+export function resolveSlashCommand(command: ParsedSlashCommand): ResolvedSlashCommand {
+	const name = resolveBuiltinSlashCommandName(command.name);
+	return {
+		...command,
+		name,
+		originalName: command.name,
+		isAlias: name !== command.name,
+	};
+}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
@@ -8,7 +8,13 @@
  * extension commands are expanded by the daemon-side session.
  */
 
-import { BUILTIN_SLASH_COMMANDS, type BuiltinSlashCommand } from "../../core/slash-commands.js";
+import {
+	BUILTIN_SLASH_COMMANDS,
+	type BuiltinSlashCommand,
+	isBuiltinSlashCommandName,
+	type ParsedSlashCommand,
+	resolveBuiltinSlashCommandName,
+} from "../../core/slash-commands.js";
 
 const AGENTS_VIEW_COMMAND_NAMES = ["login", "logout", "model", "quit"] as const;
 
@@ -27,22 +33,7 @@ export const AGENTS_VIEW_SLASH_COMMANDS: readonly BuiltinSlashCommand[] = AGENTS
 	return { ...builtin, description: AGENTS_VIEW_COMMAND_DESCRIPTIONS[name] ?? builtin.description };
 });
 
-export interface ParsedSlashCommand {
-	name: string;
-	args: string;
-}
-
-export function parseSlashCommand(text: string): ParsedSlashCommand | undefined {
-	if (!text.startsWith("/")) {
-		return undefined;
-	}
-	const spaceIndex = text.indexOf(" ");
-	const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-	if (!name) {
-		return undefined;
-	}
-	return { name, args: spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim() };
-}
+export { type ParsedSlashCommand, parseSlashCommand } from "../../core/slash-commands.js";
 
 export type AgentsViewCommandKind =
 	/** Whitelisted built-in that runs directly in the agents view. */
@@ -53,11 +44,16 @@ export type AgentsViewCommandKind =
 	| "unknown";
 
 export function classifyAgentsViewCommand(name: string): AgentsViewCommandKind {
-	if ((AGENTS_VIEW_COMMAND_NAMES as readonly string[]).includes(name)) {
+	const canonicalName = resolveBuiltinSlashCommandName(name);
+	if ((AGENTS_VIEW_COMMAND_NAMES as readonly string[]).includes(canonicalName)) {
 		return "agents-view";
 	}
-	if (BUILTIN_SLASH_COMMANDS.some((command) => command.name === name)) {
+	if (isBuiltinSlashCommandName(name)) {
 		return "session-only";
 	}
 	return "unknown";
+}
+
+export function resolveAgentsViewCommand(command: ParsedSlashCommand): ParsedSlashCommand {
+	return { ...command, name: resolveBuiltinSlashCommandName(command.name) };
 }

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -41,6 +41,7 @@ import {
 	classifyAgentsViewCommand,
 	type ParsedSlashCommand,
 	parseSlashCommand,
+	resolveAgentsViewCommand,
 } from "./agents-view-commands.js";
 import {
 	type AgentsViewRow,
@@ -625,13 +626,18 @@ class AgentsViewMode implements Component, Focusable {
 			const kind = classifyAgentsViewCommand(command.name);
 			if (kind === "agents-view") {
 				this.editor.setText("");
-				await this.runSlashCommand(command);
+				await this.runSlashCommand(resolveAgentsViewCommand(command));
 				return;
 			}
 			if (kind === "session-only") {
 				this.editor.setText("");
+				const resolvedCommand = resolveAgentsViewCommand(command);
+				const commandLabel =
+					resolvedCommand.name === command.name
+						? `/${command.name}`
+						: `/${command.name} maps to /${resolvedCommand.name}, which`;
 				this.setStatusMessage(
-					`/${command.name} is only available inside an agent session — press ${keyText("tui.select.confirm")} on an agent to open it`,
+					`${commandLabel} is only available inside an agent session — press ${keyText("tui.select.confirm")} on an agent to open it`,
 				);
 				return;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -60,7 +60,12 @@ import { DefaultPackageManager } from "../../core/package-manager.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
-import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
+import {
+	BUILTIN_SLASH_COMMANDS,
+	isBuiltinSlashCommandName,
+	parseSlashCommand,
+	resolveBuiltinSlashCommandName,
+} from "../../core/slash-commands.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { PRIME_BUTTERFLY_LOGO } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
@@ -694,10 +699,9 @@ export class InteractiveMode {
 	private getBuiltInCommandConflictDiagnostics(
 		commands: readonly AgentConnectionSlashCommand[],
 	): AgentConnectionResourceDiagnostic[] {
-		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => command.name));
 		return commands
 			.filter((command) => command.source === "extension")
-			.filter((command) => builtinNames.has(command.registeredName ?? command.name))
+			.filter((command) => isBuiltinSlashCommandName(command.registeredName ?? command.name))
 			.map((command) => ({
 				type: "warning" as const,
 				message:
@@ -712,6 +716,7 @@ export class InteractiveMode {
 		// Define commands for autocomplete
 		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
 			name: command.name,
+			aliases: command.aliases,
 			description: command.description,
 			argumentHint: command.argumentHint,
 		}));
@@ -756,10 +761,9 @@ export class InteractiveMode {
 			}));
 
 		// Convert extension commands to SlashCommand format
-		const builtinCommandNames = new Set(slashCommands.map((c) => c.name));
 		const extensionCommands: SlashCommand[] = connectionCommands
 			.filter((cmd) => cmd.source === "extension")
-			.filter((cmd) => !builtinCommandNames.has(cmd.name))
+			.filter((cmd) => !isBuiltinSlashCommandName(cmd.name))
 			.map((cmd) => ({
 				name: cmd.name,
 				description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
@@ -3130,121 +3134,126 @@ export class InteractiveMode {
 			text = text.trim();
 			if (!text) return;
 
+			const slashCommand = parseSlashCommand(text);
+			const commandName = slashCommand ? resolveBuiltinSlashCommandName(slashCommand.name) : undefined;
+			const commandArgs = slashCommand?.args ?? "";
+			const canonicalCommandText = commandName ? `/${commandName}${commandArgs ? ` ${commandArgs}` : ""}` : text;
+
 			// Handle commands
-			if (text === "/settings") {
+			if (commandName === "settings" && !commandArgs) {
 				await this.showSettingsSelector();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/scoped-models") {
+			if (commandName === "scoped-models" && !commandArgs) {
 				this.editor.setText("");
 				await this.showModelsSelector();
 				return;
 			}
-			if (text === "/model" || text.startsWith("/model ")) {
-				const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
+			if (commandName === "model") {
+				const searchTerm = commandArgs || undefined;
 				this.editor.setText("");
 				await this.handleModelCommand(searchTerm);
 				return;
 			}
-			if (text === "/export" || text.startsWith("/export ")) {
-				await this.handleExportCommand(text);
+			if (commandName === "export") {
+				await this.handleExportCommand(canonicalCommandText);
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/import" || text.startsWith("/import ")) {
-				await this.handleImportCommand(text);
+			if (commandName === "import") {
+				await this.handleImportCommand(canonicalCommandText);
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/share") {
+			if (commandName === "share" && !commandArgs) {
 				await this.handleShareCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/copy") {
+			if (commandName === "copy" && !commandArgs) {
 				await this.handleCopyCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/name" || text.startsWith("/name ")) {
-				await this.handleNameCommand(text);
+			if (commandName === "name") {
+				await this.handleNameCommand(canonicalCommandText);
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/session") {
+			if (commandName === "session" && !commandArgs) {
 				await this.handleSessionCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/context" || text === "/usage") {
+			if (commandName === "context" && !commandArgs) {
 				await this.handleContextCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/goal" || text === "/goal status") {
+			if (commandName === "goal" && (!commandArgs || commandArgs === "status")) {
 				this.handleGoalStatusCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/changelog") {
+			if (commandName === "changelog" && !commandArgs) {
 				this.handleChangelogCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/hotkeys") {
+			if (commandName === "hotkeys" && !commandArgs) {
 				this.handleHotkeysCommand();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/fork") {
+			if (commandName === "fork" && !commandArgs) {
 				void this.showUserMessageSelector();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/clone") {
+			if (commandName === "clone" && !commandArgs) {
 				this.editor.setText("");
 				await this.handleCloneCommand();
 				return;
 			}
-			if (text === "/tree") {
+			if (commandName === "tree" && !commandArgs) {
 				void this.showTreeSelector();
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/login") {
+			if (commandName === "login" && !commandArgs) {
 				this.editor.setText("");
 				await this.showOAuthSelector("login");
 				return;
 			}
-			if (text === "/logout") {
+			if (commandName === "logout" && !commandArgs) {
 				this.editor.setText("");
 				await this.showOAuthSelector("logout");
 				return;
 			}
-			if (text === "/new" || text === "/clear") {
+			if (commandName === "new" && !commandArgs) {
 				this.editor.setText("");
 				await this.handleClearCommand();
 				return;
 			}
-			if (text === "/compact" || text.startsWith("/compact ")) {
-				const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
+			if (commandName === "compact") {
+				const customInstructions = commandArgs || undefined;
 				this.editor.setText("");
 				await this.handleCompactCommand(customInstructions);
 				return;
 			}
-			if (text === "/refine" || text.startsWith("/refine ")) {
-				const refineArgs = text.startsWith("/refine ") ? text.slice(8).trim() : undefined;
+			if (commandName === "refine") {
+				const refineArgs = commandArgs || undefined;
 				this.editor.setText("");
 				await this.handleRefineCommand(refineArgs);
 				return;
 			}
-			if (text === "/reload") {
+			if (commandName === "reload" && !commandArgs) {
 				this.editor.setText("");
 				await this.handleReloadCommand();
 				return;
 			}
-			if (text === "/debug") {
+			if (commandName === "debug" && !commandArgs) {
 				await this.handleDebugCommand();
 				this.editor.setText("");
 				return;

--- a/packages/coding-agent/test/agents-view-commands.test.ts
+++ b/packages/coding-agent/test/agents-view-commands.test.ts
@@ -4,6 +4,7 @@ import {
 	AGENTS_VIEW_SLASH_COMMANDS,
 	classifyAgentsViewCommand,
 	parseSlashCommand,
+	resolveAgentsViewCommand,
 } from "../src/modes/agents-view/agents-view-commands.js";
 
 describe("parseSlashCommand", () => {
@@ -41,6 +42,11 @@ describe("classifyAgentsViewCommand", () => {
 		for (const name of ["compact", "fork", "settings", "resume", "new", "clear", "export"]) {
 			expect(classifyAgentsViewCommand(name)).toBe("session-only");
 		}
+	});
+
+	test("aliases classify by their canonical built-in target", () => {
+		expect(classifyAgentsViewCommand("clear")).toBe("session-only");
+		expect(resolveAgentsViewCommand({ name: "clear", args: "" })).toEqual({ name: "new", args: "" });
 	});
 
 	test("non-built-ins pass through for daemon-side expansion", () => {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+	BUILTIN_SLASH_COMMANDS,
+	isBuiltinSlashCommandName,
+	parseSlashCommand,
+	resolveBuiltinSlashCommandName,
+	resolveSlashCommand,
+} from "../src/core/slash-commands.js";
+
+describe("slash command aliases", () => {
+	test("keeps aliases hidden on canonical command entries", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "clear")).toBeUndefined();
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "usage")).toBeUndefined();
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "new")).toMatchObject({
+			description: "Start a new session",
+			aliases: ["clear"],
+		});
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "context")).toMatchObject({
+			description: "Show token, cost, and context usage for agent and sub-agents",
+			aliases: ["usage"],
+		});
+	});
+
+	test("resolves /clear to /new through the alias path", () => {
+		const parsed = parseSlashCommand("/clear");
+
+		expect(parsed).toEqual({ name: "clear", args: "" });
+		expect(isBuiltinSlashCommandName("clear")).toBe(true);
+		expect(resolveBuiltinSlashCommandName("clear")).toBe("new");
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "new",
+			args: "",
+			originalName: "clear",
+			isAlias: true,
+		});
+	});
+
+	test("preserves arguments when resolving aliases", () => {
+		const parsed = parseSlashCommand("/usage latest turn");
+
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "context",
+			args: "latest turn",
+			originalName: "usage",
+			isAlias: true,
+		});
+	});
+});

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -226,6 +226,7 @@ type Awaitable<T> = T | Promise<T>;
 
 export interface SlashCommand {
 	name: string;
+	aliases?: readonly string[];
 	description?: string;
 	argumentHint?: string;
 	// Function to get argument completions for this command
@@ -309,17 +310,19 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const prefix = textBeforeCursor.slice(1);
 				const commandItems = this.commands.map((cmd) => {
 					const name = "name" in cmd ? cmd.name : cmd.value;
+					const aliases = "aliases" in cmd && cmd.aliases ? cmd.aliases : [];
 					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
 					const desc = cmd.description ?? "";
 					const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
 					return {
 						name,
+						searchText: [name, ...aliases].join(" "),
 						label: name,
 						description: fullDesc || undefined,
 					};
 				});
 
-				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
+				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.searchText).map((item) => ({
 					value: item.name,
 					label: item.label,
 					...(item.description && { description: item.description }),

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -55,6 +55,27 @@ const getSuggestions = (
 ) => provider.getSuggestions(lines, cursorLine, cursorCol, { signal: new AbortController().signal, force });
 
 describe("CombinedAutocompleteProvider", () => {
+	describe("slash commands", () => {
+		it("matches command aliases while previewing and completing the canonical command", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{
+						name: "new",
+						aliases: ["clear"],
+						description: "Start a new session",
+					},
+				],
+				"/tmp",
+			);
+			const result = await getSuggestions(provider, ["/clear"], 0, 6);
+
+			assert.deepStrictEqual(result, {
+				prefix: "/clear",
+				items: [{ value: "new", label: "new", description: "Start a new session" }],
+			});
+		});
+	});
+
 	describe("extractPathPrefix", () => {
 		it("extracts / from 'hey /' when forced", async () => {
 			const provider = new CombinedAutocompleteProvider([], "/tmp");


### PR DESCRIPTION
## Context
This is a draft implementation of slash-command aliases for familiar command names across agent harnesses. The immediate example is typing `/clear`, which many users expect, while Prime Agent's canonical command remains `/new`.

## What changed
- Adds a shared slash-command alias framework in `slash-commands.ts`.
- Maps `/clear` to `/new` as a hidden alias, not a separate visible command.
- Maps `/usage` to `/context` as a hidden alias, not a separate visible command.
- Resolves aliases before built-in interactive dispatch.
- Resolves aliases canonically in agents-view classification and status handling.
- Adds autocomplete alias matching so typing `/clear` previews and completes the canonical `/new` row with the `/new` description.

## How to try it
In the full TUI or agents view:
```text
/clear
/usage
```

Expected behavior:
- Typing `/clear` in autocomplete shows the canonical `new` command row with `Start a new session`, not a visible `clear` alias row.
- Accepting the completion inserts `/new`.
- Submitting `/clear` directly still follows the same path as `/new`.
- `/usage` follows the same path as `/context`.
- In agents view, aliases map to the canonical command and show the same contextual availability messages as the target command.

## Validation
- `npm --workspace packages/tui test -- autocomplete.test.ts`
- `npm --workspace packages/coding-agent test -- slash-commands.test.ts agents-view-commands.test.ts`
- `npm run check`
- Pre-commit hook reran `npm run check`.

## Review focus
- Whether aliases should stay hardcoded for common compatibility names or become user-configurable later.
- Whether `/usage -> /context` is the right compatibility mapping.
- Whether hidden alias matching is the right autocomplete behavior.

## Known gaps / intentional limits
- This only adds built-in aliases; it does not add a user-facing alias config file.
- No aliases beyond `/clear` and `/usage` in this draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing command routing only; behavior is covered by new unit tests and does not touch auth or persistence.
> 
> **Overview**
> Adds a **shared alias layer** for built-in slash commands so familiar names resolve to canonical commands without appearing as separate entries.
> 
> **`/clear` → `/new`** and **`/usage` → `/context`** are defined as hidden aliases on the canonical built-ins. Parsing and resolution live in `slash-commands.ts` (`parseSlashCommand`, `resolveBuiltinSlashCommandName`, `resolveSlashCommand`), and the interactive session submit path routes through resolved names instead of duplicating string checks for alias spellings.
> 
> **Agents view** classifies and runs whitelisted commands against the canonical name, and session-only hints explain when an alias maps to another command (e.g. `/clear` → `/new`).
> 
> **Autocomplete** matches alias text but previews and inserts the canonical command name and description. Extension built-in conflict detection treats alias names as reserved built-ins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82b014903939dae2407f6c89efefbe60f718198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add slash command aliases to the coding agent (e.g. `/clear` → `/new`, `/usage` → `/context`)
> - Introduces an alias system in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/163/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051) mapping `clear` → `new` and `usage` → `context`; aliases resolve to their canonical command before dispatch.
> - Updates autocomplete in [autocomplete.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/163/files#diff-f0cde3565b6b9c46877a7ffbe713304887d72fddd2af9844e4e2d9a3f147af85) so typing an alias surfaces the canonical command suggestion and completion inserts the canonical name.
> - Extends conflict detection in interactive and agents-view modes so extension commands colliding with an alias are excluded, matching behavior for canonical built-in names.
> - Behavioral Change: `/clear` and `/usage` are no longer listed as top-level commands in autocomplete; they are hidden aliases that route to `/new` and `/context` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f82b014.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->