### PR TITLE
add daemon ps command to list all daemons on a machine

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -14,6 +14,7 @@ import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
 import { isLocalPath } from "../utils/paths.js";
 import { isValidThinkingLevel } from "./args.js";
 import { formatSessionListTable } from "./daemon-list-format.js";
+import { runPs, runReap } from "./daemon-ps.js";
 
 interface ParsedDaemonClientCommand {
 	command: string;
@@ -25,6 +26,7 @@ interface ParsedDaemonClientCommand {
 const DAEMON_CLIENT_COMMANDS = new Set([
 	"help",
 	"start",
+	"ps",
 	"list",
 	"create",
 	"attach",
@@ -145,6 +147,11 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 
 	if (parsed.command === "start") {
 		await runStart(parsed);
+		return;
+	}
+
+	if (parsed.command === "ps") {
+		await runPsCommand(parsed);
 		return;
 	}
 
@@ -631,6 +638,25 @@ async function runStart(parsed: ParsedDaemonClientCommand): Promise<void> {
 	}
 
 	throw new Error(`Timed out waiting for daemon to start on ${parsed.socketPath}`);
+}
+
+async function runPsCommand(parsed: ParsedDaemonClientCommand): Promise<void> {
+	let reap = false;
+	let force = false;
+	for (const arg of parsed.positionals) {
+		if (arg === "--reap" || arg === "reap") {
+			reap = true;
+		} else if (arg === "--force" || arg === "-f") {
+			force = true;
+		} else {
+			throw new Error(`Unknown ps option: ${arg}`);
+		}
+	}
+	if (reap) {
+		await runReap(parsed.json, force);
+		return;
+	}
+	await runPs(parsed.json);
 }
 
 async function canConnectToDaemon(socketPath: string, timeoutMs: number): Promise<boolean> {
@@ -1324,6 +1350,7 @@ function printDaemonHelp(): void {
 ${chalk.bold("Commands:")}
   help                          Show daemon help
   start                         Start the background daemon and return
+  ps [--reap [--force]]         List all daemons on this machine; --reap stops idle/orphaned ones
   list [-a|--all]               List active sessions; include inactive sessions with -a
   create [name]                 Create a new active session
   attach <session>              Attach an interactive terminal to a live session
@@ -1355,6 +1382,8 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock scratch
   ${APP_NAME} daemon start --socket /tmp/prime-agent.sock --model openai/gpt-4o-mini
   ${APP_NAME} daemon start --foreground --socket /tmp/prime-agent.sock --offline
+  ${APP_NAME} daemon ps
+  ${APP_NAME} daemon ps --reap
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock list
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock list -a
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock create scratch

--- a/packages/coding-agent/src/cli/daemon-ps-format.ts
+++ b/packages/coding-agent/src/cli/daemon-ps-format.ts
@@ -1,0 +1,88 @@
+import chalk from "chalk";
+import type { DaemonInfo, DaemonStatus } from "./daemon-ps.js";
+
+type DaemonRow = {
+	socket: string;
+	pid: string;
+	version: string;
+	status: string;
+	sessions: string;
+	uptime: string;
+};
+
+export function formatDaemonListTable(daemons: readonly DaemonInfo[]): string {
+	const rows = daemons.map((daemon) => ({
+		socket: daemon.isDefault ? `${daemon.socketPath} *` : daemon.socketPath,
+		pid: daemon.pid !== undefined ? String(daemon.pid) : "",
+		version: daemon.version ?? "",
+		status: daemon.status,
+		sessions: daemon.sessionCount !== undefined ? String(daemon.sessionCount) : "",
+		uptime: formatUptime(daemon.uptimeSeconds),
+	}));
+	const table = formatTable(["socket", "pid", "version", "status", "sessions", "uptime"], rows, formatDaemonCell);
+	return daemons.some((daemon) => daemon.isDefault) ? `${table}\n\n${chalk.dim("* default daemon")}` : table;
+}
+
+function formatDaemonCell(_row: DaemonRow, column: keyof DaemonRow, value: string): string {
+	if (column !== "status") {
+		return value;
+	}
+	return colorStatus(value.trim() as DaemonStatus, value);
+}
+
+function colorStatus(status: DaemonStatus, value: string): string {
+	switch (status) {
+		case "current":
+			return chalk.green(value);
+		case "stale":
+			return chalk.yellow(value);
+		case "unreachable":
+			return chalk.red(value);
+		case "orphan-file":
+			return chalk.dim(value);
+	}
+}
+
+export function formatUptime(uptimeSeconds: number | undefined): string {
+	if (uptimeSeconds === undefined || !Number.isFinite(uptimeSeconds)) {
+		return "";
+	}
+	const seconds = Math.max(0, Math.floor(uptimeSeconds));
+	if (seconds < 60) {
+		return `${seconds}s`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) {
+		return `${minutes}m`;
+	}
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) {
+		return `${hours}h`;
+	}
+	const days = Math.floor(hours / 24);
+	if (days < 7) {
+		return `${days}d`;
+	}
+	return `${Math.floor(days / 7)}w`;
+}
+
+function formatTable<T extends Record<string, string>>(
+	columns: Array<keyof T>,
+	rows: T[],
+	formatCell?: (row: T, column: keyof T, value: string) => string,
+): string {
+	const widths = columns.map((column) =>
+		Math.max(String(column).length, ...rows.map((row) => String(row[column]).length)),
+	);
+	const lines = [columns.map((column, index) => String(column).padEnd(widths[index])).join("  ")];
+	for (const row of rows) {
+		const line = columns
+			.map((column, index) => {
+				const value = String(row[column]).padEnd(widths[index]);
+				return formatCell ? formatCell(row, column, value) : value;
+			})
+			.join("  ");
+		lines.push(line);
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -277,52 +277,86 @@ export async function runPs(json: boolean): Promise<void> {
 	console.log(formatDaemonListTable(daemons));
 }
 
+export type ReapAction =
+	| { kind: "remove-file"; daemon: DaemonInfo }
+	| { kind: "kill"; daemon: DaemonInfo }
+	| { kind: "shutdown"; daemon: DaemonInfo }
+	| { kind: "skip"; daemon: DaemonInfo; reason: string };
+
 /**
- * Reap clearly-safe daemons: orphaned socket files, and reachable idle daemons
- * on non-default sockets. The user's default daemon and any daemon with live
- * sessions are never touched. Unreachable (hung) daemons are killed only with
- * `force`.
+ * Decide what to do with each discovered daemon (pure, no side effects). Reap
+ * targets only clearly-safe daemons: orphaned socket files, and reachable idle
+ * daemons on non-default sockets. The user's default daemon and any daemon with
+ * live sessions are never touched. Unreachable (hung) daemons are killed only
+ * with `force`, and never via a pid that backs more than one discovered daemon
+ * (e.g. macOS lsof reports every unix socket a process holds, so killing a
+ * shared pid could take down a reachable daemon with live sessions).
  */
+export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAction[] {
+	const pidCounts = new Map<number, number>();
+	for (const daemon of daemons) {
+		if (daemon.pid !== undefined) {
+			pidCounts.set(daemon.pid, (pidCounts.get(daemon.pid) ?? 0) + 1);
+		}
+	}
+
+	return daemons.map((daemon): ReapAction => {
+		if (daemon.isDefault) {
+			return { kind: "skip", daemon, reason: "default daemon" };
+		}
+		if (daemon.status === "orphan-file") {
+			return { kind: "remove-file", daemon };
+		}
+		if (daemon.status === "unreachable") {
+			if (!force || daemon.pid === undefined) {
+				return { kind: "skip", daemon, reason: "unreachable; pass --force to kill" };
+			}
+			if ((pidCounts.get(daemon.pid) ?? 0) > 1) {
+				return {
+					kind: "skip",
+					daemon,
+					reason: `unreachable; pid ${daemon.pid} also backs another daemon, not killing`,
+				};
+			}
+			return { kind: "kill", daemon };
+		}
+		if (daemon.sessionCount !== 0) {
+			return { kind: "skip", daemon, reason: `has ${daemon.sessionCount ?? "unknown"} session(s)` };
+		}
+		return { kind: "shutdown", daemon };
+	});
+}
+
 export async function runReap(json: boolean, force: boolean): Promise<void> {
 	const daemons = await discoverDaemons();
 	const reaped: Array<{ socketPath: string; action: string }> = [];
 	const skipped: Array<{ socketPath: string; reason: string }> = [];
 
-	for (const daemon of daemons) {
-		if (daemon.isDefault) {
-			skipped.push({ socketPath: daemon.socketPath, reason: "default daemon" });
-			continue;
-		}
-		if (daemon.status === "orphan-file") {
-			if (removeSocketFile(daemon.socketPath)) {
-				reaped.push({ socketPath: daemon.socketPath, action: "removed stale socket file" });
-			} else {
-				skipped.push({ socketPath: daemon.socketPath, reason: "could not remove socket file" });
-			}
-			continue;
-		}
-		if (daemon.status === "unreachable") {
-			if (force && daemon.pid !== undefined) {
-				killDaemon(daemon.pid);
-				removeSocketFile(daemon.socketPath);
-				reaped.push({ socketPath: daemon.socketPath, action: `killed unreachable daemon (pid ${daemon.pid})` });
-			} else {
-				skipped.push({ socketPath: daemon.socketPath, reason: "unreachable; pass --force to kill" });
-			}
-			continue;
-		}
-		if (daemon.sessionCount !== 0) {
-			skipped.push({ socketPath: daemon.socketPath, reason: `has ${daemon.sessionCount ?? "unknown"} session(s)` });
-			continue;
-		}
-		const stopped = await shutdownDaemon(daemon.socketPath);
-		if (stopped) {
-			reaped.push({
-				socketPath: daemon.socketPath,
-				action: `stopped idle daemon${daemon.pid ? ` (pid ${daemon.pid})` : ""}`,
-			});
-		} else {
-			skipped.push({ socketPath: daemon.socketPath, reason: "shutdown request failed" });
+	for (const action of planReap(daemons, force)) {
+		const { socketPath, pid } = action.daemon;
+		switch (action.kind) {
+			case "skip":
+				skipped.push({ socketPath, reason: action.reason });
+				break;
+			case "remove-file":
+				if (removeSocketFile(socketPath)) {
+					reaped.push({ socketPath, action: "removed stale socket file" });
+				} else {
+					skipped.push({ socketPath, reason: "could not remove socket file" });
+				}
+				break;
+			case "kill":
+				killDaemon(pid!);
+				removeSocketFile(socketPath);
+				reaped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
+				break;
+			case "shutdown":
+				if (await shutdownDaemon(socketPath)) {
+					reaped.push({ socketPath, action: `stopped idle daemon${pid ? ` (pid ${pid})` : ""}` });
+				} else {
+					skipped.push({ socketPath, reason: "shutdown request failed" });
+				}
+				break;
 		}
 	}
 
@@ -361,15 +395,49 @@ function killDaemon(pid: number): void {
 	}
 }
 
-async function shutdownDaemon(socketPath: string): Promise<boolean> {
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function canConnectToSocket(socketPath: string, timeoutMs: number): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
 	try {
-		await client.connect(1000);
-		await client.request({ type: "shutdown" }).catch(() => undefined);
+		await client.connect(timeoutMs);
 		return true;
 	} catch {
 		return false;
 	} finally {
 		client.close();
 	}
+}
+
+/**
+ * Ask a daemon to shut down and confirm it actually stopped listening. The
+ * shutdown ack alone is not proof, so success is reported only once the socket
+ * stops accepting connections.
+ */
+async function shutdownDaemon(socketPath: string): Promise<boolean> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(1000);
+	} catch {
+		client.close();
+		return false;
+	}
+	try {
+		await client.request({ type: "shutdown" });
+	} catch {
+		// The daemon may still stop; the connectivity check below is the source of truth.
+	} finally {
+		client.close();
+	}
+
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		if (!(await canConnectToSocket(socketPath, 250))) {
+			return true;
+		}
+		await delay(50);
+	}
+	return false;
 }

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -286,11 +286,16 @@ export type ReapAction =
 /**
  * Decide what to do with each discovered daemon (pure, no side effects). Reap
  * targets only clearly-safe daemons: orphaned socket files, and reachable idle
- * daemons on non-default sockets. The user's default daemon and any daemon with
- * live sessions are never touched. Unreachable (hung) daemons are killed only
- * with `force`, and never via a pid that backs more than one discovered daemon
- * (e.g. macOS lsof reports every unix socket a process holds, so killing a
- * shared pid could take down a reachable daemon with live sessions).
+ * daemons on non-default sockets. The user's default daemon, and any reachable
+ * daemon with live sessions, are never touched.
+ *
+ * Unreachable (hung) daemons can't report a session count, so they are only
+ * ever killed with `force`, and even then never via a pid that backs more than
+ * one discovered daemon (e.g. macOS lsof reports every unix socket a process
+ * holds, so killing a shared pid could take down a reachable daemon with live
+ * sessions). runReap additionally re-probes a kill candidate immediately before
+ * the SIGTERM and backs off to the session-aware paths if it has since become
+ * reachable, so a daemon that recovered with live sessions is never killed.
  */
 export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAction[] {
 	const pidCounts = new Map<number, number>();
@@ -345,11 +350,28 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 					skipped.push({ socketPath, reason: "could not remove socket file" });
 				}
 				break;
-			case "kill":
-				killDaemon(pid!);
-				removeSocketFile(socketPath);
-				reaped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
+			case "kill": {
+				// Re-probe right before killing: discovery and this kill happen at
+				// different moments, so a daemon classified "unreachable" may have
+				// since started answering. Never SIGTERM one that now responds with
+				// live sessions; defer to the session-aware paths instead.
+				const recheck = await probeDaemon(socketPath);
+				if (!recheck.reachable) {
+					killDaemon(pid!);
+					removeSocketFile(socketPath);
+					reaped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
+				} else if (recheck.sessionCount !== 0) {
+					skipped.push({
+						socketPath,
+						reason: `now reachable with ${recheck.sessionCount ?? "unknown"} session(s)`,
+					});
+				} else if (await shutdownDaemon(socketPath)) {
+					reaped.push({ socketPath, action: `stopped idle daemon (pid ${pid})` });
+				} else {
+					skipped.push({ socketPath, reason: "shutdown request failed" });
+				}
 				break;
+			}
 			case "shutdown":
 				if (await shutdownDaemon(socketPath)) {
 					reaped.push({ socketPath, action: `stopped idle daemon${pid ? ` (pid ${pid})` : ""}` });

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -285,9 +285,10 @@ export type ReapAction =
 
 /**
  * Decide what to do with each discovered daemon (pure, no side effects). Reap
- * targets only clearly-safe daemons: orphaned socket files, and reachable idle
- * daemons on non-default sockets. The user's default daemon, and any reachable
- * daemon with live sessions, are never touched.
+ * targets only clearly-safe daemons: orphaned socket files (including a stale
+ * default daemon.sock with no live process), and reachable idle daemons on
+ * non-default sockets. A reachable default daemon, and any reachable daemon with
+ * live sessions, are never touched.
  *
  * Unreachable (hung) daemons can't report a session count, so they are only
  * ever killed with `force`, and even then never via a pid that backs more than
@@ -306,11 +307,14 @@ export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAc
 	}
 
 	return daemons.map((daemon): ReapAction => {
-		if (daemon.isDefault) {
-			return { kind: "skip", daemon, reason: "default daemon" };
-		}
+		// An orphan socket file has no owning process, so removing it is safe even
+		// on the default path (a stale daemon.sock left by a crash). Decide this
+		// before the default guard so a dead default socket still gets cleaned up.
 		if (daemon.status === "orphan-file") {
 			return { kind: "remove-file", daemon };
+		}
+		if (daemon.isDefault) {
+			return { kind: "skip", daemon, reason: "default daemon" };
 		}
 		if (daemon.status === "unreachable") {
 			if (!force || daemon.pid === undefined) {
@@ -343,13 +347,19 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 			case "skip":
 				skipped.push({ socketPath, reason: action.reason });
 				break;
-			case "remove-file":
-				if (removeSocketFile(socketPath)) {
+			case "remove-file": {
+				// Re-probe before unlinking: a path marked orphan-file at discovery
+				// may have since become a live listener. Only remove it if it is
+				// still unreachable, so we never delete a socket a daemon is using.
+				if ((await probeDaemon(socketPath)).reachable) {
+					skipped.push({ socketPath, reason: "now reachable; not removing socket file" });
+				} else if (removeSocketFile(socketPath)) {
 					reaped.push({ socketPath, action: "removed stale socket file" });
 				} else {
 					skipped.push({ socketPath, reason: "could not remove socket file" });
 				}
 				break;
+			}
 			case "kill": {
 				// Re-probe right before killing: discovery and this kill happen at
 				// different moments, so a daemon classified "unreachable" may have

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -353,31 +353,20 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 			case "kill": {
 				// Re-probe right before killing: discovery and this kill happen at
 				// different moments, so a daemon classified "unreachable" may have
-				// since started answering. Never SIGTERM one that now responds with
-				// live sessions; defer to the session-aware paths instead.
+				// since started answering. Never SIGTERM one that now responds;
+				// defer to the session-aware shutdown path instead.
 				const recheck = await probeDaemon(socketPath);
 				if (!recheck.reachable) {
 					killDaemon(pid!);
 					removeSocketFile(socketPath);
 					reaped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
-				} else if (recheck.sessionCount !== 0) {
-					skipped.push({
-						socketPath,
-						reason: `now reachable with ${recheck.sessionCount ?? "unknown"} session(s)`,
-					});
-				} else if (await shutdownDaemon(socketPath)) {
-					reaped.push({ socketPath, action: `stopped idle daemon (pid ${pid})` });
 				} else {
-					skipped.push({ socketPath, reason: "shutdown request failed" });
+					apply(await reapReachableDaemon(socketPath, pid), socketPath, reaped, skipped);
 				}
 				break;
 			}
 			case "shutdown":
-				if (await shutdownDaemon(socketPath)) {
-					reaped.push({ socketPath, action: `stopped idle daemon${pid ? ` (pid ${pid})` : ""}` });
-				} else {
-					skipped.push({ socketPath, reason: "shutdown request failed" });
-				}
+				apply(await reapReachableDaemon(socketPath, pid), socketPath, reaped, skipped);
 				break;
 		}
 	}
@@ -396,6 +385,39 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 	for (const entry of skipped) {
 		console.log(chalk.dim(`kept   ${entry.socketPath}: ${entry.reason}`));
 	}
+}
+
+type ReapOutcome = { reaped: string } | { skipped: string };
+
+function apply(
+	outcome: ReapOutcome,
+	socketPath: string,
+	reaped: Array<{ socketPath: string; action: string }>,
+	skipped: Array<{ socketPath: string; reason: string }>,
+): void {
+	if ("reaped" in outcome) {
+		reaped.push({ socketPath, action: outcome.reaped });
+	} else {
+		skipped.push({ socketPath, reason: outcome.skipped });
+	}
+}
+
+/**
+ * Gracefully stop a daemon, but only after a fresh probe confirms it is idle.
+ * Discovery and reap happen at different moments, so the session count is
+ * re-checked here to avoid stopping a daemon that gained a session in between.
+ */
+async function reapReachableDaemon(socketPath: string, pid: number | undefined): Promise<ReapOutcome> {
+	const probe = await probeDaemon(socketPath);
+	if (!probe.reachable) {
+		return { skipped: "no longer reachable" };
+	}
+	if (probe.sessionCount !== 0) {
+		return { skipped: `now has ${probe.sessionCount ?? "unknown"} session(s)` };
+	}
+	return (await shutdownDaemon(socketPath))
+		? { reaped: `stopped idle daemon${pid ? ` (pid ${pid})` : ""}` }
+		: { skipped: "shutdown request failed" };
 }
 
 function removeSocketFile(socketPath: string): boolean {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -1,0 +1,375 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, readdirSync, unlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import chalk from "chalk";
+import { APP_NAME, VERSION } from "../config.js";
+import { DaemonClient } from "../modes/daemon/daemon-client.js";
+import { DAEMON_PROTOCOL_VERSION } from "../modes/daemon/daemon-protocol.js";
+import { defaultDaemonSocketDir, defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
+import { formatDaemonListTable } from "./daemon-ps-format.js";
+
+/**
+ * `daemon ps` discovers every prime-agent daemon on the machine, not just the
+ * one on a single socket. Discovery has two sources merged by socket path:
+ *
+ *  1. The OS list of listening unix sockets owned by a prime-agent process
+ *     (`ss -lxp` on Linux, `lsof` on macOS). Daemons set process.title to
+ *     APP_NAME and carry nothing useful in argv, so the socket→pid mapping the
+ *     kernel keeps is the only reliable way to find daemons on arbitrary
+ *     `--daemon-socket` paths. This is the same data as `ss -lxp | grep
+ *     prime-agent`, just parsed.
+ *  2. A sweep of the default socket dir, which catches orphaned socket *files*
+ *     left behind by daemons that are no longer running.
+ *
+ * Each discovered socket is then probed with the existing daemon_hello + list
+ * primitives, so introspection works even against stale daemons running an
+ * older build (a new protocol command would not).
+ */
+
+export type DaemonStatus = "current" | "stale" | "unreachable" | "orphan-file";
+
+export interface DiscoveredDaemonProcess {
+	pid: number;
+	socketPath: string;
+	uptimeSeconds?: number;
+}
+
+export interface DaemonInfo {
+	socketPath: string;
+	pid?: number;
+	uptimeSeconds?: number;
+	version?: string;
+	protocolVersion?: number;
+	sessionCount?: number;
+	status: DaemonStatus;
+	isDefault: boolean;
+}
+
+const STATUS_ORDER: Record<DaemonStatus, number> = {
+	current: 0,
+	stale: 1,
+	unreachable: 2,
+	"orphan-file": 3,
+};
+
+// Linux comm names (and thus the process name ss reports) are capped at 15 chars.
+const MAX_COMM_LENGTH = 15;
+
+/** Normalize a socket path so process-scan and dir-sweep entries merge cleanly. */
+function normalizeSocketPath(socketPath: string): string {
+	if (process.platform === "win32") {
+		return socketPath;
+	}
+	return resolve(socketPath);
+}
+
+function processNameMatches(name: string, appName: string): boolean {
+	return name === appName || appName.slice(0, MAX_COMM_LENGTH) === name;
+}
+
+/** Parse `ss -lxp` output into the prime-agent daemons listening on unix sockets. */
+export function parseSsListeners(stdout: string, appName: string): DiscoveredDaemonProcess[] {
+	const daemons: DiscoveredDaemonProcess[] = [];
+	for (const line of stdout.split("\n")) {
+		const fields = line.trim().split(/\s+/);
+		if (fields[1] !== "LISTEN") {
+			continue;
+		}
+		const socketPath = fields[4];
+		if (!socketPath?.startsWith("/")) {
+			continue;
+		}
+		const owner = line.match(/users:\(\("([^"]+)",pid=(\d+)/);
+		if (!owner || !processNameMatches(owner[1]!, appName)) {
+			continue;
+		}
+		daemons.push({ pid: Number.parseInt(owner[2]!, 10), socketPath: normalizeSocketPath(socketPath) });
+	}
+	return daemons;
+}
+
+/** Parse `lsof -nP -F pn -U -a -c <app>` output into listening unix socket owners (macOS fallback). */
+export function parseLsofListeners(stdout: string): DiscoveredDaemonProcess[] {
+	const daemons: DiscoveredDaemonProcess[] = [];
+	const seen = new Set<string>();
+	let pid: number | undefined;
+	for (const line of stdout.split("\n")) {
+		const field = line[0];
+		const value = line.slice(1);
+		if (field === "p") {
+			pid = Number.parseInt(value, 10);
+		} else if (field === "n" && pid !== undefined && value.startsWith("/")) {
+			const socketPath = normalizeSocketPath(value);
+			const key = `${pid}:${socketPath}`;
+			if (!seen.has(key)) {
+				seen.add(key);
+				daemons.push({ pid, socketPath });
+			}
+		}
+	}
+	return daemons;
+}
+
+/** Parse `ps -o pid=,etimes=` output into a pid → uptime-seconds map. */
+export function parsePsEtimes(stdout: string): Map<number, number> {
+	const uptimes = new Map<number, number>();
+	for (const line of stdout.split("\n")) {
+		const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+		if (match) {
+			uptimes.set(Number.parseInt(match[1]!, 10), Number.parseInt(match[2]!, 10));
+		}
+	}
+	return uptimes;
+}
+
+function scanListeningDaemons(): DiscoveredDaemonProcess[] {
+	if (process.platform === "win32") {
+		return [];
+	}
+	const ss = spawnSync("ss", ["-lxp"], { encoding: "utf8" });
+	if (!ss.error && ss.status === 0 && typeof ss.stdout === "string") {
+		return enrichUptimes(parseSsListeners(ss.stdout, APP_NAME));
+	}
+	const lsof = spawnSync("lsof", ["-nP", "-F", "pn", "-U", "-a", "-c", APP_NAME], { encoding: "utf8" });
+	if (!lsof.error && typeof lsof.stdout === "string") {
+		return enrichUptimes(parseLsofListeners(lsof.stdout));
+	}
+	return [];
+}
+
+function enrichUptimes(daemons: DiscoveredDaemonProcess[]): DiscoveredDaemonProcess[] {
+	const pids = daemons.map((daemon) => daemon.pid);
+	if (pids.length === 0) {
+		return daemons;
+	}
+	const ps = spawnSync("ps", ["-o", "pid=,etimes=", "-p", pids.join(",")], { encoding: "utf8" });
+	if (ps.error || typeof ps.stdout !== "string") {
+		return daemons;
+	}
+	const uptimes = parsePsEtimes(ps.stdout);
+	return daemons.map((daemon) => ({ ...daemon, uptimeSeconds: uptimes.get(daemon.pid) }));
+}
+
+/** Socket files in the default socket dir (may be live daemons or orphaned files). */
+function scanSocketDir(): string[] {
+	if (process.platform === "win32") {
+		return [];
+	}
+	const dir = defaultDaemonSocketDir();
+	if (!existsSync(dir)) {
+		return [];
+	}
+	const sockets: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const socketPath = join(dir, entry);
+		try {
+			if (lstatSync(socketPath).isSocket()) {
+				sockets.push(normalizeSocketPath(socketPath));
+			}
+		} catch {
+			// Entry vanished between readdir and lstat; ignore.
+		}
+	}
+	return sockets;
+}
+
+interface ProbeResult {
+	version?: string;
+	protocolVersion?: number;
+	sessionCount?: number;
+	reachable: boolean;
+}
+
+async function probeDaemon(socketPath: string): Promise<ProbeResult> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(300);
+	} catch {
+		client.close();
+		return { reachable: false };
+	}
+	try {
+		let version: string | undefined;
+		let protocolVersion: number | undefined;
+		try {
+			const hello = await client.waitForHello(1500);
+			version = hello.appVersion;
+			protocolVersion = hello.protocol.version;
+		} catch {
+			// Connected but no recognizable greeting: an old/foreign daemon.
+		}
+		let sessionCount: number | undefined;
+		try {
+			const response = await client.request({ type: "list" });
+			if (response.success) {
+				const sessions = (response.data as { sessions?: unknown })?.sessions;
+				if (Array.isArray(sessions)) {
+					sessionCount = sessions.length;
+				}
+			}
+		} catch {
+			// Leave sessionCount undefined when the daemon will not answer list.
+		}
+		return { version, protocolVersion, sessionCount, reachable: true };
+	} finally {
+		client.close();
+	}
+}
+
+function classifyReachable(probe: ProbeResult): DaemonStatus {
+	if (probe.protocolVersion === DAEMON_PROTOCOL_VERSION && probe.version === VERSION) {
+		return "current";
+	}
+	return "stale";
+}
+
+/** Discover every daemon on the machine and probe each for version + session count. */
+export async function discoverDaemons(): Promise<DaemonInfo[]> {
+	const processBySocket = new Map<string, DiscoveredDaemonProcess>();
+	for (const daemon of scanListeningDaemons()) {
+		processBySocket.set(daemon.socketPath, daemon);
+	}
+
+	const sockets = new Set<string>([...processBySocket.keys(), ...scanSocketDir()]);
+	const defaultSocket = normalizeSocketPath(defaultDaemonSocketPath());
+
+	const infos = await Promise.all(
+		[...sockets].map(async (socketPath): Promise<DaemonInfo> => {
+			const proc = processBySocket.get(socketPath);
+			const probe = await probeDaemon(socketPath);
+			const status: DaemonStatus = probe.reachable ? classifyReachable(probe) : proc ? "unreachable" : "orphan-file";
+			return {
+				socketPath,
+				pid: proc?.pid,
+				uptimeSeconds: proc?.uptimeSeconds,
+				version: probe.version,
+				protocolVersion: probe.protocolVersion,
+				sessionCount: probe.sessionCount,
+				status,
+				isDefault: socketPath === defaultSocket,
+			};
+		}),
+	);
+
+	return sortDaemons(infos);
+}
+
+export function sortDaemons(infos: DaemonInfo[]): DaemonInfo[] {
+	return [...infos].sort((left, right) => {
+		if (left.isDefault !== right.isDefault) {
+			return left.isDefault ? -1 : 1;
+		}
+		const statusDelta = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+		return statusDelta || left.socketPath.localeCompare(right.socketPath);
+	});
+}
+
+export async function runPs(json: boolean): Promise<void> {
+	const daemons = await discoverDaemons();
+	if (json) {
+		console.log(JSON.stringify(daemons, null, 2));
+		return;
+	}
+	if (daemons.length === 0) {
+		console.log("No daemons found.");
+		return;
+	}
+	console.log(formatDaemonListTable(daemons));
+}
+
+/**
+ * Reap clearly-safe daemons: orphaned socket files, and reachable idle daemons
+ * on non-default sockets. The user's default daemon and any daemon with live
+ * sessions are never touched. Unreachable (hung) daemons are killed only with
+ * `force`.
+ */
+export async function runReap(json: boolean, force: boolean): Promise<void> {
+	const daemons = await discoverDaemons();
+	const reaped: Array<{ socketPath: string; action: string }> = [];
+	const skipped: Array<{ socketPath: string; reason: string }> = [];
+
+	for (const daemon of daemons) {
+		if (daemon.isDefault) {
+			skipped.push({ socketPath: daemon.socketPath, reason: "default daemon" });
+			continue;
+		}
+		if (daemon.status === "orphan-file") {
+			if (removeSocketFile(daemon.socketPath)) {
+				reaped.push({ socketPath: daemon.socketPath, action: "removed stale socket file" });
+			} else {
+				skipped.push({ socketPath: daemon.socketPath, reason: "could not remove socket file" });
+			}
+			continue;
+		}
+		if (daemon.status === "unreachable") {
+			if (force && daemon.pid !== undefined) {
+				killDaemon(daemon.pid);
+				removeSocketFile(daemon.socketPath);
+				reaped.push({ socketPath: daemon.socketPath, action: `killed unreachable daemon (pid ${daemon.pid})` });
+			} else {
+				skipped.push({ socketPath: daemon.socketPath, reason: "unreachable; pass --force to kill" });
+			}
+			continue;
+		}
+		if (daemon.sessionCount !== 0) {
+			skipped.push({ socketPath: daemon.socketPath, reason: `has ${daemon.sessionCount ?? "unknown"} session(s)` });
+			continue;
+		}
+		const stopped = await shutdownDaemon(daemon.socketPath);
+		if (stopped) {
+			reaped.push({
+				socketPath: daemon.socketPath,
+				action: `stopped idle daemon${daemon.pid ? ` (pid ${daemon.pid})` : ""}`,
+			});
+		} else {
+			skipped.push({ socketPath: daemon.socketPath, reason: "shutdown request failed" });
+		}
+	}
+
+	if (json) {
+		console.log(JSON.stringify({ reaped, skipped }, null, 2));
+		return;
+	}
+	if (reaped.length === 0 && skipped.length === 0) {
+		console.log("No daemons found.");
+		return;
+	}
+	for (const entry of reaped) {
+		console.log(chalk.green(`reaped ${entry.socketPath}: ${entry.action}`));
+	}
+	for (const entry of skipped) {
+		console.log(chalk.dim(`kept   ${entry.socketPath}: ${entry.reason}`));
+	}
+}
+
+function removeSocketFile(socketPath: string): boolean {
+	try {
+		if (existsSync(socketPath)) {
+			unlinkSync(socketPath);
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function killDaemon(pid: number): void {
+	try {
+		process.kill(pid, "SIGTERM");
+	} catch {
+		// Process already gone or not permitted; the socket file cleanup still runs.
+	}
+}
+
+async function shutdownDaemon(socketPath: string): Promise<boolean> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(1000);
+		await client.request({ type: "shutdown" }).catch(() => undefined);
+		return true;
+	} catch {
+		return false;
+	} finally {
+		client.close();
+	}
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -52,7 +52,7 @@ export function cleanupDaemonSocketPath(socketPath: string): void {
 	}
 }
 
-function defaultDaemonSocketDir(): string {
+export function defaultDaemonSocketDir(): string {
 	const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
 	return join(tmpdir(), `prime-agent-${suffix}`);
 }

--- a/packages/coding-agent/test/daemon-ps-format.test.ts
+++ b/packages/coding-agent/test/daemon-ps-format.test.ts
@@ -1,0 +1,50 @@
+import stripAnsi from "strip-ansi";
+import { describe, expect, it } from "vitest";
+import type { DaemonInfo } from "../src/cli/daemon-ps.js";
+import { formatDaemonListTable, formatUptime } from "../src/cli/daemon-ps-format.js";
+
+describe("formatUptime", () => {
+	it("formats seconds into a compact human duration", () => {
+		expect(formatUptime(0)).toBe("0s");
+		expect(formatUptime(45)).toBe("45s");
+		expect(formatUptime(90)).toBe("1m");
+		expect(formatUptime(3 * 3600)).toBe("3h");
+		expect(formatUptime(5 * 86400)).toBe("5d");
+		expect(formatUptime(14 * 86400)).toBe("2w");
+	});
+
+	it("returns empty for unknown uptime", () => {
+		expect(formatUptime(undefined)).toBe("");
+	});
+});
+
+describe("formatDaemonListTable", () => {
+	it("renders columns, marks the default daemon, and shows blanks for missing fields", () => {
+		const daemons: DaemonInfo[] = [
+			{
+				socketPath: "/tmp/prime-agent-1000/daemon.sock",
+				pid: 1234,
+				uptimeSeconds: 7200,
+				version: "0.1.5",
+				protocolVersion: 1,
+				sessionCount: 2,
+				status: "current",
+				isDefault: true,
+			},
+			{
+				socketPath: "/tmp/orphan.sock",
+				status: "orphan-file",
+				isDefault: false,
+			},
+		];
+
+		const table = stripAnsi(formatDaemonListTable(daemons));
+		const lines = table.split("\n");
+		expect(lines[0]!.trim().split(/\s+/)).toEqual(["socket", "pid", "version", "status", "sessions", "uptime"]);
+		expect(table).toContain("/tmp/prime-agent-1000/daemon.sock *");
+		expect(table).toContain("* default daemon");
+		expect(table).toContain("current");
+		expect(table).toContain("orphan-file");
+		expect(table).toContain("2h");
+	});
+});

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -98,6 +98,18 @@ describe("planReap", () => {
 		expect(plan.map((action) => action.kind)).toEqual(["shutdown", "remove-file"]);
 	});
 
+	it("removes a stale default socket file but never stops a live default daemon", () => {
+		const plan = planReap(
+			[
+				makeDaemon({ socketPath: "/tmp/default.sock", status: "orphan-file", isDefault: true }),
+				makeDaemon({ socketPath: "/tmp/live-default.sock", status: "current", isDefault: true, sessionCount: 0 }),
+			],
+			true,
+		);
+		expect(plan[0]!.kind).toBe("remove-file");
+		expect(plan[1]!.kind).toBe("skip");
+	});
+
 	it("only kills unreachable daemons with --force", () => {
 		const daemon = makeDaemon({ socketPath: "/tmp/hung.sock", status: "unreachable", pid: 7 });
 		expect(planReap([daemon], false)[0]!.kind).toBe("skip");

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+	type DaemonInfo,
+	parseLsofListeners,
+	parsePsEtimes,
+	parseSsListeners,
+	sortDaemons,
+} from "../src/cli/daemon-ps.js";
+
+describe("parseSsListeners", () => {
+	const stdout = [
+		"Netid State  Recv-Q Send-Q Local Address:Port  Peer Address:Port",
+		'u_str LISTEN 0      511    /tmp/custom.sock 10147608 * 0 users:(("prime-agent",pid=1234,fd=22))',
+		'u_str LISTEN 0      511    /tmp/prime-agent-1000/daemon.sock 79453846 * 0 users:(("prime-agent",pid=5678,fd=24))',
+		'u_str LISTEN 0      4096   /run/dbus/system_bus_socket 123 * 0 users:(("dbus-daemon",pid=900,fd=3))',
+		'u_str ESTAB  0      0      /tmp/other.sock 456 * 0 users:(("prime-agent",pid=4321,fd=9))',
+		"",
+	].join("\n");
+
+	it("extracts socket + pid for prime-agent LISTEN sockets only", () => {
+		const daemons = parseSsListeners(stdout, "prime-agent");
+		expect(daemons).toEqual([
+			{ pid: 1234, socketPath: "/tmp/custom.sock" },
+			{ pid: 5678, socketPath: "/tmp/prime-agent-1000/daemon.sock" },
+		]);
+	});
+
+	it("ignores sockets owned by other processes and non-LISTEN states", () => {
+		const daemons = parseSsListeners(stdout, "prime-agent");
+		expect(daemons.some((daemon) => daemon.socketPath.includes("dbus"))).toBe(false);
+		expect(daemons.some((daemon) => daemon.pid === 4321)).toBe(false);
+	});
+
+	it("honors a different app name", () => {
+		expect(parseSsListeners(stdout, "pi")).toEqual([]);
+	});
+});
+
+describe("parseLsofListeners", () => {
+	it("pairs each pid with its listening unix socket paths", () => {
+		const stdout = ["p1234", "fu", "n/tmp/a.sock", "p5678", "n/tmp/b.sock", "n0x0 (not a path)", ""].join("\n");
+		expect(parseLsofListeners(stdout)).toEqual([
+			{ pid: 1234, socketPath: "/tmp/a.sock" },
+			{ pid: 5678, socketPath: "/tmp/b.sock" },
+		]);
+	});
+});
+
+describe("parsePsEtimes", () => {
+	it("maps pid to elapsed seconds", () => {
+		const uptimes = parsePsEtimes("  1234  86400\n  5678      42\n");
+		expect(uptimes.get(1234)).toBe(86400);
+		expect(uptimes.get(5678)).toBe(42);
+		expect(uptimes.size).toBe(2);
+	});
+});
+
+describe("sortDaemons", () => {
+	it("orders default first, then by status, then socket", () => {
+		const daemons: DaemonInfo[] = [
+			makeDaemon({ socketPath: "/tmp/z.sock", status: "orphan-file" }),
+			makeDaemon({ socketPath: "/tmp/a.sock", status: "stale" }),
+			makeDaemon({ socketPath: "/tmp/default.sock", status: "current", isDefault: true }),
+			makeDaemon({ socketPath: "/tmp/b.sock", status: "current" }),
+			makeDaemon({ socketPath: "/tmp/c.sock", status: "unreachable" }),
+		];
+		expect(sortDaemons(daemons).map((daemon) => daemon.socketPath)).toEqual([
+			"/tmp/default.sock",
+			"/tmp/b.sock",
+			"/tmp/a.sock",
+			"/tmp/c.sock",
+			"/tmp/z.sock",
+		]);
+	});
+});
+
+function makeDaemon(options: Partial<DaemonInfo> & { socketPath: string; status: DaemonInfo["status"] }): DaemonInfo {
+	return {
+		isDefault: false,
+		...options,
+	};
+}

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -4,6 +4,7 @@ import {
 	parseLsofListeners,
 	parsePsEtimes,
 	parseSsListeners,
+	planReap,
 	sortDaemons,
 } from "../src/cli/daemon-ps.js";
 
@@ -71,6 +72,49 @@ describe("sortDaemons", () => {
 			"/tmp/c.sock",
 			"/tmp/z.sock",
 		]);
+	});
+});
+
+describe("planReap", () => {
+	it("never touches the default daemon or daemons with live sessions", () => {
+		const plan = planReap(
+			[
+				makeDaemon({ socketPath: "/tmp/default.sock", status: "stale", isDefault: true, sessionCount: 0, pid: 1 }),
+				makeDaemon({ socketPath: "/tmp/busy.sock", status: "current", sessionCount: 3, pid: 2 }),
+			],
+			true,
+		);
+		expect(plan.map((action) => action.kind)).toEqual(["skip", "skip"]);
+	});
+
+	it("removes orphan files and stops reachable idle non-default daemons", () => {
+		const plan = planReap(
+			[
+				makeDaemon({ socketPath: "/tmp/idle.sock", status: "current", sessionCount: 0, pid: 5 }),
+				makeDaemon({ socketPath: "/tmp/orphan.sock", status: "orphan-file" }),
+			],
+			false,
+		);
+		expect(plan.map((action) => action.kind)).toEqual(["shutdown", "remove-file"]);
+	});
+
+	it("only kills unreachable daemons with --force", () => {
+		const daemon = makeDaemon({ socketPath: "/tmp/hung.sock", status: "unreachable", pid: 7 });
+		expect(planReap([daemon], false)[0]!.kind).toBe("skip");
+		expect(planReap([daemon], true)[0]!.kind).toBe("kill");
+	});
+
+	it("refuses to kill a pid that backs more than one discovered daemon", () => {
+		const plan = planReap(
+			[
+				makeDaemon({ socketPath: "/tmp/listening.sock", status: "current", sessionCount: 4, pid: 99 }),
+				makeDaemon({ socketPath: "/tmp/phantom.sock", status: "unreachable", pid: 99 }),
+			],
+			true,
+		);
+		const phantom = plan.find((action) => action.daemon.socketPath === "/tmp/phantom.sock");
+		expect(phantom?.kind).toBe("skip");
+		expect(phantom && phantom.kind === "skip" ? phantom.reason : "").toContain("also backs another daemon");
 	});
 });
 


### PR DESCRIPTION
- there was no way to see every daemon running on a box, since the existing list command only talks to one socket, making orphaned test daemons hard to find.
- adds a ps subcommand that discovers all daemons via their listening sockets and reports pid, version, session count, uptime, and whether each is reachable, stale, or orphaned.
- an optional reap flag stops idle and orphaned daemons while always leaving the default daemon and any with live sessions untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `--reap` can shut down daemons or send SIGTERM with `--force`, though guards and re-probes limit mistaken kills; discovery is Unix-only (no-op on Windows).
> 
> **Overview**
> Adds **`daemon ps`**, which discovers every prime-agent daemon on the host (not just one `--socket`), merges **listening-socket scans** (`ss -lxp` / `lsof`) with a sweep of the **default socket directory**, then **probes** each path via `DaemonClient` (`hello` + `list`) to show pid, version, session count, uptime, and status (`current`, `stale`, `unreachable`, `orphan-file`). Output is a colorized table or `--json`; the default socket is marked with `*`.
> 
> **`daemon ps --reap`** (optional **`--force`**) cleans up idle/orphaned daemons: removes stale socket files, gracefully shuts down reachable idle non-default daemons with zero sessions, and with `--force` may **SIGTERM** unreachable daemons—while **never** stopping the live default daemon, daemons with sessions, or PIDs shared across multiple discovered sockets. Re-probes run immediately before destructive actions.
> 
> Wires the subcommand in `daemon-command.ts` (no socket connect for `ps`), exports **`defaultDaemonSocketDir`** for discovery, and adds **`daemon-ps.ts`**, **`daemon-ps-format.ts`**, plus unit tests for parsers, sorting, `planReap`, and table formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16585ffc652b7160e899cca7e3fcce351ddd78db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `daemon ps` command to list and reap daemon processes on a machine
> - Adds a new `daemon ps` subcommand to the coding-agent CLI that discovers all running daemon processes on the local machine via `ss -lxp` and `lsof`, enriches results with uptime, and prints a formatted table with columns for socket, pid, version, status, sessions, and uptime.
> - Adds a `--reap` flag (with optional `--force`) that removes orphaned socket files, gracefully shuts down idle daemons, and optionally kills unreachable ones.
> - Exports `defaultDaemonSocketDir` from [daemon-socket.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/188/files#diff-59c4ea71700afcf7d09d14c5d30e2c73fd0c71b28284e8758cd8fbd4b2337dbc) to support cross-module discovery.
> - Adds unit tests for parsing, sorting, table formatting, and reap planning logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16585ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->