### PR TITLE
feed pasted images into model context

### DIFF
--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -19,22 +19,31 @@ export function imageMarkerIds(text: string): number[] {
 }
 
 /**
+ * `[id, image]` pairs from `pending` whose marker still appears in `text`, in
+ * paste order (the map's insertion order). Each id appears at most once even if
+ * its marker is duplicated in the text.
+ */
+export function collectMarkedImageEntries<T>(pending: ReadonlyMap<number, T>, text: string): Array<[number, T]> {
+	if (pending.size === 0) {
+		return [];
+	}
+	const present = new Set(imageMarkerIds(text));
+	const entries: Array<[number, T]> = [];
+	for (const [id, image] of pending) {
+		if (present.has(id)) {
+			entries.push([id, image]);
+		}
+	}
+	return entries;
+}
+
+/**
  * Images from `pending` whose marker still appears in `text`, in paste order
  * (the map's insertion order). Each image is returned at most once even if its
  * marker is duplicated in the text.
  */
 export function collectMarkedImages<T>(pending: ReadonlyMap<number, T>, text: string): T[] {
-	if (pending.size === 0) {
-		return [];
-	}
-	const present = new Set(imageMarkerIds(text));
-	const images: T[] = [];
-	for (const [id, image] of pending) {
-		if (present.has(id)) {
-			images.push(image);
-		}
-	}
-	return images;
+	return collectMarkedImageEntries(pending, text).map(([, image]) => image);
 }
 
 /** Delete entries from `pending` whose marker no longer appears in `text`. */

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -45,16 +45,3 @@ export function collectMarkedImageEntries<T>(pending: ReadonlyMap<number, T>, te
 export function collectMarkedImages<T>(pending: ReadonlyMap<number, T>, text: string): T[] {
 	return collectMarkedImageEntries(pending, text).map(([, image]) => image);
 }
-
-/** Delete entries from `pending` whose marker no longer appears in `text`. */
-export function pruneMarkedImages<T>(pending: Map<number, T>, text: string): void {
-	if (pending.size === 0) {
-		return;
-	}
-	const present = new Set(imageMarkerIds(text));
-	for (const id of pending.keys()) {
-		if (!present.has(id)) {
-			pending.delete(id);
-		}
-	}
-}

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -37,3 +37,34 @@ export function collectMarkedImages<T>(pending: ReadonlyMap<number, T>, text: st
 	}
 	return images;
 }
