### PR TITLE
add agent summaries and status to the agents view

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -133,6 +133,31 @@ export interface SessionStateEntry extends SessionEntryBase {
 	state: SessionState;
 }
 
+/** Whether an idle agent's turn left the task complete or awaiting more input. */
+export type AgentTaskState = "needs_input" | "completed";
+
+/**
+ * Latest short status for an agent, shown in the agents view. The summary is a
+ * one-line description of what the agent is doing or just did; taskState is the
+ * completion judgment for an idle session (omitted while the agent is working).
+ */
+export interface AgentStatus {
+	summary: string;
+	taskState?: AgentTaskState;
+	/** Message count this status was derived from, used to skip redundant work. */
+	basedOnMessageCount: number;
+}
+
+/**
+ * Session status entry written by the daemon's background summarizer. Append-only
+ * metadata: ignored by buildSessionContext and every other reader, so older code
+ * (and tools that parse these jsonl files) skip it as an unknown entry type.
+ */
+export interface AgentStatusEntry extends SessionEntryBase {
+	type: "agent_status";
+	status: AgentStatus;
+}
+
 /**
  * Custom message entry for extensions to inject messages into LLM context.
  * Use customType to identify your extension's entries.
@@ -165,7 +190,8 @@ export type SessionEntry =
 	| CustomMessageEntry
 	| LabelEntry
 	| SessionInfoEntry
-	| SessionStateEntry;
+	| SessionStateEntry
+	| AgentStatusEntry;
 
 /** Raw file entry (includes header) */
 export type FileEntry = SessionHeader | SessionEntry;
