### PR TITLE
condense ipython tool calls into a single-line summary

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -70,12 +70,11 @@ const OUTPUT_PREVIEW_LINES = 5;
 const INPUT_PREVIEW_LINES = 3;
 const DIFF_PREVIEW_LINES = 12;
 
-// Cap the descriptor so the trailing duration / result hint stay visible; the
-// panel line truncates anything that still overflows on narrow terminals.
+// Cap so the trailing duration/counts stay visible on narrow widths.
 const DESCRIPTOR_MAX_WIDTH = 64;
 
 const COMMENT_LINE_PATTERN = /^\s*#/;
-// Strip a leading `cd … &&` (or `;`) so we surface the real command after it.
+// Strip a leading `cd … &&` to surface the real command.
 const CD_PREFIX_PATTERN = /^\s*cd\s+[^&;|]+(?:&&|;)\s*/;
 
 function collapseWhitespace(text: string): string {
@@ -89,13 +88,7 @@ function truncateDescriptor(text: string): string {
 	return `${text.slice(0, DESCRIPTOR_MAX_WIDTH - 1).trimEnd()}…`;
 }
 
-/**
- * Best-effort, deterministic one-line descriptor for a cell — the leading
- * meaningful command for shell cells, or the first real statement for python.
- * No model involved: it surfaces the cell's own first line of intent so the
- * collapsed view is more useful than `%%bash`. Returns "" when there's nothing
- * meaningful yet (e.g. code still streaming).
- */
+/** Leading meaningful command of a cell; "" while code is still streaming. */
 function summarizeCell(code: string): string {
 	const lines = code.split("\n");
 	const isBashCell = CELL_MAGIC_PATTERN.test(lines[0] ?? "");
@@ -105,7 +98,6 @@ function summarizeCell(code: string): string {
 		if (!trimmed || COMMENT_LINE_PATTERN.test(trimmed)) {
 			continue;
 		}
-		// `!cmd` shell escapes in python read as the command they run.
 		const command = trimmed.replace(MAGIC_LINE_PATTERN, "").trim();
 		if (!command) {
 			continue;
@@ -291,10 +283,8 @@ export class IPythonCellComponent implements Component {
 
 		const details = readDetails(this.state.details);
 
-		// Default view: one condensed line per tool call. The leading space matches
-		// the one-column indent of message text; code/output/diffs stay hidden until
-		// the block is expanded with ctrl+o. Cached by state version so the line only
-		// re-renders when its own content changes — never on every global repaint.
+		// Collapsed default: one line, indented to match message text. Cached by
+		// state version so it never re-renders on unrelated repaints (would flicker).
 		if (!this.state.expanded) {
 			const line = truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "");
 			return this.renderCache.set(safeWidth, this.stateVersion, [line]);
@@ -317,12 +307,7 @@ export class IPythonCellComponent implements Component {
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
 
-	/**
-	 * The condensed single line shown by default: a status marker, the cell
-	 * language, the leading command (bash only — python first-lines are usually
-	 * imports/setup), live in/out line counts, and — once finished — the duration
-	 * and any error name.
-	 */
+	// Command is bash-only: python first-lines are usually imports/setup, not intent.
 	private collapsedLine(details: IpythonDetails): string {
 		const code = this.state.code.trimEnd();
 		const isBashCell = CELL_MAGIC_PATTERN.test(code.split("\n")[0] ?? "");
@@ -372,12 +357,8 @@ export class IPythonCellComponent implements Component {
 		}
 	}
 
-	/**
-	 * Condensed input/output line counts (`↑in ↓out lines`), updated live as the
-	 * cell's code and output stream in. The `lines` unit disambiguates from the
-	 * activity line's token counts. Output is omitted for edits — the diff renders
-	 * on expand and its stdout is just the "Edited" confirmation.
-	 */
+	// `↑in ↓out lines` — the "lines" unit disambiguates from the token counts on
+	// the activity line. Output is omitted for edits (the diff shows on expand).
 	private lineCounts(details: IpythonDetails): string | undefined {
 		const codeLines = this.state.code.split("\n");
 		const isBashCell = CELL_MAGIC_PATTERN.test(codeLines[0] ?? "");
@@ -422,9 +403,8 @@ export class IPythonCellComponent implements Component {
 		if (status === "aborted") {
 			return "aborted";
 		}
-		// A finalized result (not partial) with any completion signal is "done" —
-		// keyed off the result, not off having observed the live start, so tool
-		// calls rehydrated from a past session render as done rather than running.
+		// Keyed off the result, not executionStarted, so calls rehydrated from a
+		// past session (which never saw the live start) render done, not running.
 		if (!this.state.isPartial && (status !== undefined || this.state.executionStarted || this.hasResult(details))) {
 			return "done";
 		}
@@ -434,7 +414,6 @@ export class IPythonCellComponent implements Component {
 		return "queued";
 	}
 
-	/** Whether a result payload has been captured (output, diffs, or an error). */
 	private hasResult(details: IpythonDetails): boolean {
 		return (
 			details.stdout !== undefined ||

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -1,4 +1,10 @@
-import { type Component, VersionedRenderCache, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	truncateToWidth,
+	VersionedRenderCache,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
@@ -63,6 +69,51 @@ const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 const OUTPUT_PREVIEW_LINES = 5;
 const INPUT_PREVIEW_LINES = 3;
 const DIFF_PREVIEW_LINES = 12;
+
+// Cap the descriptor so the trailing duration / result hint stay visible; the
+// panel line truncates anything that still overflows on narrow terminals.
+const DESCRIPTOR_MAX_WIDTH = 64;
+
+const COMMENT_LINE_PATTERN = /^\s*#/;
+// Strip a leading `cd … &&` (or `;`) so we surface the real command after it.
+const CD_PREFIX_PATTERN = /^\s*cd\s+[^&;|]+(?:&&|;)\s*/;
+
+function collapseWhitespace(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function truncateDescriptor(text: string): string {
+	if (text.length <= DESCRIPTOR_MAX_WIDTH) {
+		return text;
+	}
+	return `${text.slice(0, DESCRIPTOR_MAX_WIDTH - 1).trimEnd()}…`;
+}
+
+/**
+ * Best-effort, deterministic one-line descriptor for a cell — the leading
+ * meaningful command for shell cells, or the first real statement for python.
+ * No model involved: it surfaces the cell's own first line of intent so the
+ * collapsed view is more useful than `%%bash`. Returns "" when there's nothing
+ * meaningful yet (e.g. code still streaming).
+ */
+function summarizeCell(code: string): string {
+	const lines = code.split("\n");
+	const isBashCell = CELL_MAGIC_PATTERN.test(lines[0] ?? "");
+	const body = isBashCell ? lines.slice(1) : lines;
+	for (const rawLine of body) {
+		const trimmed = rawLine.trim();
+		if (!trimmed || COMMENT_LINE_PATTERN.test(trimmed)) {
+			continue;
+		}
+		// `!cmd` shell escapes in python read as the command they run.
+		const command = trimmed.replace(MAGIC_LINE_PATTERN, "").trim();
+		if (!command) {
+			continue;
+		}
+		return truncateDescriptor(collapseWhitespace(command.replace(CD_PREFIX_PATTERN, "")));
+	}
+	return "";
+}
 
 export function getIpythonCodeFromArgs(args: unknown): string {
 	if (!args || typeof args !== "object" || !("code" in args)) {
@@ -239,6 +290,16 @@ export class IPythonCellComponent implements Component {
 		}
 
 		const details = readDetails(this.state.details);
+
+		// Default view: one condensed line per tool call. The leading space matches
+		// the one-column indent of message text; code/output/diffs stay hidden until
+		// the block is expanded with ctrl+o. Cached by state version so the line only
+		// re-renders when its own content changes — never on every global repaint.
+		if (!this.state.expanded) {
+			const line = truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "");
+			return this.renderCache.set(safeWidth, this.stateVersion, [line]);
+		}
+
 		const lines: string[] = [];
 		let expandHintShown = false;
 		const withExpandHint: ExpandHintFormatter = (label) => {
@@ -256,6 +317,90 @@ export class IPythonCellComponent implements Component {
 		return this.renderCache.set(safeWidth, this.stateVersion, lines);
 	}
 
+	/**
+	 * The condensed single line shown by default: a status marker, the cell
+	 * language, the leading command (bash only — python first-lines are usually
+	 * imports/setup), live in/out line counts, and — once finished — the duration
+	 * and any error name.
+	 */
+	private collapsedLine(details: IpythonDetails): string {
+		const code = this.state.code.trimEnd();
+		const isBashCell = CELL_MAGIC_PATTERN.test(code.split("\n")[0] ?? "");
+		const parts = [`${this.marker(details)} ${theme.fg("muted", isBashCell ? "bash" : "python")}`];
+
+		if (isBashCell) {
+			const command = summarizeCell(code);
+			if (command) {
+				parts.push(this.highlightInputLine(command, true));
+			} else if (!this.state.executionStarted) {
+				parts.push(theme.fg("muted", "waiting for code"));
+			}
+		}
+
+		const counts = this.lineCounts(details);
+		if (counts) {
+			parts.push(theme.fg("muted", counts));
+		}
+
+		const duration = formatDuration(details.durationMs);
+		if (duration) {
+			parts.push(theme.fg("muted", duration));
+		}
+
+		const errorName = !this.state.isPartial ? (details.error?.ename ?? details.errorEname) : undefined;
+		if (errorName) {
+			parts.push(theme.fg("error", errorName));
+		}
+
+		parts.push(keyHint("app.tools.expand", "to expand"));
+		return parts.join(theme.fg("dim", " · "));
+	}
+
+	/** Status marker — color carries running/done/error; ✓/✗ once finished. */
+	private marker(details: IpythonDetails): string {
+		switch (this.statusKind(details)) {
+			case "error":
+				return theme.fg("error", "✗");
+			case "aborted":
+				return theme.fg("warning", "✗");
+			case "done":
+				return theme.fg("success", "✓");
+			case "running":
+				return theme.fg("bashMode", "▸");
+			default: // queued
+				return theme.fg("muted", "▸");
+		}
+	}
+
+	/**
+	 * Condensed input/output line counts (`↑in ↓out lines`), updated live as the
+	 * cell's code and output stream in. The `lines` unit disambiguates from the
+	 * activity line's token counts. Output is omitted for edits — the diff renders
+	 * on expand and its stdout is just the "Edited" confirmation.
+	 */
+	private lineCounts(details: IpythonDetails): string | undefined {
+		const codeLines = this.state.code.split("\n");
+		const isBashCell = CELL_MAGIC_PATTERN.test(codeLines[0] ?? "");
+		const body = isBashCell ? codeLines.slice(1) : codeLines;
+		const input = body.filter((line) => line.trim().length > 0).length;
+
+		const hasDiffs = (details.diffs?.length ?? 0) > 0;
+		const structured = [details.stdout, details.stderr, details.result]
+			.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+			.join("\n");
+		const outputText = (structured || textFromBlocks(this.state.content)).trim();
+		const output = hasDiffs || !outputText ? 0 : outputText.split("\n").length;
+
+		const segments: string[] = [];
+		if (input > 0) {
+			segments.push(`↑ ${input}`);
+		}
+		if (output > 0) {
+			segments.push(`↓ ${output}`);
+		}
+		return segments.length > 0 ? `${segments.join(" ")} lines` : undefined;
+	}
+
 	private header(details: IpythonDetails): string {
 		// Name the cell so the status reads as part of this tool call instead of
 		// a floating label between the surrounding blocks.
@@ -269,21 +414,51 @@ export class IPythonCellComponent implements Component {
 		return parts.join(theme.fg("dim", " · "));
 	}
 
-	private status(details: IpythonDetails): { label: string } {
+	private statusKind(details: IpythonDetails): "error" | "aborted" | "running" | "queued" | "done" {
 		const status = details.status;
 		if (this.state.isError || status === "error") {
-			return { label: theme.fg("error", "error") };
+			return "error";
 		}
 		if (status === "aborted") {
-			return { label: theme.fg("warning", "aborted") };
+			return "aborted";
 		}
-		if (this.state.isPartial || (this.state.executionStarted && !status)) {
-			return { label: theme.fg("bashMode", "running") };
+		// A finalized result (not partial) with any completion signal is "done" —
+		// keyed off the result, not off having observed the live start, so tool
+		// calls rehydrated from a past session render as done rather than running.
+		if (!this.state.isPartial && (status !== undefined || this.state.executionStarted || this.hasResult(details))) {
+			return "done";
 		}
-		if (!this.state.executionStarted) {
-			return { label: theme.fg("muted", "queued") };
+		if (this.state.isPartial || this.state.executionStarted) {
+			return "running";
 		}
-		return { label: theme.fg("success", "done") };
+		return "queued";
+	}
+
+	/** Whether a result payload has been captured (output, diffs, or an error). */
+	private hasResult(details: IpythonDetails): boolean {
+		return (
+			details.stdout !== undefined ||
+			details.stderr !== undefined ||
+			details.result !== undefined ||
+			details.error !== undefined ||
+			(details.diffs?.length ?? 0) > 0 ||
+			(this.state.content?.length ?? 0) > 0
+		);
+	}
+
+	private status(details: IpythonDetails): { label: string } {
+		switch (this.statusKind(details)) {
+			case "error":
+				return { label: theme.fg("error", "error") };
+			case "aborted":
+				return { label: theme.fg("warning", "aborted") };
+			case "running":
+				return { label: theme.fg("bashMode", "running") };
+			case "queued":
+				return { label: theme.fg("muted", "queued") };
+			default:
+				return { label: theme.fg("success", "done") };
+		}
 	}
 
 	private renderCode(lines: string[], width: number, withExpandHint: ExpandHintFormatter, hasDiffs: boolean): boolean {

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -28,6 +28,7 @@ describe("IPythonCellComponent diff rendering", () => {
 			},
 			executionStarted: true,
 			argsComplete: true,
+			expanded: true,
 		});
 
 		// Header carries the path and the +/- line counts.
@@ -50,6 +51,7 @@ describe("IPythonCellComponent diff rendering", () => {
 			},
 			executionStarted: true,
 			argsComplete: true,
+			expanded: true,
 		}).render(72);
 		// Every rendered line is exactly the panel width (no ragged backgrounds).
 		expect(out.every((line) => stripAnsi(line).length === 72)).toBe(true);
@@ -86,7 +88,9 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: false,
 		});
-		expect(collapsed).toMatch(/\+\d+ lines/);
+		// Collapsed is a single line: the diff itself is hidden behind the expand hint.
+		expect(collapsed).toContain("to expand");
+		expect(collapsed).not.toContain("ROW");
 
 		const expanded = renderCell({
 			code: "await edit(...)",
@@ -95,7 +99,7 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: true,
 		});
-		expect(expanded).not.toMatch(/\+\d+ lines/);
+		expect(expanded).toContain("ROW");
 	});
 
 	it("renders multiple diffs from a single cell", () => {
@@ -111,6 +115,7 @@ describe("IPythonCellComponent diff rendering", () => {
 			},
 			executionStarted: true,
 			argsComplete: true,
+			expanded: true,
 		});
 		expect(out).toContain("edit a.py");
 		expect(out).toContain("edit b.py");

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -106,11 +106,14 @@ describe("marquee TUI components", () => {
 		const component = new IPythonCellComponent(state);
 
 		const collapsed = await renderInVirtualTerminal(component);
-		expect(collapsed).toContain("bash · error · 1.2s");
+		// Collapsed: marker + the bash command + duration + error name, on one line.
+		expect(collapsed).toContain("bash");
+		expect(collapsed).toContain("echo hi");
+		expect(collapsed).not.toContain("%%bash");
+		expect(collapsed).toContain("1.2s");
+		expect(collapsed).toContain("ValueError");
+		expect(collapsed).not.toContain("ValueError: bad");
 		expect(collapsed).not.toContain("ipython");
-		expect(collapsed).toContain("%%bash");
-		expect(collapsed).toContain("hi");
-		expect(collapsed).toContain("ValueError: bad");
 		expect(collapsed).toContain("Ctrl+O to expand");
 		expect(collapsed).not.toContain("traceback collapsed");
 		expect(collapsed).not.toContain('File "<stdin>"');
@@ -159,8 +162,9 @@ describe("marquee TUI components", () => {
 		const component = new IPythonCellComponent(state);
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
-		expect(collapsed).toContain("cat: /tmp/missing-file: No such file or directory");
+		expect(collapsed).toContain("cat /tmp/missing-file");
 		expect(collapsed).toContain("CalledProcessError · Ctrl+O to expand");
+		expect(collapsed).not.toContain("No such file or directory");
 		expect(collapsed).not.toContain("returned non-zero exit status 1.");
 		expect(collapsed).not.toContain("traceback collapsed");
 		expect(collapsed).not.toContain("get_ipython().run_cell_magic");
@@ -239,18 +243,16 @@ describe("marquee TUI components", () => {
 		const component = new IPythonCellComponent(state);
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
-		expect(collapsed).toContain("line_0 = 0");
-		expect(collapsed).toContain("line_2 = 2");
-		expect(collapsed).not.toContain("line_3 = 3");
-		expect(collapsed).not.toContain("line_4 = 4");
+		// Collapsed python shows no code — just the input line count and expand hint.
+		expect(collapsed).not.toContain("line_0 = 0");
 		expect(collapsed).not.toContain("line_7 = 7");
-		expect(collapsed).toContain("… +5 lines");
+		expect(collapsed).toContain("↑ 8");
 		expect(collapsed.match(/to expand/g)?.length).toBe(1);
 
 		component.update({ ...state, expanded: true });
 		const expanded = stripAnsi(component.render(100).join("\n"));
+		expect(expanded).toContain("line_0 = 0");
 		expect(expanded).toContain("line_7 = 7");
-		expect(expanded).not.toContain("… +5 lines");
 	});
 
 	test("shows one expand hint when ipython input and output are both collapsed", () => {
@@ -266,24 +268,9 @@ describe("marquee TUI components", () => {
 		});
 
 		const collapsed = stripAnsi(component.render(100).join("\n"));
-		expect(collapsed).toContain("… +5 lines");
-		expect(collapsed).toContain("… +3 lines");
+		// A single status line carries both counts and exactly one expand hint.
+		expect(collapsed).toContain("↑ 8 ↓ 8 lines");
 		expect(collapsed.match(/to expand/g)?.length).toBe(1);
-	});
-
-	test("pluralizes singular collapsed ipython line markers", () => {
-		const component = new IPythonCellComponent({
-			code: Array.from({ length: 4 }, (_, index) => `line_${index} = ${index}`).join("\n"),
-			content: [{ type: "text", text: Array.from({ length: 6 }, (_, index) => `out_${index}`).join("\n") }],
-			details: { status: "ok", durationMs: 15 },
-			executionStarted: true,
-			argsComplete: true,
-			expanded: false,
-		});
-
-		const collapsed = stripAnsi(component.render(100).join("\n"));
-		expect(collapsed.match(/… \+1 line\b/g)?.length).toBe(2);
-		expect(collapsed).not.toContain("… +1 lines");
 	});
 
 	test("reflows cached ipython cells when terminal width changes", () => {
@@ -298,6 +285,8 @@ describe("marquee TUI components", () => {
 			details: { status: "ok", durationMs: 15 },
 			executionStarted: true,
 			argsComplete: true,
+			// Expanded so the long code/output lines wrap and reflow with width.
+			expanded: true,
 		};
 		const component = new IPythonCellComponent(state);
 
@@ -807,18 +796,25 @@ describe("marquee TUI components", () => {
 			isError: false,
 		});
 
+		// Collapsed: routed through the cell renderer (a status line), not the
+		// generic JSON arg dump.
+		const collapsed = stripAnsi(component.render(100).join("\n"));
+		expect(collapsed).toContain("python");
+		expect(collapsed).toContain("12ms");
+		expect(collapsed).not.toContain("ipython");
+		expect(collapsed).not.toContain('"code"');
+
+		// Expanded: full panel with the code and output on the panel background.
+		component.setExpanded(true);
 		const rawOutput = component.render(100).join("\n");
 		expect(rawOutput).toMatch(/\x1b\[48;(?:2|5);/);
-		// The panel background spans the full line with the content padded inside.
 		const panelLine = component.render(100).find((line) => line.includes("\x1b[48;")) ?? "";
 		expect(panelLine.startsWith("\x1b[48;")).toBe(true);
 		expect(panelLine.endsWith("\x1b[49m")).toBe(true);
 		expect(visibleWidth(panelLine)).toBe(100);
-		const output = stripAnsi(rawOutput);
-		expect(output).toContain("python · done · 12ms");
-		expect(output).not.toContain("ipython");
-		expect(output).toContain("print(55)");
-		expect(output).toContain("55");
-		expect(output).not.toContain('"code"');
+		const expanded = stripAnsi(rawOutput);
+		expect(expanded).toContain("print(55)");
+		expect(expanded).toContain("55");
+		expect(expanded).not.toContain('"code"');
 	});
 });


### PR DESCRIPTION
- collapses each ipython tool call to one status line — a marker, language, the leading bash command, live input/output line counts, and duration — instead of a multi-line code and output preview that was rarely informative.
- ctrl+o still expands any call to its full code, output, and diffs.
- conveys running/done/error through the marker and color rather than animation, so it stays cheap to render and rehydrates correctly when reattaching to a past session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and status labeling only; expand behavior and execution paths are unchanged aside from clearer done-state when rehydrating past sessions.
> 
> **Overview**
> Collapsed IPython/bash tool calls now render as **one truncated status line** instead of multi-line code/output previews. The line shows a colored status glyph (✓/✗/▸), language, the leading **bash** command (with `cd … &&` stripped and comments skipped), **↑/↓ line counts**, duration, and error name, plus the expand key hint.
> 
> **`statusKind`** now treats a cell as **done** when any result exists (stdout, stderr, result, error, diffs, or content), so sessions rehydrated without a live `executionStarted` event no longer show **running**. Expanded view (Ctrl+O) is unchanged: full panel with code, output, and diffs.
> 
> Tests were updated to expect the new collapsed copy and to set **`expanded: true`** where full diff/panel output is asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2035cfc9a235536c69c36f512ca56f5c9980f64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Condense collapsed IPython tool calls into a single-line status summary
> - Collapsed `IPythonCellComponent` cells now render a single status line instead of a multi-line preview, showing a status marker (✓/✗/▸), language (bash/python), an optional summarized bash command, input/output line counts, duration, and error name.
> - New helpers `summarizeCell`, `collapseWhitespace`, and `truncateDescriptor` strip magic prefixes, comments, blank lines, and leading `cd … &&` sequences before truncating the command to fit available width.
> - `statusKind` normalizes cell state to a single category (`done`/`error`/`aborted`/`running`/`queued`); cells rehydrated with results but no live start now show `done` instead of `running`.
> - Behavioral Change: collapsed bash cells show the extracted command; collapsed python cells show only line counts with no code preview; diff cells suppress output line counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2035cfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->