### PR TITLE
open prime-agent in a new chat by default

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -217,9 +217,10 @@ export function printHelp(extensionFlags?: ExtensionFlag[]): void {
 	console.log(`${chalk.bold(APP_NAME)} - AI coding assistant with an ipython tool
 
 ${chalk.bold("Usage:")}
-  ${APP_NAME} [options] [@files...] [messages...]
+  ${APP_NAME} [options] [@files...] [messages...]   Open a new chat (press left to reach the agents view)
 
 ${chalk.bold("Commands:")}
+  ${APP_NAME} agents                    Open the agents view (alias: manage)
   ${APP_NAME} install <source> [-l]     Install extension source and add to settings
   ${APP_NAME} remove <source> [-l]      Remove extension source from settings
   ${APP_NAME} uninstall <source> [-l]   Alias for remove

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -816,9 +816,8 @@ async function findActiveDaemonSessionSummary(
 	}
 }
 
-// Remove a freshly-created default chat session from the daemon when the user
-// left it without sending anything, so abandoned new-chats don't pile up in the
-// agents view. Best-effort: a failure here must not block the agents view.
+// Best-effort: drop an abandoned new-chat (no message sent) so it doesn't linger
+// in the agents view. Any failure leaves the session in place.
 async function discardEmptyDaemonSession(socketPath: string, activeSessionId: string): Promise<void> {
 	const client = new DaemonClient(socketPath);
 	try {
@@ -1286,8 +1285,7 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 
 		await daemonReady;
-		// A no-args `prime-agent` lands here on the default new-chat path: no
-		// attach, no session selector, so the connection creates a fresh session.
+		// No attach and no session selector means the connection creates a fresh session.
 		const isFreshDefaultSession =
 			!activeDaemonSessionSummary && !getInteractiveDaemonSessionPath(parsed, sessionManager);
 		const { connection: agentConnection, summary } = await createDaemonInteractiveConnection({
@@ -1299,6 +1297,9 @@ export async function main(args: string[], options?: MainOptions) {
 			sessionPath: activeDaemonSessionSummary ? undefined : getInteractiveDaemonSessionPath(parsed, sessionManager),
 		});
 
+		// onShutdown fires on both the quit and return-to-agents-view paths, so a
+		// straight Ctrl+C quit (which process.exits before run() returns) still cleans up.
+		const freshDefaultActiveSessionId = isFreshDefaultSession ? summary.activeSessionId : undefined;
 		const interactiveMode = new InteractiveMode({
 			agentConnection,
 			uiServices: daemonUiServices,
@@ -1314,14 +1315,14 @@ export async function main(args: string[], options?: MainOptions) {
 			// view was not rendered here, so we intentionally leave
 			// agentsViewOwnsStartupNotices unset and let the in-session fallback run.
 			returnToAgentsView: true,
+			onShutdown: freshDefaultActiveSessionId
+				? () => discardEmptyDaemonSession(daemonSocketPath, freshDefaultActiveSessionId)
+				: undefined,
 		});
 
 		await preloadCodeHighlighter();
 		printTimings();
 		await interactiveMode.run();
-		if (isFreshDefaultSession && summary.activeSessionId) {
-			await discardEmptyDaemonSession(daemonSocketPath, summary.activeSessionId);
-		}
 		await launchAgentsView(false);
 		return;
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1312,6 +1312,10 @@ export async function main(args: string[], options?: MainOptions) {
 				},
 				(activeSessionId) => discardEmptyDaemonSession(daemonSocketPath, activeSessionId),
 			);
+			// The deferred path only ever fresh-creates with this same config, so the
+			// startup resolution is authoritative — there is no attached session whose
+			// summary could carry a different fallback (resolveAttachModelFallbackMessage
+			// only matters when attaching to an existing session).
 			attachModelFallbackMessage = startupModel.modelFallbackMessage;
 		} else {
 			const { connection, summary } = await createDaemonInteractiveConnection({

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -833,7 +833,15 @@ async function discardEmptyDaemonSession(socketPath: string, activeSessionId: st
 			return;
 		}
 		const summary = state.data;
-		if (summary.messageCount > 0 || summary.pendingMessageCount > 0 || summary.isStreaming) {
+		// Keep the session if it holds any work: messages, a queued/streaming turn,
+		// an in-progress compaction, or a running user bash command.
+		if (
+			summary.messageCount > 0 ||
+			summary.pendingMessageCount > 0 ||
+			summary.isStreaming ||
+			summary.isCompacting ||
+			summary.isBashRunning
+		) {
 			return;
 		}
 		await client.request({ type: "kill", activeSessionId }, 3000);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -50,10 +50,12 @@ import { SettingsManager } from "./core/settings-manager.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import {
+	type AgentConnection,
 	createInteractiveModeLocalSessionHost,
 	createInteractiveModeUiServicesFromServices,
 	DaemonAgentConnection,
 	DaemonClient,
+	DeferredAgentConnection,
 	defaultDaemonSocketPath,
 	InProcessAgentConnection,
 	InteractiveMode,
@@ -816,32 +818,6 @@ async function findActiveDaemonSessionSummary(
 	}
 }
 
-// Best-effort: drop an abandoned new-chat (no message sent) so it doesn't linger
-// in the agents view. Any failure leaves the session in place.
-async function discardEmptyDaemonSession(socketPath: string, activeSessionId: string): Promise<void> {
-	const client = new DaemonClient(socketPath);
-	try {
-		await client.connect(250);
-	} catch {
-		return;
-	}
-	try {
-		const state = await client.request({ type: "get_state", activeSessionId }, 3000);
-		if (!state.success || !isDaemonSessionSummary(state.data)) {
-			return;
-		}
-		const summary = state.data;
-		if (summary.messageCount > 0 || summary.pendingMessageCount > 0 || summary.isStreaming) {
-			return;
-		}
-		await client.request({ type: "kill", activeSessionId }, 3000);
-	} catch {
-		// Cleanup is best-effort; leave the session in place on any error.
-	} finally {
-		client.close();
-	}
-}
-
 async function normalizeDaemonRichTuiAttachArgs(args: string[]): Promise<string[] | undefined> {
 	const shortcut = parseDaemonRichTuiAttachShortcut(args);
 	if (!shortcut) {
@@ -1285,27 +1261,50 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 
 		await daemonReady;
-		// No attach and no session selector means the connection creates a fresh session.
+		// No attach and no session selector means a fresh default chat. Defer the
+		// daemon session until the first action so startup is instant and leaving
+		// straight to the agents view (or quitting) creates nothing to clean up.
 		const isFreshDefaultSession =
 			!activeDaemonSessionSummary && !getInteractiveDaemonSessionPath(parsed, sessionManager);
-		const { connection: agentConnection, summary } = await createDaemonInteractiveConnection({
-			socketPath: daemonSocketPath,
-			config: defaultSessionConfig,
-			activeSessionId: activeDaemonSessionSummary
-				? getDaemonSummaryActiveSessionId(activeDaemonSessionSummary)
-				: undefined,
-			sessionPath: activeDaemonSessionSummary ? undefined : getInteractiveDaemonSessionPath(parsed, sessionManager),
-		});
+		let agentConnection: AgentConnection;
+		let attachModelFallbackMessage: string | undefined;
+		if (isFreshDefaultSession) {
+			agentConnection = new DeferredAgentConnection(
+				async () =>
+					(await createDaemonInteractiveConnection({ socketPath: daemonSocketPath, config: defaultSessionConfig }))
+						.connection,
+				{
+					cwd: sessionManager.getCwd(),
+					sessionDir,
+					model: startupModel.model,
+					thinkingLevel: prepared.sessionOptions.thinkingLevel ?? defaultSessionConfig.thinking ?? "off",
+					scopedModels: prepared.sessionOptions.scopedModels ?? [],
+					availableModels: services.modelRegistry.getAvailable(),
+					steeringMode: settingsManager.getSteeringMode(),
+					followUpMode: settingsManager.getFollowUpMode(),
+					autoCompactionEnabled: settingsManager.getCompactionEnabled(),
+				},
+			);
+			attachModelFallbackMessage = startupModel.modelFallbackMessage;
+		} else {
+			const { connection, summary } = await createDaemonInteractiveConnection({
+				socketPath: daemonSocketPath,
+				config: defaultSessionConfig,
+				activeSessionId: activeDaemonSessionSummary
+					? getDaemonSummaryActiveSessionId(activeDaemonSessionSummary)
+					: undefined,
+				sessionPath: getInteractiveDaemonSessionPath(parsed, sessionManager),
+			});
+			agentConnection = connection;
+			attachModelFallbackMessage = resolveAttachModelFallbackMessage(summary, startupModel.modelFallbackMessage);
+		}
 
-		// onShutdown fires on both the quit and return-to-agents-view paths, so a
-		// straight Ctrl+C quit (which process.exits before run() returns) still cleans up.
-		const freshDefaultActiveSessionId = isFreshDefaultSession ? getDaemonSummaryActiveSessionId(summary) : undefined;
 		const interactiveMode = new InteractiveMode({
 			agentConnection,
 			uiServices: daemonUiServices,
 			bindLocalSessionExtensions: false,
 			migratedProviders,
-			modelFallbackMessage: resolveAttachModelFallbackMessage(summary, startupModel.modelFallbackMessage),
+			modelFallbackMessage: attachModelFallbackMessage,
 			initialMessage,
 			initialImages,
 			initialMessages: parsed.messages,
@@ -1315,9 +1314,6 @@ export async function main(args: string[], options?: MainOptions) {
 			// view was not rendered here, so we intentionally leave
 			// agentsViewOwnsStartupNotices unset and let the in-session fallback run.
 			returnToAgentsView: true,
-			onShutdown: freshDefaultActiveSessionId
-				? () => discardEmptyDaemonSession(daemonSocketPath, freshDefaultActiveSessionId)
-				: undefined,
 		});
 
 		await preloadCodeHighlighter();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1296,9 +1296,16 @@ export async function main(args: string[], options?: MainOptions) {
 		let attachModelFallbackMessage: string | undefined;
 		if (isFreshDefaultSession) {
 			agentConnection = new DeferredAgentConnection(
-				async () =>
-					(await createDaemonInteractiveConnection({ socketPath: daemonSocketPath, config: defaultSessionConfig }))
-						.connection,
+				async () => {
+					const created = await createDaemonInteractiveConnection({
+						socketPath: daemonSocketPath,
+						config: defaultSessionConfig,
+					});
+					return {
+						connection: created.connection,
+						activeSessionId: getDaemonSummaryActiveSessionId(created.summary),
+					};
+				},
 				{
 					cwd: sessionManager.getCwd(),
 					sessionDir,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -818,6 +818,32 @@ async function findActiveDaemonSessionSummary(
 	}
 }
 
+// Best-effort: kill a promoted session that never received a message so abandoned
+// new-chats don't linger in the agents view. Any failure leaves it in place.
+async function discardEmptyDaemonSession(socketPath: string, activeSessionId: string): Promise<void> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(250);
+	} catch {
+		return;
+	}
+	try {
+		const state = await client.request({ type: "get_state", activeSessionId }, 3000);
+		if (!state.success || !isDaemonSessionSummary(state.data)) {
+			return;
+		}
+		const summary = state.data;
+		if (summary.messageCount > 0 || summary.pendingMessageCount > 0 || summary.isStreaming) {
+			return;
+		}
+		await client.request({ type: "kill", activeSessionId }, 3000);
+	} catch {
+		// Best-effort cleanup; leave the session in place on any error.
+	} finally {
+		client.close();
+	}
+}
+
 async function normalizeDaemonRichTuiAttachArgs(args: string[]): Promise<string[] | undefined> {
 	const shortcut = parseDaemonRichTuiAttachShortcut(args);
 	if (!shortcut) {
@@ -1284,6 +1310,7 @@ export async function main(args: string[], options?: MainOptions) {
 					followUpMode: settingsManager.getFollowUpMode(),
 					autoCompactionEnabled: settingsManager.getCompactionEnabled(),
 				},
+				(activeSessionId) => discardEmptyDaemonSession(daemonSocketPath, activeSessionId),
 			);
 			attachModelFallbackMessage = startupModel.modelFallbackMessage;
 		} else {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -138,6 +138,15 @@ function toPrintOutputMode(appMode: AppMode): Exclude<Mode, "rpc" | "daemon"> {
 	return appMode === "json" ? "json" : "text";
 }
 
+// `prime-agent agents` / `prime-agent manage` open the agents view directly; the
+// leading verb is stripped so the remaining args parse as usual.
+export function parseAgentsViewCommand(args: string[]): { explicitAgentsView: boolean; args: string[] } {
+	if (args[0] === "agents" || args[0] === "manage") {
+		return { explicitAgentsView: true, args: args.slice(1) };
+	}
+	return { explicitAgentsView: false, args };
+}
+
 export interface InteractiveDaemonStartupDecision {
 	appMode: AppMode;
 	startupBenchmark: boolean;
@@ -159,6 +168,7 @@ export function shouldUseDaemonInteractive(options: InteractiveDaemonStartupDeci
 export interface AgentsViewStartupDecision {
 	useDaemonInteractive: boolean;
 	needsOnboarding: boolean;
+	explicitAgentsView?: boolean;
 	session?: string;
 	resume?: boolean;
 	continue?: boolean;
@@ -168,6 +178,9 @@ export interface AgentsViewStartupDecision {
 export function shouldOpenAgentsViewForDaemonInteractive(options: AgentsViewStartupDecision): boolean {
 	return (
 		options.useDaemonInteractive &&
+		// `prime-agent` opens a new chat by default; the agents view is reached via
+		// left-arrow from a session or requested explicitly (`agents`/`manage`).
+		!!options.explicitAgentsView &&
 		// Onboarding lives in InteractiveMode, so a first run must take the
 		// direct session path; the agents view would otherwise require creating
 		// an agent before the onboarding splash ever renders.
@@ -803,6 +816,33 @@ async function findActiveDaemonSessionSummary(
 	}
 }
 
+// Remove a freshly-created default chat session from the daemon when the user
+// left it without sending anything, so abandoned new-chats don't pile up in the
+// agents view. Best-effort: a failure here must not block the agents view.
+async function discardEmptyDaemonSession(socketPath: string, activeSessionId: string): Promise<void> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(250);
+	} catch {
+		return;
+	}
+	try {
+		const state = await client.request({ type: "get_state", activeSessionId }, 3000);
+		if (!state.success || !isDaemonSessionSummary(state.data)) {
+			return;
+		}
+		const summary = state.data;
+		if (summary.messageCount > 0 || summary.pendingMessageCount > 0 || summary.isStreaming) {
+			return;
+		}
+		await client.request({ type: "kill", activeSessionId }, 3000);
+	} catch {
+		// Cleanup is best-effort; leave the session in place on any error.
+	} finally {
+		client.close();
+	}
+}
+
 async function normalizeDaemonRichTuiAttachArgs(args: string[]): Promise<string[] | undefined> {
 	const shortcut = parseDaemonRichTuiAttachShortcut(args);
 	if (!shortcut) {
@@ -949,6 +989,11 @@ export async function main(args: string[], options?: MainOptions) {
 	if (await handleDaemonCommand(args)) {
 		return;
 	}
+
+	// `prime-agent agents` / `prime-agent manage` open the agents view directly.
+	const agentsViewCommand = parseAgentsViewCommand(args);
+	const explicitAgentsView = agentsViewCommand.explicitAgentsView;
+	args = agentsViewCommand.args;
 
 	const parsed = parseArgs(args);
 	if (parsed.diagnostics.length > 0) {
@@ -1221,6 +1266,7 @@ export async function main(args: string[], options?: MainOptions) {
 		if (
 			shouldOpenAgentsViewForDaemonInteractive({
 				useDaemonInteractive,
+				explicitAgentsView,
 				needsOnboarding: shouldRunOnboarding({
 					settingsManager,
 					modelRegistry: services.modelRegistry,
@@ -1240,6 +1286,10 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 
 		await daemonReady;
+		// A no-args `prime-agent` lands here on the default new-chat path: no
+		// attach, no session selector, so the connection creates a fresh session.
+		const isFreshDefaultSession =
+			!activeDaemonSessionSummary && !getInteractiveDaemonSessionPath(parsed, sessionManager);
 		const { connection: agentConnection, summary } = await createDaemonInteractiveConnection({
 			socketPath: daemonSocketPath,
 			config: defaultSessionConfig,
@@ -1269,6 +1319,9 @@ export async function main(args: string[], options?: MainOptions) {
 		await preloadCodeHighlighter();
 		printTimings();
 		await interactiveMode.run();
+		if (isFreshDefaultSession && summary.activeSessionId) {
+			await discardEmptyDaemonSession(daemonSocketPath, summary.activeSessionId);
+		}
 		await launchAgentsView(false);
 		return;
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1299,7 +1299,7 @@ export async function main(args: string[], options?: MainOptions) {
 
 		// onShutdown fires on both the quit and return-to-agents-view paths, so a
 		// straight Ctrl+C quit (which process.exits before run() returns) still cleans up.
-		const freshDefaultActiveSessionId = isFreshDefaultSession ? summary.activeSessionId : undefined;
+		const freshDefaultActiveSessionId = isFreshDefaultSession ? getDaemonSummaryActiveSessionId(summary) : undefined;
 		const interactiveMode = new InteractiveMode({
 			agentConnection,
 			uiServices: daemonUiServices,

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -8,6 +8,7 @@ import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { SessionManager } from "../../core/session-manager.js";
 import type { SessionStats } from "../../core/session-stats.js";
+import { emptyUsage } from "../../core/usage.js";
 import type {
 	AgentConnection,
 	AgentConnectionBeforeSessionInvalidateListener,
@@ -52,14 +53,16 @@ export interface DeferredAgentConnectionSeed {
 	autoCompactionEnabled: boolean;
 }
 
-const EMPTY_RESOURCE_SNAPSHOT: AgentConnectionResourceSnapshot = {
-	contextFiles: [],
-	skills: [],
-	prompts: [],
-	extensions: [],
-	themes: [],
-	diagnostics: { skills: [], prompts: [], extensions: [], themes: [] },
-};
+function emptyResourceSnapshot(): AgentConnectionResourceSnapshot {
+	return {
+		contextFiles: [],
+		skills: [],
+		prompts: [],
+		extensions: [],
+		themes: [],
+		diagnostics: { skills: [], prompts: [], extensions: [], themes: [] },
+	};
+}
 
 /**
  * Opens the chat instantly by serving local catalog data, and only creates the
@@ -71,6 +74,7 @@ const EMPTY_RESOURCE_SNAPSHOT: AgentConnectionResourceSnapshot = {
 export class DeferredAgentConnection implements AgentConnection {
 	private readonly listeners = new Set<AgentConnectionEventListener>();
 	private readonly beforeInvalidateListeners = new Set<AgentConnectionBeforeSessionInvalidateListener>();
+	private readonly beforeInvalidateRealUnsubs = new Map<AgentConnectionBeforeSessionInvalidateListener, () => void>();
 	private real: AgentConnection | undefined;
 	private realUnsub: (() => void) | undefined;
 	private promotion: Promise<AgentConnection> | undefined;
@@ -98,8 +102,12 @@ export class DeferredAgentConnection implements AgentConnection {
 			return this.real.onBeforeSessionInvalidate(listener);
 		}
 		this.beforeInvalidateListeners.add(listener);
+		// Unsubscribe must work whether called before or after promotion forwards
+		// the listener to the real connection.
 		return () => {
 			this.beforeInvalidateListeners.delete(listener);
+			this.beforeInvalidateRealUnsubs.get(listener)?.();
+			this.beforeInvalidateRealUnsubs.delete(listener);
 		};
 	}
 
@@ -114,7 +122,12 @@ export class DeferredAgentConnection implements AgentConnection {
 			return Promise.resolve(this.real);
 		}
 		if (!this.promotion) {
-			this.promotion = this.promote();
+			// Drop a failed attempt so a later action can retry instead of replaying
+			// the same rejection forever.
+			this.promotion = this.promote().catch((error) => {
+				this.promotion = undefined;
+				throw error;
+			});
 		}
 		return this.promotion;
 	}
@@ -128,7 +141,7 @@ export class DeferredAgentConnection implements AgentConnection {
 			return real;
 		}
 		for (const listener of this.beforeInvalidateListeners) {
-			real.onBeforeSessionInvalidate(listener);
+			this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
 		}
 		this.beforeInvalidateListeners.clear();
 		this.realUnsub = real.subscribe((event) => this.emit(event));
@@ -186,7 +199,7 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	async getResourceSnapshot(): Promise<AgentConnectionResourceSnapshot> {
-		return this.real ? this.real.getResourceSnapshot() : EMPTY_RESOURCE_SNAPSHOT;
+		return this.real ? this.real.getResourceSnapshot() : emptyResourceSnapshot();
 	}
 
 	async getAvailableModels(): Promise<AgentConnectionModel[]> {
@@ -211,7 +224,17 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	async getContextTree(): Promise<ContextTreeNode> {
-		return (await this.ensure()).getContextTree();
+		if (this.real) {
+			return this.real.getContextTree();
+		}
+		return {
+			id: "root",
+			label: "",
+			status: "active",
+			ownUsage: emptyUsage(),
+			totalUsage: emptyUsage(),
+			children: [],
+		};
 	}
 
 	async getSessionContext(): Promise<AgentConnectionSessionContext> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -122,7 +122,7 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	private async emitAndWait(event: AgentConnectionEvent): Promise<void> {
-		await Promise.allSettled([...this.listeners].map((listener) => listener(event)));
+		await Promise.allSettled([...this.listeners].map((listener) => Promise.resolve().then(() => listener(event))));
 	}
 
 	private ensure(): Promise<AgentConnection> {
@@ -142,25 +142,33 @@ export class DeferredAgentConnection implements AgentConnection {
 
 	private async promote(): Promise<AgentConnection> {
 		const real = await this.factory();
-		// dispose() may have run while factory() was in flight. Tear the real
-		// connection down and reject so callers don't act on a dead session.
-		if (this.disposed) {
+		// dispose() may have run, or the initial fetch may throw. In either case tear
+		// the real connection down and reject so we never commit a half-promoted
+		// connection (this.real set without session_replaced or a tracked id).
+		try {
+			if (this.disposed) {
+				throw new Error("Deferred connection disposed before promotion completed");
+			}
+			const [state, messages] = await Promise.all([real.getState(), real.getMessages()]);
+			if (this.disposed) {
+				throw new Error("Deferred connection disposed before promotion completed");
+			}
+			this.real = real;
+			this.promotedActiveSessionId = state.activeSessionId;
+			for (const listener of this.beforeInvalidateListeners) {
+				this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
+			}
+			this.beforeInvalidateListeners.clear();
+			this.realUnsub = real.subscribe((event) => this.emit(event));
+			// Wait for the UI to rebind to the (empty) real session before the caller's
+			// action runs, so the action's own events aren't double-rendered against a
+			// concurrent full re-render.
+			await this.emitAndWait({ type: "session_replaced", state, messages });
+			return real;
+		} catch (error) {
 			await real.dispose().catch(() => undefined);
-			throw new Error("Deferred connection disposed before promotion completed");
+			throw error;
 		}
-		this.real = real;
-		for (const listener of this.beforeInvalidateListeners) {
-			this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
-		}
-		this.beforeInvalidateListeners.clear();
-		this.realUnsub = real.subscribe((event) => this.emit(event));
-		const [state, messages] = await Promise.all([real.getState(), real.getMessages()]);
-		this.promotedActiveSessionId = state.activeSessionId;
-		// Wait for the UI to rebind to the (empty) real session before the caller's
-		// action runs, so the action's own events aren't double-rendered against a
-		// concurrent full re-render.
-		await this.emitAndWait({ type: "session_replaced", state, messages });
-		return real;
 	}
 
 	private defaultState(): AgentConnectionState {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -1,0 +1,443 @@
+import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { ImageContent, Transport } from "@earendil-works/pi-ai";
+import type { CompactionResult } from "../../core/compaction/index.js";
+import type { ContextTreeNode } from "../../core/context-tree.js";
+import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
+import { emptyGoalState } from "../../core/goals.js";
+import type { RefinementResult } from "../../core/refinement/index.js";
+import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
+import type { SessionStats } from "../../core/session-stats.js";
+import type {
+	AgentConnection,
+	AgentConnectionBeforeSessionInvalidateListener,
+	AgentConnectionEvent,
+	AgentConnectionEventListener,
+	AgentConnectionExecuteBashOptions,
+	AgentConnectionExtensionUiResponse,
+	AgentConnectionForkOptions,
+	AgentConnectionModel,
+	AgentConnectionModelCycleResult,
+	AgentConnectionNavigateTreeOptions,
+	AgentConnectionNavigateTreeResult,
+	AgentConnectionNewSessionOptions,
+	AgentConnectionPromptOptions,
+	AgentConnectionQueueMode,
+	AgentConnectionQueueState,
+	AgentConnectionResourceSnapshot,
+	AgentConnectionSavedSessionInfo,
+	AgentConnectionSavedSessionScope,
+	AgentConnectionScopedModel,
+	AgentConnectionSessionContext,
+	AgentConnectionSessionListProgress,
+	AgentConnectionSessionTreeNode,
+	AgentConnectionSlashCommand,
+	AgentConnectionSnapshot,
+	AgentConnectionState,
+	AgentConnectionSwitchSessionOptions,
+	AgentConnectionToolDefinition,
+	AgentConnectionUserMessage,
+} from "./types.js";
+
+/** Local data used to render the chat before a session exists. */
+export interface DeferredAgentConnectionSeed {
+	cwd: string;
+	sessionDir?: string;
+	model?: AgentConnectionModel;
+	thinkingLevel: ThinkingLevel;
+	scopedModels: AgentConnectionScopedModel[];
+	availableModels: AgentConnectionModel[];
+	steeringMode: AgentConnectionQueueMode;
+	followUpMode: AgentConnectionQueueMode;
+	autoCompactionEnabled: boolean;
+}
+
+const EMPTY_RESOURCE_SNAPSHOT: AgentConnectionResourceSnapshot = {
+	contextFiles: [],
+	skills: [],
+	prompts: [],
+	extensions: [],
+	themes: [],
+	diagnostics: { skills: [], prompts: [], extensions: [], themes: [] },
+};
+
+/**
+ * Opens the chat instantly by serving local catalog data, and only creates the
+ * real daemon session on the first action (a prompt, model change, etc.). Until
+ * then nothing is created, so pressing left to the agents view — or quitting —
+ * costs nothing. On creation it pipes the real connection's events through and
+ * emits one session_replaced so the UI rebinds to the live catalog.
+ */
+export class DeferredAgentConnection implements AgentConnection {
+	private readonly listeners = new Set<AgentConnectionEventListener>();
+	private readonly beforeInvalidateListeners = new Set<AgentConnectionBeforeSessionInvalidateListener>();
+	private real: AgentConnection | undefined;
+	private realUnsub: (() => void) | undefined;
+	private promotion: Promise<AgentConnection> | undefined;
+
+	constructor(
+		private readonly factory: () => Promise<AgentConnection>,
+		private readonly seed: DeferredAgentConnectionSeed,
+	) {}
+
+	/** True once the real session has been created. */
+	get created(): boolean {
+		return this.real !== undefined;
+	}
+
+	subscribe(listener: AgentConnectionEventListener): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	onBeforeSessionInvalidate(listener: AgentConnectionBeforeSessionInvalidateListener): () => void {
+		if (this.real) {
+			return this.real.onBeforeSessionInvalidate(listener);
+		}
+		this.beforeInvalidateListeners.add(listener);
+		return () => {
+			this.beforeInvalidateListeners.delete(listener);
+		};
+	}
+
+	private emit(event: AgentConnectionEvent): void {
+		for (const listener of [...this.listeners]) {
+			void listener(event);
+		}
+	}
+
+	private ensure(): Promise<AgentConnection> {
+		if (this.real) {
+			return Promise.resolve(this.real);
+		}
+		if (!this.promotion) {
+			this.promotion = this.promote();
+		}
+		return this.promotion;
+	}
+
+	private async promote(): Promise<AgentConnection> {
+		const real = await this.factory();
+		this.real = real;
+		for (const listener of this.beforeInvalidateListeners) {
+			real.onBeforeSessionInvalidate(listener);
+		}
+		this.beforeInvalidateListeners.clear();
+		this.realUnsub = real.subscribe((event) => this.emit(event));
+		const [state, messages] = await Promise.all([real.getState(), real.getMessages()]);
+		this.emit({ type: "session_replaced", state, messages });
+		return real;
+	}
+
+	private defaultState(): AgentConnectionState {
+		return {
+			cwd: this.seed.cwd,
+			model: this.seed.model,
+			thinkingLevel: this.seed.thinkingLevel,
+			availableThinkingLevels: [],
+			isStreaming: false,
+			isCompacting: false,
+			isBashRunning: false,
+			retryAttempt: 0,
+			steeringMode: this.seed.steeringMode,
+			followUpMode: this.seed.followUpMode,
+			sessionId: "",
+			sessionDir: this.seed.sessionDir,
+			leafId: null,
+			autoCompactionEnabled: this.seed.autoCompactionEnabled,
+			messageCount: 0,
+			pendingMessageCount: 0,
+			compactionCount: 0,
+			goal: emptyGoalState(),
+			scopedModels: this.seed.scopedModels,
+			activeToolNames: [],
+			contextUsage: undefined,
+		};
+	}
+
+	async getState(): Promise<AgentConnectionState> {
+		return this.real ? this.real.getState() : this.defaultState();
+	}
+
+	async getInitialSnapshot(): Promise<AgentConnectionSnapshot> {
+		if (this.real) {
+			return this.real.getInitialSnapshot();
+		}
+		return { state: this.defaultState(), messages: [], sessionTree: { tree: [], leafId: null } };
+	}
+
+	async getMessages(): Promise<AgentMessage[]> {
+		return this.real ? this.real.getMessages() : [];
+	}
+
+	async getCommands(): Promise<AgentConnectionSlashCommand[]> {
+		return this.real ? this.real.getCommands() : [];
+	}
+
+	async getResourceSnapshot(): Promise<AgentConnectionResourceSnapshot> {
+		return this.real ? this.real.getResourceSnapshot() : EMPTY_RESOURCE_SNAPSHOT;
+	}
+
+	async getAvailableModels(): Promise<AgentConnectionModel[]> {
+		return this.real ? this.real.getAvailableModels() : this.seed.availableModels;
+	}
+
+	async getSessionStats(): Promise<SessionStats> {
+		if (this.real) {
+			return this.real.getSessionStats();
+		}
+		return {
+			sessionFile: undefined,
+			sessionId: "",
+			userMessages: 0,
+			assistantMessages: 0,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 0,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+		};
+	}
+
+	async getContextTree(): Promise<ContextTreeNode> {
+		return (await this.ensure()).getContextTree();
+	}
+
+	async getSessionContext(): Promise<AgentConnectionSessionContext> {
+		if (this.real) {
+			return this.real.getSessionContext();
+		}
+		return {
+			messages: [],
+			thinkingLevel: this.seed.thinkingLevel,
+			model: this.seed.model ? { provider: this.seed.model.provider, modelId: this.seed.model.id } : null,
+		};
+	}
+
+	async getSessionTree(): Promise<{ tree: AgentConnectionSessionTreeNode[]; leafId: string | null }> {
+		return this.real ? this.real.getSessionTree() : { tree: [], leafId: null };
+	}
+
+	async listSavedSessions(
+		scope: AgentConnectionSavedSessionScope,
+		onProgress?: AgentConnectionSessionListProgress,
+	): Promise<AgentConnectionSavedSessionInfo[]> {
+		return this.real ? this.real.listSavedSessions(scope, onProgress) : [];
+	}
+
+	async getQueue(): Promise<AgentConnectionQueueState> {
+		return this.real ? this.real.getQueue() : { steering: [], followUp: [] };
+	}
+
+	async clearQueue(): Promise<AgentConnectionQueueState> {
+		return this.real ? this.real.clearQueue() : { steering: [], followUp: [] };
+	}
+
+	async listCronJobs(options?: { includeInactive?: boolean }): Promise<AgentCronJob[]> {
+		return this.real ? this.real.listCronJobs(options) : [];
+	}
+
+	async getHeartbeat(): Promise<AgentCronJob | undefined> {
+		return this.real ? this.real.getHeartbeat() : undefined;
+	}
+
+	async getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]> {
+		return this.real ? this.real.getUserMessagesForForking() : [];
+	}
+
+	async getLastAssistantText(): Promise<string | undefined> {
+		return this.real ? this.real.getLastAssistantText() : undefined;
+	}
+
+	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {
+		return this.real ? this.real.getToolDefinition(name) : undefined;
+	}
+
+	async setSessionEntryLabel(entryId: string, label: string | undefined): Promise<void> {
+		return (await this.ensure()).setSessionEntryLabel(entryId, label);
+	}
+
+	async respondToExtensionUiRequest(requestId: string, response: AgentConnectionExtensionUiResponse): Promise<void> {
+		if (this.real) {
+			await this.real.respondToExtensionUiRequest(requestId, response);
+		}
+	}
+
+	async prompt(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
+		return (await this.ensure()).prompt(message, options);
+	}
+
+	async steer(message: string, images?: ImageContent[]): Promise<void> {
+		return (await this.ensure()).steer(message, images);
+	}
+
+	async followUp(message: string, images?: ImageContent[]): Promise<void> {
+		return (await this.ensure()).followUp(message, images);
+	}
+
+	async abort(): Promise<void> {
+		if (this.real) {
+			await this.real.abort();
+		}
+	}
+
+	async cancelRlmChild(childId: string): Promise<boolean> {
+		return this.real ? this.real.cancelRlmChild(childId) : false;
+	}
+
+	async waitForIdle(): Promise<void> {
+		if (this.real) {
+			await this.real.waitForIdle();
+		}
+	}
+
+	async executeBash(command: string, options?: AgentConnectionExecuteBashOptions): Promise<void> {
+		return (await this.ensure()).executeBash(command, options);
+	}
+
+	async abortBash(): Promise<void> {
+		if (this.real) {
+			await this.real.abortBash();
+		}
+	}
+
+	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {
+		return (await this.ensure()).setModel(provider, modelId);
+	}
+
+	async cycleModel(direction?: "forward" | "backward"): Promise<AgentConnectionModelCycleResult | undefined> {
+		return (await this.ensure()).cycleModel(direction);
+	}
+
+	async setScopedModels(scopedModels: AgentConnectionScopedModel[]): Promise<void> {
+		return (await this.ensure()).setScopedModels(scopedModels);
+	}
+
+	async setThinkingLevel(level: ThinkingLevel): Promise<void> {
+		return (await this.ensure()).setThinkingLevel(level);
+	}
+
+	async cycleThinkingLevel(): Promise<ThinkingLevel | undefined> {
+		return (await this.ensure()).cycleThinkingLevel();
+	}
+
+	async setTransport(transport: Transport): Promise<void> {
+		return (await this.ensure()).setTransport(transport);
+	}
+
+	async setSteeringMode(mode: AgentConnectionQueueMode): Promise<void> {
+		return (await this.ensure()).setSteeringMode(mode);
+	}
+
+	async setFollowUpMode(mode: AgentConnectionQueueMode): Promise<void> {
+		return (await this.ensure()).setFollowUpMode(mode);
+	}
+
+	async setAutoCompactionEnabled(enabled: boolean): Promise<void> {
+		return (await this.ensure()).setAutoCompactionEnabled(enabled);
+	}
+
+	async compact(customInstructions?: string): Promise<CompactionResult> {
+		return (await this.ensure()).compact(customInstructions);
+	}
+
+	async refine(options?: { instructions?: string; rollbackId?: string }): Promise<RefinementResult> {
+		return (await this.ensure()).refine(options);
+	}
+
+	async abortCompaction(): Promise<void> {
+		if (this.real) {
+			await this.real.abortCompaction();
+		}
+	}
+
+	async abortBranchSummary(): Promise<void> {
+		if (this.real) {
+			await this.real.abortBranchSummary();
+		}
+	}
+
+	async abortRetry(): Promise<void> {
+		if (this.real) {
+			await this.real.abortRetry();
+		}
+	}
+
+	async reload(): Promise<void> {
+		return (await this.ensure()).reload();
+	}
+
+	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
+		return (await this.ensure()).newSession(options);
+	}
+
+	async switchSession(
+		sessionPath: string,
+		options?: AgentConnectionSwitchSessionOptions,
+	): Promise<{ cancelled: boolean }> {
+		return (await this.ensure()).switchSession(sessionPath, options);
+	}
+
+	async fork(
+		entryId: string,
+		options?: AgentConnectionForkOptions,
+	): Promise<{ cancelled: boolean; selectedText?: string }> {
+		return (await this.ensure()).fork(entryId, options);
+	}
+
+	async navigateTree(
+		targetId: string,
+		options?: AgentConnectionNavigateTreeOptions,
+	): Promise<AgentConnectionNavigateTreeResult> {
+		return (await this.ensure()).navigateTree(targetId, options);
+	}
+
+	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
+		return (await this.ensure()).importFromJsonl(inputPath, cwdOverride);
+	}
+
+	async exportToHtml(outputPath?: string): Promise<string> {
+		return (await this.ensure()).exportToHtml(outputPath);
+	}
+
+	async exportToJsonl(outputPath?: string): Promise<string> {
+		return (await this.ensure()).exportToJsonl(outputPath);
+	}
+
+	async setSessionName(name: string): Promise<void> {
+		return (await this.ensure()).setSessionName(name);
+	}
+
+	async renameSavedSession(sessionPath: string, name: string): Promise<void> {
+		return (await this.ensure()).renameSavedSession(sessionPath, name);
+	}
+
+	async deleteSavedSession(sessionPath: string): Promise<DeleteSessionFileResult> {
+		return (await this.ensure()).deleteSavedSession(sessionPath);
+	}
+
+	async addCronJob(schedule: string, prompt: string): Promise<AgentCronJob> {
+		return (await this.ensure()).addCronJob(schedule, prompt);
+	}
+
+	async cancelCronJob(jobId: string): Promise<AgentCronJob> {
+		return (await this.ensure()).cancelCronJob(jobId);
+	}
+
+	async setHeartbeat(schedule: string, instruction: string): Promise<AgentCronJob> {
+		return (await this.ensure()).setHeartbeat(schedule, instruction);
+	}
+
+	async updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined> {
+		return (await this.ensure()).updateHeartbeat(action);
+	}
+
+	async dispose(): Promise<void> {
+		this.realUnsub?.();
+		this.realUnsub = undefined;
+		if (this.real) {
+			await this.real.dispose();
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -117,6 +117,10 @@ export class DeferredAgentConnection implements AgentConnection {
 		}
 	}
 
+	private async emitAndWait(event: AgentConnectionEvent): Promise<void> {
+		await Promise.allSettled([...this.listeners].map((listener) => listener(event)));
+	}
+
 	private ensure(): Promise<AgentConnection> {
 		if (this.real) {
 			return Promise.resolve(this.real);
@@ -146,7 +150,10 @@ export class DeferredAgentConnection implements AgentConnection {
 		this.beforeInvalidateListeners.clear();
 		this.realUnsub = real.subscribe((event) => this.emit(event));
 		const [state, messages] = await Promise.all([real.getState(), real.getMessages()]);
-		this.emit({ type: "session_replaced", state, messages });
+		// Wait for the UI to rebind to the (empty) real session before the caller's
+		// action runs, so the action's own events aren't double-rendered against a
+		// concurrent full re-render.
+		await this.emitAndWait({ type: "session_replaced", state, messages });
 		return real;
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -6,6 +6,7 @@ import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-j
 import { emptyGoalState } from "../../core/goals.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
+import { SessionManager } from "../../core/session-manager.js";
 import type { SessionStats } from "../../core/session-stats.js";
 import type {
 	AgentConnection,
@@ -73,6 +74,7 @@ export class DeferredAgentConnection implements AgentConnection {
 	private real: AgentConnection | undefined;
 	private realUnsub: (() => void) | undefined;
 	private promotion: Promise<AgentConnection> | undefined;
+	private disposed = false;
 
 	constructor(
 		private readonly factory: () => Promise<AgentConnection>,
@@ -120,6 +122,11 @@ export class DeferredAgentConnection implements AgentConnection {
 	private async promote(): Promise<AgentConnection> {
 		const real = await this.factory();
 		this.real = real;
+		// dispose() may have run while factory() was in flight; let it tear the
+		// real connection down instead of wiring up a session no one is watching.
+		if (this.disposed) {
+			return real;
+		}
 		for (const listener of this.beforeInvalidateListeners) {
 			real.onBeforeSessionInvalidate(listener);
 		}
@@ -171,6 +178,9 @@ export class DeferredAgentConnection implements AgentConnection {
 		return this.real ? this.real.getMessages() : [];
 	}
 
+	// Extension/skill commands and resources are session-scoped, so they stay
+	// empty until promotion; builtin slash commands work meanwhile, and the
+	// session_replaced on first action repopulates the catalog.
 	async getCommands(): Promise<AgentConnectionSlashCommand[]> {
 		return this.real ? this.real.getCommands() : [];
 	}
@@ -223,7 +233,13 @@ export class DeferredAgentConnection implements AgentConnection {
 		scope: AgentConnectionSavedSessionScope,
 		onProgress?: AgentConnectionSessionListProgress,
 	): Promise<AgentConnectionSavedSessionInfo[]> {
-		return this.real ? this.real.listSavedSessions(scope, onProgress) : [];
+		if (this.real) {
+			return this.real.listSavedSessions(scope, onProgress);
+		}
+		// Saved sessions live on disk, so the resume picker works without a session.
+		return scope === "current"
+			? SessionManager.list(this.seed.cwd, this.seed.sessionDir, onProgress)
+			: SessionManager.listAll(onProgress, this.seed.sessionDir);
 	}
 
 	async getQueue(): Promise<AgentConnectionQueueState> {
@@ -434,10 +450,17 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	async dispose(): Promise<void> {
+		this.disposed = true;
+		// Wait out an in-flight promotion so a session created during teardown is
+		// not left attached with no client.
+		if (this.promotion) {
+			await this.promotion.catch(() => undefined);
+		}
 		this.realUnsub?.();
 		this.realUnsub = undefined;
 		if (this.real) {
 			await this.real.dispose();
+			this.real = undefined;
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -78,11 +78,15 @@ export class DeferredAgentConnection implements AgentConnection {
 	private real: AgentConnection | undefined;
 	private realUnsub: (() => void) | undefined;
 	private promotion: Promise<AgentConnection> | undefined;
+	private promotedActiveSessionId: string | undefined;
 	private disposed = false;
 
 	constructor(
 		private readonly factory: () => Promise<AgentConnection>,
 		private readonly seed: DeferredAgentConnectionSeed,
+		// Called on teardown with the promoted session id so the caller can drop it
+		// if it was created but never used (e.g. cycled the model, then left).
+		private readonly discardEmptySession?: (activeSessionId: string) => Promise<void>,
 	) {}
 
 	/** True once the real session has been created. */
@@ -138,18 +142,20 @@ export class DeferredAgentConnection implements AgentConnection {
 
 	private async promote(): Promise<AgentConnection> {
 		const real = await this.factory();
-		this.real = real;
-		// dispose() may have run while factory() was in flight; let it tear the
-		// real connection down instead of wiring up a session no one is watching.
+		// dispose() may have run while factory() was in flight. Tear the real
+		// connection down and reject so callers don't act on a dead session.
 		if (this.disposed) {
-			return real;
+			await real.dispose().catch(() => undefined);
+			throw new Error("Deferred connection disposed before promotion completed");
 		}
+		this.real = real;
 		for (const listener of this.beforeInvalidateListeners) {
 			this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
 		}
 		this.beforeInvalidateListeners.clear();
 		this.realUnsub = real.subscribe((event) => this.emit(event));
 		const [state, messages] = await Promise.all([real.getState(), real.getMessages()]);
+		this.promotedActiveSessionId = state.activeSessionId;
 		// Wait for the UI to rebind to the (empty) real session before the caller's
 		// action runs, so the action's own events aren't double-rendered against a
 		// concurrent full re-render.
@@ -491,6 +497,11 @@ export class DeferredAgentConnection implements AgentConnection {
 		if (this.real) {
 			await this.real.dispose();
 			this.real = undefined;
+			// A promoted-but-never-messaged session (e.g. only a model cycle) would
+			// otherwise linger in the daemon; let the caller drop it if abandoned.
+			if (this.promotedActiveSessionId && this.discardEmptySession) {
+				await this.discardEmptySession(this.promotedActiveSessionId).catch(() => undefined);
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -158,11 +158,13 @@ export class DeferredAgentConnection implements AgentConnection {
 			}
 			this.real = real;
 			this.promotedActiveSessionId = activeSessionId;
+			this.realUnsub = real.subscribe((event) => this.emit(event));
+			// Clear the buffer only after wiring succeeds, so a throw here keeps the
+			// listeners for a retry.
 			for (const listener of this.beforeInvalidateListeners) {
 				this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
 			}
 			this.beforeInvalidateListeners.clear();
-			this.realUnsub = real.subscribe((event) => this.emit(event));
 			// Wait for the UI to rebind to the (empty) real session before the caller's
 			// action runs, so the action's own events aren't double-rendered against a
 			// concurrent full re-render.
@@ -171,6 +173,13 @@ export class DeferredAgentConnection implements AgentConnection {
 		} catch (error) {
 			await real.dispose().catch(() => undefined);
 			await this.discardEmptySession?.(activeSessionId).catch(() => undefined);
+			// Roll back a partial commit so ensure() retries instead of short-circuiting
+			// to this disposed connection.
+			if (this.real === real) {
+				this.realUnsub = undefined;
+				this.real = undefined;
+				this.promotedActiveSessionId = undefined;
+			}
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -82,10 +82,12 @@ export class DeferredAgentConnection implements AgentConnection {
 	private disposed = false;
 
 	constructor(
-		private readonly factory: () => Promise<AgentConnection>,
+		// Creates the real session and returns its connection plus the daemon
+		// activeSessionId, so the id is known even if a later setup step fails.
+		private readonly factory: () => Promise<{ connection: AgentConnection; activeSessionId: string }>,
 		private readonly seed: DeferredAgentConnectionSeed,
-		// Called on teardown with the promoted session id so the caller can drop it
-		// if it was created but never used (e.g. cycled the model, then left).
+		// Called with a promoted session id so the caller can drop it if it was
+		// created but never used (e.g. cycled the model then left, or setup failed).
 		private readonly discardEmptySession?: (activeSessionId: string) => Promise<void>,
 	) {}
 
@@ -141,10 +143,11 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	private async promote(): Promise<AgentConnection> {
-		const real = await this.factory();
-		// dispose() may have run, or the initial fetch may throw. In either case tear
-		// the real connection down and reject so we never commit a half-promoted
-		// connection (this.real set without session_replaced or a tracked id).
+		const { connection: real, activeSessionId } = await this.factory();
+		// dispose() may have run, or a setup step may throw. In any of those cases
+		// tear down the client AND drop the daemon session the factory just created,
+		// so a failed/cancelled promotion never commits half-state or orphans an
+		// empty agent (and retries can't pile more up).
 		try {
 			if (this.disposed) {
 				throw new Error("Deferred connection disposed before promotion completed");
@@ -154,7 +157,7 @@ export class DeferredAgentConnection implements AgentConnection {
 				throw new Error("Deferred connection disposed before promotion completed");
 			}
 			this.real = real;
-			this.promotedActiveSessionId = state.activeSessionId;
+			this.promotedActiveSessionId = activeSessionId;
 			for (const listener of this.beforeInvalidateListeners) {
 				this.beforeInvalidateRealUnsubs.set(listener, real.onBeforeSessionInvalidate(listener));
 			}
@@ -167,6 +170,7 @@ export class DeferredAgentConnection implements AgentConnection {
 			return real;
 		} catch (error) {
 			await real.dispose().catch(() => undefined);
+			await this.discardEmptySession?.(activeSessionId).catch(() => undefined);
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -1,4 +1,5 @@
 export { DaemonAgentConnection } from "./daemon-agent-connection.js";
+export { DeferredAgentConnection, type DeferredAgentConnectionSeed } from "./deferred-agent-connection.js";
 export { InProcessAgentConnection } from "./in-process-agent-connection.js";
 export { createAgentConnectionCommands, createAgentConnectionState } from "./snapshot.js";
 export type {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1535,9 +1535,8 @@ export class AgentDaemon {
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
 		const cascadeError = await this.closeChildSessions(state, reason);
-		// A killed session that never received a message carries no work worth
-		// keeping (e.g. an abandoned default new-chat). Discard it outright rather
-		// than persisting a sleep state that would clutter the saved-session list.
+		// A killed session with no messages (abandoned new-chat) is discarded
+		// outright instead of persisting a sleep state that clutters the list.
 		const isEmptyKilledSession = reason === "killed" && state.runtime.session.messages.length === 0;
 		let persistError: unknown;
 		if (reason !== "shutdown" && !isEmptyKilledSession) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1535,8 +1535,12 @@ export class AgentDaemon {
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
 		const cascadeError = await this.closeChildSessions(state, reason);
+		// A killed session that never received a message carries no work worth
+		// keeping (e.g. an abandoned default new-chat). Discard it outright rather
+		// than persisting a sleep state that would clutter the saved-session list.
+		const isEmptyKilledSession = reason === "killed" && state.runtime.session.messages.length === 0;
 		let persistError: unknown;
-		if (reason !== "shutdown") {
+		if (reason !== "shutdown" && !isEmptyKilledSession) {
 			try {
 				state.runtime.session.sessionManager.appendSessionState({ status: "sleep" });
 			} catch (error) {
@@ -1555,6 +1559,12 @@ export class AgentDaemon {
 		}
 		state.clients.clear();
 		this.sessions.delete(state.activeSessionId);
+		if (isEmptyKilledSession) {
+			const sessionFile = state.runtime.session.sessionFile;
+			if (sessionFile) {
+				await deleteSessionFile(sessionFile).catch(() => undefined);
+			}
+		}
 		if (persistError && reason !== "shutdown" && reason !== "completed") {
 			throw persistError;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -33,6 +33,7 @@ export interface SessionSummary {
 	thinkingLevel?: ThinkingLevel;
 	isStreaming: boolean;
 	isCompacting: boolean;
+	isBashRunning?: boolean;
 	attachedClients: number;
 	messageCount: number;
 	pendingMessageCount: number;
@@ -132,6 +133,7 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		thinkingLevel: session.thinkingLevel,
 		isStreaming: session.isStreaming,
 		isCompacting: session.isCompacting,
+		isBashRunning: session.isBashRunning,
 		attachedClients: activeSession.clients.size,
 		messageCount: session.messages.length,
 		pendingMessageCount: session.pendingMessageCount,

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -18,7 +18,12 @@ export type {
 	AgentConnectionSlashCommand,
 	AgentConnectionState,
 } from "./agent-connection/index.js";
-export { DaemonAgentConnection, InProcessAgentConnection } from "./agent-connection/index.js";
+export {
+	DaemonAgentConnection,
+	DeferredAgentConnection,
+	type DeferredAgentConnectionSeed,
+	InProcessAgentConnection,
+} from "./agent-connection/index.js";
 export { type AgentsViewModeOptions, runAgentsViewMode } from "./agents-view/agents-view-mode.js";
 export {
 	type AgentsViewRow,

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -191,6 +191,48 @@ describe("DeferredAgentConnection", () => {
 		fake.emit({ type: "session_status", recap: "late" });
 		expect(events).toEqual([]);
 	});
+
+	test("getContextTree does not create a session", async () => {
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		const tree = await conn.getContextTree();
+		expect(tree.children).toEqual([]);
+		expect(factory).not.toHaveBeenCalled();
+		expect(conn.created).toBe(false);
+	});
+
+	test("retries promotion after a failed first attempt", async () => {
+		const fake = new FakeRealConnection();
+		let attempt = 0;
+		const factory = vi.fn(async () => {
+			attempt += 1;
+			if (attempt === 1) {
+				throw new Error("daemon unavailable");
+			}
+			return fake as unknown as AgentConnection;
+		});
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		await expect(conn.prompt("first")).rejects.toThrow("daemon unavailable");
+		await conn.prompt("second");
+
+		expect(factory).toHaveBeenCalledTimes(2);
+		expect(fake.promptCalls).toEqual(["second"]);
+	});
+
+	test("unsubscribing a before-invalidate listener after promotion detaches it from the real connection", async () => {
+		const { fake, factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+		const listener = vi.fn();
+		const unsubscribe = conn.onBeforeSessionInvalidate(listener);
+
+		await conn.prompt("go");
+		expect(fake.beforeInvalidate.has(listener)).toBe(true);
+
+		unsubscribe();
+		expect(fake.beforeInvalidate.has(listener)).toBe(false);
+	});
 });
 
 describe("DeferredAgentConnection with a real-style saved-session lister", () => {

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -164,4 +164,44 @@ describe("DeferredAgentConnection", () => {
 		expect(factory).not.toHaveBeenCalled();
 		expect(conn.created).toBe(false);
 	});
+
+	test("disposes a session created while teardown was in flight", async () => {
+		const fake = new FakeRealConnection();
+		let resolveFactory: (connection: AgentConnection) => void = () => {};
+		const factory = vi.fn(
+			() =>
+				new Promise<AgentConnection>((resolve) => {
+					resolveFactory = resolve;
+				}),
+		);
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		// Start promotion, then dispose before the factory resolves.
+		const prompting = conn.prompt("go").catch(() => undefined);
+		const disposing = conn.dispose();
+		resolveFactory(fake as unknown as AgentConnection);
+		await Promise.all([prompting, disposing]);
+
+		expect(fake.disposed).toBe(true);
+		// The aborted promotion never wires events through.
+		const events: AgentConnectionEvent[] = [];
+		conn.subscribe((event) => {
+			events.push(event);
+		});
+		fake.emit({ type: "session_status", recap: "late" });
+		expect(events).toEqual([]);
+	});
+});
+
+describe("DeferredAgentConnection with a real-style saved-session lister", () => {
+	test("delegates saved-session listing once promoted", async () => {
+		const saved = [{ id: "s1" }] as unknown as Awaited<ReturnType<AgentConnection["listSavedSessions"]>>;
+		const fake = Object.assign(new FakeRealConnection(), {
+			listSavedSessions: async () => saved,
+		});
+		const conn = new DeferredAgentConnection(async () => fake as unknown as AgentConnection, SEED);
+
+		await conn.prompt("go");
+		expect(await conn.listSavedSessions("current")).toBe(saved);
+	});
 });

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -57,7 +57,10 @@ class FakeRealConnection {
 }
 
 function makeFactory(fake = new FakeRealConnection()) {
-	const factory = vi.fn(async () => fake as unknown as AgentConnection);
+	const factory = vi.fn(async () => ({
+		connection: fake as unknown as AgentConnection,
+		activeSessionId: "real-session",
+	}));
 	return { factory, fake };
 }
 
@@ -167,22 +170,28 @@ describe("DeferredAgentConnection", () => {
 
 	test("disposes a session created while teardown was in flight", async () => {
 		const fake = new FakeRealConnection();
-		let resolveFactory: (connection: AgentConnection) => void = () => {};
+		const discarded: string[] = [];
+		type FactoryResult = { connection: AgentConnection; activeSessionId: string };
+		let resolveFactory: (result: FactoryResult) => void = () => {};
 		const factory = vi.fn(
 			() =>
-				new Promise<AgentConnection>((resolve) => {
+				new Promise<FactoryResult>((resolve) => {
 					resolveFactory = resolve;
 				}),
 		);
-		const conn = new DeferredAgentConnection(factory, SEED);
+		const conn = new DeferredAgentConnection(factory, SEED, async (id) => {
+			discarded.push(id);
+		});
 
 		// Start promotion, then dispose before the factory resolves.
 		const prompting = conn.prompt("go").catch(() => undefined);
 		const disposing = conn.dispose();
-		resolveFactory(fake as unknown as AgentConnection);
+		resolveFactory({ connection: fake as unknown as AgentConnection, activeSessionId: "real-session" });
 		await Promise.all([prompting, disposing]);
 
 		expect(fake.disposed).toBe(true);
+		// The session the factory created during teardown is dropped, not orphaned.
+		expect(discarded).toEqual(["real-session"]);
 		// The aborted promotion never wires events through.
 		const events: AgentConnectionEvent[] = [];
 		conn.subscribe((event) => {
@@ -200,7 +209,10 @@ describe("DeferredAgentConnection", () => {
 			order.push("prompt");
 			return originalPrompt(message);
 		};
-		const conn = new DeferredAgentConnection(async () => fake as unknown as AgentConnection, SEED);
+		const conn = new DeferredAgentConnection(
+			async () => ({ connection: fake as unknown as AgentConnection, activeSessionId: "real-session" }),
+			SEED,
+		);
 		conn.subscribe(async (event) => {
 			if (event.type === "session_replaced") {
 				// Simulate the UI's async rebind work.
@@ -219,7 +231,10 @@ describe("DeferredAgentConnection", () => {
 	test("discards an abandoned promoted session on dispose", async () => {
 		const discarded: string[] = [];
 		const conn = new DeferredAgentConnection(
-			async () => new FakeRealConnection() as unknown as AgentConnection,
+			async () => ({
+				connection: new FakeRealConnection() as unknown as AgentConnection,
+				activeSessionId: "real-session",
+			}),
 			SEED,
 			async (id) => {
 				discarded.push(id);
@@ -252,7 +267,7 @@ describe("DeferredAgentConnection", () => {
 		};
 		const discarded: string[] = [];
 		const conn = new DeferredAgentConnection(
-			async () => fake as unknown as AgentConnection,
+			async () => ({ connection: fake as unknown as AgentConnection, activeSessionId: "real-session" }),
 			SEED,
 			async (id) => {
 				discarded.push(id);
@@ -260,12 +275,11 @@ describe("DeferredAgentConnection", () => {
 		);
 
 		await expect(conn.prompt("go")).rejects.toThrow("state fetch failed");
-		// The uncommitted connection was torn down and nothing was left half-wired.
+		// The uncommitted connection was torn down and its orphaned daemon session
+		// discarded, leaving nothing half-wired.
 		expect(fake.disposed).toBe(true);
 		expect(conn.created).toBe(false);
-
-		await conn.dispose();
-		expect(discarded).toEqual([]);
+		expect(discarded).toEqual(["real-session"]);
 	});
 
 	test("getContextTree does not create a session", async () => {
@@ -286,7 +300,7 @@ describe("DeferredAgentConnection", () => {
 			if (attempt === 1) {
 				throw new Error("daemon unavailable");
 			}
-			return fake as unknown as AgentConnection;
+			return { connection: fake as unknown as AgentConnection, activeSessionId: "real-session" };
 		});
 		const conn = new DeferredAgentConnection(factory, SEED);
 
@@ -317,7 +331,10 @@ describe("DeferredAgentConnection with a real-style saved-session lister", () =>
 		const fake = Object.assign(new FakeRealConnection(), {
 			listSavedSessions: async () => saved,
 		});
-		const conn = new DeferredAgentConnection(async () => fake as unknown as AgentConnection, SEED);
+		const conn = new DeferredAgentConnection(
+			async () => ({ connection: fake as unknown as AgentConnection, activeSessionId: "real-session" }),
+			SEED,
+		);
 
 		await conn.prompt("go");
 		expect(await conn.listSavedSessions("current")).toBe(saved);

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -192,6 +192,30 @@ describe("DeferredAgentConnection", () => {
 		expect(events).toEqual([]);
 	});
 
+	test("finishes the session_replaced handler before sending the triggering action", async () => {
+		const order: string[] = [];
+		const fake = new FakeRealConnection();
+		const originalPrompt = fake.prompt.bind(fake);
+		fake.prompt = async (message: string) => {
+			order.push("prompt");
+			return originalPrompt(message);
+		};
+		const conn = new DeferredAgentConnection(async () => fake as unknown as AgentConnection, SEED);
+		conn.subscribe(async (event) => {
+			if (event.type === "session_replaced") {
+				// Simulate the UI's async rebind work.
+				await Promise.resolve();
+				order.push("replaced");
+			}
+		});
+
+		await conn.prompt("hi");
+
+		// The action must not be sent until the UI has rebound, or its events
+		// would double-render against the rebind.
+		expect(order).toEqual(["replaced", "prompt"]);
+	});
+
 	test("getContextTree does not create a session", async () => {
 		const { factory } = makeFactory();
 		const conn = new DeferredAgentConnection(factory, SEED);

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -311,6 +311,33 @@ describe("DeferredAgentConnection", () => {
 		expect(fake.promptCalls).toEqual(["second"]);
 	});
 
+	test("rolls back a partial commit so a later action retries", async () => {
+		const fakes: FakeRealConnection[] = [];
+		let attempt = 0;
+		const factory = vi.fn(async () => {
+			const fake = new FakeRealConnection();
+			attempt += 1;
+			if (attempt === 1) {
+				// Throw after this.real is already assigned in promote().
+				fake.subscribe = () => {
+					throw new Error("subscribe failed");
+				};
+			}
+			fakes.push(fake);
+			return { connection: fake as unknown as AgentConnection, activeSessionId: "real-session" };
+		});
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		await expect(conn.prompt("first")).rejects.toThrow("subscribe failed");
+		expect(conn.created).toBe(false);
+		expect(fakes[0].disposed).toBe(true);
+
+		await conn.prompt("second");
+		expect(factory).toHaveBeenCalledTimes(2);
+		expect(conn.created).toBe(true);
+		expect(fakes[1].promptCalls).toEqual(["second"]);
+	});
+
 	test("unsubscribing a before-invalidate listener after promotion detaches it from the real connection", async () => {
 		const { fake, factory } = makeFactory();
 		const conn = new DeferredAgentConnection(factory, SEED);

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -43,7 +43,7 @@ class FakeRealConnection {
 		}
 	}
 	async getState() {
-		return { sessionId: "real-session", cwd: "/tmp/project" };
+		return { sessionId: "real-session", activeSessionId: "real-session", cwd: "/tmp/project" };
 	}
 	async getMessages() {
 		return [{ role: "user", content: "hi" }];
@@ -214,6 +214,35 @@ describe("DeferredAgentConnection", () => {
 		// The action must not be sent until the UI has rebound, or its events
 		// would double-render against the rebind.
 		expect(order).toEqual(["replaced", "prompt"]);
+	});
+
+	test("discards an abandoned promoted session on dispose", async () => {
+		const discarded: string[] = [];
+		const conn = new DeferredAgentConnection(
+			async () => new FakeRealConnection() as unknown as AgentConnection,
+			SEED,
+			async (id) => {
+				discarded.push(id);
+			},
+		);
+
+		await conn.prompt("go"); // promotes the session
+		await conn.dispose();
+
+		expect(discarded).toEqual(["real-session"]);
+	});
+
+	test("does not attempt discard when never promoted", async () => {
+		const discarded: string[] = [];
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED, async (id) => {
+			discarded.push(id);
+		});
+
+		await conn.dispose();
+
+		expect(factory).not.toHaveBeenCalled();
+		expect(discarded).toEqual([]);
 	});
 
 	test("getContextTree does not create a session", async () => {

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -245,6 +245,29 @@ describe("DeferredAgentConnection", () => {
 		expect(discarded).toEqual([]);
 	});
 
+	test("does not half-promote when the initial state fetch fails", async () => {
+		const fake = new FakeRealConnection();
+		fake.getState = async () => {
+			throw new Error("state fetch failed");
+		};
+		const discarded: string[] = [];
+		const conn = new DeferredAgentConnection(
+			async () => fake as unknown as AgentConnection,
+			SEED,
+			async (id) => {
+				discarded.push(id);
+			},
+		);
+
+		await expect(conn.prompt("go")).rejects.toThrow("state fetch failed");
+		// The uncommitted connection was torn down and nothing was left half-wired.
+		expect(fake.disposed).toBe(true);
+		expect(conn.created).toBe(false);
+
+		await conn.dispose();
+		expect(discarded).toEqual([]);
+	});
+
 	test("getContextTree does not create a session", async () => {
 		const { factory } = makeFactory();
 		const conn = new DeferredAgentConnection(factory, SEED);

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	DeferredAgentConnection,
+	type DeferredAgentConnectionSeed,
+} from "../src/modes/agent-connection/deferred-agent-connection.js";
+import type {
+	AgentConnection,
+	AgentConnectionEvent,
+	AgentConnectionModel,
+} from "../src/modes/agent-connection/types.js";
+
+const MODEL = { provider: "anthropic", id: "claude-x" } as unknown as AgentConnectionModel;
+
+const SEED: DeferredAgentConnectionSeed = {
+	cwd: "/tmp/project",
+	sessionDir: "/tmp/sessions",
+	model: MODEL,
+	thinkingLevel: "off",
+	scopedModels: [],
+	availableModels: [MODEL],
+	steeringMode: "all",
+	followUpMode: "all",
+	autoCompactionEnabled: true,
+};
+
+class FakeRealConnection {
+	readonly listeners = new Set<(event: AgentConnectionEvent) => void>();
+	readonly beforeInvalidate = new Set<() => void>();
+	readonly promptCalls: string[] = [];
+	disposed = false;
+
+	subscribe(listener: (event: AgentConnectionEvent) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+	onBeforeSessionInvalidate(listener: () => void): () => void {
+		this.beforeInvalidate.add(listener);
+		return () => this.beforeInvalidate.delete(listener);
+	}
+	emit(event: AgentConnectionEvent): void {
+		for (const listener of [...this.listeners]) {
+			listener(event);
+		}
+	}
+	async getState() {
+		return { sessionId: "real-session", cwd: "/tmp/project" };
+	}
+	async getMessages() {
+		return [{ role: "user", content: "hi" }];
+	}
+	async prompt(message: string) {
+		this.promptCalls.push(message);
+	}
+	async dispose() {
+		this.disposed = true;
+	}
+}
+
+function makeFactory(fake = new FakeRealConnection()) {
+	const factory = vi.fn(async () => fake as unknown as AgentConnection);
+	return { factory, fake };
+}
+
+describe("DeferredAgentConnection", () => {
+	test("serves local catalog and creates nothing for reads or dispose", async () => {
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		const state = await conn.getState();
+		expect(state.model).toBe(MODEL);
+		expect(state.cwd).toBe("/tmp/project");
+		expect(state.messageCount).toBe(0);
+		expect(await conn.getCommands()).toEqual([]);
+		expect(await conn.getMessages()).toEqual([]);
+		expect(await conn.getAvailableModels()).toEqual([MODEL]);
+		expect(await conn.getQueue()).toEqual({ steering: [], followUp: [] });
+		expect((await conn.getSessionStats()).totalMessages).toBe(0);
+
+		await conn.dispose();
+		expect(factory).not.toHaveBeenCalled();
+		expect(conn.created).toBe(false);
+	});
+
+	test("creates the session on first prompt and delegates", async () => {
+		const { factory, fake } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+		const events: AgentConnectionEvent[] = [];
+		conn.subscribe((event) => {
+			events.push(event);
+		});
+
+		await conn.prompt("do the thing");
+
+		expect(factory).toHaveBeenCalledTimes(1);
+		expect(fake.promptCalls).toEqual(["do the thing"]);
+		expect(conn.created).toBe(true);
+		expect(events.some((event) => event.type === "session_replaced")).toBe(true);
+	});
+
+	test("is single-flight when actions race the first creation", async () => {
+		const { factory, fake } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		await Promise.all([conn.prompt("a"), conn.prompt("b")]);
+
+		expect(factory).toHaveBeenCalledTimes(1);
+		expect(fake.promptCalls.sort()).toEqual(["a", "b"]);
+	});
+
+	test("pipes real connection events through after promotion", async () => {
+		const { fake, factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+		const events: AgentConnectionEvent[] = [];
+		conn.subscribe((event) => {
+			events.push(event);
+		});
+
+		await conn.prompt("go");
+		const replacedCount = events.filter((event) => event.type === "session_replaced").length;
+		fake.emit({ type: "session_status", recap: "working" });
+
+		expect(events.at(-1)).toEqual({ type: "session_status", recap: "working" });
+		// Promotion emits exactly one session_replaced; later events are not re-replays.
+		expect(replacedCount).toBe(1);
+	});
+
+	test("buffers onBeforeSessionInvalidate listeners until promotion", async () => {
+		const { fake, factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+		const listener = vi.fn();
+		conn.onBeforeSessionInvalidate(listener);
+
+		expect(fake.beforeInvalidate.size).toBe(0);
+		await conn.prompt("go");
+		expect(fake.beforeInvalidate.has(listener)).toBe(true);
+	});
+
+	test("dispose after creation tears down the real connection", async () => {
+		const { fake, factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+		const events: AgentConnectionEvent[] = [];
+		conn.subscribe((event) => {
+			events.push(event);
+		});
+		await conn.prompt("go");
+
+		await conn.dispose();
+		expect(fake.disposed).toBe(true);
+
+		const countAfterDispose = events.length;
+		fake.emit({ type: "session_status", recap: "late" });
+		expect(events.length).toBe(countAfterDispose);
+	});
+
+	test("read-only stop actions never create a session", async () => {
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		await conn.abort();
+		await conn.waitForIdle();
+		await conn.abortBash();
+		expect(await conn.cancelRlmChild("child")).toBe(false);
+
+		expect(factory).not.toHaveBeenCalled();
+		expect(conn.created).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -6,6 +6,7 @@ import {
 	findActiveDaemonSessionSummaryForInteractiveStartup,
 	findActiveDaemonSessionSummaryForSessionFile,
 	type InteractiveDaemonStartupDecision,
+	parseAgentsViewCommand,
 	parseDaemonRichTuiAttachShortcut,
 	resolveRuntimeSessionOptions,
 	shouldEnsureDaemonBeforeActiveSessionLookup,
@@ -65,22 +66,44 @@ describe("interactive startup routing", () => {
 });
 
 describe("daemon-backed interactive session manager routing", () => {
-	test("opens agents view for default daemon-backed interactive startup", () => {
+	test("opens a new chat (not the agents view) for default daemon-backed interactive startup", () => {
 		expect(
 			shouldOpenAgentsViewForDaemonInteractive({
 				useDaemonInteractive: true,
 				needsOnboarding: false,
 			}),
+		).toBe(false);
+	});
+
+	test("opens the agents view when explicitly requested via the agents/manage command", () => {
+		expect(
+			shouldOpenAgentsViewForDaemonInteractive({
+				useDaemonInteractive: true,
+				needsOnboarding: false,
+				explicitAgentsView: true,
+			}),
 		).toBe(true);
 	});
 
 	const directAttachCases: Array<[string, Parameters<typeof shouldOpenAgentsViewForDaemonInteractive>[0]]> = [
-		["non-daemon interactive path", { useDaemonInteractive: false, needsOnboarding: false }],
-		["pending onboarding", { useDaemonInteractive: true, needsOnboarding: true }],
-		["explicit session", { useDaemonInteractive: true, needsOnboarding: false, session: "active-1" }],
-		["resume picker", { useDaemonInteractive: true, needsOnboarding: false, resume: true }],
-		["continue recent", { useDaemonInteractive: true, needsOnboarding: false, continue: true }],
-		["fork", { useDaemonInteractive: true, needsOnboarding: false, fork: "source-session-id" }],
+		[
+			"non-daemon interactive path",
+			{ useDaemonInteractive: false, needsOnboarding: false, explicitAgentsView: true },
+		],
+		["pending onboarding", { useDaemonInteractive: true, needsOnboarding: true, explicitAgentsView: true }],
+		[
+			"explicit session",
+			{ useDaemonInteractive: true, needsOnboarding: false, explicitAgentsView: true, session: "active-1" },
+		],
+		["resume picker", { useDaemonInteractive: true, needsOnboarding: false, explicitAgentsView: true, resume: true }],
+		[
+			"continue recent",
+			{ useDaemonInteractive: true, needsOnboarding: false, explicitAgentsView: true, continue: true },
+		],
+		[
+			"fork",
+			{ useDaemonInteractive: true, needsOnboarding: false, explicitAgentsView: true, fork: "source-session-id" },
+		],
 	];
 
 	test.each(directAttachCases)("does not open agents view for %s", (_label, decision) => {
@@ -167,6 +190,33 @@ describe("daemon-backed interactive session manager routing", () => {
 				"/tmp/project/../project/session.jsonl",
 			),
 		).toBe(activeSummary);
+	});
+});
+
+describe("agents view command parsing", () => {
+	test("routes the agents verb to the agents view and strips it", () => {
+		expect(parseAgentsViewCommand(["agents"])).toEqual({ explicitAgentsView: true, args: [] });
+	});
+
+	test("treats manage as an alias for agents", () => {
+		expect(parseAgentsViewCommand(["manage", "--verbose"])).toEqual({
+			explicitAgentsView: true,
+			args: ["--verbose"],
+		});
+	});
+
+	test("leaves a normal message untouched", () => {
+		expect(parseAgentsViewCommand(["fix the agents view"])).toEqual({
+			explicitAgentsView: false,
+			args: ["fix the agents view"],
+		});
+	});
+
+	test("only matches the verb as the first token", () => {
+		expect(parseAgentsViewCommand(["--verbose", "agents"])).toEqual({
+			explicitAgentsView: false,
+			args: ["--verbose", "agents"],
+		});
 	});
 });
 


### PR DESCRIPTION
- running prime-agent with no arguments now drops you straight into a new chat with a focused input, instead of the agents list, which was confusing to land on.
- the agents view is still one left-arrow away from a session, and is now reachable directly with prime-agent agents (or the manage alias).
- abandoned new chats that never received a message are discarded from the daemon on exit so they don't pile up in the agents view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default interactive startup path and daemon session lifecycle (deferred create, kill-on-abandon); behavior is covered by new unit tests but affects when sessions exist and what appears in the agents view.
> 
> **Overview**
> **Default startup** now lands in an empty new chat instead of the agents list. The agents view opens only when you run `prime-agent agents` or `prime-agent manage` (parsed via `parseAgentsViewCommand`), or navigate left from a session.
> 
> For a fresh daemon-backed chat with no attach/resume flags, **`DeferredAgentConnection`** renders the UI from local seed data and creates the real daemon session only on the first mutating action (prompt, model cycle, bash, etc.). Quitting or backing out to agents without acting leaves **no daemon session** to clean up.
> 
> **Abandoned empty sessions** are trimmed: `discardEmptyDaemonSession` kills daemon sessions with no messages and no in-flight work (including `isBashRunning` on summaries), and the daemon’s `closeSessionOnce` skips persisting sleep state and deletes session files for empty killed sessions.
> 
> Help text documents the new default and the `agents` / `manage` commands. Routing tests reflect that the agents view is no longer the default daemon interactive entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797dec2558b149196a9b333f5df76bae3c4b88d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open prime-agent in a new chat by default instead of the agents view
> - Default daemon-backed interactive startup no longer creates a session immediately; a session is created only on the first user action via the new `DeferredAgentConnection` class in [deferred-agent-connection.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/205/files#diff-697fa86e9fe21981663f90b08e02bbacd5114eae4804d15bda274e418e839479).
> - The agents view now opens only when the user explicitly passes `agents` or `manage` as the first CLI argument, parsed by the new `parseAgentsViewCommand` function in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/205/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586).
> - Abandoned sessions (no messages, no activity) are automatically killed and their session files deleted via the new `discardEmptyDaemonSession` helper and updated `closeSessionOnce` logic in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/205/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450).
> - `SessionSummary` now includes `isBashRunning` to support the empty-session discard check.
> - Behavioral Change: the agents view no longer opens by default on startup; users must explicitly invoke `agents` or `manage` to reach it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 797dec2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->