### PR TITLE
release 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.1.3",
+				"@earendil-works/pi-coding-agent": "^0.1.4",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5913,10 +5913,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.1.3",
+				"@earendil-works/pi-ai": "^0.1.4",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5943,7 +5943,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5985,13 +5985,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.1.3",
-				"@earendil-works/pi-ai": "^0.1.3",
-				"@earendil-works/pi-tui": "^0.1.3",
+				"@earendil-works/pi-agent-core": "^0.1.4",
+				"@earendil-works/pi-ai": "^0.1.4",
+				"@earendil-works/pi-tui": "^0.1.4",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6134,7 +6134,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.1.3",
+		"@earendil-works/pi-coding-agent": "^0.1.4",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.1.3",
+		"@earendil-works/pi-ai": "^0.1.4",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.1.3",
-		"@earendil-works/pi-ai": "^0.1.3",
-		"@earendil-works/pi-tui": "^0.1.3",
+		"@earendil-works/pi-agent-core": "^0.1.4",
+		"@earendil-works/pi-ai": "^0.1.4",
+		"@earendil-works/pi-tui": "^0.1.4",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the root package and all four published packages from 0.1.3 to 0.1.4.
- syncs the internal dependency ranges and updates the lockfile to match.
- version-only bump with no publish; tagging and release are not part of this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or behavioral code diffs.
> 
> **Overview**
> Bumps the **prime-agent** workspace and all four published `@earendil-works/pi-*` packages from **0.1.3** to **0.1.4**.
> 
> Internal dependency ranges (`pi-ai`, `pi-agent-core`, `pi-tui`, `pi-coding-agent`) are updated to `^0.1.4`, and **package-lock.json** is refreshed so workspace entries match. There are **no application or library source changes** in this PR—only version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820f2c9d81e3f83815c6cc0a49240c828fbca493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.1.4 across all packages
> Bumps all internal package versions from 0.1.3 to 0.1.4 and updates inter-package dependency ranges to `^0.1.4`. Affected packages: `pi-ai`, `pi-tui`, `pi-agent-core`, `pi-coding-agent`, and the root package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 820f2c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->