### PR TITLE
space agents view shortcut hints

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1443,7 +1443,7 @@ class AgentsViewMode implements Component, Focusable {
 			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)
-			.join("    ");
+			.join("   ");
 		return truncateToWidth(theme.fg("muted", hints), width);
 	}
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1443,7 +1443,7 @@ class AgentsViewMode implements Component, Focusable {
 			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)
-			.join("  ");
+			.join("    ");
 		return truncateToWidth(theme.fg("muted", hints), width);
 	}
 


### PR DESCRIPTION
- increased spacing between agents view shortcut hint groups so each key/action pair reads as a unit.
- left the underlying keybindings and actions unchanged.
- validated with npm run check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic TUI footer formatting only; no logic, keybindings, or daemon interaction changes.
> 
> **Overview**
> Widens the separator between shortcut hint groups in the **agents view** footer (`renderHints` in `AgentsViewMode`) from two spaces to three, so each key/action pair reads more clearly as its own unit.
> 
> Keybindings and the hints that appear for the current selection are unchanged; only the muted footer line layout is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1518f0f2f2a66bede9d604e2e853244c7ed86b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase spacing between hint segments in agents view status line
> Changes the join separator between hint strings in the agents view from two spaces to three spaces in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/171/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1518f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->