### PR TITLE
keep viewport anchored when toggling tool output expansion

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4921,7 +4921,10 @@ export class InteractiveMode {
 			}
 		}
 		this.childAgentDetail.setToolsExpanded(expanded);
-		this.ui.requestRender();
+		// Expanding/collapsing changes blocks above the viewport, which would
+		// otherwise force a full redraw that scrolls to the top and replays the
+		// whole transcript. Keep the user anchored at their current position.
+		this.ui.requestRenderPreservingViewport();
 	}
 
 	private toggleThinkingBlockVisibility(): void {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1248,7 +1248,7 @@ describe("InteractiveMode.setToolsExpanded", () => {
 			builtInHeader: header,
 			chatContainer: { children: [chatChild] },
 			childAgentDetail,
-			ui: { requestRender: vi.fn() },
+			ui: { requestRender: vi.fn(), requestRenderPreservingViewport: vi.fn() },
 		};
 
 		(InteractiveMode as any).prototype.setToolsExpanded.call(fakeThis, true);
@@ -1257,7 +1257,8 @@ describe("InteractiveMode.setToolsExpanded", () => {
 		expect(header.setExpanded).toHaveBeenCalledWith(true);
 		expect(chatChild.setExpanded).toHaveBeenCalledWith(true);
 		expect(childAgentDetail.setToolsExpanded).toHaveBeenCalledWith(true);
-		expect(fakeThis.ui.requestRender).toHaveBeenCalledTimes(1);
+		// Expansion keeps the user anchored, so it uses the viewport-preserving path.
+		expect(fakeThis.ui.requestRenderPreservingViewport).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1173,7 +1173,7 @@ export class TUI extends Container {
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					fullRender(true, preserveViewport);
 					return;
 				}
 				if (extraLines > 0) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1049,7 +1049,11 @@ export class TUI extends Container {
 				this.terminal.write(buffer);
 				this.cursorRow = Math.max(0, newLines.length - 1);
 				this.hardwareCursorRow = this.cursorRow;
-				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+				// Reset (not just grow) the high-water mark to the repainted content,
+				// mirroring the scrollback-clearing path. Otherwise a preserving
+				// collapse leaves maxLinesRendered inflated, and the next plain render
+				// would re-trigger clearOnShrink and do a destructive full redraw.
+				this.maxLinesRendered = newLines.length;
 				this.previousViewportTop = windowStart;
 				this.positionHardwareCursor(cursorPos, newLines.length);
 				this.previousLines = newLines;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1012,11 +1012,14 @@ export class TUI extends Container {
 			// (now-resized) transcript from the top. Only meaningful when there
 			// is a previous frame on screen to paint over.
 			if (preserveViewport && this.previousLines.length > 0) {
-				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				const windowStart = Math.max(0, newLines.length - height);
 				const visibleCount = newLines.length - windowStart;
 				// Rows the previous frame occupied on screen.
 				const prevScreenRows = Math.min(height, this.previousLines.length);
+				// Only delete Kitty images within the repainted viewport. Images that
+				// live in scrollback above the visible slice are never redrawn here, so
+				// deleting them would leave broken history when the user scrolls up.
+				buffer += this.deleteChangedKittyImages(prevViewportTop, prevViewportTop + prevScreenRows - 1);
 				// Move the hardware cursor up to the top of the visible screen.
 				// Use the local prevViewportTop (height-adjusted earlier in doRender)
 				// rather than the field, so the move stays consistent with the rest

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -260,6 +260,7 @@ export class TUI extends Container {
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
+	private preserveViewportOnNextRender = false; // One-shot: repaint visible viewport in place instead of replaying scrollback
 	private stopped = false;
 
 	// Overlay stack for modal components rendered on top of base content
@@ -521,6 +522,20 @@ export class TUI extends Container {
 		if (this.renderRequested) return;
 		this.renderRequested = true;
 		process.nextTick(() => this.scheduleRender());
+	}
+
+	/**
+	 * Request a render that keeps the user anchored at their current scroll
+	 * position. Normally, when content above the visible viewport changes, the
+	 * renderer falls back to a full redraw that clears scrollback and replays
+	 * the entire transcript from the top. For deliberate toggles (e.g. expanding
+	 * all tool output) that is jarring — it scrolls to the top and reprints
+	 * everything. This instead repaints only the visible viewport in place,
+	 * leaving scrollback untouched.
+	 */
+	requestRenderPreservingViewport(): void {
+		this.preserveViewportOnNextRender = true;
+		this.requestRender();
 	}
 
 	private scheduleRender(): void {
@@ -956,6 +971,9 @@ export class TUI extends Container {
 
 	private doRender(): void {
 		if (this.stopped) return;
+		// One-shot: consume here so it never leaks into a later render.
+		const preserveViewport = this.preserveViewportOnNextRender;
+		this.preserveViewportOnNextRender = false;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
 		const widthChanged = this.previousWidth !== 0 && this.previousWidth !== width;
@@ -984,9 +1002,55 @@ export class TUI extends Container {
 		newLines = this.applyLineResets(newLines);
 
 		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		const fullRender = (clear: boolean, preserveViewport = false): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
+
+			// Viewport-preserving repaint: rewrite only the visible viewport in
+			// place, leaving terminal scrollback untouched. Keeps the user
+			// anchored at their current focus instead of replaying the whole
+			// (now-resized) transcript from the top. Only meaningful when there
+			// is a previous frame on screen to paint over.
+			if (preserveViewport && this.previousLines.length > 0) {
+				buffer += this.deleteKittyImages(this.previousKittyImageIds);
+				const windowStart = Math.max(0, newLines.length - height);
+				const visibleCount = newLines.length - windowStart;
+				// Rows the previous frame occupied on screen.
+				const prevScreenRows = Math.min(height, this.previousLines.length);
+				// Move the hardware cursor up to the top of the visible screen.
+				const screenRow = Math.max(
+					0,
+					Math.min(prevScreenRows - 1, this.hardwareCursorRow - this.previousViewportTop),
+				);
+				if (screenRow > 0) buffer += `\x1b[${screenRow}A`;
+				buffer += "\r";
+				for (let i = 0; i < visibleCount; i++) {
+					if (i > 0) buffer += "\r\n";
+					buffer += "\x1b[2K"; // Clear current line
+					buffer += newLines[windowStart + i];
+				}
+				// Clear any rows the previous frame used below the new content.
+				if (visibleCount < prevScreenRows) {
+					const leftover = prevScreenRows - visibleCount;
+					for (let i = 0; i < leftover; i++) {
+						buffer += "\r\n\x1b[2K";
+					}
+					buffer += `\x1b[${leftover}A`; // Back up to the last content row
+				}
+				buffer += "\x1b[?2026l"; // End synchronized output
+				this.terminal.write(buffer);
+				this.cursorRow = Math.max(0, newLines.length - 1);
+				this.hardwareCursorRow = this.cursorRow;
+				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+				this.previousViewportTop = windowStart;
+				this.positionHardwareCursor(cursorPos, newLines.length);
+				this.previousLines = newLines;
+				this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+				this.previousWidth = width;
+				this.previousHeight = height;
+				return;
+			}
+
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
@@ -1050,7 +1114,7 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.clearOnShrink && newLines.length < this.maxLinesRendered && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (maxLinesRendered=${this.maxLinesRendered})`);
-			fullRender(true);
+			fullRender(true, preserveViewport);
 			return;
 		}
 
@@ -1098,7 +1162,7 @@ export class TUI extends Container {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true);
+					fullRender(true, preserveViewport);
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
@@ -1140,7 +1204,7 @@ export class TUI extends Container {
 		// If the first changed line is above the previous viewport, we need a full redraw.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
+			fullRender(true, preserveViewport);
 			return;
 		}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1038,12 +1038,16 @@ export class TUI extends Container {
 					buffer += newLines[windowStart + i];
 				}
 				// Clear any rows the previous frame used below the new content.
+				// Row 0 is already occupied (by content, or by the visibleCount === 0
+				// clear above), so only clear the rows below it — clamping with
+				// max(visibleCount, 1) avoids emitting a newline past the last screen
+				// row, which would scroll the terminal.
 				if (visibleCount < prevScreenRows) {
-					const leftover = prevScreenRows - visibleCount;
+					const leftover = prevScreenRows - Math.max(visibleCount, 1);
 					for (let i = 0; i < leftover; i++) {
 						buffer += "\r\n\x1b[2K";
 					}
-					buffer += `\x1b[${leftover}A`; // Back up to the last content row
+					if (leftover > 0) buffer += `\x1b[${leftover}A`; // Back up to the last content row
 				}
 				buffer += "\x1b[?2026l"; // End synchronized output
 				this.terminal.write(buffer);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1024,6 +1024,11 @@ export class TUI extends Container {
 				const screenRow = Math.max(0, Math.min(prevScreenRows - 1, this.hardwareCursorRow - prevViewportTop));
 				if (screenRow > 0) buffer += `\x1b[${screenRow}A`;
 				buffer += "\r";
+				// Clear the top row up front: the loop below clears it on its first
+				// iteration, but when there is no content (visibleCount === 0) the
+				// loop never runs and the leftover-clear moves down before clearing,
+				// which would leave row 0 stale.
+				if (visibleCount === 0) buffer += "\x1b[2K";
 				for (let i = 0; i < visibleCount; i++) {
 					if (i > 0) buffer += "\r\n";
 					buffer += "\x1b[2K"; // Clear current line

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1018,10 +1018,10 @@ export class TUI extends Container {
 				// Rows the previous frame occupied on screen.
 				const prevScreenRows = Math.min(height, this.previousLines.length);
 				// Move the hardware cursor up to the top of the visible screen.
-				const screenRow = Math.max(
-					0,
-					Math.min(prevScreenRows - 1, this.hardwareCursorRow - this.previousViewportTop),
-				);
+				// Use the local prevViewportTop (height-adjusted earlier in doRender)
+				// rather than the field, so the move stays consistent with the rest
+				// of the render when the terminal height changed this frame.
+				const screenRow = Math.max(0, Math.min(prevScreenRows - 1, this.hardwareCursorRow - prevViewportTop));
 				if (screenRow > 0) buffer += `\x1b[${screenRow}A`;
 				buffer += "\r";
 				for (let i = 0; i < visibleCount; i++) {

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -688,4 +688,34 @@ describe("TUI viewport-preserving render", () => {
 
 		tui.stop();
 	});
+
+	it("only deletes Kitty images within the repainted viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const aboveImage = encodeKitty("AAAA", { columns: 2, rows: 1, imageId: 101, moveCursor: false });
+		const visibleImage = encodeKitty("BBBB", { columns: 2, rows: 1, imageId: 202, moveCursor: false });
+		const lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		lines[2] = aboveImage; // scrollback (above the 10-row viewport)
+		lines[25] = visibleImage; // within the visible slice
+		component.lines = lines;
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// Expand near the top so the repaint takes the viewport-preserving path.
+		const expanded = [...component.lines];
+		expanded.splice(6, 0, "Expanded A", "Expanded B", "Expanded C");
+		component.lines = expanded;
+		tui.requestRenderPreservingViewport();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(writes.includes(deleteKittyImage(202)), "Visible-slice image is deleted before being redrawn");
+		assert.ok(!writes.includes(deleteKittyImage(101)), "Image in scrollback above the viewport must not be deleted");
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -618,3 +618,74 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI viewport-preserving render", () => {
+	// Regression: pressing Ctrl+O to expand all tool output changed lines above
+	// the viewport, which forced a full redraw that cleared scrollback and
+	// replayed the whole transcript from the top. requestRenderPreservingViewport
+	// repaints only the visible viewport in place and leaves scrollback alone.
+	it("repaints in place without clearing scrollback when content above the viewport grows", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// More lines than the viewport, so the top scrolls into scrollback.
+		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		const initialRedraws = tui.fullRedraws;
+
+		// "Expand" a block near the top: insert lines after Line 2 so the first
+		// changed line is far above the viewport.
+		const expanded = [...component.lines];
+		expanded.splice(3, 0, "Expanded A", "Expanded B", "Expanded C");
+		component.lines = expanded;
+		tui.requestRenderPreservingViewport();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(tui.fullRedraws > initialRedraws, "Should take the full-redraw branch");
+		assert.ok(!writes.includes("\x1b[3J"), "Must not clear scrollback");
+		assert.ok(!writes.includes("\x1b[2J"), "Must not clear the screen");
+
+		// The viewport stays anchored at the latest content (the bottom).
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[viewport.length - 1]?.includes("Line 29"), "Latest line stays at the bottom");
+
+		// Scrollback above the viewport is untouched — it still holds the
+		// pre-toggle lines rather than being replayed.
+		const scrollback = terminal.getScrollBuffer();
+		assert.ok(
+			scrollback.some((l) => l.includes("Line 0")),
+			"Original scrollback content is preserved",
+		);
+
+		tui.stop();
+	});
+
+	it("falls back to a scrollback-clearing redraw for a normal render", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		const expanded = [...component.lines];
+		expanded.splice(3, 0, "Expanded A", "Expanded B", "Expanded C");
+		component.lines = expanded;
+		// Plain render (no preservation) still clears scrollback and replays.
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "Normal render clears scrollback");
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -718,4 +718,34 @@ describe("TUI viewport-preserving render", () => {
 
 		tui.stop();
 	});
+
+	it("does not leave maxLinesRendered inflated after a preserving collapse", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		tui.setClearOnShrink(true);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+
+		// Collapse (content shrinks) via the preserving path.
+		component.lines = Array.from({ length: 12 }, (_, i) => `Line ${i}`);
+		tui.requestRenderPreservingViewport();
+		await terminal.waitForRender();
+
+		const redrawsAfterCollapse = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// A subsequent plain render with unchanged content must not re-trigger a
+		// clearOnShrink full redraw (which would clear scrollback and replay).
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redrawsAfterCollapse, "No extra full redraw after the collapse settled");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Must not clear scrollback on the follow-up render");
+
+		tui.stop();
+	});
 });


### PR DESCRIPTION
- ctrl+o expanded every tool output block but jerked the view to the top and replayed the whole transcript line by line, because growing blocks above the viewport forced a scrollback-clearing full redraw.
- added a viewport-preserving render path that repaints only the visible region in place and leaves scrollback untouched, so the user stays anchored where they were.
- routed the expand/collapse toggle through it and added regression tests covering the anchored repaint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core terminal rendering (`doRender` / full-redraw branches) and cursor/Kitty state; behavior is well covered by new tests but regressions could affect any caller that sets the preserve flag.
> 
> **Overview**
> **Ctrl+O** (expand/collapse all tool output) no longer jumps to the top and replays the full transcript when blocks above the visible area grow or shrink.
> 
> The TUI gains **`requestRenderPreservingViewport()`**, a one-shot flag on the next render. When a full redraw would normally run (e.g. first changed line above the viewport, shrink with `clearOnShrink`, deleted lines), that path can instead **repaint only the bottom viewport slice in place**—no `\x1b[2J` / `\x1b[3J`, scrollback unchanged. Kitty image deletes are limited to the repainted rows so images in scrollback are not broken. **`maxLinesRendered`** is reset after a preserving repaint so a later collapse does not trigger another destructive full redraw.
> 
> **`InteractiveMode.setToolsExpanded`** now calls this API instead of **`requestRender()`**. Tests cover scrollback preservation, normal render still clearing scrollback, Kitty scope, and post-collapse state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e508a5e1945b001343d871fc42c65e9de03b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep viewport anchored when toggling tool output expansion in interactive mode
> - Adds `requestRenderPreservingViewport()` to [`tui.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/186/files#diff-0aed3a4b69095fa2ae0cffa8689c7dad409e8b36ab77544b0defb1474fde7311), which repaints only the visible viewport lines without clearing scrollback or the full screen.
> - `InteractiveMode.setToolsExpanded` in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/186/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) now calls `requestRenderPreservingViewport()` instead of `requestRender()`, so expanding or collapsing tool output blocks above the viewport no longer jumps the user's scroll position.
> - The viewport-preserving path deletes only Kitty images within the repainted viewport and resets `maxLinesRendered` to avoid triggering a `clearOnShrink` redraw on the next render.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7e508a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->