### PR TITLE
skip /tmp rlm dir for non-persisted sessions

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3586,15 +3586,27 @@ export class AgentSession {
 	}
 
 	private _rlmKernelEnv(): Record<string, string> {
-		return {
+		const env: Record<string, string> = {
 			RLM_DEPTH: String(this._rlmDepth),
 			RLM_MAX_DEPTH: String(this._rlmMaxDepth),
 			RLM_HARNESS_STATE_DIR: getGlobalHarnessStateDir(),
-			RLM_SESSION_DIR: this._ensureRlmSessionDir(),
 		};
+		const rlmSessionDir = this._ensureRlmSessionDir();
+		if (rlmSessionDir) {
+			env.RLM_SESSION_DIR = rlmSessionDir;
+		}
+		return env;
 	}
 
-	private _ensureRlmSessionDir(): string {
+	/**
+	 * Returns the RLM session dir, or undefined when there's no persistent artifact
+	 * dir (e.g. the ephemeral viewer client). Don't create a /tmp dir here: this runs
+	 * on every kernel build, but a viewer never does RLM work, so eager mkdtemp just
+	 * leaks empty dirs. The temp dir is created lazily in _createChildRlmSessionDir,
+	 * the one place that genuinely needs a writable dir. Mirrors the kernel-snapshot
+	 * path, which also no-ops without a persistent dir.
+	 */
+	private _ensureRlmSessionDir(): string | undefined {
 		if (this._rlmSessionDir) {
 			mkdirSync(this._rlmSessionDir, { recursive: true });
 			return this._rlmSessionDir;
@@ -3607,12 +3619,13 @@ export class AgentSession {
 			return sessionArtifactDir;
 		}
 
-		this._rlmSessionDir = mkdtempSync(join(tmpdir(), "prime-agent-rlm-"));
-		return this._rlmSessionDir;
+		return undefined;
 	}
 
 	private _createChildRlmSessionDir(): string {
-		const parentDir = this._ensureRlmSessionDir();
+		// Spawning a child is genuine RLM work, so a writable dir is required. Fall
+		// back to a temp dir only here when there's no persistent artifact dir.
+		const parentDir = this._ensureRlmSessionDir() ?? this._createEphemeralRlmSessionDir();
 		for (let i = 0; i < 100; i++) {
 			const childDir = join(parentDir, `sub-${randomUUID().slice(0, 8)}`);
 			try {
@@ -3626,6 +3639,11 @@ export class AgentSession {
 			}
 		}
 		throw new Error("Unable to create unique RLM child session directory");
+	}
+
+	private _createEphemeralRlmSessionDir(): string {
+		this._rlmSessionDir = mkdtempSync(join(tmpdir(), "prime-agent-rlm-"));
+		return this._rlmSessionDir;
 	}
 
 	private _usageForCurrentMessages(): RlmUsage {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3598,14 +3598,9 @@ export class AgentSession {
 		return env;
 	}
 
-	/**
-	 * Returns the RLM session dir, or undefined when there's no persistent artifact
-	 * dir (e.g. the ephemeral viewer client). Don't create a /tmp dir here: this runs
-	 * on every kernel build, but a viewer never does RLM work, so eager mkdtemp just
-	 * leaks empty dirs. The temp dir is created lazily in _createChildRlmSessionDir,
-	 * the one place that genuinely needs a writable dir. Mirrors the kernel-snapshot
-	 * path, which also no-ops without a persistent dir.
-	 */
+	// Undefined when there's no persistent artifact dir (e.g. the viewer client):
+	// don't mkdtemp here, since this runs on every kernel build but a viewer never
+	// does RLM work. The temp dir is created lazily in _createChildRlmSessionDir.
 	private _ensureRlmSessionDir(): string | undefined {
 		if (this._rlmSessionDir) {
 			mkdirSync(this._rlmSessionDir, { recursive: true });
@@ -3623,8 +3618,7 @@ export class AgentSession {
 	}
 
 	private _createChildRlmSessionDir(): string {
-		// Spawning a child is genuine RLM work, so a writable dir is required. Fall
-		// back to a temp dir only here when there's no persistent artifact dir.
+		// A child needs a writable dir; fall back to a temp dir only when there's none.
 		const parentDir = this._ensureRlmSessionDir() ?? this._createEphemeralRlmSessionDir();
 		for (let i = 0; i < 100; i++) {
 			const childDir = join(parentDir, `sub-${randomUUID().slice(0, 8)}`);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3618,7 +3618,6 @@ export class AgentSession {
 	}
 
 	private _createChildRlmSessionDir(): string {
-		// A child needs a writable dir; fall back to a temp dir only when there's none.
 		const parentDir = this._ensureRlmSessionDir() ?? this._createEphemeralRlmSessionDir();
 		for (let i = 0; i < 100; i++) {
 			const childDir = join(parentDir, `sub-${randomUUID().slice(0, 8)}`);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -836,3 +836,70 @@ print(_result.answer)
 		}
 	});
 });
+
+interface InspectableRlmDirSession {
+	_ensureRlmSessionDir(): string | undefined;
+	_rlmKernelEnv(): Record<string, string>;
+}
+
+describe("AgentSession RLM session dir", () => {
+	let tempDir: string;
+	let session: AgentSession | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-rlm-dir-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		session?.dispose();
+		session = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function createSession(sessionManager: SessionManager): AgentSession {
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const agent = new Agent({
+			convertToLlm,
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "", tools: [], thinkingLevel: "off" },
+			streamFn: () => streamAnswer("ignored"),
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager: SettingsManager.create(tempDir, tempDir),
+			cwd: tempDir,
+			modelRegistry: ModelRegistry.create(authStorage, join(tempDir, "models.json")),
+			resourceLoader: createTestResourceLoader(),
+		});
+		return session;
+	}
+
+	it("does not create a /tmp dir or set RLM_SESSION_DIR for a non-persisted session", () => {
+		const root = createSession(SessionManager.inMemory(tempDir));
+		const inspectable = root as unknown as InspectableRlmDirSession;
+
+		const before = readdirSync(tmpdir()).filter((name) => name.startsWith("prime-agent-rlm-"));
+
+		expect(inspectable._ensureRlmSessionDir()).toBeUndefined();
+		const env = inspectable._rlmKernelEnv();
+		expect(env.RLM_SESSION_DIR).toBeUndefined();
+		expect(env).toMatchObject({ RLM_DEPTH: "0" });
+
+		const after = readdirSync(tmpdir()).filter((name) => name.startsWith("prime-agent-rlm-"));
+		expect(after).toEqual(before);
+	});
+
+	it("uses the persistent artifact dir and sets RLM_SESSION_DIR for a persisted session", () => {
+		const sessionManager = SessionManager.create(tempDir, join(tempDir, "sessions"));
+		const root = createSession(sessionManager);
+		const inspectable = root as unknown as InspectableRlmDirSession;
+
+		const artifactDir = sessionManager.getSessionArtifactDir();
+		expect(artifactDir).toBeDefined();
+		expect(inspectable._ensureRlmSessionDir()).toBe(artifactDir);
+		expect(inspectable._rlmKernelEnv().RLM_SESSION_DIR).toBe(artifactDir);
+	});
+});


### PR DESCRIPTION
- ephemeral viewer clients use a non-persisted session manager, so the rlm session dir helper was falling back to mkdtemp on every kernel build and leaking empty prime-agent-rlm-* dirs into /tmp.
- the helper now returns undefined when there is no persistent artifact dir, mirroring the kernel-snapshot path, and the env var is only set when a dir actually exists.
- the temp dir is created lazily only when a child agent is genuinely spawned, so real rlm work still gets a writable dir while viewers create nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lifecycle fix for RLM env/session dirs with new unit tests; persisted sessions and actual child spawns still get writable directories.
> 
> **Overview**
> Stops **leaking empty `prime-agent-rlm-*` directories in `/tmp`** for sessions without a persistent artifact dir (e.g. ephemeral viewer clients), where `_ensureRlmSessionDir` ran on every IPython kernel build via `_rlmKernelEnv`.
> 
> **`_ensureRlmSessionDir`** now returns **`undefined`** when there is no configured or persisted artifact directory, instead of always calling `mkdtemp`. **`_rlmKernelEnv`** only sets **`RLM_SESSION_DIR`** when a directory actually exists. **`_createEphemeralRlmSessionDir`** creates the temp dir **lazily** when **`_createChildRlmSessionDir`** needs a parent for a real RLM child spawn.
> 
> Tests assert in-memory sessions leave `/tmp` unchanged and omit `RLM_SESSION_DIR`, while persisted sessions still use the artifact dir in kernel env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb5ff080f4037d3d068ee4374627822111783259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip /tmp RLM session dir creation for non-persisted sessions
> - `AgentSession._ensureRlmSessionDir` now returns `undefined` instead of creating a temp directory when no persistent artifact dir exists.
> - `AgentSession._rlmKernelEnv` only sets `RLM_SESSION_DIR` in the kernel env when `_ensureRlmSessionDir()` returns a path.
> - A new `_createEphemeralRlmSessionDir` helper lazily creates a temp dir only when a child RLM session dir is actually needed.
> - Behavioral Change: non-persisted (viewer) sessions no longer produce stray `/tmp` directories at session init time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb5ff08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->