### PR TITLE
fix alt+up/alt+down shortcut in terminals without kitty protocol

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -1043,7 +1043,11 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 
 		case "up":
 			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
+				return (
+					data === "\x1b[1;3A" ||
+					data === "\x1bp" ||
+					matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt)
+				);
 			}
 			if (modifier === 0) {
 				return (
@@ -1058,7 +1062,11 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 
 		case "down":
 			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
+				return (
+					data === "\x1b[1;3B" ||
+					data === "\x1bn" ||
+					matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt)
+				);
 			}
 			if (modifier === 0) {
 				return (

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -481,6 +481,9 @@ describe("matchesKey", () => {
 		it("should match alt+arrows", () => {
 			assert.strictEqual(matchesKey("\x1bp", "alt+up"), true);
 			assert.strictEqual(matchesKey("\x1bp", "up"), false);
+			// Standard xterm CSI modified-arrow sequences (terminals without Kitty protocol)
+			assert.strictEqual(matchesKey("\x1b[1;3A", "alt+up"), true);
+			assert.strictEqual(matchesKey("\x1b[1;3B", "alt+down"), true);
 		});
 
 		it("should match rxvt modifier sequences", () => {


### PR DESCRIPTION
- the shortcut to restore queued messages (alt+up) only worked in terminals that speak the kitty keyboard protocol, so most users on terminal.app, iterm2, and vscode saw nothing happen.
- alt+up and alt+down were missing the standard xterm modified-arrow sequences that alt+left and alt+right already accepted, so those terminals' keypresses went unmatched.
- added the missing sequences and a test so the shortcut works regardless of which keyboard protocol the terminal uses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to legacy key matching in the TUI keys module with regression tests; no auth or data handling impact.
> 
> **Overview**
> **Alt+up** and **alt+down** now match the standard xterm CSI modified-arrow sequences (`\x1b[1;3A` / `\x1b[1;3B`) in `matchesKey`, alongside the existing `\x1bp` / `\x1bn` and Kitty paths—matching what **alt+left** / **alt+right** already accepted.
> 
> That fixes shortcuts such as **restore queued messages** (`alt+up`) and **model reorder** (`alt+down`) on common terminals (Terminal.app, iTerm2, VS Code) that do not use the Kitty keyboard protocol. Unit tests cover the new sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bda3d028094c0b256ee252ef4d1f5ed5094300b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix alt+up/alt+down shortcuts in terminals without kitty protocol
> Adds recognition of standard xterm CSI sequences `\x1b[1;3A` (alt+up) and `\x1b[1;3B` (alt+down) in the `matchesKey` function in [keys.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/174/files#diff-c4967c48e0748404d8098865b5c26f3cde0386f443cdc0876af23a893ce7774a). Previously, only legacy and kitty protocol sequences were matched, so alt+arrow shortcuts failed in terminals that emit standard xterm CSI sequences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bda3d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->