### PR TITLE
add daemon shutdown --all to stop every daemon

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -163,8 +163,7 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 		return;
 	}
 
-	// `shutdown --all` discovers and stops every daemon, so it must not depend on
-	// one socket being reachable; handle it before connecting a single client.
+	// shutdown --all must not depend on one socket being reachable.
 	if (parsed.command === "shutdown" && parsed.positionals.some((arg) => arg === "--all" || arg === "-a")) {
 		await runShutdownAll(parsed.json);
 		return;

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -163,7 +163,6 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 		return;
 	}
 
-	// shutdown --all must not depend on one socket being reachable.
 	if (parsed.command === "shutdown" && parsed.positionals.some((arg) => arg === "--all" || arg === "-a")) {
 		await runShutdownAll(parsed.json);
 		return;

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -15,7 +15,7 @@ import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
 import { isLocalPath } from "../utils/paths.js";
 import { isValidThinkingLevel } from "./args.js";
 import { formatSessionListTable } from "./daemon-list-format.js";
-import { runPs, runReap } from "./daemon-ps.js";
+import { runPs, runReap, runShutdownAll } from "./daemon-ps.js";
 
 interface ParsedDaemonClientCommand {
 	command: string;
@@ -160,6 +160,13 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 
 	if (parsed.command === "ps") {
 		await runPsCommand(parsed);
+		return;
+	}
+
+	// `shutdown --all` discovers and stops every daemon, so it must not depend on
+	// one socket being reachable; handle it before connecting a single client.
+	if (parsed.command === "shutdown" && parsed.positionals.some((arg) => arg === "--all" || arg === "-a")) {
+		await runShutdownAll(parsed.json);
 		return;
 	}
 
@@ -1472,7 +1479,7 @@ ${chalk.bold("Commands:")}
   cron add <session> <schedule> -- <message>
                                 Schedule a prompt for a session
   cron cancel <job-id>           Cancel a scheduled cron job
-  shutdown                      Stop the daemon
+  shutdown [--all]              Stop the daemon; --all force-stops every daemon on this machine
 
 ${chalk.bold("Options:")}
   --socket <path>               Socket path (default: ${defaultDaemonSocketPath()})
@@ -1500,5 +1507,6 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock prompt <session> "Say hello"
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock attach <session>
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock shutdown
+  ${APP_NAME} daemon shutdown --all
 `);
 }

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -336,6 +336,104 @@ export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAc
 	});
 }
 
+/**
+ * Decide what to do with each discovered daemon for `shutdown --all` (pure, no
+ * side effects). Unlike reap, this is the recovery hammer: every daemon is a
+ * target, including the default daemon and daemons with live sessions. Reachable
+ * daemons get a graceful `shutdown` (runShutdownAll escalates to a force-kill if
+ * the daemon does not actually stop); unreachable daemons are killed by pid; and
+ * orphaned socket files are removed. No daemon is ever skipped.
+ */
+export function planShutdownAll(daemons: readonly DaemonInfo[]): ReapAction[] {
+	return daemons.map((daemon): ReapAction => {
+		if (daemon.status === "orphan-file") {
+			return { kind: "remove-file", daemon };
+		}
+		if (daemon.status === "unreachable") {
+			// status is "unreachable" only when a live process was found, so pid is
+			// set; fall back to socket-file cleanup in the impossible case it is not.
+			return daemon.pid === undefined ? { kind: "remove-file", daemon } : { kind: "kill", daemon };
+		}
+		return { kind: "shutdown", daemon };
+	});
+}
+
+export async function runShutdownAll(json: boolean): Promise<void> {
+	const daemons = await discoverDaemons();
+	const stopped: Array<{ socketPath: string; action: string }> = [];
+	const failed: Array<{ socketPath: string; reason: string }> = [];
+
+	for (const action of planShutdownAll(daemons)) {
+		const { socketPath, pid } = action.daemon;
+		switch (action.kind) {
+			case "remove-file": {
+				// A path marked orphan-file at discovery may have become a live
+				// listener since; shut it down properly if so, else drop the file.
+				if ((await probeDaemon(socketPath)).reachable) {
+					apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
+				} else if (removeSocketFile(socketPath)) {
+					stopped.push({ socketPath, action: "removed stale socket file" });
+				} else {
+					failed.push({ socketPath, reason: "could not remove socket file" });
+				}
+				break;
+			}
+			case "kill": {
+				// Re-probe right before killing: a daemon classified "unreachable" at
+				// discovery may have started answering since. Prefer the graceful path
+				// (which persists sessions) when it now responds.
+				if ((await probeDaemon(socketPath)).reachable) {
+					apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
+				} else {
+					await forceKillDaemon(pid!);
+					removeSocketFile(socketPath);
+					stopped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
+				}
+				break;
+			}
+			case "shutdown":
+				apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
+				break;
+			case "skip":
+				// planShutdownAll never skips.
+				break;
+		}
+	}
+
+	if (json) {
+		console.log(JSON.stringify({ stopped, failed }, null, 2));
+		return;
+	}
+	if (stopped.length === 0 && failed.length === 0) {
+		console.log("No daemons found.");
+		return;
+	}
+	for (const entry of stopped) {
+		console.log(chalk.green(`stopped ${entry.socketPath}: ${entry.action}`));
+	}
+	for (const entry of failed) {
+		console.log(chalk.red(`failed  ${entry.socketPath}: ${entry.reason}`));
+	}
+}
+
+/**
+ * Stop a reachable daemon, escalating to a force-kill if it will not stop on its
+ * own. The graceful request is tried first so sessions are persisted, but a hung
+ * daemon cannot process the shutdown command, so a daemon still listening after
+ * the request is killed by pid (and its socket file cleaned up).
+ */
+async function stopDaemonForcefully(socketPath: string, pid: number | undefined): Promise<ReapOutcome> {
+	if (await shutdownDaemon(socketPath)) {
+		return { reaped: `stopped daemon${pid ? ` (pid ${pid})` : ""}` };
+	}
+	if (pid === undefined) {
+		return { skipped: "shutdown request failed and no pid to kill" };
+	}
+	await forceKillDaemon(pid);
+	removeSocketFile(socketPath);
+	return { reaped: `force-killed unresponsive daemon (pid ${pid})` };
+}
+
 export async function runReap(json: boolean, force: boolean): Promise<void> {
 	const daemons = await discoverDaemons();
 	const reaped: Array<{ socketPath: string; action: string }> = [];
@@ -446,6 +544,36 @@ function killDaemon(pid: number): void {
 		process.kill(pid, "SIGTERM");
 	} catch {
 		// Process already gone or not permitted; the socket file cleanup still runs.
+	}
+}
+
+/**
+ * Force a daemon to exit. SIGTERM is tried first for a clean teardown, but a
+ * wedged event loop never runs its handler, so SIGKILL follows if the process is
+ * still alive shortly after. SIGKILL cannot be caught, so it always wins.
+ */
+async function forceKillDaemon(pid: number): Promise<void> {
+	killDaemon(pid);
+	const deadline = Date.now() + 1000;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) {
+			return;
+		}
+		await delay(50);
+	}
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// Process already gone or not permitted; the socket file cleanup still runs.
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -197,19 +197,21 @@ async function probeDaemon(socketPath: string): Promise<ProbeResult> {
 	try {
 		let version: string | undefined;
 		let protocolVersion: number | undefined;
+		let greeted = false;
 		try {
 			const hello = await client.waitForHello(1500);
 			version = hello.appVersion;
 			protocolVersion = hello.protocol.version;
+			greeted = true;
 		} catch {
 			// Connected but no recognizable greeting: an old/foreign daemon.
 		}
 		let sessionCount: number | undefined;
 		try {
-			// Short timeout: a wedged daemon accepts the connection but never answers,
-			// and the default 30s would stall discovery on exactly the daemons we most
-			// need to reap.
-			const response = await client.request({ type: "list" }, 1500);
+			// A daemon that greeted us is responsive, so allow the full time to answer
+			// (reap needs an accurate session count). One that never greeted is wedged
+			// or foreign, so cap the wait to keep discovery from stalling 30s on it.
+			const response = await client.request({ type: "list" }, greeted ? 30000 : 1500);
 			if (response.success) {
 				const sessions = (response.data as { sessions?: unknown })?.sessions;
 				if (Array.isArray(sessions)) {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -137,7 +137,6 @@ function scanListeningDaemons(): DiscoveredDaemonProcess[] {
 	return [];
 }
 
-/** Whether the OS still reports `pid` listening on `socketPath` (a live daemon). */
 function isDaemonProcessListening(pid: number, socketPath: string): boolean {
 	const target = normalizeSocketPath(socketPath);
 	return scanListeningDaemons().some((daemon) => daemon.pid === pid && daemon.socketPath === target);
@@ -208,9 +207,6 @@ async function probeDaemon(socketPath: string): Promise<ProbeResult> {
 		}
 		let sessionCount: number | undefined;
 		try {
-			// A daemon that greeted us is responsive, so allow the full time to answer
-			// (reap needs an accurate session count). One that never greeted is wedged
-			// or foreign, so cap the wait to keep discovery from stalling 30s on it.
 			const response = await client.request({ type: "list" }, greeted ? 30000 : 1500);
 			if (response.success) {
 				const sessions = (response.data as { sessions?: unknown })?.sessions;
@@ -347,7 +343,6 @@ export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAc
 	});
 }
 
-/** Plan `shutdown --all`: every daemon is a target, none skipped. */
 export function planShutdownAll(daemons: readonly DaemonInfo[]): ReapAction[] {
 	return daemons.map((daemon): ReapAction => {
 		if (daemon.status === "orphan-file") {
@@ -360,8 +355,6 @@ export function planShutdownAll(daemons: readonly DaemonInfo[]): ReapAction[] {
 	});
 }
 
-// One process can appear under several socket paths, so shut down gracefully
-// before any kill on another of its paths could terminate it first.
 const SHUTDOWN_ALL_ACTION_ORDER: Record<ReapAction["kind"], number> = {
 	shutdown: 0,
 	"remove-file": 1,
@@ -373,7 +366,6 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 	const daemons = await discoverDaemons();
 	const stopped: Array<{ socketPath: string; action: string }> = [];
 	const failed: Array<{ socketPath: string; reason: string }> = [];
-	// Pids already stopped this run; never signal one twice (it may be reused).
 	const handledPids = new Set<number>();
 
 	const actions = [...planShutdownAll(daemons)].sort(
@@ -402,9 +394,6 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 				if ((await probeDaemon(socketPath)).reachable) {
 					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				} else if (isDaemonProcessListening(pid!, socketPath)) {
-					// A wedged daemon: connect fails but the OS still lists this pid
-					// listening on the socket. Re-confirming via the scan (rather than a
-					// connect) avoids signalling a pid that has since exited and reused.
 					await forceKillDaemon(pid!);
 					handledPids.add(pid!);
 					removeSocketFile(socketPath);
@@ -419,7 +408,6 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 				apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				break;
 			case "skip":
-				// planShutdownAll never skips.
 				break;
 		}
 	}
@@ -440,11 +428,6 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 	}
 }
 
-/**
- * Graceful shutdown first (persists sessions); if the socket has not stopped,
- * only kill when it still listens, so a daemon that already exited never has its
- * (possibly reused) pid signalled.
- */
 async function stopDaemonForcefully(
 	socketPath: string,
 	pid: number | undefined,
@@ -582,7 +565,6 @@ function killDaemon(pid: number): void {
 	}
 }
 
-/** SIGTERM, then SIGKILL if still alive — a wedged event loop never runs its SIGTERM handler. */
 async function forceKillDaemon(pid: number): Promise<void> {
 	killDaemon(pid);
 	const deadline = Date.now() + 1000;
@@ -594,9 +576,7 @@ async function forceKillDaemon(pid: number): Promise<void> {
 	}
 	try {
 		process.kill(pid, "SIGKILL");
-	} catch {
-		// Process already gone or not permitted; the socket file cleanup still runs.
-	}
+	} catch {}
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -638,8 +618,6 @@ async function shutdownDaemon(socketPath: string): Promise<boolean> {
 		return false;
 	}
 	try {
-		// Short timeout: a wedged daemon never acks, and the connectivity check
-		// below is the source of truth anyway.
 		await client.request({ type: "shutdown" }, 1500);
 	} catch {
 		// The daemon may still stop; the connectivity check below is the source of truth.

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -336,32 +336,21 @@ export function planReap(daemons: readonly DaemonInfo[], force: boolean): ReapAc
 	});
 }
 
-/**
- * Decide what to do with each discovered daemon for `shutdown --all` (pure, no
- * side effects). Unlike reap, this is the recovery hammer: every daemon is a
- * target, including the default daemon and daemons with live sessions. Reachable
- * daemons get a graceful `shutdown` (runShutdownAll escalates to a force-kill if
- * the daemon does not actually stop); unreachable daemons are killed by pid; and
- * orphaned socket files are removed. No daemon is ever skipped.
- */
+/** Plan `shutdown --all`: every daemon is a target, none skipped. */
 export function planShutdownAll(daemons: readonly DaemonInfo[]): ReapAction[] {
 	return daemons.map((daemon): ReapAction => {
 		if (daemon.status === "orphan-file") {
 			return { kind: "remove-file", daemon };
 		}
 		if (daemon.status === "unreachable") {
-			// status is "unreachable" only when a live process was found, so pid is
-			// set; fall back to socket-file cleanup in the impossible case it is not.
 			return daemon.pid === undefined ? { kind: "remove-file", daemon } : { kind: "kill", daemon };
 		}
 		return { kind: "shutdown", daemon };
 	});
 }
 
-// Graceful shutdowns run before any kill: a single process can surface under
-// several socket paths (e.g. macOS lsof reports every unix socket a process
-// holds), so stopping it gracefully first lets its sessions persist before a
-// kill on another of its paths could terminate it.
+// One process can appear under several socket paths, so shut down gracefully
+// before any kill on another of its paths could terminate it first.
 const SHUTDOWN_ALL_ACTION_ORDER: Record<ReapAction["kind"], number> = {
 	shutdown: 0,
 	"remove-file": 1,
@@ -373,8 +362,7 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 	const daemons = await discoverDaemons();
 	const stopped: Array<{ socketPath: string; action: string }> = [];
 	const failed: Array<{ socketPath: string; reason: string }> = [];
-	// Pids already stopped this run. A later entry for the same process must not
-	// signal the pid again: it is already down, and the pid may have been reused.
+	// Pids already stopped this run; never signal one twice (it may be reused).
 	const handledPids = new Set<number>();
 
 	const actions = [...planShutdownAll(daemons)].sort(
@@ -390,8 +378,6 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 		}
 		switch (action.kind) {
 			case "remove-file": {
-				// A path marked orphan-file at discovery may have become a live
-				// listener since; shut it down properly if so, else drop the file.
 				if ((await probeDaemon(socketPath)).reachable) {
 					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				} else if (removeSocketFile(socketPath)) {
@@ -402,22 +388,16 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 				break;
 			}
 			case "kill": {
-				// Re-probe right before killing: a daemon classified "unreachable" at
-				// discovery may have started answering since. Prefer the graceful path
-				// (which persists sessions) when it now responds.
 				if ((await probeDaemon(socketPath)).reachable) {
 					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				} else if (await canConnectToSocket(socketPath, 250)) {
-					// Probe failed but the socket still accepts connections: a wedged
-					// daemon. Killing its pid is safe because something is still there.
+					// Socket still listens: a wedged daemon, safe to kill by pid.
 					await forceKillDaemon(pid!);
 					handledPids.add(pid!);
 					removeSocketFile(socketPath);
 					stopped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
 				} else {
-					// The socket no longer accepts connections: the daemon already
-					// exited. Never signal the pid (it may have been recycled); just
-					// clean up the leftover socket file.
+					// Socket dead: the daemon exited; don't signal a possibly-reused pid.
 					removeSocketFile(socketPath);
 					stopped.push({ socketPath, action: "daemon already stopped" });
 				}
@@ -449,11 +429,9 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 }
 
 /**
- * Stop a reachable daemon, escalating to a force-kill only if it will not stop on
- * its own. The graceful request is tried first so sessions are persisted. If it
- * does not confirm the socket stopped, the socket is re-checked: a daemon that
- * already exited (connect now fails) is left alone — signalling its pid could hit
- * a recycled process — while one still listening is wedged and is killed by pid.
+ * Graceful shutdown first (persists sessions); if the socket has not stopped,
+ * only kill when it still listens, so a daemon that already exited never has its
+ * (possibly reused) pid signalled.
  */
 async function stopDaemonForcefully(
 	socketPath: string,
@@ -592,11 +570,7 @@ function killDaemon(pid: number): void {
 	}
 }
 
-/**
- * Force a daemon to exit. SIGTERM is tried first for a clean teardown, but a
- * wedged event loop never runs its handler, so SIGKILL follows if the process is
- * still alive shortly after. SIGKILL cannot be caught, so it always wins.
- */
+/** SIGTERM, then SIGKILL if still alive — a wedged event loop never runs its SIGTERM handler. */
 async function forceKillDaemon(pid: number): Promise<void> {
 	killDaemon(pid);
 	const deadline = Date.now() + 1000;

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -137,6 +137,12 @@ function scanListeningDaemons(): DiscoveredDaemonProcess[] {
 	return [];
 }
 
+/** Whether the OS still reports `pid` listening on `socketPath` (a live daemon). */
+function isDaemonProcessListening(pid: number, socketPath: string): boolean {
+	const target = normalizeSocketPath(socketPath);
+	return scanListeningDaemons().some((daemon) => daemon.pid === pid && daemon.socketPath === target);
+}
+
 function enrichUptimes(daemons: DiscoveredDaemonProcess[]): DiscoveredDaemonProcess[] {
 	const pids = daemons.map((daemon) => daemon.pid);
 	if (pids.length === 0) {
@@ -200,7 +206,10 @@ async function probeDaemon(socketPath: string): Promise<ProbeResult> {
 		}
 		let sessionCount: number | undefined;
 		try {
-			const response = await client.request({ type: "list" });
+			// Short timeout: a wedged daemon accepts the connection but never answers,
+			// and the default 30s would stall discovery on exactly the daemons we most
+			// need to reap.
+			const response = await client.request({ type: "list" }, 1500);
 			if (response.success) {
 				const sessions = (response.data as { sessions?: unknown })?.sessions;
 				if (Array.isArray(sessions)) {
@@ -390,14 +399,15 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 			case "kill": {
 				if ((await probeDaemon(socketPath)).reachable) {
 					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
-				} else if (await canConnectToSocket(socketPath, 250)) {
-					// Socket still listens: a wedged daemon, safe to kill by pid.
+				} else if (isDaemonProcessListening(pid!, socketPath)) {
+					// A wedged daemon: connect fails but the OS still lists this pid
+					// listening on the socket. Re-confirming via the scan (rather than a
+					// connect) avoids signalling a pid that has since exited and reused.
 					await forceKillDaemon(pid!);
 					handledPids.add(pid!);
 					removeSocketFile(socketPath);
 					stopped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
 				} else {
-					// Socket dead: the daemon exited; don't signal a possibly-reused pid.
 					removeSocketFile(socketPath);
 					stopped.push({ socketPath, action: "daemon already stopped" });
 				}
@@ -626,7 +636,9 @@ async function shutdownDaemon(socketPath: string): Promise<boolean> {
 		return false;
 	}
 	try {
-		await client.request({ type: "shutdown" });
+		// Short timeout: a wedged daemon never acks, and the connectivity check
+		// below is the source of truth anyway.
+		await client.request({ type: "shutdown" }, 1500);
 	} catch {
 		// The daemon may still stop; the connectivity check below is the source of truth.
 	} finally {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -358,19 +358,42 @@ export function planShutdownAll(daemons: readonly DaemonInfo[]): ReapAction[] {
 	});
 }
 
+// Graceful shutdowns run before any kill: a single process can surface under
+// several socket paths (e.g. macOS lsof reports every unix socket a process
+// holds), so stopping it gracefully first lets its sessions persist before a
+// kill on another of its paths could terminate it.
+const SHUTDOWN_ALL_ACTION_ORDER: Record<ReapAction["kind"], number> = {
+	shutdown: 0,
+	"remove-file": 1,
+	kill: 2,
+	skip: 3,
+};
+
 export async function runShutdownAll(json: boolean): Promise<void> {
 	const daemons = await discoverDaemons();
 	const stopped: Array<{ socketPath: string; action: string }> = [];
 	const failed: Array<{ socketPath: string; reason: string }> = [];
+	// Pids already stopped this run. A later entry for the same process must not
+	// signal the pid again: it is already down, and the pid may have been reused.
+	const handledPids = new Set<number>();
 
-	for (const action of planShutdownAll(daemons)) {
+	const actions = [...planShutdownAll(daemons)].sort(
+		(left, right) => SHUTDOWN_ALL_ACTION_ORDER[left.kind] - SHUTDOWN_ALL_ACTION_ORDER[right.kind],
+	);
+
+	for (const action of actions) {
 		const { socketPath, pid } = action.daemon;
+		if (pid !== undefined && handledPids.has(pid)) {
+			removeSocketFile(socketPath);
+			stopped.push({ socketPath, action: `already stopped (pid ${pid})` });
+			continue;
+		}
 		switch (action.kind) {
 			case "remove-file": {
 				// A path marked orphan-file at discovery may have become a live
 				// listener since; shut it down properly if so, else drop the file.
 				if ((await probeDaemon(socketPath)).reachable) {
-					apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
+					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				} else if (removeSocketFile(socketPath)) {
 					stopped.push({ socketPath, action: "removed stale socket file" });
 				} else {
@@ -383,16 +406,25 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 				// discovery may have started answering since. Prefer the graceful path
 				// (which persists sessions) when it now responds.
 				if ((await probeDaemon(socketPath)).reachable) {
-					apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
-				} else {
+					apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
+				} else if (await canConnectToSocket(socketPath, 250)) {
+					// Probe failed but the socket still accepts connections: a wedged
+					// daemon. Killing its pid is safe because something is still there.
 					await forceKillDaemon(pid!);
+					handledPids.add(pid!);
 					removeSocketFile(socketPath);
 					stopped.push({ socketPath, action: `killed unreachable daemon (pid ${pid})` });
+				} else {
+					// The socket no longer accepts connections: the daemon already
+					// exited. Never signal the pid (it may have been recycled); just
+					// clean up the leftover socket file.
+					removeSocketFile(socketPath);
+					stopped.push({ socketPath, action: "daemon already stopped" });
 				}
 				break;
 			}
 			case "shutdown":
-				apply(await stopDaemonForcefully(socketPath, pid), socketPath, stopped, failed);
+				apply(await stopDaemonForcefully(socketPath, pid, handledPids), socketPath, stopped, failed);
 				break;
 			case "skip":
 				// planShutdownAll never skips.
@@ -417,19 +449,32 @@ export async function runShutdownAll(json: boolean): Promise<void> {
 }
 
 /**
- * Stop a reachable daemon, escalating to a force-kill if it will not stop on its
- * own. The graceful request is tried first so sessions are persisted, but a hung
- * daemon cannot process the shutdown command, so a daemon still listening after
- * the request is killed by pid (and its socket file cleaned up).
+ * Stop a reachable daemon, escalating to a force-kill only if it will not stop on
+ * its own. The graceful request is tried first so sessions are persisted. If it
+ * does not confirm the socket stopped, the socket is re-checked: a daemon that
+ * already exited (connect now fails) is left alone — signalling its pid could hit
+ * a recycled process — while one still listening is wedged and is killed by pid.
  */
-async function stopDaemonForcefully(socketPath: string, pid: number | undefined): Promise<ReapOutcome> {
+async function stopDaemonForcefully(
+	socketPath: string,
+	pid: number | undefined,
+	handledPids: Set<number>,
+): Promise<ReapOutcome> {
 	if (await shutdownDaemon(socketPath)) {
+		if (pid !== undefined) {
+			handledPids.add(pid);
+		}
 		return { reaped: `stopped daemon${pid ? ` (pid ${pid})` : ""}` };
 	}
+	if (!(await canConnectToSocket(socketPath, 250))) {
+		removeSocketFile(socketPath);
+		return { reaped: "daemon already stopped" };
+	}
 	if (pid === undefined) {
-		return { skipped: "shutdown request failed and no pid to kill" };
+		return { skipped: "still listening but no pid to kill" };
 	}
 	await forceKillDaemon(pid);
+	handledPids.add(pid);
 	removeSocketFile(socketPath);
 	return { reaped: `force-killed unresponsive daemon (pid ${pid})` };
 }

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -5,6 +5,7 @@ import {
 	parsePsEtimes,
 	parseSsListeners,
 	planReap,
+	planShutdownAll,
 	sortDaemons,
 } from "../src/cli/daemon-ps.js";
 
@@ -127,6 +128,31 @@ describe("planReap", () => {
 		const phantom = plan.find((action) => action.daemon.socketPath === "/tmp/phantom.sock");
 		expect(phantom?.kind).toBe("skip");
 		expect(phantom && phantom.kind === "skip" ? phantom.reason : "").toContain("also backs another daemon");
+	});
+});
+
+describe("planShutdownAll", () => {
+	it("targets every daemon reap would skip", () => {
+		const plan = planShutdownAll([
+			makeDaemon({ socketPath: "/tmp/default.sock", status: "current", isDefault: true, sessionCount: 0, pid: 1 }),
+			makeDaemon({ socketPath: "/tmp/busy.sock", status: "current", sessionCount: 3, pid: 2 }),
+			makeDaemon({ socketPath: "/tmp/hung.sock", status: "unreachable", pid: 7 }),
+			makeDaemon({ socketPath: "/tmp/orphan.sock", status: "orphan-file" }),
+		]);
+		expect(plan.map((action) => action.kind)).toEqual(["shutdown", "shutdown", "kill", "remove-file"]);
+	});
+
+	it("never skips a daemon", () => {
+		const plan = planShutdownAll([
+			makeDaemon({ socketPath: "/tmp/a.sock", status: "stale", pid: 9 }),
+			makeDaemon({ socketPath: "/tmp/b.sock", status: "unreachable", pid: 10 }),
+		]);
+		expect(plan.some((action) => action.kind === "skip")).toBe(false);
+	});
+
+	it("removes the socket file for an unreachable daemon with no pid", () => {
+		const plan = planShutdownAll([makeDaemon({ socketPath: "/tmp/c.sock", status: "unreachable" })]);
+		expect(plan[0]!.kind).toBe("remove-file");
 	});
 });
 


### PR DESCRIPTION
- prime agent could wedge with no way to recover other than manually hunting down and killing stale background daemons.
- adds a shutdown --all flag that discovers every daemon for the user, gracefully stops the responsive ones, and force-kills any that are hung or unreachable.
- runs from a separate terminal since the stuck session can't host the command, and reuses the existing daemon discovery so it works even against old or wedged daemons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Force-stops all daemons including those with live sessions and uses SIGKILL escalation; local process management only, but destructive if run unintentionally.
> 
> **Overview**
> Adds **`daemon shutdown --all`** (or **`-a`**) so you can recover from a wedged session by stopping every discovered daemon **without** connecting to a specific socket—intended to run from another terminal.
> 
> **`runShutdownAll`** reuses machine-wide discovery (`discoverDaemons`), plans per-daemon actions via **`planShutdownAll`** (unlike **`planReap`**, it **never skips** default daemons or daemons with active sessions), deduplicates by pid, and runs graceful **`shutdown`** first. Unresponsive listeners escalate through **`stopDaemonForcefully`** (SIGTERM, then **`forceKillDaemon`** with SIGKILL), with stale socket file removal where appropriate.
> 
> **`probeDaemon`** uses a longer **`list`** timeout when hello succeeds (for busy daemons), and **`shutdown`** requests get an explicit timeout. Help text documents the new flag and example usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bed4786ff0b9ef6f9ada20221b287ec009ea6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `daemon shutdown --all` to stop every running daemon
> - Adds a `--all`/`-a` flag to `daemon shutdown` that stops all discovered daemons without connecting to a specific socket first.
> - Implements `runShutdownAll` in [daemon-ps.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/203/files#diff-d26d176c2fa21f2284ca0dc614dfb273ec8abfce710655afccc3aa35628c848a): discovers all daemon sockets, plans actions (graceful shutdown, force-kill, or file removal), and reports per-socket results as JSON or colored output.
> - Unreachable daemons with a known PID are force-killed (SIGKILL escalation after 1s); orphan socket files without a PID are removed directly.
> - Adds `planShutdownAll` and supporting utilities (`stopDaemonForcefully`, `forceKillDaemon`, `isProcessAlive`) with tests in [daemon-ps.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/203/files#diff-ea4f01d0fb1c6e90c5122d750bcd26d5feedc953ce2520b5cc47a7f6c3f9d6fc).
> - Risk: force-kill path sends SIGKILL to processes that don't exit promptly, which may leave shared resources in an inconsistent state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bed478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->