### PR TITLE
Port rlm-harness read/search Python guidance into RLM prompt

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -20,6 +20,8 @@ const IPYTHON_CONTROL_PROMPT = [
 	"",
 	"Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.",
 	"",
+	"Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.",
+	"",
 	"Each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. Keep dependent shell steps inside one `%%bash` cell when they need shared shell state, or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `%%bash` calls.",
 	"",
 	"Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, notes, parsed outputs, and helper data structures all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.",

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -69,6 +69,8 @@ describe("buildRlmPrompt", () => {
 				"",
 				"Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.",
 				"",
+				"Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.",
+				"",
 				"Each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. Keep dependent shell steps inside one `%%bash` cell when they need shared shell state, or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `%%bash` calls.",
 				"",
 				"Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, notes, parsed outputs, and helper data structures all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.",
@@ -106,6 +108,18 @@ describe("buildRlmPrompt", () => {
 		});
 
 		expect(prompt).toContain("it must be the first line of the code cell");
+	});
+
+	test("documents preferring Python for reading and searching files when ipython is active", () => {
+		const prompt = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(prompt).toContain("Use Python for reading, searching, and editing files");
+		expect(prompt).toContain("Always assign read/search results to named variables");
 	});
 
 	test("includes the edit skill guidance only when the edit skill is installed", () => {


### PR DESCRIPTION
Follow-up to #161. That PR mirrored rlm-harness [#99](https://github.com/PrimeIntellect-ai/rlm-harness/pull/99) (`1d7831a` — the `%%bash` first-line rule and `edit`-skill guidance) into the coding-agent RLM system prompt, but skipped the other prompt change that landed in rlm-harness the same week: [#93](https://github.com/PrimeIntellect-ai/rlm-harness/pull/93) (`d098d73`).

This adds the missing paragraph to `IPYTHON_CONTROL_PROMPT`, so the two prompts stay aligned:

> Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.

Placed right after the "do not install dependencies into the IPython kernel" paragraph, matching its position in rlm-harness.

## Changes
- `rlm.ts`: add the paragraph to `IPYTHON_CONTROL_PROMPT`.
- `system-prompt.test.ts`: update the full-prompt fixture and add a test asserting the guidance appears when IPython is active.

## Test
`vitest --run test/system-prompt.test.ts` — 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only text in the RLM system message; no runtime, auth, or execution path changes.
> 
> **Overview**
> Adds a missing **IPython control** paragraph to `IPYTHON_CONTROL_PROMPT` so the coding-agent RLM system prompt matches rlm-harness: agents are told to **use Python for reading, searching, and editing files** (reusable variables, slice/filter without re-reading) and to **assign read/search results to named variables**.
> 
> The block sits after the “do not install dependencies into the IPython kernel” guidance and only appears when IPython is an active tool, same as the rest of `IPYTHON_CONTROL_PROMPT`.
> 
> Tests update the full-prompt fixture and add coverage that this guidance is present when `ipython` is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3d4edbc6590e869136354b67208e2716c01b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Python file read/search guidance to the RLM IPython control prompt
> Inserts a new guidance paragraph into `IPYTHON_CONTROL_PROMPT` in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/167/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) advising the agent to use Python for reading, searching, and editing files, and to always assign results to named variables. A corresponding test is added to assert the new lines appear in the built prompt when IPython is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd3d4ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->