### PR TITLE
preserve ipython kernel state across session resume

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -194,7 +194,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			targetSessionFile,
 		});
 		this.beforeSessionInvalidate?.();
-		this.session.dispose();
+		// Await the kernel's final snapshot flush before invalidating the session.
+		await this.session.disposeAsync();
 		await this.disposeHostedSubagentRuntimes();
 	}
 
@@ -531,7 +532,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			disposeError ??= error;
 		}
 		try {
-			this.session.dispose();
+			// Await the kernel's final snapshot flush before tearing the session down.
+			await this.session.disposeAsync();
 		} catch (error) {
 			disposeError ??= error;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -114,7 +114,7 @@ import {
 	validateGoalObjective,
 } from "./goals.js";
 import type { HostRequestHandlers } from "./kernel/index.js";
-import type { RestoreResult } from "./kernel/state-snapshot.js";
+import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -694,6 +694,8 @@ export class AgentSession {
 	private _extensionErrorUnsubscriber?: () => void;
 	private _disposed = false;
 	private _ipythonKernelProvisioner?: IpythonKernelProvisioner;
+	/** Artifact dir backing the current provisioner's kernel snapshot, if any. */
+	private _ipythonKernelSnapshotDir?: string;
 	private readonly _prewarmIpythonKernel: boolean;
 	private _rlmDepth: number;
 	private _rlmMaxDepth: number;
@@ -3443,12 +3445,13 @@ export class AgentSession {
 			// Rebuilding (e.g. /reload) replaces the provisioner; drop the previous
 			// kernel so the session never holds two live kernels.
 			void this._ipythonKernelProvisioner?.dispose();
+			this._ipythonKernelSnapshotDir = this.sessionManager.getSessionArtifactDir();
 			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
 				env: this._rlmKernelEnv(),
 				sessionId: this.sessionId,
 				hostHandlers: this._createKernelHostHandlers(),
 				pythonSkills,
-				snapshotDir: this.sessionManager.getSessionArtifactDir(),
+				snapshotDir: this._ipythonKernelSnapshotDir,
 				onRestore: (result) => this._onIpythonStateRestored(result),
 			});
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {
@@ -3492,7 +3495,13 @@ export class AgentSession {
 			includeAllExtensionTools: options.includeAllExtensionTools,
 		});
 
-		if (this._prewarmIpythonKernel && this.getActiveToolNames().includes("ipython")) {
+		// Prewarm when configured, or whenever we're resuming a session that already
+		// has a kernel snapshot — so its state is revived and the model is told what
+		// came back before the first turn, rather than a turn later when the kernel
+		// would otherwise lazily start on first use.
+		const hasSnapshot =
+			!!this._ipythonKernelSnapshotDir && existsSync(snapshotPathIn(this._ipythonKernelSnapshotDir));
+		if ((this._prewarmIpythonKernel || hasSnapshot) && this.getActiveToolNames().includes("ipython")) {
 			this._ipythonKernelProvisioner?.prewarm();
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2576,7 +2576,9 @@ export class AgentSession {
 				`Your IPython kernel state was revived from your previous session. These names are available again: ${result.restored.join(", ")}.`,
 			);
 		} else {
-			lines.push("Your IPython kernel was restarted and its previous state could not be revived.");
+			lines.push(
+				"Your previous IPython kernel state could not be revived; the kernel is starting fresh, so re-create any variables, imports, or loaded data you need.",
+			);
 		}
 		if (result.failed.length > 0) {
 			lines.push(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3443,8 +3443,10 @@ export class AgentSession {
 			);
 		} else {
 			// Rebuilding (e.g. /reload) replaces the provisioner; drop the previous
-			// kernel so the session never holds two live kernels.
-			void this._ipythonKernelProvisioner?.dispose();
+			// kernel so the session never holds two live kernels. Gate the new kernel's
+			// startup on the old one's dispose (which flushes a final snapshot), so a
+			// reload can't restore from a snapshot the old kernel is still writing.
+			const previousDispose = this._ipythonKernelProvisioner?.dispose();
 			this._ipythonKernelSnapshotDir = this.sessionManager.getSessionArtifactDir();
 			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
 				env: this._rlmKernelEnv(),
@@ -3452,6 +3454,7 @@ export class AgentSession {
 				hostHandlers: this._createKernelHostHandlers(),
 				pythonSkills,
 				snapshotDir: this._ipythonKernelSnapshotDir,
+				readyGate: previousDispose,
 				onRestore: (result) => this._onIpythonStateRestored(result),
 			});
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3446,6 +3446,7 @@ export class AgentSession {
 				sessionId: this.sessionId,
 				hostHandlers: this._createKernelHostHandlers(),
 				pythonSkills,
+				snapshotDir: this.sessionManager.getSessionArtifactDir(),
 				onRestore: (result) => this._onIpythonStateRestored(result),
 			});
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -114,6 +114,7 @@ import {
 	validateGoalObjective,
 } from "./goals.js";
 import type { HostRequestHandlers } from "./kernel/index.js";
+import type { RestoreResult } from "./kernel/state-snapshot.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -2563,6 +2564,36 @@ export class AgentSession {
 		await this._ipythonKernelProvisioner?.restart();
 	}
 
+	/**
+	 * Tell the model when a resumed session revived its IPython kernel state, so it
+	 * knows which variables are actually available instead of assuming the kernel is
+	 * the one it left. Delivered as context before the next turn.
+	 */
+	private _onIpythonStateRestored(result: RestoreResult): void {
+		const lines = ["<ipython_state_restored>"];
+		if (result.restored.length > 0) {
+			lines.push(
+				`Your IPython kernel state was revived from your previous session. These names are available again: ${result.restored.join(", ")}.`,
+			);
+		} else {
+			lines.push("Your IPython kernel was restarted and its previous state could not be revived.");
+		}
+		if (result.failed.length > 0) {
+			lines.push(
+				`These could not be restored and must be recreated if needed: ${result.failed.map((f) => f.name).join(", ")}.`,
+			);
+		}
+		lines.push("</ipython_state_restored>");
+		void this.sendCustomMessage(
+			{
+				customType: "ipython_state_restored",
+				content: lines.join("\n"),
+				display: false,
+			},
+			{ deliverAs: "nextTurn" },
+		).catch(() => {});
+	}
+
 	// =========================================================================
 	// Queue Mode Management
 	// =========================================================================
@@ -3415,6 +3446,7 @@ export class AgentSession {
 				sessionId: this.sessionId,
 				hostHandlers: this._createKernelHostHandlers(),
 				pythonSkills,
+				onRestore: (result) => this._onIpythonStateRestored(result),
 			});
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {
 				ipython: { provisioner: this._ipythonKernelProvisioner },

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -696,6 +696,8 @@ export class AgentSession {
 	private _ipythonKernelProvisioner?: IpythonKernelProvisioner;
 	/** Artifact dir backing the current provisioner's kernel snapshot, if any. */
 	private _ipythonKernelSnapshotDir?: string;
+	/** True once the runtime has been built once; later builds are in-process rebuilds (/reload). */
+	private _ipythonRuntimeBuilt = false;
 	private readonly _prewarmIpythonKernel: boolean;
 	private _rlmDepth: number;
 	private _rlmMaxDepth: number;
@@ -1701,6 +1703,23 @@ export class AgentSession {
 	 * Remove all listeners and disconnect from agent.
 	 * Call this when completely done with the session.
 	 */
+	/**
+	 * Async teardown for graceful quit/switch: await the IPython kernel's dispose
+	 * (which flushes a final namespace snapshot) before the synchronous dispose, so
+	 * the latest state reaches disk instead of racing process exit.
+	 */
+	async disposeAsync(): Promise<void> {
+		if (this._disposed) {
+			return;
+		}
+		try {
+			await this._ipythonKernelProvisioner?.dispose();
+		} catch {
+			// a failed kernel startup already cleaned up after itself
+		}
+		this.dispose();
+	}
+
 	dispose(): void {
 		if (this._disposed) {
 			return;
@@ -3448,6 +3467,10 @@ export class AgentSession {
 			// reload can't restore from a snapshot the old kernel is still writing.
 			const previousDispose = this._ipythonKernelProvisioner?.dispose();
 			this._ipythonKernelSnapshotDir = this.sessionManager.getSessionArtifactDir();
+			// Only surface the "revived from your previous session" notice on the first
+			// build (a genuine resume). A later rebuild (/reload) restores state silently
+			// for continuity — the conversation is unchanged, so there's nothing to flag.
+			const notifyRestore = !this._ipythonRuntimeBuilt;
 			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
 				env: this._rlmKernelEnv(),
 				sessionId: this.sessionId,
@@ -3455,7 +3478,7 @@ export class AgentSession {
 				pythonSkills,
 				snapshotDir: this._ipythonKernelSnapshotDir,
 				readyGate: previousDispose,
-				onRestore: (result) => this._onIpythonStateRestored(result),
+				onRestore: notifyRestore ? (result) => this._onIpythonStateRestored(result) : undefined,
 			});
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {
 				ipython: { provisioner: this._ipythonKernelProvisioner },
@@ -3507,6 +3530,9 @@ export class AgentSession {
 		if ((this._prewarmIpythonKernel || hasSnapshot) && this.getActiveToolNames().includes("ipython")) {
 			this._ipythonKernelProvisioner?.prewarm();
 		}
+
+		// Subsequent builds are in-process rebuilds (/reload), not a fresh resume.
+		this._ipythonRuntimeBuilt = true;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -11,10 +11,13 @@ import { fileURLToPath } from "node:url";
 import { getPackageDir } from "../../config.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 
-const BOOTSTRAP_SCHEMA = 6;
+const BOOTSTRAP_SCHEMA = 7;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
+// Serializes the kernel's user namespace so it can be revived across session
+// resume. Internal-only; intentionally not surfaced to the model as an import.
+const STATE_SNAPSHOT_REQUIREMENT = "dill";
 const DEFAULT_RLM_EXTRA_PACKAGES = [
 	{ uvArg: "requests", importName: "requests", promptLabel: "requests" },
 	{ uvArg: "httpx", importName: "httpx", promptLabel: "httpx" },
@@ -75,6 +78,7 @@ interface BootstrapVersion {
 	schema: number;
 	ipykernel?: string;
 	runtime?: string;
+	snapshot?: string;
 	extraUvArgs?: string[];
 	pythonSkills?: BootstrapPythonSkill[];
 }
@@ -405,6 +409,7 @@ async function readBootstrapVersion(venv: string): Promise<BootstrapVersion | nu
 			schema: parsed.schema,
 			ipykernel: typeof parsed.ipykernel === "string" ? parsed.ipykernel : undefined,
 			runtime: typeof parsed.runtime === "string" ? parsed.runtime : undefined,
+			snapshot: typeof parsed.snapshot === "string" ? parsed.snapshot : undefined,
 			extraUvArgs,
 			pythonSkills,
 		};
@@ -448,6 +453,7 @@ function bootstrapBaseVersionCurrent(version: BootstrapVersion | null): boolean 
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
 		version.runtime === RUNTIME_REQUIREMENT &&
+		version.snapshot === STATE_SNAPSHOT_REQUIREMENT &&
 		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
 	);
 }
@@ -457,6 +463,7 @@ async function writeBootstrapVersion(venv: string, pythonSkills: readonly Bootst
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
 		runtime: RUNTIME_REQUIREMENT,
+		snapshot: STATE_SNAPSHOT_REQUIREMENT,
 		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 		pythonSkills: [...pythonSkills],
 	};
@@ -501,6 +508,7 @@ async function bootstrapVenv(
 		python,
 		IPYKERNEL_REQUIREMENT,
 		runtimeRequirement,
+		STATE_SNAPSHOT_REQUIREMENT,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
 	await syncPythonSkills(uv, venv, python, pythonSkills, options);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -329,7 +329,8 @@ function installSignalHandlersOnce(): void {
 	signalHandlersInstalled = true;
 
 	const asyncShutdown = async (): Promise<void> => {
-		await Promise.allSettled([...liveKernels].map((k) => k.shutdown()));
+		// These paths can await, so flush the namespace snapshot before tearing down.
+		await Promise.allSettled([...liveKernels].map((k) => k.shutdown({ snapshot: true })));
 	};
 
 	// `beforeExit` and signal handlers can await async cleanup. `exit`
@@ -933,11 +934,16 @@ export class KernelManager {
 		}
 	}
 
-	async shutdown(): Promise<void> {
+	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
 			this.cleanupResources();
 			return;
+		}
+		// Best-effort final flush (bounded) before teardown — used by signal handlers
+		// so a SIGINT/SIGTERM exit doesn't lose work the debounced snapshot hasn't saved.
+		if (opts.snapshot) {
+			await this.flushSnapshotForDispose();
 		}
 		this.state = "shutdown";
 		liveKernels.delete(this);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -9,6 +9,15 @@ import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
 import { ensureKernelPython, type KernelBootstrapProgressHandler, type KernelPythonSkill } from "./bootstrap.js";
+import {
+	buildRestoreCode,
+	buildSnapshotCode,
+	DEFAULT_SNAPSHOT_MAX_BYTES,
+	parseRestoreResult,
+	parseSnapshotResult,
+	type RestoreResult,
+	type SnapshotResult,
+} from "./state-snapshot.js";
 
 const DELIM = Buffer.from("<IDS|MSG>");
 const PROTOCOL_VERSION = "5.3";
@@ -18,6 +27,12 @@ const READY_TIMEOUT_MS = 5000;
 const IOPUB_SUBSCRIBE_DELAY_MS = 50;
 const DEFAULT_MAX_OUTPUT_CHARS = 65536;
 const HOST_REQUEST_DISPOSE_TIMEOUT_MS = 5000;
+const DEFAULT_SNAPSHOT_DEBOUNCE_MS = 1500;
+// Snapshot/restore cells can be large to (de)serialize; give them room beyond the user cap.
+const SNAPSHOT_MAX_OUTPUT_CHARS = 1_000_000;
+// Cap how long a graceful dispose waits on the final snapshot; the debounced
+// on-disk copy is the fallback if this is exceeded.
+const SNAPSHOT_DISPOSE_TIMEOUT_MS = 5000;
 
 /** Comm target the kernel-side `rlm.host_request` shim opens for typed host requests. */
 export const HOST_COMM_TARGET = "host.request";
@@ -31,6 +46,18 @@ export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<R
 /** Host request handlers keyed by request type (e.g. "rlm.run", "goal.complete"). */
 export type HostRequestHandlers = Record<string, HostRequestHandler>;
 
+/** Where and how to persist the kernel's user namespace so it survives resume. */
+export interface KernelSnapshotConfig {
+	/** Absolute path for the dill payload. */
+	path: string;
+	/** Absolute path for the JSON manifest written alongside the payload. */
+	manifestPath: string;
+	/** Skip variables (and abort the payload) above this many bytes. Default 256 MiB. */
+	maxBytes?: number;
+	/** Debounce window for the auto-snapshot after a successful execution. Default 1500 ms. */
+	debounceMs?: number;
+}
+
 export interface KernelManagerOptions {
 	/** Python interpreter that has `ipykernel` available. Defaults to the auto-bootstrapped kernel. */
 	python?: string;
@@ -39,6 +66,8 @@ export interface KernelManagerOptions {
 	sessionId?: string;
 	hostHandlers?: HostRequestHandlers;
 	pythonSkills?: readonly KernelPythonSkill[];
+	/** Persist/revive the user namespace across kernel restarts and session resume. */
+	snapshot?: KernelSnapshotConfig;
 	/** Default: "prime-agent". */
 	username?: string;
 }
@@ -298,7 +327,7 @@ function installSignalHandlersOnce(): void {
 export class KernelManager {
 	private readonly options: Pick<
 		KernelManagerOptions,
-		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills"
+		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills" | "snapshot"
 	> &
 		Required<Pick<KernelManagerOptions, "username">>;
 	private readonly session = uuid();
@@ -323,6 +352,8 @@ export class KernelManager {
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
+	/** Pending debounced auto-snapshot, if one has been scheduled. */
+	private snapshotTimer?: ReturnType<typeof globalThis.setTimeout>;
 
 	constructor(options: KernelManagerOptions) {
 		this.options = {
@@ -332,6 +363,7 @@ export class KernelManager {
 			sessionId: options.sessionId,
 			hostHandlers: options.hostHandlers,
 			pythonSkills: options.pythonSkills,
+			snapshot: options.snapshot,
 			username: options.username ?? "prime-agent",
 		};
 	}
@@ -503,6 +535,17 @@ export class KernelManager {
 	}
 
 	async execute(code: string, opts: ExecuteOptions = {}): Promise<ExecuteResult> {
+		const result = await this.enqueueExecute(code, opts);
+		// Refresh the on-disk snapshot after real work so a later resume (or a
+		// crash before graceful shutdown) revives the most recent namespace.
+		if (result.status === "ok") {
+			this.scheduleSnapshot();
+		}
+		return result;
+	}
+
+	/** Queue and run a cell, serializing against all other executions. */
+	private async enqueueExecute(code: string, opts: ExecuteOptions): Promise<ExecuteResult> {
 		if (opts.signal?.aborted) {
 			return { stdout: "", stderr: "", status: "aborted", durationMs: 0 };
 		}
@@ -814,6 +857,7 @@ export class KernelManager {
 	}
 
 	private cleanupResources(): void {
+		this.clearSnapshotTimer();
 		this.rejectActiveExecution(new Error("Kernel has been shut down"));
 		this.shell?.close();
 		this.iopub?.close();
@@ -894,20 +938,97 @@ export class KernelManager {
 		}
 	}
 
+	/**
+	 * Serialize the user namespace to disk (best-effort, per-variable). No-op when
+	 * the kernel isn't running or no snapshot target was configured. Never throws.
+	 */
+	async snapshotState(): Promise<SnapshotResult | null> {
+		const cfg = this.options.snapshot;
+		if (!cfg || !this.isRunning) return null;
+		const code = buildSnapshotCode(cfg.path, cfg.manifestPath, cfg.maxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES);
+		try {
+			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			if (r.status !== "ok") {
+				this.appendKernelDiagnostic(`state snapshot failed: ${r.error?.evalue ?? r.stderr}`);
+				return null;
+			}
+			return parseSnapshotResult(r.stdout, cfg.path);
+		} catch (error) {
+			this.appendKernelDiagnostic(`state snapshot error: ${errorMessage(error)}`);
+			return null;
+		}
+	}
+
+	/**
+	 * Revive a previously snapshotted namespace into the kernel. Call right after
+	 * start() and before the runtime bootstrap, which then refreshes live handles
+	 * (rlm, skills) over anything restored. Never throws.
+	 */
+	async restoreState(): Promise<RestoreResult | null> {
+		const cfg = this.options.snapshot;
+		if (!cfg) return null;
+		const code = buildRestoreCode(cfg.path);
+		try {
+			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			if (r.status !== "ok") {
+				this.appendKernelDiagnostic(`state restore failed: ${r.error?.evalue ?? r.stderr}`);
+				return null;
+			}
+			return parseRestoreResult(r.stdout, cfg.path);
+		} catch (error) {
+			this.appendKernelDiagnostic(`state restore error: ${errorMessage(error)}`);
+			return null;
+		}
+	}
+
+	private scheduleSnapshot(): void {
+		const cfg = this.options.snapshot;
+		if (!cfg) return;
+		if (this.snapshotTimer) clearTimeout(this.snapshotTimer);
+		this.snapshotTimer = globalThis.setTimeout(() => {
+			this.snapshotTimer = undefined;
+			void this.snapshotState();
+		}, cfg.debounceMs ?? DEFAULT_SNAPSHOT_DEBOUNCE_MS);
+		if (this.snapshotTimer && typeof this.snapshotTimer === "object" && "unref" in this.snapshotTimer) {
+			this.snapshotTimer.unref();
+		}
+	}
+
+	private clearSnapshotTimer(): void {
+		if (this.snapshotTimer) {
+			clearTimeout(this.snapshotTimer);
+			this.snapshotTimer = undefined;
+		}
+	}
+
+	/** Best-effort final snapshot before a graceful dispose, bounded by a timeout. */
+	private async flushSnapshotForDispose(): Promise<void> {
+		if (!this.options.snapshot || !this.isRunning) return;
+		let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const guard = new Promise<void>((resolve) => {
+			timeout = globalThis.setTimeout(resolve, SNAPSHOT_DISPOSE_TIMEOUT_MS);
+			if (timeout && typeof timeout === "object" && "unref" in timeout) timeout.unref();
+		});
+		try {
+			await Promise.race([this.snapshotState().then(() => undefined), guard]);
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+	}
+
 	/** Graceful cleanup. Waits briefly for in-flight host request handlers before closing sockets. */
 	dispose(): Promise<void> {
-		this.state = "shutdown";
-		liveKernels.delete(this);
-		const inFlightHostRequests = [...this.inFlightHostRequests];
-		if (inFlightHostRequests.length === 0) {
-			this.cleanupResources();
-			return Promise.resolve();
-		}
-
 		return (async () => {
+			// Final namespace flush while the kernel is still live (session end / reload).
+			await this.flushSnapshotForDispose();
+			this.state = "shutdown";
+			liveKernels.delete(this);
+			const inFlightHostRequests = [...this.inFlightHostRequests];
 			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel long-running child loops.
 			try {
-				await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_DISPOSE_TIMEOUT_MS);
+				if (inFlightHostRequests.length > 0) {
+					await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_DISPOSE_TIMEOUT_MS);
+				}
 			} finally {
 				this.cleanupResources();
 			}

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -6,10 +6,12 @@
 // with `dill` independently, so a single unpicklable object (open file, socket,
 // GPU tensor, …) is skipped and reported rather than aborting the whole snapshot.
 import { join } from "node:path";
-import { getSessionsDir } from "../../config.js";
 
 /** Default ceiling on a snapshot payload. Over-cap variables are skipped + reported. */
 export const DEFAULT_SNAPSHOT_MAX_BYTES = 256 * 1024 * 1024;
+
+/** Base filename for the kernel snapshot within a session's artifact directory. */
+const KERNEL_STATE_BASENAME = "kernel-state";
 
 /** Marker the Python helpers print so the host can recover the JSON result line. */
 const RESULT_MARKER = "__PRIME_AGENT_KERNEL_STATE__";
@@ -32,19 +34,14 @@ export interface RestoreResult {
 	path: string;
 }
 
-/** Directory holding per-session kernel snapshots, alongside the session JSONL files. */
-export function kernelStateDir(): string {
-	return join(getSessionsDir(), "kernel-state");
+/** Absolute path to the dill payload within a session's artifact directory. */
+export function snapshotPathIn(artifactDir: string): string {
+	return join(artifactDir, `${KERNEL_STATE_BASENAME}.dill`);
 }
 
-/** Absolute path to the dill payload for a session's kernel snapshot. */
-export function snapshotPathFor(sessionId: string): string {
-	return join(kernelStateDir(), `${sessionId}.dill`);
-}
-
-/** Absolute path to the JSON manifest describing a session's snapshot. */
-export function manifestPathFor(sessionId: string): string {
-	return join(kernelStateDir(), `${sessionId}.json`);
+/** Absolute path to the JSON manifest within a session's artifact directory. */
+export function manifestPathIn(artifactDir: string): string {
+	return join(artifactDir, `${KERNEL_STATE_BASENAME}.json`);
 }
 
 /** Render a JS string as a Python string literal (JSON's escaping is a valid subset). */

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -1,0 +1,252 @@
+// Serialize the IPython kernel's user namespace so it can be revived when a
+// session resumes. The kernel is otherwise spawned fresh on resume, leaving the
+// model believing it still has access to variables/imports it defined earlier.
+//
+// Snapshotting is best-effort and per-variable: each top-level name is pickled
+// with `dill` independently, so a single unpicklable object (open file, socket,
+// GPU tensor, …) is skipped and reported rather than aborting the whole snapshot.
+import { join } from "node:path";
+import { getSessionsDir } from "../../config.js";
+
+/** Default ceiling on a snapshot payload. Over-cap variables are skipped + reported. */
+export const DEFAULT_SNAPSHOT_MAX_BYTES = 256 * 1024 * 1024;
+
+/** Marker the Python helpers print so the host can recover the JSON result line. */
+const RESULT_MARKER = "__PRIME_AGENT_KERNEL_STATE__";
+
+export interface SnapshotResult {
+	/** Top-level names successfully serialized into the payload. */
+	saved: string[];
+	/** Names that could not be serialized, with a short reason. */
+	skipped: { name: string; reason: string }[];
+	/** Payload size on disk, in bytes. */
+	bytes: number;
+	path: string;
+}
+
+export interface RestoreResult {
+	/** Names successfully revived into the kernel namespace. */
+	restored: string[];
+	/** Names present in the snapshot that failed to revive, with a short reason. */
+	failed: { name: string; reason: string }[];
+	path: string;
+}
+
+/** Directory holding per-session kernel snapshots, alongside the session JSONL files. */
+export function kernelStateDir(): string {
+	return join(getSessionsDir(), "kernel-state");
+}
+
+/** Absolute path to the dill payload for a session's kernel snapshot. */
+export function snapshotPathFor(sessionId: string): string {
+	return join(kernelStateDir(), `${sessionId}.dill`);
+}
+
+/** Absolute path to the JSON manifest describing a session's snapshot. */
+export function manifestPathFor(sessionId: string): string {
+	return join(kernelStateDir(), `${sessionId}.json`);
+}
+
+/** Render a JS string as a Python string literal (JSON's escaping is a valid subset). */
+function pyStr(value: string): string {
+	return JSON.stringify(value);
+}
+
+/**
+ * Python that serializes the user namespace to `outPath` (atomic write) and a
+ * sibling `.json` manifest, then prints a single marker line with the result.
+ */
+export function buildSnapshotCode(outPath: string, manifestPath: string, maxBytes: number): string {
+	return `
+def _prime_agent_snapshot_state():
+    import builtins, json, os, sys, datetime
+    try:
+        import dill
+    except Exception as _err:
+        print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "dill unavailable: " + str(_err)}))
+        return
+    dill.settings["recurse"] = True
+
+    ip = None
+    try:
+        ip = get_ipython()  # noqa: F821 (injected by IPython)
+    except Exception:
+        ip = None
+    ns = ip.user_ns if ip is not None else globals()
+    hidden = set(getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else set()
+    # rlm and the wrapped skill modules are live, connection-bound handles that
+    # the bootstrap re-creates on restore; never snapshot them.
+    always_skip = {"rlm", "In", "Out", "get_ipython", "exit", "quit", "open"}
+
+    payload = {}
+    skipped = []
+    total = 0
+    for name in list(ns.keys()):
+        if name.startswith("_") or name in hidden or name in always_skip:
+            continue
+        if name in vars(builtins):
+            continue
+        value = ns[name]
+        # Modules are pickled by reference and re-imported on restore.
+        try:
+            blob = dill.dumps(value)
+        except Exception as _err:
+            skipped.append({"name": name, "reason": type(_err).__name__ + ": " + str(_err)[:200]})
+            continue
+        if len(blob) > ${maxBytes} or total + len(blob) > ${maxBytes}:
+            skipped.append({"name": name, "reason": "exceeds snapshot size cap"})
+            continue
+        payload[name] = blob
+        total += len(blob)
+
+    os.makedirs(os.path.dirname(${pyStr(outPath)}), exist_ok=True)
+    tmp = ${pyStr(outPath)} + ".tmp"
+    try:
+        with open(tmp, "wb") as fh:
+            dill.dump(payload, fh)
+        os.replace(tmp, ${pyStr(outPath)})
+    except Exception as _err:
+        try:
+            os.remove(tmp)
+        except Exception:
+            pass
+        print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "write failed: " + str(_err)}))
+        return
+
+    bytes_written = os.path.getsize(${pyStr(outPath)})
+    saved = sorted(payload.keys())
+    manifest = {
+        "version": 1,
+        "savedNames": saved,
+        "skipped": skipped,
+        "bytes": bytes_written,
+        "pythonVersion": sys.version.split()[0],
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(${pyStr(manifestPath)}, "w") as fh:
+            json.dump(manifest, fh)
+    except Exception:
+        pass
+    print(${pyStr(RESULT_MARKER)} + json.dumps({"saved": saved, "skipped": skipped, "bytes": bytes_written}))
+
+
+try:
+    _prime_agent_snapshot_state()
+finally:
+    del _prime_agent_snapshot_state
+`.trim();
+}
+
+/**
+ * Python that loads the payload at `inPath` (if present) into the user namespace,
+ * reviving each name independently, then prints a single marker line with the result.
+ * Tolerant of a missing or corrupt file: reports an empty restore, never raises.
+ */
+export function buildRestoreCode(inPath: string): string {
+	return `
+def _prime_agent_restore_state():
+    import json, os, sys
+    if not os.path.exists(${pyStr(inPath)}):
+        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": []}))
+        return
+    try:
+        import dill
+    except Exception as _err:
+        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "dill unavailable: " + str(_err)}))
+        return
+
+    try:
+        with open(${pyStr(inPath)}, "rb") as fh:
+            payload = dill.load(fh)
+    except Exception as _err:
+        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "load failed: " + str(_err)}))
+        return
+
+    ip = None
+    try:
+        ip = get_ipython()  # noqa: F821
+    except Exception:
+        ip = None
+    ns = ip.user_ns if ip is not None else globals()
+
+    restored = []
+    failed = []
+    for name, blob in payload.items():
+        try:
+            ns[name] = dill.loads(blob)
+            restored.append(name)
+        except Exception as _err:
+            failed.append({"name": name, "reason": type(_err).__name__ + ": " + str(_err)[:200]})
+    print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": sorted(restored), "failed": failed}))
+
+
+try:
+    _prime_agent_restore_state()
+finally:
+    del _prime_agent_restore_state
+`.trim();
+}
+
+interface RawSnapshot {
+	saved?: unknown;
+	skipped?: unknown;
+	bytes?: unknown;
+	error?: unknown;
+}
+
+interface RawRestore {
+	restored?: unknown;
+	failed?: unknown;
+	error?: unknown;
+}
+
+function asStringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function asReasonArray(value: unknown): { name: string; reason: string }[] {
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((entry) => {
+		if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
+			const { name, reason } = entry as { name: string; reason?: unknown };
+			return [{ name, reason: typeof reason === "string" ? reason : "" }];
+		}
+		return [];
+	});
+}
+
+/** Pull the marker line out of cell stdout and parse it, or null if absent/invalid. */
+function parseMarkerLine<T>(stdout: string): T | null {
+	const index = stdout.lastIndexOf(RESULT_MARKER);
+	if (index === -1) return null;
+	const rest = stdout.slice(index + RESULT_MARKER.length);
+	const line = rest.split("\n", 1)[0]?.trim();
+	if (!line) return null;
+	try {
+		return JSON.parse(line) as T;
+	} catch {
+		return null;
+	}
+}
+
+export function parseSnapshotResult(stdout: string, path: string): SnapshotResult | null {
+	const raw = parseMarkerLine<RawSnapshot>(stdout);
+	if (!raw || raw.error) return null;
+	return {
+		saved: asStringArray(raw.saved),
+		skipped: asReasonArray(raw.skipped),
+		bytes: typeof raw.bytes === "number" ? raw.bytes : 0,
+		path,
+	};
+}
+
+export function parseRestoreResult(stdout: string, path: string): RestoreResult | null {
+	const raw = parseMarkerLine<RawRestore>(stdout);
+	if (!raw || raw.error) return null;
+	return {
+		restored: asStringArray(raw.restored),
+		failed: asReasonArray(raw.failed),
+		path,
+	};
+}

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -54,23 +54,25 @@ function pyStr(value: string): string {
  * sibling `.json` manifest, then prints a single marker line with the result.
  */
 export function buildSnapshotCode(outPath: string, manifestPath: string, maxBytes: number): string {
+	// All builtins are sourced via the locally-imported _b alias so the helper keeps
+	// working even when the user namespace shadows names like list/open/print/len.
 	return `
 def _prime_agent_snapshot_state():
-    import builtins, json, os, sys, datetime
+    import builtins as _b, json, os, sys, datetime
     try:
         import dill
-    except Exception as _err:
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "dill unavailable: " + str(_err)}))
+    except _b.Exception as _err:
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "dill unavailable: " + _b.str(_err)}))
         return
     dill.settings["recurse"] = True
 
     ip = None
     try:
         ip = get_ipython()  # noqa: F821 (injected by IPython)
-    except Exception:
+    except _b.Exception:
         ip = None
-    ns = ip.user_ns if ip is not None else globals()
-    hidden = set(getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else set()
+    ns = ip.user_ns if ip is not None else _b.globals()
+    hidden = _b.set(_b.getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else _b.set()
     # rlm and the wrapped skill modules are live, connection-bound handles that
     # the bootstrap re-creates on restore; never snapshot them.
     always_skip = {"rlm", "In", "Out", "get_ipython", "exit", "quit", "open"}
@@ -78,40 +80,41 @@ def _prime_agent_snapshot_state():
     payload = {}
     skipped = []
     total = 0
-    for name in list(ns.keys()):
+    for name in _b.list(ns.keys()):
+        # Skip internals (dunder/underscore), IPython-injected names, and live
+        # handles. A name matching a builtin (e.g. "list") is a user shadow worth
+        # keeping — builtins themselves are not enumerated as user_ns keys.
         if name.startswith("_") or name in hidden or name in always_skip:
-            continue
-        if name in vars(builtins):
             continue
         value = ns[name]
         # Modules are pickled by reference and re-imported on restore.
         try:
             blob = dill.dumps(value)
-        except Exception as _err:
-            skipped.append({"name": name, "reason": type(_err).__name__ + ": " + str(_err)[:200]})
+        except _b.Exception as _err:
+            skipped.append({"name": name, "reason": _b.type(_err).__name__ + ": " + _b.str(_err)[:200]})
             continue
-        if len(blob) > ${maxBytes} or total + len(blob) > ${maxBytes}:
+        if _b.len(blob) > ${maxBytes} or total + _b.len(blob) > ${maxBytes}:
             skipped.append({"name": name, "reason": "exceeds snapshot size cap"})
             continue
         payload[name] = blob
-        total += len(blob)
+        total += _b.len(blob)
 
     os.makedirs(os.path.dirname(${pyStr(outPath)}), exist_ok=True)
     tmp = ${pyStr(outPath)} + ".tmp"
     try:
-        with open(tmp, "wb") as fh:
+        with _b.open(tmp, "wb") as fh:
             dill.dump(payload, fh)
         os.replace(tmp, ${pyStr(outPath)})
-    except Exception as _err:
+    except _b.Exception as _err:
         try:
             os.remove(tmp)
-        except Exception:
+        except _b.Exception:
             pass
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "write failed: " + str(_err)}))
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"error": "write failed: " + _b.str(_err)}))
         return
 
     bytes_written = os.path.getsize(${pyStr(outPath)})
-    saved = sorted(payload.keys())
+    saved = _b.sorted(payload.keys())
     manifest = {
         "version": 1,
         "savedNames": saved,
@@ -121,11 +124,11 @@ def _prime_agent_snapshot_state():
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
     try:
-        with open(${pyStr(manifestPath)}, "w") as fh:
+        with _b.open(${pyStr(manifestPath)}, "w") as fh:
             json.dump(manifest, fh)
-    except Exception:
+    except _b.Exception:
         pass
-    print(${pyStr(RESULT_MARKER)} + json.dumps({"saved": saved, "skipped": skipped, "bytes": bytes_written}))
+    _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"saved": saved, "skipped": skipped, "bytes": bytes_written}))
 
 
 try:
@@ -141,34 +144,36 @@ finally:
  * Tolerant of a missing or corrupt file: reports an empty restore, never raises.
  */
 export function buildRestoreCode(inPath: string): string {
+	// Builtins via the local _b alias so a shadowed name in the user namespace
+	// (list/open/print/…) can't break the restore path.
 	return `
 def _prime_agent_restore_state():
-    import json, os, sys
+    import builtins as _b, json, os, sys
     if not os.path.exists(${pyStr(inPath)}):
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": []}))
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": []}))
         return
     try:
         import dill
-    except Exception as _err:
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "dill unavailable: " + str(_err)}))
+    except _b.Exception as _err:
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "dill unavailable: " + _b.str(_err)}))
         return
 
     try:
-        with open(${pyStr(inPath)}, "rb") as fh:
+        with _b.open(${pyStr(inPath)}, "rb") as fh:
             payload = dill.load(fh)
-    except Exception as _err:
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "load failed: " + str(_err)}))
+    except _b.Exception as _err:
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "load failed: " + _b.str(_err)}))
         return
-    if not isinstance(payload, dict):
-        print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "corrupt snapshot: not a dict"}))
+    if not _b.isinstance(payload, _b.dict):
+        _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": [], "failed": [], "error": "corrupt snapshot: not a dict"}))
         return
 
     ip = None
     try:
         ip = get_ipython()  # noqa: F821
-    except Exception:
+    except _b.Exception:
         ip = None
-    ns = ip.user_ns if ip is not None else globals()
+    ns = ip.user_ns if ip is not None else _b.globals()
 
     restored = []
     failed = []
@@ -176,9 +181,9 @@ def _prime_agent_restore_state():
         try:
             ns[name] = dill.loads(blob)
             restored.append(name)
-        except Exception as _err:
-            failed.append({"name": name, "reason": type(_err).__name__ + ": " + str(_err)[:200]})
-    print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": sorted(restored), "failed": failed}))
+        except _b.Exception as _err:
+            failed.append({"name": name, "reason": _b.type(_err).__name__ + ": " + _b.str(_err)[:200]})
+    _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"restored": _b.sorted(restored), "failed": failed}))
 
 
 try:

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -1,24 +1,28 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { unlink } from "node:fs/promises";
-import { basename } from "node:path";
-import { manifestPathFor, snapshotPathFor } from "./kernel/state-snapshot.js";
+import { rm, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 
 export type DeleteSessionFileResult = { ok: true; method: "trash" | "unlink" } | { ok: false; error: string };
 
-/** Best-effort removal of a session's kernel snapshot payload + manifest. */
-async function deleteKernelStateFor(sessionPath: string): Promise<void> {
+/**
+ * Permanently remove a session's artifact directory (kernel state snapshot, rlm
+ * scratch files, …), which lives at `<dirname(sessionDir)>/session-artifacts/<id>`.
+ * Only invoked on delete, never on deactivation.
+ */
+async function deleteSessionArtifacts(sessionPath: string): Promise<void> {
 	const sessionId = basename(sessionPath).replace(/\.jsonl$/, "");
 	if (!sessionId) return;
-	await Promise.allSettled([unlink(snapshotPathFor(sessionId)), unlink(manifestPathFor(sessionId))]);
+	const artifactDir = join(dirname(dirname(sessionPath)), "session-artifacts", sessionId);
+	await rm(artifactDir, { recursive: true, force: true });
 }
 
 /**
  * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
- * Also removes the session's kernel state snapshot, which is derived data.
+ * Also permanently removes the session's artifact directory, which is derived data.
  */
 export async function deleteSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
-	await deleteKernelStateFor(sessionPath);
+	await deleteSessionArtifacts(sessionPath);
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
 	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
 

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -17,12 +17,8 @@ async function deleteSessionArtifacts(sessionPath: string): Promise<void> {
 	await rm(artifactDir, { recursive: true, force: true });
 }
 
-/**
- * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
- * Also permanently removes the session's artifact directory, which is derived data.
- */
-export async function deleteSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
-	await deleteSessionArtifacts(sessionPath);
+/** Remove the session `.jsonl`, trying the `trash` CLI first, then falling back to unlink. */
+async function removeSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
 	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
 
@@ -52,4 +48,18 @@ export async function deleteSessionFile(sessionPath: string): Promise<DeleteSess
 		const error = trashErrorHint ? `${unlinkError} (${trashErrorHint})` : unlinkError;
 		return { ok: false, error };
 	}
+}
+
+/**
+ * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
+ * Also permanently removes the session's artifact directory (derived data), but only
+ * once the session file itself is gone — otherwise a failed delete would orphan a
+ * session whose kernel snapshot has already been destroyed.
+ */
+export async function deleteSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
+	const result = await removeSessionFile(sessionPath);
+	if (result.ok) {
+		await deleteSessionArtifacts(sessionPath);
+	}
+	return result;
 }

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -1,13 +1,24 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
+import { basename } from "node:path";
+import { manifestPathFor, snapshotPathFor } from "./kernel/state-snapshot.js";
 
 export type DeleteSessionFileResult = { ok: true; method: "trash" | "unlink" } | { ok: false; error: string };
 
