### PR TITLE
move global startup notices to the agents view

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1249,7 +1249,9 @@ export async function main(args: string[], options?: MainOptions) {
 			initialMessages: parsed.messages,
 			verbose: parsed.verbose,
 			// Resumed/attached daemon sessions are part of the same fleet; left
-			// arrow takes them to the agents view like any other session.
+			// arrow takes them to the agents view like any other session. The agents
+			// view was not rendered here, so we intentionally leave
+			// agentsViewOwnsStartupNotices unset and let the in-session fallback run.
 			returnToAgentsView: true,
 		});
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -225,6 +225,8 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 				modelFallbackMessage: resolveAttachModelFallbackMessage(opened.summary, options.modelFallbackMessage),
 				verbose: options.verbose,
 				returnToAgentsView: true,
+				// The agents view renders the global notices itself, so suppress them in-session.
+				agentsViewOwnsStartupNotices: true,
 				// Matches the node id scheme used by snapshot child seeding
 				// (rlmChildId, falling back to the child's active session id).
 				initialSubagentNodeId: result.subagent

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -94,6 +94,10 @@ type AgentsViewPersistentState = {
 	selectedRowIdentity?: string;
 	statusMessage?: string;
 	initialPromptsSent?: boolean;
+	// Gathered once and reused across agents-view instances so the notices survive
+	// re-entry and render the moment they resolve, even if the first view was left early.
+	startupNotices?: StartupNotices;
+	startupNoticesPromise?: Promise<StartupNotices>;
 };
 
 type PromptCommand = Extract<DaemonCommand, { type: "prompt" }>;
