### PR TITLE
speed up opening long agent sessions

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1470,13 +1470,22 @@ export class SessionManager {
 	 * @param cwdOverride Optional cwd override instead of the session header cwd.
 	 */
 	static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
-		// Extract cwd from session header if possible, otherwise use process.cwd()
-		const entries = loadEntriesFromFile(path);
-		const header = entries.find((e) => e.type === "session") as SessionHeader | undefined;
-		const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
+		// Only the header's cwd is needed to construct the manager; the constructor
+		// (setSessionFile) performs the full parse. Read just the first line here
+		// instead of parsing the entire file a second time — that double parse is a
+		// needless O(n) cost on open and is noticeable for long sessions.
+		let cwd = cwdOverride;
+		if (!cwd) {
+			try {
+				cwd = readSessionHeader(path)?.cwd;
+			} catch {
+				// Missing or malformed header: fall back to process.cwd(), matching the
+				// previous behavior when loadEntriesFromFile() yielded no session header.
+			}
+		}
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ?? resolve(path, "..");
-		return new SessionManager(cwd, dir, path, true);
+		return new SessionManager(cwd ?? process.cwd(), dir, path, true);
 	}
 
 	/**

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1480,13 +1480,22 @@ export class SessionManager {
 		// instead of parsing the entire file a second time — that double parse is a
 		// needless O(n) cost on open and is noticeable for long sessions.
 		let cwd = cwdOverride;
-		if (!cwd) {
+		if (cwd === undefined) {
+			let header: Partial<SessionHeader> | undefined;
 			try {
-				cwd = readSessionHeader(path)?.cwd;
+				header = readSessionHeader(path);
 			} catch {
-				// Missing or malformed header: fall back to process.cwd(), matching the
-				// previous behavior when loadEntriesFromFile() yielded no session header.
+				header = undefined;
 			}
+			// readSessionHeader only inspects the first physical line. If that isn't a
+			// valid session header (e.g. a leading blank/whitespace or malformed line),
+			// fall back to the full loader, which trims and skips such lines exactly
+			// like setSessionFile does — so this.cwd stays consistent with the header
+			// the session is actually loaded with. This slow path is rare.
+			if (header?.type !== "session" || typeof header.id !== "string") {
+				header = loadEntriesFromFile(path).find((e) => e.type === "session") as SessionHeader | undefined;
+			}
+			cwd = header?.cwd;
 		}
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ?? resolve(path, "..");

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1237,7 +1237,12 @@ export class SessionManager {
 	 * Uses tree traversal from current leaf.
 	 */
 	buildSessionContext(): SessionContext {
-		return buildSessionContext(this.getEntries(), this.leafId, this.byId);
+		// Pass fileEntries directly rather than getEntries(): the resolved context
+		// is computed from the leaf-to-root walk over byId (which already excludes
+		// the header), so the entries argument is only a fallback for an undefined
+		// leaf — never hit here since leafId is always set or null. Avoids an O(n)
+		// array copy on every call (attach, get_session_context, agent init, ...).
+		return buildSessionContext(this.fileEntries as SessionEntry[], this.leafId, this.byId);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -156,7 +156,10 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (this.latestSnapshotIsFresh && this.latestSnapshot) {
 			return this.latestSnapshot;
 		}
-		const [state, messagesData, sessionContextData, sessionTree] = await Promise.all([
+		// The session tree is intentionally not fetched here: it is large on long
+		// sessions and only needed when the user opens the tree/branch selector.
+		// getSessionTree() fetches it lazily via get_session_tree on first use.
+		const [state, messagesData, sessionContextData] = await Promise.all([
 			this.requestData<AgentConnectionState>({
 				type: "get_connection_state",
 				activeSessionId: this.activeSessionId,
@@ -169,10 +172,6 @@ export class DaemonAgentConnection implements AgentConnection {
 				type: "get_session_context",
 				activeSessionId: this.activeSessionId,
 			}),
-			this.requestData<{ tree: AgentConnectionSessionTreeNode[]; leafId: string | null }>({
-				type: "get_session_tree",
-				activeSessionId: this.activeSessionId,
-			}),
 		]);
 		// Children only travel in the attach snapshot; a session event arriving
 		// before the first read marks the cache stale, but the attach-time child
@@ -183,7 +182,6 @@ export class DaemonAgentConnection implements AgentConnection {
 			state,
 			messages: messagesData.messages,
 			sessionContext: sessionContextData.context,
-			sessionTree,
 			...(children ? { children } : {}),
 		};
 		if (this.lastEventSequence !== undefined) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1059,10 +1059,11 @@ class AgentDaemon {
 			state: createAgentConnectionState(state.runtime, state.activeSessionId),
 			messages: state.runtime.session.messages,
 			sessionContext: sessionManager.buildSessionContext(),
-			sessionTree: {
-				tree: sessionManager.getTree(),
-				leafId: sessionManager.getLeafId(),
-			},
+			// The session tree is omitted on purpose: it carries every entry's full
+			// body (tens of MB on long sessions) but is only needed when the user
+			// opens the tree/branch selector. Clients fetch it lazily via
+			// get_session_tree (see DaemonAgentConnection.getSessionTree), keeping
+			// attach cheap regardless of transcript length.
 			lastEventSequence: state.lastEventSequence,
 			...(parent ? { parent } : {}),
 			...(children.length > 0 ? { children } : {}),

--- a/packages/coding-agent/src/modes/rpc/jsonl.ts
+++ b/packages/coding-agent/src/modes/rpc/jsonl.ts
@@ -20,31 +20,51 @@ export function serializeJsonLine(value: unknown): string {
  */
 export function attachJsonlLineReader(stream: Readable, onLine: (line: string) => void): () => void {
 	const decoder = new StringDecoder("utf8");
-	let buffer = "";
+	// Segments of the current, not-yet-terminated line. We never concatenate into a
+	// single growing buffer: appending to one accumulator and rescanning it with
+	// indexOf("\n") on every chunk is O(n^2) when a single record is split across
+	// many socket reads (e.g. a multi-MB attach snapshot arriving in 64KB chunks).
+	// Instead each chunk is scanned once (offset-advancing indexOf) and the segments
+	// are joined exactly once, when the terminating newline arrives.
+	let pending: string[] = [];
 
 	const emitLine = (line: string) => {
 		onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
 	};
 
+	const emitFrom = (segment: string) => {
+		if (pending.length === 0) {
+			emitLine(segment);
+		} else {
+			pending.push(segment);
+			emitLine(pending.join(""));
+			pending = [];
+		}
+	};
+
 	const onData = (chunk: string | Buffer) => {
-		buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
+		const text = typeof chunk === "string" ? chunk : decoder.write(chunk);
 
-		while (true) {
-			const newlineIndex = buffer.indexOf("\n");
-			if (newlineIndex === -1) {
-				return;
-			}
-
-			emitLine(buffer.slice(0, newlineIndex));
-			buffer = buffer.slice(newlineIndex + 1);
+		let start = 0;
+		let newlineIndex = text.indexOf("\n");
+		while (newlineIndex !== -1) {
+			emitFrom(text.slice(start, newlineIndex));
+			start = newlineIndex + 1;
+			newlineIndex = text.indexOf("\n", start);
+		}
+		if (start < text.length) {
+			pending.push(text.slice(start));
 		}
 	};
 
 	const onEnd = () => {
-		buffer += decoder.end();
-		if (buffer.length > 0) {
-			emitLine(buffer);
-			buffer = "";
+		const tail = decoder.end();
+		if (tail.length > 0) {
+			pending.push(tail);
+		}
+		if (pending.length > 0) {
+			emitLine(pending.join(""));
+			pending = [];
 		}
 	};
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -649,7 +649,8 @@ describe("DaemonAgentConnection", () => {
 		await connection.attach();
 		emitSequencedQueueUpdate(fakeClient, "active-1", 13);
 
-		await expect(connection.getInitialSnapshot()).resolves.toMatchObject({
+		const snapshot = await connection.getInitialSnapshot();
+		expect(snapshot).toMatchObject({
 			state: {
 				sessionId: "session-current",
 			},
@@ -657,16 +658,15 @@ describe("DaemonAgentConnection", () => {
 			sessionContext: {
 				messages: [{ role: "user", content: "context prompt", timestamp: 3 }],
 			},
-			sessionTree: {
-				leafId: "user-1",
-			},
 		});
+		// The session tree is fetched lazily (only when the tree/branch selector is
+		// opened), so refreshing the initial snapshot must not request it.
+		expect(snapshot.sessionTree).toBeUndefined();
 		expect(fakeClient.requests.map((request) => request.type)).toEqual([
 			"attach",
 			"get_connection_state",
 			"get_messages",
 			"get_session_context",
-			"get_session_tree",
 		]);
 	});
 

--- a/packages/coding-agent/test/rpc-jsonl.test.ts
+++ b/packages/coding-agent/test/rpc-jsonl.test.ts
@@ -1,6 +1,23 @@
+import { EventEmitter } from "node:events";
+import { performance } from "node:perf_hooks";
 import { Readable } from "node:stream";
 import { describe, expect, test } from "vitest";
 import { attachJsonlLineReader, serializeJsonLine } from "../src/modes/rpc/jsonl.js";
+
+/**
+ * Drive the reader with precise control over chunk boundaries (Readable.from
+ * coalesces chunks at its own discretion, which hides boundary-splitting bugs).
+ */
+function readChunks(chunks: Array<string | Buffer>): string[] {
+	const lines: string[] = [];
+	const emitter = new EventEmitter();
+	attachJsonlLineReader(emitter as unknown as Readable, (line) => lines.push(line));
+	for (const chunk of chunks) {
+		emitter.emit("data", chunk);
+	}
+	emitter.emit("end");
+	return lines;
+}
 
 describe("RPC JSONL framing", () => {
 	test("serializes strict JSONL records without escaping Unicode separators", () => {
@@ -61,5 +78,60 @@ describe("RPC JSONL framing", () => {
 		await done;
 
 		expect(lines).toEqual(['{"a":1}']);
+	});
+
+	test("reassembles a record split across many small chunks", () => {
+		const record = serializeJsonLine({ text: "x".repeat(5000) });
+		const chunks: string[] = [];
+		for (let i = 0; i < record.length; i += 7) {
+			chunks.push(record.slice(i, i + 7));
+		}
+
+		const lines = readChunks(chunks);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ text: "x".repeat(5000) });
+	});
+
+	test("trims CR even when the CRLF straddles a chunk boundary", () => {
+		expect(readChunks(['{"a":1}\r', '\n{"b":2}\r\n'])).toEqual(['{"a":1}', '{"b":2}']);
+	});
+
+	test("emits empty lines for blank records", () => {
+		expect(readChunks(['{"a":1}\n', "\n", '{"b":2}\n'])).toEqual(['{"a":1}', "", '{"b":2}']);
+	});
+
+	test("reassembles a multibyte codepoint split across Buffer chunks", () => {
+		const euro = Buffer.from("€", "utf8"); // E2 82 AC
+		const lines = readChunks([
+			Buffer.from('{"c":"'),
+			euro.subarray(0, 1),
+			euro.subarray(1, 2),
+			euro.subarray(2, 3),
+			Buffer.from('"}\n'),
+		]);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ c: "€" });
+	});
+
+	test("decodes a large single record split into many chunks in linear time", () => {
+		// The previous accumulate-and-rescan reader was O(n^2): an 8MB record in
+		// 16KB chunks took multiple seconds. The linear reader stays well under a
+		// second; the generous threshold catches a quadratic regression.
+		const record = serializeJsonLine({ blob: "y".repeat(8 * 1024 * 1024) });
+		const chunkSize = 16 * 1024;
+		const chunks: string[] = [];
+		for (let i = 0; i < record.length; i += chunkSize) {
+			chunks.push(record.slice(i, i + chunkSize));
+		}
+
+		const start = performance.now();
+		const lines = readChunks(chunks);
+		const elapsed = performance.now() - start;
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0]).blob.length).toBe(8 * 1024 * 1024);
+		expect(elapsed).toBeLessThan(1000);
 	});
 });

--- a/packages/coding-agent/test/session-cwd.test.ts
+++ b/packages/coding-agent/test/session-cwd.test.ts
@@ -54,6 +54,27 @@ describe("session cwd handling", () => {
 		});
 	});
 
+	it("reads the header cwd even when the file starts with a blank line", () => {
+		// open() reads the first physical line for the header, but the full loader
+		// trims and skips leading blank lines. A leading blank line must not make
+		// getCwd() fall back to process.cwd() and disagree with the loaded header.
+		const sessionDir = createTempDir("pi-session-cwd-blank-line");
+		const sessionFile = join(sessionDir, "session.jsonl");
+		cleanupPaths.push(sessionDir);
+		const headerCwd = join(sessionDir, "project");
+		const header = JSON.stringify({
+			type: "session",
+			version: 3,
+			id: "session-id",
+			timestamp: new Date().toISOString(),
+			cwd: headerCwd,
+		});
+		writeFileSync(sessionFile, `\n${header}\n`);
+
+		const sessionManager = SessionManager.open(sessionFile);
+		expect(sessionManager.getCwd()).toBe(headerCwd);
+	});
+
 	it("supports overriding the effective cwd when opening a session", () => {
 		const fallbackCwd = createTempDir("pi-session-cwd-override");
 		const missingCwd = join(fallbackCwd, "does-not-exist");


### PR DESCRIPTION
- opening a long session from the agents view took 2-3 seconds because the client's socket decoder reassembled the incoming snapshot by rescanning a growing buffer on every chunk, which is quadratic for a large single message.
- the decoder now scans each chunk once and joins segments only when a line completes, and the attach snapshot no longer ships the full session tree (tens of mb on long sessions) since it is only needed when the branch view is opened and is already fetched on demand.
- also stopped parsing saved session files twice on open and removed a redundant per-call copy of all entries when building the session context.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up opening long agent sessions by deferring session tree loading and fixing O(n²) line reader
> - `getInitialSnapshot` and the daemon `attach` response no longer include `sessionTree`; clients must fetch it lazily via `get_session_tree`. This avoids transferring a large object on every session open.
> - `SessionManager.open` now reads only the first line via `readSessionHeader` to get `cwd` instead of parsing the full session file twice.
> - `SessionManager.buildSessionContext` passes `this.fileEntries` directly instead of calling `this.getEntries()`, avoiding an O(n) array copy on each call.
> - `attachJsonlLineReader` in [jsonl.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/178/files#diff-304d7897da39bddd729733b2b2f6e50937a73f26f156687c07a7859106eaaca5) is reimplemented to accumulate segments in an array and advance with `indexOf`, reducing large-record processing from O(n²) to O(n).
> - Behavioral Change: callers of `getInitialSnapshot` and `attach` that previously read `sessionTree` from the response will now receive `undefined` and must request the tree separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 875da8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Daemon attach snapshots no longer include sessionTree by default, which can break clients that assumed it on connect; session cwd fast-path adds a fallback but changes open behavior for malformed leading lines.
> 
> **Overview**
> Improves **opening long agent sessions** by cutting redundant work on the client, daemon, and session file paths.
> 
> The daemon **attach / initial snapshot** no longer includes the full **session tree** (often tens of MB). Clients load it on demand via `get_session_tree` when opening the branch/tree UI; `getInitialSnapshot` also stops prefetching the tree after a stale cache refresh.
> 
> **`attachJsonlLineReader`** now scans each socket chunk once and joins line segments only when a newline completes, replacing a growing-buffer rescan that was **quadratic** on large single JSONL records (e.g. multi‑MB attach payloads).
> 
> **`SessionManager.open`** derives `cwd` from the first-line header read instead of parsing the whole JSONL file before the constructor’s full load, with a rare fallback when the first physical line isn’t a valid header (e.g. leading blank line). **`buildSessionContext`** passes `fileEntries` directly to avoid an **O(n)** `getEntries()` copy on hot paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875da8eee5171f76925e8f6adc67a2c381e43726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->