+/** Best-effort removal of a session's kernel snapshot payload + manifest. */
+async function deleteKernelStateFor(sessionPath: string): Promise<void> {
+	const sessionId = basename(sessionPath).replace(/\.jsonl$/, "");
+	if (!sessionId) return;
+	await Promise.allSettled([unlink(snapshotPathFor(sessionId)), unlink(manifestPathFor(sessionId))]);
+}
+
 /**
  * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
+ * Also removes the session's kernel state snapshot, which is derived data.
  */
 export async function deleteSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
+	await deleteKernelStateFor(sessionPath);
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
 	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
 

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -146,6 +146,9 @@ export interface IpythonToolOptions {
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Per-session artifact dir where the kernel namespace snapshot is stored. Omit to disable snapshots. */
 	snapshotDir?: string;
+	/** Resolves before this kernel starts — e.g. the previous provisioner's dispose, so a
+	 * /reload's old-kernel snapshot flush can't race the new kernel's restore. */
+	readyGate?: Promise<unknown>;
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
 	/**
@@ -198,7 +201,10 @@ export class IpythonKernelProvisioner {
 	/** Restart the kernel if one is running (e.g. after compaction). */
 	async restart(): Promise<void> {
 		try {
-			await this.startedManager?.restart();
+			// Await any in-flight startup first, so we restart a fully-started kernel and
+			// delete the snapshot after (not during) a concurrent restore.
+			const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
+			await m?.restart();
 		} finally {
 			// Compaction deliberately wipes the namespace and tells the model so. Drop the
 			// stale on-disk snapshot too — even if the restart threw — so a later resume
@@ -272,6 +278,13 @@ export class IpythonKernelProvisioner {
 	}
 
 	private async startKernel(): Promise<KernelManager> {
+		// Wait for a previous provisioner (e.g. on /reload) to finish disposing — and
+		// flushing its final snapshot — before we read that snapshot back, so the two
+		// kernels can't race over the same on-disk file. Guarded so the common
+		// no-gate path stays synchronous (callers rely on prompt startup progress).
+		if (this.options?.readyGate) {
+			await this.options.readyGate.catch(() => {});
+		}
 		const snapshotDir = this.options?.snapshotDir;
 		const m = new KernelManager({
 			python: this.options?.python,
@@ -287,20 +300,17 @@ export class IpythonKernelProvisioner {
 		});
 		this.emitStartupProgress("Starting IPython kernel...");
 		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
+		// Whether a snapshot existed decides if we notify the model on success.
+		let pendingRestore: RestoreResult | undefined;
 		try {
 			// Revive a prior session's namespace before the bootstrap, so the bootstrap
 			// then overwrites live handles (rlm, skills) on top of anything restored.
 			if (snapshotDir) {
-				// Whether a snapshot existed decides if we notify: a pre-existing snapshot
-				// means we attempted a revive, so the model is always told the outcome —
-				// including a corrupt/empty restore — instead of silently assuming state.
 				const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
 				this.emitStartupProgress("Restoring IPython state...");
 				const restore = await m.restoreState();
 				if (snapshotExisted) {
-					const result = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
-					this._lastRestore = result;
-					this.options?.onRestore?.(result);
+					pendingRestore = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
 				}
 			}
 			this.emitStartupProgress("Preparing IPython runtime...");
@@ -313,6 +323,12 @@ export class IpythonKernelProvisioner {
 			// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
 			void m.dispose();
 			throw error;
+		}
+		// Only tell the model what was revived once the kernel is actually usable —
+		// a notice claiming restored state must never outlive a failed bootstrap.
+		if (pendingRestore) {
+			this._lastRestore = pendingRestore;
+			this.options?.onRestore?.(pendingRestore);
 		}
 		if (this.options?.kernelManagerRef) {
 			this.options.kernelManagerRef.current = m;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,6 +4,7 @@ import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
 import { type HostRequestHandlers, KernelManager } from "../kernel/index.js";
+import { manifestPathFor, type RestoreResult, snapshotPathFor } from "../kernel/state-snapshot.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
@@ -141,6 +142,11 @@ export interface IpythonToolOptions {
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
+	/**
+	 * Fires once per kernel start when a previous session's namespace was revived
+	 * (some names restored or some failed), so the session can tell the model.
+	 */
+	onRestore?: (result: RestoreResult) => void;
 	/** Shared provisioner owning the kernel lifecycle. When provided, the remaining options are ignored. */
 	provisioner?: IpythonKernelProvisioner;
 }
@@ -157,6 +163,7 @@ export class IpythonKernelProvisioner {
 	private startedManager?: KernelManager;
 	private readonly startupListeners = new Set<KernelBootstrapProgressHandler>();
 	private lastStartupMessage?: string;
+	private _lastRestore?: RestoreResult;
 
 	constructor(
 		private readonly cwd: string,
@@ -170,6 +177,11 @@ export class IpythonKernelProvisioner {
 	/** The kernel manager, once a startup has completed successfully. */
 	get manager(): KernelManager | undefined {
 		return this.startedManager;
+	}
+
+	/** Result of reviving a prior session's namespace on the last kernel start, if any. */
+	get lastRestore(): RestoreResult | undefined {
+		return this._lastRestore;
 	}
 
 	/** Start the kernel in the background. Failures are swallowed here and surface on the next ensure(). */
@@ -240,16 +252,31 @@ export class IpythonKernelProvisioner {
 	}
 
 	private async startKernel(): Promise<KernelManager> {
+		const sessionId = this.options?.sessionId;
 		const m = new KernelManager({
 			python: this.options?.python,
 			cwd: this.cwd,
 			env: this.options?.env,
-			sessionId: this.options?.sessionId,
+			sessionId,
 			hostHandlers: this.options?.hostHandlers,
 			pythonSkills: this.options?.pythonSkills,
+			// Only sessions with a stable id get a per-session snapshot to revive.
+			snapshot: sessionId
+				? { path: snapshotPathFor(sessionId), manifestPath: manifestPathFor(sessionId) }
+				: undefined,
 		});
 		this.emitStartupProgress("Starting IPython kernel...");
 		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
+		// Revive a prior session's namespace before the bootstrap, so the bootstrap
+		// then overwrites live handles (rlm, skills) on top of anything restored.
+		if (sessionId) {
+			this.emitStartupProgress("Restoring IPython state...");
+			const restore = await m.restoreState();
+			if (restore && (restore.restored.length > 0 || restore.failed.length > 0)) {
+				this._lastRestore = restore;
+				this.options?.onRestore?.(restore);
+			}
+		}
 		this.emitStartupProgress("Preparing IPython runtime...");
 		const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
 		if (bootstrap.status !== "ok") {
@@ -274,7 +301,7 @@ export function createIpythonToolDefinition(
 		name: "ipython",
 		label: "ipython",
 		description:
-			"Execute Python scratchpad code and `%%bash` shell cells in a persistent IPython kernel. Variables, imports, and loaded data persist across calls. Project imports, tests, scripts, CLIs, and dependency checks should run through the target project's own environment.",
+			"Execute Python scratchpad code and `%%bash` shell cells in a persistent IPython kernel. Variables, imports, and loaded data persist across calls, and are revived on a best-effort basis when a session is resumed (objects that cannot be serialized are dropped and reported). Project imports, tests, scripts, CLIs, and dependency checks should run through the target project's own environment.",
 		promptSnippet: "ipython - persistent agent notebook for Python scratchpad code and %%bash orchestration",
 		// The kernel is single-threaded — pi must not run two ipython calls in parallel within a batch.
 		executionMode: "sequential",

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -1,4 +1,5 @@
 // TODO: reconsider whether the persistent kernel is needed once RLM-1 weights land.
+import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
@@ -196,14 +197,20 @@ export class IpythonKernelProvisioner {
 
 	/** Restart the kernel if one is running (e.g. after compaction). */
 	async restart(): Promise<void> {
-		await this.startedManager?.restart();
-		// Compaction deliberately wipes the namespace and tells the model so. Drop the
-		// stale on-disk snapshot too, so a resume right after compaction doesn't revive
-		// state the model was told is gone (a later cell re-creates a fresh snapshot).
-		this._lastRestore = undefined;
-		const dir = this.options?.snapshotDir;
-		if (dir) {
-			await Promise.allSettled([rm(snapshotPathIn(dir), { force: true }), rm(manifestPathIn(dir), { force: true })]);
+		try {
+			await this.startedManager?.restart();
+		} finally {
+			// Compaction deliberately wipes the namespace and tells the model so. Drop the
+			// stale on-disk snapshot too — even if the restart threw — so a later resume
+			// doesn't revive state the model was told is gone (a fresh cell re-snapshots).
+			this._lastRestore = undefined;
+			const dir = this.options?.snapshotDir;
+			if (dir) {
+				await Promise.allSettled([
+					rm(snapshotPathIn(dir), { force: true }),
+					rm(manifestPathIn(dir), { force: true }),
+				]);
+			}
 		}
 	}
 
@@ -280,22 +287,32 @@ export class IpythonKernelProvisioner {
 		});
 		this.emitStartupProgress("Starting IPython kernel...");
 		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
-		// Revive a prior session's namespace before the bootstrap, so the bootstrap
-		// then overwrites live handles (rlm, skills) on top of anything restored.
-		if (snapshotDir) {
-			this.emitStartupProgress("Restoring IPython state...");
-			const restore = await m.restoreState();
-			if (restore && (restore.restored.length > 0 || restore.failed.length > 0)) {
-				this._lastRestore = restore;
-				this.options?.onRestore?.(restore);
+		try {
+			// Revive a prior session's namespace before the bootstrap, so the bootstrap
+			// then overwrites live handles (rlm, skills) on top of anything restored.
+			if (snapshotDir) {
+				// Whether a snapshot existed decides if we notify: a pre-existing snapshot
+				// means we attempted a revive, so the model is always told the outcome —
+				// including a corrupt/empty restore — instead of silently assuming state.
+				const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
+				this.emitStartupProgress("Restoring IPython state...");
+				const restore = await m.restoreState();
+				if (snapshotExisted) {
+					const result = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
+					this._lastRestore = result;
+					this.options?.onRestore?.(result);
+				}
 			}
-		}
-		this.emitStartupProgress("Preparing IPython runtime...");
-		const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
-		if (bootstrap.status !== "ok") {
-			const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+			this.emitStartupProgress("Preparing IPython runtime...");
+			const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
+			if (bootstrap.status !== "ok") {
+				const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+				throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+			}
+		} catch (error) {
+			// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
 			void m.dispose();
-			throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+			throw error;
 		}
 		if (this.options?.kernelManagerRef) {
 			this.options.kernelManagerRef.current = m;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -1,4 +1,5 @@
 // TODO: reconsider whether the persistent kernel is needed once RLM-1 weights land.
+import { rm } from "node:fs/promises";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
@@ -196,6 +197,14 @@ export class IpythonKernelProvisioner {
 	/** Restart the kernel if one is running (e.g. after compaction). */
 	async restart(): Promise<void> {
 		await this.startedManager?.restart();
+		// Compaction deliberately wipes the namespace and tells the model so. Drop the
+		// stale on-disk snapshot too, so a resume right after compaction doesn't revive
+		// state the model was told is gone (a later cell re-creates a fresh snapshot).
+		this._lastRestore = undefined;
+		const dir = this.options?.snapshotDir;
+		if (dir) {
+			await Promise.allSettled([rm(snapshotPathIn(dir), { force: true }), rm(manifestPathIn(dir), { force: true })]);
+		}
 	}
 
 	/** Dispose the kernel owned by this provisioner, including one still starting up. */

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,7 +4,7 @@ import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
 import { type HostRequestHandlers, KernelManager } from "../kernel/index.js";
-import { manifestPathFor, type RestoreResult, snapshotPathFor } from "../kernel/state-snapshot.js";
+import { manifestPathIn, type RestoreResult, snapshotPathIn } from "../kernel/state-snapshot.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
@@ -140,6 +140,8 @@ export interface IpythonToolOptions {
 	/** Typed host request handlers for the kernel↔host bridge (rlm.run, goal.*, …). */
 	hostHandlers?: HostRequestHandlers;
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
+	/** Per-session artifact dir where the kernel namespace snapshot is stored. Omit to disable snapshots. */
+	snapshotDir?: string;
 	/** Filled after the first kernel start so the owning session can restart it after compaction. */
 	kernelManagerRef?: { current?: KernelManager };
 	/**
@@ -252,24 +254,24 @@ export class IpythonKernelProvisioner {
 	}
 
 	private async startKernel(): Promise<KernelManager> {
-		const sessionId = this.options?.sessionId;
+		const snapshotDir = this.options?.snapshotDir;
 		const m = new KernelManager({
 			python: this.options?.python,
 			cwd: this.cwd,
 			env: this.options?.env,
-			sessionId,
+			sessionId: this.options?.sessionId,
 			hostHandlers: this.options?.hostHandlers,
 			pythonSkills: this.options?.pythonSkills,
-			// Only sessions with a stable id get a per-session snapshot to revive.
-			snapshot: sessionId
-				? { path: snapshotPathFor(sessionId), manifestPath: manifestPathFor(sessionId) }
+			// Only persistent sessions (which have an artifact dir) get a revivable snapshot.
+			snapshot: snapshotDir
+				? { path: snapshotPathIn(snapshotDir), manifestPath: manifestPathIn(snapshotDir) }
 				: undefined,
 		});
 		this.emitStartupProgress("Starting IPython kernel...");
 		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
 		// Revive a prior session's namespace before the bootstrap, so the bootstrap
 		// then overwrites live handles (rlm, skills) on top of anything restored.
-		if (sessionId) {
+		if (snapshotDir) {
 			this.emitStartupProgress("Restoring IPython state...");
 			const restore = await m.restoreState();
 			if (restore && (restore.restored.length > 0 || restore.failed.length > 0)) {

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -224,7 +224,14 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const parsed = parseDiffLine(rawLine);
 		if (!parsed) {
 			rows.push(
-				buildRichDiffLine({ bg: "toolPanelBg", gutterFg: "toolDiffContext", gutter: "", content: replaceTabs(rawLine), language, width }),
+				buildRichDiffLine({
+					bg: "toolPanelBg",
+					gutterFg: "toolDiffContext",
+					gutter: "",
+					content: replaceTabs(rawLine),
+					language,
+					width,
+				}),
 			);
 			continue;
 		}
@@ -257,7 +264,14 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else {
 			rows.push(
-				buildRichDiffLine({ bg: "toolPanelBg", gutterFg: "toolDiffContext", gutter, content: text, language, width }),
+				buildRichDiffLine({
+					bg: "toolPanelBg",
+					gutterFg: "toolDiffContext",
+					gutter,
+					content: text,
+					language,
+					width,
+				}),
 			);
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -286,12 +286,7 @@ export class IPythonCellComponent implements Component {
 		return { label: theme.fg("success", "done") };
 	}
 
-	private renderCode(
-		lines: string[],
-		width: number,
-		withExpandHint: ExpandHintFormatter,
-		hasDiffs: boolean,
-	): boolean {
+	private renderCode(lines: string[], width: number, withExpandHint: ExpandHintFormatter, hasDiffs: boolean): boolean {
 		const code = this.state.code.trimEnd();
 		if (!code) {
 			this.addBlank(lines, width);

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupSessionResources } from "@earendil-works/pi-ai";
@@ -95,6 +95,21 @@ describe("IpythonKernelProvisioner", () => {
 		provisioner.prewarm();
 		await provisioner.dispose();
 		expect(provisioner.manager).toBeUndefined();
+	});
+
+	it("restart() drops the on-disk snapshot so a compaction wipe isn't revived on resume", async () => {
+		const snapshotDir = join(tempDir, "artifacts");
+		const provisioner = new IpythonKernelProvisioner(tempDir, { snapshotDir });
+		const dill = join(snapshotDir, "kernel-state.dill");
+		const manifest = join(snapshotDir, "kernel-state.json");
+		mkdirSync(snapshotDir, { recursive: true });
+		writeFileSync(dill, "payload");
+		writeFileSync(manifest, "{}");
+
+		await provisioner.restart();
+
+		expect(existsSync(dill)).toBe(false);
+		expect(existsSync(manifest)).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -97,6 +97,23 @@ describe("IpythonKernelProvisioner", () => {
 		expect(provisioner.manager).toBeUndefined();
 	});
 
+	it("waits for readyGate before starting the kernel", async () => {
+		const { python, countRuns } = writeFakePython();
+		let release: () => void = () => {};
+		const gate = new Promise<void>((r) => {
+			release = r;
+		});
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python, readyGate: gate });
+
+		const started = provisioner.ensure().catch(() => {});
+		await new Promise((r) => setTimeout(r, 50));
+		expect(countRuns()).toBe(0); // gated: must not spawn the kernel yet
+
+		release();
+		await started;
+		expect(countRuns()).toBe(1);
+	});
+
 	it("restart() drops the on-disk snapshot so a compaction wipe isn't revived on resume", async () => {
 		const snapshotDir = join(tempDir, "artifacts");
 		const provisioner = new IpythonKernelProvisioner(tempDir, { snapshotDir });

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -27,9 +27,10 @@ function writeBootstrapVersion(venv: string, pythonSkills: readonly KernelPython
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
 		`${JSON.stringify({
-			schema: 6,
+			schema: 7,
 			ipykernel: "ipykernel",
 			runtime: "prime-agent-runtime",
+			snapshot: "dill",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: pythonSkills.map((skill) => ({
 				importName: skill.importName,
@@ -170,14 +171,16 @@ describe("kernel bootstrap", () => {
 		expect(log).toContain("pip install --python");
 		expect(log).toContain("ipykernel");
 		expect(log).toContain("prime-agent-runtime");
+		expect(log).toContain("dill");
 		for (const uvArg of DEFAULT_RLM_EXTRA_UV_ARGS) {
 			expect(log).toContain(uvArg);
 		}
 		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
 		expect(version).toEqual({
-			schema: 6,
+			schema: 7,
 			ipykernel: "ipykernel",
 			runtime: "prime-agent-runtime",
+			snapshot: "dill",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: [],
 		});

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -93,6 +93,32 @@ describeIfKernel("kernel state snapshot round-trip (real kernel)", () => {
 		}
 	}, 60_000);
 
+	it("snapshots and revives user variables that shadow builtins", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "prime-agent-state-shadow-"));
+		const path = join(dir, "shadow.dill");
+		const cfg = { path, manifestPath: join(dir, "shadow.json") };
+		const writer = new KernelManager({ python: python as string, cwd: dir, snapshot: cfg });
+		try {
+			// Shadow builtins the snapshot helper itself relies on (list/print) plus a
+			// plain builtin-named var (id); the helper must still run and capture them.
+			await writer.execute("list = [10, 20]\nprint = 'shadowed'\nid = 99");
+			const snap = await writer.snapshotState();
+			expect(snap).not.toBeNull();
+			expect(snap?.saved).toEqual(expect.arrayContaining(["list", "print", "id"]));
+		} finally {
+			await writer.dispose();
+		}
+
+		const reader = new KernelManager({ python: python as string, cwd: dir, snapshot: cfg });
+		try {
+			const restore = await reader.restoreState();
+			expect(restore?.restored).toEqual(expect.arrayContaining(["list", "print", "id"]));
+		} finally {
+			await reader.dispose();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	}, 60_000);
+
 	it("treats a corrupt (non-dict) snapshot as no restore without throwing", async () => {
 		const badDir = mkdtempSync(join(tmpdir(), "prime-agent-state-corrupt-"));
 		const badPath = join(badDir, "corrupt.dill");

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
+
+/** Find a python that can launch an ipykernel and has dill, or null to skip. */
+function resolveKernelPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((p): p is string => Boolean(p));
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import ipykernel, dill"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+const python = resolveKernelPython();
+const describeIfKernel = python ? describe : describe.skip;
+
+describeIfKernel("kernel state snapshot round-trip (real kernel)", () => {
+	let dir = "";
+	let snapshotPath = "";
+	let manifestPath = "";
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "prime-agent-state-roundtrip-"));
+		snapshotPath = join(dir, "session.dill");
+		manifestPath = join(dir, "session.json");
+	});
+
+	afterAll(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	});
+
+	function newManager(): KernelManager {
+		return new KernelManager({
+			python: python as string,
+			cwd: dir,
+			snapshot: { path: snapshotPath, manifestPath },
+		});
+	}
+
+	it("saves picklable names, reports unpicklable ones, then revives them in a fresh kernel", async () => {
+		const writer = newManager();
+		try {
+			await writer.execute("x = 42");
+			await writer.execute("df = [1, 2, 3]");
+			await writer.execute("def double(n):\n    return n * 2");
+			await writer.execute("import socket\nsock = socket.socket()");
+
+			const snap = await writer.snapshotState();
+			expect(snap).not.toBeNull();
+			expect(snap?.saved).toEqual(expect.arrayContaining(["x", "df", "double"]));
+			// A live socket cannot be pickled and must be reported, not silently dropped.
+			expect(snap?.skipped.map((s) => s.name)).toContain("sock");
+			expect(existsSync(snapshotPath)).toBe(true);
+			expect(existsSync(manifestPath)).toBe(true);
+		} finally {
+			await writer.dispose();
+		}
+
+		const reader = newManager();
+		try {
+			const restore = await reader.restoreState();
+			expect(restore?.restored).toEqual(expect.arrayContaining(["x", "df", "double"]));
+			expect(restore?.failed.map((f) => f.name) ?? []).not.toContain("x");
+
+			const echo = await reader.execute("print(x, double(x), sum(df))");
+			expect(echo.stdout.trim()).toBe("42 84 6");
+		} finally {
+			await reader.dispose();
+		}
+	}, 60_000);
+
+	it("treats a missing snapshot as an empty restore (clean start)", async () => {
+		const freshDir = mkdtempSync(join(tmpdir(), "prime-agent-state-empty-"));
+		const manager = new KernelManager({
+			python: python as string,
+			cwd: freshDir,
+			snapshot: { path: join(freshDir, "missing.dill"), manifestPath: join(freshDir, "missing.json") },
+		});
+		try {
+			const restore = await manager.restoreState();
+			expect(restore).toEqual({ restored: [], failed: [], path: join(freshDir, "missing.dill") });
+		} finally {
+			await manager.dispose();
+			rmSync(freshDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+
+	it("auto-snapshots after a successful execution (debounced)", async () => {
+		const autoDir = mkdtempSync(join(tmpdir(), "prime-agent-state-auto-"));
+		const autoPath = join(autoDir, "auto.dill");
+		const manager = new KernelManager({
+			python: python as string,
+			cwd: autoDir,
+			snapshot: { path: autoPath, manifestPath: join(autoDir, "auto.json"), debounceMs: 50 },
+		});
+		try {
+			await manager.execute("auto_var = 'persisted'");
+			await expect.poll(() => existsSync(autoPath), { timeout: 10_000 }).toBe(true);
+		} finally {
+			await manager.dispose();
+			rmSync(autoDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+});

--- a/packages/coding-agent/test/kernel-state-snapshot.test.ts
+++ b/packages/coding-agent/test/kernel-state-snapshot.test.ts
@@ -1,0 +1,114 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getSessionsDir } from "../src/config.js";
+import {
+	buildRestoreCode,
+	buildSnapshotCode,
+	DEFAULT_SNAPSHOT_MAX_BYTES,
+	kernelStateDir,
+	manifestPathFor,
+	parseRestoreResult,
+	parseSnapshotResult,
+	snapshotPathFor,
+} from "../src/core/kernel/state-snapshot.js";
+
+// Kept in sync with the marker the Python helpers print.
+const MARKER = "__PRIME_AGENT_KERNEL_STATE__";
+
+describe("kernel state snapshot paths", () => {
+	it("places snapshot + manifest under <sessionsDir>/kernel-state", () => {
+		expect(kernelStateDir()).toBe(join(getSessionsDir(), "kernel-state"));
+		expect(snapshotPathFor("abc-123")).toBe(join(getSessionsDir(), "kernel-state", "abc-123.dill"));
+		expect(manifestPathFor("abc-123")).toBe(join(getSessionsDir(), "kernel-state", "abc-123.json"));
+	});
+});
+
+describe("parseSnapshotResult", () => {
+	it("parses a valid marker line", () => {
+		const stdout = `${MARKER}${JSON.stringify({
+			saved: ["x", "y"],
+			skipped: [{ name: "sock", reason: "TypeError: cannot pickle" }],
+			bytes: 1234,
+		})}\n`;
+		const result = parseSnapshotResult(stdout, "/tmp/s.dill");
+		expect(result).toEqual({
+			saved: ["x", "y"],
+			skipped: [{ name: "sock", reason: "TypeError: cannot pickle" }],
+			bytes: 1234,
+			path: "/tmp/s.dill",
+		});
+	});
+
+	it("ignores stdout printed before the marker line", () => {
+		const stdout = `some earlier print output\n${MARKER}${JSON.stringify({ saved: ["a"], skipped: [], bytes: 7 })}`;
+		expect(parseSnapshotResult(stdout, "/tmp/s.dill")?.saved).toEqual(["a"]);
+	});
+
+	it("returns null when the marker is absent", () => {
+		expect(parseSnapshotResult("no marker here", "/tmp/s.dill")).toBeNull();
+	});
+
+	it("returns null when the payload reports an error", () => {
+		const stdout = `${MARKER}${JSON.stringify({ error: "dill unavailable" })}`;
+		expect(parseSnapshotResult(stdout, "/tmp/s.dill")).toBeNull();
+	});
+
+	it("returns null on malformed JSON", () => {
+		expect(parseSnapshotResult(`${MARKER}{not json`, "/tmp/s.dill")).toBeNull();
+	});
+
+	it("tolerates missing fields", () => {
+		const result = parseSnapshotResult(`${MARKER}{}`, "/tmp/s.dill");
+		expect(result).toEqual({ saved: [], skipped: [], bytes: 0, path: "/tmp/s.dill" });
+	});
+});
+
+describe("parseRestoreResult", () => {
+	it("parses restored and failed names", () => {
+		const stdout = `${MARKER}${JSON.stringify({
+			restored: ["df", "model"],
+			failed: [{ name: "conn", reason: "TypeError" }],
+		})}`;
+		expect(parseRestoreResult(stdout, "/tmp/s.dill")).toEqual({
+			restored: ["df", "model"],
+			failed: [{ name: "conn", reason: "TypeError" }],
+			path: "/tmp/s.dill",
+		});
+	});
+
+	it("returns null when the marker is absent", () => {
+		expect(parseRestoreResult("", "/tmp/s.dill")).toBeNull();
+	});
+
+	it("returns null when the payload reports an error", () => {
+		expect(parseRestoreResult(`${MARKER}${JSON.stringify({ error: "load failed" })}`, "/tmp/s.dill")).toBeNull();
+	});
+});
+
+describe("buildSnapshotCode", () => {
+	const code = buildSnapshotCode("/state/sess.dill", "/state/sess.json", DEFAULT_SNAPSHOT_MAX_BYTES);
+
+	it("embeds the output, manifest paths, and the byte cap", () => {
+		expect(code).toContain('"/state/sess.dill"');
+		expect(code).toContain('"/state/sess.json"');
+		expect(code).toContain(String(DEFAULT_SNAPSHOT_MAX_BYTES));
+	});
+
+	it("uses dill, an atomic write, and skips internal handles", () => {
+		expect(code).toContain("import dill");
+		expect(code).toContain("os.replace");
+		// rlm and the IPython display names must never be serialized.
+		expect(code).toContain('"rlm"');
+		expect(code).toContain(`print(${JSON.stringify(MARKER)}`);
+	});
+});
+
+describe("buildRestoreCode", () => {
+	const code = buildRestoreCode("/state/sess.dill");
+
+	it("embeds the input path and no-ops when the file is missing", () => {
+		expect(code).toContain('"/state/sess.dill"');
+		expect(code).toContain("os.path.exists");
+		expect(code).toContain("dill.loads");
+	});
+});

--- a/packages/coding-agent/test/kernel-state-snapshot.test.ts
+++ b/packages/coding-agent/test/kernel-state-snapshot.test.ts
@@ -1,25 +1,23 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { getSessionsDir } from "../src/config.js";
 import {
 	buildRestoreCode,
 	buildSnapshotCode,
 	DEFAULT_SNAPSHOT_MAX_BYTES,
-	kernelStateDir,
-	manifestPathFor,
+	manifestPathIn,
 	parseRestoreResult,
 	parseSnapshotResult,
-	snapshotPathFor,
+	snapshotPathIn,
 } from "../src/core/kernel/state-snapshot.js";
 
 // Kept in sync with the marker the Python helpers print.
 const MARKER = "__PRIME_AGENT_KERNEL_STATE__";
 
 describe("kernel state snapshot paths", () => {
-	it("places snapshot + manifest under <sessionsDir>/kernel-state", () => {
-		expect(kernelStateDir()).toBe(join(getSessionsDir(), "kernel-state"));
-		expect(snapshotPathFor("abc-123")).toBe(join(getSessionsDir(), "kernel-state", "abc-123.dill"));
-		expect(manifestPathFor("abc-123")).toBe(join(getSessionsDir(), "kernel-state", "abc-123.json"));
+	it("places snapshot + manifest inside the session artifact directory", () => {
+		const artifactDir = "/home/u/.prime/agent/session-artifacts/abc-123";
+		expect(snapshotPathIn(artifactDir)).toBe(join(artifactDir, "kernel-state.dill"));
+		expect(manifestPathIn(artifactDir)).toBe(join(artifactDir, "kernel-state.json"));
 	});
 });
 

--- a/packages/coding-agent/test/session-artifacts-delete.test.ts
+++ b/packages/coding-agent/test/session-artifacts-delete.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deleteSessionFile } from "../src/core/session-file-actions.js";
+
+let root = "";
+
+describe("deleteSessionFile removes the session artifact directory", () => {
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "prime-agent-session-delete-"));
+	});
+
+	afterEach(() => {
+		if (root) rmSync(root, { recursive: true, force: true });
+		root = "";
+	});
+
+	it("permanently deletes <root>/session-artifacts/<id> alongside the session file", async () => {
+		const sessionId = "session-xyz";
+		const sessionsDir = join(root, "sessions");
+		mkdirSync(sessionsDir, { recursive: true });
+		const sessionPath = join(sessionsDir, `${sessionId}.jsonl`);
+		writeFileSync(sessionPath, '{"type":"session"}\n');
+
+		const artifactDir = join(root, "session-artifacts", sessionId);
+		mkdirSync(artifactDir, { recursive: true });
+		writeFileSync(join(artifactDir, "kernel-state.dill"), "payload");
+		writeFileSync(join(artifactDir, "kernel-state.json"), "{}");
+
+		const result = await deleteSessionFile(sessionPath);
+
+		expect(result.ok).toBe(true);
+		expect(existsSync(artifactDir)).toBe(false);
+		expect(existsSync(sessionPath)).toBe(false);
+	});
+
+	it("succeeds when the session has no artifact directory", async () => {
+		const sessionsDir = join(root, "sessions");
+		mkdirSync(sessionsDir, { recursive: true });
+		const sessionPath = join(sessionsDir, "no-artifacts.jsonl");
+		writeFileSync(sessionPath, "{}\n");
+
+		const result = await deleteSessionFile(sessionPath);
+		expect(result.ok).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -149,6 +149,7 @@ describe("AgentSessionRuntime characterization", () => {
 			},
 			setSubagentRuntimeHost: vi.fn(),
 			dispose: disposeSession,
+			disposeAsync: disposeSession,
 		} as unknown as AgentSession;
 		const services = { cwd: "/tmp", agentDir: "/tmp" } as unknown as AgentSessionServices;
 		const createRuntime: CreateAgentSessionRuntimeFactory = async () => {


### PR DESCRIPTION
- resuming a session used to start a fresh ipython kernel, so the model assumed it still had variables and imports that were actually gone, leading to inaccurate behaviour.
- the kernel now serializes its user namespace to disk per-variable with dill, debounced after each cell plus a final flush on shutdown, and revives it when the session's kernel next starts.
- serialization is best-effort: objects that can't be pickled are skipped and reported, and the model is told on resume which names came back and which couldn't.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve IPython kernel namespace across session resume using dill snapshots
> - After each successful cell execution, the kernel debounces a snapshot of its user namespace to disk using `dill`, stored in a per-session artifact directory.
> - On session resume, `IpythonKernelProvisioner.startKernel` restores the prior namespace from the snapshot before bootstrapping, and injects a hidden context message listing restored variables via `AgentSession._onIpythonStateRestored`.
> - On session teardown, dispose, or process signal (SIGINT/SIGTERM), a bounded final snapshot flush runs before the kernel shuts down via the new `disposeAsync()` path.
> - After a `/reload` or compaction restart, the old kernel's dispose completes before the new kernel starts (via `readyGate`) to prevent snapshot races; the snapshot is deleted after restart to avoid unintended restoration.
> - Bootstrap schema is bumped to 7 and `dill` is added as a required venv dependency in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/181/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae). Deleting a session file now also removes its artifact directory via [session-file-actions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/181/files#diff-f3d71edaa939c91b6b5811464e334586b0a44f75d390df10c87eb939b1f4362a).
> - Risk: snapshot/restore failures are swallowed silently; corrupt or oversized snapshots may silently skip restoration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33f18af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel lifecycle, shutdown ordering, and on-disk session artifacts; unpicklable or corrupt state is handled best-effort but resume behavior may surprise users or increase startup cost when snapshots exist.
> 
> **Overview**
> Adds **dill-based snapshot/restore** of the IPython user namespace so resumed sessions can revive variables and imports instead of starting from an empty kernel.
> 
> `KernelManager` gains optional `snapshot` config: debounced auto-snapshots after successful cells, `snapshotState`/`restoreState`, and a bounded final flush on `dispose`/`shutdown` (including signal handlers). New `state-snapshot.ts` drives per-variable serialization with skip reporting. Kernel bootstrap schema **7** installs **dill**.
> 
> `IpythonKernelProvisioner` wires snapshots into the session artifact dir, restores before RLM bootstrap, uses **`readyGate`** so `/reload` waits for the old kernel’s flush, drops snapshot files on compaction **restart**, and exposes **`onRestore`**. `AgentSession` prewarms when a snapshot exists, notifies the model once on genuine resume via a custom message, and **`disposeAsync`** flushes the kernel before sync dispose; **`AgentSessionRuntime`** awaits that on quit/switch.
> 
> **`deleteSessionFile`** now removes `session-artifacts/<id>` after the `.jsonl` is deleted. Minor UI formatting-only diffs in diff/ipython-cell components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f18afcbcb327c15457e0d947cf0b9de2a4a3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->