### PR TITLE
daemon: report heartbeat and activity to the orchestrator

### DIFF
--- a/packages/coding-agent/src/modes/daemon/connect-listener.ts
+++ b/packages/coding-agent/src/modes/daemon/connect-listener.ts
@@ -1,0 +1,224 @@
+/**
+ * Token-authenticated TCP entrypoint for cloud agents (Prime Agent Swarm).
+ *
+ * The daemon's JSONL protocol normally rides a local unix socket. For a cloud
+ * agent the daemon also listens on a TCP port that the platform exposes
+ * publicly. TLS is terminated at the exposure edge, so inside the sandbox this
+ * is plain TCP.
+ *
+ * Because the exposed port is public, every connection must authenticate by
+ * sending the short-lived connect token the backend minted as its first line:
+ *
+ *     PRIME-AGENT-CONNECT <jwt>\n
+ *
+ * The token is an RS256 JWT (aud "prime-agent-daemon") verified with the public
+ * key the backend ships into the sandbox. Verified sockets are handed to the
+ * normal daemon connection handler unchanged — the transport stays raw JSONL,
+ * so a future websocket transport can reuse `verifyConnectToken` and the same
+ * handler without touching either.
+ */
+
+import { createPublicKey, verify as cryptoVerify, type KeyObject } from "node:crypto";
+import { createServer, type Server, type Socket } from "node:net";
+
+export const CONNECT_PREFIX = "PRIME-AGENT-CONNECT ";
+export const CONNECT_TOKEN_AUDIENCE = "prime-agent-daemon";
+
+const PREAMBLE_TIMEOUT_MS = 5_000;
+const PREAMBLE_MAX_BYTES = 8 * 1024;
+
+export interface ConnectListenerConfig {
+	port: number;
+	publicKey: string;
+	agentId: string;
+}
+
+export interface ConnectTokenClaims {
+	agent_id: string;
+	sandbox_id?: string;
+	user_id?: string;
+	aud: string;
+	exp: number;
+	iat?: number;
+}
+
+/**
+ * Build connect-listener config from the environment, or null when the daemon
+ * is not a cloud agent (no shipped public key / agent id / daemon port).
+ */
+export function readConnectConfigFromEnv(env: NodeJS.ProcessEnv = process.env): ConnectListenerConfig | null {
+	const port = Number(env.PRIME_AGENT_DAEMON_PORT);
+	const publicKey = env.PRIME_AGENT_CONNECT_PUBLIC_KEY;
+	const agentId = env.PRIME_AGENT_ID;
+	if (!Number.isInteger(port) || port <= 0 || !publicKey || !agentId) {
+		return null;
+	}
+	return { port, publicKey, agentId };
+}
+
+function base64UrlToBuffer(value: string): Buffer {
+	return Buffer.from(value, "base64url");
+}
+
+/**
+ * Verify a connect token. Returns the claims when valid for `agentId`, else
+ * null. RS256 only — any other alg (including "none") is rejected.
+ */
+export function verifyConnectToken(
+	token: string,
+	options: { publicKey: string | KeyObject; agentId: string; now?: number },
+): ConnectTokenClaims | null {
+	const parts = token.split(".");
+	if (parts.length !== 3) {
+		return null;
+	}
+	const [encodedHeader, encodedPayload, encodedSignature] = parts;
+
+	let header: { alg?: string };
+	let claims: ConnectTokenClaims;
+	try {
+		header = JSON.parse(base64UrlToBuffer(encodedHeader).toString("utf8"));
+		claims = JSON.parse(base64UrlToBuffer(encodedPayload).toString("utf8"));
+	} catch {
+		return null;
+	}
+	// Reject anything that isn't RS256 (notably "none") before touching the key.
+	if (header.alg !== "RS256") {
+		return null;
+	}
+
+	let key: KeyObject;
+	try {
+		key = typeof options.publicKey === "string" ? createPublicKey(options.publicKey) : options.publicKey;
+	} catch {
+		return null;
+	}
+
+	const signed = Buffer.from(`${encodedHeader}.${encodedPayload}`);
+	try {
+		if (!cryptoVerify("RSA-SHA256", signed, key, base64UrlToBuffer(encodedSignature))) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	const now = options.now ?? Math.floor(Date.now() / 1000);
+	if (typeof claims.exp !== "number" || claims.exp <= now) {
+		return null;
+	}
+	if (claims.aud !== CONNECT_TOKEN_AUDIENCE) {
+		return null;
+	}
+	if (claims.agent_id !== options.agentId) {
+		return null;
+	}
+	return claims;
+}
+
+/** Read the first newline-delimited line, bounded by size and time. */
+function readPreambleLine(socket: Socket): Promise<{ line: string; rest: Buffer } | null> {
+	return new Promise((resolve) => {
+		const chunks: Buffer[] = [];
+		let total = 0;
+		let settled = false;
+
+		const onData = (chunk: Buffer) => {
+			chunks.push(chunk);
+			total += chunk.length;
+			const buf = Buffer.concat(chunks);
+			const newline = buf.indexOf(0x0a);
+			if (newline !== -1) {
+				let end = newline;
+				if (end > 0 && buf[end - 1] === 0x0d) {
+					end -= 1; // strip a trailing \r
+				}
+				finish({ line: buf.subarray(0, end).toString("utf8"), rest: buf.subarray(newline + 1) });
+			} else if (total > PREAMBLE_MAX_BYTES) {
+				finish(null);
+			}
+		};
+		const onErrorOrClose = () => finish(null);
+		const timer = setTimeout(() => finish(null), PREAMBLE_TIMEOUT_MS);
+		timer.unref?.();
+
+		function finish(result: { line: string; rest: Buffer } | null) {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timer);
+			socket.off("data", onData);
+			socket.off("error", onErrorOrClose);
+			socket.off("close", onErrorOrClose);
+			resolve(result);
+		}
+
+		socket.on("data", onData);
+		socket.on("error", onErrorOrClose);
+		socket.on("close", onErrorOrClose);
+	});
+}
+
+export class DaemonConnectListener {
+	private server?: Server;
+
+	constructor(
+		private readonly config: ConnectListenerConfig,
+		private readonly onAuthenticated: (socket: Socket) => void,
+		private readonly deps: { log?: (message: string) => void } = {},
+	) {}
+
+	start(): void {
+		if (this.server) {
+			return;
+		}
+		this.server = createServer((socket) => void this.handleSocket(socket));
+		this.server.on("error", (error) => this.deps.log?.(`listener error: ${error.message}`));
+		this.server.listen(this.config.port, "0.0.0.0", () => {
+			this.deps.log?.(`connect listener on :${this.config.port}`);
+		});
+	}
+
+	stop(): void {
+		this.server?.close();
+		this.server = undefined;
+	}
+
+	/** Address the server actually bound (useful when started on port 0). */
+	address() {
+		return this.server?.address() ?? null;
+	}
+
+	private async handleSocket(socket: Socket): Promise<void> {
+		const guard = () => socket.destroy();
+		socket.on("error", guard);
+
+		const preamble = await readPreambleLine(socket);
+		if (!preamble || !preamble.line.startsWith(CONNECT_PREFIX)) {
+			this.deps.log?.("rejected connection: missing or malformed preamble");
+			socket.destroy();
+			return;
+		}
+
+		const token = preamble.line.slice(CONNECT_PREFIX.length).trim();
+		const claims = verifyConnectToken(token, {
+			publicKey: this.config.publicKey,
+			agentId: this.config.agentId,
+		});
+		if (!claims) {
+			this.deps.log?.("rejected connection: invalid connect token");
+			socket.destroy();
+			return;
+		}
+
+		// Hand the authenticated socket to the normal daemon handler. Re-queue
+		// any bytes that arrived after the preamble line so the JSONL reader
+		// sees them.
+		socket.off("error", guard);
+		if (preamble.rest.length > 0) {
+			socket.unshift(preamble.rest);
+		}
+		this.onAuthenticated(socket);
+	}
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -63,6 +63,12 @@ import {
 	prepareDaemonSocketPath,
 	restrictDaemonSocketPath,
 } from "./daemon-socket.js";
+import {
+	type AgentActivity,
+	type OrchestratorActivitySnapshot,
+	OrchestratorReporter,
+	readReporterConfigFromEnv,
+} from "./orchestrator-reporter.js";
 
 export interface DaemonModeOptions {
 	socketPath?: string;
@@ -159,6 +165,7 @@ class AgentDaemon {
 	private readonly sessions = new Map<string, ActiveSessionState>();
 	private readonly closingSessions = new Map<string, Promise<void>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
+	private reporter?: OrchestratorReporter;
 
 	constructor(
 		private readonly socketPath: string,
@@ -202,6 +209,46 @@ class AgentDaemon {
 		this.registerSignalHandlers();
 		console.error(`Prime Agent daemon listening on ${this.socketPath}`);
 		void this.restoreActiveSessions();
+		this.startOrchestratorReporting();
+	}
+
+	/**
+	 * When running as a cloud agent (bootstrap env vars present), report
+	 * liveness and activity to the Prime Agent Swarm control plane. No-op for
+	 * local daemons.
+	 */
+	private startOrchestratorReporting(): void {
+		const config = readReporterConfigFromEnv();
+		if (!config) {
+			return;
+		}
+		this.reporter = new OrchestratorReporter(config, () => this.deriveActivity(), {
+			log: (message) => console.error(`[orchestrator] ${message}`),
+		});
+		this.reporter.start();
+	}
+
+	/**
+	 * Collapse the daemon's live sessions into a single control-plane activity.
+	 * Heuristic starting point: any streaming/pending/model/tool session means
+	 * the agent is working; otherwise it is waiting (needs_input) when sessions
+	 * exist, or completed when idle with none.
+	 */
+	private deriveActivity(): OrchestratorActivitySnapshot {
+		const summaries = buildSessionList([...this.sessions.values()], []);
+		const topLevel = summaries.filter((summary) => summary.runtimeKind !== "subagent");
+		const working = summaries.some(
+			(summary) =>
+				summary.isStreaming ||
+				summary.pendingMessageCount > 0 ||
+				summary.status === "model" ||
+				summary.status === "tool",
+		);
+		const status: AgentActivity = working ? "working" : topLevel.length > 0 ? "needs_input" : "completed";
+		return {
+			status,
+			rootAgentSessionId: topLevel[0]?.activeSessionId ?? topLevel[0]?.sessionId,
+		};
 	}
 
 	/**
@@ -1206,6 +1253,7 @@ class AgentDaemon {
 			process.exit(exitCode);
 		}
 		this.shuttingDown = true;
+		this.reporter?.stop();
 
 		for (const cleanup of this.signalCleanupHandlers) {
 			cleanup();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -37,6 +37,7 @@ import {
 	type DaemonSocketClient,
 	resolveActiveSessionState,
 } from "./active-session-state.js";
+import { DaemonConnectListener, readConnectConfigFromEnv } from "./connect-listener.js";
 import { serializeDaemonError } from "./daemon-errors.js";
 import { bindActiveSessionState } from "./daemon-extension-binding.js";
 import {
@@ -166,6 +167,7 @@ class AgentDaemon {
 	private readonly closingSessions = new Map<string, Promise<void>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
 	private reporter?: OrchestratorReporter;
+	private connectListener?: DaemonConnectListener;
 
 	constructor(
 		private readonly socketPath: string,
@@ -210,6 +212,23 @@ class AgentDaemon {
 		console.error(`Prime Agent daemon listening on ${this.socketPath}`);
 		void this.restoreActiveSessions();
 		this.startOrchestratorReporting();
+		this.startConnectListener();
+	}
+
+	/**
+	 * For a cloud agent (connect public key + daemon port shipped in), accept
+	 * token-authenticated TCP connections on the exposed port and hand them to
+	 * the normal daemon handler. No-op for local daemons.
+	 */
+	private startConnectListener(): void {
+		const config = readConnectConfigFromEnv();
+		if (!config) {
+			return;
+		}
+		this.connectListener = new DaemonConnectListener(config, (socket) => this.handleConnection(socket), {
+			log: (message) => console.error(`[connect] ${message}`),
+		});
+		this.connectListener.start();
 	}
 
 	/**
@@ -1254,6 +1273,7 @@ class AgentDaemon {
 		}
 		this.shuttingDown = true;
 		this.reporter?.stop();
+		this.connectListener?.stop();
 
 		for (const cleanup of this.signalCleanupHandlers) {
 			cleanup();

--- a/packages/coding-agent/src/modes/daemon/orchestrator-reporter.ts
+++ b/packages/coding-agent/src/modes/daemon/orchestrator-reporter.ts
@@ -1,0 +1,134 @@
+/**
+ * Reports daemon liveness and agent activity to the Prime Agent Swarm control
+ * plane.
+ *
+ * Active only when the bootstrap environment variables are present — i.e. when
+ * the daemon runs as a cloud agent inside a Prime Sandbox. For a local daemon
+ * the env vars are absent and this is a no-op.
+ *
+ * Contract (backend `prime_agent` module):
+ *   POST {ORCHESTRATOR_URL}/daemon/heartbeat   {protocol_version}
+ *   POST {ORCHESTRATOR_URL}/daemon/status      {status, root_agent_session_id?, protocol_version?}
+ * both authenticated with `Authorization: Bearer <PRIME_AGENT_BOOTSTRAP_TOKEN>`.
+ */
+
+export type AgentActivity = "working" | "needs_input" | "completed";
+
+export interface OrchestratorActivitySnapshot {
+	status: AgentActivity;
+	rootAgentSessionId?: string;
+}
+
+export interface OrchestratorReporterConfig {
+	orchestratorUrl: string;
+	agentId: string;
+	bootstrapToken: string;
+	protocolVersion: string;
+	heartbeatIntervalMs: number;
+}
+
+export interface OrchestratorReporterDeps {
+	fetch?: typeof fetch;
+	log?: (message: string) => void;
+}
+
+const DEFAULT_HEARTBEAT_SECONDS = 30;
+const PROTOCOL_VERSION = "1";
+
+/**
+ * Build reporter config from the environment, or null when the daemon is not
+ * running as a cloud agent (bootstrap vars absent).
+ */
+export function readReporterConfigFromEnv(env: NodeJS.ProcessEnv = process.env): OrchestratorReporterConfig | null {
+	const orchestratorUrl = env.ORCHESTRATOR_URL?.replace(/\/+$/, "");
+	const agentId = env.PRIME_AGENT_ID;
+	const bootstrapToken = env.PRIME_AGENT_BOOTSTRAP_TOKEN;
+	if (!orchestratorUrl || !agentId || !bootstrapToken) {
+		return null;
+	}
+
+	const seconds = Number(env.PRIME_AGENT_HEARTBEAT_SECONDS ?? DEFAULT_HEARTBEAT_SECONDS);
+	const heartbeatSeconds = Number.isFinite(seconds) && seconds > 0 ? seconds : DEFAULT_HEARTBEAT_SECONDS;
+
+	return {
+		orchestratorUrl,
+		agentId,
+		bootstrapToken,
+		protocolVersion: PROTOCOL_VERSION,
+		heartbeatIntervalMs: heartbeatSeconds * 1000,
+	};
+}
+
+export class OrchestratorReporter {
+	private timer: ReturnType<typeof setInterval> | undefined;
+	private lastStatus: AgentActivity | undefined;
+	private lastRootSessionId: string | undefined;
+
+	constructor(
+		private readonly config: OrchestratorReporterConfig,
+		private readonly getSnapshot: () => OrchestratorActivitySnapshot,
+		private readonly deps: OrchestratorReporterDeps = {},
+	) {}
+
+	/** Post an initial status + heartbeat, then heartbeat on an interval. */
+	start(): void {
+		if (this.timer) {
+			return;
+		}
+		void this.tick();
+		this.timer = setInterval(() => void this.tick(), this.config.heartbeatIntervalMs);
+		// A heartbeat loop should not keep the process alive on its own.
+		this.timer.unref?.();
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = undefined;
+		}
+	}
+
+	/** One heartbeat plus a status report if the activity changed. */
+	async tick(): Promise<void> {
+		await this.heartbeat();
+		await this.reportStatus(this.getSnapshot());
+	}
+
+	async heartbeat(): Promise<void> {
+		await this.post("/daemon/heartbeat", { protocol_version: this.config.protocolVersion });
+	}
+
+	/** Post a status update only when it differs from the last reported one. */
+	async reportStatus(snapshot: OrchestratorActivitySnapshot): Promise<void> {
+		if (snapshot.status === this.lastStatus && snapshot.rootAgentSessionId === this.lastRootSessionId) {
+			return;
+		}
+		this.lastStatus = snapshot.status;
+		this.lastRootSessionId = snapshot.rootAgentSessionId;
+		await this.post("/daemon/status", {
+			status: snapshot.status,
+			root_agent_session_id: snapshot.rootAgentSessionId,
+			protocol_version: this.config.protocolVersion,
+		});
+	}
+
+	private async post(path: string, body: unknown): Promise<void> {
+		const doFetch = this.deps.fetch ?? fetch;
+		try {
+			const response = await doFetch(`${this.config.orchestratorUrl}${path}`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${this.config.bootstrapToken}`,
+				},
+				body: JSON.stringify(body),
+			});
+			if (!response.ok) {
+				this.deps.log?.(`${path} -> ${response.status}`);
+			}
+		} catch (error) {
+			// Never let a transient reporting error disrupt the daemon.
+			this.deps.log?.(`${path} failed: ${(error as Error).message}`);
+		}
+	}
+}

--- a/packages/coding-agent/test/connect-listener.test.ts
+++ b/packages/coding-agent/test/connect-listener.test.ts
@@ -1,0 +1,150 @@
+import { sign as cryptoSign, generateKeyPairSync, type KeyObject } from "node:crypto";
+import { connect, type Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	CONNECT_PREFIX,
+	type ConnectListenerConfig,
+	DaemonConnectListener,
+	readConnectConfigFromEnv,
+	verifyConnectToken,
+} from "../src/modes/daemon/connect-listener.js";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const PUBLIC_PEM = publicKey.export({ type: "spki", format: "pem" }).toString();
+
+function b64url(input: Buffer | string): string {
+	return Buffer.from(input).toString("base64url");
+}
+
+function makeToken(claims: Record<string, unknown>, opts: { key?: KeyObject; alg?: string } = {}): string {
+	const header = b64url(JSON.stringify({ alg: opts.alg ?? "RS256", typ: "JWT" }));
+	const payload = b64url(JSON.stringify(claims));
+	const signingInput = `${header}.${payload}`;
+	const signature =
+		opts.alg === "none" ? "" : b64url(cryptoSign("RSA-SHA256", Buffer.from(signingInput), opts.key ?? privateKey));
+	return `${signingInput}.${signature}`;
+}
+
+const future = () => Math.floor(Date.now() / 1000) + 600;
+const validClaims = () => ({ agent_id: "agent-1", sandbox_id: "sb-1", aud: "prime-agent-daemon", exp: future() });
+
+describe("readConnectConfigFromEnv", () => {
+	it("returns null without the cloud-agent env", () => {
+		expect(readConnectConfigFromEnv({})).toBeNull();
+		expect(readConnectConfigFromEnv({ PRIME_AGENT_DAEMON_PORT: "8000", PRIME_AGENT_ID: "a" })).toBeNull();
+	});
+
+	it("builds config when key, port and id are present", () => {
+		const config = readConnectConfigFromEnv({
+			PRIME_AGENT_DAEMON_PORT: "8000",
+			PRIME_AGENT_ID: "agent-1",
+			PRIME_AGENT_CONNECT_PUBLIC_KEY: PUBLIC_PEM,
+		});
+		expect(config).toEqual({ port: 8000, publicKey: PUBLIC_PEM, agentId: "agent-1" });
+	});
+});
+
+describe("verifyConnectToken", () => {
+	const verify = (token: string) => verifyConnectToken(token, { publicKey: PUBLIC_PEM, agentId: "agent-1" });
+
+	it("accepts a valid token", () => {
+		expect(verify(makeToken(validClaims()))?.agent_id).toBe("agent-1");
+	});
+
+	it("rejects a token signed by a different key", () => {
+		const other = generateKeyPairSync("rsa", { modulusLength: 2048 }).privateKey;
+		expect(verify(makeToken(validClaims(), { key: other }))).toBeNull();
+	});
+
+	it("rejects alg=none", () => {
+		expect(verify(makeToken(validClaims(), { alg: "none" }))).toBeNull();
+	});
+
+	it("rejects an expired token", () => {
+		expect(verify(makeToken({ ...validClaims(), exp: Math.floor(Date.now() / 1000) - 5 }))).toBeNull();
+	});
+
+	it("rejects the wrong audience", () => {
+		expect(verify(makeToken({ ...validClaims(), aud: "sandbox-gateway" }))).toBeNull();
+	});
+
+	it("rejects a token for a different agent", () => {
+		expect(verify(makeToken({ ...validClaims(), agent_id: "agent-2" }))).toBeNull();
+	});
+
+	it("rejects malformed tokens", () => {
+		expect(verify("not.a.token")).toBeNull();
+		expect(verify("garbage")).toBeNull();
+	});
+});
+
+describe("DaemonConnectListener", () => {
+	let listener: DaemonConnectListener | undefined;
+	const open: Socket[] = [];
+
+	afterEach(() => {
+		for (const s of open) s.destroy();
+		open.length = 0;
+		listener?.stop();
+		listener = undefined;
+	});
+
+	function startListener(onAuthenticated: (socket: Socket) => void): Promise<number> {
+		const config: ConnectListenerConfig = { port: 0, publicKey: PUBLIC_PEM, agentId: "agent-1" };
+		listener = new DaemonConnectListener(config, onAuthenticated);
+		listener.start();
+		return new Promise((resolve, reject) => {
+			let tries = 0;
+			const poll = () => {
+				const addr = listener?.address();
+				if (addr && typeof addr === "object") return resolve(addr.port);
+				if (tries++ > 50) return reject(new Error("listener did not bind"));
+				setTimeout(poll, 10);
+			};
+			poll();
+		});
+	}
+
+	it("hands a valid connection to the daemon handler with buffered bytes intact", async () => {
+		const received: Buffer[] = [];
+		const port = await startListener((socket) => {
+			socket.on("data", (chunk) => received.push(chunk));
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			const client = connect(port, "127.0.0.1", () => {
+				client.write(`${CONNECT_PREFIX}${makeToken(validClaims())}\n{"id":"1","type":"list"}\n`);
+			});
+			open.push(client);
+			client.on("error", reject);
+			const deadline = setTimeout(() => reject(new Error("no handoff")), 2000);
+			const check = setInterval(() => {
+				if (received.length > 0) {
+					clearInterval(check);
+					clearTimeout(deadline);
+					resolve();
+				}
+			}, 10);
+		});
+
+		expect(Buffer.concat(received).toString("utf8")).toContain('"type":"list"');
+	});
+
+	it("drops a connection with an invalid token", async () => {
+		let handed = false;
+		const port = await startListener(() => {
+			handed = true;
+		});
+
+		await new Promise<void>((resolve) => {
+			const client = connect(port, "127.0.0.1", () => {
+				client.write(`${CONNECT_PREFIX}bad.token.here\n`);
+			});
+			open.push(client);
+			client.on("close", () => resolve());
+			client.on("error", () => resolve());
+		});
+
+		expect(handed).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/orchestrator-reporter.test.ts
+++ b/packages/coding-agent/test/orchestrator-reporter.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	OrchestratorReporter,
+	type OrchestratorReporterConfig,
+	readReporterConfigFromEnv,
+} from "../src/modes/daemon/orchestrator-reporter.js";
+
+const CONFIG: OrchestratorReporterConfig = {
+	orchestratorUrl: "http://backend.test/api/v1/prime-agent",
+	agentId: "agent-1",
+	bootstrapToken: "pa-agent-1.secret",
+	protocolVersion: "1",
+	heartbeatIntervalMs: 30_000,
+};
+
+function fetchSpy() {
+	return vi.fn(async () => new Response(null, { status: 200 }));
+}
+
+function callsTo(fetchMock: ReturnType<typeof fetchSpy>, path: string) {
+	return fetchMock.mock.calls.filter(([url]) => String(url).endsWith(path));
+}
+
+describe("readReporterConfigFromEnv", () => {
+	it("returns null when bootstrap vars are absent", () => {
+		expect(readReporterConfigFromEnv({})).toBeNull();
+		expect(readReporterConfigFromEnv({ ORCHESTRATOR_URL: "http://x", PRIME_AGENT_ID: "a" })).toBeNull();
+	});
+
+	it("builds config and strips a trailing slash from the url", () => {
+		const config = readReporterConfigFromEnv({
+			ORCHESTRATOR_URL: "http://backend.test/api/v1/prime-agent/",
+			PRIME_AGENT_ID: "agent-1",
+			PRIME_AGENT_BOOTSTRAP_TOKEN: "tok",
+			PRIME_AGENT_HEARTBEAT_SECONDS: "10",
+		});
+		expect(config).not.toBeNull();
+		expect(config?.orchestratorUrl).toBe("http://backend.test/api/v1/prime-agent");
+		expect(config?.heartbeatIntervalMs).toBe(10_000);
+	});
+
+	it("falls back to the default interval for bad values", () => {
+		const config = readReporterConfigFromEnv({
+			ORCHESTRATOR_URL: "http://x",
+			PRIME_AGENT_ID: "a",
+			PRIME_AGENT_BOOTSTRAP_TOKEN: "t",
+			PRIME_AGENT_HEARTBEAT_SECONDS: "nonsense",
+		});
+		expect(config?.heartbeatIntervalMs).toBe(30_000);
+	});
+});
+
+describe("OrchestratorReporter", () => {
+	let fetchMock: ReturnType<typeof fetchSpy>;
+
+	beforeEach(() => {
+		fetchMock = fetchSpy();
+	});
+
+	it("heartbeats with the bootstrap token and posts the initial status", async () => {
+		const reporter = new OrchestratorReporter(CONFIG, () => ({ status: "completed" }), { fetch: fetchMock });
+		await reporter.tick();
+
+		const heartbeats = callsTo(fetchMock, "/daemon/heartbeat");
+		const statuses = callsTo(fetchMock, "/daemon/status");
+		expect(heartbeats).toHaveLength(1);
+		expect(statuses).toHaveLength(1);
+
+		const [, init] = heartbeats[0];
+		expect((init?.headers as Record<string, string>).authorization).toBe("Bearer pa-agent-1.secret");
+		expect(JSON.parse(String((statuses[0][1] as RequestInit).body)).status).toBe("completed");
+	});
+
+	it("only re-posts status when the activity changes", async () => {
+		let activity: "working" | "needs_input" | "completed" = "completed";
+		const reporter = new OrchestratorReporter(CONFIG, () => ({ status: activity }), { fetch: fetchMock });
+
+		await reporter.tick(); // completed (initial)
+		await reporter.tick(); // unchanged -> no new status post
+		activity = "working";
+		await reporter.tick(); // changed -> posts
+
+		expect(callsTo(fetchMock, "/daemon/heartbeat")).toHaveLength(3);
+		const statuses = callsTo(fetchMock, "/daemon/status");
+		expect(statuses).toHaveLength(2);
+		expect(JSON.parse(String((statuses[1][1] as RequestInit).body)).status).toBe("working");
+	});
+
+	it("includes the root session id in status updates", async () => {
+		const reporter = new OrchestratorReporter(CONFIG, () => ({ status: "working", rootAgentSessionId: "sess-1" }), {
+			fetch: fetchMock,
+		});
+		await reporter.reportStatus({ status: "working", rootAgentSessionId: "sess-1" });
+
+		const body = JSON.parse(String((callsTo(fetchMock, "/daemon/status")[0][1] as RequestInit).body));
+		expect(body.root_agent_session_id).toBe("sess-1");
+	});
+
+	it("swallows fetch errors so reporting never breaks the daemon", async () => {
+		const failing = vi.fn(async () => {
+			throw new Error("network down");
+		});
+		const logs: string[] = [];
+		const reporter = new OrchestratorReporter(CONFIG, () => ({ status: "completed" }), {
+			fetch: failing,
+			log: (message) => logs.push(message),
+		});
+
+		await expect(reporter.tick()).resolves.toBeUndefined();
+		expect(logs.some((line) => line.includes("failed"))).toBe(true);
+	});
+});


### PR DESCRIPTION
part of prime agent swarm — pairs with the platform control plane (PrimeIntellect-ai/platform#3041).

- when the daemon runs as a cloud agent (PRIME_AGENT_ID / ORCHESTRATOR_URL / PRIME_AGENT_BOOTSTRAP_TOKEN present) it now reports to the control plane: an initial status, a heartbeat every 30s, and an agent-activity update (working / needs_input / completed) whenever the activity changes. no-op for local daemons.
- adds a self-contained OrchestratorReporter (auth via the per-agent bootstrap token, reporting errors swallowed so they never disrupt the daemon), wired into AgentDaemon start/shutdown. activity is derived from the daemon's live session list.
- this replaces the cloud shim that faked these calls in the platform local harness. unit-tested with a stubbed fetch.

note: the activity mapping is a documented starting heuristic. next daemon piece is authenticating the connect token + binding the exposed port. CI pre-commit/check is currently broken repo-wide by leftover .worktrees/*/biome.json configs; biome, tsgo, and vitest were run on the changed files directly and pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report heartbeat and activity status from daemon to orchestrator
> - Adds `OrchestratorReporter` in [orchestrator-reporter.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/175/files#diff-d7779325afb3de1384622fc58905d5ebe94382a2386a481b902f2aad7b206159) that periodically POSTs authenticated heartbeats and status updates to the orchestrator control plane.
> - Config is derived from environment variables (`ORCHESTRATOR_URL`, `PRIME_AGENT_ID`, `PRIME_AGENT_BOOTSTRAP_TOKEN`); reporting is skipped when any are absent.
> - `AgentDaemon` in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/175/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) starts reporting after session restoration and stops it during shutdown.
> - Activity state (`working` | `needs_input` | `completed`) is derived from live sessions: `working` if any session is streaming or processing, `needs_input` if top-level sessions exist but are idle, otherwise `completed`.
> - Redundant status POSTs are suppressed when neither status nor root session ID has changed since the last post.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cf0dd6c. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->