@@ -1119,6 +1145,35 @@ export class SessionManager {
 			const entry = entries[i];
 			if (entry.type === "session_state") {
 				return { status: entry.state.status };
+			}
+		}
+		return undefined;
+	}
+
+	/** Append the latest agent status (summary + completion judgment). Returns entry id. */
+	appendAgentStatus(status: AgentStatus): string {
+		const entry: AgentStatusEntry = {
+			type: "agent_status",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			status: {
+				summary: status.summary,
+				taskState: status.taskState,
+				basedOnMessageCount: status.basedOnMessageCount,
+			},
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/** Get the latest agent status from the most recent agent_status entry, if any. */
+	getLatestAgentStatus(): AgentStatus | undefined {
+		const entries = this.getEntries();
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const entry = entries[i];
+			if (entry.type === "agent_status") {
+				return { ...entry.status };
 			}
 		}
 		return undefined;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1161,12 +1161,14 @@ export class SessionManager {
 
 	/** Get the latest agent status from the most recent agent_status entry, if any. */
 	getLatestAgentStatus(): AgentStatus | undefined {
-		const entries = this.getEntries();
-		for (let i = entries.length - 1; i >= 0; i--) {
-			const entry = entries[i];
-			if (entry.type === "agent_status") {
-				return { ...entry.status };
+		// Walk the current leaf to root so we only read status on the active branch,
+		// not a sibling branch's status that happens to sit later in the file.
+		let current = this.leafId ? this.byId.get(this.leafId) : undefined;
+		while (current) {
+			if (current.type === "agent_status") {
+				return { ...current.status };
 			}
+			current = current.parentId ? this.byId.get(current.parentId) : undefined;
 		}
 		return undefined;
 	}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -136,11 +136,7 @@ export interface SessionStateEntry extends SessionEntryBase {
 /** Whether an idle agent's turn left the task complete or awaiting more input. */
 export type AgentTaskState = "needs_input" | "completed";
 
-/**
- * Latest short status for an agent, shown in the agents view. The summary is a
- * one-line description of what the agent is doing or just did; taskState is the
- * completion judgment for an idle session (omitted while the agent is working).
- */
+/** Latest short status for an agent, shown in the agents view. */
 export interface AgentStatus {
 	summary: string;
 	taskState?: AgentTaskState;
@@ -148,11 +144,7 @@ export interface AgentStatus {
 	basedOnMessageCount: number;
 }
 
-/**
- * Session status entry written by the daemon's background summarizer. Append-only
- * metadata: ignored by buildSessionContext and every other reader, so older code
- * (and tools that parse these jsonl files) skip it as an unknown entry type.
- */
+/** Append-only status entry; ignored by buildSessionContext and other readers. */
 export interface AgentStatusEntry extends SessionEntryBase {
 	type: "agent_status";
 	status: AgentStatus;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -633,6 +633,17 @@ export class DaemonAgentConnection implements AgentConnection {
 			await this.emit({ type: "session_event", event: message.event });
 			return;
 		}
+		if (message.type === "session_status") {
+			// Keep a cached snapshot's recap current so a later re-attach seeds it.
+			if (this.latestSnapshot) {
+				this.latestSnapshot = {
+					...this.latestSnapshot,
+					state: { ...this.latestSnapshot.state, recap: message.recap },
+				};
+			}
+			await this.emit({ type: "session_status", recap: message.recap });
+			return;
+		}
 		if (message.type === "session_replaced") {
 			const latestSnapshot: AgentConnectionSnapshot = {
 				state: message.state,

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -47,7 +47,10 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
-		recap: sessionManager.getLatestAgentStatus()?.summary,
+		// Persisted status is the baseline recap; the daemon overlays the fresher
+		// in-memory summary on attach. Optional-call so a minimal session manager
+		// (e.g. in tests) without the accessor doesn't break snapshot building.
+		recap: sessionManager.getLatestAgentStatus?.()?.summary,
 	};
 }
 

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -47,6 +47,7 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
+		recap: sessionManager.getLatestAgentStatus()?.summary,
 	};
 }
 

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -47,9 +47,8 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
-		// Persisted status is the baseline recap; the daemon overlays the fresher
-		// in-memory summary on attach. Optional-call so a minimal session manager
-		// (e.g. in tests) without the accessor doesn't break snapshot building.
+		// Baseline recap; the daemon overlays the live summary on attach. Optional-call
+		// so a minimal session manager (tests) without the accessor still works.
 		recap: sessionManager.getLatestAgentStatus?.()?.summary,
 	};
 }

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -13,6 +13,14 @@ import type {
 	AgentConnectionState,
 } from "./types.js";
 
+function persistedRecap(
+	sessionManager: { getLatestAgentStatus?: () => { summary: string; basedOnMessageCount: number } | undefined },
+	messageCount: number,
+): string | undefined {
+	const status = sessionManager.getLatestAgentStatus?.();
+	return status && status.basedOnMessageCount === messageCount ? status.summary : undefined;
+}
+
 export function createAgentConnectionState(
 	runtime: AgentSessionRuntime,
 	activeSessionId?: string,
@@ -47,9 +55,10 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
-		// Baseline recap; the daemon overlays the live summary on attach. Optional-call
-		// so a minimal session manager (tests) without the accessor still works.
-		recap: sessionManager.getLatestAgentStatus?.()?.summary,
+		// Baseline recap; the daemon overlays the live summary on attach. Only use it
+		// while it matches the current turn so attach never seeds a stale recap.
+		// Optional-call so a minimal session manager (tests) still works.
+		recap: persistedRecap(sessionManager, session.messages.length),
 	};
 }
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -175,6 +175,15 @@ export interface AgentConnectionSessionStateEntry extends AgentConnectionSession
 	state: AgentConnectionSavedSessionState;
 }
 
+export interface AgentConnectionAgentStatusEntry extends AgentConnectionSessionEntryBase {
+	type: "agent_status";
+	status: {
+		summary: string;
+		taskState?: "needs_input" | "completed";
+		basedOnMessageCount: number;
+	};
+}
+
 export type AgentConnectionSessionEntry =
 	| AgentConnectionSessionMessageEntry
 	| AgentConnectionThinkingLevelChangeEntry
@@ -186,7 +195,8 @@ export type AgentConnectionSessionEntry =
 	| AgentConnectionCustomMessageEntry
 	| AgentConnectionLabelEntry
 	| AgentConnectionSessionInfoEntry
-	| AgentConnectionSessionStateEntry;
+	| AgentConnectionSessionStateEntry
+	| AgentConnectionAgentStatusEntry;
 
 export interface AgentConnectionSessionTreeNode {
 	entry: AgentConnectionSessionEntry;
@@ -265,6 +275,8 @@ export interface AgentConnectionState {
 	scopedModels: AgentConnectionScopedModel[];
 	activeToolNames: string[];
 	contextUsage: SessionStats["contextUsage"];
+	/** One-line recap of the agent's recent work, shown above the prompt. */
+	recap?: string;
 }
 
 export interface AgentConnectionSlashCommand {
@@ -496,6 +508,7 @@ export type AgentConnectionSessionEvent =
 export type AgentConnectionEvent =
 	| { type: "session_event"; event: AgentConnectionSessionEvent }
 	| { type: "session_replaced"; state: AgentConnectionState; messages: AgentMessage[] }
+	| { type: "session_status"; recap?: string }
 	| { type: "extension_ui_request"; request: AgentConnectionExtensionUiRequest }
 	| { type: "closed"; error?: string };
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -61,6 +61,7 @@ const SESSION_NAME_MAX_LENGTH = 80;
 const DEFAULT_PROMPT_PLACEHOLDER = "Describe a task for a new session";
 const REPLY_PROMPT_FALLBACK_PLACEHOLDER = "Write a reply to this agent";
 const COMPLETED_ROW_ICON = "✓";
+const NEEDS_INPUT_ROW_ICON = "●";
 const WORKING_ICON_FRAMES = ["◇", "◈", "◆", "◈"] as const;
 const SELECTED_ROW_MARKER = "\0agents-view-selected-row\0";
 // Tags a spawn-code line so finalize can wrap the whole row in a panel
@@ -1388,7 +1389,12 @@ class AgentsViewMode implements Component, Focusable {
 
 	private getAgentCountsText(): string {
 		const counts = countRowsBySection(this.rows);
-		return `${counts.working} working, ${counts.completed} completed`;
+		const parts: string[] = [];
+		if (counts["needs-input"] > 0) {
+			parts.push(`${counts["needs-input"]} needs input`);
+		}
+		parts.push(`${counts.working} working`, `${counts.completed} completed`);
+		return parts.join(", ");
 	}
 
 	private renderSessionRows(width: number, maxRows: number): string[] {
@@ -1467,7 +1473,12 @@ class AgentsViewMode implements Component, Focusable {
 			: pendingKill
 				? `${keyText("app.agents.delete")} again to stop`
 				: row.title;
-		const titleCell = formatTableCell(title, titleWidth);
+		// Append the background summary as a dim suffix on the same line, e.g.
+		// "fix auth · Refactoring token validation". Hidden during delete/stop
+		// confirmations so the warning text stands alone.
+		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
+		const titleContent = summaryText ? `${title} ${theme.fg("dim", `· ${summaryText}`)}` : title;
+		const titleCell = formatTableCell(titleContent, titleWidth);
 		const cells = [
 			icon,
 			pendingDelete || pendingKill ? theme.fg("error", titleCell) : titleCell,
@@ -1574,6 +1585,8 @@ class AgentsViewMode implements Component, Focusable {
 		switch (section) {
 			case "working":
 				return WORKING_ICON_FRAMES[this.workingIconFrame % WORKING_ICON_FRAMES.length] ?? WORKING_ICON_FRAMES[0];
+			case "needs-input":
+				return NEEDS_INPUT_ROW_ICON;
 			case "completed":
 				return COMPLETED_ROW_ICON;
 			default: {
@@ -1587,6 +1600,8 @@ class AgentsViewMode implements Component, Focusable {
 		switch (section) {
 			case "working":
 				return theme.bold(icon);
+			case "needs-input":
+				return theme.fg("warning", icon);
 			case "completed":
 				return theme.fg("success", icon);
 			default: {
@@ -1605,7 +1620,7 @@ type DisplayItem =
 
 function buildDisplayItems(rows: readonly AgentsViewRow[]): DisplayItem[] {
 	const items: DisplayItem[] = [];
-	const sections: AgentsViewSection[] = ["working", "completed"];
+	const sections: AgentsViewSection[] = ["needs-input", "working", "completed"];
 	for (const [index, section] of sections.entries()) {
 		if (index > 0) {
 			items.push({ type: "spacer" });
@@ -1643,6 +1658,7 @@ function countRowsBySection(rows: readonly AgentsViewRow[]): Record<AgentsViewSe
 	const agents = rows.filter((row) => row.kind === "agent");
 	return {
 		working: agents.filter((row) => row.section === "working").length,
+		"needs-input": agents.filter((row) => row.section === "needs-input").length,
 		completed: agents.filter((row) => row.section === "completed").length,
 	};
 }

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -1,7 +1,7 @@
 import { basename } from "node:path";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
 
-export type AgentsViewSection = "working" | "completed";
+export type AgentsViewSection = "working" | "needs-input" | "completed";
 
 export type AgentsViewRowKind = "agent" | "subagent-summary" | "subagent" | "subagent-code";
 
@@ -35,6 +35,12 @@ export function classifyAgentsViewSession(summary: SessionSummary): AgentsViewSe
 	if (summary.status === "model" || summary.status === "tool") {
 		return "working";
 	}
+	// An idle session defaults to Completed and only moves to Needs Input on an
+	// explicit summarizer verdict. So a slow/failed/absent classification just
+	// leaves it under Completed rather than lingering in Working.
+	if (summary.taskState === "needs_input") {
+		return "needs-input";
+	}
 	return "completed";
 }
 
@@ -51,6 +57,8 @@ export function sectionTitle(section: AgentsViewSection): string {
 	switch (section) {
 		case "working":
 			return "Working";
+		case "needs-input":
+			return "Needs Input";
 		case "completed":
 			return "Completed";
 		default: {
@@ -298,10 +306,12 @@ function isSubagentSummary(summary: SessionSummary): boolean {
 
 function sectionRank(section: AgentsViewSection): number {
 	switch (section) {
-		case "working":
+		case "needs-input":
 			return 0;
-		case "completed":
+		case "working":
 			return 1;
+		case "completed":
+			return 2;
 		default: {
 			const _exhaustive: never = section;
 			return _exhaustive;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -35,9 +35,7 @@ export function classifyAgentsViewSession(summary: SessionSummary): AgentsViewSe
 	if (summary.status === "model" || summary.status === "tool") {
 		return "working";
 	}
-	// An idle session defaults to Completed and only moves to Needs Input on an
-	// explicit summarizer verdict. So a slow/failed/absent classification just
-	// leaves it under Completed rather than lingering in Working.
+	// Idle defaults to Completed; only an explicit verdict moves it to Needs Input.
 	if (summary.taskState === "needs_input") {
 		return "needs-input";
 	}

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Socket } from "node:net";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
+import type { AgentStatus } from "../../core/session-manager.js";
 import type { DaemonClientCapability, DaemonEventSequence, DaemonExtensionUIResponse } from "./daemon-protocol.js";
 import { formatSessionDisplayId, matchesSessionIdSuffix } from "./daemon-session-id.js";
 
@@ -20,6 +21,8 @@ export interface ActiveSessionState {
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
 	lastEventSequence: DaemonEventSequence;
 	unsubscribe?: () => void;
+	/** Latest background status summary, surfaced in the agents view. */
+	summaryState?: AgentStatus;
 }
 
 export interface ActiveSessionExtensionUiRequest {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1133,6 +1133,10 @@ class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
+		// Abort in-flight status work first (synchronously), before any await or
+		// dispose, so a finishing summarize bails on its aborted guard instead of
+		// appending agent_status to a session being torn down.
+		this.summarizer.forget(state.activeSessionId);
 		const cascadeError = await this.closeChildSessions(state, reason);
 		let persistError: unknown;
 		if (reason !== "shutdown") {
@@ -1153,7 +1157,6 @@ class AgentDaemon {
 			client.attachedActiveSessionIds.delete(state.activeSessionId);
 		}
 		state.clients.clear();
-		this.summarizer.forget(state.activeSessionId);
 		this.sessions.delete(state.activeSessionId);
 		if (persistError && reason !== "shutdown" && reason !== "completed") {
 			throw persistError;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -56,7 +56,12 @@ import {
 	isDaemonDialogExtensionUiRequest,
 	success,
 } from "./daemon-protocol.js";
-import { buildRlmChildSnapshots, buildSessionList, summaryForActiveSession } from "./daemon-session-list.js";
+import {
+	buildRlmChildSnapshots,
+	buildSessionList,
+	isSummaryCurrent,
+	summaryForActiveSession,
+} from "./daemon-session-list.js";
 import { DaemonSessionSummarizer } from "./daemon-session-summarizer.js";
 import {
 	cleanupDaemonSocketPath,
@@ -1067,8 +1072,9 @@ class AgentDaemon {
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		// Prefer the live in-memory recap over the persisted baseline.
-		if (state.summaryState?.summary) {
+		// Prefer the live in-memory recap over the persisted baseline, but only
+		// while it matches the current turn so we don't seed a stale recap.
+		if (state.summaryState?.summary && isSummaryCurrent(state)) {
 			connectionState.recap = state.summaryState.summary;
 		}
 		return {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1066,10 +1066,16 @@ class AgentDaemon {
 					}
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
+		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
+		// Prefer the live in-memory recap (including working-session lines that are
+		// never persisted) over the persisted baseline seeded above.
+		if (state.summaryState?.summary) {
+			connectionState.recap = state.summaryState.summary;
+		}
 		return {
 			activeSessionId: state.activeSessionId,
 			summary: summaryForActiveSession(state),
-			state: createAgentConnectionState(state.runtime, state.activeSessionId),
+			state: connectionState,
 			messages: state.runtime.session.messages,
 			sessionContext: sessionManager.buildSessionContext(),
 			// The session tree is omitted on purpose: it carries every entry's full

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -57,6 +57,7 @@ import {
 	success,
 } from "./daemon-protocol.js";
 import { buildRlmChildSnapshots, buildSessionList, summaryForActiveSession } from "./daemon-session-list.js";
+import { DaemonSessionSummarizer } from "./daemon-session-summarizer.js";
 import {
 	cleanupDaemonSocketPath,
 	defaultDaemonSocketPath,
@@ -159,6 +160,15 @@ class AgentDaemon {
 	private readonly sessions = new Map<string, ActiveSessionState>();
 	private readonly closingSessions = new Map<string, Promise<void>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
+	private readonly summarizer = new DaemonSessionSummarizer(
+		() => [...this.sessions.values()].filter((state) => state.runtime.metadata.kind !== "subagent"),
+		(state) =>
+			this.broadcastToSession(state, {
+				type: "session_status",
+				activeSessionId: state.activeSessionId,
+				recap: state.summaryState?.summary,
+			}),
+	);
 
 	constructor(
 		private readonly socketPath: string,
@@ -200,6 +210,7 @@ class AgentDaemon {
 		}
 
 		this.registerSignalHandlers();
+		this.summarizer.start();
 		console.error(`Prime Agent daemon listening on ${this.socketPath}`);
 		void this.restoreActiveSessions();
 	}
@@ -281,6 +292,8 @@ class AgentDaemon {
 			} catch {
 				// Marking is best-effort; the session still works unrestored.
 			}
+			// Restore the last persisted status so it shows before the first sweep.
+			this.summarizer.seed(state);
 		}
 		return state;
 	}
@@ -1134,6 +1147,7 @@ class AgentDaemon {
 			client.attachedActiveSessionIds.delete(state.activeSessionId);
 		}
 		state.clients.clear();
+		this.summarizer.forget(state.activeSessionId);
 		this.sessions.delete(state.activeSessionId);
 		if (persistError && reason !== "shutdown" && reason !== "completed") {
 			throw persistError;
@@ -1159,6 +1173,14 @@ class AgentDaemon {
 	}
 
 	private broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void {
+		// A finished turn (or compaction) is the cue to refresh this session's
+		// status, so an idle completion verdict lands promptly.
+		if (
+			message.type === "session_event" &&
+			(message.event.type === "turn_end" || message.event.type === "compaction_end")
+		) {
+			this.summarizer.notifyActivity(state);
+		}
 		const sequencedMessage = this.addSessionEventMeta(state, message);
 		for (const client of state.clients) {
 			if (!shouldSendDaemonOutboundToClient(client, sequencedMessage)) {
@@ -1208,6 +1230,7 @@ class AgentDaemon {
 		}
 		this.shuttingDown = true;
 
+		this.summarizer.stop();
 		for (const cleanup of this.signalCleanupHandlers) {
 			cleanup();
 		}
@@ -1292,13 +1315,20 @@ function normalizeClientCapabilities(
 type SequencedDaemonOutbound = Extract<
 	DaemonOutbound,
 	{
-		type: "session_event" | "session_replaced" | "session_closed" | "extension_ui_request" | "extension_error";
+		type:
+			| "session_event"
+			| "session_status"
+			| "session_replaced"
+			| "session_closed"
+			| "extension_ui_request"
+			| "extension_error";
 	}
 >;
 
 function isSequencedSessionOutbound(message: DaemonOutbound): message is SequencedDaemonOutbound {
 	return (
 		message.type === "session_event" ||
+		message.type === "session_status" ||
 		message.type === "session_replaced" ||
 		message.type === "session_closed" ||
 		message.type === "extension_ui_request" ||

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1067,8 +1067,7 @@ class AgentDaemon {
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		// Prefer the live in-memory recap (including working-session lines that are
-		// never persisted) over the persisted baseline seeded above.
+		// Prefer the live in-memory recap over the persisted baseline.
 		if (state.summaryState?.summary) {
 			connectionState.recap = state.summaryState.summary;
 		}
@@ -1133,9 +1132,8 @@ class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
-		// Abort in-flight status work first (synchronously), before any await or
-		// dispose, so a finishing summarize bails on its aborted guard instead of
-		// appending agent_status to a session being torn down.
+		// Abort in-flight status work before any await/dispose so it can't write
+		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
 		const cascadeError = await this.closeChildSessions(state, reason);
 		let persistError: unknown;
@@ -1182,8 +1180,7 @@ class AgentDaemon {
 	}
 
 	private broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void {
-		// A finished turn (or compaction) is the cue to refresh this session's
-		// status, so an idle completion verdict lands promptly.
+		// A finished turn/compaction is the cue to refresh status.
 		if (
 			message.type === "session_event" &&
 			(message.event.type === "turn_end" || message.event.type === "compaction_end")

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -315,6 +315,7 @@ export type DaemonOutbound =
 			serverCapabilities: readonly DaemonClientCapability[];
 	  }
 	| { type: "session_event"; activeSessionId: string; event: AgentConnectionSessionEvent; meta?: DaemonEventMeta }
+	| { type: "session_status"; activeSessionId: string; recap?: string; meta?: DaemonEventMeta }
 	| {
 			type: "session_replaced";
 			activeSessionId: string;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -152,8 +152,18 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
 		summary: activeSession.summaryState?.summary,
-		taskState: activeSession.summaryState?.taskState,
+		// Only trust the verdict while it matches the current turn; once new
+		// messages arrive a not-yet-refreshed verdict is stale, so we drop it and
+		// the view falls back to completed until the summarizer catches up.
+		taskState: isVerdictCurrent(activeSession) ? activeSession.summaryState?.taskState : undefined,
 	};
+}
+
+function isVerdictCurrent(activeSession: ActiveSessionState): boolean {
+	const status = activeSession.summaryState;
+	return (
+		status?.taskState !== undefined && status.basedOnMessageCount === activeSession.runtime.session.messages.length
+	);
 }
 
 export function summaryForInactiveSession(session: SessionInfo): SessionSummary {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -151,17 +151,17 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		spawnCode: metadata.spawnCode ? metadata.spawnCode.slice(0, SPAWN_CODE_MAX_CHARS) : undefined,
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
-		summary: activeSession.summaryState?.summary,
-		// Drop a stale verdict once new messages arrive (falls back to completed).
-		taskState: isVerdictCurrent(activeSession) ? activeSession.summaryState?.taskState : undefined,
+		// Drop both summary and verdict once new messages arrive; a stale recap
+		// would describe a prior turn. The summarizer refreshes within seconds.
+		...(isSummaryCurrent(activeSession)
+			? { summary: activeSession.summaryState?.summary, taskState: activeSession.summaryState?.taskState }
+			: {}),
 	};
 }
 
-function isVerdictCurrent(activeSession: ActiveSessionState): boolean {
+export function isSummaryCurrent(activeSession: ActiveSessionState): boolean {
 	const status = activeSession.summaryState;
-	return (
-		status?.taskState !== undefined && status.basedOnMessageCount === activeSession.runtime.session.messages.length
-	);
+	return status !== undefined && status.basedOnMessageCount === activeSession.runtime.session.messages.length;
 }
 
 export function summaryForInactiveSession(session: SessionInfo): SessionSummary {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -152,9 +152,7 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
 		summary: activeSession.summaryState?.summary,
-		// Only trust the verdict while it matches the current turn; once new
-		// messages arrive a not-yet-refreshed verdict is stale, so we drop it and
-		// the view falls back to completed until the summarizer catches up.
+		// Drop a stale verdict once new messages arrive (falls back to completed).
 		taskState: isVerdictCurrent(activeSession) ? activeSession.summaryState?.taskState : undefined,
 	};
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -5,7 +5,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { compactRlmText } from "../../core/agent-session.js";
 import type { AgentSessionRuntimeMetadata } from "../../core/agent-session-runtime.js";
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.js";
-import type { SessionInfo } from "../../core/session-manager.js";
+import type { AgentTaskState, SessionInfo } from "../../core/session-manager.js";
 import type {
 	AgentConnectionRlmChildAgentSnapshot,
 	AgentConnectionRlmChildAgentTranscriptLine,
@@ -49,6 +49,10 @@ export interface SessionSummary {
 	spawnCode?: string;
 	modelFallbackMessage?: string;
 	diagnostics?: AgentSessionRuntimeDiagnostic[];
+	/** One-line background summary of what the agent is doing or just did. */
+	summary?: string;
+	/** Completion verdict for an idle session; absent while working or unjudged. */
+	taskState?: AgentTaskState;
 }
 
 /**
@@ -147,6 +151,8 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		spawnCode: metadata.spawnCode ? metadata.spawnCode.slice(0, SPAWN_CODE_MAX_CHARS) : undefined,
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
+		summary: activeSession.summaryState?.summary,
+		taskState: activeSession.summaryState?.taskState,
 	};
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -5,30 +5,19 @@ import type { ModelRegistry } from "../../core/model-registry.js";
 import type { AgentStatus, AgentTaskState } from "../../core/session-manager.js";
 import type { ActiveSessionState } from "./active-session-state.js";
 
-// Periodic backstop that refreshes "what it's doing" lines for long-running
-// sessions; turn-end activity drives the timely idle verdict separately.
 const SWEEP_INTERVAL_MS = 25_000;
-// Wait for the agent to settle after a turn before judging completion, so a
-// tool-use loop's rapid turn_end bursts collapse into one summarization.
+// Collapse a tool-use loop's rapid turn_end bursts into one summarization.
 const SETTLE_DEBOUNCE_MS = 2_000;
 
-// Small open-weight model self-hosted on Prime Inference for background status
-// summaries — kept off the proxied frontier models. Resolved through the
-// session's own registry; when unavailable the daemon skips summarization and
-// the agents view falls back to its streaming-only heuristic.
+// Small self-hosted open-weight model, off the proxied frontier models.
 const SUMMARY_MODEL_PROVIDER = "prime-inference";
 const SUMMARY_MODEL_ID = "nvidia/nemotron-3-nano-30b-a3b";
 
-// Feed more than the latest message so the summary reflects the recent arc of
-// work, not a single line, while staying small for a cheap model.
 const SUMMARY_CONTEXT_MESSAGES = 8;
 const SUMMARY_MAX_CHARS_PER_MESSAGE = 600;
-// Generous so a chatty model that narrates before answering still reaches the
-// SUMMARY line; strict parsing discards everything before it.
+// Generous so a chatty model still reaches the SUMMARY line before truncation.
 const SUMMARY_MAX_TOKENS = 400;
 
-// Concise on purpose: the earlier (compaction) prompt is paragraphs long; a
-// status line only needs a short clause plus a completion verdict.
 export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI coding agent dashboard. You are given the recent conversation between a user and the agent, plus whether the agent is currently working or idle.
 
 Output ONLY these two lines, nothing before or after. Do not think out loud, explain, or add any other text.
@@ -90,11 +79,7 @@ function clamp(text: string, max: number): string {
 	return normalized.length > max ? `${normalized.slice(0, max)}…` : normalized;
 }
 
-/**
- * Serialize the trailing slice of a conversation into a compact prompt body.
- * Tool calls are noted by name so the summary can mention concrete activity
- * without dragging in full tool arguments or output.
- */
+/** Serialize the trailing messages into a compact prompt body (tool calls by name only). */
 export function buildStatusContext(messages: readonly AgentMessage[], isWorking: boolean): string {
 	const recent = messages.slice(-SUMMARY_CONTEXT_MESSAGES);
 	const lines: string[] = [];
@@ -116,18 +101,12 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
 }
 
 /**
- * Parse the two-line model reply into a summary and (for idle sessions) a
- * completion verdict. Strict on purpose: chatty/reasoning models narrate before
- * answering, so we require an explicit `SUMMARY:` line (taking the last one, in
- * case the answer follows reasoning) and never fall back to free text — that
- * would surface the model's chain-of-thought as the recap. Returns undefined
- * when no usable summary line was produced. WORKING-while-idle and unrecognized
- * verdicts fall back to needs_input so a session is never marked complete on a
- * malformed or hedged reply.
+ * Parse the two-line reply. Requires an explicit `SUMMARY:` line (last one wins,
+ * after any reasoning) and never falls back to free text, so a model's
+ * chain-of-thought can't leak into the recap. Idle verdicts default to
+ * needs_input on anything unrecognized.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
-	// Drop inline reasoning some open models emit (<think>, <thinking>,
-	// <reasoning>, <redacted_thinking>), including any unclosed leftover tags.
 	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
 	const cleaned = text
 		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
@@ -167,11 +146,7 @@ export interface GenerateAgentStatusParams {
 	signal?: AbortSignal;
 }
 
-/**
- * Run one cheap model call to produce a fresh status for a session. Returns
- * undefined when summarization is unavailable (no cheap model / auth), the
- * conversation is empty, or the call fails — callers then leave status as-is.
- */
+/** One cheap model call for a fresh status, or undefined if unavailable/empty/failed. */
 export async function generateAgentStatus(params: GenerateAgentStatusParams): Promise<AgentStatusResult | undefined> {
 	const { registry, messages, isWorking, signal } = params;
 	if (messages.length === 0) {
@@ -227,28 +202,22 @@ function isSessionWorking(state: ActiveSessionState): boolean {
 }
 
 /**
- * Owns background status summarization for daemon-hosted top-level sessions.
- * A periodic sweep refreshes working sessions; turn-end activity (debounced)
- * drives the idle completion verdict. Status is kept in memory on the session
- * state (the agents view picks it up on its next poll) and the settled idle
- * verdict is persisted append-only so it survives a daemon restart.
+ * Background status summarization for daemon-hosted top-level sessions. A
+ * periodic sweep refreshes working sessions; debounced turn-end activity drives
+ * the idle verdict. Status lives in memory; settled idle verdicts are persisted.
  */
 export class DaemonSessionSummarizer {
 	private interval: ReturnType<typeof setInterval> | undefined;
 	private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	// Maps an in-flight session id to a controller so a closing session can abort
-	// its summary and we can drop the result instead of writing after dispose.
+	// Controller per in-flight summary so a closing session can abort its write.
 	private readonly inFlight = new Map<string, AbortController>();
-	// Sessions whose summary was requested while one was already running; they get
-	// one more pass when the in-flight run finishes so a refresh is never dropped.
+	// Sessions requested while one was running; get one more pass on completion.
 	private readonly rerunRequested = new Set<string>();
 
 	constructor(
 		private readonly listTopLevelSessions: () => readonly ActiveSessionState[],
-		// Notified when a session's status text changes, so the daemon can push a
-		// live recap to that session's attached clients.
 		private readonly onStatusChanged?: (state: ActiveSessionState) => void,
-		// Injectable for tests; defaults to the real cheap-model call.
+		// Injectable for tests.
 		private readonly generate: (
 			params: GenerateAgentStatusParams,
 		) => Promise<AgentStatusResult | undefined> = generateAgentStatus,
@@ -288,8 +257,6 @@ export class DaemonSessionSummarizer {
 			clearTimeout(timer);
 			this.debounceTimers.delete(activeSessionId);
 		}
-		// Abort an in-flight summary so its result is discarded rather than written
-		// to a session that is being disposed, and drop any queued re-run.
 		this.inFlight.get(activeSessionId)?.abort();
 		this.rerunRequested.delete(activeSessionId);
 	}
@@ -329,8 +296,7 @@ export class DaemonSessionSummarizer {
 		}
 		const id = state.activeSessionId;
 		if (this.inFlight.has(id)) {
-			// Don't drop this request — run once more after the current pass finishes.
-			this.rerunRequested.add(id);
+			this.rerunRequested.add(id); // run once more after the current pass
 			return;
 		}
 		const session = state.runtime.session;
@@ -341,18 +307,14 @@ export class DaemonSessionSummarizer {
 		const messageCount = messages.length;
 		const isWorking = isSessionWorking(state);
 		const previous = state.summaryState;
-		// Skip an idle session that already has a current verdict. Working sessions
-		// are never skipped on unchanged count: their recap should keep up with the
-		// in-progress turn (the periodic sweep relies on this), and the streaming
-		// partial below gives the model fresh content to summarize.
+		// Idle sessions with a current verdict need no refresh; working sessions
+		// always refresh so the recap keeps up with the in-progress turn.
 		const contentUnchanged = previous?.basedOnMessageCount === messageCount;
 		const owesIdleVerdict = !isWorking && previous?.taskState === undefined;
 		if (contentUnchanged && !isWorking && !owesIdleVerdict) {
 			return;
 		}
-		// Include the in-progress assistant message so a long streaming turn gets a
-		// recap that reflects what the agent is doing right now, not just the last
-		// completed message.
+		// Include the in-progress message so a long streaming turn gets a live recap.
 		const streaming = isWorking ? session.state.streamingMessage : undefined;
 		const contextMessages = streaming ? [...messages, streaming] : messages;
 
@@ -368,11 +330,8 @@ export class DaemonSessionSummarizer {
 			if (!result) {
 				return;
 			}
-			// The model call is async: the session may have closed, been replaced
-			// (switchSession/fork/newSession), started a new turn, or begun streaming
-			// while it ran. Discard a result that no longer matches the captured
-			// session so we never record/persist a verdict for a turn that has moved
-			// on, nor append after the session is disposed or swapped.
+			// Discard if the session closed, was swapped, or moved to a new turn
+			// during the async call — never write a verdict for stale state.
 			if (
 				controller.signal.aborted ||
 				state.runtime.session !== session ||
@@ -381,9 +340,8 @@ export class DaemonSessionSummarizer {
 			) {
 				return;
 			}
-			// A working refresh carries no verdict; keep the prior one when the turn
-			// (message count) is unchanged so we don't drop a still-valid needs_input
-			// and flip the session to completed once it goes idle again.
+			// A working refresh carries no verdict; keep the prior one at the same
+			// message count so a still-valid needs_input isn't dropped.
 			const taskState =
 				result.taskState ?? (previous?.basedOnMessageCount === messageCount ? previous?.taskState : undefined);
 			const status: AgentStatus = {
@@ -393,13 +351,12 @@ export class DaemonSessionSummarizer {
 			};
 			const changed = previous?.summary !== status.summary || previous?.taskState !== status.taskState;
 			state.summaryState = status;
-			// Persist only settled idle verdicts: a stable status to restore on
-			// restart, and no writes interleaved with the agent's own streaming.
+			// Persist only settled idle verdicts, never mid-stream.
 			if (!isWorking) {
 				try {
 					session.sessionManager.appendAgentStatus(status);
 				} catch {
-					// Persistence is best-effort; the in-memory status still shows.
+					// best-effort; in-memory status still shows
 				}
 			}
 			if (changed) {
@@ -407,9 +364,7 @@ export class DaemonSessionSummarizer {
 			}
 		} finally {
 			this.inFlight.delete(id);
-			// Honor a request that arrived while this pass was running. Re-debounce
-			// rather than re-run immediately so a busy session can't chain back-to-back
-			// model calls; the refresh still lands seconds later, not next sweep.
+			// Re-debounce a request that arrived mid-pass instead of dropping it.
 			if (this.rerunRequested.delete(id)) {
 				this.notifyActivity(state);
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -239,6 +239,9 @@ export class DaemonSessionSummarizer {
 	// Maps an in-flight session id to a controller so a closing session can abort
 	// its summary and we can drop the result instead of writing after dispose.
 	private readonly inFlight = new Map<string, AbortController>();
+	// Sessions whose summary was requested while one was already running; they get
+	// one more pass when the in-flight run finishes so a refresh is never dropped.
+	private readonly rerunRequested = new Set<string>();
 
 	constructor(
 		private readonly listTopLevelSessions: () => readonly ActiveSessionState[],
@@ -275,6 +278,7 @@ export class DaemonSessionSummarizer {
 		for (const controller of this.inFlight.values()) {
 			controller.abort();
 		}
+		this.rerunRequested.clear();
 	}
 
 	/** Drop any pending work for a session that is closing. */
@@ -285,8 +289,9 @@ export class DaemonSessionSummarizer {
 			this.debounceTimers.delete(activeSessionId);
 		}
 		// Abort an in-flight summary so its result is discarded rather than written
-		// to a session that is being disposed.
+		// to a session that is being disposed, and drop any queued re-run.
 		this.inFlight.get(activeSessionId)?.abort();
+		this.rerunRequested.delete(activeSessionId);
 	}
 
 	/** Seed in-memory status from the persisted entry when a session is added. */
@@ -324,6 +329,8 @@ export class DaemonSessionSummarizer {
 		}
 		const id = state.activeSessionId;
 		if (this.inFlight.has(id)) {
+			// Don't drop this request — run once more after the current pass finishes.
+			this.rerunRequested.add(id);
 			return;
 		}
 		const session = state.runtime.session;
@@ -374,12 +381,17 @@ export class DaemonSessionSummarizer {
 			) {
 				return;
 			}
+			// A working refresh carries no verdict; keep the prior one when the turn
+			// (message count) is unchanged so we don't drop a still-valid needs_input
+			// and flip the session to completed once it goes idle again.
+			const taskState =
+				result.taskState ?? (previous?.basedOnMessageCount === messageCount ? previous?.taskState : undefined);
 			const status: AgentStatus = {
 				summary: result.summary,
-				taskState: result.taskState,
+				taskState,
 				basedOnMessageCount: messageCount,
 			};
-			const changed = agentStatusChanged(previous, result);
+			const changed = previous?.summary !== status.summary || previous?.taskState !== status.taskState;
 			state.summaryState = status;
 			// Persist only settled idle verdicts: a stable status to restore on
 			// restart, and no writes interleaved with the agent's own streaming.
@@ -395,6 +407,12 @@ export class DaemonSessionSummarizer {
 			}
 		} finally {
 			this.inFlight.delete(id);
+			// Honor a request that arrived while this pass was running. Re-debounce
+			// rather than re-run immediately so a busy session can't chain back-to-back
+			// model calls; the refresh still lands seconds later, not next sweep.
+			if (this.rerunRequested.delete(id)) {
+				this.notifyActivity(state);
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -126,8 +126,12 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
  * malformed or hedged reply.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
-	// Drop any <think>…</think> reasoning some open models emit inline.
-	const cleaned = text.replace(/<think>[\s\S]*?<\/think>/gi, " ").replace(/<\/?think>/gi, " ");
+	// Drop inline reasoning some open models emit (<think>, <thinking>,
+	// <reasoning>, <redacted_thinking>), including any unclosed leftover tags.
+	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
+	const cleaned = text
+		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
+		.replace(reasoningTag, " ");
 	let summary: string | undefined;
 	let status: string | undefined;
 	for (const rawLine of cleaned.split("\n")) {
@@ -334,6 +338,13 @@ export class DaemonSessionSummarizer {
 		try {
 			const result = await this.generate({ registry: session.modelRegistry, messages, isWorking });
 			if (!result) {
+				return;
+			}
+			// The model call is async: the session may have started a new turn or
+			// begun streaming while it ran. Discard a result that no longer matches
+			// the live state so we never record (or persist) a verdict for a turn
+			// that has moved on, nor append while the agent might be writing.
+			if (isSessionWorking(state) !== isWorking || session.messages.length !== messageCount) {
 				return;
 			}
 			const status: AgentStatus = {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -236,7 +236,9 @@ function isSessionWorking(state: ActiveSessionState): boolean {
 export class DaemonSessionSummarizer {
 	private interval: ReturnType<typeof setInterval> | undefined;
 	private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	private readonly inFlight = new Set<string>();
+	// Maps an in-flight session id to a controller so a closing session can abort
+	// its summary and we can drop the result instead of writing after dispose.
+	private readonly inFlight = new Map<string, AbortController>();
 
 	constructor(
 		private readonly listTopLevelSessions: () => readonly ActiveSessionState[],
@@ -270,6 +272,9 @@ export class DaemonSessionSummarizer {
 			clearTimeout(timer);
 		}
 		this.debounceTimers.clear();
+		for (const controller of this.inFlight.values()) {
+			controller.abort();
+		}
 	}
 
 	/** Drop any pending work for a session that is closing. */
@@ -279,6 +284,9 @@ export class DaemonSessionSummarizer {
 			clearTimeout(timer);
 			this.debounceTimers.delete(activeSessionId);
 		}
+		// Abort an in-flight summary so its result is discarded rather than written
+		// to a session that is being disposed.
+		this.inFlight.get(activeSessionId)?.abort();
 	}
 
 	/** Seed in-memory status from the persisted entry when a session is added. */
@@ -334,17 +342,27 @@ export class DaemonSessionSummarizer {
 			return;
 		}
 
-		this.inFlight.add(id);
+		const controller = new AbortController();
+		this.inFlight.set(id, controller);
 		try {
-			const result = await this.generate({ registry: session.modelRegistry, messages, isWorking });
+			const result = await this.generate({
+				registry: session.modelRegistry,
+				messages,
+				isWorking,
+				signal: controller.signal,
+			});
 			if (!result) {
 				return;
 			}
-			// The model call is async: the session may have started a new turn or
-			// begun streaming while it ran. Discard a result that no longer matches
-			// the live state so we never record (or persist) a verdict for a turn
-			// that has moved on, nor append while the agent might be writing.
-			if (isSessionWorking(state) !== isWorking || session.messages.length !== messageCount) {
+			// The model call is async: the session may have closed, started a new
+			// turn, or begun streaming while it ran. Discard a result that no longer
+			// matches the live state so we never record (or persist) a verdict for a
+			// turn that has moved on, nor append after the session is disposed.
+			if (
+				controller.signal.aborted ||
+				isSessionWorking(state) !== isWorking ||
+				session.messages.length !== messageCount
+			) {
 				return;
 			}
 			const status: AgentStatus = {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -1,0 +1,362 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "../../core/model-registry.js";
+import type { AgentStatus, AgentTaskState } from "../../core/session-manager.js";
+import type { ActiveSessionState } from "./active-session-state.js";
+
+// Periodic backstop that refreshes "what it's doing" lines for long-running
+// sessions; turn-end activity drives the timely idle verdict separately.
+const SWEEP_INTERVAL_MS = 25_000;
+// Wait for the agent to settle after a turn before judging completion, so a
+// tool-use loop's rapid turn_end bursts collapse into one summarization.
+const SETTLE_DEBOUNCE_MS = 2_000;
+
+// Small open-weight model self-hosted on Prime Inference for background status
+// summaries — kept off the proxied frontier models. Resolved through the
+// session's own registry; when unavailable the daemon skips summarization and
+// the agents view falls back to its streaming-only heuristic.
+const SUMMARY_MODEL_PROVIDER = "prime-inference";
+const SUMMARY_MODEL_ID = "nvidia/nemotron-3-nano-30b-a3b";
+
+// Feed more than the latest message so the summary reflects the recent arc of
+// work, not a single line, while staying small for a cheap model.
+const SUMMARY_CONTEXT_MESSAGES = 8;
+const SUMMARY_MAX_CHARS_PER_MESSAGE = 600;
+// Generous so a chatty model that narrates before answering still reaches the
+// SUMMARY line; strict parsing discards everything before it.
+const SUMMARY_MAX_TOKENS = 400;
+
+// Concise on purpose: the earlier (compaction) prompt is paragraphs long; a
+// status line only needs a short clause plus a completion verdict.
+export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI coding agent dashboard. You are given the recent conversation between a user and the agent, plus whether the agent is currently working or idle.
+
+Output ONLY these two lines, nothing before or after. Do not think out loud, explain, or add any other text.
+SUMMARY: a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period
+STATUS: one of WORKING, NEEDS_INPUT, COMPLETED
+
+STATUS meaning:
+- WORKING: the agent is mid-task and still acting.
+- COMPLETED: the agent finished its turn AND the user's request is fully done with nothing left.
+- NEEDS_INPUT: the agent finished its turn but the task is not fully done — it asked a question, hit a blocker, or needs more prompting.
+When the agent is idle and you are unsure between COMPLETED and NEEDS_INPUT, choose NEEDS_INPUT.
+
+Example:
+SUMMARY: Refactoring the auth middleware and updating its tests
+STATUS: WORKING`;
+
+export interface AgentStatusResult {
+	summary: string;
+	taskState?: AgentTaskState;
+}
+
+/** Resolve the cheap summary model, or undefined when it has no configured auth. */
+export function resolveSummaryModel(registry: ModelRegistry): Model<Api> | undefined {
+	const model = registry.find(SUMMARY_MODEL_PROVIDER, SUMMARY_MODEL_ID);
+	if (model && registry.hasConfiguredAuth(model)) {
+		return model;
+	}
+	return undefined;
+}
+
+function messageText(content: unknown): { text: string; tools: string[] } {
+	if (typeof content === "string") {
+		return { text: content, tools: [] };
+	}
+	if (!Array.isArray(content)) {
+		return { text: "", tools: [] };
+	}
+	const parts: string[] = [];
+	const tools: string[] = [];
+	for (const block of content) {
+		if (typeof block !== "object" || block === null) {
+			continue;
+		}
+		const type = (block as { type?: unknown }).type;
+		if (type === "text" && typeof (block as { text?: unknown }).text === "string") {
+			parts.push((block as { text: string }).text);
+		} else if (type === "tool_use" || type === "toolUse") {
+			const name = (block as { name?: unknown }).name;
+			if (typeof name === "string") {
+				tools.push(name);
+			}
+		}
+	}
+	return { text: parts.join("\n"), tools };
+}
+
+function clamp(text: string, max: number): string {
+	const normalized = text.replace(/\s+/g, " ").trim();
+	return normalized.length > max ? `${normalized.slice(0, max)}…` : normalized;
+}
+
+/**
+ * Serialize the trailing slice of a conversation into a compact prompt body.
+ * Tool calls are noted by name so the summary can mention concrete activity
+ * without dragging in full tool arguments or output.
+ */
+export function buildStatusContext(messages: readonly AgentMessage[], isWorking: boolean): string {
+	const recent = messages.slice(-SUMMARY_CONTEXT_MESSAGES);
+	const lines: string[] = [];
+	for (const message of recent) {
+		const role = message.role;
+		if (role !== "user" && role !== "assistant" && role !== "toolResult" && role !== "custom") {
+			continue;
+		}
+		const { text, tools } = messageText(message.content);
+		const body = clamp(text, SUMMARY_MAX_CHARS_PER_MESSAGE);
+		const toolNote = tools.length > 0 ? `[tools: ${[...new Set(tools)].join(", ")}]` : "";
+		const rendered = [body, toolNote].filter((part) => part.length > 0).join(" ");
+		if (rendered) {
+			lines.push(`${role}: ${rendered}`);
+		}
+	}
+	const state = isWorking ? "working" : "idle (finished its turn)";
+	return `<agent-state>${state}</agent-state>\n<conversation>\n${lines.join("\n")}\n</conversation>`;
+}
+
+/**
+ * Parse the two-line model reply into a summary and (for idle sessions) a
+ * completion verdict. Strict on purpose: chatty/reasoning models narrate before
+ * answering, so we require an explicit `SUMMARY:` line (taking the last one, in
+ * case the answer follows reasoning) and never fall back to free text — that
+ * would surface the model's chain-of-thought as the recap. Returns undefined
+ * when no usable summary line was produced. WORKING-while-idle and unrecognized
+ * verdicts fall back to needs_input so a session is never marked complete on a
+ * malformed or hedged reply.
+ */
+export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
+	// Drop any <think>…</think> reasoning some open models emit inline.
+	const cleaned = text.replace(/<think>[\s\S]*?<\/think>/gi, " ").replace(/<\/?think>/gi, " ");
+	let summary: string | undefined;
+	let status: string | undefined;
+	for (const rawLine of cleaned.split("\n")) {
+		const line = rawLine.trim();
+		const summaryMatch = /^summary\s*:\s*(.+)$/i.exec(line);
+		if (summaryMatch) {
+			const candidate = summaryMatch[1]!.trim().replace(/[.\s]+$/, "");
+			// Skip an echoed prompt template (e.g. "<one present-tense clause…>").
+			if (candidate && !candidate.startsWith("<") && !/present-tense|12 words/i.test(candidate)) {
+				summary = candidate;
+			}
+			continue;
+		}
+		const statusMatch = /^status\s*:\s*([a-z_]+)/i.exec(line);
+		if (statusMatch) {
+			status = statusMatch[1]!.toUpperCase();
+		}
+	}
+	if (!summary) {
+		return undefined;
+	}
+	if (isWorking) {
+		return { summary };
+	}
+	const taskState: AgentTaskState = status === "COMPLETED" ? "completed" : "needs_input";
+	return { summary, taskState };
+}
+
+export interface GenerateAgentStatusParams {
+	registry: ModelRegistry;
+	messages: readonly AgentMessage[];
+	isWorking: boolean;
+	signal?: AbortSignal;
+}
+
+/**
+ * Run one cheap model call to produce a fresh status for a session. Returns
+ * undefined when summarization is unavailable (no cheap model / auth), the
+ * conversation is empty, or the call fails — callers then leave status as-is.
+ */
+export async function generateAgentStatus(params: GenerateAgentStatusParams): Promise<AgentStatusResult | undefined> {
+	const { registry, messages, isWorking, signal } = params;
+	if (messages.length === 0) {
+		return undefined;
+	}
+	const model = resolveSummaryModel(registry);
+	if (!model) {
+		return undefined;
+	}
+	const auth = await registry.getApiKeyAndHeaders(model);
+	if (!auth.ok || !auth.apiKey) {
+		return undefined;
+	}
+	try {
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt: AGENT_STATUS_SYSTEM_PROMPT,
+				messages: [
+					{
+						role: "user" as const,
+						content: [{ type: "text" as const, text: buildStatusContext(messages, isWorking) }],
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ maxTokens: SUMMARY_MAX_TOKENS, apiKey: auth.apiKey, headers: auth.headers, signal },
+		);
+		if (response.stopReason === "error") {
+			return undefined;
+		}
+		const textContent = response.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n");
+		return parseAgentStatusResponse(textContent, isWorking);
+	} catch {
+		return undefined;
+	}
+}
+
+/** True when the new status differs enough from the stored one to be worth broadcasting. */
+export function agentStatusChanged(previous: AgentStatus | undefined, next: AgentStatusResult): boolean {
+	if (!previous) {
+		return true;
+	}
+	return previous.summary !== next.summary || previous.taskState !== next.taskState;
+}
+
+function isSessionWorking(state: ActiveSessionState): boolean {
+	const session = state.runtime.session;
+	return session.isStreaming || session.isCompacting || session.pendingMessageCount > 0;
+}
+
+/**
+ * Owns background status summarization for daemon-hosted top-level sessions.
+ * A periodic sweep refreshes working sessions; turn-end activity (debounced)
+ * drives the idle completion verdict. Status is kept in memory on the session
+ * state (the agents view picks it up on its next poll) and the settled idle
+ * verdict is persisted append-only so it survives a daemon restart.
+ */
+export class DaemonSessionSummarizer {
+	private interval: ReturnType<typeof setInterval> | undefined;
+	private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private readonly inFlight = new Set<string>();
+
+	constructor(
+		private readonly listTopLevelSessions: () => readonly ActiveSessionState[],
+		// Notified when a session's status text changes, so the daemon can push a
+		// live recap to that session's attached clients.
+		private readonly onStatusChanged?: (state: ActiveSessionState) => void,
+		// Injectable for tests; defaults to the real cheap-model call.
+		private readonly generate: (
+			params: GenerateAgentStatusParams,
+		) => Promise<AgentStatusResult | undefined> = generateAgentStatus,
+	) {}
+
+	start(): void {
+		if (this.interval) {
+			return;
+		}
+		this.interval = setInterval(() => {
+			for (const state of this.listTopLevelSessions()) {
+				void this.summarize(state);
+			}
+		}, SWEEP_INTERVAL_MS);
+		this.interval.unref?.();
+	}
+
+	stop(): void {
+		if (this.interval) {
+			clearInterval(this.interval);
+			this.interval = undefined;
+		}
+		for (const timer of this.debounceTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.debounceTimers.clear();
+	}
+
+	/** Drop any pending work for a session that is closing. */
+	forget(activeSessionId: string): void {
+		const timer = this.debounceTimers.get(activeSessionId);
+		if (timer) {
+			clearTimeout(timer);
+			this.debounceTimers.delete(activeSessionId);
+		}
+	}
+
+	/** Seed in-memory status from the persisted entry when a session is added. */
+	seed(state: ActiveSessionState): void {
+		if (state.summaryState) {
+			return;
+		}
+		const persisted = state.runtime.session.sessionManager.getLatestAgentStatus();
+		if (persisted) {
+			state.summaryState = persisted;
+		}
+	}
+
+	/** Called when a session finishes a turn; debounce until the agent settles. */
+	notifyActivity(state: ActiveSessionState): void {
+		if (state.runtime.metadata.kind === "subagent") {
+			return;
+		}
+		const id = state.activeSessionId;
+		const existing = this.debounceTimers.get(id);
+		if (existing) {
+			clearTimeout(existing);
+		}
+		const timer = setTimeout(() => {
+			this.debounceTimers.delete(id);
+			void this.summarize(state);
+		}, SETTLE_DEBOUNCE_MS);
+		timer.unref?.();
+		this.debounceTimers.set(id, timer);
+	}
+
+	private async summarize(state: ActiveSessionState): Promise<void> {
+		if (state.runtime.metadata.kind === "subagent") {
+			return;
+		}
+		const id = state.activeSessionId;
+		if (this.inFlight.has(id)) {
+			return;
+		}
+		const session = state.runtime.session;
+		const messages = session.messages;
+		if (messages.length === 0) {
+			return;
+		}
+		const messageCount = messages.length;
+		const isWorking = isSessionWorking(state);
+		const previous = state.summaryState;
+		// Skip when nothing changed, unless an idle session still owes a completion
+		// verdict for its current (settled) content.
+		const contentUnchanged = previous?.basedOnMessageCount === messageCount;
+		const owesIdleVerdict = !isWorking && previous?.taskState === undefined;
+		if (contentUnchanged && !owesIdleVerdict) {
+			return;
+		}
+
+		this.inFlight.add(id);
+		try {
+			const result = await this.generate({ registry: session.modelRegistry, messages, isWorking });
+			if (!result) {
+				return;
+			}
+			const status: AgentStatus = {
+				summary: result.summary,
+				taskState: result.taskState,
+				basedOnMessageCount: messageCount,
+			};
+			const changed = agentStatusChanged(previous, result);
+			state.summaryState = status;
+			// Persist only settled idle verdicts: a stable status to restore on
+			// restart, and no writes interleaved with the agent's own streaming.
+			if (!isWorking) {
+				try {
+					session.sessionManager.appendAgentStatus(status);
+				} catch {
+					// Persistence is best-effort; the in-memory status still shows.
+				}
+			}
+			if (changed) {
+				this.onStatusChanged?.(state);
+			}
+		} finally {
+			this.inFlight.delete(id);
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -334,32 +334,41 @@ export class DaemonSessionSummarizer {
 		const messageCount = messages.length;
 		const isWorking = isSessionWorking(state);
 		const previous = state.summaryState;
-		// Skip when nothing changed, unless an idle session still owes a completion
-		// verdict for its current (settled) content.
+		// Skip an idle session that already has a current verdict. Working sessions
+		// are never skipped on unchanged count: their recap should keep up with the
+		// in-progress turn (the periodic sweep relies on this), and the streaming
+		// partial below gives the model fresh content to summarize.
 		const contentUnchanged = previous?.basedOnMessageCount === messageCount;
 		const owesIdleVerdict = !isWorking && previous?.taskState === undefined;
-		if (contentUnchanged && !owesIdleVerdict) {
+		if (contentUnchanged && !isWorking && !owesIdleVerdict) {
 			return;
 		}
+		// Include the in-progress assistant message so a long streaming turn gets a
+		// recap that reflects what the agent is doing right now, not just the last
+		// completed message.
+		const streaming = isWorking ? session.state.streamingMessage : undefined;
+		const contextMessages = streaming ? [...messages, streaming] : messages;
 
 		const controller = new AbortController();
 		this.inFlight.set(id, controller);
 		try {
 			const result = await this.generate({
 				registry: session.modelRegistry,
-				messages,
+				messages: contextMessages,
 				isWorking,
 				signal: controller.signal,
 			});
 			if (!result) {
 				return;
 			}
-			// The model call is async: the session may have closed, started a new
-			// turn, or begun streaming while it ran. Discard a result that no longer
-			// matches the live state so we never record (or persist) a verdict for a
-			// turn that has moved on, nor append after the session is disposed.
+			// The model call is async: the session may have closed, been replaced
+			// (switchSession/fork/newSession), started a new turn, or begun streaming
+			// while it ran. Discard a result that no longer matches the captured
+			// session so we never record/persist a verdict for a turn that has moved
+			// on, nor append after the session is disposed or swapped.
 			if (
 				controller.signal.aborted ||
+				state.runtime.session !== session ||
 				isSessionWorking(state) !== isWorking ||
 				session.messages.length !== messageCount
 			) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3671,6 +3671,9 @@ export class InteractiveMode {
 					this.ui.requestRender();
 				} else if (event.message.role === "user") {
 					this.addMessageToChat(event.message);
+					// A new turn makes the recap stale; clear it until the summarizer pushes a fresh one.
+					this.sessionRecap = undefined;
+					this.renderRecap();
 					this.updatePendingMessagesDisplay();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2512,10 +2512,7 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	/**
-	 * Render the agent's one-line recap directly above the editor. Shown only
-	 * when a recap exists, so sessions without one cost no vertical space.
-	 */
+	/** Render the recap line above the editor, only when one exists. */
 	private renderRecap(): void {
 		if (!this.recapContainer) return;
 		this.recapContainer.clear();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -550,6 +550,10 @@ export class InteractiveMode {
 	private widgetContainerAbove!: Container;
 	private widgetContainerBelow!: Container;
 
+	// One-line recap of the agent's recent work, rendered just above the editor.
+	private recapContainer!: Container;
+	private sessionRecap: string | undefined;
+
 	// Custom footer from extension (undefined = use built-in footer)
 	private customFooter: (Component & { dispose?(): void }) | undefined = undefined;
 
@@ -622,6 +626,7 @@ export class InteractiveMode {
 		this.childAgentDetail.onKill = (nodeId) => void this.killChildAgent(nodeId);
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
+		this.recapContainer = new Container();
 		this.keybindings = KeybindingsManager.create();
 		setKeybindings(this.keybindings);
 		const editorPaddingX = this.settingsManager.getEditorPaddingX();
@@ -865,6 +870,8 @@ export class InteractiveMode {
 		this.mainContainer.addChild(this.mainViewContainer);
 		this.renderWidgets(); // Initialize with default spacer
 		this.mainContainer.addChild(this.widgetContainerAbove);
+		this.renderRecap();
+		this.mainContainer.addChild(this.recapContainer);
 		this.mainContainer.addChild(this.editorContainer);
 		this.mainContainer.addChild(this.childAgentSummary);
 		this.mainContainer.addChild(this.widgetContainerBelow);
@@ -1945,6 +1952,8 @@ export class InteractiveMode {
 	private applyConnectionStateSnapshot(state: AgentConnectionState): void {
 		this.connectionState = state;
 		this.footer.setAutoCompactEnabled(state.autoCompactionEnabled);
+		this.sessionRecap = state.recap;
+		this.renderRecap();
 	}
 
 	private patchConnectionState(patch: Partial<AgentConnectionState>): void {
@@ -2500,6 +2509,22 @@ export class InteractiveMode {
 		if (!this.widgetContainerAbove || !this.widgetContainerBelow) return;
 		this.renderWidgetContainer(this.widgetContainerAbove, this.extensionWidgetsAbove, true, true);
 		this.renderWidgetContainer(this.widgetContainerBelow, this.extensionWidgetsBelow, false, false);
+		this.ui.requestRender();
+	}
+
+	/**
+	 * Render the agent's one-line recap directly above the editor. Shown only
+	 * when a recap exists, so sessions without one cost no vertical space.
+	 */
+	private renderRecap(): void {
+		if (!this.recapContainer) return;
+		this.recapContainer.clear();
+		const recap = this.sessionRecap?.trim();
+		if (recap) {
+			this.recapContainer.addChild(new Text(theme.fg("dim", `Recap: ${recap}`), 1, 0));
+			// Blank line between the recap and the prompt bar below it.
+			this.recapContainer.addChild(new Spacer(1));
+		}
 		this.ui.requestRender();
 	}
 
@@ -3363,6 +3388,10 @@ export class InteractiveMode {
 					await this.rebindCurrentSession();
 					await this.renderInitialMessages();
 					this.ui.requestRender();
+				} else if (event.type === "session_status") {
+					this.sessionRecap = event.recap;
+					this.patchConnectionState({ recap: event.recap });
+					this.renderRecap();
 				} else if (event.type === "extension_ui_request") {
 					await this.handleConnectionExtensionUiRequest(event.request);
 				} else if (event.type === "closed") {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -29,6 +29,21 @@ describe("agents view state", () => {
 		expect(classifyAgentsViewSession(makeSummary({ status: "idle", messageCount: 4 }))).toBe("completed");
 	});
 
+	test("idle sessions split by the summarizer's completion verdict", () => {
+		// Working is heuristic and ignores taskState.
+		expect(classifyAgentsViewSession(makeSummary({ isStreaming: true, taskState: "completed" }))).toBe("working");
+		// Idle sessions follow the verdict; absent one they stay completed.
+		expect(classifyAgentsViewSession(makeSummary({ status: "idle", taskState: "needs_input" }))).toBe("needs-input");
+		expect(classifyAgentsViewSession(makeSummary({ status: "idle", taskState: "completed" }))).toBe("completed");
+		expect(classifyAgentsViewSession(makeSummary({ status: "idle", taskState: undefined }))).toBe("completed");
+	});
+
+	test("defaults an idle session with no verdict to completed", () => {
+		// A slow, failed, or absent classification never lingers in Working; only
+		// an explicit needs_input verdict moves an idle session out of completed.
+		expect(classifyAgentsViewSession(makeSummary({ status: "idle", taskState: undefined }))).toBe("completed");
+	});
+
 	test("sorts rows by section and most recent modified time", () => {
 		const rows = buildAgentsViewRows([
 			makeSummary({ sessionName: "completed", status: "idle", messageCount: 2, modified: "2026-01-01T00:00:00Z" }),

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -61,6 +61,23 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		expect(state.summaryState).toBeUndefined();
 	});
 
+	test("discards a verdict when the session is forgotten (closed) mid-call", async () => {
+		vi.useFakeTimers();
+		const state = makeState({ working: false });
+		let summarizer!: DaemonSessionSummarizer;
+		const generate = vi.fn().mockImplementation(async () => {
+			summarizer.forget(state.activeSessionId); // session closes while the model runs
+			return { summary: "Result after close", taskState: "completed" };
+		});
+		summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+		expect(generate).toHaveBeenCalledOnce();
+		// Aborted → nothing written to the disposed session.
+		expect(state.summaryState).toBeUndefined();
+	});
+
 	test("discards a verdict when a new turn arrives during the model call", async () => {
 		vi.useFakeTimers();
 		const state = makeState({ working: false });

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -77,6 +77,18 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		expect(generate.mock.calls[0]?.[0]).toMatchObject({ isWorking: true });
 	});
 
+	test("a working refresh preserves a still-valid verdict at the same message count", async () => {
+		vi.useFakeTimers();
+		const generate = vi.fn().mockResolvedValue({ summary: "Editing the router" }); // working → no verdict
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+		const state = makeState({ working: true });
+		state.summaryState = { summary: "Asked which db", taskState: "needs_input", basedOnMessageCount: 2 };
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+		expect(state.summaryState).toMatchObject({ summary: "Editing the router", taskState: "needs_input" });
+	});
+
 	test("discards a verdict when the session is forgotten (closed) mid-call", async () => {
 		vi.useFakeTimers();
 		const state = makeState({ working: false });

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
+import { DaemonSessionSummarizer } from "../src/modes/daemon/daemon-session-summarizer.js";
+
+// The debounce the summarizer waits for after a turn settles (kept in sync with
+// SETTLE_DEBOUNCE_MS in the module).
+const SETTLE_MS = 2000;
+
+function makeState(opts: { working?: boolean; messages?: number } = {}): ActiveSessionState {
+	const appended: unknown[] = [];
+	return {
+		activeSessionId: "a1",
+		summaryState: undefined,
+		runtime: {
+			metadata: { kind: "top-level" },
+			session: {
+				isStreaming: opts.working ?? false,
+				isCompacting: false,
+				pendingMessageCount: 0,
+				messages: Array.from({ length: opts.messages ?? 2 }, () => ({ role: "user", content: "hi" })),
+				modelRegistry: {},
+				sessionManager: { appendAgentStatus: (s: unknown) => appended.push(s) },
+			},
+		},
+	} as unknown as ActiveSessionState;
+}
+
+describe("DaemonSessionSummarizer lifecycle", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("runs the model call after the settle debounce and records the verdict", async () => {
+		vi.useFakeTimers();
+		const generate = vi.fn().mockResolvedValue({ summary: "Added the health endpoint", taskState: "completed" });
+		const onStatusChanged = vi.fn();
+		const summarizer = new DaemonSessionSummarizer(() => [], onStatusChanged, generate);
+		const state = makeState({ working: false });
+
+		summarizer.notifyActivity(state);
+		// No model call until the agent has settled for the debounce window.
+		await vi.advanceTimersByTimeAsync(SETTLE_MS - 500);
+		expect(generate).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(600);
+		expect(generate).toHaveBeenCalledOnce();
+		expect(state.summaryState).toMatchObject({ summary: "Added the health endpoint", taskState: "completed" });
+		expect(onStatusChanged).toHaveBeenCalled();
+	});
+
+	test("a failing model leaves no verdict — the view then defaults to completed", async () => {
+		vi.useFakeTimers();
+		const generate = vi.fn().mockResolvedValue(undefined); // 404 / 401 / timeout / unparseable
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+		const state = makeState({ working: false });
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+		expect(generate).toHaveBeenCalledOnce();
+		// No status recorded; taskState stays undefined so classification → completed.
+		expect(state.summaryState).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -60,4 +60,21 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		// No status recorded; taskState stays undefined so classification → completed.
 		expect(state.summaryState).toBeUndefined();
 	});
+
+	test("discards a verdict when a new turn arrives during the model call", async () => {
+		vi.useFakeTimers();
+		const state = makeState({ working: false });
+		// The model "responds" only after the session has moved on to a new turn.
+		const generate = vi.fn().mockImplementation(async () => {
+			(state.runtime.session.messages as unknown[]).push({ role: "user", content: "another task" });
+			return { summary: "Stale summary for the old turn", taskState: "completed" };
+		});
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+		expect(generate).toHaveBeenCalledOnce();
+		// Result is for an outdated turn → dropped, nothing persisted.
+		expect(state.summaryState).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -18,6 +18,7 @@ function makeState(opts: { working?: boolean; messages?: number } = {}): ActiveS
 				isCompacting: false,
 				pendingMessageCount: 0,
 				messages: Array.from({ length: opts.messages ?? 2 }, () => ({ role: "user", content: "hi" })),
+				state: { streamingMessage: undefined },
 				modelRegistry: {},
 				sessionManager: { appendAgentStatus: (s: unknown) => appended.push(s) },
 			},
@@ -59,6 +60,21 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		expect(generate).toHaveBeenCalledOnce();
 		// No status recorded; taskState stays undefined so classification → completed.
 		expect(state.summaryState).toBeUndefined();
+	});
+
+	test("refreshes a working session even when the message count is unchanged", async () => {
+		vi.useFakeTimers();
+		const generate = vi.fn().mockResolvedValue({ summary: "Editing the router" });
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+		const state = makeState({ working: true });
+		// A status already exists for the current message count, so an idle session
+		// would be skipped — but a working one must still refresh its recap.
+		state.summaryState = { summary: "Editing the router", taskState: undefined, basedOnMessageCount: 2 };
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+		expect(generate).toHaveBeenCalledOnce();
+		expect(generate.mock.calls[0]?.[0]).toMatchObject({ isWorking: true });
 	});
 
 	test("discards a verdict when the session is forgotten (closed) mid-call", async () => {

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -1,0 +1,108 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { describe, expect, test } from "vitest";
+import type { AgentStatus } from "../src/core/session-manager.js";
+import {
+	agentStatusChanged,
+	buildStatusContext,
+	parseAgentStatusResponse,
+} from "../src/modes/daemon/daemon-session-summarizer.js";
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: 0 } as unknown as AgentMessage;
+}
+
+function assistantMessage(text: string, tools: string[] = []): AgentMessage {
+	const content = [{ type: "text", text }, ...tools.map((name) => ({ type: "tool_use", name, id: name, input: {} }))];
+	return { role: "assistant", content, timestamp: 0 } as unknown as AgentMessage;
+}
+
+describe("daemon session summarizer", () => {
+	describe("parseAgentStatusResponse", () => {
+		test("parses summary and completion verdict for an idle session", () => {
+			const result = parseAgentStatusResponse("SUMMARY: Added the API reference page.\nSTATUS: COMPLETED", false);
+			expect(result).toEqual({ summary: "Added the API reference page", taskState: "completed" });
+		});
+
+		test("maps NEEDS_INPUT for idle sessions", () => {
+			const result = parseAgentStatusResponse("SUMMARY: Asked which database to target\nSTATUS: NEEDS_INPUT", false);
+			expect(result?.taskState).toBe("needs_input");
+		});
+
+		test("omits the verdict while working", () => {
+			const result = parseAgentStatusResponse("SUMMARY: Refactoring token validation\nSTATUS: WORKING", true);
+			expect(result).toEqual({ summary: "Refactoring token validation" });
+		});
+
+		test("falls back to needs_input on an unrecognized or hedged idle verdict", () => {
+			expect(parseAgentStatusResponse("SUMMARY: Something\nSTATUS: WORKING", false)?.taskState).toBe("needs_input");
+			expect(parseAgentStatusResponse("SUMMARY: Something\nSTATUS: MAYBE", false)?.taskState).toBe("needs_input");
+			expect(parseAgentStatusResponse("SUMMARY: Something", false)?.taskState).toBe("needs_input");
+		});
+
+		test("requires the SUMMARY marker and never surfaces free-form text", () => {
+			// A chatty/reasoning model that narrates instead of answering yields no
+			// recap rather than leaking its thinking.
+			expect(parseAgentStatusResponse("Investigating the failing test.", true)).toBeUndefined();
+			expect(
+				parseAgentStatusResponse(
+					"We need to produce exactly two lines: SUMMARY: <one present-tense clause> and STATUS: with a",
+					false,
+				),
+			).toBeUndefined();
+		});
+
+		test("takes the answer after inline reasoning and strips think tags", () => {
+			const reasoning =
+				"<think>Let me decide. The agent finished editing.</think>\nSUMMARY: Updated the login handler\nSTATUS: COMPLETED";
+			expect(parseAgentStatusResponse(reasoning, false)).toEqual({
+				summary: "Updated the login handler",
+				taskState: "completed",
+			});
+		});
+
+		test("ignores an echoed prompt template", () => {
+			const echoed = "SUMMARY: <one present-tense clause, at most 12 words, no trailing period>\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(echoed, true)).toBeUndefined();
+		});
+
+		test("returns undefined when no summary is present", () => {
+			expect(parseAgentStatusResponse("", false)).toBeUndefined();
+			expect(parseAgentStatusResponse("STATUS: COMPLETED", false)).toBeUndefined();
+		});
+	});
+
+	describe("buildStatusContext", () => {
+		test("includes the agent state and the trailing conversation with tool names", () => {
+			const context = buildStatusContext(
+				[userMessage("add a login endpoint"), assistantMessage("Editing the router", ["Edit", "Bash"])],
+				true,
+			);
+			expect(context).toContain("<agent-state>working</agent-state>");
+			expect(context).toContain("user: add a login endpoint");
+			expect(context).toContain("assistant: Editing the router [tools: Edit, Bash]");
+		});
+
+		test("marks idle sessions as finished", () => {
+			expect(buildStatusContext([userMessage("hi")], false)).toContain("idle (finished its turn)");
+		});
+
+		test("only keeps the most recent messages", () => {
+			const messages = Array.from({ length: 20 }, (_, i) => userMessage(`message ${i}`));
+			const context = buildStatusContext(messages, false);
+			expect(context).toContain("message 19");
+			expect(context).not.toContain("message 0\n");
+		});
+	});
+
+	describe("agentStatusChanged", () => {
+		const base: AgentStatus = { summary: "Working on it", taskState: "needs_input", basedOnMessageCount: 4 };
+		test("is true when there is no previous status", () => {
+			expect(agentStatusChanged(undefined, { summary: "x" })).toBe(true);
+		});
+		test("detects summary and verdict changes", () => {
+			expect(agentStatusChanged(base, { summary: "Working on it", taskState: "needs_input" })).toBe(false);
+			expect(agentStatusChanged(base, { summary: "Done", taskState: "needs_input" })).toBe(true);
+			expect(agentStatusChanged(base, { summary: "Working on it", taskState: "completed" })).toBe(true);
+		});
+	});
+});

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -65,6 +65,16 @@ describe("daemon session summarizer", () => {
 			expect(parseAgentStatusResponse(echoed, true)).toBeUndefined();
 		});
 
+		test("strips reasoning tag variants before parsing", () => {
+			for (const tag of ["think", "thinking", "reasoning", "redacted_thinking"]) {
+				const text = `<${tag}>deliberating about the answer</${tag}>\nSUMMARY: Wired the recap line\nSTATUS: COMPLETED`;
+				expect(parseAgentStatusResponse(text, false)).toEqual({
+					summary: "Wired the recap line",
+					taskState: "completed",
+				});
+			}
+		});
+
 		test("returns undefined when no summary is present", () => {
 			expect(parseAgentStatusResponse("", false)).toBeUndefined();
 			expect(parseAgentStatusResponse("STATUS: COMPLETED", false)).toBeUndefined();

--- a/packages/coding-agent/test/session-manager/agent-status.test.ts
+++ b/packages/coding-agent/test/session-manager/agent-status.test.ts
@@ -35,6 +35,29 @@ describe("SessionManager agent status", () => {
 		}
 	});
 
+	it("reads the status on the active branch, not a sibling branch's later entry", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "agent-status-branch-"));
+		try {
+			const session = SessionManager.create(join(tempDir, "p"), join(tempDir, "s"));
+			const m1 = session.appendMessage(userMsg("first"));
+			const m2 = session.appendMessage(assistantMsg("reply"));
+
+			// Branch A off m1, leave a status on it.
+			session.branch(m1);
+			const branchAStatus = session.appendAgentStatus({ summary: "branch A", basedOnMessageCount: 1 });
+
+			// Branch B off m2 with a status appended later in the file.
+			session.branch(m2);
+			session.appendAgentStatus({ summary: "branch B", basedOnMessageCount: 1 });
+
+			// Re-activate branch A; its status must win despite B being later in the file.
+			session.branch(branchAStatus);
+			expect(session.getLatestAgentStatus()?.summary).toBe("branch A");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("is ignored by context building so it never reaches the model", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "agent-status-context-"));
 		try {

--- a/packages/coding-agent/test/session-manager/agent-status.test.ts
+++ b/packages/coding-agent/test/session-manager/agent-status.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildSessionContext, loadEntriesFromFile, SessionManager } from "../../src/core/session-manager.js";
+import { assistantMsg, userMsg } from "../utilities.js";
+
+describe("SessionManager agent status", () => {
+	it("persists the latest agent status append-only and reads it back", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "agent-status-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(cwd, sessionDir);
+
+			session.appendMessage(userMsg("add a login endpoint"));
+			session.appendMessage(assistantMsg("done"));
+			session.appendAgentStatus({ summary: "Working", taskState: undefined, basedOnMessageCount: 2 });
+			session.appendAgentStatus({ summary: "Added login endpoint", taskState: "completed", basedOnMessageCount: 2 });
+
+			// Latest entry wins.
+			expect(session.getLatestAgentStatus()).toEqual({
+				summary: "Added login endpoint",
+				taskState: "completed",
+				basedOnMessageCount: 2,
+			});
+
+			// Append-only: re-reading the raw file recovers both entries and the
+			// two conversation messages untouched.
+			const entries = loadEntriesFromFile(session.getSessionFile()!);
+			expect(entries.filter((entry) => entry.type === "agent_status")).toHaveLength(2);
+			expect(entries.filter((entry) => entry.type === "message")).toHaveLength(2);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("is ignored by context building so it never reaches the model", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "agent-status-context-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(cwd, sessionDir);
+
+			session.appendMessage(userMsg("hello"));
+			session.appendMessage(assistantMsg("hi"));
+			session.appendAgentStatus({ summary: "Greeted the user", taskState: "completed", basedOnMessageCount: 2 });
+
+			const context = buildSessionContext(session.getEntries(), session.getLeafId());
+			expect(context.messages).toHaveLength(2);
+			expect(context.messages.every((message) => message.role === "user" || message.role === "assistant")).toBe(
+				true,
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
- adds a short one-line summary for each agent and splits sessions into needs input, working, and completed in the agents view, refreshed periodically by a small self-hosted prime inference model.
- persists the latest status append-only on the session and shows a live "recap:" line above the prompt bar when you open a session.
- idle sessions default to completed and only move to needs input on an explicit model verdict, so a slow or failing summarizer never leaves a session stuck in working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Each active top-level session triggers periodic and debounced background LLM calls after turns/compactions, adding inference cost and dependency on summary-model auth; stale-status guards limit wrong verdicts but session close mid-flight is handled explicitly.
> 
> **Overview**
> Adds **one-line agent status** across the daemon fleet and attached session UI: a background summarizer, persisted `agent_status` entries, and live `session_status` / `recap` wiring.
> 
> A new **`DaemonSessionSummarizer`** runs on a timer and after debounced `turn_end` / `compaction_end` events. It calls a small **prime-inference** model to emit a short recap plus an idle verdict (`needs_input` vs `completed`). Results live in **`ActiveSessionState.summaryState`**, settled idle verdicts are **append-only** via `SessionManager.appendAgentStatus` (excluded from LLM context), and changes are **broadcast** as `session_status` with `recap`.
> 
> The **agents view** gains a **Needs Input** section (above Working), row suffixes with dim summaries, and classification that only moves idle sessions there on an explicit `needs_input` verdict—otherwise they stay **completed** so a slow or failed summarizer does not leave agents stuck in Working.
> 
> **Interactive mode** shows **`Recap: …`** above the prompt from connection state and `session_status` events; the recap clears when a new user turn starts. Attach snapshots seed recap only when persisted status matches the current message count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772968c010a91ba83edc52d48a9ed772fe3dfcfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent summaries and "needs input" status to the agents view
> - A new background summarizer ([daemon-session-summarizer.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/182/files#diff-f7613b331eb488c0bb7d4cd012f97c2bfb45fb01444ab63d0c9378839666625a)) periodically generates a one-line recap and an idle verdict (`needs_input` or `completed`) for each top-level daemon session using a cheap model call.
> - The daemon broadcasts `session_status` messages to connected clients and persists settled idle verdicts as `agent_status` entries in the session file via `SessionManager.appendAgentStatus`.
> - The agents view gains a "Needs Input" section (ranked above Working and Completed) showing agents awaiting user action, with a distinct ● warning-color icon and dimmed summary text on each row.
> - The interactive UI renders a dimmed "Recap: …" line above the input editor, populated on attach and updated live via `session_status` events; it clears at the start of each new user turn.
> - Behavioral Change: idle sessions previously all fell into Completed; they now split into Needs Input vs Completed based on the summarizer verdict, which may shift session ordering in the agents view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 772968c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->