### PR TITLE
persist selected model across updates and default prime inference to opus 4.8

### DIFF
--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -535,11 +535,8 @@ export async function findInitialModel(options: {
 
 	// 3. Try saved default from settings
 	if (defaultProvider && defaultModelId) {
-		// Exact registry hit wins. Otherwise, if the saved provider is still authed,
-		// reconstruct the model from the provider template (same as resolveCliModel)
-		// so a saved id that's missing from this build's model snapshot — common for
-		// proxy providers like prime-inference whose catalog churns between releases —
-		// persists across updates instead of silently reverting to a provider default.
+		// Rebuild from the provider template when the saved id is missing from this
+		// build's snapshot (e.g. prime-inference catalog churn), so it survives updates.
 		const found =
 			modelRegistry.find(defaultProvider, defaultModelId) ??
 			buildFallbackModel(defaultProvider, defaultModelId, modelRegistry.getAll());

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -17,7 +17,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	openai: "gpt-5.4",
 	"azure-openai-responses": "gpt-5.4",
 	"openai-codex": "gpt-5.5",
-	"prime-inference": "openai/gpt-5.5",
+	"prime-inference": "anthropic/claude-opus-4.8",
 	deepseek: "deepseek-v4-pro",
 	google: "gemini-3.1-pro-preview",
 	"google-vertex": "gemini-3.1-pro-preview",
@@ -535,7 +535,14 @@ export async function findInitialModel(options: {
 
 	// 3. Try saved default from settings
 	if (defaultProvider && defaultModelId) {
-		const found = modelRegistry.find(defaultProvider, defaultModelId);
+		// Exact registry hit wins. Otherwise, if the saved provider is still authed,
+		// reconstruct the model from the provider template (same as resolveCliModel)
+		// so a saved id that's missing from this build's model snapshot — common for
+		// proxy providers like prime-inference whose catalog churns between releases —
+		// persists across updates instead of silently reverting to a provider default.
+		const found =
+			modelRegistry.find(defaultProvider, defaultModelId) ??
+			buildFallbackModel(defaultProvider, defaultModelId, modelRegistry.getAll());
 		if (found && modelRegistry.hasConfiguredAuth(found)) {
 			model = found;
 			if (defaultThinkingLevel) {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -498,9 +498,6 @@ describe("default model selection", () => {
 	});
 
 	test("findInitialModel rebuilds a saved default missing from the model snapshot when the provider is authed", async () => {
-		// Mirrors prime-inference: the saved id isn't in this build's snapshot, but
-		// the provider still has other models + auth. The choice should persist
-		// instead of reverting to the provider default.
 		const primeSnapshotModel: Model<"anthropic-messages"> = {
 			id: "openai/gpt-5.5",
 			name: "GPT 5.5 (Prime Inference)",
@@ -533,9 +530,6 @@ describe("default model selection", () => {
 	});
 
 	test("findInitialModel does not rebuild a saved default for an unauthed provider", async () => {
-		// Guard: the rebuild path is auth-gated, so a saved provider without auth
-		// still falls through to an available model rather than resurrecting a
-		// model the user cannot use.
 		const primeSnapshotModel: Model<"anthropic-messages"> = {
 			id: "openai/gpt-5.5",
 			name: "GPT 5.5 (Prime Inference)",

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -405,7 +405,7 @@ describe("default model selection", () => {
 	test("openai defaults track current models", () => {
 		expect(defaultModelPerProvider.openai).toBe("gpt-5.4");
 		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.5");
-		expect(defaultModelPerProvider["prime-inference"]).toBe("openai/gpt-5.5");
+		expect(defaultModelPerProvider["prime-inference"]).toBe("anthropic/claude-opus-4.8");
 	});
 
 	test("zai, minimax, and cerebras defaults track current models", () => {
@@ -490,6 +490,76 @@ describe("default model selection", () => {
 			isContinuing: false,
 			defaultProvider: savedDefault.provider,
 			defaultModelId: savedDefault.id,
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.provider).toBe("prime-inference");
+		expect(result.model?.id).toBe("openai/gpt-5.5");
+	});
+
+	test("findInitialModel rebuilds a saved default missing from the model snapshot when the provider is authed", async () => {
+		// Mirrors prime-inference: the saved id isn't in this build's snapshot, but
+		// the provider still has other models + auth. The choice should persist
+		// instead of reverting to the provider default.
+		const primeSnapshotModel: Model<"anthropic-messages"> = {
+			id: "openai/gpt-5.5",
+			name: "GPT 5.5 (Prime Inference)",
+			api: "anthropic-messages",
+			provider: "prime-inference",
+			baseUrl: "https://api.pinference.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		const registry = {
+			find: () => undefined,
+			getAll: () => [primeSnapshotModel],
+			hasConfiguredAuth: (model: Model<"anthropic-messages">) => model.provider === "prime-inference",
+			getAvailable: async () => [primeSnapshotModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: "prime-inference",
+			defaultModelId: "anthropic/claude-opus-4.6",
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.provider).toBe("prime-inference");
+		expect(result.model?.id).toBe("anthropic/claude-opus-4.6");
+	});
+
+	test("findInitialModel does not rebuild a saved default for an unauthed provider", async () => {
+		// Guard: the rebuild path is auth-gated, so a saved provider without auth
+		// still falls through to an available model rather than resurrecting a
+		// model the user cannot use.
+		const primeSnapshotModel: Model<"anthropic-messages"> = {
+			id: "openai/gpt-5.5",
+			name: "GPT 5.5 (Prime Inference)",
+			api: "anthropic-messages",
+			provider: "prime-inference",
+			baseUrl: "https://api.pinference.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		const registry = {
+			find: () => undefined,
+			getAll: () => [...mockModels, primeSnapshotModel],
+			hasConfiguredAuth: (model: Model<"anthropic-messages">) => model.provider === "prime-inference",
+			getAvailable: async () => [primeSnapshotModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: "anthropic",
+			defaultModelId: "claude-ghost-9",
 			modelRegistry: registry,
 		});
 


### PR DESCRIPTION
- a model chosen through prime inference reverted to a default after updating, because startup resolution required an exact match against the model snapshot baked into each release and that snapshot churns between versions.
- saved-default resolution now rebuilds the model from the provider template when the exact id is missing but the provider is still authed, matching how the cli and new-session paths already handle unknown ids.
- also switches the prime inference default model from gpt-5.5 to claude opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only initial model selection defaults and fallback when a saved id isn’t in the snapshot; auth gating is unchanged and no security-sensitive paths are touched.
> 
> **Overview**
> **Saved defaults** now survive releases where the baked-in model catalog drops the user’s exact id (common for **prime-inference**). `findInitialModel` still looks up the saved provider/id in the registry; if that misses, it **reconstructs** the model via existing `buildFallbackModel` (provider template + saved id) and uses it when that provider still has **configured auth**—same idea as the CLI path for unknown ids.
> 
> The **prime-inference** built-in default is updated from `openai/gpt-5.5` to `anthropic/claude-opus-4.8`. Tests cover rebuild-on-missing-snapshot (authed) and no-rebuild when the saved provider isn’t authed (falls through to other defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bfc9929b0480c5d3ec500f0af824a41f29b68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist selected model across updates and default prime-inference to `anthropic/claude-opus-4.8`
> - Changes the default model for the `prime-inference` provider from `openai/gpt-5.5` to `anthropic/claude-opus-4.8` in [model-resolver.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/204/files#diff-22e2eb9b044dcbda43aec220ab0d91127a4f6ed0cc7e2757843bd6bc6aeaa144).
> - When a saved default model ID is missing from the current model snapshot, `findInitialModel` now reconstructs the model from provider templates via `buildFallbackModel` instead of skipping to other selection paths, preserving the user's selection across registry updates.
> - The rebuild is skipped if the provider has no configured auth, in which case the function falls back to an available authenticated model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44bfc99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->