### PR TITLE
fix tui flicker when attaching to long or streaming sessions

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1227,9 +1227,15 @@ export class TUI extends Container {
 		// top. Repaint only the visible window in place instead, leaving
 		// scrollback (and the user's history) untouched. Short transcripts that
 		// fit on screen keep the cheap full redraw.
+		//
+		// Only do this while the transcript is growing (the streaming case). A
+		// shrink — a rebuild or compaction that replaces the transcript with
+		// fewer lines — leaves the now-removed lines stale in scrollback above the
+		// visible window, so it still needs the scrollback-clearing redraw. That
+		// is a one-time event, so it costs no recurring flicker.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			const preserveScrollback = newLines.length > height;
+			const preserveScrollback = newLines.length > height && newLines.length >= this.previousLines.length;
 			fullRender(true, preserveScrollback || preserveViewport);
 			return;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1217,10 +1217,20 @@ export class TUI extends Container {
 		}
 
 		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// If the first changed line is above the previous viewport, the rows on
+		// screen no longer correspond to newLines, so we have to repaint.
+		//
+		// When the transcript is taller than the viewport — e.g. attaching to a
+		// long or still-streaming session, where off-screen tool results keep
+		// resolving — clearing scrollback and replaying the whole transcript on
+		// every such change is what makes the screen flicker and scroll from the
+		// top. Repaint only the visible window in place instead, leaving
+		// scrollback (and the user's history) untouched. Short transcripts that
+		// fit on screen keep the cheap full redraw.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true, preserveViewport);
+			const preserveScrollback = newLines.length > height;
+			fullRender(true, preserveScrollback || preserveViewport);
 			return;
 		}
 

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -793,4 +793,31 @@ describe("TUI above-viewport changes on a tall transcript", () => {
 
 		tui.stop();
 	});
