### PR TITLE
bump version to 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.1.6",
+				"@earendil-works/pi-coding-agent": "^0.1.7",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5913,10 +5913,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.1.6",
+				"@earendil-works/pi-ai": "^0.1.7",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5943,7 +5943,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5985,13 +5985,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.1.6",
-				"@earendil-works/pi-ai": "^0.1.6",
-				"@earendil-works/pi-tui": "^0.1.6",
+				"@earendil-works/pi-agent-core": "^0.1.7",
+				"@earendil-works/pi-ai": "^0.1.7",
+				"@earendil-works/pi-tui": "^0.1.7",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6134,7 +6134,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.1.6",
+		"@earendil-works/pi-coding-agent": "^0.1.7",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.1.6",
+		"@earendil-works/pi-ai": "^0.1.7",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.1.6",
-		"@earendil-works/pi-ai": "^0.1.6",
-		"@earendil-works/pi-tui": "^0.1.6",
+		"@earendil-works/pi-agent-core": "^0.1.7",
+		"@earendil-works/pi-ai": "^0.1.7",
+		"@earendil-works/pi-tui": "^0.1.7",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the root package and the four published packages (agent, ai, coding-agent, tui) to 0.1.7.
- syncs the internal dependency ranges and the lockfile to match, with no other code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no runtime or behavioral code changes.
> 
> **Overview**
> Bumps **0.1.6 → 0.1.7** across the `prime-agent` root and the four published workspace packages: `@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent`, and `pi-tui`.
> 
> Internal semver ranges (e.g. `coding-agent` → `pi-agent-core` / `pi-ai` / `pi-tui`, root → `pi-coding-agent`, `agent` → `pi-ai`) and **`package-lock.json`** are updated to match. **No application or library source changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6db15572bddb1bb80a16bba1fe0cb81edae0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all package versions from 0.1.6 to 0.1.7
> Updates the version field in all workspace `package.json` files and their cross-package `@earendil-works/*` dependencies from `^0.1.6` to `^0.1.7`. The lockfile is updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db6db15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->