### PR TITLE
feat(coding-agent): add persistent session heartbeat

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a first draft of daemon-backed cron jobs for scheduling prompts against long-running sessions without using `/goal`.
+
 ## [0.1.3] - 2026-06-12
 
 ### Added

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -7,6 +7,7 @@ import { spawn } from "child_process";
 import { APP_NAME, expandTildePath } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
+import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
 import { DaemonClient, type DaemonClientMessageListener } from "../modes/daemon/daemon-client.js";
 import type { DaemonOutbound, DaemonResponse } from "../modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../modes/daemon/daemon-session-list.js";
@@ -38,6 +39,7 @@ const DAEMON_CLIENT_COMMANDS = new Set([
 	"messages",
 	"stats",
 	"commands",
+	"cron",
 	"shutdown",
 ]);
 
@@ -93,6 +95,12 @@ function parseDaemonClientCommand(args: string[]): ParsedDaemonClientCommand {
 
 		if (passthrough) {
 			positionals.push(arg);
+			continue;
+		}
+
+		if (arg === "--" && command === "cron") {
+			positionals.push(arg);
+			passthrough = true;
 			continue;
 		}
 
@@ -219,6 +227,9 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 					{ type: "get_commands", activeSessionId: requireActiveSessionId(parsed.positionals) },
 					true,
 				);
+				return;
+			case "cron":
+				await runCron(client, parsed.positionals, parsed.json);
 				return;
 			case "shutdown":
 				await printResponseData(client, { type: "shutdown" }, parsed.json);
@@ -777,6 +788,79 @@ async function runMessageCommand(
 	await printResponseData(client, { type, activeSessionId, message }, json);
 }
 
