### PR TITLE
render diffs for ipython file edits in the tui

### DIFF
--- a/packages/coding-agent/skills/edit/src/edit/__init__.py
+++ b/packages/coding-agent/skills/edit/src/edit/__init__.py
@@ -44,17 +44,12 @@ async def run(path: str, old_str: str, new_str: str) -> str:
     return f"Edited {path}"
 
 
-# Custom MIME the kernel watches for to render a real diff in the TUI. Keep in
-# sync with DIFF_DISPLAY_MIME in packages/coding-agent/src/core/kernel/index.ts.
+# Keep in sync with DIFF_DISPLAY_MIME in src/core/kernel/index.ts.
 _DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json"
 
 
 def _emit_diff(path: str, old_str: str, new_str: str, start_line: int) -> None:
-    """Stream a structured diff to the host as a ``display_data`` side-effect.
-
-    Best-effort: outside an IPython kernel there is nothing to display, so any
-    failure here is swallowed — the edit itself has already been written.
-    """
+    """Stream a diff to the host via display_data; best-effort outside IPython."""
     try:
         from IPython.display import display
 

--- a/packages/coding-agent/skills/edit/src/edit/__init__.py
+++ b/packages/coding-agent/skills/edit/src/edit/__init__.py
@@ -37,5 +37,38 @@ async def run(path: str, old_str: str, new_str: str) -> str:
             f"found {count} occurrences in {path}, need exactly 1 — "
             "widen the snippet to make it unique"
         )
+    match_index = content.index(old_str)
+    start_line = content.count("\n", 0, match_index) + 1
     filepath.write_text(content.replace(old_str, new_str, 1), encoding="utf-8")
+    _emit_diff(path, old_str, new_str, start_line)
     return f"Edited {path}"
+
+
+# Custom MIME the kernel watches for to render a real diff in the TUI. Keep in
+# sync with DIFF_DISPLAY_MIME in packages/coding-agent/src/core/kernel/index.ts.
+_DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json"
+
+
+def _emit_diff(path: str, old_str: str, new_str: str, start_line: int) -> None:
+    """Stream a structured diff to the host as a ``display_data`` side-effect.
+
+    Best-effort: outside an IPython kernel there is nothing to display, so any
+    failure here is swallowed — the edit itself has already been written.
+    """
+    try:
+        from IPython.display import display
+
+        display(
+            {
+                _DIFF_DISPLAY_MIME: {
+                    "path": path,
+                    "old_str": old_str,
+                    "new_str": new_str,
+                    "start_line": start_line,
+                },
+                "text/plain": f"Edited {path}",
+            },
+            raw=True,
+        )
+    except Exception:
+        pass

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -55,11 +55,7 @@ export interface ExecuteOptions {
 	maxOutputChars?: number;
 }
 
-/**
- * Custom MIME type the `edit` skill uses to stream structured diff data out of
- * the kernel as a `display_data` side-effect, so the TUI can render a real diff
- * instead of the plain "Edited <path>" confirmation text.
- */
+/** MIME tag the `edit` skill emits diff payloads under, via `display_data`. */
 export const DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json";
 
 /** One file edit, captured from a {@link DIFF_DISPLAY_MIME} display payload. */
