### PR TITLE
add prompt editor redo and clean prompt copy

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -10,7 +10,10 @@ After editing `keybindings.json`, run `/reload` in pi to apply the changes witho
 
 ## Key Format
 
-`modifier+key` where modifiers are `ctrl`, `shift`, `alt` (combinable) and keys are:
+`modifier+key` where modifiers are `ctrl`, `shift`, `alt`, `super` (combinable) and keys are:
+
+`super` is the Command key on macOS and the Windows/Meta key elsewhere. It is only delivered to the terminal when the terminal forwards it (e.g. via the Kitty keyboard protocol); terminals that intercept Command/Meta will not trigger `super` bindings, so a non-`super` fallback is kept where it matters.
+
 
 - **Letters:** `a-z`
 - **Digits:** `0-9`
@@ -64,7 +67,8 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 |--------|---------|-------------|
 | `tui.editor.yank` | `ctrl+y` | Paste most recently deleted text |
 | `tui.editor.yankPop` | `alt+y` | Cycle through deleted text after yank |
-| `tui.editor.undo` | `ctrl+-` | Undo last edit |
+| `tui.editor.undo` | `ctrl+-`, `super+z` | Undo last edit |
+| `tui.editor.redo` | `super+shift+z`, `alt+shift+z` | Redo last undone edit |
 
 ### TUI Clipboard and Selection
 
@@ -89,6 +93,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
+| `app.clipboard.copyPrompt` | `super+c` | Copy the current prompt to the clipboard (plain text, no soft-wrap newlines) |
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -27,6 +27,7 @@ export interface AppKeybindings {
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
+	"app.clipboard.copyPrompt": true;
 	"app.session.new": true;
 	"app.session.tree": true;
 	"app.session.fork": true;
@@ -109,6 +110,10 @@ export const KEYBINDINGS = {
 	"app.clipboard.pasteImage": {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard",
+	},
+	"app.clipboard.copyPrompt": {
+		defaultKeys: "super+c",
+		description: "Copy prompt to clipboard",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },
 	"app.session.tree": { defaultKeys: [], description: "Open session tree" },

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3059,6 +3059,7 @@ export class InteractiveMode {
 		// Register app action handlers
 		this.defaultEditor.onAction("app.clear", () => this.handleCtrlC());
 		this.defaultEditor.onAction("app.interrupt", () => this.handleInterruptKey());
+		this.defaultEditor.onAction("app.clipboard.copyPrompt", () => void this.handleCopyPromptCommand());
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onAction("app.suspend", () => this.handleCtrlZ());
 		this.defaultEditor.onAction("app.thinking.cycle", () => this.cycleThinkingLevel());
@@ -6413,6 +6414,25 @@ export class InteractiveMode {
 		try {
 			await copyToClipboard(text);
 			this.showStatus("Copied last agent message to clipboard");
+		} catch (error) {
+			this.showError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	/**
+	 * Copy the current prompt to the clipboard as plain text. Paste markers are
+	 * expanded and only logical newlines are kept - the cosmetic line breaks
+	 * introduced by terminal soft-wrapping never exist in the editor buffer.
+	 */
+	private async handleCopyPromptCommand(): Promise<void> {
+		const text = this.editor.getExpandedText?.() ?? this.editor.getText();
+		if (!text) {
+			return;
+		}
+
+		try {
+			await copyToClipboard(text);
+			this.showStatus("Copied prompt to clipboard");
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
 		}

--- a/packages/coding-agent/test/custom-editor.test.ts
+++ b/packages/coding-agent/test/custom-editor.test.ts
@@ -106,6 +106,18 @@ describe("CustomEditor", () => {
 		}
 	});
 
+	it("routes Cmd+C to the copy-prompt action without mutating the text", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const handler = vi.fn();
+		editor.onAction("app.clipboard.copyPrompt", handler);
+		editor.setText("hello world");
+
+		editor.handleInput("\x1b[99;9u"); // super+c (Cmd+C)
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("hello world");
+	});
+
 	it("renders no header when the callback returns undefined", () => {
 		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
 		const withoutCallback = editor.render(40);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -282,8 +282,10 @@ export class Editor implements Component, Focusable {
 	// to.
 	private snappedFromCursorCol: number | null = null;
 
-	// Undo support
+	// Undo/redo support. Editing pushes onto undoStack and clears redoStack;
+	// undo moves the current state onto redoStack, redo moves it back.
 	private undoStack = new UndoStack<EditorState>();
+	private redoStack = new UndoStack<EditorState>();
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -653,9 +655,13 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		// Undo
+		// Undo / redo
 		if (kb.matches(data, "tui.editor.undo")) {
 			this.undo();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.redo")) {
+			this.redo();
 			return;
 		}
 
@@ -2031,12 +2037,30 @@ export class Editor implements Component, Focusable {
 
 	private pushUndoSnapshot(): void {
 		this.undoStack.push(this.state);
+		// A fresh edit invalidates the redo future.
+		this.redoStack.clear();
 	}
 
 	private undo(): void {
 		this.historyIndex = -1; // Exit history browsing mode
 		const snapshot = this.undoStack.pop();
 		if (!snapshot) return;
+		// Preserve the pre-undo state so it can be redone.
+		this.redoStack.push(this.state);
+		Object.assign(this.state, snapshot);
+		this.lastAction = null;
+		this.preferredVisualCol = null;
+		if (this.onChange) {
+			this.onChange(this.getText());
+		}
+	}
+
+	private redo(): void {
+		this.historyIndex = -1; // Exit history browsing mode
+		const snapshot = this.redoStack.pop();
+		if (!snapshot) return;
+		// Preserve the pre-redo state so it can be undone again.
+		this.undoStack.push(this.state);
 		Object.assign(this.state, snapshot);
 		this.lastAction = null;
 		this.preferredVisualCol = null;

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -27,6 +27,7 @@ export interface Keybindings {
 	"tui.editor.yank": true;
 	"tui.editor.yankPop": true;
 	"tui.editor.undo": true;
+	"tui.editor.redo": true;
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
@@ -114,7 +115,8 @@ export const TUI_KEYBINDINGS = {
 	},
 	"tui.editor.yank": { defaultKeys: "ctrl+y", description: "Yank" },
 	"tui.editor.yankPop": { defaultKeys: "alt+y", description: "Yank pop" },
-	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo" },
+	"tui.editor.undo": { defaultKeys: ["ctrl+-", "super+z"], description: "Undo" },
+	"tui.editor.redo": { defaultKeys: ["super+shift+z", "alt+shift+z"], description: "Redo" },
 	"tui.input.newLine": { defaultKeys: "shift+enter", description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3831,4 +3831,93 @@ describe("Editor component", () => {
 			assert.strictEqual(submitted, pastedText);
 		});
 	});
+
+	describe("Undo and redo", () => {
+		const UNDO = "\x1f"; // ctrl+-
+		const SUPER_Z = "\x1b[122;9u"; // super+z (Cmd+Z)
+		const SUPER_SHIFT_Z = "\x1b[122;10u"; // super+shift+z (Cmd+Shift+Z)
+
+		function type(editor: Editor, text: string): void {
+			for (const ch of text) editor.handleInput(ch);
+		}
+
+		it("undo reverts a typed word", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "hello");
+			assert.strictEqual(editor.getText(), "hello");
+
+			editor.handleInput(UNDO);
+			assert.strictEqual(editor.getText(), "");
+		});
+
+		it("redo re-applies an undone change", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "hello");
+
+			editor.handleInput(UNDO);
+			assert.strictEqual(editor.getText(), "");
+
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "hello");
+		});
+
+		it("Cmd+Z undoes and Cmd+Shift+Z redoes", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "world");
+
+			editor.handleInput(SUPER_Z);
+			assert.strictEqual(editor.getText(), "");
+
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "world");
+		});
+
+		it("a fresh edit clears the redo future", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "hi");
+
+			editor.handleInput(UNDO);
+			assert.strictEqual(editor.getText(), "");
+
+			type(editor, "x");
+			// Redo must be a no-op now that a new edit invalidated the future.
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "x");
+		});
+
+		it("redo is a no-op when nothing has been undone", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "abc");
+
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "abc");
+		});
+
+		it("undo restores text cleared via setText, and redo clears it again", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			// Simulate Esc-to-clear: parent calls setText("") on a non-empty prompt.
+			editor.setText("draft prompt");
+			editor.setText("");
+			assert.strictEqual(editor.getText(), "");
+
+			editor.handleInput(SUPER_Z);
+			assert.strictEqual(editor.getText(), "draft prompt");
+
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "");
+		});
+
+		it("undo reverts a paste as a single step", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			type(editor, "before ");
+			editor.handleInput("\x1b[200~pasted text\x1b[201~");
+			assert.strictEqual(editor.getText(), "before pasted text");
+
+			editor.handleInput(UNDO);
+			assert.strictEqual(editor.getText(), "before ");
+
+			editor.handleInput(SUPER_SHIFT_Z);
+			assert.strictEqual(editor.getText(), "before pasted text");
+		});
+	});
 });

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -35,4 +35,18 @@ describe("KeybindingsManager", () => {
 		]);
 		assert.deepStrictEqual(keybindings.getKeys("tui.editor.cursorLeft"), ["left", "ctrl+b"]);
 	});