+async function runCron(client: DaemonClient, args: string[], json: boolean): Promise<void> {
+	const subcommand = args[0] ?? "list";
+	if (subcommand === "list") {
+		const includeInactive = args.includes("--all") || args.includes("-a");
+		const activeSessionId = args.find((arg) => !arg.startsWith("-") && arg !== "list");
+		const response = await client.request({ type: "cron_list", activeSessionId, includeInactive });
+		const data = requireSuccess(response);
+		if (json) {
+			printJson(data);
+			return;
+		}
+		const jobs = getCronJobs(data);
+		if (!jobs) {
+			printJson(data);
+			return;
+		}
+		if (jobs.length === 0) {
+			console.log("No cron jobs.");
+			return;
+		}
+		for (const job of jobs) {
+			console.log(formatAgentCronJob(job));
+		}
+		return;
+	}
+
+	if (subcommand === "add" || subcommand === "schedule") {
+		const separator = args.indexOf("--");
+		if (separator < 0) {
+			throw new Error("Usage: daemon cron add <session> <schedule> -- <message>");
+		}
+		const activeSessionId = args[1];
+		if (!activeSessionId) {
+			throw new Error("Usage: daemon cron add <session> <schedule> -- <message>");
+		}
+		const schedule = args.slice(2, separator).join(" ").trim();
+		const message = args
+			.slice(separator + 1)
+			.join(" ")
+			.trim();
+		if (!schedule || !message) {
+			throw new Error("Usage: daemon cron add <session> <schedule> -- <message>");
+		}
+		const response = await client.request({ type: "cron_add", activeSessionId, schedule, prompt: message });
+		const data = requireSuccess(response);
+		if (json) {
+			printJson(data);
+			return;
+		}
+		const job = getCronJob(data);
+		console.log(job ? `Scheduled ${job.id} next=${job.nextRunAt ?? "-"}` : "Scheduled cron job.");
+		return;
+	}
+
+	if (subcommand === "cancel" || subcommand === "delete" || subcommand === "remove") {
+		const jobId = args[1];
+		if (!jobId) {
+			throw new Error("Usage: daemon cron cancel <job-id>");
+		}
+		const response = await client.request({ type: "cron_cancel", jobId });
+		const data = requireSuccess(response);
+		if (json) {
+			printJson(data);
+			return;
+		}
+		const job = getCronJob(data);
+		console.log(job ? `Cancelled ${job.id}` : "Cancelled cron job.");
+		return;
+	}
+
+	throw new Error(`Unknown cron command: ${subcommand}`);
+}
+
 async function printResponseData(
 	client: DaemonClient,
 	command: Parameters<DaemonClient["request"]>[0],
@@ -1314,6 +1398,26 @@ function isLiveSessionSummary(value: unknown): value is SessionSummary & { activ
 	return isSessionSummary(value) && typeof value.activeSessionId === "string";
 }
 
+function getCronJobs(value: unknown): AgentCronJob[] | undefined {
+	if (!value || typeof value !== "object") {
+		return undefined;
+	}
+	const jobs = (value as { jobs?: unknown }).jobs;
+	return Array.isArray(jobs) ? (jobs as AgentCronJob[]) : undefined;
+}
+
+function getCronJob(value: unknown): { id: string; nextRunAt?: string } | undefined {
+	if (!value || typeof value !== "object") {
+		return undefined;
+	}
+	const job = (value as { job?: unknown }).job;
+	if (!job || typeof job !== "object" || typeof (job as { id?: unknown }).id !== "string") {
+		return undefined;
+	}
+	const candidate = job as { id: string; nextRunAt?: unknown };
+	return { id: candidate.id, ...(typeof candidate.nextRunAt === "string" ? { nextRunAt: candidate.nextRunAt } : {}) };
+}
+
 function printDaemonHelp(): void {
 	console.log(`${chalk.bold("Usage:")}
   ${APP_NAME} daemon [options] [session name]
@@ -1337,6 +1441,10 @@ ${chalk.bold("Commands:")}
   messages <session>            Print messages as JSON
   stats <session>               Print session stats as JSON
   commands <session>            Print available commands as JSON
+  cron list [-a|--all] [session] List scheduled cron jobs
+  cron add <session> <schedule> -- <message>
+                                Schedule a prompt for a session
+  cron cancel <job-id>           Cancel a scheduled cron job
   shutdown                      Stop the daemon
 
 ${chalk.bold("Options:")}
@@ -1358,6 +1466,8 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock list
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock list -a
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock create scratch
+  ${APP_NAME} daemon --socket /tmp/prime-agent.sock cron add <session> "*/30 * * * *" -- "Check progress"
+  ${APP_NAME} daemon --socket /tmp/prime-agent.sock cron list
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock prompt <session> "Say hello"
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock attach <session>
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock shutdown

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -522,6 +522,11 @@ export function getSettingsPath(): string {
 	return join(getAgentDir(), "settings.json");
 }
 
+/** Get path to cron jobs store */
+export function getCronJobsPath(agentDir: string = getAgentDir()): string {
+	return join(agentDir, "cron-jobs.json");
+}
+
 /** Get path to tools directory */
 export function getToolsDir(): string {
 	return join(getAgentDir(), "tools");

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -1,0 +1,805 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "./extensions/types.js";
+
+export type AgentCronJobStatus = "active" | "paused" | "completed" | "cancelled";
+export type AgentCronScheduleKind = "once" | "cron" | "interval";
+export type AgentCronJobSource = "cron" | "heartbeat";
+export type AgentHeartbeatUpdateAction = "pause" | "resume" | "clear";
+
+export interface AgentCronSchedule {
+	kind: AgentCronScheduleKind;
+	expression: string;
+	intervalMs?: number;
+}
+
+export interface AgentCronJob {
+	id: string;
+	status: AgentCronJobStatus;
+	source?: AgentCronJobSource;
+	activeSessionId: string;
+	sessionId: string;
+	sessionFile: string;
+	cwd: string;
+	prompt: string;
+	schedule: AgentCronSchedule;
+	createdAt: string;
+	updatedAt: string;
+	nextRunAt?: string;
+	lastRunAt?: string;
+	lastError?: string;
+	runCount: number;
+}
+
+export interface CreateAgentCronJobInput {
+	activeSessionId: string;
+	sessionId: string;
+	sessionFile: string;
+	cwd: string;
+	prompt: string;
+	scheduleText: string;
+	source?: AgentCronJobSource;
+	now?: Date;
+}
+
+export interface AgentCronSchedulerHooks {
+	runJob: (job: AgentCronJob) => Promise<void>;
+	now?: () => Date;
+	onError?: (job: AgentCronJob, error: unknown) => void;
+}
+
+interface CronJobsFile {
+	jobs?: unknown;
+}
+
+const MAX_TIMEOUT_MS = 2_147_483_647;
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60_000;
+export const DEFAULT_HEARTBEAT_SCHEDULE = "every 5m";
+
+const createHeartbeatSchema = Type.Object(
+	{
+		instruction: Type.String({
+			description:
+				"Required instruction to inject into this same session on each heartbeat. Include enough context for the future turn to act safely.",
+		}),
+		interval: Type.Optional(
+			Type.String({
+				description:
+					"Optional heartbeat cadence. Defaults to 'every 5m'. Examples: '30s', 'every 10m', '@hourly', or '*/30 * * * *'.",
+			}),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+const updateHeartbeatSchema = Type.Object(
+	{
+		action: Type.Union([Type.Literal("pause"), Type.Literal("resume"), Type.Literal("clear")], {
+			description:
+				"Heartbeat lifecycle action. Use 'pause' to stop firing temporarily, 'resume' to continue, or 'clear' to remove it.",
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+type CreateHeartbeatArgs = Static<typeof createHeartbeatSchema>;
+type UpdateHeartbeatArgs = Static<typeof updateHeartbeatSchema>;
+
+export type ParsedHeartbeatCommand =
+	| { type: "status" }
+	| { type: "pause" }
+	| { type: "resume" }
+	| { type: "clear" }
+	| { type: "set"; schedule: string; instruction: string };
+
+export interface AgentCronToolController {
+	getHeartbeat(): AgentCronJob | undefined;
+	createHeartbeat(instruction: string, interval?: string): AgentCronJob;
+	updateHeartbeat(action: AgentHeartbeatUpdateAction): AgentCronJob | undefined;
+}
+
+export class AgentCronJobStore {
+	constructor(private readonly filePath: string) {}
+
+	list(): AgentCronJob[] {
+		return this.readJobs().sort((a, b) => compareOptionalIso(a.nextRunAt, b.nextRunAt));
+	}
+
+	create(input: CreateAgentCronJobInput): AgentCronJob {
+		const now = input.now ?? new Date();
+		const prompt = input.prompt.trim();
+		if (!prompt) {
+			throw new Error("Cron job prompt cannot be empty");
+		}
+		const parsed = parseAgentCronSchedule(input.scheduleText, now);
+		const nowIso = now.toISOString();
+		const job: AgentCronJob = {
+			id: randomUUID(),
+			status: "active",
+			source: input.source ?? "cron",
+			activeSessionId: input.activeSessionId,
+			sessionId: input.sessionId,
+			sessionFile: input.sessionFile,
+			cwd: input.cwd,
+			prompt,
+			schedule: parsed.schedule,
+			createdAt: nowIso,
+			updatedAt: nowIso,
+			nextRunAt: parsed.nextRunAt.toISOString(),
+			runCount: 0,
+		};
+		this.writeJobs([...this.readJobs(), job]);
+		return job;
+	}
+
+	getHeartbeat(activeSessionId: string): AgentCronJob | undefined {
+		return this.readJobs()
+			.filter((job) => {
+				return (
+					job.activeSessionId === activeSessionId &&
+					job.source === "heartbeat" &&
+					(job.status === "active" || job.status === "paused")
+				);
+			})
+			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+	}
+
+	createHeartbeat(input: CreateAgentCronJobInput): AgentCronJob {
+		const now = input.now ?? new Date();
+		const parsed = parseAgentCronSchedule(input.scheduleText, now);
+		if (parsed.schedule.kind === "once") {
+			throw new Error("Heartbeat schedule must be recurring");
+		}
+		const existing = this.readJobs().map((job) => {
+			if (
+				job.activeSessionId === input.activeSessionId &&
+				job.source === "heartbeat" &&
+				(job.status === "active" || job.status === "paused")
+			) {
+				return { ...job, status: "cancelled" as const, nextRunAt: undefined, updatedAt: now.toISOString() };
+			}
+			return job;
+		});
+		const prompt = input.prompt.trim();
+		if (!prompt) {
+			throw new Error("Heartbeat instruction cannot be empty");
+		}
+		const nowIso = now.toISOString();
+		const job: AgentCronJob = {
+			id: randomUUID(),
+			status: "active",
+			source: "heartbeat",
+			activeSessionId: input.activeSessionId,
+			sessionId: input.sessionId,
+			sessionFile: input.sessionFile,
+			cwd: input.cwd,
+			prompt,
+			schedule: parsed.schedule,
+			createdAt: nowIso,
+			updatedAt: nowIso,
+			nextRunAt: parsed.nextRunAt.toISOString(),
+			runCount: 0,
+		};
+		this.writeJobs([...existing, job]);
+		return job;
+	}
+
+	pauseHeartbeat(activeSessionId: string, now = new Date()): AgentCronJob | undefined {
+		let paused: AgentCronJob | undefined;
+		const current = this.getHeartbeat(activeSessionId);
+		if (!current) {
+			return undefined;
+		}
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== current.id) {
+				return job;
+			}
+			paused = { ...job, status: "paused", nextRunAt: undefined, updatedAt: now.toISOString() };
+			return paused;
+		});
+		this.writeJobs(jobs);
+		return paused;
+	}
+
+	resumeHeartbeat(activeSessionId: string, now = new Date()): AgentCronJob | undefined {
+		let resumed: AgentCronJob | undefined;
+		const current = this.getHeartbeat(activeSessionId);
+		if (!current) {
+			return undefined;
+		}
+		const nextRunAt = nextRunAtForSchedule(current.schedule, now);
+		if (!nextRunAt) {
+			throw new Error("Heartbeat schedule must be recurring");
+		}
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== current.id) {
+				return job;
+			}
+			resumed = { ...job, status: "active", nextRunAt: nextRunAt.toISOString(), updatedAt: now.toISOString() };
+			return resumed;
+		});
+		this.writeJobs(jobs);
+		return resumed;
+	}
+
+	clearHeartbeat(activeSessionId: string, now = new Date()): AgentCronJob | undefined {
+		let cleared: AgentCronJob | undefined;
+		const current = this.getHeartbeat(activeSessionId);
+		if (!current) {
+			return undefined;
+		}
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== current.id) {
+				return job;
+			}
+			cleared = { ...job, status: "cancelled", nextRunAt: undefined, updatedAt: now.toISOString() };
+			return cleared;
+		});
+		this.writeJobs(jobs);
+		return cleared;
+	}
+
+	cancel(id: string, now = new Date()): AgentCronJob | undefined {
+		let cancelled: AgentCronJob | undefined;
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== id || job.status === "cancelled") {
+				return job;
+			}
+			cancelled = { ...job, status: "cancelled", nextRunAt: undefined, updatedAt: now.toISOString() };
+			return cancelled;
+		});
+		if (cancelled) {
+			this.writeJobs(jobs);
+		}
+		return cancelled;
+	}
+
+	recordRunResult(id: string, result: { now?: Date; error?: unknown }): AgentCronJob | undefined {
+		const now = result.now ?? new Date();
+		let updated: AgentCronJob | undefined;
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== id) {
+				return job;
+			}
+			if (job.status !== "active") {
+				updated = job;
+				return job;
+			}
+			const lastError = result.error === undefined ? undefined : errorMessage(result.error);
+			const nextRunAt =
+				job.schedule.kind === "cron"
+					? nextRunAtForSchedule(job.schedule, new Date(now.getTime() + 1))
+					: job.schedule.kind === "interval"
+						? nextRunAtForSchedule(job.schedule, now)
+						: undefined;
+			updated = {
+				...job,
+				status: job.schedule.kind === "once" ? "completed" : "active",
+				nextRunAt: nextRunAt?.toISOString(),
+				lastRunAt: now.toISOString(),
+				lastError,
+				runCount: job.runCount + 1,
+				updatedAt: now.toISOString(),
+			};
+			return updated;
+		});
+		if (updated) {
+			this.writeJobs(jobs);
+		}
+		return updated;
+	}
+
+	due(now = new Date()): AgentCronJob[] {
+		return this.readJobs().filter((job) => {
+			return job.status === "active" && job.nextRunAt !== undefined && Date.parse(job.nextRunAt) <= now.getTime();
+		});
+	}
+
+	nextActiveRunAt(): Date | undefined {
+		const times = this.readJobs()
+			.filter((job) => job.status === "active" && job.nextRunAt !== undefined)
+			.map((job) => new Date(job.nextRunAt!))
+			.filter((date) => Number.isFinite(date.getTime()))
+			.sort((a, b) => a.getTime() - b.getTime());
+		return times[0];
+	}
+
+	private readJobs(): AgentCronJob[] {
+		if (!existsSync(this.filePath)) {
+			return [];
+		}
+		const parsed = JSON.parse(readFileSync(this.filePath, "utf-8")) as CronJobsFile;
+		if (!Array.isArray(parsed.jobs)) {
+			return [];
+		}
+		return parsed.jobs.filter(isAgentCronJob);
+	}
+
+	private writeJobs(jobs: readonly AgentCronJob[]): void {
+		mkdirSync(dirname(this.filePath), { recursive: true });
+		const tempPath = `${this.filePath}.tmp`;
+		writeFileSync(tempPath, `${JSON.stringify({ jobs }, null, 2)}\n`, "utf-8");
+		renameSync(tempPath, this.filePath);
+	}
+}
+
+export class AgentCronScheduler {
+	private timer: ReturnType<typeof setTimeout> | undefined;
+	private running = false;
+	private stopped = true;
+
+	constructor(
+		private readonly store: AgentCronJobStore,
+		private readonly hooks: AgentCronSchedulerHooks,
+	) {}
+
+	start(): void {
+		this.stopped = false;
+		this.scheduleNext();
+	}
+
+	stop(): void {
+		this.stopped = true;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = undefined;
+		}
+	}
+
+	wake(): void {
+		if (this.stopped) {
+			return;
+		}
+		this.scheduleNext(0);
+	}
+
+	async runDue(now = this.now()): Promise<number> {
+		if (this.running) {
+			return 0;
+		}
+		this.running = true;
+		let handled = 0;
+		try {
+			for (const job of this.store.due(now)) {
+				handled++;
+				let error: unknown;
+				try {
+					await this.hooks.runJob(job);
+				} catch (runError) {
+					error = runError;
+					this.hooks.onError?.(job, runError);
+				}
+				this.store.recordRunResult(job.id, { now: this.now(), error });
+			}
+		} finally {
+			this.running = false;
+			if (!this.stopped) {
+				this.scheduleNext();
+			}
+		}
+		return handled;
+	}
+
+	private scheduleNext(delayMs?: number): void {
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = undefined;
+		}
+		const now = this.now();
+		const nextDelay =
+			delayMs ??
+			(() => {
+				const next = this.store.nextActiveRunAt();
+				if (!next) {
+					return undefined;
+				}
+				return Math.max(0, next.getTime() - now.getTime());
+			})();
+		if (nextDelay === undefined) {
+			return;
+		}
+		this.timer = setTimeout(
+			() => {
+				void this.runDue();
+			},
+			Math.min(nextDelay, MAX_TIMEOUT_MS),
+		);
+	}
+
+	private now(): Date {
+		return this.hooks.now?.() ?? new Date();
+	}
+}
+
+export function parseAgentCronSchedule(
+	input: string,
+	now = new Date(),
+): { schedule: AgentCronSchedule; nextRunAt: Date } {
+	const text = stripMatchingQuotes(input.trim());
+	if (!text) {
+		throw new Error("Cron schedule cannot be empty");
+	}
+
+	const inMatch = /^in\s+(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$/i.exec(text);
+	if (inMatch) {
+		const amount = Number.parseInt(inMatch[1]!, 10);
+		const unit = inMatch[2]!.toLowerCase();
+		const multiplier = unit.startsWith("m")
+			? ONE_MINUTE_MS
+			: unit.startsWith("h")
+				? 60 * ONE_MINUTE_MS
+				: 24 * 60 * ONE_MINUTE_MS;
+		return {
+			schedule: { kind: "once", expression: text },
+			nextRunAt: new Date(now.getTime() + amount * multiplier),
+		};
+	}
+
+	const everyMatch =
+		/^(?:every|each)\s+(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)$/i.exec(
+			text,
+		);
+	if (everyMatch) {
+		const amount = Number.parseInt(everyMatch[1]!, 10);
+		const unit = everyMatch[2]!.toLowerCase();
+		const multiplier = unit.startsWith("s")
+			? ONE_SECOND_MS
+			: unit.startsWith("m")
+				? ONE_MINUTE_MS
+				: 60 * ONE_MINUTE_MS;
+		const intervalMs = amount * multiplier;
+		if (intervalMs < 10 * ONE_SECOND_MS) {
+			throw new Error("Recurring interval must be at least 10 seconds");
+		}
+		return {
+			schedule: { kind: "interval", expression: text, intervalMs },
+			nextRunAt: new Date(now.getTime() + intervalMs),
+		};
+	}
+
+	if (text.toLowerCase().startsWith("at ")) {
+		const when = new Date(text.slice(3).trim());
+		if (!Number.isFinite(when.getTime())) {
+			throw new Error("Invalid one-shot schedule. Use: at <ISO date>");
+		}
+		if (when.getTime() <= now.getTime()) {
+			throw new Error("One-shot schedule must be in the future");
+		}
+		return { schedule: { kind: "once", expression: text }, nextRunAt: when };
+	}
+
+	const expression = normalizeCronAlias(text);
+	const nextRunAt = nextCronRunAfter(expression, now);
+	return { schedule: { kind: "cron", expression }, nextRunAt };
+}
+
+export function normalizeHeartbeatSchedule(input: string | undefined): string {
+	const text = input?.trim();
+	if (!text) {
+		return DEFAULT_HEARTBEAT_SCHEDULE;
+	}
+	if (/^\d+\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)$/i.test(text)) {
+		return `every ${text}`;
+	}
+	return text;
+}
+
+export function parseHeartbeatCommand(input: string): ParsedHeartbeatCommand {
+	const text = input.replace(/^\/heartbeat\b/, "").trim();
+	if (!text || text === "status") {
+		return { type: "status" };
+	}
+	if (text === "pause") {
+		return { type: "pause" };
+	}
+	if (text === "resume") {
+		return { type: "resume" };
+	}
+	if (text === "clear" || text === "stop") {
+		return { type: "clear" };
+	}
+
+	const option = consumeEveryOption(text);
+	if (option) {
+		if (!option.rest) {
+			throw new Error("Usage: /heartbeat [--every <interval>] <instruction>");
+		}
+		return {
+			type: "set",
+			schedule: normalizeHeartbeatSchedule(option.interval),
+			instruction: option.rest,
+		};
+	}
+
+	const leadingSchedule = consumeLeadingEverySchedule(text);
+	if (leadingSchedule) {
+		if (!leadingSchedule.rest) {
+			throw new Error("Usage: /heartbeat [--every <interval>] <instruction>");
+		}
+		return {
+			type: "set",
+			schedule: normalizeHeartbeatSchedule(leadingSchedule.interval),
+			instruction: leadingSchedule.rest,
+		};
+	}
+
+	return { type: "set", schedule: DEFAULT_HEARTBEAT_SCHEDULE, instruction: text };
+}
+
+export function nextRunAtForSchedule(schedule: AgentCronSchedule, after: Date): Date | undefined {
+	if (schedule.kind === "once") {
+		return undefined;
+	}
+	if (schedule.kind === "interval") {
+		if (!schedule.intervalMs || schedule.intervalMs <= 0) {
+			throw new Error(`Invalid interval schedule: ${schedule.expression}`);
+		}
+		return new Date(after.getTime() + schedule.intervalMs);
+	}
+	return nextCronRunAfter(schedule.expression, after);
+}
+
+export function formatAgentCronJob(job: AgentCronJob): string {
+	const next = job.nextRunAt ? new Date(job.nextRunAt).toLocaleString() : "-";
+	const last = job.lastRunAt ? new Date(job.lastRunAt).toLocaleString() : "-";
+	const preview = job.prompt.replace(/\s+/g, " ").slice(0, 80);
+	const error = job.lastError ? ` error=${job.lastError}` : "";
+	return `${job.id} ${job.status} next=${next} last=${last} runs=${job.runCount} schedule="${job.schedule.expression}" prompt="${preview}"${error}`;
+}
+
+export function createAgentHeartbeatToolDefinitions(controller: AgentCronToolController): ToolDefinition[] {
+	return [
+		{
+			name: "get_heartbeat",
+			label: "Get Heartbeat",
+			description: "Get the persistent heartbeat configured for this daemon-backed session, if one exists.",
+			promptGuidelines: [
+				"Use get_heartbeat to inspect the current heartbeat before changing it, or when the user asks about heartbeat status.",
+			],
+			parameters: Type.Object({}, { additionalProperties: false }),
+			execute: async () => {
+				const job = controller.getHeartbeat();
+				return {
+					content: [{ type: "text", text: JSON.stringify({ heartbeat: job ?? null }, null, 2) }],
+					details: job ?? null,
+				};
+			},
+		},
+		{
+			name: "create_heartbeat",
+			label: "Create Heartbeat",
+			description:
+				"Create or replace the single persistent heartbeat for this same daemon-backed session. Use this only when the user explicitly asks for a recurring check-in, reminder, heartbeat, or continuation.",
+			promptGuidelines: [
+				"Use create_heartbeat when the user explicitly asks this session to keep checking in or continue itself on a cadence.",
+				"Do not create heartbeats on your own initiative. If the requested instruction is ambiguous, ask a concise follow-up.",
+				"The interval defaults to every 5 minutes when the user does not specify one.",
+			],
+			parameters: createHeartbeatSchema,
+			execute: async (_toolCallId: string, params: CreateHeartbeatArgs) => {
+				const job = controller.createHeartbeat(params.instruction, params.interval);
+				return {
+					content: [{ type: "text", text: JSON.stringify({ heartbeat: job }, null, 2) }],
+					details: job,
+				};
+			},
+		},
+		{
+			name: "update_heartbeat",
+			label: "Update Heartbeat",
+			description:
+				"Pause, resume, or clear the persistent heartbeat for this daemon-backed session. Use this only when the user explicitly asks to change heartbeat lifecycle state.",
+			promptGuidelines: [
+				"Use update_heartbeat only when the user explicitly asks to pause, resume, stop, or clear the heartbeat.",
+			],
+			parameters: updateHeartbeatSchema,
+			execute: async (_toolCallId: string, params: UpdateHeartbeatArgs) => {
+				const job = controller.updateHeartbeat(params.action);
+				return {
+					content: [{ type: "text", text: JSON.stringify({ heartbeat: job ?? null }, null, 2) }],
+					details: job ?? null,
+				};
+			},
+		},
+	];
+}
+
+function consumeEveryOption(text: string): { interval: string; rest: string } | undefined {
+	const match =
+		/^--every(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\d+\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours))|(\S+))(?:\s+|$)([\s\S]*)$/i.exec(
+			text,
+		);
+	if (!match) {
+		return undefined;
+	}
+	return {
+		interval: match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+		rest: match[5]?.trim() ?? "",
+	};
+}
+
+function consumeLeadingEverySchedule(text: string): { interval: string; rest: string } | undefined {
+	const match =
+		/^(every|each)\s+\d+\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b/i.exec(text);
+	if (!match) {
+		return undefined;
+	}
+	return {
+		interval: match[0],
+		rest: text
+			.slice(match[0].length)
+			.trim()
+			.replace(/^--\s*/, "")
+			.trim(),
+	};
+}
+
+function nextCronRunAfter(expression: string, after: Date): Date {
+	const fields = parseCronExpression(expression);
+	const candidate = new Date(after.getTime());
+	candidate.setSeconds(0, 0);
+	candidate.setMinutes(candidate.getMinutes() + 1);
+
+	const deadline = candidate.getTime() + 366 * 24 * 60 * ONE_MINUTE_MS;
+	while (candidate.getTime() <= deadline) {
+		if (matchesCronFields(candidate, fields)) {
+			return candidate;
+		}
+		candidate.setMinutes(candidate.getMinutes() + 1);
+	}
+	throw new Error(`Cron schedule did not match within one year: ${expression}`);
+}
+
+function parseCronExpression(expression: string): CronFields {
+	const parts = expression.trim().split(/\s+/);
+	if (parts.length !== 5) {
+		throw new Error(
+			"Unsupported cron schedule. Use 'in 10m', 'at <ISO date>', @hourly, or five fields: minute hour day month weekday",
+		);
+	}
+	return {
+		minute: parseCronField(parts[0]!, 0, 59),
+		hour: parseCronField(parts[1]!, 0, 23),
+		dayOfMonth: parseCronField(parts[2]!, 1, 31),
+		month: parseCronField(parts[3]!, 1, 12),
+		dayOfWeek: parseCronField(parts[4]!, 0, 7),
+	};
+}
+
+interface CronFields {
+	minute: Set<number>;
+	hour: Set<number>;
+	dayOfMonth: Set<number>;
+	month: Set<number>;
+	dayOfWeek: Set<number>;
+}
+
+function parseCronField(field: string, min: number, max: number): Set<number> {
+	const values = new Set<number>();
+	for (const part of field.split(",")) {
+		if (!part) {
+			throw new Error(`Invalid cron field: ${field}`);
+		}
+		const [rangeText, stepText] = part.split("/");
+		const step = stepText === undefined ? 1 : parseCronNumber(stepText, 1, max);
+		let start: number;
+		let end: number;
+		if (rangeText === "*") {
+			start = min;
+			end = max;
+		} else if (rangeText?.includes("-")) {
+			const [startText, endText] = rangeText.split("-");
+			start = parseCronNumber(startText, min, max);
+			end = parseCronNumber(endText, min, max);
+			if (start > end) {
+				throw new Error(`Invalid cron range: ${rangeText}`);
+			}
+		} else {
+			start = parseCronNumber(rangeText, min, max);
+			end = start;
+		}
+		for (let value = start; value <= end; value += step) {
+			values.add(value);
+		}
+	}
+	return values;
+}
+
+function parseCronNumber(value: string | undefined, min: number, max: number): number {
+	if (!value || !/^\d+$/.test(value)) {
+		throw new Error(`Invalid cron number: ${value ?? ""}`);
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (parsed < min || parsed > max) {
+		throw new Error(`Cron number out of range: ${value}`);
+	}
+	return parsed;
+}
+
+function matchesCronFields(date: Date, fields: CronFields): boolean {
+	const day = date.getDay();
+	const dayMatches = fields.dayOfWeek.has(day) || (day === 0 && fields.dayOfWeek.has(7));
+	return (
+		fields.minute.has(date.getMinutes()) &&
+		fields.hour.has(date.getHours()) &&
+		fields.dayOfMonth.has(date.getDate()) &&
+		fields.month.has(date.getMonth() + 1) &&
+		dayMatches
+	);
+}
+
+function normalizeCronAlias(text: string): string {
+	switch (text) {
+		case "@hourly":
+			return "0 * * * *";
+		case "@daily":
+			return "0 0 * * *";
+		case "@weekly":
+			return "0 0 * * 0";
+		case "@monthly":
+			return "0 0 1 * *";
+		default:
+			return text;
+	}
+}
+
+function stripMatchingQuotes(value: string): string {
+	if (
+		value.length >= 2 &&
+		((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+	) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+function compareOptionalIso(left: string | undefined, right: string | undefined): number {
+	if (left === right) {
+		return 0;
+	}
+	if (left === undefined) {
+		return 1;
+	}
+	if (right === undefined) {
+		return -1;
+	}
+	return Date.parse(left) - Date.parse(right);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isAgentCronJob(value: unknown): value is AgentCronJob {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const candidate = value as Partial<AgentCronJob>;
+	return (
+		typeof candidate.id === "string" &&
+		(candidate.status === "active" ||
+			candidate.status === "paused" ||
+			candidate.status === "completed" ||
+			candidate.status === "cancelled") &&
+		(candidate.source === undefined || candidate.source === "cron" || candidate.source === "heartbeat") &&
+		typeof candidate.activeSessionId === "string" &&
+		typeof candidate.sessionId === "string" &&
+		typeof candidate.sessionFile === "string" &&
+		typeof candidate.cwd === "string" &&
+		typeof candidate.prompt === "string" &&
+		typeof candidate.schedule === "object" &&
+		candidate.schedule !== null &&
+		(candidate.schedule.kind === "once" ||
+			candidate.schedule.kind === "cron" ||
+			(candidate.schedule.kind === "interval" &&
+				typeof candidate.schedule.intervalMs === "number" &&
+				candidate.schedule.intervalMs > 0)) &&
+		typeof candidate.schedule.expression === "string" &&
+		typeof candidate.createdAt === "string" &&
+		typeof candidate.updatedAt === "string" &&
+		typeof candidate.runCount === "number"
+	);
+}

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -45,6 +45,11 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	},
 	{ name: "refine", description: "Refine editable harness prompt notes, skills, subagents, and memory" },
 	{ name: "goal", description: "Set or view a persistent goal; supports pause, resume, and clear" },
+	{
+		name: "heartbeat",
+		description: "Set or view a persistent heartbeat; supports pause, resume, and clear",
+		argumentHint: "[--every <interval>] <instruction>",
+	},
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -3,6 +3,7 @@ import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core"
 import type { ImageContent, Transport } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
+import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type { SessionStats } from "../../core/session-stats.js";
@@ -298,6 +299,57 @@ export class DaemonAgentConnection implements AgentConnection {
 			type: "clear_queue",
 			activeSessionId: this.activeSessionId,
 		});
+	}
+
+	async listCronJobs(options: { includeInactive?: boolean } = {}): Promise<AgentCronJob[]> {
+		const data = await this.requestData<{ jobs: AgentCronJob[] }>({
+			type: "cron_list",
+			activeSessionId: this.activeSessionId,
+			includeInactive: options.includeInactive,
+		});
+		return data.jobs;
+	}
+
+	async addCronJob(schedule: string, prompt: string): Promise<AgentCronJob> {
+		const data = await this.requestData<{ job: AgentCronJob }>({
+			type: "cron_add",
+			activeSessionId: this.activeSessionId,
+			schedule,
+			prompt,
+		});
+		return data.job;
+	}
+
+	async cancelCronJob(jobId: string): Promise<AgentCronJob> {
+		const data = await this.requestData<{ job: AgentCronJob }>({ type: "cron_cancel", jobId });
+		return data.job;
+	}
+
+	async getHeartbeat(): Promise<AgentCronJob | undefined> {
+		const data = await this.requestData<{ heartbeat?: AgentCronJob | null }>({
+			type: "heartbeat_get",
+			activeSessionId: this.activeSessionId,
+		});
+		return data.heartbeat ?? undefined;
+	}
+
+	async setHeartbeat(schedule: string, instruction: string): Promise<AgentCronJob> {
+		const data = await this.requestData<{ heartbeat: AgentCronJob }>({
+			type: "heartbeat_set",
+			activeSessionId: this.activeSessionId,
+			schedule,
+			prompt: instruction,
+		});
+		return data.heartbeat;
+	}
+
+	async updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined> {
+		const data = await this.requestData<{ heartbeat?: AgentCronJob | null }>({
+			type: "heartbeat_update",
+			activeSessionId: this.activeSessionId,
+			action,
+		});
+		return data.heartbeat ?? undefined;
 	}
 
 	async getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]> {
@@ -766,6 +818,7 @@ function invalidatesCachedSnapshot(commandType: DaemonCommandBody["type"]): bool
 		case "get_resource_snapshot":
 		case "get_available_models":
 		case "get_queue":
+		case "cron_list":
 		case "get_session_context":
 		case "get_session_tree":
 		case "get_user_messages_for_forking":

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -4,6 +4,7 @@ import type { ImageContent, Transport } from "@earendil-works/pi-ai";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
+import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import { type DeleteSessionFileResult, deleteSessionFile } from "../../core/session-file-actions.js";
 import { SessionManager } from "../../core/session-manager.js";
@@ -149,6 +150,30 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async clearQueue(): Promise<AgentConnectionQueueState> {
 		return this.session.clearQueue();
+	}
+
+	async listCronJobs(_options: { includeInactive?: boolean } = {}): Promise<AgentCronJob[]> {
+		return [];
+	}
+
+	async addCronJob(_schedule: string, _prompt: string): Promise<AgentCronJob> {
+		throw new Error("Cron jobs require daemon mode");
+	}
+
+	async cancelCronJob(_jobId: string): Promise<AgentCronJob> {
+		throw new Error("Cron jobs require daemon mode");
+	}
+
+	async getHeartbeat(): Promise<AgentCronJob | undefined> {
+		return undefined;
+	}
+
+	async setHeartbeat(_schedule: string, _instruction: string): Promise<AgentCronJob> {
+		throw new Error("Heartbeats require daemon mode");
+	}
+
+	async updateHeartbeat(_action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined> {
+		throw new Error("Heartbeats require daemon mode");
 	}
 
 	async getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]> {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -11,6 +11,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
+import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { GoalState } from "../../core/goals.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
@@ -522,6 +523,12 @@ export interface AgentConnection {
 	): Promise<AgentConnectionSavedSessionInfo[]>;
 	getQueue(): Promise<AgentConnectionQueueState>;
 	clearQueue(): Promise<AgentConnectionQueueState>;
+	listCronJobs(options?: { includeInactive?: boolean }): Promise<AgentCronJob[]>;
+	addCronJob(schedule: string, prompt: string): Promise<AgentCronJob>;
+	cancelCronJob(jobId: string): Promise<AgentCronJob>;
+	getHeartbeat(): Promise<AgentCronJob | undefined>;
+	setHeartbeat(schedule: string, instruction: string): Promise<AgentCronJob>;
+	updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined>;
 	getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]>;
 	getLastAssistantText(): Promise<string | undefined>;
 	getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -8,13 +8,22 @@
 
 import { createServer, type Server, type Socket } from "node:net";
 import { resolve } from "node:path";
-import { VERSION } from "../../config.js";
+import { getCronJobsPath, VERSION } from "../../config.js";
 import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import {
 	AgentSessionRuntime,
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionRuntime,
 } from "../../core/agent-session-runtime.js";
+import {
+	type AgentCronJob,
+	AgentCronJobStore,
+	AgentCronScheduler,
+	type AgentHeartbeatUpdateAction,
+	createAgentHeartbeatToolDefinitions,
+	DEFAULT_HEARTBEAT_SCHEDULE,
+	normalizeHeartbeatSchedule,
+} from "../../core/cron-jobs.js";
 import type {
 	CreateRlmSubagentRuntimeOptions,
 	RlmSubagentRuntime,
@@ -100,6 +109,12 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_available_models",
 	"get_queue",
 	"clear_queue",
+	"cron_list",
+	"cron_add",
+	"cron_cancel",
+	"heartbeat_get",
+	"heartbeat_set",
+	"heartbeat_update",
 	"set_model",
 	"cycle_model",
 	"set_scoped_models",
@@ -159,11 +174,24 @@ class AgentDaemon {
 	private readonly sessions = new Map<string, ActiveSessionState>();
 	private readonly closingSessions = new Map<string, Promise<void>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
+	private readonly cronStore: AgentCronJobStore;
+	private readonly cronScheduler: AgentCronScheduler;
 
 	constructor(
 		private readonly socketPath: string,
 		private readonly options: DaemonModeOptions,
-	) {}
+	) {
+		if (!options.defaultSessionConfig.agentDir) {
+			throw new Error("Daemon config is missing agentDir");
+		}
+		this.cronStore = new AgentCronJobStore(getCronJobsPath(options.defaultSessionConfig.agentDir));
+		this.cronScheduler = new AgentCronScheduler(this.cronStore, {
+			runJob: (job) => this.runCronJob(job),
+			onError: (job, error) => {
+				console.error(`Cron job ${job.id} failed: ${error instanceof Error ? error.message : String(error)}`);
+			},
+		});
+	}
 
 	async start(): Promise<void> {
 		await prepareDaemonSocketPath(this.socketPath);
@@ -202,6 +230,7 @@ class AgentDaemon {
 		this.registerSignalHandlers();
 		console.error(`Prime Agent daemon listening on ${this.socketPath}`);
 		void this.restoreActiveSessions();
+		this.cronScheduler.start();
 	}
 
 	/**
@@ -318,13 +347,106 @@ class AgentDaemon {
 			// visible in session lists again.
 			sessionManager.appendSessionState({ status: "sleep" });
 		}
+		let stateRef: ActiveSessionState | undefined;
 		const runtime = await createAgentSessionRuntime(this.options.createRuntime, {
 			cwd: sessionManager.getCwd(),
 			agentDir: config.agentDir,
 			sessionManager,
 			sessionConfig: config,
+			sessionOptions: {
+				customTools: [
+					...createAgentHeartbeatToolDefinitions({
+						getHeartbeat: () => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.cronStore.getHeartbeat(stateRef.activeSessionId);
+						},
+						createHeartbeat: (instruction, interval) => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.createHeartbeatForState(stateRef, interval ?? DEFAULT_HEARTBEAT_SCHEDULE, instruction);
+						},
+						updateHeartbeat: (action) => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.updateHeartbeatForState(stateRef, action);
+						},
+					}),
+				],
+			},
 		});
-		return this.addRuntime(runtime, command.name);
+		const state = await this.addRuntime(runtime, command.name);
+		stateRef = state;
+		return state;
+	}
+
+	private async runCronJob(job: AgentCronJob): Promise<void> {
+		const state = await this.getOrCreateCronJobSession(job);
+		await state.runtime.session.prompt(job.prompt, {
+			streamingBehavior: state.runtime.session.isStreaming ? "followUp" : undefined,
+			source: "rpc",
+		});
+	}
+
+	private createCronJobForState(state: ActiveSessionState, schedule: string, prompt: string): AgentCronJob {
+		const session = state.runtime.session;
+		const sessionFile = session.sessionFile;
+		if (!sessionFile) {
+			throw new Error("Heartbeats require a persisted session file");
+		}
+		const job = this.cronStore.create({
+			activeSessionId: state.activeSessionId,
+			sessionId: session.sessionId,
+			sessionFile,
+			cwd: state.runtime.cwd,
+			scheduleText: schedule,
+			prompt,
+		});
+		this.cronScheduler.wake();
+		return job;
+	}
+
+	private createHeartbeatForState(state: ActiveSessionState, schedule: string, instruction: string): AgentCronJob {
+		const session = state.runtime.session;
+		const sessionFile = session.sessionFile;
+		if (!sessionFile) {
+			throw new Error("Heartbeats require a persisted session file");
+		}
+		const job = this.cronStore.createHeartbeat({
+			activeSessionId: state.activeSessionId,
+			sessionId: session.sessionId,
+			sessionFile,
+			cwd: state.runtime.cwd,
+			scheduleText: normalizeHeartbeatSchedule(schedule),
+			prompt: instruction,
+		});
+		this.cronScheduler.wake();
+		return job;
+	}
+
+	private updateHeartbeatForState(
+		state: ActiveSessionState,
+		action: AgentHeartbeatUpdateAction,
+	): AgentCronJob | undefined {
+		const job =
+			action === "pause"
+				? this.cronStore.pauseHeartbeat(state.activeSessionId)
+				: action === "resume"
+					? this.cronStore.resumeHeartbeat(state.activeSessionId)
+					: this.cronStore.clearHeartbeat(state.activeSessionId);
+		this.cronScheduler.wake();
+		return job;
+	}
+
+	private async getOrCreateCronJobSession(job: AgentCronJob): Promise<ActiveSessionState> {
+		const current = this.sessions.get(job.activeSessionId) ?? this.findSessionBySessionFile(job.sessionFile);
+		if (current) {
+			return current;
+		}
+		return this.createRuntime({ type: "create", sessionPath: job.sessionFile });
 	}
 
 	private findSessionBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
@@ -389,6 +511,7 @@ class AgentDaemon {
 		if (options.parentSession.sessionFile) {
 			sessionManager.newSession({ parentSession: options.parentSession.sessionFile });
 		}
+		let stateRef: ActiveSessionState | undefined;
 		const runtime = await createAgentSessionRuntime(this.options.createRuntime, {
 			cwd: sessionManager.getCwd(),
 			agentDir: parentState.runtime.services.agentDir,
@@ -401,7 +524,29 @@ class AgentDaemon {
 				scopedModels: options.scopedModels,
 				initialActiveToolNames: options.activeToolNames,
 				allowedToolNames: options.allowedToolNames,
-				customTools: options.customTools,
+				customTools: [
+					...(options.customTools ?? []),
+					...createAgentHeartbeatToolDefinitions({
+						getHeartbeat: () => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.cronStore.getHeartbeat(stateRef.activeSessionId);
+						},
+						createHeartbeat: (instruction, interval) => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.createHeartbeatForState(stateRef, interval ?? DEFAULT_HEARTBEAT_SCHEDULE, instruction);
+						},
+						updateHeartbeat: (action) => {
+							if (!stateRef) {
+								throw new Error("Heartbeat state is not ready for this session yet");
+							}
+							return this.updateHeartbeatForState(stateRef, action);
+						},
+					}),
+				],
 				includeGoals: options.includeGoals,
 				rlmDepth: options.rlmDepth,
 				rlmMaxDepth: options.rlmMaxDepth,
@@ -420,7 +565,8 @@ class AgentDaemon {
 				sessionDir: options.sessionDir,
 			},
 		});
-		await this.addRuntime(runtime);
+		const state = await this.addRuntime(runtime);
+		stateRef = state;
 		return runtime;
 	}
 
@@ -778,6 +924,51 @@ class AgentDaemon {
 			case "clear_queue": {
 				const state = this.getSessionState(command.activeSessionId);
 				return success(command.id, "clear_queue", state.runtime.session.clearQueue());
+			}
+
+			case "cron_list": {
+				const jobs = this.cronStore.list().filter((job) => {
+					if (!command.includeInactive && job.status !== "active") {
+						return false;
+					}
+					if (command.activeSessionId && job.activeSessionId !== command.activeSessionId) {
+						return false;
+					}
+					return true;
+				});
+				return success(command.id, "cron_list", { jobs });
+			}
+
+			case "cron_add": {
+				const state = this.getSessionState(command.activeSessionId);
+				const job = this.createCronJobForState(state, command.schedule, command.prompt);
+				return success(command.id, "cron_add", { job });
+			}
+
+			case "cron_cancel": {
+				const job = this.cronStore.cancel(command.jobId);
+				if (!job) {
+					throw new Error(`No cron job found: ${command.jobId}`);
+				}
+				this.cronScheduler.wake();
+				return success(command.id, "cron_cancel", { job });
+			}
+
+			case "heartbeat_get": {
+				const heartbeat = this.cronStore.getHeartbeat(command.activeSessionId);
+				return success(command.id, "heartbeat_get", { heartbeat: heartbeat ?? null });
+			}
+
+			case "heartbeat_set": {
+				const state = this.getSessionState(command.activeSessionId);
+				const heartbeat = this.createHeartbeatForState(state, command.schedule, command.prompt);
+				return success(command.id, "heartbeat_set", { heartbeat });
+			}
+
+			case "heartbeat_update": {
+				const state = this.getSessionState(command.activeSessionId);
+				const heartbeat = this.updateHeartbeatForState(state, command.action);
+				return success(command.id, "heartbeat_update", { heartbeat: heartbeat ?? null });
 			}
 
 			case "set_model": {
@@ -1209,6 +1400,7 @@ class AgentDaemon {
 		for (const cleanup of this.signalCleanupHandlers) {
 			cleanup();
 		}
+		this.cronScheduler.stop();
 		for (const state of [...this.sessions.values()]) {
 			await this.closeSession(state, "shutdown");
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Transport } from "@earendil-works/pi-ai";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
+import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { SessionCwdIssue } from "../../core/session-cwd.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type {
@@ -193,6 +194,12 @@ export type DaemonCommand =
 	| { id?: string; type: "get_available_models"; activeSessionId: string }
 	| { id?: string; type: "get_queue"; activeSessionId: string }
 	| { id?: string; type: "clear_queue"; activeSessionId: string }
+	| { id?: string; type: "cron_list"; activeSessionId?: string; includeInactive?: boolean }
+	| { id?: string; type: "cron_add"; activeSessionId: string; schedule: string; prompt: string }
+	| { id?: string; type: "cron_cancel"; jobId: string }
+	| { id?: string; type: "heartbeat_get"; activeSessionId: string }
+	| { id?: string; type: "heartbeat_set"; activeSessionId: string; schedule: string; prompt: string }
+	| { id?: string; type: "heartbeat_update"; activeSessionId: string; action: AgentHeartbeatUpdateAction }
 	| { id?: string; type: "set_model"; activeSessionId: string; provider: string; modelId: string }
 	| { id?: string; type: "cycle_model"; activeSessionId: string; direction?: "forward" | "backward" }
 	| { id?: string; type: "set_scoped_models"; activeSessionId: string; scopedModels: AgentConnectionScopedModel[] }
@@ -301,6 +308,8 @@ export interface DaemonSavedSessionInfo {
 export type DaemonDeleteSavedSessionResult = DeleteSessionFileResult;
 
 export type DaemonResourceSnapshot = AgentConnectionResourceSnapshot;
+
+export type DaemonCronJob = AgentCronJob;
 
 export type DaemonOutbound =
 	| DaemonResponse

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -41,6 +41,7 @@ import {
 import { spawn, spawnSync } from "child_process";
 import { APP_TITLE, getAgentDir, getDebugLogPath, getShareViewerUrl, VERSION } from "../../config.js";
 import { isNoModelsAvailableMessage } from "../../core/auth-guidance.js";
+import { type AgentCronJob, parseHeartbeatCommand } from "../../core/cron-jobs.js";
 import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
@@ -3184,6 +3185,11 @@ export class InteractiveMode {
 			}
 			if (text === "/goal" || text === "/goal status") {
 				this.handleGoalStatusCommand();
+				this.editor.setText("");
+				return;
+			}
+			if (text === "/heartbeat" || text.startsWith("/heartbeat ")) {
+				await this.handleHeartbeatCommand(text);
 				this.editor.setText("");
 				return;
 			}
@@ -6498,6 +6504,78 @@ export class InteractiveMode {
 			lines.push(`${theme.fg("dim", "Error:")} ${goal.lastError}`);
 		}
 
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new Text(lines.join("\n"), 1, 0));
+		this.ui.requestRender();
+	}
+
+	private async handleHeartbeatCommand(text: string): Promise<void> {
+		try {
+			const command = parseHeartbeatCommand(text);
+			switch (command.type) {
+				case "status": {
+					const heartbeat = await this.agentConnection.getHeartbeat();
+					this.showHeartbeat(heartbeat);
+					return;
+				}
+				case "set": {
+					const heartbeat = await this.agentConnection.setHeartbeat(command.schedule, command.instruction);
+					this.showStatus(`Heartbeat set\nNext run: ${heartbeat.nextRunAt ?? "-"}`);
+					return;
+				}
+				case "pause": {
+					const heartbeat = await this.agentConnection.updateHeartbeat("pause");
+					if (!heartbeat) {
+						this.showStatus("No active heartbeat");
+						return;
+					}
+					this.showStatus("Heartbeat paused");
+					return;
+				}
+				case "resume": {
+					const heartbeat = await this.agentConnection.updateHeartbeat("resume");
+					if (!heartbeat) {
+						this.showStatus("No active heartbeat");
+						return;
+					}
+					this.showStatus(`Heartbeat resumed\nNext run: ${heartbeat.nextRunAt ?? "-"}`);
+					return;
+				}
+				case "clear": {
+					const heartbeat = await this.agentConnection.updateHeartbeat("clear");
+					if (!heartbeat) {
+						this.showStatus("No active heartbeat");
+						return;
+					}
+					this.showStatus("Heartbeat cleared");
+					return;
+				}
+			}
+		} catch (error) {
+			this.showError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	private showHeartbeat(job: AgentCronJob | undefined): void {
+		if (!job) {
+			this.showStatus("No active heartbeat");
+			return;
+		}
+		const next = job.nextRunAt ? new Date(job.nextRunAt).toLocaleString() : "-";
+		const last = job.lastRunAt ? new Date(job.lastRunAt).toLocaleString() : "-";
+		const lines = [
+			theme.bold("Heartbeat"),
+			"",
+			`${theme.fg("dim", "Status:")} ${job.status}`,
+			`${theme.fg("dim", "Every:")} ${job.schedule.expression}`,
+			`${theme.fg("dim", "Instruction:")} ${job.prompt}`,
+			`${theme.fg("dim", "Next:")} ${next}`,
+			`${theme.fg("dim", "Last:")} ${last}`,
+			`${theme.fg("dim", "Runs:")} ${job.runCount}`,
+		];
+		if (job.lastError) {
+			lines.push(`${theme.fg("dim", "Error:")} ${job.lastError}`);
+		}
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(lines.join("\n"), 1, 0));
 		this.ui.requestRender();

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1,0 +1,384 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	AgentCronJobStore,
+	AgentCronScheduler,
+	createAgentHeartbeatToolDefinitions,
+	parseAgentCronSchedule,
+	parseHeartbeatCommand,
+} from "../src/core/cron-jobs.js";
+
+const start = new Date("2026-01-01T12:34:00.000Z");
+
+describe("parseAgentCronSchedule", () => {
+	it("parses one-shot relative schedules", () => {
+		const parsed = parseAgentCronSchedule("in 15m", start);
+
+		expect(parsed.schedule).toEqual({ kind: "once", expression: "in 15m" });
+		expect(parsed.nextRunAt.toISOString()).toBe("2026-01-01T12:49:00.000Z");
+	});
+
+	it("parses cron aliases and five-field cron subsets", () => {
+		expect(parseAgentCronSchedule("@hourly", start).nextRunAt.toISOString()).toBe("2026-01-01T13:00:00.000Z");
+		expect(parseAgentCronSchedule("*/30 * * * *", start).nextRunAt.toISOString()).toBe("2026-01-01T13:00:00.000Z");
+	});
+
+	it("parses recurring heartbeat intervals with seconds", () => {
+		const parsed = parseAgentCronSchedule("every 30s", start);
+
+		expect(parsed.schedule).toEqual({ kind: "interval", expression: "every 30s", intervalMs: 30_000 });
+		expect(parsed.nextRunAt.toISOString()).toBe("2026-01-01T12:34:30.000Z");
+	});
+
+	it("rejects unsupported cron syntax", () => {
+		expect(() => parseAgentCronSchedule("0 9 * * MON", start)).toThrow("Invalid cron number");
+	});
+});
+
+describe("parseHeartbeatCommand", () => {
+	it("matches the goal-style status and lifecycle commands", () => {
+		expect(parseHeartbeatCommand("/heartbeat")).toEqual({ type: "status" });
+		expect(parseHeartbeatCommand("/heartbeat status")).toEqual({ type: "status" });
+		expect(parseHeartbeatCommand("/heartbeat pause")).toEqual({ type: "pause" });
+		expect(parseHeartbeatCommand("/heartbeat resume")).toEqual({ type: "resume" });
+		expect(parseHeartbeatCommand("/heartbeat clear")).toEqual({ type: "clear" });
+		expect(parseHeartbeatCommand("/heartbeat stop")).toEqual({ type: "clear" });
+	});
+
+	it("defaults new heartbeat instructions to every five minutes", () => {
+		expect(parseHeartbeatCommand("/heartbeat check on me")).toEqual({
+			type: "set",
+			schedule: "every 5m",
+			instruction: "check on me",
+		});
+	});
+
+	it("accepts explicit heartbeat intervals", () => {
+		expect(parseHeartbeatCommand("/heartbeat --every 30s check on me")).toEqual({
+			type: "set",
+			schedule: "every 30s",
+			instruction: "check on me",
+		});
+		expect(parseHeartbeatCommand("/heartbeat every 10m -- check status")).toEqual({
+			type: "set",
+			schedule: "every 10m",
+			instruction: "check status",
+		});
+	});
+});
+
+describe("AgentCronJobStore", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("persists, reloads, and cancels jobs", () => {
+		const storePath = makeStorePath(tempDirs);
+		const store = new AgentCronJobStore(storePath);
+		const job = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1h",
+			prompt: "check the long run",
+			now: start,
+		});
+
+		expect(job.nextRunAt).toBe("2026-01-01T13:34:00.000Z");
+		expect(new AgentCronJobStore(storePath).list()).toMatchObject([
+			{
+				id: job.id,
+				status: "active",
+				prompt: "check the long run",
+			},
+		]);
+
+		const cancelled = store.cancel(job.id, new Date("2026-01-01T12:40:00.000Z"));
+
+		expect(cancelled).toMatchObject({ id: job.id, status: "cancelled" });
+		expect(store.list()[0]).toMatchObject({ id: job.id, status: "cancelled" });
+		expect(store.list()[0]).not.toHaveProperty("nextRunAt");
+	});
+
+	it("keeps overdue jobs eligible for the scheduler after restart", () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1m",
+			prompt: "check the long run",
+			now: start,
+		});
+
+		expect(store.nextActiveRunAt()?.toISOString()).toBe("2026-01-01T12:35:00.000Z");
+	});
+
+	it("keeps one persistent heartbeat per active session", () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		const first = store.createHeartbeat({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "every 30s",
+			prompt: "check on me",
+			now: start,
+		});
+		const second = store.createHeartbeat({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "every 5m",
+			prompt: "continue the work",
+			now: new Date("2026-01-01T12:35:00.000Z"),
+		});
+
+		expect(store.getHeartbeat("active-1")).toMatchObject({ id: second.id, prompt: "continue the work" });
+		expect(store.list().find((job) => job.id === first.id)).toMatchObject({ status: "cancelled" });
+	});
+
+	it("pauses, resumes, and clears heartbeat state", () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		const job = store.createHeartbeat({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "every 30s",
+			prompt: "check on me",
+			now: start,
+		});
+
+		expect(store.pauseHeartbeat("active-1", new Date("2026-01-01T12:34:10.000Z"))).toMatchObject({
+			id: job.id,
+			status: "paused",
+		});
+		expect(store.getHeartbeat("active-1")).not.toHaveProperty("nextRunAt");
+		expect(store.resumeHeartbeat("active-1", new Date("2026-01-01T12:35:00.000Z"))).toMatchObject({
+			id: job.id,
+			status: "active",
+			nextRunAt: "2026-01-01T12:35:30.000Z",
+		});
+		expect(store.clearHeartbeat("active-1", new Date("2026-01-01T12:36:00.000Z"))).toMatchObject({
+			id: job.id,
+			status: "cancelled",
+		});
+		expect(store.getHeartbeat("active-1")).toBeUndefined();
+	});
+
+	it("rejects one-shot heartbeat schedules", () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+
+		expect(() =>
+			store.createHeartbeat({
+				activeSessionId: "active-1",
+				sessionId: "session-1",
+				sessionFile: "/tmp/session.jsonl",
+				cwd: "/tmp/project",
+				scheduleText: "in 5m",
+				prompt: "check on me",
+				now: start,
+			}),
+		).toThrow("Heartbeat schedule must be recurring");
+	});
+});
+
+describe("AgentCronScheduler", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("runs due one-shot jobs and marks them completed", async () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		const job = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1m",
+			prompt: "continue the audit",
+			now: start,
+		});
+		const prompts: string[] = [];
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:35:00.000Z"),
+			runJob: async (dueJob) => {
+				prompts.push(dueJob.prompt);
+			},
+		});
+
+		await scheduler.runDue(new Date("2026-01-01T12:35:00.000Z"));
+
+		expect(prompts).toEqual(["continue the audit"]);
+		expect(store.list()[0]).toMatchObject({
+			id: job.id,
+			status: "completed",
+			runCount: 1,
+			lastRunAt: "2026-01-01T12:35:00.000Z",
+		});
+		expect(store.list()[0]).not.toHaveProperty("nextRunAt");
+	});
+
+	it("reschedules recurring jobs after each run", async () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "* * * * *",
+			prompt: "poll status",
+			now: new Date("2026-01-01T12:34:00.000Z"),
+		});
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:35:00.000Z"),
+			runJob: async () => {},
+		});
+
+		await scheduler.runDue(new Date("2026-01-01T12:35:00.000Z"));
+
+		expect(store.list()[0]).toMatchObject({
+			status: "active",
+			runCount: 1,
+			lastRunAt: "2026-01-01T12:35:00.000Z",
+			nextRunAt: "2026-01-01T12:36:00.000Z",
+		});
+	});
+
+	it("reschedules interval heartbeats after each run", async () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "every 30s",
+			prompt: "check on me",
+			now: start,
+		});
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:34:30.000Z"),
+			runJob: async () => {},
+		});
+
+		await scheduler.runDue(new Date("2026-01-01T12:34:30.000Z"));
+
+		expect(store.list()[0]).toMatchObject({
+			status: "active",
+			runCount: 1,
+			lastRunAt: "2026-01-01T12:34:30.000Z",
+			nextRunAt: "2026-01-01T12:35:00.000Z",
+		});
+	});
+});
+
+describe("createAgentHeartbeatToolDefinitions", () => {
+	it("lets the model create a heartbeat when explicitly requested", async () => {
+		const tools = createAgentHeartbeatToolDefinitions({
+			getHeartbeat: () => undefined,
+			createHeartbeat: (instruction, interval) =>
+				({
+					id: "job-1",
+					status: "active",
+					source: "heartbeat",
+					activeSessionId: "active-1",
+					sessionId: "session-1",
+					sessionFile: "/tmp/session.jsonl",
+					cwd: "/tmp/project",
+					prompt: instruction,
+					schedule: { kind: "interval", expression: interval ?? "every 5m", intervalMs: 30_000 },
+					createdAt: start.toISOString(),
+					updatedAt: start.toISOString(),
+					nextRunAt: "2026-01-01T12:34:30.000Z",
+					runCount: 0,
+				}) as const,
+			updateHeartbeat: () => undefined,
+		});
+		const tool = tools.find((candidate) => candidate.name === "create_heartbeat");
+
+		expect(tool).toBeDefined();
+
+		const result = await tool!.execute(
+			"tool-1",
+			{ interval: "every 30s", instruction: "check on me" },
+			undefined,
+			undefined,
+			{} as never,
+		);
+
+		expect(result.details).toMatchObject({
+			id: "job-1",
+			schedule: { expression: "every 30s" },
+			prompt: "check on me",
+		});
+	});
+
+	it("lets the model inspect and update heartbeat state", async () => {
+		const tools = createAgentHeartbeatToolDefinitions({
+			getHeartbeat: () =>
+				({
+					id: "job-1",
+					status: "active",
+					source: "heartbeat",
+					activeSessionId: "active-1",
+					sessionId: "session-1",
+					sessionFile: "/tmp/session.jsonl",
+					cwd: "/tmp/project",
+					prompt: "check on me",
+					schedule: { kind: "interval", expression: "every 30s", intervalMs: 30_000 },
+					createdAt: start.toISOString(),
+					updatedAt: start.toISOString(),
+					nextRunAt: "2026-01-01T12:34:30.000Z",
+					runCount: 0,
+				}) as const,
+			createHeartbeat: () => {
+				throw new Error("not used");
+			},
+			updateHeartbeat: (action) =>
+				({
+					id: "job-1",
+					status: action === "pause" ? "paused" : "cancelled",
+					source: "heartbeat",
+					activeSessionId: "active-1",
+					sessionId: "session-1",
+					sessionFile: "/tmp/session.jsonl",
+					cwd: "/tmp/project",
+					prompt: "check on me",
+					schedule: { kind: "interval", expression: "every 30s", intervalMs: 30_000 },
+					createdAt: start.toISOString(),
+					updatedAt: start.toISOString(),
+					runCount: 0,
+				}) as const,
+		});
+
+		const getResult = await tools
+			.find((candidate) => candidate.name === "get_heartbeat")!
+			.execute("tool-1", {}, undefined, undefined, {} as never);
+		const updateResult = await tools
+			.find((candidate) => candidate.name === "update_heartbeat")!
+			.execute("tool-2", { action: "pause" }, undefined, undefined, {} as never);
+
+		expect(getResult.details).toMatchObject({ id: "job-1", status: "active" });
+		expect(updateResult.details).toMatchObject({ id: "job-1", status: "paused" });
+	});
+});
+
+function makeStorePath(tempDirs: string[]): string {
+	const dir = mkdtempSync(join(tmpdir(), "prime-agent-cron-"));
+	tempDirs.push(dir);
+	return join(dir, "cron-jobs.json");
+}

--- a/packages/coding-agent/test/daemon-command.test.ts
+++ b/packages/coding-agent/test/daemon-command.test.ts
@@ -6,6 +6,9 @@ const daemonClientMock = vi.hoisted(() => {
 	type Command = {
 		type: string;
 		name?: string;
+		activeSessionId?: string;
+		schedule?: string;
+		prompt?: string;
 		sessionPath?: string;
 		config?: { extensionFlagValues?: Record<string, boolean | string> };
 	};
@@ -219,6 +222,30 @@ describe("daemon command", () => {
 		expect(client?.requests[0]).toMatchObject({
 			type: "create",
 			sessionPath: "abc123",
+		});
+	});
+
+	it("preserves cron add separator before the scheduled prompt", async () => {
+		await expect(
+			handleDaemonCommand([
+				"daemon",
+				"--socket",
+				"/tmp/prime-agent.sock",
+				"cron",
+				"add",
+				"active-1",
+				"in 5m",
+				"--",
+				"check status",
+			]),
+		).resolves.toBe(true);
+
+		const client = daemonClientMock.instances[0];
+		expect(client?.requests[0]).toEqual({
+			type: "cron_add",
+			activeSessionId: "active-1",
+			schedule: "in 5m",
+			prompt: "check status",
 		});
 	});
 });

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.js";
+
+describe("built-in slash commands", () => {
+	test("exposes heartbeat without exposing a cron slash command", () => {
+		const commandNames = BUILTIN_SLASH_COMMANDS.map((command) => command.name);
+
+		expect(commandNames).toContain("heartbeat");
+		expect(commandNames).not.toContain("cron");
+	});
+});


### PR DESCRIPTION
## Context
This is a draft implementation of persistent session heartbeats for long-running Prime Agent work. The goal is to let a daemon-backed session keep checking in on a cadence without needing an active `/goal` loop or an external tmux/script wrapper.

## What changed
- Adds durable daemon-backed scheduler storage at `cron-jobs.json` under the agent config directory.
- Makes `/heartbeat` a goal-style single persistent session state:
  - `/heartbeat` or `/heartbeat status`
  - `/heartbeat [--every <interval>] <instruction>`
  - `/heartbeat pause`
  - `/heartbeat resume`
  - `/heartbeat clear` or `/heartbeat stop`
- Defaults `/heartbeat <instruction>` to `every 5m` when no interval is specified.
- Replaces the old model tool draft with goal-like tools: `get_heartbeat`, `create_heartbeat`, and `update_heartbeat`.
- Supports recurring intervals like `every 30s`, `30s`, `every 10m`, cron aliases like `@hourly`, and five-field cron expressions through the heartbeat scheduler.
- Keeps the slash-command surface heartbeat-only; there is no `/cron` command in this draft.

## How to try it
In a daemon-backed Prime Agent session:
```text
/heartbeat check on me
/heartbeat status
/heartbeat --every 30s check on me
/heartbeat pause
/heartbeat resume
/heartbeat clear
```

Natural-language self-setup should work when tools are enabled, e.g.:
```text
Set up a recurring heartbeat every 30 seconds to check on me.
```

## Validation
- `npm --workspace packages/coding-agent test -- cron-jobs.test.ts daemon-command.test.ts slash-commands.test.ts`
- `npm run check`
- Pre-commit hook reran `npm run check`.

I also ran the full `npm --workspace packages/coding-agent test`; it still has unrelated extension-loader environment failures because local tests cannot import `@earendil-works/pi-agent-core/dist/index.js`, plus one existing git watcher timeout.

## Review focus
- Whether `/heartbeat` should mirror `/goal` this closely.
- Whether the default interval should stay `5m`.
- Whether seconds-level intervals should stay in this draft or be limited later.
- Whether richer TUI management should be separate from this first pass.

## Known gaps / intentional limits
- Heartbeat schedules must be recurring.
- Fixed intervals support seconds/minutes/hours; cron expressions remain minute-granularity and local-time only.
- No weekday/month names like `MON`, no cron seconds field, and no timezone support for cron expressions.
- In-process connections can inspect no heartbeat but cannot set one; heartbeat scheduling is daemon-backed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Background scheduler can inject prompts into live sessions (including model-initiated heartbeats), affecting cost and behavior; daemon now hard-requires `agentDir` and runs timers for the process lifetime.
> 
> **Overview**
> Adds **daemon-backed scheduled prompts** so long-running sessions can fire agent turns on a timer without relying on `/goal` or external wrappers.
> 
> A new `cron-jobs.json` store and in-process scheduler support one-shot (`in 10m`, `at <date>`), interval (`every 30s`), and five-field cron schedules. When a job is due, the daemon loads or reattaches the target session and calls `prompt` with the stored text (follow-up if the session is already streaming).
> 
> **User-facing surfaces:** `daemon cron list|add|cancel` (add uses `--` between schedule and message), `/heartbeat` in interactive mode (goal-style status / set / pause / resume / clear, default `every 5m`), and model tools `get_heartbeat`, `create_heartbeat`, `update_heartbeat` on daemon sessions. Heartbeats are a single recurring job per session (`source: heartbeat`); general cron jobs can target any session. In-process `AgentConnection` stubs return empty or error for these APIs.
> 
> Daemon startup now requires `agentDir`, starts the scheduler, and stops it on shutdown; protocol and client adapters gain `cron_*` and `heartbeat_*` commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf6fb083b666067fcd1c095e7f88e5c67ae8479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent session heartbeat and cron job scheduling to the coding agent daemon
> - Introduces `AgentCronJobStore` and `AgentCronScheduler` in [cron-jobs.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/165/files#diff-fb783dad61580c3b11d0731df2a325b6e3dd852fc430a309a5f3ae7ebcc826dd) for persistent, file-backed scheduling of prompts against long-running daemon sessions, supporting one-shot, interval, and cron expressions.
> - Adds a `cron` subcommand to the daemon CLI for listing, adding, and cancelling cron jobs, with `--` as a separator between schedule and free-form prompt text.
> - Exposes `/heartbeat` as a built-in slash command in interactive mode; users can set, pause, resume, clear, and inspect a per-session recurring heartbeat from the UI.
> - Extends the `AgentConnection` interface and both daemon and in-process implementations with `listCronJobs`, `addCronJob`, `cancelCronJob`, `getHeartbeat`, `setHeartbeat`, and `updateHeartbeat` methods; in-process connections throw to signal daemon-only capability.
> - Wires heartbeat tool definitions into daemon session runtimes (including subagent runtimes) so the model can manage heartbeats directly as tools.
> - Risk: daemon now requires `agentDir` to be set (throws in constructor if missing), and the scheduler starts on daemon startup, adding background timer activity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cf6fb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->