### PR TITLE
Align shared RLM prompt sections with rlm-harness

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -16,8 +16,6 @@ const IPYTHON_CONTROL_PROMPT = [
 	"",
 	"When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
 	"",
-	'Project import checks are target-environment checks. If the user asks whether the current project, package, or repository imports from Python, do not run `import <project>` directly in IPython. Use a `%%bash` cell with the target environment, such as `uv run python -c "import <package>"`, `.venv/bin/python -c "import <package>"`, or the documented project command.',
-	"",
 	"Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.",
 	"",
 	"Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.",
@@ -25,8 +23,6 @@ const IPYTHON_CONTROL_PROMPT = [
 	"Each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. Keep dependent shell steps inside one `%%bash` cell when they need shared shell state, or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `%%bash` calls.",
 	"",
 	"Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, notes, parsed outputs, and helper data structures all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.",
-	"",
-	`The kernel has these Python imports available: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}. Import them directly; no pip install needed.`,
 	"",
 	"Global continual harness state is available as `rlm.harness` and `rlm.get_harness_state()`. Use it to record reset-free improvements to prompt notes, memory, reusable skills, and subagent specs that should persist across Prime Agent sessions. Use explicit CRUD calls such as `rlm.harness.create_memory(...)`, `rlm.harness.update_memory(...)`, `rlm.harness.delete_memory(...)`, `rlm.harness.create_skill(...)`, `rlm.harness.update_skill(...)`, `rlm.harness.delete_skill(...)`, `rlm.harness.create_subagent(...)`, `rlm.harness.update_subagent(...)`, `rlm.harness.delete_subagent(...)`, `rlm.harness.create_prompt_note(...)`, `rlm.harness.update_prompt_note(...)`, `rlm.harness.delete_prompt_note(...)`, plus `rlm.harness.record_refinement(...)` and `rlm.harness.overview()`.",
 	"",
@@ -44,8 +40,11 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		"You are a general purpose agent that uses code to solve tasks.",
 		"You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
 		"When you are done, stop calling tools and state your final answer.",
+		"",
 		`Working directory: ${cwd}`,
 		`Conversation log: ${messagesPath}`,
+		`Pre-installed Python packages: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}.`,
+		"Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
 	];
 
 	const skillLines: string[] = [];
@@ -54,13 +53,12 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	}
 	if (installedSkills.length > 0) {
 		const installed = installedSkills.map((skill) => `\`${skill}\``).join(", ");
-		skillLines.push(`Configured Python skills for IPython: ${installed}.`);
+		skillLines.push(`Installed skills (pre-imported): ${installed}.`);
 		skillLines.push(
-			"When available, each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+			"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 		);
-		skillLines.push("If a Python skill is unavailable, calling it raises a RuntimeError with the import error.");
 		skillLines.push(
-			"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
+			"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 		);
 		if (installedSkills.includes("edit")) {
 			skillLines.push(

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -51,21 +51,21 @@ describe("buildRlmPrompt", () => {
 				"You are a general purpose agent that uses code to solve tasks.",
 				"You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
 				"When you are done, stop calling tools and state your final answer.",
+				"",
 				"Working directory: /repo",
 				"Conversation log: /repo/.pi/sessions/session.jsonl",
+				`Pre-installed Python packages: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}.`,
+				"Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
 				"",
-				"Configured Python skills for IPython: `websearch`.",
-				"When available, each Python skill is an async callable by the same import name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
-				"If a Python skill is unavailable, calling it raises a RuntimeError with the import error.",
-				"Each Python skill may also be available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
+				"Installed skills (pre-imported): `websearch`.",
+				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
+				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
 				"IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or compaction.",
 				"",
 				"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 				"",
 				"When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
-				"",
-				'Project import checks are target-environment checks. If the user asks whether the current project, package, or repository imports from Python, do not run `import <project>` directly in IPython. Use a `%%bash` cell with the target environment, such as `uv run python -c "import <package>"`, `.venv/bin/python -c "import <package>"`, or the documented project command.',
 				"",
 				"Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.",
 				"",
@@ -74,8 +74,6 @@ describe("buildRlmPrompt", () => {
 				"Each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. Keep dependent shell steps inside one `%%bash` cell when they need shared shell state, or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `%%bash` calls.",
 				"",
 				"Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, notes, parsed outputs, and helper data structures all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.",
-				"",
-				`The kernel has these Python imports available: ${DEFAULT_RLM_EXTRA_IMPORT_LABELS.join(", ")}. Import them directly; no pip install needed.`,
 				"",
 				"Global continual harness state is available as `rlm.harness` and `rlm.get_harness_state()`. Use it to record reset-free improvements to prompt notes, memory, reusable skills, and subagent specs that should persist across Prime Agent sessions. Use explicit CRUD calls such as `rlm.harness.create_memory(...)`, `rlm.harness.update_memory(...)`, `rlm.harness.delete_memory(...)`, `rlm.harness.create_skill(...)`, `rlm.harness.update_skill(...)`, `rlm.harness.delete_skill(...)`, `rlm.harness.create_subagent(...)`, `rlm.harness.update_subagent(...)`, `rlm.harness.delete_subagent(...)`, `rlm.harness.create_prompt_note(...)`, `rlm.harness.update_prompt_note(...)`, `rlm.harness.delete_prompt_note(...)`, plus `rlm.harness.record_refinement(...)` and `rlm.harness.overview()`.",
 				"",
@@ -360,9 +358,6 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("run_subagent(...)");
 		expect(prompt).toContain("named subagent registries");
 		expect(prompt).toContain("Do not assume IPython is the native runtime");
-		expect(prompt).toContain("Project import checks are target-environment checks");
-		expect(prompt).toContain("do not run `import <project>` directly in IPython");
-		expect(prompt).toContain('uv run python -c "import <package>"');
 		expect(prompt).toContain("do not install dependencies into the IPython kernel");
 		expect(prompt).toContain("run it through that project's own environment");
 		expect(prompt).not.toContain("!cd build && make");
@@ -455,7 +450,7 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt).not.toContain("Configured Python skills for IPython");
+		expect(prompt).not.toContain("Installed skills (pre-imported)");
 		expect(prompt).toContain("<available_skills>");
 		expect(prompt).toContain("<name>websearch</name>");
 		expect(prompt).toContain("<type>markdown</type>");
@@ -470,7 +465,7 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt).toContain("Configured Python skills for IPython: `web_search`.");
+		expect(prompt).toContain("Installed skills (pre-imported): `web_search`.");
 		expect(prompt).toContain("<name>web-search</name>");
 		expect(prompt).toContain("<type>python</type>");
 		expect(prompt).toContain("<python_import>web_search</python_import>");


### PR DESCRIPTION
Stacked on top of #167. Where #167 ported a single missing paragraph, this brings the **sections that prime-agent and rlm-harness intend to share** into exact alignment with rlm-harness ([`src/rlm/prompt.py`](https://github.com/PrimeIntellect-ai/rlm-harness/blob/main/src/rlm/prompt.py)).

> ⚠️ Review #167 first — this PR targets that branch, so the diff here is only the alignment commit.

## What's aligned (prime-agent → rlm-harness)
- **Environment block**
  - Blank line after the role intro (matches rlm-harness spacing).
  - New `Pre-installed Python packages: …` line (uses `DEFAULT_RLM_EXTRA_IMPORT_LABELS`, so it stays accurate to what prime-agent actually installs).
  - New `Install additional packages with \`uv pip install <pkg>\` …` hint.
  - The old `The kernel has these Python imports available: …` line inside the IPython prompt is **removed** — it's the same package list, now surfaced in the env block (matching how rlm-harness does it), so keeping both would duplicate.
- **Skills wording** — matched verbatim to rlm-harness: `Installed skills (pre-imported):`, `Each skill is an async function by the same name.`, `Each skill is also available as a shell command…`. Dropped the prime-agent-only `If a Python skill is unavailable, calling it raises a RuntimeError…` line.
- **Project-import paragraph** — removed (`Project import checks are target-environment checks…`); it has no rlm-harness counterpart.

## Intentionally NOT changed
These are product-specific to prime-agent and were explicitly kept out of scope, so the two prompts remain divergent here by design:
- The continual-harness / refinement system (`rlm.harness` CRUD, "RLM-native call contract…", "Treat harness refinement…").
- The background sub-agent line (`asyncio.create_task(rlm(...))`).
- The kernel-state paragraphs ("Each `%%bash` cell runs in a throw-away subshell…", "Python state in the kernel… persists…").
- rlm-harness's git-history guard (not brought over).

## Tests
`vitest --run test/system-prompt.test.ts` — 15 passed. Updated the full-prompt fixture and the affected `toContain`/`not.toContain` assertions (skills wording, removed project-import paragraph, relocated package list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only text changes in `rlm.ts` and tests; no agent runtime, auth, or tool execution logic is modified.
> 
> **Overview**
> Aligns **prime-agent**’s shared RLM system prompt copy with **rlm-harness** so both stacks describe the same environment and skills contract.
> 
> The **environment block** in `buildRlmPrompt` now adds a blank line after the role intro, lists **pre-installed Python packages** via `DEFAULT_RLM_EXTRA_IMPORT_LABELS`, and documents **`uv pip install`** for extra deps. The duplicate **kernel imports** line is removed from `IPYTHON_CONTROL_PROMPT` so package guidance lives in one place.
> 
> **Skills** wording is updated to rlm-harness phrasing (`Installed skills (pre-imported)`, async **function**, unconditional shell CLI). The prime-agent-only **RuntimeError** note is dropped.
> 
> The **project-import** paragraph (don’t `import <project>` in IPython; use target env via `%%bash`) is **removed** from the IPython section. Tests in `system-prompt.test.ts` match the new fixture and assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9018dd243de1a9b1be6dd235e7d3a34887be5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace goal tools with a kernel host bridge for goal lifecycle management
> - Replaces the dedicated `create_goal`/`get_goal`/`update_goal` tools with a generic `host.request` comm bridge; goals are now created and completed via `goal.create()` / `goal.complete()` Python calls in the IPython kernel.
> - Introduces a new bundled `goal` Python skill ([`skills/goal/src/goal/__init__.py`](https://github.com/PrimeIntellect-ai/prime-agent/pull/168/files#diff-bd071c73661774d8d701254d6367a1fd419fb6f7cc0bb4d274dcc10f7d908988)) that issues typed host requests (`goal.get`, `goal.create`, `goal.complete`) over the bridge.
> - Generalizes `KernelManager` to accept `hostHandlers` (a map of request type → handler) instead of a single `rlmRunHandler`; `rlm.run` is now just one entry in that map.
> - Replaces the `includeGoalTools`/`autoActivateGoalTools` session flags with a single `includeGoals` boolean across all session creation paths.
> - Updates the Python runtime (`rlm/__init__.py`) to send requests over the `host.request` comm target using a public `host_request(type, payload)` function.
> - Risk: callers of `KernelManager`, `createAgentSessionFromServices`, and `IpythonToolOptions` must migrate to the new `hostHandlers`/`includeGoals` API; old fields are removed with no fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf9018d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->