### PR TITLE
add glm-5.2 from prime inference

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -150,6 +150,7 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"x-ai/grok-4.20-multi-agent": { contextWindow: 2000000, maxTokens: 30000 },
 	"z-ai/glm-5": { contextWindow: 202752, maxTokens: 131072 },
 	"z-ai/glm-5.1": { contextWindow: 202800, maxTokens: 131072 },
+	"z-ai/glm-5.2": { contextWindow: 202800, maxTokens: 131072 },
 };
 
 const OPENAI_RESPONSES_NONE_REASONING_MODELS = new Set([

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -13276,6 +13276,24 @@ export const MODELS = {
 			contextWindow: 202800,
 			maxTokens: 131072,
 		} satisfies Model<"openai-completions">,
+		"z-ai/glm-5.2": {
+			id: "z-ai/glm-5.2",
+			name: "GLM 5.2 (Prime Inference)",
+			api: "openai-completions",
+			provider: "prime-inference",
+			baseUrl: "https://api.pinference.ai/api/v1",
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false,"maxTokensField":"max_tokens","supportsStrictMode":false,"thinkingFormat":"zai"},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1.68,
+				output: 5.28,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 202800,
+			maxTokens: 131072,
+		} satisfies Model<"openai-completions">,
 	},
 	"vercel-ai-gateway": {
 		"alibaba/qwen-3-14b": {

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -16,7 +16,7 @@ describe("Prime Inference models", () => {
 	it("registers the Prime Inference catalog", () => {
 		const modelIds = getModels("prime-inference").map((model) => model.id);
 
-		expect(modelIds.length).toBe(27);
+		expect(modelIds.length).toBe(28);
 		expect(modelIds).toEqual(
 			expect.arrayContaining([
 				"anthropic/claude-opus-4.7",
@@ -33,6 +33,7 @@ describe("Prime Inference models", () => {
 				"x-ai/grok-4.20",
 				"z-ai/glm-5",
 				"z-ai/glm-5.1",
+				"z-ai/glm-5.2",
 			]),
 		);
 		expect(modelIds).not.toContain("google/gemini-2.5-pro");
@@ -82,6 +83,12 @@ describe("Prime Inference models", () => {
 		const glm51 = getModel("prime-inference", "z-ai/glm-5.1");
 		expect(glm51.reasoning).toBe(true);
 		expect(glm51.compat).toMatchObject({
+			supportsReasoningEffort: false,
+			thinkingFormat: "zai",
+		});
+		const glm52 = getModel("prime-inference", "z-ai/glm-5.2");
+		expect(glm52.reasoning).toBe(true);
+		expect(glm52.compat).toMatchObject({
 			supportsReasoningEffort: false,
 			thinkingFormat: "zai",
 		});


### PR DESCRIPTION
- adds glm-5.2 from the prime inference catalog as a selectable model, following the just-released listing on the models endpoint.
- it inherits the existing zai thinking configuration and reasoning support shared by the other glm-5 models.
- updates the prime inference model test to cover the new entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model-catalog and generated metadata only; no auth, routing, or runtime logic changes beyond selecting a new provider model ID.
> 
> **Overview**
> Adds **`z-ai/glm-5.2`** to the curated Prime Inference model list so it appears in the picker once the Prime `/models` endpoint lists it.
> 
> The new entry uses the same **202800 / 131072** context and max-token limits as GLM 5.1, and the generated catalog entry marks it as a **reasoning** model with **`thinkingFormat: "zai"`** (via the existing `z-ai/glm-` compat path). Pricing in `models.generated.ts` comes from the Prime API at generation time (e.g. $1.68 / $5.28 per million tokens in this diff).
> 
> Prime Inference tests now expect **28** models, include `z-ai/glm-5.2` in the catalog assertion, and assert GLM 5.2 matches GLM 5.1’s reasoning and compat settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e4ec359ce1aad90a19f3c875bfbaf3ce692def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GLM 5.2 model from Prime Inference provider
> Adds `z-ai/glm-5.2` to the Prime Inference catalog in [models.generated.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/191/files#diff-ff7c21ac6b779f6c8f30964fa301e7f89a29bfa77866258b05b9be7f35291fdd) with a 202800 context window, 131072 max tokens, reasoning enabled, and `thinkingFormat: "zai"`. The model uses the `openai-completions` API and does not support store, developer role, strict mode, or reasoning effort controls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0e4ec3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->