+
+	it("clears scrollback when a still-tall transcript shrinks (rebuild/compaction)", async () => {
+		// A rebuild or compaction can replace the transcript with fewer lines that
+		// still exceed the viewport. Preserving scrollback there would leave the
+		// removed lines stale above the visible window, so the shrink must take the
+		// scrollback-clearing redraw even though the result is still taller than
+		// the viewport.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// Replace with a shorter transcript that is still taller than the 10-row
+		// viewport (15 lines), as a compaction would.
+		component.lines = Array.from({ length: 15 }, (_, i) => `Rebuilt ${i}`);
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "A still-tall shrink clears stale scrollback");
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -666,25 +666,28 @@ describe("TUI viewport-preserving render", () => {
 		tui.stop();
 	});
 
-	it("falls back to a scrollback-clearing redraw for a normal render", async () => {
+	it("still clears scrollback when a tall transcript shrinks below the viewport", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
 		const component = new TestComponent();
 		tui.addChild(component);
 
+		// Tall transcript: viewport anchored at the bottom with history in scrollback.
 		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
 		tui.start();
 		await terminal.waitForRender();
 		terminal.clearWrites();
 
-		const expanded = [...component.lines];
-		expanded.splice(3, 0, "Expanded A", "Expanded B", "Expanded C");
-		component.lines = expanded;
-		// Plain render (no preservation) still clears scrollback and replays.
+		// Collapse to a handful of lines that fit on screen (e.g. a rebuild after
+		// compaction). The visible window no longer maps onto the old scrollback,
+		// so a destructive redraw that clears scrollback and replays is correct —
+		// the in-place repaint is only used while the transcript stays taller than
+		// the viewport.
+		component.lines = ["Summary A", "Summary B", "Summary C"];
 		tui.requestRender();
 		await terminal.waitForRender();
 
-		assert.ok(terminal.getWrites().includes("\x1b[3J"), "Normal render clears scrollback");
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "Shrinking below the viewport clears scrollback");
 
 		tui.stop();
 	});
@@ -745,6 +748,48 @@ describe("TUI viewport-preserving render", () => {
 
 		assert.strictEqual(tui.fullRedraws, redrawsAfterCollapse, "No extra full redraw after the collapse settled");
 		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Must not clear scrollback on the follow-up render");
+
+		tui.stop();
+	});
+});
+
+describe("TUI above-viewport changes on a tall transcript", () => {
+	it("repaints in place instead of clearing scrollback when off-screen content changes", async () => {
+		// Reproduces the attach-then-stream flicker: when a transcript is taller
+		// than the viewport and content above the visible window changes (e.g. an
+		// off-screen tool result resolving while the model streams), the renderer
+		// used to clear scrollback and replay the whole transcript on every change,
+		// flickering and scrolling from the top. It should now repaint only the
+		// visible window in place, leaving scrollback and history intact.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// 30 lines into a 10-row terminal: viewport anchored at the bottom, with
+		// lines 0-19 living in scrollback above the visible window.
+		component.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+
+		assert.ok(terminal.getViewport().join("\n").includes("Line 29"), "Latest line visible after initial paint");
+		terminal.clearWrites();
+
+		// Mutate several lines above the viewport, as off-screen tool results would
+		// while the model is streaming.
+		for (const i of [3, 7, 12]) {
+			component.lines[i] = `Line ${i} (updated)`;
+			tui.requestRender();
+			await terminal.waitForRender();
+		}
+
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "Off-screen changes must not clear the screen");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Off-screen changes must not clear scrollback");
+
+		const viewport = terminal.getViewport().join("\n");
+		assert.ok(viewport.includes("Line 29"), "Viewport stays anchored at the latest content");
+		assert.ok(viewport.includes("Line 20"), "Bottom window remains visible");
+		assert.ok(!viewport.includes("Line 0 "), "Did not scroll back to the top");
 
 		tui.stop();
 	});


### PR DESCRIPTION
- opening an ongoing or old session could flicker and scroll from the top because the renderer cleared scrollback and replayed the entire transcript whenever off-screen content changed.
- now repaints only the visible window in place when the transcript is taller than the viewport, keeping you anchored at the latest messages and leaving scrollback history intact.
- a transcript that shrinks below the viewport still takes the clean full redraw, and added a regression test covering the attach-then-stream case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core TUI redraw branching and scrollback/CSI behavior for tall transcripts; wrong conditions could leave stale scrollback or miss needed full redraws, but behavior is narrowly gated and covered by new tests.
> 
> **Overview**
> Fixes attach-then-stream flicker when a transcript is taller than the terminal and updates happen **above** the visible window (e.g. off-screen tool results resolving while the model streams).
> 
> Previously, `TUI` treated that case like any other above-viewport change and ran a full redraw that erased scrollback (`CSI 3J`) and replayed the whole transcript, which jumped the view to the top. It now chooses an **in-place repaint of only the visible rows** when the transcript is still taller than the viewport **and** line count is not shrinking, so scrollback and bottom anchoring stay intact. Short transcripts that fit on screen still use the normal scrollback-clearing full redraw; **shrinks** (including compaction/rebuild with fewer lines, even if still taller than the viewport) still clear scrollback so stale history above the window is not left behind.
> 
> Regression coverage in `tui-render.test.ts` adds the streaming/off-screen update case and tightens shrink scenarios (below viewport vs still-tall shrink).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fa6bc5cdd44041497cd5e4f00a2c36ec3559b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TUI flicker when attaching to long or streaming sessions
> - When content changes above the previous viewport, the renderer now checks if the transcript is taller than the viewport and not shrinking; if so, it repaints only the visible window in place instead of clearing scrollback and replaying the full transcript.
> - If the transcript shrinks below the viewport height, a full scrollback-clearing redraw is still performed.
> - The fix is in the `TUI.render` method in [tui.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/192/files#diff-0aed3a4b69095fa2ae0cffa8689c7dad409e8b36ab77544b0defb1474fde7311), which now computes `preserveScrollback` before calling `fullRender`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2fa6bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->