@@ -287,6 +291,7 @@ class AgentsViewMode implements Component, Focusable {
 		private readonly persistentState: AgentsViewPersistentState = {},
 	) {
 		this.selectedRowIdentity = persistentState.selectedRowIdentity;
+		this.startupNotices = persistentState.startupNotices;
 		this.keybindings = KeybindingsManager.create();
 		setKeybindings(this.keybindings);
 		setRegisteredThemes(options.uiServices.getThemes());
@@ -435,13 +440,23 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private loadStartupNotices(): void {
-		void gatherStartupNotices({
-			version: VERSION,
-			cwd: this.options.uiServices.getInitialCwd(),
-			agentDir: getAgentDir(),
-			settingsManager: this.options.uiServices.settingsManager,
-		})
+		if (this.persistentState.startupNotices) {
+			return;
+		}
+		// Reuse an in-flight gather from an earlier agents-view instance so leaving and
+		// re-entering does not re-run the checks or lose a result that resolved meanwhile.
+		const promise =
+			this.persistentState.startupNoticesPromise ??
+			gatherStartupNotices({
+				version: VERSION,
+				cwd: this.options.uiServices.getInitialCwd(),
+				agentDir: getAgentDir(),
+				settingsManager: this.options.uiServices.settingsManager,
+			});
+		this.persistentState.startupNoticesPromise = promise;
+		void promise
 			.then((notices) => {
+				this.persistentState.startupNotices = notices;
 				this.startupNotices = notices;
 				this.ui.requestRender();
 			})

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -283,15 +283,12 @@ class AgentsViewMode implements Component, Focusable {
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
 	private stopped = false;
 	private anthropicSubscriptionWarningShown = false;
-	// Global update/setup notices, resolved once on startup and shown above the list.
-	private startupNotices: StartupNotices | undefined;
 
 	constructor(
 		private readonly options: AgentsViewModeOptions,
 		private readonly persistentState: AgentsViewPersistentState = {},
 	) {
 		this.selectedRowIdentity = persistentState.selectedRowIdentity;
-		this.startupNotices = persistentState.startupNotices;
 		this.keybindings = KeybindingsManager.create();
 		setKeybindings(this.keybindings);
 		setRegisteredThemes(options.uiServices.getThemes());
@@ -440,13 +437,14 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private loadStartupNotices(): void {
+		// Notices live on persistentState (read directly in renderStartupNotices), so they
+		// survive leaving and re-entering the agents view regardless of which instance's
+		// gather resolved. Already have them? Nothing to do.
 		if (this.persistentState.startupNotices) {
-			// May have resolved on a prior instance after this one's constructor ran.
-			this.startupNotices = this.persistentState.startupNotices;
 			return;
 		}
-		// Reuse an in-flight gather from an earlier agents-view instance so leaving and
-		// re-entering does not re-run the checks or lose a result that resolved meanwhile.
+		// Reuse an in-flight gather from an earlier agents-view instance so re-entry does
+		// not re-run the checks or lose a result that resolved meanwhile.
 		const promise =
 			this.persistentState.startupNoticesPromise ??
 			gatherStartupNotices({
@@ -459,14 +457,15 @@ class AgentsViewMode implements Component, Focusable {
 		void promise
 			.then((notices) => {
 				this.persistentState.startupNotices = notices;
-				this.startupNotices = notices;
+				// Best-effort immediate paint; a re-entered instance also picks this up on
+				// its next poll tick since render reads persistentState directly.
 				this.ui.requestRender();
 			})
 			.catch(() => {});
 	}
 
 	private renderStartupNotices(width: number): string[] {
-		const notices = this.startupNotices;
+		const notices = this.persistentState.startupNotices;
 		if (!notices) {
 			return [];
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -441,6 +441,8 @@ class AgentsViewMode implements Component, Focusable {
 
 	private loadStartupNotices(): void {
 		if (this.persistentState.startupNotices) {
+			// May have resolved on a prior instance after this one's constructor ran.
+			this.startupNotices = this.persistentState.startupNotices;
 			return;
 		}
 		// Reuse an in-flight gather from an earlier agents-view instance so leaving and

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -10,8 +10,9 @@ import {
 	TUI,
 	truncateToWidth,
 	visibleWidth,
+	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { APP_TITLE, VERSION } from "../../config.js";
+import { APP_TITLE, getAgentDir, VERSION } from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { findExactModelReferenceMatch } from "../../core/model-resolver.js";
@@ -35,6 +36,13 @@ import {
 	stopThemeWatcher,
 	theme,
 } from "../interactive/theme/theme.js";
+import {
+	formatPackageUpdateNotice,
+	formatTmuxWarningNotice,
+	formatUpdateAvailableNotice,
+	gatherStartupNotices,
+	type StartupNotices,
+} from "../shared/startup-notices.js";
 import {
 	AGENTS_VIEW_SLASH_COMMANDS,
 	type AgentsViewCommandName,
@@ -269,6 +277,8 @@ class AgentsViewMode implements Component, Focusable {
 	private statusMessageTimer: ReturnType<typeof setTimeout> | undefined;
 	private stopped = false;
 	private anthropicSubscriptionWarningShown = false;
+	// Global update/setup notices, resolved once on startup and shown above the list.
+	private startupNotices: StartupNotices | undefined;
 
 	constructor(
 		private readonly options: AgentsViewModeOptions,
@@ -339,6 +349,7 @@ class AgentsViewMode implements Component, Focusable {
 
 		await this.refreshSessions();
 		await this.sendInitialPrompts();
+		this.loadStartupNotices();
 		this.pollTimer = setInterval(() => {
 			void this.refreshSessions();
 		}, POLL_INTERVAL_MS);
@@ -411,10 +422,49 @@ class AgentsViewMode implements Component, Focusable {
 		}
 		const lines: string[] = [];
 		lines.push(...this.splash.render(width));
+		const noticeLines = this.renderStartupNotices(width);
+		if (noticeLines.length > 0) {
+			lines.push("", ...noticeLines);
+		}
 		lines.push("");
 		const listRows = Math.max(0, height - lines.length);
 		lines.push(...this.renderSessionRows(width, listRows));
 		return lines;
+	}
+
+	private loadStartupNotices(): void {
+		void gatherStartupNotices({
+			version: VERSION,
+			cwd: this.options.uiServices.getInitialCwd(),
+			agentDir: getAgentDir(),
+			settingsManager: this.options.uiServices.settingsManager,
+		})
+			.then((notices) => {
+				this.startupNotices = notices;
+				this.ui.requestRender();
+			})
+			.catch(() => {});
+	}
+
+	private renderStartupNotices(width: number): string[] {
+		const notices = this.startupNotices;
+		if (!notices) {
+			return [];
+		}
+		const formatted: string[] = [];
+		if (notices.newVersion) {
+			formatted.push(formatUpdateAvailableNotice(notices.newVersion));
+		}
+		if (notices.packageUpdates.length > 0) {
+			formatted.push(formatPackageUpdateNotice(notices.packageUpdates));
+		}
+		if (notices.tmuxWarning) {
+			formatted.push(formatTmuxWarningNotice(notices.tmuxWarning));
+		}
+		// Match the splash header's one-column gutter and wrap so long notices
+		// (e.g. the tmux fix instructions) stay readable instead of truncating.
+		const wrapWidth = Math.max(1, width - 1);
+		return formatted.flatMap((line) => wrapTextWithAnsi(line, wrapWidth).map((wrapped) => ` ${wrapped}`));
 	}
 
 	private handleListNavigation(data: string): boolean {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -429,6 +429,12 @@ export interface InteractiveModeOptions {
 	onShutdown?: () => void | Promise<void>;
 	/** Allow returning from a full session to the agents view without stopping the daemon-owned agent. */
 	returnToAgentsView?: boolean;
+	/**
+	 * The agents view already surfaced global startup notices (app/extension updates, tmux setup),
+	 * so this session must not repeat them in its chat stream. Distinct from `returnToAgentsView`,
+	 * which also covers direct daemon attaches where the agents view was never shown.
+	 */
+	agentsViewOwnsStartupNotices?: boolean;
 	/** Open the read-only detail view for this subagent node right after startup. */
 	initialSubagentNodeId?: string;
 }
@@ -938,9 +944,11 @@ export class InteractiveMode {
 		await this.init();
 
 		// Global, environment-scoped notices (app update, extension updates, tmux setup)
-		// belong on the agents view, not in a conversation. When launched from the agents
-		// view it owns them, so skip the checks here entirely.
-		const ownsGlobalStartupNotices = !this.options.returnToAgentsView;
+		// belong on the agents view, not in a conversation. When the agents view already
+		// showed them, skip the checks here entirely. (This is narrower than
+		// `returnToAgentsView`, which is also set for direct daemon attaches that never
+		// rendered the agents view and still want the in-session fallback.)
+		const ownsGlobalStartupNotices = !this.options.agentsViewOwnsStartupNotices;
 		const newVersionPromise = ownsGlobalStartupNotices ? checkForNewPiVersion(this.version) : undefined;
 		const packageUpdatesPromise = ownsGlobalStartupNotices
 			? checkForPackageUpdates({

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,7 +56,6 @@ import { emptyGoalState, formatGoalUsage, type GoalState } from "../../core/goal
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
-import { DefaultPackageManager } from "../../core/package-manager.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
@@ -94,6 +93,12 @@ import type {
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
+import {
+	checkForPackageUpdates,
+	checkTmuxKeyboardSetup,
+	formatPackageUpdateNotice,
+	formatUpdateAvailableNotice,
+} from "../shared/startup-notices.js";
 import { AGENT_ACTIVITY_LABELS, AgentActivityTracker, formatTokenCount } from "./agent-activity.js";
 import { type AuthenticationResult, getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "./auth-flows.js";
 import { ArminComponent } from "./components/armin.js";
@@ -518,6 +523,8 @@ export class InteractiveMode {
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
 	private initialConnectionSnapshotConsumed = false;
+	// Whether the session already had messages when first rendered (i.e. a resumed session).
+	private sessionHadInitialMessages = false;
 
 	// Agent subscription unsubscribe function
 	private unsubscribe?: () => void;
@@ -930,9 +937,19 @@ export class InteractiveMode {
 	async run(): Promise<InteractiveModeRunResult> {
 		await this.init();
 
-		const newVersionPromise = checkForNewPiVersion(this.version);
-		const packageUpdatesPromise = this.checkForPackageUpdates();
-		const tmuxKeyboardWarningPromise = this.checkTmuxKeyboardSetup();
+		// Global, environment-scoped notices (app update, extension updates, tmux setup)
+		// belong on the agents view, not in a conversation. When launched from the agents
+		// view it owns them, so skip the checks here entirely.
+		const ownsGlobalStartupNotices = !this.options.returnToAgentsView;
+		const newVersionPromise = ownsGlobalStartupNotices ? checkForNewPiVersion(this.version) : undefined;
+		const packageUpdatesPromise = ownsGlobalStartupNotices
+			? checkForPackageUpdates({
+					cwd: this.getCurrentCwd(),
+					agentDir: getAgentDir(),
+					settingsManager: this.settingsManager,
+				})
+			: undefined;
+		const tmuxKeyboardWarningPromise = ownsGlobalStartupNotices ? checkTmuxKeyboardSetup() : undefined;
 
 		// Show startup warnings
 		const { migratedProviders, modelFallbackMessage, initialMessage, initialImages, initialMessages } = this.options;
@@ -982,8 +999,15 @@ export class InteractiveMode {
 			}
 			deferredStartupNotificationsShown = true;
 
+			// The agents view owns these for daemon sessions. When there is no agents view,
+			// show them once at the top of a fresh session, but never append them under a
+			// restored conversation where they read as disconnected clutter.
+			if (!ownsGlobalStartupNotices || this.sessionHadInitialMessages) {
+				return;
+			}
+
 			void newVersionPromise
-				.then((newVersion) => {
+				?.then((newVersion) => {
 					if (newVersion) {
 						this.showNewVersionNotification(newVersion);
 					}
@@ -991,7 +1015,7 @@ export class InteractiveMode {
 				.catch(() => {});
 
 			void packageUpdatesPromise
-				.then((updates) => {
+				?.then((updates) => {
 					if (updates.length > 0) {
 						this.showPackageUpdateNotification(updates);
 					}
@@ -999,7 +1023,7 @@ export class InteractiveMode {
 				.catch(() => {});
 
 			void tmuxKeyboardWarningPromise
-				.then((warning) => {
+				?.then((warning) => {
 					if (warning) {
 						this.showWarning(warning);
 					}
@@ -1174,71 +1198,6 @@ export class InteractiveMode {
 
 		this.showStatus("Model selection required. Use /model to continue.");
 		return false;
-	}
-
-	private async checkForPackageUpdates(): Promise<string[]> {
-		if (process.env.PI_OFFLINE) {
-			return [];
-		}
-
-		try {
-			const packageManager = new DefaultPackageManager({
-				cwd: this.getCurrentCwd(),
-				agentDir: getAgentDir(),
-				settingsManager: this.settingsManager,
-			});
-			const updates = await packageManager.checkForAvailableUpdates();
-			return updates.map((update) => update.displayName);
-		} catch {
-			return [];
-		}
-	}
-
-	private async checkTmuxKeyboardSetup(): Promise<string | undefined> {
-		if (!process.env.TMUX) return undefined;
-
-		const runTmuxShow = (option: string): Promise<string | undefined> => {
-			return new Promise((resolve) => {
-				const proc = spawn("tmux", ["show", "-gv", option], {
-					stdio: ["ignore", "pipe", "ignore"],
-				});
-				let stdout = "";
-				const timer = setTimeout(() => {
-					proc.kill();
-					resolve(undefined);
-				}, 2000);
-
-				proc.stdout?.on("data", (data) => {
-					stdout += data.toString();
-				});
-				proc.on("error", () => {
-					clearTimeout(timer);
-					resolve(undefined);
-				});
-				proc.on("close", (code) => {
-					clearTimeout(timer);
-					resolve(code === 0 ? stdout.trim() : undefined);
-				});
-			});
-		};
-
-		const [extendedKeys, extendedKeysFormat] = await Promise.all([
-			runTmuxShow("extended-keys"),
-			runTmuxShow("extended-keys-format"),
-		]);
-
-		// If we couldn't query tmux (timeout, sandbox, etc.), don't warn
-		if (extendedKeys === undefined) return undefined;
-
-		if (extendedKeys !== "on" && extendedKeys !== "always") {
-			return "tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.";
-		}
-
-		if (extendedKeysFormat === "xterm") {
-			return "tmux extended-keys-format is xterm. Pi works best with csi-u. Add `set -g extended-keys-format csi-u` to ~/.tmux.conf and restart tmux.";
-		}
-
-		return undefined;
 	}
 
 	private getMarkdownThemeWithSettings(): MarkdownTheme {
@@ -4565,6 +4524,7 @@ export class InteractiveMode {
 			const snapshot = await this.agentConnection.getInitialSnapshot();
 			this.initialConnectionSnapshotConsumed = true;
 			context = this.getSessionContextFromConnectionSnapshot(snapshot);
+			this.sessionHadInitialMessages = context.messages.length > 0;
 			state = snapshot.state;
 			this.seedChildAgentInspector(snapshot.children);
 		}
@@ -5021,28 +4981,12 @@ export class InteractiveMode {
 	}
 
 	showNewVersionNotification(newVersion: string): void {
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("accent", "Update available:"))} ` +
-					`${theme.fg("muted", `v${newVersion}. Run `)}${theme.fg("accent", "prime-agent update")}`,
-				1,
-				0,
-			),
-		);
+		this.chatContainer.addChild(new Text(formatUpdateAvailableNotice(newVersion), 1, 0));
 		this.ui.requestRender();
 	}
 
 	showPackageUpdateNotification(packages: string[]): void {
-		const packageList = packages.join(", ");
-
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("warning", "Package updates available:"))} ` +
-					`${theme.fg("muted", `${packageList}. Run `)}${theme.fg("accent", "prime-agent update --extensions")}`,
-				1,
-				0,
-			),
-		);
+		this.chatContainer.addChild(new Text(formatPackageUpdateNotice(packages), 1, 0));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/shared/startup-notices.ts
+++ b/packages/coding-agent/src/modes/shared/startup-notices.ts
@@ -1,0 +1,128 @@
+/**
+ * Global, environment-scoped startup notices (app update, extension updates, tmux setup).
+ *
+ * These are not tied to any single conversation, so they are surfaced on the agents
+ * view rather than appended to a session's chat stream. The checks and styled
+ * formatters live here so both the agents view and the interactive fallback render
+ * identical wording.
+ */
+
+import { spawn } from "node:child_process";
+import { DefaultPackageManager } from "../../core/package-manager.js";
+import type { SettingsManager } from "../../core/settings-manager.js";
+import { checkForNewPiVersion } from "../../utils/version-check.js";
+import { theme } from "../interactive/theme/theme.js";
+
+export interface StartupNotices {
+	/** Newer Prime Agent version available, if any. */
+	newVersion?: string;
+	/** Display names of extensions with available updates. */
+	packageUpdates: string[];
+	/** tmux keyboard setup warning, if the current tmux config is suboptimal. */
+	tmuxWarning?: string;
+}
+
+export interface StartupNoticeCheckOptions {
+	version: string;
+	cwd: string;
+	agentDir: string;
+	settingsManager: SettingsManager;
+}
+
+/** Run every startup check in parallel and collect the results. */
+export async function gatherStartupNotices(options: StartupNoticeCheckOptions): Promise<StartupNotices> {
+	const [newVersion, packageUpdates, tmuxWarning] = await Promise.all([
+		checkForNewPiVersion(options.version),
+		checkForPackageUpdates(options),
+		checkTmuxKeyboardSetup(),
+	]);
+	return { newVersion, packageUpdates, tmuxWarning };
+}
+
+export async function checkForPackageUpdates(options: {
+	cwd: string;
+	agentDir: string;
+	settingsManager: SettingsManager;
+}): Promise<string[]> {
+	if (process.env.PI_OFFLINE) {
+		return [];
+	}
+
+	try {
+		const packageManager = new DefaultPackageManager({
+			cwd: options.cwd,
+			agentDir: options.agentDir,
+			settingsManager: options.settingsManager,
+		});
+		const updates = await packageManager.checkForAvailableUpdates();
+		return updates.map((update) => update.displayName);
+	} catch {
+		return [];
+	}
+}
+
+export async function checkTmuxKeyboardSetup(): Promise<string | undefined> {
+	if (!process.env.TMUX) return undefined;
+
+	const runTmuxShow = (option: string): Promise<string | undefined> => {
+		return new Promise((resolve) => {
+			const proc = spawn("tmux", ["show", "-gv", option], {
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+			let stdout = "";
+			const timer = setTimeout(() => {
+				proc.kill();
+				resolve(undefined);
+			}, 2000);
+
+			proc.stdout?.on("data", (data) => {
+				stdout += data.toString();
+			});
+			proc.on("error", () => {
+				clearTimeout(timer);
+				resolve(undefined);
+			});
+			proc.on("close", (code) => {
+				clearTimeout(timer);
+				resolve(code === 0 ? stdout.trim() : undefined);
+			});
+		});
+	};
+
+	const [extendedKeys, extendedKeysFormat] = await Promise.all([
+		runTmuxShow("extended-keys"),
+		runTmuxShow("extended-keys-format"),
+	]);
+
+	// If we couldn't query tmux (timeout, sandbox, etc.), don't warn
+	if (extendedKeys === undefined) return undefined;
+
+	if (extendedKeys !== "on" && extendedKeys !== "always") {
+		return "tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.";
+	}
+
+	if (extendedKeysFormat === "xterm") {
+		return "tmux extended-keys-format is xterm. Pi works best with csi-u. Add `set -g extended-keys-format csi-u` to ~/.tmux.conf and restart tmux.";
+	}
+
+	return undefined;
+}
+
+export function formatUpdateAvailableNotice(newVersion: string): string {
+	return (
+		`${theme.bold(theme.fg("accent", "Update available:"))} ` +
+		`${theme.fg("muted", `v${newVersion}. Run `)}${theme.fg("accent", "prime-agent update")}`
+	);
+}
+
+export function formatPackageUpdateNotice(packages: string[]): string {
+	const packageList = packages.join(", ");
+	return (
+		`${theme.bold(theme.fg("warning", "Package updates available:"))} ` +
+		`${theme.fg("muted", `${packageList}. Run `)}${theme.fg("accent", "prime-agent update --extensions")}`
+	);
+}
+
+export function formatTmuxWarningNotice(message: string): string {
+	return theme.fg("warning", `⚠ ${message}`);
+}

--- a/packages/coding-agent/test/startup-notices.test.ts
+++ b/packages/coding-agent/test/startup-notices.test.ts
@@ -1,0 +1,35 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import {
+	formatPackageUpdateNotice,
+	formatTmuxWarningNotice,
+	formatUpdateAvailableNotice,
+} from "../src/modes/shared/startup-notices.js";
+
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_PATTERN, "");
+}
+
+describe("startup notice formatters", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("update notice mentions the version and prime-agent update command", () => {
+		const output = stripAnsi(formatUpdateAvailableNotice("1.2.3"));
+		expect(output).toBe("Update available: v1.2.3. Run prime-agent update");
+		expect(output).not.toContain("pi update");
+	});
+
+	test("package update notice lists packages and the extensions command", () => {
+		const output = stripAnsi(formatPackageUpdateNotice(["npm:@foo/bar", "npm:@baz/qux"]));
+		expect(output).toBe("Package updates available: npm:@foo/bar, npm:@baz/qux. Run prime-agent update --extensions");
+	});
+
+	test("tmux warning notice is prefixed with the warning glyph", () => {
+		const output = stripAnsi(formatTmuxWarningNotice("tmux extended-keys is off."));
+		expect(output).toBe("⚠ tmux extended-keys is off.");
+	});
+});


### PR DESCRIPTION
- update, extension-update, and tmux setup warnings used to be appended to the bottom of every chat session, reappearing disconnected from context each time a session was reopened.
- these environment-wide notices now surface on the agents view, which already shows the version, instead of cluttering individual conversations.
- when a session is launched directly without the agents view, the notices show once at the top of a fresh session and never under restored history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and notice placement only; checks and copy were moved/refactored with a small formatter test, no auth or data-path changes.
> 
> **Overview**
> **Global startup notices** (app update, extension updates, tmux keyboard hints) now appear on the **agents view** under the splash header instead of in each chat session.
> 
> A shared **`startup-notices`** module runs the checks and formats the lines; the agents view gathers them once into **persistent state** (survives re-entry) and wraps long text. Opening a session from the agents view sets **`agentsViewOwnsStartupNotices`** so interactive mode does not repeat the same notices.
> 
> **Interactive mode** still shows these notices only as a fallback: fresh sessions that never went through the agents view (e.g. direct daemon attach), and **never** when the session already had messages on first render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a90d6d7270e0c027d598c90be4318f1cb1b3c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move global startup notices from the chat stream to the agents view header
> - Extracts startup notice logic (version check, package update check, tmux keyboard setup) into a shared module at [startup-notices.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/183/files#diff-394845873ed4b2cf23ff7b7b264ccb3826282402a2ff43b2e5437bcaf6a2fa65) so both the agents view and interactive mode use identical formatting.
> - The agents view now fetches and renders startup notices at the top of the screen, cached across re-entries via persistent state.
> - Interactive sessions launched from the agents view suppress duplicate notices via the new `agentsViewOwnsStartupNotices` flag on `InteractiveModeOptions`.
> - Resumed/restored sessions with existing messages no longer show startup notices appended mid-conversation.
> - Behavioral Change: users running direct (non-agents-view) sessions will see notices once at the top of a fresh conversation only; resumed sessions will never show them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59a90d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->