### PR TITLE
open chat when sending a message from agents view

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -751,7 +751,12 @@ class AgentsViewMode implements Component, Focusable {
 			await this.sendReply(this.replyActiveSessionId, text);
 			return;
 		}
-		await this.createAgentForPrompt(text);
+		const created = await this.createAgentForPrompt(text);
+		if (created) {
+			// Opening a message should drop straight into its chat rather than
+			// leaving the user staring at the new row in the agents view.
+			this.finish({ type: "open", summary: created.summary });
+		}
 	}
 
 	private async runSlashCommand(command: ParsedSlashCommand): Promise<void> {
@@ -1276,7 +1281,10 @@ class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	private async createAgentForPrompt(text: string, images?: ImageContent[]): Promise<string | undefined> {
+	private async createAgentForPrompt(
+		text: string,
+		images?: ImageContent[],
+	): Promise<{ summary: SessionSummary; activeSessionId: string } | undefined> {
 		const client = this.requireClient();
 		this.setStatusMessage("Creating agent...");
 		try {
@@ -1294,7 +1302,7 @@ class AgentsViewMode implements Component, Focusable {
 			this.selectedActiveSessionId = activeSessionId;
 			this.persistentState.selectedRowIdentity = this.selectedRowIdentity;
 			this.restoreSelection();
-			return activeSessionId;
+			return { summary, activeSessionId };
 		} catch (error) {
 			this.setStatusMessage(formatError("Failed to create agent", error));
 			return undefined;
@@ -1333,10 +1341,11 @@ class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		const remainingMessages = this.options.initialMessage ? initialMessages : initialMessages.slice(1);
-		const activeSessionId = await this.createAgentForPrompt(firstMessage, this.options.initialImages);
-		if (!activeSessionId) {
+		const created = await this.createAgentForPrompt(firstMessage, this.options.initialImages);
+		if (!created) {
 			return;
 		}
+		const { activeSessionId } = created;
 		for (const message of remainingMessages) {
 			try {
 				await this.sendPrompt(activeSessionId, message, undefined, "followUp");

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -753,8 +753,6 @@ class AgentsViewMode implements Component, Focusable {
 		}
 		const created = await this.createAgentForPrompt(text);
 		if (created) {
-			// Opening a message should drop straight into its chat rather than
-			// leaving the user staring at the new row in the agents view.
 			this.finish({ type: "open", summary: created.summary });
 		}
 	}


### PR DESCRIPTION
- sending a chat message from the agents view spun up a new agent row but left you in the list, so you had to manually open it.
- the message path now navigates straight into the new session the same way pressing enter on a row does.
- the startup multi-message flow is left untouched so it still sends follow-up prompts without jumping into the chat early.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/navigation change in agents view with no auth, data, or API contract changes beyond a private helper return type.
> 
> **Overview**
> Submitting a **new task** from the agents view now **opens that agent’s chat** immediately, using the same `{ type: "open", summary }` path as confirming a row with Enter.
> 
> `createAgentForPrompt` now returns **`{ summary, activeSessionId }`** so the submit handler can pass the full `SessionSummary` into `finish`. The **startup multi-message** path still only uses `activeSessionId` to send follow-up prompts and **does not** auto-open the session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3930429d644ff4219f66a0af362004125fa464a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open chat automatically when sending a message from the agents view
> When a new agent is created from the agents view editor, `AgentsViewMode.onEditorSubmit` now calls `finish({ type: "open", summary })` after creation, opening the chat for that session immediately. `createAgentForPrompt` return type is updated from a plain `activeSessionId` string to an object `{ summary, activeSessionId }` to carry the data needed for the open action.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3930429.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->