+
+	it("binds Cmd+Z to undo and Cmd+Shift+Z to redo by default", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+
+		assert.deepStrictEqual(keybindings.getKeys("tui.editor.undo"), ["ctrl+-", "super+z"]);
+		assert.deepStrictEqual(keybindings.getKeys("tui.editor.redo"), ["super+shift+z", "alt+shift+z"]);
+	});
+
+	it("matches Cmd+Z / Cmd+Shift+Z kitty sequences to undo / redo", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+
+		assert.ok(keybindings.matches("\x1b[122;9u", "tui.editor.undo"));
+		assert.ok(keybindings.matches("\x1b[122;10u", "tui.editor.redo"));
+	});
 });


### PR DESCRIPTION
- the prompt editor now supports redo (cmd+shift+z) alongside undo, and binds cmd+z to undo so it behaves like a standard text editor; the existing ctrl+- still works on terminals that don't forward the command key.
- pressing esc to clear the prompt is undoable, so cmd+z brings the cleared text back.
- adds cmd+c to copy the current prompt to the clipboard as plain text, keeping real newlines but dropping the cosmetic line breaks the terminal adds for soft-wrapping.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add redo support to the prompt editor and add copy-prompt-to-clipboard action
> - Adds a `redoStack` to [packages/tui/src/components/editor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/176/files#diff-7b6fb102370899178db8d26e334f97123c72bc2127ed9a8d7b4952049b423d42) so undo operations can be reversed with redo; new edits clear the redo history.
> - Binds redo to `super+shift+z` / `alt+shift+z` and extends undo to also accept `super+z` via [packages/tui/src/keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/176/files#diff-37682caae521449d71ec7baf447af9ef6725c48fba2e43a93fbd9661814884be).
> - Adds a new `app.clipboard.copyPrompt` action bound to `super+c` that copies the current prompt text (preferring expanded text) to the clipboard and surfaces success/error status messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dff91e9. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->