+
+/**
+ * Evict oldest entries (insertion order) from `images` until the total of
+ * `sizeOf` is within `maxBytes`. Ids in `keep` are never evicted, so an image
+ * whose marker is still live retains its bytes even if that holds the total
+ * above the cap.
+ */
+export function evictImagesToBudget<T>(
+	images: Map<number, T>,
+	sizeOf: (value: T) => number,
+	maxBytes: number,
+	keep: ReadonlySet<number>,
+): void {
+	let total = 0;
+	for (const value of images.values()) {
+		total += sizeOf(value);
+	}
+	for (const key of [...images.keys()]) {
+		if (total <= maxBytes) {
+			break;
+		}
+		if (keep.has(key)) {
+			continue;
+		}
+		const value = images.get(key);
+		if (value !== undefined) {
+			total -= sizeOf(value);
+			images.delete(key);
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pasted images are represented in the editor as `[image #N]` markers while the
+ * image bytes are held aside in a pending map keyed by N. On submit the markers
+ * still present in the text decide which images are attached to the prompt, so
+ * deleting a marker drops its image.
+ */
+
+/** Matches `[image #N]` markers inserted when an image is pasted into the editor. */
+const IMAGE_MARKER_REGEX = /\[image #(\d+)\]/g;
+
+/** The marker text inserted into the editor for pasted image `id`. */
+export function formatImageMarker(id: number): string {
+	return `[image #${id}]`;
+}
+
+/** Marker ids that appear in `text`, in order of appearance. */
+export function imageMarkerIds(text: string): number[] {
+	return [...text.matchAll(IMAGE_MARKER_REGEX)].map((match) => Number(match[1]));
+}
+
+/**
+ * Images from `pending` whose marker still appears in `text`, in paste order
+ * (the map's insertion order). Each image is returned at most once even if its
+ * marker is duplicated in the text.
+ */
+export function collectMarkedImages<T>(pending: ReadonlyMap<number, T>, text: string): T[] {
+	if (pending.size === 0) {
+		return [];
+	}
+	const present = new Set(imageMarkerIds(text));
+	const images: T[] = [];
+	for (const [id, image] of pending) {
+		if (present.has(id)) {
+			images.push(image);
+		}
+	}
+	return images;
+}
+
+/** Delete entries from `pending` whose marker no longer appears in `text`. */
+export function pruneMarkedImages<T>(pending: Map<number, T>, text: string): void {
+	if (pending.size === 0) {
+		return;
+	}
+	const present = new Set(imageMarkerIds(text));
+	for (const id of pending.keys()) {
+		if (!present.has(id)) {
+			pending.delete(id);
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -1,8 +1,9 @@
 /**
  * Pasted images are represented in the editor as `[image #N]` markers while the
- * image bytes are held aside in a pending map keyed by N. On submit the markers
- * still present in the text decide which images are attached to the prompt, so
- * deleting a marker drops its image.
+ * image bytes are held aside in a registry keyed by N. The markers present in
+ * the submitted text decide which images are attached to the prompt, so deleting
+ * a marker drops its image and restoring it (undo, history, retry) brings it back
+ * as long as the bytes are still in the registry.
  */
 
 /** Matches `[image #N]` markers inserted when an image is pasted into the editor. */
@@ -19,29 +20,20 @@ export function imageMarkerIds(text: string): number[] {
 }
 
 /**
- * `[id, image]` pairs from `pending` whose marker still appears in `text`, in
- * paste order (the map's insertion order). Each id appears at most once even if
- * its marker is duplicated in the text.
- */
-export function collectMarkedImageEntries<T>(pending: ReadonlyMap<number, T>, text: string): Array<[number, T]> {
-	if (pending.size === 0) {
-		return [];
-	}
-	const present = new Set(imageMarkerIds(text));
-	const entries: Array<[number, T]> = [];
-	for (const [id, image] of pending) {
-		if (present.has(id)) {
-			entries.push([id, image]);
-		}
-	}
-	return entries;
-}
-
-/**
  * Images from `pending` whose marker still appears in `text`, in paste order
  * (the map's insertion order). Each image is returned at most once even if its
  * marker is duplicated in the text.
  */
 export function collectMarkedImages<T>(pending: ReadonlyMap<number, T>, text: string): T[] {
-	return collectMarkedImageEntries(pending, text).map(([, image]) => image);
+	if (pending.size === 0) {
+		return [];
+	}
+	const present = new Set(imageMarkerIds(text));
+	const images: T[] = [];
+	for (const [id, image] of pending) {
+		if (present.has(id)) {
+			images.push(image);
+		}
+	}
+	return images;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -133,7 +133,7 @@ import { ToolExecutionComponent, type ToolExecutionDefinition } from "./componen
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
-import { collectMarkedImageEntries, formatImageMarker } from "./image-markers.js";
+import { collectMarkedImages, formatImageMarker } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -313,9 +313,6 @@ export class BrandSplashHeader implements Component {
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
-	// markerId -> image, so the markers in `text` can be re-resolved if the
-	// message is later restored to the editor (dequeue).
-	images?: Map<number, ImageContent>;
 };
 
 type GoalAnnouncementSnapshot = {
@@ -335,6 +332,11 @@ const MODEL_SELECTOR_ACTIONS: readonly ModelSelectorAction[] = [
 ];
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+
+// Cap on retained pasted-image bytes (base64). Images are resized below the
+// inline limit before storing, so this holds many recent pastes; the oldest are
+// evicted past the cap to keep a long session bounded.
+const MAX_PASTED_IMAGE_BYTES = 64 * 1024 * 1024;
 
 function isDeadTerminalError(error: unknown): boolean {
 	if (!error || typeof error !== "object" || !("code" in error)) {
@@ -523,13 +525,13 @@ export class InteractiveMode {
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
 	private initialConnectionSnapshotConsumed = false;
 
-	// Images pasted into the editor, keyed by the `[image #N]` marker shown to the
-	// user. Collected on submit and attached to the prompt as multimodal content.
-	private pendingImages = new Map<number, ImageContent>();
+	// Registry of images pasted this session, keyed by the `[image #N]` marker
+	// shown to the user. Insertion-ordered; the bytes persist (bounded by
+	// MAX_PASTED_IMAGE_BYTES) so a marker resolves to its image whenever the text
+	// reappears — on submit, undo, history recall, retry, or dequeue. A submission
+	// attaches only the images whose markers are present in the sent text.
+	private pastedImages = new Map<number, ImageContent>();
 	private nextImageMarkerId = 1;
-	// Images for a normal (non-streaming) submission, handed to the main input
-	// loop which owns the prompt() call.
-	private submittedImages: Map<number, ImageContent> | undefined;
 
 	// Agent subscription unsubscribe function
 	private unsubscribe?: () => void;
@@ -1058,22 +1060,16 @@ export class InteractiveMode {
 			}
 			if (!(await this.ensurePromptReady())) {
 				this.editor.setText(userInput);
-				// Re-register images so the restored markers resolve once the send is
-				// unblocked; setText prunes nothing, but pendingImages was cleared on submit.
-				if (this.submittedImages) {
-					for (const [id, image] of this.submittedImages) {
-						this.pendingImages.set(id, image);
-					}
-					this.submittedImages = undefined;
-				}
 				this.showStatus("Complete onboarding to send the restored prompt.");
 				continue;
 			}
 			showDeferredStartupNotifications();
 			showModelFallbackWarning();
 			await sendInitialPrompts();
-			const images = this.imageList(this.submittedImages);
-			this.submittedImages = undefined;
+			// Collect images from the markers in the submitted text. The registry
+			// still holds them (it is not cleared on submit), so this works even after
+			// the text was restored to the editor by onboarding, history, or a retry.
+			const images = this.collectImagesFor(userInput);
 			try {
 				await this.agentConnection.prompt(userInput, { images });
 			} catch (error: unknown) {
@@ -3149,11 +3145,11 @@ export class InteractiveMode {
 				? { type: "image", data: resized.data, mimeType: resized.mimeType }
 				: raw;
 
-			// Register the image as a pending attachment and insert a visible marker.
-			// The image is attached to the next prompt as multimodal content rather
-			// than written to disk, so a vision model receives it directly.
+			// Register the image and insert a visible marker. The image is attached to
+			// the prompt as multimodal content rather than written to disk, so a vision
+			// model receives it directly.
 			const markerId = this.nextImageMarkerId++;
-			this.pendingImages.set(markerId, attachment);
+			this.rememberPastedImage(markerId, attachment);
 			this.editor.insertTextAtCursor?.(formatImageMarker(markerId));
 			this.ui.requestRender();
 
@@ -3167,31 +3163,35 @@ export class InteractiveMode {
 	}
 
 	/**
-	 * Collect the `markerId -> image` entries whose `[image #N]` markers are still
-	 * present in `text`, then clear all pending images since the editor is cleared
-	 * on submit. Marker presence at submit time is the single source of truth: an
-	 * image whose marker was deleted is simply not collected, and one whose marker
-	 * is restored (e.g. via undo) still resolves because the bytes are never pruned
-	 * mid-edit. The id is preserved so a queued message can be restored to the
-	 * editor and re-resolve its markers.
+	 * Record a pasted image, evicting the oldest entries once the retained bytes
+	 * exceed {@link MAX_PASTED_IMAGE_BYTES} so a long session stays bounded. The
+	 * just-added image is always kept.
 	 */
-	private takeImageMap(text: string): Map<number, ImageContent> {
-		const entries = collectMarkedImageEntries(this.pendingImages, text);
-		this.pendingImages.clear();
-		return new Map(entries);
-	}
-
-	/** Like {@link takeImageMap} but as a plain list for direct submission. */
-	private takeImagesFor(text: string): ImageContent[] | undefined {
-		return this.imageList(this.takeImageMap(text));
-	}
-
-	/** A `markerId -> image` map as a plain list for submission, or undefined if empty. */
-	private imageList(images: Map<number, ImageContent> | undefined): ImageContent[] | undefined {
-		if (!images || images.size === 0) {
-			return undefined;
+	private rememberPastedImage(id: number, image: ImageContent): void {
+		this.pastedImages.set(id, image);
+		let total = 0;
+		for (const img of this.pastedImages.values()) {
+			total += img.data.length;
 		}
-		return [...images.values()];
+		for (const key of this.pastedImages.keys()) {
+			if (total <= MAX_PASTED_IMAGE_BYTES || key === id) {
+				break;
+			}
+			total -= this.pastedImages.get(key)?.data.length ?? 0;
+			this.pastedImages.delete(key);
+		}
+	}
+
+	/**
+	 * The images whose `[image #N]` markers are present in `text`, or undefined if
+	 * none. Read-only: the registry is never cleared here, so deleting a marker
+	 * simply drops its image while restoring the marker (undo, history, retry,
+	 * dequeue) brings it back. Marker presence in the sent text is the single
+	 * source of truth.
+	 */
+	private collectImagesFor(text: string): ImageContent[] | undefined {
+		const images = collectMarkedImages(this.pastedImages, text);
+		return images.length > 0 ? images : undefined;
 	}
 
 	private setupEditorSubmitHandler(): void {
@@ -3379,13 +3379,12 @@ export class InteractiveMode {
 
 			// Queue input during compaction (extension commands execute immediately)
 			if (this.isAgentCompacting()) {
-				const images = this.takeImageMap(text);
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					await this.agentConnection.prompt(text, { images: this.imageList(images) });
+					await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
 				} else {
-					this.queueCompactionMessage(text, "steer", images.size > 0 ? images : undefined);
+					this.queueCompactionMessage(text, "steer");
 				}
 				return;
 			}
@@ -3393,7 +3392,7 @@ export class InteractiveMode {
 			// If streaming, use prompt() with steer behavior
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing
 			if (this.isAgentStreaming()) {
-				const images = this.takeImagesFor(text);
+				const images = this.collectImagesFor(text);
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
 				await this.agentConnection.prompt(text, { streamingBehavior: "steer", images });
@@ -3406,8 +3405,6 @@ export class InteractiveMode {
 			// First, move any pending bash components to chat
 			this.flushPendingBashComponents();
 
-			// Hand images to the main input loop, which owns the prompt() call.
-			this.submittedImages = this.takeImageMap(text);
 			if (this.onInputCallback) {
 				this.onInputCallback(text);
 			}
@@ -4914,13 +4911,12 @@ export class InteractiveMode {
 
 		// Queue input during compaction (extension commands execute immediately)
 		if (this.isAgentCompacting()) {
-			const images = this.takeImageMap(text);
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.agentConnection.prompt(text, { images: this.imageList(images) });
+				await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
 			} else {
-				this.queueCompactionMessage(text, "followUp", images.size > 0 ? images : undefined);
+				this.queueCompactionMessage(text, "followUp");
 			}
 			return;
 		}
@@ -4928,7 +4924,7 @@ export class InteractiveMode {
 		// Alt+Enter queues a follow-up message (waits until agent finishes)
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.isAgentStreaming()) {
-			const images = this.takeImagesFor(text);
+			const images = this.collectImagesFor(text);
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");
 			await this.agentConnection.prompt(text, { streamingBehavior: "followUp", images });
@@ -5138,11 +5134,7 @@ export class InteractiveMode {
 	 * Clear all queued messages and return their contents.
 	 * Clears both session queue and compaction queue.
 	 */
-	private async clearAllQueues(): Promise<{
-		steering: string[];
-		followUp: string[];
-		images: Map<number, ImageContent>;
-	}> {
+	private async clearAllQueues(): Promise<{ steering: string[]; followUp: string[] }> {
 		const { steering, followUp } = await this.agentConnection.clearQueue();
 		this.connectionQueue = { steering: [], followUp: [] };
 		const compactionSteering = this.compactionQueuedMessages
@@ -5151,22 +5143,10 @@ export class InteractiveMode {
 		const compactionFollowUp = this.compactionQueuedMessages
 			.filter((msg) => msg.mode === "followUp")
 			.map((msg) => msg.text);
-		// Carry the compaction queue's images out so a dequeue can re-register them
-		// against the markers restored to the editor. (Server-queued messages return
-		// text only, so their images can't be recovered here.)
-		const images = new Map<number, ImageContent>();
-		for (const msg of this.compactionQueuedMessages) {
-			if (msg.images) {
-				for (const [id, image] of msg.images) {
-					images.set(id, image);
-				}
-			}
-		}
 		this.compactionQueuedMessages = [];
 		return {
 			steering: [...steering, ...compactionSteering],
 			followUp: [...followUp, ...compactionFollowUp],
-			images,
 		};
 	}
 
@@ -5204,7 +5184,7 @@ export class InteractiveMode {
 	}
 
 	private async restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): Promise<number> {
-		const { steering, followUp, images } = await this.clearAllQueues();
+		const { steering, followUp } = await this.clearAllQueues();
 		const allQueued = [...steering, ...followUp];
 		if (allQueued.length === 0) {
 			this.updatePendingMessagesDisplay();
@@ -5216,12 +5196,9 @@ export class InteractiveMode {
 		const queuedText = allQueued.join("\n\n");
 		const currentText = options?.currentText ?? this.editor.getText();
 		const combinedText = [queuedText, currentText].filter((t) => t.trim()).join("\n\n");
+		// The image registry persists, so the restored `[image #N]` markers resolve
+		// on resubmit without any re-registration here.
 		this.editor.setText(combinedText);
-		// Re-register images after setText (which prunes via onChange) so their
-		// `[image #N]` markers in the restored text resolve again on resubmit.
-		for (const [id, image] of images) {
-			this.pendingImages.set(id, image);
-		}
 		this.updatePendingMessagesDisplay();
 		if (options?.abort) {
 			await this.agentConnection.abort();
@@ -5229,8 +5206,8 @@ export class InteractiveMode {
 		return allQueued.length;
 	}
 
-	private queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: Map<number, ImageContent>): void {
-		this.compactionQueuedMessages.push({ text, mode, images });
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
+		this.compactionQueuedMessages.push({ text, mode });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
 		this.updatePendingMessagesDisplay();
@@ -5271,11 +5248,11 @@ export class InteractiveMode {
 				// When retry is pending, queue messages for the retry turn
 				for (const message of queuedMessages) {
 					if (this.isExtensionCommand(message.text)) {
-						await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
+						await this.agentConnection.prompt(message.text, { images: this.collectImagesFor(message.text) });
 					} else if (message.mode === "followUp") {
-						await this.agentConnection.followUp(message.text, this.imageList(message.images));
+						await this.agentConnection.followUp(message.text, this.collectImagesFor(message.text));
 					} else {
-						await this.agentConnection.steer(message.text, this.imageList(message.images));
+						await this.agentConnection.steer(message.text, this.collectImagesFor(message.text));
 					}
 				}
 				this.updatePendingMessagesDisplay();
@@ -5287,7 +5264,7 @@ export class InteractiveMode {
 			if (firstPromptIndex === -1) {
 				// All extension commands - execute them all
 				for (const message of queuedMessages) {
-					await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
+					await this.agentConnection.prompt(message.text, { images: this.collectImagesFor(message.text) });
 				}
 				return;
 			}
@@ -5298,12 +5275,12 @@ export class InteractiveMode {
 			const rest = queuedMessages.slice(firstPromptIndex + 1);
 
 			for (const message of preCommands) {
-				await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
+				await this.agentConnection.prompt(message.text, { images: this.collectImagesFor(message.text) });
 			}
 
 			// Send first prompt (starts streaming)
 			const promptPromise = this.agentConnection
-				.prompt(firstPrompt.text, { images: this.imageList(firstPrompt.images) })
+				.prompt(firstPrompt.text, { images: this.collectImagesFor(firstPrompt.text) })
 				.catch((error) => {
 					void restoreQueue(error);
 				});
@@ -5311,11 +5288,11 @@ export class InteractiveMode {
 			// Queue remaining messages
 			for (const message of rest) {
 				if (this.isExtensionCommand(message.text)) {
-					await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
+					await this.agentConnection.prompt(message.text, { images: this.collectImagesFor(message.text) });
 				} else if (message.mode === "followUp") {
-					await this.agentConnection.followUp(message.text, this.imageList(message.images));
+					await this.agentConnection.followUp(message.text, this.collectImagesFor(message.text));
 				} else {
-					await this.agentConnection.steer(message.text, this.imageList(message.images));
+					await this.agentConnection.steer(message.text, this.collectImagesFor(message.text));
 				}
 			}
 			this.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -133,7 +133,7 @@ import { ToolExecutionComponent, type ToolExecutionDefinition } from "./componen
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
-import { collectMarkedImages, formatImageMarker } from "./image-markers.js";
+import { collectMarkedImages, evictImagesToBudget, formatImageMarker, imageMarkerIds } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -3165,21 +3165,32 @@ export class InteractiveMode {
 	/**
 	 * Record a pasted image, evicting the oldest entries once the retained bytes
 	 * exceed {@link MAX_PASTED_IMAGE_BYTES} so a long session stays bounded. The
-	 * just-added image is always kept.
+	 * just-added image and any whose marker is still referenced (editor or queues)
+	 * are never evicted, so a live marker never loses its image.
 	 */
 	private rememberPastedImage(id: number, image: ImageContent): void {
 		this.pastedImages.set(id, image);
-		let total = 0;
-		for (const img of this.pastedImages.values()) {
-			total += img.data.length;
-		}
-		for (const key of this.pastedImages.keys()) {
-			if (total <= MAX_PASTED_IMAGE_BYTES || key === id) {
-				break;
+		const keep = this.liveImageMarkerIds();
+		keep.add(id);
+		evictImagesToBudget(this.pastedImages, (img) => img.data.length, MAX_PASTED_IMAGE_BYTES, keep);
+	}
+
+	/** Marker ids still referenced in the editor or any queue (never safe to evict). */
+	private liveImageMarkerIds(): Set<number> {
+		const ids = new Set<number>();
+		const add = (text: string) => {
+			for (const markerId of imageMarkerIds(text)) {
+				ids.add(markerId);
 			}
-			total -= this.pastedImages.get(key)?.data.length ?? 0;
-			this.pastedImages.delete(key);
+		};
+		add(this.editor.getText());
+		for (const msg of this.compactionQueuedMessages) {
+			add(msg.text);
 		}
+		for (const msg of [...this.connectionQueue.steering, ...this.connectionQueue.followUp]) {
+			add(msg);
+		}
+		return ids;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -529,7 +529,7 @@ export class InteractiveMode {
 	private nextImageMarkerId = 1;
 	// Images for a normal (non-streaming) submission, handed to the main input
 	// loop which owns the prompt() call.
-	private submittedImages: ImageContent[] | undefined;
+	private submittedImages: Map<number, ImageContent> | undefined;
 
 	// Agent subscription unsubscribe function
 	private unsubscribe?: () => void;
@@ -1058,13 +1058,21 @@ export class InteractiveMode {
 			}
 			if (!(await this.ensurePromptReady())) {
 				this.editor.setText(userInput);
+				// Re-register images so the restored markers resolve once the send is
+				// unblocked; setText prunes nothing, but pendingImages was cleared on submit.
+				if (this.submittedImages) {
+					for (const [id, image] of this.submittedImages) {
+						this.pendingImages.set(id, image);
+					}
+					this.submittedImages = undefined;
+				}
 				this.showStatus("Complete onboarding to send the restored prompt.");
 				continue;
 			}
 			showDeferredStartupNotifications();
 			showModelFallbackWarning();
 			await sendInitialPrompts();
-			const images = this.submittedImages;
+			const images = this.imageList(this.submittedImages);
 			this.submittedImages = undefined;
 			try {
 				await this.agentConnection.prompt(userInput, { images });
@@ -3399,7 +3407,7 @@ export class InteractiveMode {
 			this.flushPendingBashComponents();
 
 			// Hand images to the main input loop, which owns the prompt() call.
-			this.submittedImages = this.takeImagesFor(text);
+			this.submittedImages = this.takeImageMap(text);
 			if (this.onInputCallback) {
 				this.onInputCallback(text);
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2105,9 +2105,11 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		// Pasted images belong to the session being torn down; drop them so markers
 		// in a newly loaded session can't resolve to the previous session's bytes.
-		// nextImageMarkerId stays monotonic so a new paste never reuses an id that
-		// may still appear in restored text.
+		// Clear prompt history alongside them so a recalled entry can't reference an
+		// image that was just dropped. nextImageMarkerId stays monotonic so a new
+		// paste never reuses an id that may still appear in restored text.
 		this.pastedImages.clear();
+		this.defaultEditor.clearHistory?.();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		// The discarded component's loader interval keeps firing otherwise; no

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -133,7 +133,7 @@ import { ToolExecutionComponent, type ToolExecutionDefinition } from "./componen
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
-import { collectMarkedImageEntries, formatImageMarker, pruneMarkedImages } from "./image-markers.js";
+import { collectMarkedImageEntries, formatImageMarker } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -3112,10 +3112,6 @@ export class InteractiveMode {
 		this.defaultEditor.onChange = (text: string) => {
 			if (text.length > 0) {
 				this.clearCtrlCExitHint();
-				// Drop images whose marker the user edited away. Skip on empty text:
-				// the editor fires onChange("") right before onSubmit, and submit needs
-				// the pending images to still be present (takeImagesFor clears them).
-				this.prunePendingImages(text);
 			}
 		};
 
@@ -3164,9 +3160,12 @@ export class InteractiveMode {
 
 	/**
 	 * Collect the `markerId -> image` entries whose `[image #N]` markers are still
-	 * present in `text` (so deleting a marker drops its image), then clear all
-	 * pending images since the editor is cleared on submit. The id is preserved so
-	 * a queued message can be restored to the editor and re-resolve its markers.
+	 * present in `text`, then clear all pending images since the editor is cleared
+	 * on submit. Marker presence at submit time is the single source of truth: an
+	 * image whose marker was deleted is simply not collected, and one whose marker
+	 * is restored (e.g. via undo) still resolves because the bytes are never pruned
+	 * mid-edit. The id is preserved so a queued message can be restored to the
+	 * editor and re-resolve its markers.
 	 */
 	private takeImageMap(text: string): Map<number, ImageContent> {
 		const entries = collectMarkedImageEntries(this.pendingImages, text);
@@ -3185,11 +3184,6 @@ export class InteractiveMode {
 			return undefined;
 		}
 		return [...images.values()];
-	}
-
-	/** Drop pending images whose marker no longer appears in the editor text. */
-	private prunePendingImages(text: string): void {
-		pruneMarkedImages(this.pendingImages, text);
 	}
 
 	private setupEditorSubmitHandler(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3,7 +3,6 @@
  * Handles TUI rendering and user interaction, delegating agent execution to AgentConnection.
  */
 
-import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -70,7 +69,7 @@ import type { TruncationResult } from "../../core/tools/truncate.js";
 import { PRIME_BUTTERFLY_LOGO } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
-import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.js";
+import { readClipboardImage } from "../../utils/clipboard-image.js";
 import { parseGitUrl } from "../../utils/git.js";
 import { getCwdRelativePath } from "../../utils/paths.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
@@ -133,6 +132,7 @@ import { ToolExecutionComponent, type ToolExecutionDefinition } from "./componen
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
+import { collectMarkedImages, formatImageMarker, pruneMarkedImages } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -312,6 +312,7 @@ export class BrandSplashHeader implements Component {
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
+	images?: ImageContent[];
 };
 
 type GoalAnnouncementSnapshot = {
@@ -518,6 +519,14 @@ export class InteractiveMode {
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
 	private initialConnectionSnapshotConsumed = false;
+
+	// Images pasted into the editor, keyed by the `[image #N]` marker shown to the
+	// user. Collected on submit and attached to the prompt as multimodal content.
+	private pendingImages = new Map<number, ImageContent>();
+	private nextImageMarkerId = 1;
+	// Images for a normal (non-streaming) submission, handed to the main input
+	// loop which owns the prompt() call.
+	private submittedImages: ImageContent[] | undefined;
 
 	// Agent subscription unsubscribe function
 	private unsubscribe?: () => void;
@@ -1052,8 +1061,10 @@ export class InteractiveMode {
 			showDeferredStartupNotifications();
 			showModelFallbackWarning();
 			await sendInitialPrompts();
+			const images = this.submittedImages;
+			this.submittedImages = undefined;
 			try {
-				await this.agentConnection.prompt(userInput);
+				await this.agentConnection.prompt(userInput, { images });
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);
@@ -3098,6 +3109,10 @@ export class InteractiveMode {
 		this.defaultEditor.onChange = (text: string) => {
 			if (text.length > 0) {
 				this.clearCtrlCExitHint();
+				// Drop images whose marker the user edited away. Skip on empty text:
+				// the editor fires onChange("") right before onSubmit, and submit needs
+				// the pending images to still be present (takeImagesFor clears them).
+				this.prunePendingImages(text);
 			}
 		};
 
@@ -3114,19 +3129,41 @@ export class InteractiveMode {
 				return;
 			}
 
-			// Write to temp file
-			const tmpDir = os.tmpdir();
-			const ext = extensionForImageMimeType(image.mimeType) ?? "png";
-			const fileName = `pi-clipboard-${crypto.randomUUID()}.${ext}`;
-			const filePath = path.join(tmpDir, fileName);
-			fs.writeFileSync(filePath, Buffer.from(image.bytes));
-
-			// Insert file path directly
-			this.editor.insertTextAtCursor?.(filePath);
+			// Register the image as a pending attachment and insert a visible marker.
+			// The image is attached to the next prompt as multimodal content rather
+			// than written to disk, so a vision model receives it directly.
+			const markerId = this.nextImageMarkerId++;
+			this.pendingImages.set(markerId, {
+				type: "image",
+				data: Buffer.from(image.bytes).toString("base64"),
+				mimeType: image.mimeType,
+			});
+			this.editor.insertTextAtCursor?.(formatImageMarker(markerId));
 			this.ui.requestRender();
+
+			const model = this.getCurrentModel();
+			if (model && !model.input.includes("image")) {
+				this.showStatus("Current model does not support images; the attachment will be omitted.");
+			}
 		} catch {
 			// Silently ignore clipboard errors (may not have permission, etc.)
 		}
+	}
+
+	/**
+	 * Collect the images whose `[image #N]` markers are still present in `text`
+	 * (so deleting a marker drops its image), then clear all pending images since
+	 * the editor is cleared on submit.
+	 */
+	private takeImagesFor(text: string): ImageContent[] | undefined {
+		const images = collectMarkedImages(this.pendingImages, text);
+		this.pendingImages.clear();
+		return images.length > 0 ? images : undefined;
+	}
+
+	/** Drop pending images whose marker no longer appears in the editor text. */
+	private prunePendingImages(text: string): void {
+		pruneMarkedImages(this.pendingImages, text);
 	}
 
 	private setupEditorSubmitHandler(): void {
@@ -3314,12 +3351,13 @@ export class InteractiveMode {
 
 			// Queue input during compaction (extension commands execute immediately)
 			if (this.isAgentCompacting()) {
+				const images = this.takeImagesFor(text);
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					await this.agentConnection.prompt(text);
+					await this.agentConnection.prompt(text, { images });
 				} else {
-					this.queueCompactionMessage(text, "steer");
+					this.queueCompactionMessage(text, "steer", images);
 				}
 				return;
 			}
@@ -3327,9 +3365,10 @@ export class InteractiveMode {
 			// If streaming, use prompt() with steer behavior
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing
 			if (this.isAgentStreaming()) {
+				const images = this.takeImagesFor(text);
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.agentConnection.prompt(text, { streamingBehavior: "steer" });
+				await this.agentConnection.prompt(text, { streamingBehavior: "steer", images });
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 				return;
@@ -3339,6 +3378,8 @@ export class InteractiveMode {
 			// First, move any pending bash components to chat
 			this.flushPendingBashComponents();
 
+			// Hand images to the main input loop, which owns the prompt() call.
+			this.submittedImages = this.takeImagesFor(text);
 			if (this.onInputCallback) {
 				this.onInputCallback(text);
 			}
@@ -4845,12 +4886,13 @@ export class InteractiveMode {
 
 		// Queue input during compaction (extension commands execute immediately)
 		if (this.isAgentCompacting()) {
+			const images = this.takeImagesFor(text);
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.agentConnection.prompt(text);
+				await this.agentConnection.prompt(text, { images });
 			} else {
-				this.queueCompactionMessage(text, "followUp");
+				this.queueCompactionMessage(text, "followUp", images);
 			}
 			return;
 		}
@@ -4858,9 +4900,10 @@ export class InteractiveMode {
 		// Alt+Enter queues a follow-up message (waits until agent finishes)
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.isAgentStreaming()) {
+			const images = this.takeImagesFor(text);
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");
-			await this.agentConnection.prompt(text, { streamingBehavior: "followUp" });
+			await this.agentConnection.prompt(text, { streamingBehavior: "followUp", images });
 			this.updatePendingMessagesDisplay();
 			this.ui.requestRender();
 		}
@@ -5137,8 +5180,8 @@ export class InteractiveMode {
 		return allQueued.length;
 	}
 
-	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
-		this.compactionQueuedMessages.push({ text, mode });
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: ImageContent[]): void {
+		this.compactionQueuedMessages.push({ text, mode, images });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
 		this.updatePendingMessagesDisplay();
@@ -5179,11 +5222,11 @@ export class InteractiveMode {
 				// When retry is pending, queue messages for the retry turn
 				for (const message of queuedMessages) {
 					if (this.isExtensionCommand(message.text)) {
-						await this.agentConnection.prompt(message.text);
+						await this.agentConnection.prompt(message.text, { images: message.images });
 					} else if (message.mode === "followUp") {
-						await this.agentConnection.followUp(message.text);
+						await this.agentConnection.followUp(message.text, message.images);
 					} else {
-						await this.agentConnection.steer(message.text);
+						await this.agentConnection.steer(message.text, message.images);
 					}
 				}
 				this.updatePendingMessagesDisplay();
@@ -5195,7 +5238,7 @@ export class InteractiveMode {
 			if (firstPromptIndex === -1) {
 				// All extension commands - execute them all
 				for (const message of queuedMessages) {
-					await this.agentConnection.prompt(message.text);
+					await this.agentConnection.prompt(message.text, { images: message.images });
 				}
 				return;
 			}
@@ -5206,22 +5249,24 @@ export class InteractiveMode {
 			const rest = queuedMessages.slice(firstPromptIndex + 1);
 
 			for (const message of preCommands) {
-				await this.agentConnection.prompt(message.text);
+				await this.agentConnection.prompt(message.text, { images: message.images });
 			}
 
 			// Send first prompt (starts streaming)
-			const promptPromise = this.agentConnection.prompt(firstPrompt.text).catch((error) => {
-				void restoreQueue(error);
-			});
+			const promptPromise = this.agentConnection
+				.prompt(firstPrompt.text, { images: firstPrompt.images })
+				.catch((error) => {
+					void restoreQueue(error);
+				});
 
 			// Queue remaining messages
 			for (const message of rest) {
 				if (this.isExtensionCommand(message.text)) {
-					await this.agentConnection.prompt(message.text);
+					await this.agentConnection.prompt(message.text, { images: message.images });
 				} else if (message.mode === "followUp") {
-					await this.agentConnection.followUp(message.text);
+					await this.agentConnection.followUp(message.text, message.images);
 				} else {
-					await this.agentConnection.steer(message.text);
+					await this.agentConnection.steer(message.text, message.images);
 				}
 			}
 			this.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3204,8 +3204,16 @@ export class InteractiveMode {
 	 * simply drops its image while restoring the marker (undo, history, retry,
 	 * dequeue) brings it back. Marker presence in the sent text is the single
 	 * source of truth.
+	 *
+	 * Resolved against the current model: if it has no image input, attachments
+	 * are dropped here (matching the paste-time hint) rather than sent and
+	 * downgraded downstream.
 	 */
 	private collectImagesFor(text: string): ImageContent[] | undefined {
+		const model = this.getCurrentModel();
+		if (model && !model.input.includes("image")) {
+			return undefined;
+		}
 		const images = collectMarkedImages(this.pastedImages, text);
 		return images.length > 0 ? images : undefined;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3180,7 +3180,11 @@ export class InteractiveMode {
 		evictImagesToBudget(this.pastedImages, (img) => img.data.length, MAX_PASTED_IMAGE_BYTES, keep);
 	}
 
-	/** Marker ids still referenced in the editor or any queue (never safe to evict). */
+	/**
+	 * Marker ids still reachable — current editor text, prompt history (recallable
+	 * with the up arrow), the compaction queue, and the connection queue. These are
+	 * never evicted so a recall or resend never finds a marker with no image.
+	 */
 	private liveImageMarkerIds(): Set<number> {
 		const ids = new Set<number>();
 		const add = (text: string) => {
@@ -3189,6 +3193,9 @@ export class InteractiveMode {
 			}
 		};
 		add(this.editor.getText());
+		for (const entry of this.editor.getHistory?.() ?? []) {
+			add(entry);
+		}
 		for (const msg of this.compactionQueuedMessages) {
 			add(msg.text);
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -71,6 +71,7 @@ import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { readClipboardImage } from "../../utils/clipboard-image.js";
 import { parseGitUrl } from "../../utils/git.js";
+import { resizeImage } from "../../utils/image-resize.js";
 import { getCwdRelativePath } from "../../utils/paths.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
 import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../../utils/tools-manager.js";
@@ -132,7 +133,7 @@ import { ToolExecutionComponent, type ToolExecutionDefinition } from "./componen
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
-import { collectMarkedImages, formatImageMarker, pruneMarkedImages } from "./image-markers.js";
+import { collectMarkedImageEntries, formatImageMarker, pruneMarkedImages } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -312,7 +313,9 @@ export class BrandSplashHeader implements Component {
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
-	images?: ImageContent[];
+	// markerId -> image, so the markers in `text` can be re-resolved if the
+	// message is later restored to the editor (dequeue).
+	images?: Map<number, ImageContent>;
 };
 
 type GoalAnnouncementSnapshot = {
@@ -3129,15 +3132,24 @@ export class InteractiveMode {
 				return;
 			}
 
+			// Resize down to the inline image size limit, mirroring the CLI @file
+			// path, so large screenshots don't exceed provider limits. Fall back to
+			// the raw bytes if resizing is unavailable.
+			const raw: ImageContent = {
+				type: "image",
+				data: Buffer.from(image.bytes).toString("base64"),
+				mimeType: image.mimeType,
+			};
+			const resized = await resizeImage(raw);
+			const attachment: ImageContent = resized
+				? { type: "image", data: resized.data, mimeType: resized.mimeType }
+				: raw;
+
 			// Register the image as a pending attachment and insert a visible marker.
 			// The image is attached to the next prompt as multimodal content rather
 			// than written to disk, so a vision model receives it directly.
 			const markerId = this.nextImageMarkerId++;
-			this.pendingImages.set(markerId, {
-				type: "image",
-				data: Buffer.from(image.bytes).toString("base64"),
-				mimeType: image.mimeType,
-			});
+			this.pendingImages.set(markerId, attachment);
 			this.editor.insertTextAtCursor?.(formatImageMarker(markerId));
 			this.ui.requestRender();
 
@@ -3151,14 +3163,28 @@ export class InteractiveMode {
 	}
 
 	/**
-	 * Collect the images whose `[image #N]` markers are still present in `text`
-	 * (so deleting a marker drops its image), then clear all pending images since
-	 * the editor is cleared on submit.
+	 * Collect the `markerId -> image` entries whose `[image #N]` markers are still
+	 * present in `text` (so deleting a marker drops its image), then clear all
+	 * pending images since the editor is cleared on submit. The id is preserved so
+	 * a queued message can be restored to the editor and re-resolve its markers.
 	 */
-	private takeImagesFor(text: string): ImageContent[] | undefined {
-		const images = collectMarkedImages(this.pendingImages, text);
+	private takeImageMap(text: string): Map<number, ImageContent> {
+		const entries = collectMarkedImageEntries(this.pendingImages, text);
 		this.pendingImages.clear();
-		return images.length > 0 ? images : undefined;
+		return new Map(entries);
+	}
+
+	/** Like {@link takeImageMap} but as a plain list for direct submission. */
+	private takeImagesFor(text: string): ImageContent[] | undefined {
+		return this.imageList(this.takeImageMap(text));
+	}
+
+	/** A `markerId -> image` map as a plain list for submission, or undefined if empty. */
+	private imageList(images: Map<number, ImageContent> | undefined): ImageContent[] | undefined {
+		if (!images || images.size === 0) {
+			return undefined;
+		}
+		return [...images.values()];
 	}
 
 	/** Drop pending images whose marker no longer appears in the editor text. */
@@ -3351,13 +3377,13 @@ export class InteractiveMode {
 
 			// Queue input during compaction (extension commands execute immediately)
 			if (this.isAgentCompacting()) {
-				const images = this.takeImagesFor(text);
+				const images = this.takeImageMap(text);
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					await this.agentConnection.prompt(text, { images });
+					await this.agentConnection.prompt(text, { images: this.imageList(images) });
 				} else {
-					this.queueCompactionMessage(text, "steer", images);
+					this.queueCompactionMessage(text, "steer", images.size > 0 ? images : undefined);
 				}
 				return;
 			}
@@ -4886,13 +4912,13 @@ export class InteractiveMode {
 
 		// Queue input during compaction (extension commands execute immediately)
 		if (this.isAgentCompacting()) {
-			const images = this.takeImagesFor(text);
+			const images = this.takeImageMap(text);
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.agentConnection.prompt(text, { images });
+				await this.agentConnection.prompt(text, { images: this.imageList(images) });
 			} else {
-				this.queueCompactionMessage(text, "followUp", images);
+				this.queueCompactionMessage(text, "followUp", images.size > 0 ? images : undefined);
 			}
 			return;
 		}
@@ -5110,7 +5136,11 @@ export class InteractiveMode {
 	 * Clear all queued messages and return their contents.
 	 * Clears both session queue and compaction queue.
 	 */
-	private async clearAllQueues(): Promise<{ steering: string[]; followUp: string[] }> {
+	private async clearAllQueues(): Promise<{
+		steering: string[];
+		followUp: string[];
+		images: Map<number, ImageContent>;
+	}> {
 		const { steering, followUp } = await this.agentConnection.clearQueue();
 		this.connectionQueue = { steering: [], followUp: [] };
 		const compactionSteering = this.compactionQueuedMessages
@@ -5119,10 +5149,22 @@ export class InteractiveMode {
 		const compactionFollowUp = this.compactionQueuedMessages
 			.filter((msg) => msg.mode === "followUp")
 			.map((msg) => msg.text);
+		// Carry the compaction queue's images out so a dequeue can re-register them
+		// against the markers restored to the editor. (Server-queued messages return
+		// text only, so their images can't be recovered here.)
+		const images = new Map<number, ImageContent>();
+		for (const msg of this.compactionQueuedMessages) {
+			if (msg.images) {
+				for (const [id, image] of msg.images) {
+					images.set(id, image);
+				}
+			}
+		}
 		this.compactionQueuedMessages = [];
 		return {
 			steering: [...steering, ...compactionSteering],
 			followUp: [...followUp, ...compactionFollowUp],
+			images,
 		};
 	}
 
@@ -5160,7 +5202,7 @@ export class InteractiveMode {
 	}
 
 	private async restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): Promise<number> {
-		const { steering, followUp } = await this.clearAllQueues();
+		const { steering, followUp, images } = await this.clearAllQueues();
 		const allQueued = [...steering, ...followUp];
 		if (allQueued.length === 0) {
 			this.updatePendingMessagesDisplay();
@@ -5173,6 +5215,11 @@ export class InteractiveMode {
 		const currentText = options?.currentText ?? this.editor.getText();
 		const combinedText = [queuedText, currentText].filter((t) => t.trim()).join("\n\n");
 		this.editor.setText(combinedText);
+		// Re-register images after setText (which prunes via onChange) so their
+		// `[image #N]` markers in the restored text resolve again on resubmit.
+		for (const [id, image] of images) {
+			this.pendingImages.set(id, image);
+		}
 		this.updatePendingMessagesDisplay();
 		if (options?.abort) {
 			await this.agentConnection.abort();
@@ -5180,7 +5227,7 @@ export class InteractiveMode {
 		return allQueued.length;
 	}
 
-	private queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: ImageContent[]): void {
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: Map<number, ImageContent>): void {
 		this.compactionQueuedMessages.push({ text, mode, images });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
@@ -5222,11 +5269,11 @@ export class InteractiveMode {
 				// When retry is pending, queue messages for the retry turn
 				for (const message of queuedMessages) {
 					if (this.isExtensionCommand(message.text)) {
-						await this.agentConnection.prompt(message.text, { images: message.images });
+						await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
 					} else if (message.mode === "followUp") {
-						await this.agentConnection.followUp(message.text, message.images);
+						await this.agentConnection.followUp(message.text, this.imageList(message.images));
 					} else {
-						await this.agentConnection.steer(message.text, message.images);
+						await this.agentConnection.steer(message.text, this.imageList(message.images));
 					}
 				}
 				this.updatePendingMessagesDisplay();
@@ -5238,7 +5285,7 @@ export class InteractiveMode {
 			if (firstPromptIndex === -1) {
 				// All extension commands - execute them all
 				for (const message of queuedMessages) {
-					await this.agentConnection.prompt(message.text, { images: message.images });
+					await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
 				}
 				return;
 			}
@@ -5249,12 +5296,12 @@ export class InteractiveMode {
 			const rest = queuedMessages.slice(firstPromptIndex + 1);
 
 			for (const message of preCommands) {
-				await this.agentConnection.prompt(message.text, { images: message.images });
+				await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
 			}
 
 			// Send first prompt (starts streaming)
 			const promptPromise = this.agentConnection
-				.prompt(firstPrompt.text, { images: firstPrompt.images })
+				.prompt(firstPrompt.text, { images: this.imageList(firstPrompt.images) })
 				.catch((error) => {
 					void restoreQueue(error);
 				});
@@ -5262,11 +5309,11 @@ export class InteractiveMode {
 			// Queue remaining messages
 			for (const message of rest) {
 				if (this.isExtensionCommand(message.text)) {
-					await this.agentConnection.prompt(message.text, { images: message.images });
+					await this.agentConnection.prompt(message.text, { images: this.imageList(message.images) });
 				} else if (message.mode === "followUp") {
-					await this.agentConnection.followUp(message.text, message.images);
+					await this.agentConnection.followUp(message.text, this.imageList(message.images));
 				} else {
-					await this.agentConnection.steer(message.text, message.images);
+					await this.agentConnection.steer(message.text, this.imageList(message.images));
 				}
 			}
 			this.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2103,6 +2103,11 @@ export class InteractiveMode {
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
+		// Pasted images belong to the session being torn down; drop them so markers
+		// in a newly loaded session can't resolve to the previous session's bytes.
+		// nextImageMarkerId stays monotonic so a new paste never reuses an id that
+		// may still appear in restored text.
+		this.pastedImages.clear();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		// The discarded component's loader interval keeps firing otherwise; no

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2105,11 +2105,17 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		// Pasted images belong to the session being torn down; drop them so markers
 		// in a newly loaded session can't resolve to the previous session's bytes.
-		// Clear prompt history alongside them so a recalled entry can't reference an
-		// image that was just dropped. nextImageMarkerId stays monotonic so a new
-		// paste never reuses an id that may still appear in restored text.
+		// Clear every editor's prompt history and draft text alongside them so no
+		// `[image #N]` marker survives without a backing image. nextImageMarkerId
+		// stays monotonic so a new paste never reuses an id that may still appear in
+		// restored text.
 		this.pastedImages.clear();
 		this.defaultEditor.clearHistory?.();
+		this.defaultEditor.setText("");
+		if (this.editor !== this.defaultEditor) {
+			this.editor.clearHistory?.();
+			this.editor.setText("");
+		}
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		// The discarded component's loader interval keeps firing otherwise; no

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { collectMarkedImages, formatImageMarker, imageMarkerIds } from "../src/modes/interactive/image-markers.js";
+import {
+	collectMarkedImages,
+	evictImagesToBudget,
+	formatImageMarker,
+	imageMarkerIds,
+} from "../src/modes/interactive/image-markers.js";
 
 describe("image markers", () => {
 	test("formatImageMarker round-trips through imageMarkerIds", () => {
@@ -46,5 +51,44 @@ describe("image markers", () => {
 		// never pruned mid-edit, the restored marker still resolves at submit time.
 		expect(collectMarkedImages(pending, "no marker")).toEqual([]);
 		expect(collectMarkedImages(pending, "back [image #1]")).toEqual(["a"]);
+	});
+
+	const size = (s: string) => s.length;
+
+	test("evictImagesToBudget drops oldest entries until within budget", () => {
+		const images = new Map([
+			[1, "aaaa"],
+			[2, "bbbb"],
+			[3, "cccc"],
+		]);
+		evictImagesToBudget(images, size, 8, new Set());
+		// Oldest (1) evicted; 2 and 3 (8 bytes) fit.
+		expect([...images.keys()]).toEqual([2, 3]);
+	});
+
+	test("evictImagesToBudget never evicts kept ids, even past budget", () => {
+		const images = new Map([
+			[1, "aaaa"],
+			[2, "bbbb"],
+			[3, "cccc"],
+		]);
+		// id 1 is live (kept) so it survives; 2 is evicted to get under budget.
+		evictImagesToBudget(images, size, 8, new Set([1]));
+		expect([...images.keys()]).toEqual([1, 3]);
+	});
+
+	test("evictImagesToBudget keeps everything when all ids are kept", () => {
+		const images = new Map([
+			[1, "aaaa"],
+			[2, "bbbb"],
+		]);
+		evictImagesToBudget(images, size, 1, new Set([1, 2]));
+		expect([...images.keys()]).toEqual([1, 2]);
+	});
+
+	test("evictImagesToBudget is a no-op within budget", () => {
+		const images = new Map([[1, "aa"]]);
+		evictImagesToBudget(images, size, 100, new Set());
+		expect([...images.keys()]).toEqual([1]);
 	});
 });

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	collectMarkedImageEntries,
 	collectMarkedImages,
 	formatImageMarker,
 	imageMarkerIds,
@@ -33,6 +34,20 @@ describe("image markers", () => {
 			[2, "b"],
 		]);
 		expect(collectMarkedImages(pending, "kept [image #1] only")).toEqual(["a"]);
+	});
+
+	test("collectMarkedImageEntries preserves marker ids for re-registration", () => {
+		const pending = new Map([
+			[3, "a"],
+			[7, "b"],
+		]);
+		// Order follows the map (paste order); ids are kept so a restored message
+		// can re-register images against the markers in its text.
+		expect(collectMarkedImageEntries(pending, "[image #7] x [image #3]")).toEqual([
+			[3, "a"],
+			[7, "b"],
+		]);
+		expect(collectMarkedImageEntries(pending, "only [image #7]")).toEqual([[7, "b"]]);
 	});
 
 	test("collectMarkedImages returns each image at most once for duplicate markers", () => {

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -5,7 +5,6 @@ import {
 	collectMarkedImages,
 	formatImageMarker,
 	imageMarkerIds,
-	pruneMarkedImages,
 } from "../src/modes/interactive/image-markers.js";
 
 describe("image markers", () => {
@@ -60,19 +59,11 @@ describe("image markers", () => {
 		expect(collectMarkedImages(new Map([[1, "a"]]), "")).toEqual([]);
 	});
 
-	test("pruneMarkedImages drops entries whose marker is gone", () => {
-		const pending = new Map([
-			[1, "a"],
-			[2, "b"],
-			[3, "c"],
-		]);
-		pruneMarkedImages(pending, "still have [image #2] and [image #3]");
-		expect([...pending.keys()]).toEqual([2, 3]);
-	});
-
-	test("pruneMarkedImages clears everything when no markers remain", () => {
+	test("a restored marker still resolves its image (undo-safe)", () => {
 		const pending = new Map([[1, "a"]]);
-		pruneMarkedImages(pending, "user deleted the marker");
-		expect(pending.size).toBe(0);
+		// Marker deleted then brought back (e.g. via editor undo). Because images are
+		// never pruned mid-edit, the restored marker still resolves at submit time.
+		expect(collectMarkedImages(pending, "no marker")).toEqual([]);
+		expect(collectMarkedImages(pending, "back [image #1]")).toEqual(["a"]);
 	});
 });

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import {
-	collectMarkedImageEntries,
-	collectMarkedImages,
-	formatImageMarker,
-	imageMarkerIds,
-} from "../src/modes/interactive/image-markers.js";
+import { collectMarkedImages, formatImageMarker, imageMarkerIds } from "../src/modes/interactive/image-markers.js";
 
 describe("image markers", () => {
 	test("formatImageMarker round-trips through imageMarkerIds", () => {
@@ -33,20 +28,6 @@ describe("image markers", () => {
 			[2, "b"],
 		]);
 		expect(collectMarkedImages(pending, "kept [image #1] only")).toEqual(["a"]);
-	});
-
-	test("collectMarkedImageEntries preserves marker ids for re-registration", () => {
-		const pending = new Map([
-			[3, "a"],
-			[7, "b"],
-		]);
-		// Order follows the map (paste order); ids are kept so a restored message
-		// can re-register images against the markers in its text.
-		expect(collectMarkedImageEntries(pending, "[image #7] x [image #3]")).toEqual([
-			[3, "a"],
-			[7, "b"],
-		]);
-		expect(collectMarkedImageEntries(pending, "only [image #7]")).toEqual([[7, "b"]]);
 	});
 
 	test("collectMarkedImages returns each image at most once for duplicate markers", () => {

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	collectMarkedImages,
+	formatImageMarker,
+	imageMarkerIds,
+	pruneMarkedImages,
+} from "../src/modes/interactive/image-markers.js";
+
+describe("image markers", () => {
+	test("formatImageMarker round-trips through imageMarkerIds", () => {
+		expect(formatImageMarker(7)).toBe("[image #7]");
+		expect(imageMarkerIds(`see ${formatImageMarker(7)}`)).toEqual([7]);
+	});
+
+	test("imageMarkerIds returns ids in order of appearance", () => {
+		expect(imageMarkerIds("a [image #2] b [image #1] c")).toEqual([2, 1]);
+		expect(imageMarkerIds("no markers here")).toEqual([]);
+	});
+
+	test("collectMarkedImages returns images in paste order, not text order", () => {
+		const pending = new Map([
+			[1, "first"],
+			[2, "second"],
+		]);
+		// Markers appear reversed in the text, but paste order is preserved.
+		expect(collectMarkedImages(pending, "[image #2] then [image #1]")).toEqual(["first", "second"]);
+	});
+
+	test("collectMarkedImages skips images whose marker was deleted", () => {
+		const pending = new Map([
+			[1, "a"],
+			[2, "b"],
+		]);
+		expect(collectMarkedImages(pending, "kept [image #1] only")).toEqual(["a"]);
+	});
+
+	test("collectMarkedImages returns each image at most once for duplicate markers", () => {
+		const pending = new Map([[1, "a"]]);
+		expect(collectMarkedImages(pending, "[image #1] [image #1]")).toEqual(["a"]);
+	});
+
+	test("collectMarkedImages returns nothing for empty input", () => {
+		expect(collectMarkedImages(new Map(), "[image #1]")).toEqual([]);
+		expect(collectMarkedImages(new Map([[1, "a"]]), "")).toEqual([]);
+	});
+
+	test("pruneMarkedImages drops entries whose marker is gone", () => {
+		const pending = new Map([
+			[1, "a"],
+			[2, "b"],
+			[3, "c"],
+		]);
+		pruneMarkedImages(pending, "still have [image #2] and [image #3]");
+		expect([...pending.keys()]).toEqual([2, 3]);
+	});
+
+	test("pruneMarkedImages clears everything when no markers remain", () => {
+		const pending = new Map([[1, "a"]]);
+		pruneMarkedImages(pending, "user deleted the marker");
+		expect(pending.size).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -370,6 +370,7 @@ describe("InteractiveMode pending bash components", () => {
 			chatContainer: new Container(),
 			pendingMessagesContainer: new Container(),
 			compactionQueuedMessages: [],
+			pastedImages: new Map(),
 			streamingComponent: undefined,
 			streamingMessage: undefined,
 			activeBashComponent: component,

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -371,6 +371,7 @@ describe("InteractiveMode pending bash components", () => {
 			pendingMessagesContainer: new Container(),
 			compactionQueuedMessages: [],
 			pastedImages: new Map(),
+			defaultEditor: { clearHistory: vi.fn() },
 			streamingComponent: undefined,
 			streamingMessage: undefined,
 			activeBashComponent: component,

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -366,12 +366,14 @@ describe("InteractiveMode pending bash components", () => {
 		const loader = (component as unknown as { loader: { intervalId: unknown } }).loader;
 		expect(loader.intervalId).not.toBeNull();
 
+		const editorStub = { clearHistory: vi.fn(), setText: vi.fn() };
 		const fakeThis = {
 			chatContainer: new Container(),
 			pendingMessagesContainer: new Container(),
 			compactionQueuedMessages: [],
 			pastedImages: new Map(),
-			defaultEditor: { clearHistory: vi.fn() },
+			defaultEditor: editorStub,
+			editor: editorStub,
 			streamingComponent: undefined,
 			streamingMessage: undefined,
 			activeBashComponent: component,

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -15,34 +15,58 @@ const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
 /** Non-global version for single-segment testing. */
 const PASTE_MARKER_SINGLE = /^\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]$/;
 
-/** Check if a segment is a paste marker (i.e. was merged by segmentWithMarkers). */
-function isPasteMarker(segment: string): boolean {
-	return segment.length >= 10 && PASTE_MARKER_SINGLE.test(segment);
+/**
+ * Regex matching image markers like `[image #1]`. Kept in sync with the marker
+ * format produced by the coding agent's image-markers helper; the tui package
+ * can't depend on the coding agent, so the pattern is duplicated here.
+ */
+const IMAGE_MARKER_REGEX = /\[image #(\d+)\]/g;
+
+/** Non-global version for single-segment testing. */
+const IMAGE_MARKER_SINGLE = /^\[image #(\d+)\]$/;
+
+/** Check if a segment is an atomic marker (paste or image) merged by segmentWithMarkers. */
+function isAtomicMarker(segment: string): boolean {
+	return segment.length >= 10 && (PASTE_MARKER_SINGLE.test(segment) || IMAGE_MARKER_SINGLE.test(segment));
 }
 
 /**
  * A segmenter that wraps Intl.Segmenter and merges graphemes that fall
- * within paste markers into single atomic segments.  This makes cursor
- * movement, deletion, word-wrap, etc. treat paste markers as single units.
+ * within paste or image markers into single atomic segments. This makes cursor
+ * movement, deletion, word-wrap, etc. treat the markers as single units.
  *
- * Only markers whose numeric ID exists in `validIds` are merged.
+ * Paste markers are only merged when their numeric ID exists in `validPasteIds`
+ * (so a stale `[paste #N]` typed by the user isn't treated as atomic). Image
+ * markers are self-contained and always merged.
  */
-function segmentWithMarkers(text: string, validIds: Set<number>): Iterable<Intl.SegmentData> {
-	// Fast path: no paste markers in the text or no valid IDs.
-	if (validIds.size === 0 || !text.includes("[paste #")) {
+function segmentWithMarkers(text: string, validPasteIds: Set<number>): Iterable<Intl.SegmentData> {
+	const hasPaste = validPasteIds.size > 0 && text.includes("[paste #");
+	const hasImage = text.includes("[image #");
+
+	// Fast path: nothing to merge.
+	if (!hasPaste && !hasImage) {
 		return baseSegmenter.segment(text);
 	}
 
-	// Find all marker spans with valid IDs.
+	// Find all marker spans (paste markers gated by valid IDs, image markers always).
 	const markers: Array<{ start: number; end: number }> = [];
-	for (const m of text.matchAll(PASTE_MARKER_REGEX)) {
-		const id = Number.parseInt(m[1]!, 10);
-		if (!validIds.has(id)) continue;
-		markers.push({ start: m.index, end: m.index + m[0].length });
+	if (hasPaste) {
+		for (const m of text.matchAll(PASTE_MARKER_REGEX)) {
+			const id = Number.parseInt(m[1]!, 10);
+			if (!validPasteIds.has(id)) continue;
+			markers.push({ start: m.index, end: m.index + m[0].length });
+		}
+	}
+	if (hasImage) {
+		for (const m of text.matchAll(IMAGE_MARKER_REGEX)) {
+			markers.push({ start: m.index, end: m.index + m[0].length });
+		}
 	}
 	if (markers.length === 0) {
 		return baseSegmenter.segment(text);
 	}
+	// The merge loop below assumes spans are sorted ascending by start.
+	markers.sort((a, b) => a.start - b.start);
 
 	// Build merged segment list.
 	const baseSegments = baseSegmenter.segment(text);
@@ -124,7 +148,7 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 		const grapheme = seg.segment;
 		const gWidth = visibleWidth(grapheme);
 		const charIndex = seg.index;
-		const isWs = !isPasteMarker(grapheme) && isWhitespaceChar(grapheme);
+		const isWs = !isAtomicMarker(grapheme) && isWhitespaceChar(grapheme);
 
 		// Overflow check before advancing.
 		if (currentWidth + gWidth > maxWidth) {
@@ -172,7 +196,7 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 		// Multiple spaces join (no break between them); the break point is
 		// after the last space before the next word.
 		const next = segments[i + 1];
-		if (isWs && next && (isPasteMarker(next.segment) || !isWhitespaceChar(next.segment))) {
+		if (isWs && next && (isAtomicMarker(next.segment) || !isWhitespaceChar(next.segment))) {
 			wrapOppIndex = next.index;
 			wrapOppWidth = currentWidth;
 		}
@@ -1872,7 +1896,7 @@ export class Editor implements Component, Focusable {
 		// Skip trailing whitespace
 		while (
 			graphemes.length > 0 &&
-			!isPasteMarker(graphemes[graphemes.length - 1]?.segment || "") &&
+			!isAtomicMarker(graphemes[graphemes.length - 1]?.segment || "") &&
 			isWhitespaceChar(graphemes[graphemes.length - 1]?.segment || "")
 		) {
 			newCol -= graphemes.pop()?.segment.length || 0;
@@ -1880,7 +1904,7 @@ export class Editor implements Component, Focusable {
 
 		if (graphemes.length > 0) {
 			const lastGrapheme = graphemes[graphemes.length - 1]?.segment || "";
-			if (isPasteMarker(lastGrapheme)) {
+			if (isAtomicMarker(lastGrapheme)) {
 				// Paste marker is a single atomic word
 				newCol -= graphemes.pop()?.segment.length || 0;
 			} else if (isPunctuationChar(lastGrapheme)) {
@@ -1888,7 +1912,7 @@ export class Editor implements Component, Focusable {
 				while (
 					graphemes.length > 0 &&
 					isPunctuationChar(graphemes[graphemes.length - 1]?.segment || "") &&
-					!isPasteMarker(graphemes[graphemes.length - 1]?.segment || "")
+					!isAtomicMarker(graphemes[graphemes.length - 1]?.segment || "")
 				) {
 					newCol -= graphemes.pop()?.segment.length || 0;
 				}
@@ -1898,7 +1922,7 @@ export class Editor implements Component, Focusable {
 					graphemes.length > 0 &&
 					!isWhitespaceChar(graphemes[graphemes.length - 1]?.segment || "") &&
 					!isPunctuationChar(graphemes[graphemes.length - 1]?.segment || "") &&
-					!isPasteMarker(graphemes[graphemes.length - 1]?.segment || "")
+					!isAtomicMarker(graphemes[graphemes.length - 1]?.segment || "")
 				) {
 					newCol -= graphemes.pop()?.segment.length || 0;
 				}
@@ -2099,19 +2123,19 @@ export class Editor implements Component, Focusable {
 		let newCol = this.state.cursorCol;
 
 		// Skip leading whitespace
-		while (!next.done && !isPasteMarker(next.value.segment) && isWhitespaceChar(next.value.segment)) {
+		while (!next.done && !isAtomicMarker(next.value.segment) && isWhitespaceChar(next.value.segment)) {
 			newCol += next.value.segment.length;
 			next = iterator.next();
 		}
 
 		if (!next.done) {
 			const firstGrapheme = next.value.segment;
-			if (isPasteMarker(firstGrapheme)) {
+			if (isAtomicMarker(firstGrapheme)) {
 				// Paste marker is a single atomic word
 				newCol += firstGrapheme.length;
 			} else if (isPunctuationChar(firstGrapheme)) {
 				// Skip punctuation run
-				while (!next.done && isPunctuationChar(next.value.segment) && !isPasteMarker(next.value.segment)) {
+				while (!next.done && isPunctuationChar(next.value.segment) && !isAtomicMarker(next.value.segment)) {
 					newCol += next.value.segment.length;
 					next = iterator.next();
 				}
@@ -2121,7 +2145,7 @@ export class Editor implements Component, Focusable {
 					!next.done &&
 					!isWhitespaceChar(next.value.segment) &&
 					!isPunctuationChar(next.value.segment) &&
-					!isPasteMarker(next.value.segment)
+					!isAtomicMarker(next.value.segment)
 				) {
 					newCol += next.value.segment.length;
 					next = iterator.next();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -405,6 +405,12 @@ export class Editor implements Component, Focusable {
 		return this.history;
 	}
 
+	/** Clear prompt history (e.g. when switching to a different session). */
+	clearHistory(): void {
+		this.history = [];
+		this.historyIndex = -1;
+	}
+
 	private isEditorEmpty(): boolean {
 		return this.state.lines.length === 1 && this.state.lines[0] === "";
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -400,6 +400,11 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	/** Prompt history entries (most recent first). */
+	getHistory(): readonly string[] {
+		return this.history;
+	}
+
 	private isEditorEmpty(): boolean {
 		return this.state.lines.length === 1 && this.state.lines[0] === "";
 	}

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -39,6 +39,9 @@ export interface EditorComponent extends Component {
 	/** Add text to history for up/down navigation */
 	addToHistory?(text: string): void;
 
+	/** Prompt history entries available for up/down navigation (most recent first). */
+	getHistory?(): readonly string[];
+
 	// =========================================================================
 	// Advanced text manipulation (optional)
 	// =========================================================================

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -42,6 +42,9 @@ export interface EditorComponent extends Component {
 	/** Prompt history entries available for up/down navigation (most recent first). */
 	getHistory?(): readonly string[];
 
+	/** Clear prompt history (e.g. when switching to a different session). */
+	clearHistory?(): void;
+
 	// =========================================================================
 	// Advanced text manipulation (optional)
 	// =========================================================================

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -726,6 +726,38 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Image marker atomicity", () => {
+		it("deletes a whole [image #N] marker with a single Backspace", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.setText("look [image #1]");
+			editor.handleInput("\x7f"); // Backspace
+
+			assert.strictEqual(editor.getText(), "look ");
+		});
+
+		it("deletes a whole [image #N] marker with a single forward Delete", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.setText("[image #12] tail");
+			editor.handleInput("\x01"); // Ctrl+A (move to start of line)
+			editor.handleInput("\x1b[3~"); // Delete (forward)
+
+			assert.strictEqual(editor.getText(), " tail");
+		});
+
+		it("leaves surrounding text intact when deleting a marker", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.setText("a [image #1] b");
+			editor.handleInput("\x1b[D"); // Left past trailing " b" word
+			editor.handleInput("\x1b[D");
+			editor.handleInput("\x7f"); // Backspace deletes the marker, not a single char
+
+			assert.strictEqual(editor.getText(), "a  b");
+		});
+	});
+
 	describe("Word wrapping", () => {
 		it("wraps at word boundaries instead of mid-word", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);


### PR DESCRIPTION
- pasting a screenshot in interactive mode used to insert a temp-file path as text, so the model only saw a string and tried to script against the file instead of seeing the image.
- pasted images are now attached as multimodal content, tracked behind a visible [image #N] marker so editing the marker away drops the image, and wired through the normal, steer, follow-up, and compaction-queue submit paths.
- shows a hint when the active model is not multimodal, and reuses the existing image pipeline that already worked for the cli file flag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Feed pasted images into model context as multimodal content via `[image #N]` markers
> - Replaces temp-file-path insertion with in-memory handling: pasted images are stored as base64 `ImageContent` in a per-session `pastedImages` Map, and a visible `[image #N]` marker is inserted at the cursor in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/184/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316).
> - Before each `agentConnection.prompt()` call, `collectImagesFor()` scans the text for markers and attaches matching images; prompts skip images if the active model has no image input capability.
> - A 64 MiB budget (`MAX_PASTED_IMAGE_BYTES`) evicts oldest unreferenced images; ids still present in editor text, history, or queues are protected from eviction.
> - The TUI editor in [editor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/184/files#diff-b7d90f64335d844108668d169aad1e82f7dc9a1fbf9d09e729c56b13ffb1943e) treats `[image #N]` markers as atomic segments for navigation, deletion, and word wrapping.
> - Session reset clears the image registry and editor history so markers don't leak across sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 071d370.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all user submit paths and multimodal prompt wiring; wrong marker/registry behavior could drop or leak attachments, but logic is isolated with unit tests.
> 
> **Overview**
> **Clipboard paste in interactive mode** no longer writes a temp file path into the prompt. Pasted screenshots are resized (same path as CLI `@file` images), stored in a session `pastedImages` registry, and the editor shows **`[image #N]`** markers. Only markers still present in the submitted text are sent as **`images`** on `prompt` / `steer` / `followUp` and through compaction queues.
> 
> **Lifecycle:** markers in editor text, prompt history, and queued messages are treated as “live” and are not evicted when enforcing a **64MB** retained-bytes cap; session reset clears the registry plus editor history/draft so markers cannot point at another session’s bytes. Non–vision models get a status hint and attachments are omitted at collect time.
> 
> **TUI:** `[image #N]` is handled like paste markers—atomic for backspace/delete, word motion, and wrap—with optional **`getHistory` / `clearHistory`** on the editor component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071d370e9831b9a2730667be35305a29ed171724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->