@@ -76,7 +72,7 @@ export interface ExecuteResult {
 	stderr: string;
 	/** Last `execute_result` payload (text/plain), if the cell produced one. */
 	result?: string;
-	/** Structured diffs emitted via {@link DIFF_DISPLAY_MIME}, in emission order. */
+	/** Diffs emitted via display_data, in order. */
 	diffs?: KernelDiffDisplay[];
 	status: "ok" | "error" | "aborted";
 	error?: { ename: string; evalue: string; traceback: string[] };

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -55,14 +55,44 @@ export interface ExecuteOptions {
 	maxOutputChars?: number;
 }
 
+/**
+ * Custom MIME type the `edit` skill uses to stream structured diff data out of
+ * the kernel as a `display_data` side-effect, so the TUI can render a real diff
+ * instead of the plain "Edited <path>" confirmation text.
+ */
+export const DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json";
+
+/** One file edit, captured from a {@link DIFF_DISPLAY_MIME} display payload. */
+export interface KernelDiffDisplay {
+	path: string;
+	oldStr: string;
+	newStr: string;
+	/** 1-based line where `oldStr` begins in the file, for absolute line numbers. */
+	startLine?: number;
+}
+
 export interface ExecuteResult {
 	stdout: string;
 	stderr: string;
 	/** Last `execute_result` payload (text/plain), if the cell produced one. */
 	result?: string;
+	/** Structured diffs emitted via {@link DIFF_DISPLAY_MIME}, in emission order. */
+	diffs?: KernelDiffDisplay[];
 	status: "ok" | "error" | "aborted";
 	error?: { ename: string; evalue: string; traceback: string[] };
 	durationMs: number;
+}
+
+/** Parse a {@link DIFF_DISPLAY_MIME} payload, tolerating malformed input. */
+function parseDiffDisplay(payload: unknown): KernelDiffDisplay | undefined {
+	if (!isRecord(payload)) {
+		return undefined;
+	}
+	const { path, old_str: oldStr, new_str: newStr, start_line: startLine } = payload;
+	if (typeof path !== "string" || typeof oldStr !== "string" || typeof newStr !== "string") {
+		return undefined;
+	}
+	return { path, oldStr, newStr, startLine: typeof startLine === "number" ? startLine : undefined };
 }
 
 interface ConnectionInfo {
@@ -104,6 +134,7 @@ interface ActiveExecution {
 	stdoutTruncated: boolean;
 	stderrTruncated: boolean;
 	result?: string;
+	diffs: KernelDiffDisplay[];
 	error?: ExecuteResult["error"];
 	status: ExecuteResult["status"];
 	resolve: (result: ExecuteResult) => void;
@@ -576,6 +607,7 @@ export class KernelManager {
 				stderr: "",
 				stdoutTruncated: false,
 				stderrTruncated: false,
+				diffs: [],
 				status: "ok",
 				resolve: result.resolve,
 				reject: result.reject,
@@ -665,6 +697,10 @@ export class KernelManager {
 		} else if (t === "execute_result") {
 			const c = incoming.content as { data: Record<string, string> };
 			if (c.data["text/plain"]) execution.result = c.data["text/plain"];
+		} else if (t === "display_data" || t === "update_display_data") {
+			const c = incoming.content as { data?: Record<string, unknown> };
+			const diff = parseDiffDisplay(c.data?.[DIFF_DISPLAY_MIME]);
+			if (diff) execution.diffs.push(diff);
 		} else if (t === "error") {
 			const c = incoming.content as { ename: string; evalue: string; traceback: string[] };
 			execution.error = c;
@@ -699,6 +735,7 @@ export class KernelManager {
 			stdout,
 			stderr,
 			result,
+			diffs: execution.diffs.length > 0 ? execution.diffs : undefined,
 			error: execution.error,
 			status,
 			durationMs: Date.now() - execution.started,

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -274,8 +274,7 @@ export function generateDiffString(
 
 	const oldLines = oldContent.split("\n");
 	const newLines = newContent.split("\n");
-	// Numbers are offset by startLine so a snippet diff can show absolute file
-	// line numbers; widen the gutter to fit the largest number we'll print.
+	// Offset by startLine so a snippet shows absolute file line numbers.
 	const maxLineNum = startLine - 1 + Math.max(oldLines.length, newLines.length);
 	const lineNumWidth = String(maxLineNum).length;
 

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -267,17 +267,20 @@ export function generateDiffString(
 	oldContent: string,
 	newContent: string,
 	contextLines = 4,
+	startLine = 1,
 ): { diff: string; firstChangedLine: number | undefined } {
 	const parts = Diff.diffLines(oldContent, newContent);
 	const output: string[] = [];
 
 	const oldLines = oldContent.split("\n");
 	const newLines = newContent.split("\n");
-	const maxLineNum = Math.max(oldLines.length, newLines.length);
+	// Numbers are offset by startLine so a snippet diff can show absolute file
+	// line numbers; widen the gutter to fit the largest number we'll print.
+	const maxLineNum = startLine - 1 + Math.max(oldLines.length, newLines.length);
 	const lineNumWidth = String(maxLineNum).length;
 
-	let oldLineNum = 1;
-	let newLineNum = 1;
+	let oldLineNum = startLine;
+	let newLineNum = startLine;
 	let lastWasChange = false;
 	let firstChangedLine: number | undefined;
 

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -124,7 +124,7 @@ export interface IpythonToolDetails {
 	stdout?: string;
 	stderr?: string;
 	result?: string;
-	/** Structured diffs streamed from file edits; rendered by the IPython cell. */
+	/** Diffs streamed from file edits, rendered by the IPython cell. */
 	diffs?: KernelDiffDisplay[];
 	error?: {
 		ename: string;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -3,7 +3,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
-import { type HostRequestHandlers, KernelManager } from "../kernel/index.js";
+import { type HostRequestHandlers, type KernelDiffDisplay, KernelManager } from "../kernel/index.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
@@ -124,6 +124,8 @@ export interface IpythonToolDetails {
 	stdout?: string;
 	stderr?: string;
 	result?: string;
+	/** Structured diffs streamed from file edits; rendered by the IPython cell. */
+	diffs?: KernelDiffDisplay[];
 	error?: {
 		ename: string;
 		evalue: string;
@@ -318,6 +320,7 @@ export function createIpythonToolDefinition(
 						stdout: r.stdout,
 						stderr: r.stderr,
 						result: r.result,
+						diffs: r.diffs,
 						error: r.error,
 					},
 					isError: r.status === "error" || r.status === "aborted",

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -150,10 +150,8 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
 type ThemeBg = Parameters<typeof theme.bg>[0];
 type ThemeColor = Parameters<typeof theme.fg>[0];
 
-// Background-aware syntax highlighting depends on inner color resets clearing
-// only the foreground. Highlighter output (and our own fallbacks) occasionally
-// emit a full reset (\x1b[0m) or a background reset (\x1b[49m); rewrite both to
-// a foreground-only reset so an enclosing background block survives the line.
+// Rewrite full/background resets to foreground-only so a row's background block
+// survives the syntax-highlighted content.
 const BG_CLEARING_RESET = /\x1b\[(?:0|49)m/g;
 
 function keepBackground(highlighted: string): string {
@@ -171,26 +169,17 @@ function highlightContent(content: string, language: string | undefined): string
 }
 
 interface DiffLineSpec {
-	/** Background block filling the row. */
 	bg: ThemeBg;
 	gutter: string;
 	gutterFg: ThemeColor;
 	content: string;
 	language: string | undefined;
 	width: number;
-	/**
-	 * When set, render content in this flat foreground color instead of syntax
-	 * highlighting. Used for added/removed lines in 256-color mode, where a
-	 * background block can't render as a subtle tint.
-	 */
+	/** Flat content color instead of syntax highlighting (256-color fallback). */
 	contentFg?: ThemeColor;
 }
 
-/**
- * Build one diff row that fills `width` exactly, on a single background block so
- * the colored region spans the full content area (Claude Code-style). The
- * caller frames each row with the panel side padding.
- */
+/** Build one diff row filling `width` on a single background block. */
 function buildRichDiffLine(spec: DiffLineSpec): string {
 	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
 	const renderedContent = spec.contentFg
@@ -211,10 +200,7 @@ export interface RichDiffOptions {
 	language?: string;
 }
 
-/**
- * A dim vertical-ellipsis row used to separate non-adjacent hunks of one file's
- * diff (matching the codex `⋮` style), filling `contentWidth` on the panel bg.
- */
+/** A dim `⋮` row separating non-adjacent hunks of one file's diff. */
 export function renderDiffSeparator(contentWidth: number): string {
 	const width = Math.max(1, contentWidth);
 	const marker = theme.fg("toolDiffContext", " ⋮");
@@ -222,16 +208,12 @@ export function renderDiffSeparator(contentWidth: number): string {
 	return theme.bg("toolPanelBg", marker + " ".repeat(pad));
 }
 
-/**
- * Render a unified diff (from {@link generateDiffString}) as full-width rows:
- * added lines on a green block, removed on red, context on the panel
- * background, each syntax-highlighted and exactly `contentWidth` wide.
- */
+/** Render a unified diff as full-width rows: green/red blocks, syntax-highlighted. */
 export function renderRichDiff(diffText: string, contentWidth: number, options: RichDiffOptions = {}): string[] {
 	const width = Math.max(1, contentWidth);
 	const language = options.language;
-	// 256-color terminals can't render the subtle green/red tints — a dark block
-	// quantizes to black. There, drop the block and color the text instead.
+	// 256-color can't render subtle tints (a dark block quantizes to black), so
+	// color the text instead of the background there.
 	const useBlocks = theme.colorMode === "truecolor";
 	const rows: string[] = [];
 

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,5 +1,6 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
-import { theme } from "../theme/theme.js";
+import { highlightCode, theme } from "../theme/theme.js";
 
 /**
  * Parse diff line to extract prefix, line number, and content.
@@ -144,4 +145,137 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
 	}
 
 	return result.join("\n");
+}
+
+type ThemeBg = Parameters<typeof theme.bg>[0];
+type ThemeColor = Parameters<typeof theme.fg>[0];
+
+// Background-aware syntax highlighting depends on inner color resets clearing
+// only the foreground. Highlighter output (and our own fallbacks) occasionally
+// emit a full reset (\x1b[0m) or a background reset (\x1b[49m); rewrite both to
+// a foreground-only reset so an enclosing background block survives the line.
+const BG_CLEARING_RESET = /\x1b\[(?:0|49)m/g;
+
+function keepBackground(highlighted: string): string {
+	return highlighted.replace(BG_CLEARING_RESET, "\x1b[39m");
+}
+
+function highlightContent(content: string, language: string | undefined): string {
+	if (!content) {
+		return "";
+	}
+	if (language) {
+		return keepBackground(highlightCode(content, language)[0] ?? content);
+	}
+	return theme.fg("mdCodeBlock", content);
+}
+
+interface DiffLineSpec {
+	/** Background block filling the row. */
+	bg: ThemeBg;
+	gutter: string;
+	gutterFg: ThemeColor;
+	content: string;
+	language: string | undefined;
+	width: number;
+	/**
+	 * When set, render content in this flat foreground color instead of syntax
+	 * highlighting. Used for added/removed lines in 256-color mode, where a
+	 * background block can't render as a subtle tint.
+	 */
+	contentFg?: ThemeColor;
+}
+
+/**
+ * Build one diff row that fills `width` exactly, on a single background block so
+ * the colored region spans the full content area (Claude Code-style). The
+ * caller frames each row with the panel side padding.
+ */
+function buildRichDiffLine(spec: DiffLineSpec): string {
+	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
+	const renderedContent = spec.contentFg
+		? theme.fg(spec.contentFg, spec.content)
+		: highlightContent(spec.content, spec.language);
+	let inner = `${styledGutter}${renderedContent}\x1b[39m`;
+	const vis = visibleWidth(inner);
+	if (vis > spec.width) {
+		inner = truncateToWidth(inner, spec.width, "");
+	} else if (vis < spec.width) {
+		inner += " ".repeat(spec.width - vis);
+	}
+	return theme.bg(spec.bg, inner);
+}
+
+export interface RichDiffOptions {
+	/** Language id for syntax highlighting the diff content (e.g. "typescript"). */
+	language?: string;
+}
+
+/**
+ * A dim vertical-ellipsis row used to separate non-adjacent hunks of one file's
+ * diff (matching the codex `⋮` style), filling `contentWidth` on the panel bg.
+ */
+export function renderDiffSeparator(contentWidth: number): string {
+	const width = Math.max(1, contentWidth);
+	const marker = theme.fg("toolDiffContext", " ⋮");
+	const pad = Math.max(0, width - visibleWidth(marker));
+	return theme.bg("toolPanelBg", marker + " ".repeat(pad));
+}
+
+/**
+ * Render a unified diff (from {@link generateDiffString}) as full-width rows:
+ * added lines on a green block, removed on red, context on the panel
+ * background, each syntax-highlighted and exactly `contentWidth` wide.
+ */
+export function renderRichDiff(diffText: string, contentWidth: number, options: RichDiffOptions = {}): string[] {
+	const width = Math.max(1, contentWidth);
+	const language = options.language;
+	// 256-color terminals can't render the subtle green/red tints — a dark block
+	// quantizes to black. There, drop the block and color the text instead.
+	const useBlocks = theme.colorMode === "truecolor";
+	const rows: string[] = [];
+
+	for (const rawLine of diffText.split("\n")) {
+		const parsed = parseDiffLine(rawLine);
+		if (!parsed) {
+			rows.push(
+				buildRichDiffLine({ bg: "toolPanelBg", gutterFg: "toolDiffContext", gutter: "", content: replaceTabs(rawLine), language, width }),
+			);
+			continue;
+		}
+		const { prefix, lineNum, content } = parsed;
+		const gutter = `${lineNum} ${prefix === " " ? " " : prefix} `;
+		const text = replaceTabs(content);
+		if (prefix === "+") {
+			rows.push(
+				buildRichDiffLine({
+					bg: useBlocks ? "toolDiffAddedBg" : "toolPanelBg",
+					gutterFg: "toolDiffAdded",
+					gutter,
+					content: text,
+					language,
+					width,
+					contentFg: useBlocks ? undefined : "toolDiffAdded",
+				}),
+			);
+		} else if (prefix === "-") {
+			rows.push(
+				buildRichDiffLine({
+					bg: useBlocks ? "toolDiffRemovedBg" : "toolPanelBg",
+					gutterFg: "toolDiffRemoved",
+					gutter,
+					content: text,
+					language,
+					width,
+					contentFg: useBlocks ? undefined : "toolDiffRemoved",
+				}),
+			);
+		} else {
+			rows.push(
+				buildRichDiffLine({ bg: "toolPanelBg", gutterFg: "toolDiffContext", gutter, content: text, language, width }),
+			);
+		}
+	}
+
+	return rows;
 }

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -186,11 +186,14 @@ function buildRichDiffLine(spec: DiffLineSpec): string {
 		? theme.fg(spec.contentFg, spec.content)
 		: highlightContent(spec.content, spec.language);
 	let inner = `${styledGutter}${renderedContent}\x1b[39m`;
-	const vis = visibleWidth(inner);
-	if (vis > spec.width) {
+	if (visibleWidth(inner) > spec.width) {
 		inner = truncateToWidth(inner, spec.width, "");
-	} else if (vis < spec.width) {
-		inner += " ".repeat(spec.width - vis);
+	}
+	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
+	// the result a cell short.
+	const pad = spec.width - visibleWidth(inner);
+	if (pad > 0) {
+		inner += " ".repeat(pad);
 	}
 	return theme.bg(spec.bg, inner);
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -304,9 +304,7 @@ export class IPythonCellComponent implements Component {
 		const rawLines = code.split("\n");
 		const expanded = this.state.expanded ?? false;
 
-		// When the cell produced edit diffs, the rendered diff below is the
-		// meaningful view — collapse the (often large) raw edit source to a single
-		// expandable bar so the cell isn't dominated by the call arguments.
+		// With a diff to show below, collapse the (often large) edit source to one bar.
 		if (hasDiffs && !expanded) {
 			const label = `${rawLines.length} line${rawLines.length === 1 ? "" : "s"} of source`;
 			this.addWrapped(lines, theme.fg("dim", "› "), withExpandHint(label), width);
@@ -372,8 +370,7 @@ export class IPythonCellComponent implements Component {
 			}
 		};
 
-		// Coalesce multiple edits to the same file into one block (codex-style):
-		// one header per file, individual edits shown as hunks separated by `⋮`.
+		// Group edits by file: one block per file, edits shown as `⋮`-separated hunks.
 		const diffsByPath = new Map<string, DiffDisplay[]>();
 		for (const diff of diffs) {
 			const existing = diffsByPath.get(diff.path);
@@ -481,7 +478,6 @@ export class IPythonCellComponent implements Component {
 		const contentWidth = toolPanelContentWidth(width);
 		const language = getLanguageFromPath(path);
 
-		// Build all hunks for this file, separating non-adjacent edits with `⋮`.
 		const rows: string[] = [];
 		let added = 0;
 		let removed = 0;
@@ -503,8 +499,7 @@ export class IPythonCellComponent implements Component {
 		const expanded = this.state.expanded ?? false;
 		const showCollapsed = !expanded && rows.length > DIFF_PREVIEW_LINES;
 		const visibleRows = showCollapsed ? rows.slice(0, DIFF_PREVIEW_LINES) : rows;
-		// Rich rows already fill the content width with their own background, so
-		// frame them directly with the panel side padding instead of toolPanelLine.
+		// Rows already fill the content width; just add the panel side padding.
 		const sidePad = theme.bg("toolPanelBg", " ".repeat(TOOL_PANEL_PADDING_X));
 		for (const row of visibleRows) {
 			lines.push(sidePad + row + sidePad);

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -1,8 +1,10 @@
 import { type Component, VersionedRenderCache, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import { highlightCode, theme } from "../theme/theme.js";
+import { generateDiffString } from "../../../core/tools/edit-diff.js";
+import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
+import { renderDiffSeparator, renderRichDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
-import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
+import { TOOL_PANEL_PADDING_X, toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
 export interface IPythonCellContentBlock {
 	type: string;
@@ -23,6 +25,13 @@ export interface IPythonCellState {
 	showImages?: boolean;
 }
 
+interface DiffDisplay {
+	path: string;
+	oldStr: string;
+	newStr: string;
+	startLine?: number;
+}
+
 interface IpythonDetails {
 	durationMs?: number;
 	status?: string;
@@ -30,6 +39,7 @@ interface IpythonDetails {
 	stdout?: string;
 	stderr?: string;
 	result?: string;
+	diffs?: DiffDisplay[];
 	error?: IpythonErrorDetails;
 }
 
@@ -52,6 +62,7 @@ const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 
 const OUTPUT_PREVIEW_LINES = 5;
 const INPUT_PREVIEW_LINES = 3;
+const DIFF_PREVIEW_LINES = 12;
 
 export function getIpythonCodeFromArgs(args: unknown): string {
 	if (!args || typeof args !== "object" || !("code" in args)) {
@@ -74,8 +85,54 @@ function readDetails(details: unknown): IpythonDetails {
 		stdout: typeof record.stdout === "string" ? record.stdout : undefined,
 		stderr: typeof record.stderr === "string" ? record.stderr : undefined,
 		result: typeof record.result === "string" ? record.result : undefined,
+		diffs: readDiffDisplays(record.diffs),
 		error,
 	};
+}
+
+function readDiffDisplays(value: unknown): DiffDisplay[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const diffs = value.flatMap((entry): DiffDisplay[] => {
+		if (!entry || typeof entry !== "object") {
+			return [];
+		}
+		const record = entry as Record<string, unknown>;
+		if (typeof record.path !== "string" || typeof record.oldStr !== "string" || typeof record.newStr !== "string") {
+			return [];
+		}
+		return [
+			{
+				path: record.path,
+				oldStr: record.oldStr,
+				newStr: record.newStr,
+				startLine: typeof record.startLine === "number" ? record.startLine : undefined,
+			},
+		];
+	});
+	return diffs.length > 0 ? diffs : undefined;
+}
+
+/** Strip one layer of repr quotes so an `execute_result` string compares cleanly. */
+function stripReprQuotes(text: string): string {
+	const trimmed = text.trim();
+	if (
+		trimmed.length >= 2 &&
+		((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"')))
+	) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+/** True when `text` is just the edit skill's "Edited <path>" confirmation for one of `diffs`. */
+function isEditConfirmation(text: string | undefined, diffs: readonly DiffDisplay[]): boolean {
+	if (!text) {
+		return false;
+	}
+	const stripped = stripReprQuotes(text);
+	return diffs.some((diff) => stripped === `Edited ${diff.path}`);
 }
 
 function readErrorDetails(value: unknown): IpythonErrorDetails | undefined {
@@ -192,8 +249,9 @@ export class IPythonCellComponent implements Component {
 			return `${theme.fg("muted", label)} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
 		};
 
+		const hasDiffs = (details.diffs?.length ?? 0) > 0;
 		lines.push(toolPanelLine(this.header(details), safeWidth));
-		const hasCode = this.renderCode(lines, safeWidth, withExpandHint);
+		const hasCode = this.renderCode(lines, safeWidth, withExpandHint, hasDiffs);
 		this.renderOutput(lines, safeWidth, details, hasCode, withExpandHint);
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
@@ -228,7 +286,12 @@ export class IPythonCellComponent implements Component {
 		return { label: theme.fg("success", "done") };
 	}
 
-	private renderCode(lines: string[], width: number, withExpandHint: ExpandHintFormatter): boolean {
+	private renderCode(
+		lines: string[],
+		width: number,
+		withExpandHint: ExpandHintFormatter,
+		hasDiffs: boolean,
+	): boolean {
 		const code = this.state.code.trimEnd();
 		if (!code) {
 			this.addBlank(lines, width);
@@ -240,6 +303,16 @@ export class IPythonCellComponent implements Component {
 		const isBashCell = CELL_MAGIC_PATTERN.test(code.split("\n")[0] ?? "");
 		const rawLines = code.split("\n");
 		const expanded = this.state.expanded ?? false;
+
+		// When the cell produced edit diffs, the rendered diff below is the
+		// meaningful view — collapse the (often large) raw edit source to a single
+		// expandable bar so the cell isn't dominated by the call arguments.
+		if (hasDiffs && !expanded) {
+			const label = `${rawLines.length} line${rawLines.length === 1 ? "" : "s"} of source`;
+			this.addWrapped(lines, theme.fg("dim", "› "), withExpandHint(label), width);
+			return true;
+		}
+
 		const showCollapsed = !expanded && rawLines.length > INPUT_PREVIEW_LINES;
 		const visibleRawLines = showCollapsed ? rawLines.slice(0, INPUT_PREVIEW_LINES) : rawLines;
 		for (const [index, rawLine] of visibleRawLines.entries()) {
@@ -287,6 +360,8 @@ export class IPythonCellComponent implements Component {
 		let outputStarted = false;
 		let renderedTextOutput = false;
 
+		const diffs = details.diffs ?? [];
+
 		const startOutput = (): void => {
 			if (outputStarted) {
 				return;
@@ -297,8 +372,27 @@ export class IPythonCellComponent implements Component {
 			}
 		};
 
+		// Coalesce multiple edits to the same file into one block (codex-style):
+		// one header per file, individual edits shown as hunks separated by `⋮`.
+		const diffsByPath = new Map<string, DiffDisplay[]>();
+		for (const diff of diffs) {
+			const existing = diffsByPath.get(diff.path);
+			if (existing) existing.push(diff);
+			else diffsByPath.set(diff.path, [diff]);
+		}
+		let fileIndex = 0;
+		for (const [path, edits] of diffsByPath) {
+			startOutput();
+			if (fileIndex > 0) {
+				this.addBlank(lines, width);
+			}
+			fileIndex++;
+			this.renderFileDiff(lines, width, path, edits, withExpandHint);
+			renderedTextOutput = true;
+		}
+
 		if (hasStructuredOutput) {
-			if (details.stdout?.trim()) {
+			if (details.stdout?.trim() && !isEditConfirmation(details.stdout, diffs)) {
 				startOutput();
 				renderedTextOutput = true;
 				this.renderOutputText(lines, width, normalizeErrorDetails(details.stdout), "out", withExpandHint);
@@ -308,7 +402,7 @@ export class IPythonCellComponent implements Component {
 				renderedTextOutput = true;
 				this.renderOutputText(lines, width, normalizeErrorDetails(details.stderr), "err", withExpandHint);
 			}
-			if (details.result?.trim()) {
+			if (details.result?.trim() && !isEditConfirmation(details.result, diffs)) {
 				startOutput();
 				renderedTextOutput = true;
 				this.renderOutputText(lines, width, normalizeErrorDetails(details.result), "out", withExpandHint);
@@ -374,6 +468,50 @@ export class IPythonCellComponent implements Component {
 				? `${imageCount} image${imageCount === 1 ? "" : "s"} rendered below`
 				: `${imageCount} image${imageCount === 1 ? "" : "s"} hidden`;
 			this.addWrapped(lines, "", theme.fg("muted", text), width);
+		}
+	}
+
+	private renderFileDiff(
+		lines: string[],
+		width: number,
+		path: string,
+		edits: readonly DiffDisplay[],
+		withExpandHint: ExpandHintFormatter,
+	): void {
+		const contentWidth = toolPanelContentWidth(width);
+		const language = getLanguageFromPath(path);
+
+		// Build all hunks for this file, separating non-adjacent edits with `⋮`.
+		const rows: string[] = [];
+		let added = 0;
+		let removed = 0;
+		edits.forEach((edit, index) => {
+			const { diff: diffText } = generateDiffString(edit.oldStr, edit.newStr, 4, edit.startLine ?? 1);
+			for (const row of diffText.split("\n")) {
+				if (row.startsWith("+")) added++;
+				else if (row.startsWith("-")) removed++;
+			}
+			if (index > 0) {
+				rows.push(renderDiffSeparator(contentWidth));
+			}
+			rows.push(...renderRichDiff(diffText, contentWidth, { language }));
+		});
+
+		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
+		this.addWrapped(lines, "", `${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
+
+		const expanded = this.state.expanded ?? false;
+		const showCollapsed = !expanded && rows.length > DIFF_PREVIEW_LINES;
+		const visibleRows = showCollapsed ? rows.slice(0, DIFF_PREVIEW_LINES) : rows;
+		// Rich rows already fill the content width with their own background, so
+		// frame them directly with the panel side padding instead of toolPanelLine.
+		const sidePad = theme.bg("toolPanelBg", " ".repeat(TOOL_PANEL_PADDING_X));
+		for (const row of visibleRows) {
+			lines.push(sidePad + row + sidePad);
+		}
+		if (showCollapsed) {
+			const hidden = rows.length - DIFF_PREVIEW_LINES;
+			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -16,6 +16,8 @@
 		"toolPendingBg": "#282832",
 		"toolSuccessBg": "#283228",
 		"toolErrorBg": "#3c2828",
+		"toolDiffAddedBg": "#015f00",
+		"toolDiffRemovedBg": "#5e0000",
 		"customMsgBg": "#2d2838"
 	},
 	"colors": {
@@ -40,6 +42,8 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolDiffAddedBg": "toolDiffAddedBg",
+		"toolDiffRemovedBg": "toolDiffRemovedBg",
 		"toolPanelBg": "#262630",
 		"toolTitle": "",
 		"toolOutput": "gray",
@@ -55,8 +59,8 @@
 		"mdHr": "gray",
 		"mdListBullet": "accent",
 
-		"toolDiffAdded": "green",
-		"toolDiffRemoved": "red",
+		"toolDiffAdded": "#3fb950",
+		"toolDiffRemoved": "#f85149",
 		"toolDiffContext": "gray",
 
 		"syntaxComment": "#6A9955",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -15,6 +15,8 @@
 		"toolPendingBg": "#e8e8f0",
 		"toolSuccessBg": "#e8f0e8",
 		"toolErrorBg": "#f0e8e8",
+		"toolDiffAddedBg": "#dafbe1",
+		"toolDiffRemovedBg": "#ffebe9",
 		"customMsgBg": "#ede7f6"
 	},
 	"colors": {
@@ -39,6 +41,8 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolDiffAddedBg": "toolDiffAddedBg",
+		"toolDiffRemovedBg": "toolDiffRemovedBg",
 		"toolPanelBg": "#ededf2",
 		"toolTitle": "",
 		"toolOutput": "mediumGray",

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -23,7 +23,9 @@
 		"customMsgBg": "#151518",
 		"toolPendingBg": "#101015",
 		"toolSuccessBg": "#0e1510",
-		"toolErrorBg": "#1a0d12"
+		"toolErrorBg": "#1a0d12",
+		"toolDiffAddedBg": "#015f00",
+		"toolDiffRemovedBg": "#5e0000"
 	},
 	"colors": {
 		"accent": "primary",
@@ -46,6 +48,8 @@
 		"toolPendingBg": "toolPendingBg",
 		"toolSuccessBg": "toolSuccessBg",
 		"toolErrorBg": "toolErrorBg",
+		"toolDiffAddedBg": "toolDiffAddedBg",
+		"toolDiffRemovedBg": "toolDiffRemovedBg",
 		"toolPanelBg": "surface",
 		"toolTitle": "",
 		"toolOutput": "muted",
@@ -59,8 +63,8 @@
 		"mdQuoteBorder": "grid",
 		"mdHr": "grid",
 		"mdListBullet": "muted",
-		"toolDiffAdded": "success",
-		"toolDiffRemoved": "error",
+		"toolDiffAdded": "#3fb950",
+		"toolDiffRemoved": "#f85149",
 		"toolDiffContext": "muted",
 		"syntaxComment": "muted",
 		"syntaxKeyword": "info",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -55,6 +55,8 @@
 				"toolPendingBg",
 				"toolSuccessBg",
 				"toolErrorBg",
+				"toolDiffAddedBg",
+				"toolDiffRemovedBg",
 				"toolPanelBg",
 				"toolTitle",
 				"toolOutput",
@@ -168,6 +170,14 @@
 				"toolErrorBg": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Tool execution box (error state)"
+				},
+				"toolDiffAddedBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Diff added-line background block"
+				},
+				"toolDiffRemovedBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Diff removed-line background block"
 				},
 				"toolPanelBg": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -212,10 +212,8 @@ function detectColorMode(): ColorMode {
 	if (process.env.TERM_PROGRAM === "Apple_Terminal") {
 		return "256color";
 	}
-	// tmux reports TERM as "screen*"/"tmux*" but forwards 24-bit color to the
-	// outer terminal when it supports it (and downsamples otherwise), so treat a
-	// tmux session as truecolor-capable. Only genuine GNU screen (STY set, no
-	// TMUX) lacks truecolor and must fall back.
+	// tmux reports TERM=screen* but forwards 24-bit color, so treat it as
+	// truecolor-capable; only genuine GNU screen (no $TMUX) falls back.
 	const inTmux = process.env.TMUX !== undefined || term.startsWith("tmux");
 	if (!inTmux && (term === "screen" || term.startsWith("screen-") || term.startsWith("screen."))) {
 		return "256color";
@@ -403,7 +401,7 @@ export class Theme {
 		return `${ansi}${text}\x1b[49m`; // Reset only background color
 	}
 
-	/** Active color depth. 256-color terminals can't render subtle background tints. */
+	/** Active color depth (truecolor vs 256color). */
 	get colorMode(): ColorMode {
 		return this.mode;
 	}

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -58,6 +58,8 @@ const ThemeJsonSchema = Type.Object({
 		toolPendingBg: ColorValueSchema,
 		toolSuccessBg: ColorValueSchema,
 		toolErrorBg: ColorValueSchema,
+		toolDiffAddedBg: ColorValueSchema,
+		toolDiffRemovedBg: ColorValueSchema,
 		toolPanelBg: ColorValueSchema,
 		toolTitle: ColorValueSchema,
 		toolOutput: ColorValueSchema,
@@ -175,6 +177,8 @@ export type ThemeBg =
 	| "toolPendingBg"
 	| "toolSuccessBg"
 	| "toolErrorBg"
+	| "toolDiffAddedBg"
+	| "toolDiffRemovedBg"
 	| "toolPanelBg";
 
 type ColorMode = "truecolor" | "256color";
@@ -208,9 +212,12 @@ function detectColorMode(): ColorMode {
 	if (process.env.TERM_PROGRAM === "Apple_Terminal") {
 		return "256color";
 	}
-	// GNU screen doesn't support truecolor unless explicitly opted in via COLORTERM=truecolor.
-	// TERM under screen is typically "screen", "screen-256color", or "screen.xterm-256color".
-	if (term === "screen" || term.startsWith("screen-") || term.startsWith("screen.")) {
+	// tmux reports TERM as "screen*"/"tmux*" but forwards 24-bit color to the
+	// outer terminal when it supports it (and downsamples otherwise), so treat a
+	// tmux session as truecolor-capable. Only genuine GNU screen (STY set, no
+	// TMUX) lacks truecolor and must fall back.
+	const inTmux = process.env.TMUX !== undefined || term.startsWith("tmux");
+	if (!inTmux && (term === "screen" || term.startsWith("screen-") || term.startsWith("screen."))) {
 		return "256color";
 	}
 	// Assume truecolor for everything else - virtually all modern terminals support it
@@ -394,6 +401,11 @@ export class Theme {
 		const ansi = this.bgColors.get(color);
 		if (!ansi) throw new Error(`Unknown theme background color: ${color}`);
 		return `${ansi}${text}\x1b[49m`; // Reset only background color
+	}
+
+	/** Active color depth. 256-color terminals can't render subtle background tints. */
+	get colorMode(): ColorMode {
+		return this.mode;
 	}
 
 	getEditorBackgroundColor(): ((str: string) => string) | undefined {
@@ -668,6 +680,8 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 		"toolPendingBg",
 		"toolSuccessBg",
 		"toolErrorBg",
+		"toolDiffAddedBg",
+		"toolDiffRemovedBg",
 		"toolPanelBg",
 	]);
 	for (const [key, value] of Object.entries(resolvedColors)) {

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -52,6 +53,23 @@ describe("IPythonCellComponent diff rendering", () => {
 		}).render(72);
 		// Every rendered line is exactly the panel width (no ragged backgrounds).
 		expect(out.every((line) => stripAnsi(line).length === 72)).toBe(true);
+	});
+
+	it("keeps full width when a wide character straddles the truncation boundary", () => {
+		// CJK chars are 2 cells wide; a narrow render forces truncation mid-character.
+		const wide = "値".repeat(60);
+		const out = new IPythonCellComponent({
+			code: "await edit(...)",
+			details: {
+				status: "ok",
+				diffs: [{ path: "a.py", oldStr: "x = 1", newStr: `x = "${wide}"`, startLine: 1 }],
+			},
+			executionStarted: true,
+			argsComplete: true,
+			expanded: true,
+		}).render(40);
+		// Measure display cells, not code units (CJK chars are 2 cells wide).
+		expect(out.every((line) => visibleWidth(line) === 40)).toBe(true);
 	});
 
 	it("collapses a long diff and shows an expand hint", () => {

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -1,0 +1,123 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderCell(state: ConstructorParameters<typeof IPythonCellComponent>[0]): string {
+	return stripAnsi(new IPythonCellComponent(state).render(80).join("\n"));
+}
+
+describe("IPythonCellComponent diff rendering", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("renders a streamed diff with absolute line numbers and suppresses the Edited confirmation", () => {
+		const out = renderCell({
+			code: 'await edit(path="sample.py", old_str="gamma", new_str="GAMMA")',
+			details: {
+				status: "ok",
+				durationMs: 12,
+				// IPython reprs the returned string, so the confirmation arrives quoted.
+				result: "'Edited sample.py'",
+				diffs: [{ path: "sample.py", oldStr: "alpha\ngamma\ndelta", newStr: "alpha\nGAMMA\ndelta", startLine: 10 }],
+			},
+			executionStarted: true,
+			argsComplete: true,
+		});
+
+		// Header carries the path and the +/- line counts.
+		expect(out).toContain("edit sample.py");
+		expect(out).toMatch(/\+1\s+-1/);
+		// Removed line keeps the old line number + content; added line the new one.
+		expect(out).toMatch(/11 -.*gamma/);
+		expect(out).toMatch(/11 \+.*GAMMA/);
+		expect(out).toMatch(/10 .*alpha/);
+		// The redundant "Edited sample.py" confirmation must not render as its own line.
+		expect(out.split("\n").some((line) => /^\s*'?Edited sample\.py'?\s*$/.test(line.trim()))).toBe(false);
+	});
+
+	it("pads every diff row to the full content width on a single background block", () => {
+		const out = new IPythonCellComponent({
+			code: "await edit(...)",
+			details: {
+				status: "ok",
+				diffs: [{ path: "sample.py", oldStr: "alpha\ngamma\ndelta", newStr: "alpha\nGAMMA\ndelta", startLine: 1 }],
+			},
+			executionStarted: true,
+			argsComplete: true,
+		}).render(72);
+		// Every rendered line is exactly the panel width (no ragged backgrounds).
+		expect(out.every((line) => stripAnsi(line).length === 72)).toBe(true);
+	});
+
+	it("collapses a long diff and shows an expand hint", () => {
+		const oldStr = Array.from({ length: 30 }, (_, i) => `row ${i}`).join("\n");
+		const newStr = oldStr
+			.split("\n")
+			.map((line, i) => (i % 2 === 0 ? line.toUpperCase() : line))
+			.join("\n");
+
+		const collapsed = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", durationMs: 9, diffs: [{ path: "big.py", oldStr, newStr, startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+		expect(collapsed).toMatch(/\+\d+ lines/);
+
+		const expanded = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", durationMs: 9, diffs: [{ path: "big.py", oldStr, newStr, startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: true,
+		});
+		expect(expanded).not.toMatch(/\+\d+ lines/);
+	});
+
+	it("renders multiple diffs from a single cell", () => {
+		const out = renderCell({
+			code: "await edit(...); await edit(...)",
+			details: {
+				status: "ok",
+				durationMs: 5,
+				diffs: [
+					{ path: "a.py", oldStr: "one", newStr: "ONE", startLine: 1 },
+					{ path: "b.py", oldStr: "two", newStr: "TWO", startLine: 2 },
+				],
+			},
+			executionStarted: true,
+			argsComplete: true,
+		});
+		expect(out).toContain("edit a.py");
+		expect(out).toContain("edit b.py");
+	});
+
+	it("coalesces multiple edits to one file into a single block with hunk separators", () => {
+		const out = renderCell({
+			code: "await edit(...); await edit(...); await edit(...)",
+			expanded: true,
+			details: {
+				status: "ok",
+				diffs: [
+					{ path: "app.py", oldStr: "a = 1", newStr: "a = 2", startLine: 1 },
+					{ path: "app.py", oldStr: "b = 1", newStr: "b = 2", startLine: 50 },
+					{ path: "app.py", oldStr: "c = 1", newStr: "c = 2", startLine: 90 },
+				],
+			},
+			executionStarted: true,
+			argsComplete: true,
+		});
+		// One consolidated header for the file, with summed counts.
+		expect(out.split("\n").filter((l) => l.includes("edit app.py")).length).toBe(1);
+		expect(out).toMatch(/edit app\.py\s+\+3\s+-3/);
+		// Non-adjacent hunks are separated by the vertical-ellipsis marker.
+		expect(out).toContain("⋮");
+		expect((out.match(/⋮/g) ?? []).length).toBe(2);
+	});
+});


### PR DESCRIPTION
- the agent edits files through the python edit skill, but those edits only surfaced as a plain "edited <path>" line with no visual diff.
- the skill now streams structured diff data out of the kernel and the ipython cell renders it as a syntax-highlighted diff with green/red background blocks in truecolor terminals, falling back to colored text where backgrounds can't render.
- multiple edits to the same file are coalesced into one block with hunk separators, and the raw edit source collapses to a single expandable bar to cut clutter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive UI and display plumbing only; no changes to how files are written or to auth/security paths.
> 
> **Overview**
> IPython file edits via the Python `edit` skill now show **visual diffs** in the TUI instead of only a plain `Edited <path>` line.
> 
> The skill streams structured edit payloads over Jupyter `display_data` (`application/vnd.prime-agent.diff+json` with path, old/new snippet, and 1-based `start_line`). The kernel collects these into `ExecuteResult.diffs`, and the ipython tool forwards them to **`IPythonCellComponent`**, which groups edits per file, renders unified hunks with **absolute line numbers**, `+/-` counts, syntax highlighting, and `⋮` separators between distant hunks. Redundant `Edited <path>` stdout/result text is hidden when a diff is shown; large edit source collapses to one expandable bar.
> 
> **`renderRichDiff`** adds full-width green/red rows (background blocks on truecolor, tinted text on 256-color). Themes gain `toolDiffAddedBg` / `toolDiffRemovedBg`; **`detectColorMode`** treats tmux as truecolor-capable when `TERM=screen*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad6f564cedd134b61422caf7104e4e7c13812d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render inline diffs for IPython file edits in the TUI
> - The `edit` skill emits a `display_data` event with a `application/vnd.prime-agent.diff+json` MIME payload after each file edit, carrying path, old/new strings, and start line.
> - The kernel manager collects these payloads during execution and attaches them as a `diffs` array on the `ExecuteResult`, which the IPython tool forwards in its details.
> - The TUI cell renderer in [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/179/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) groups diffs by file, renders them with absolute line numbers, syntax highlighting, and background color blocks, and suppresses redundant `Edited <path>` text outputs when a diff is already shown.
> - `generateDiffString` gains an optional `startLine` parameter so displayed line numbers are absolute within the file.
> - Adds `toolDiffAddedBg` / `toolDiffRemovedBg` background color tokens to all three themes (dark, light, prime) and fixes truecolor detection under tmux when `TERM=screen*`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ad6f56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->