### PR TITLE
upgrade the daemon when prime-agent updates

### DIFF
--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -122,7 +122,9 @@ export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean
 export type RunningDaemonProbe = { reachable: false } | { reachable: true; activeSessions?: SessionSummary[] };
 
 function isSessionBusy(summary: SessionSummary): boolean {
-	return summary.isStreaming || summary.isCompacting;
+	// pendingMessageCount covers queued steering/follow-ups, which live only in
+	// memory and would be lost if the daemon were stopped.
+	return summary.isStreaming || summary.isCompacting || summary.pendingMessageCount > 0;
 }
 
 export async function probeRunningDaemonSessions(socketPath: string): Promise<RunningDaemonProbe> {

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -97,23 +97,9 @@ export class StaleBusyDaemonError extends Error {
 	}
 }
 
-/**
- * Ask the daemon on socketPath to shut down and wait until it stops accepting
- * connections. Returns true once it is gone (including when nothing was running).
- */
-export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean> {
-	const client = new DaemonClient(socketPath);
-	try {
-		await client.connect(1000);
-		await client.request({ type: "shutdown" }).catch(() => undefined);
-	} catch {
-		// Connection failures mean the daemon is already gone.
-		return true;
-	} finally {
-		client.close();
-	}
-
-	const deadline = Date.now() + 5000;
+/** Poll until the daemon stops accepting connections. Returns false on timeout. */
+async function waitForDaemonGone(socketPath: string, timeoutMs = 5000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (!(await canConnectToDaemon(socketPath, 250))) {
 			return true;
@@ -121,6 +107,24 @@ export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean
 		await delay(25);
 	}
 	return false;
+}
+
+/**
+ * Ask the daemon on socketPath to shut down and wait until it stops accepting
+ * connections. A connect failure is not assumed to mean "gone" — only the poll
+ * confirms that, so a transient hiccup can't report a still-live daemon stopped.
+ */
+export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(1000);
+		await client.request({ type: "shutdown" }).catch(() => undefined);
+	} catch {
+		// Couldn't send shutdown; the poll below decides whether it actually stopped.
+	} finally {
+		client.close();
+	}
+	return waitForDaemonGone(socketPath);
 }
 
 /**
@@ -160,9 +164,11 @@ export async function probeRunningDaemonSessions(socketPath: string): Promise<Ru
  */
 async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
+	let connected = false;
 	let hasBusySessions = false;
 	try {
 		await client.connect(1000);
+		connected = true;
 		try {
 			const summaries = await listActiveDaemonSessionSummaries(client);
 			hasBusySessions = summaries.some(isSessionBusy);
@@ -171,11 +177,14 @@ async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean
 			hasBusySessions = true;
 		}
 	} catch {
-		return true;
+		// Couldn't reach it to inspect; don't send a blind shutdown, just verify below.
 	} finally {
 		client.close();
 	}
 
+	if (!connected) {
+		return waitForDaemonGone(socketPath);
+	}
 	if (hasBusySessions) {
 		return false;
 	}

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -83,28 +83,32 @@ export async function listActiveDaemonSessionSummaries(client: DaemonClient): Pr
 }
 
 /**
- * Stop a stale daemon so a current-version one can replace it, but only when it
- * has no live sessions. Returns true once the daemon is no longer accepting
- * connections.
+ * Thrown when a stale-version daemon is mid-turn and cannot be replaced without
+ * interrupting it. The message is user-facing: callers print it and exit rather
+ * than silently attaching a new client to an incompatible daemon.
  */
-async function shutdownStaleDaemonIfIdle(socketPath: string): Promise<boolean> {
+export class StaleBusyDaemonError extends Error {
+	constructor(socketPath: string) {
+		super(
+			`A previous prime-agent version's background daemon is still running an active turn on ${socketPath}, ` +
+				`and this version can't drive it. Wait for that turn to finish, or run "prime-agent daemon shutdown" to stop it and upgrade.`,
+		);
+		this.name = "StaleBusyDaemonError";
+	}
+}
+
+/**
+ * Ask the daemon on socketPath to shut down and wait until it stops accepting
+ * connections. Returns true once it is gone (including when nothing was running).
+ */
+export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
 	try {
 		await client.connect(1000);
-		let hasLiveSessions = true;
-		try {
-			const summaries = await listActiveDaemonSessionSummaries(client);
-			hasLiveSessions = summaries.some((summary) => summary.activeSessionId !== undefined);
-		} catch {
-			// If we cannot confirm the daemon is idle, leave it running rather than
-			// risking a shutdown of live sessions on a transient list failure.
-		}
-		if (hasLiveSessions) {
-			return false;
-		}
 		await client.request({ type: "shutdown" }).catch(() => undefined);
 	} catch {
 		// Connection failures mean the daemon is already gone.
+		return true;
 	} finally {
 		client.close();
 	}
@@ -119,18 +123,70 @@ async function shutdownStaleDaemonIfIdle(socketPath: string): Promise<boolean> {
 	return false;
 }
 
+/**
+ * Connect to the daemon on socketPath and return its active session summaries,
+ * or null when no daemon is reachable. Used by `update` to decide whether
+ * stopping the daemon would terminate live work.
+ */
+export async function getRunningDaemonActiveSessions(socketPath: string): Promise<SessionSummary[] | null> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(1000);
+	} catch {
+		client.close();
+		return null;
+	}
+	try {
+		const summaries = await listActiveDaemonSessionSummaries(client);
+		return summaries.filter((summary) => summary.activeSessionId !== undefined);
+	} catch {
+		return [];
+	} finally {
+		client.close();
+	}
+}
+
+/**
+ * Stop a stale daemon so a current-version one can replace it, but only when no
+ * session is mid-turn. Idle-but-loaded sessions persist to disk and reload on the
+ * fresh daemon, so only an actively streaming turn blocks the upgrade. Returns
+ * true once the daemon is no longer accepting connections.
+ */
+async function shutdownStaleDaemonIfNotStreaming(socketPath: string): Promise<boolean> {
+	const client = new DaemonClient(socketPath);
+	let hasStreamingSessions = false;
+	try {
+		await client.connect(1000);
+		try {
+			const summaries = await listActiveDaemonSessionSummaries(client);
+			hasStreamingSessions = summaries.some((summary) => summary.isStreaming);
+		} catch {
+			// If we cannot confirm the daemon is idle, treat it as busy rather than
+			// risking interrupting a live turn on a transient list failure.
+			hasStreamingSessions = true;
+		}
+	} catch {
+		// Connection failures mean the daemon is already gone.
+		return true;
+	} finally {
+		client.close();
+	}
+
+	if (hasStreamingSessions) {
+		return false;
+	}
+	return shutdownDaemonAndWait(socketPath);
+}
+
 async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promise<void> {
 	const probe = await probeDaemonVersion(socketPath);
 	if (probe === "current") {
 		return;
 	}
 	if (probe === "stale") {
-		const stopped = await shutdownStaleDaemonIfIdle(socketPath);
+		const stopped = await shutdownStaleDaemonIfNotStreaming(socketPath);
 		if (!stopped) {
-			console.error(
-				`Warning: the daemon on ${socketPath} runs a different prime-agent version but has active sessions, so it was left running. Run "prime-agent daemon shutdown" when its sessions are done to upgrade it.`,
-			);
-			return;
+			throw new StaleBusyDaemonError(socketPath);
 		}
 	}
 

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -124,23 +124,30 @@ export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean
 }
 
 /**
- * Connect to the daemon on socketPath and return its active session summaries,
- * or null when no daemon is reachable. Used by `update` to decide whether
- * stopping the daemon would terminate live work.
+ * Result of probing a daemon for `update`. `activeSessions` is undefined when the
+ * daemon is reachable but its sessions could not be listed, so callers must treat
+ * that as "possibly busy" rather than idle.
  */
-export async function getRunningDaemonActiveSessions(socketPath: string): Promise<SessionSummary[] | null> {
+export type RunningDaemonProbe = { reachable: false } | { reachable: true; activeSessions?: SessionSummary[] };
+
+/** A session whose work would be lost if the daemon were stopped now. */
+function isSessionBusy(summary: SessionSummary): boolean {
+	return summary.isStreaming || summary.isCompacting;
+}
+
+export async function probeRunningDaemonSessions(socketPath: string): Promise<RunningDaemonProbe> {
 	const client = new DaemonClient(socketPath);
 	try {
 		await client.connect(1000);
 	} catch {
 		client.close();
-		return null;
+		return { reachable: false };
 	}
 	try {
 		const summaries = await listActiveDaemonSessionSummaries(client);
-		return summaries.filter((summary) => summary.activeSessionId !== undefined);
+		return { reachable: true, activeSessions: summaries.filter((summary) => summary.activeSessionId !== undefined) };
 	} catch {
-		return [];
+		return { reachable: true };
 	} finally {
 		client.close();
 	}
@@ -148,31 +155,28 @@ export async function getRunningDaemonActiveSessions(socketPath: string): Promis
 
 /**
  * Stop a stale daemon so a current-version one can replace it, but only when no
- * session is mid-turn. Idle-but-loaded sessions persist to disk and reload on the
- * fresh daemon, so only an actively streaming turn blocks the upgrade. Returns
- * true once the daemon is no longer accepting connections.
+ * session is busy. Idle-but-loaded sessions persist to disk and reload on the
+ * fresh daemon. Returns true once the daemon is no longer accepting connections.
  */
-async function shutdownStaleDaemonIfNotStreaming(socketPath: string): Promise<boolean> {
+async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
-	let hasStreamingSessions = false;
+	let hasBusySessions = false;
 	try {
 		await client.connect(1000);
 		try {
 			const summaries = await listActiveDaemonSessionSummaries(client);
-			hasStreamingSessions = summaries.some((summary) => summary.isStreaming);
+			hasBusySessions = summaries.some(isSessionBusy);
 		} catch {
-			// If we cannot confirm the daemon is idle, treat it as busy rather than
-			// risking interrupting a live turn on a transient list failure.
-			hasStreamingSessions = true;
+			// Couldn't confirm idleness: treat as busy rather than risk interrupting work.
+			hasBusySessions = true;
 		}
 	} catch {
-		// Connection failures mean the daemon is already gone.
 		return true;
 	} finally {
 		client.close();
 	}
 
-	if (hasStreamingSessions) {
+	if (hasBusySessions) {
 		return false;
 	}
 	return shutdownDaemonAndWait(socketPath);
@@ -184,7 +188,7 @@ async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promi
 		return;
 	}
 	if (probe === "stale") {
-		const stopped = await shutdownStaleDaemonIfNotStreaming(socketPath);
+		const stopped = await shutdownStaleDaemonIfNotBusy(socketPath);
 		if (!stopped) {
 			throw new StaleBusyDaemonError(socketPath);
 		}

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -83,17 +83,17 @@ export async function listActiveDaemonSessionSummaries(client: DaemonClient): Pr
 }
 
 /**
- * Thrown when a stale-version daemon is mid-turn and cannot be replaced without
- * interrupting it. The message is user-facing: callers print it and exit rather
- * than silently attaching a new client to an incompatible daemon.
+ * Thrown when a stale-version daemon can't be replaced (it may be mid-turn, or it
+ * didn't stop in time). The message is user-facing: callers print it and exit
+ * rather than silently attaching a new client to an incompatible daemon.
  */
-export class StaleBusyDaemonError extends Error {
+export class StaleDaemonError extends Error {
 	constructor(socketPath: string) {
 		super(
-			`A previous prime-agent version's background daemon is still running an active turn on ${socketPath}, ` +
-				`and this version can't drive it. Wait for that turn to finish, or run "prime-agent daemon shutdown" to stop it and upgrade.`,
+			`A previous prime-agent version's background daemon on ${socketPath} couldn't be replaced — it may be mid-turn ` +
+				`or still shutting down, and this version can't drive it. Wait a moment and retry, or run "prime-agent daemon shutdown" to stop it and upgrade.`,
 		);
-		this.name = "StaleBusyDaemonError";
+		this.name = "StaleDaemonError";
 	}
 }
 
@@ -199,7 +199,7 @@ async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promi
 	if (probe === "stale") {
 		const stopped = await shutdownStaleDaemonIfNotBusy(socketPath);
 		if (!stopped) {
-			throw new StaleBusyDaemonError(socketPath);
+			throw new StaleDaemonError(socketPath);
 		}
 	}
 

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -82,11 +82,7 @@ export async function listActiveDaemonSessionSummaries(client: DaemonClient): Pr
 	return sessions;
 }
 
-/**
- * Thrown when a stale-version daemon can't be replaced (it may be mid-turn, or it
- * didn't stop in time). The message is user-facing: callers print it and exit
- * rather than silently attaching a new client to an incompatible daemon.
- */
+/** Thrown when a stale-version daemon can't be replaced. The message is user-facing. */
 export class StaleDaemonError extends Error {
 	constructor(socketPath: string) {
 		super(
@@ -97,7 +93,6 @@ export class StaleDaemonError extends Error {
 	}
 }
 
-/** Poll until the daemon stops accepting connections. Returns false on timeout. */
 async function waitForDaemonGone(socketPath: string, timeoutMs = 5000): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
@@ -109,32 +104,23 @@ async function waitForDaemonGone(socketPath: string, timeoutMs = 5000): Promise<
 	return false;
 }
 
-/**
- * Ask the daemon on socketPath to shut down and wait until it stops accepting
- * connections. A connect failure is not assumed to mean "gone" — only the poll
- * confirms that, so a transient hiccup can't report a still-live daemon stopped.
- */
 export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
 	try {
 		await client.connect(1000);
 		await client.request({ type: "shutdown" }).catch(() => undefined);
 	} catch {
-		// Couldn't send shutdown; the poll below decides whether it actually stopped.
+		// A connect failure isn't treated as "gone"; waitForDaemonGone is the source of truth.
 	} finally {
 		client.close();
 	}
 	return waitForDaemonGone(socketPath);
 }
 
-/**
- * Result of probing a daemon for `update`. `activeSessions` is undefined when the
- * daemon is reachable but its sessions could not be listed, so callers must treat
- * that as "possibly busy" rather than idle.
- */
+// activeSessions is undefined when the daemon is reachable but its sessions couldn't
+// be listed — callers must treat that as "possibly busy", not idle.
 export type RunningDaemonProbe = { reachable: false } | { reachable: true; activeSessions?: SessionSummary[] };
 
-/** A session whose work would be lost if the daemon were stopped now. */
 function isSessionBusy(summary: SessionSummary): boolean {
 	return summary.isStreaming || summary.isCompacting;
 }
@@ -157,11 +143,8 @@ export async function probeRunningDaemonSessions(socketPath: string): Promise<Ru
 	}
 }
 
-/**
- * Stop a stale daemon so a current-version one can replace it, but only when no
- * session is busy. Idle-but-loaded sessions persist to disk and reload on the
- * fresh daemon. Returns true once the daemon is no longer accepting connections.
- */
+// Idle-but-loaded sessions reload from disk on the fresh daemon, so only a busy
+// session blocks replacing a stale daemon.
 async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean> {
 	const client = new DaemonClient(socketPath);
 	let connected = false;

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -121,7 +121,7 @@ export async function shutdownDaemonAndWait(socketPath: string): Promise<boolean
 // be listed — callers must treat that as "possibly busy", not idle.
 export type RunningDaemonProbe = { reachable: false } | { reachable: true; activeSessions?: SessionSummary[] };
 
-function isSessionBusy(summary: SessionSummary): boolean {
+export function isSessionBusy(summary: SessionSummary): boolean {
 	// pendingMessageCount covers queued steering/follow-ups, which live only in
 	// memory and would be lost if the daemon were stopped.
 	return summary.isStreaming || summary.isCompacting || summary.pendingMessageCount > 0;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -348,10 +348,6 @@ async function promptConfirm(message: string): Promise<boolean> {
 	});
 }
 
-/**
- * Await daemon readiness, but turn an unreplaceable stale daemon into a clean
- * message and exit instead of attaching a new client to an incompatible daemon.
- */
 async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise<void> {
 	if (!daemonReady) {
 		return;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -16,7 +16,7 @@ import {
 	ensureInteractiveDaemonRunning,
 	isDaemonSessionSummary,
 	listActiveDaemonSessionSummaries,
-	StaleBusyDaemonError,
+	StaleDaemonError,
 } from "./cli/daemon-launch.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
@@ -349,8 +349,8 @@ async function promptConfirm(message: string): Promise<boolean> {
 }
 
 /**
- * Await daemon readiness, but turn a stale-busy daemon into a clean message and
- * exit instead of letting a new-version client attach to an incompatible daemon.
+ * Await daemon readiness, but turn an unreplaceable stale daemon into a clean
+ * message and exit instead of attaching a new client to an incompatible daemon.
  */
 async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise<void> {
 	if (!daemonReady) {
@@ -359,7 +359,7 @@ async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise
 	try {
 		await daemonReady;
 	} catch (error) {
-		if (error instanceof StaleBusyDaemonError) {
+		if (error instanceof StaleDaemonError) {
 			console.error(chalk.red(error.message));
 			process.exit(1);
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -16,6 +16,7 @@ import {
 	ensureInteractiveDaemonRunning,
 	isDaemonSessionSummary,
 	listActiveDaemonSessionSummaries,
+	StaleBusyDaemonError,
 } from "./cli/daemon-launch.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
@@ -345,6 +346,25 @@ async function promptConfirm(message: string): Promise<boolean> {
 			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
 		});
 	});
+}
+
+/**
+ * Await daemon readiness, but turn a stale-busy daemon into a clean message and
+ * exit instead of letting a new-version client attach to an incompatible daemon.
+ */
+async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise<void> {
+	if (!daemonReady) {
+		return;
+	}
+	try {
+		await daemonReady;
+	} catch (error) {
+		if (error instanceof StaleBusyDaemonError) {
+			console.error(chalk.red(error.message));
+			process.exit(1);
+		}
+		throw error;
+	}
 }
 
 function validateForkFlags(parsed: Args): void {
@@ -1045,7 +1065,7 @@ export async function main(args: string[], options?: MainOptions) {
 		session: parsed.session,
 	});
 	if (shouldLookupDaemonActiveSession && daemonReady) {
-		await daemonReady;
+		await awaitDaemonReady(daemonReady);
 	}
 	const activeDaemonSessionSummary =
 		shouldLookupDaemonActiveSession && parsed.session
@@ -1232,14 +1252,14 @@ export async function main(args: string[], options?: MainOptions) {
 				fork: parsed.fork,
 			})
 		) {
-			await daemonReady;
+			await awaitDaemonReady(daemonReady);
 			await preloadCodeHighlighter();
 			printTimings();
 			await launchAgentsView(true);
 			return;
 		}
 
-		await daemonReady;
+		await awaitDaemonReady(daemonReady);
 		const { connection: agentConnection, summary } = await createDaemonInteractiveConnection({
 			socketPath: daemonSocketPath,
 			config: defaultSessionConfig,

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -587,9 +587,8 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 					if (!(await confirmDaemonSessionLossBeforeUpdate(daemonProbe, options.force))) {
 						if (process.stdin.isTTY) {
 							console.log(chalk.dim("Update cancelled."));
-						} else {
-							process.exitCode = 1;
 						}
+						process.exitCode = 1;
 						return true;
 					}
 					try {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -4,7 +4,8 @@ import { spawn } from "child_process";
 import { selectConfig } from "./cli/config-selector.js";
 import {
 	ensureInteractiveDaemonRunning,
-	getRunningDaemonActiveSessions,
+	probeRunningDaemonSessions,
+	type RunningDaemonProbe,
 	shutdownDaemonAndWait,
 } from "./cli/daemon-launch.js";
 import {
@@ -368,37 +369,33 @@ function promptUpdateConfirm(message: string): Promise<boolean> {
  * Before a self-update, confirm with the user when stopping the daemon would
  * terminate live sessions. Returns false when the update should be aborted.
  */
-async function confirmDaemonSessionLossBeforeUpdate(
-	activeSessions: Awaited<ReturnType<typeof getRunningDaemonActiveSessions>>,
-	force: boolean,
-): Promise<boolean> {
-	const count = activeSessions?.length ?? 0;
-	if (count === 0) {
+async function confirmDaemonSessionLossBeforeUpdate(probe: RunningDaemonProbe, force: boolean): Promise<boolean> {
+	if (!probe.reachable || force) {
 		return true;
 	}
-	const noun = count === 1 ? "session" : "sessions";
-	const pronoun = count === 1 ? "it" : "them";
-	if (force) {
+	let detail: string;
+	if (probe.activeSessions === undefined) {
+		// Reachable but its sessions couldn't be listed: assume work may be lost.
+		detail =
+			"A running daemon's sessions could not be listed. Updating will stop the daemon and may terminate active sessions.";
+	} else if (probe.activeSessions.length === 0) {
 		return true;
+	} else {
+		const count = probe.activeSessions.length;
+		const noun = count === 1 ? "session" : "sessions";
+		const pronoun = count === 1 ? "it" : "them";
+		detail = `The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}.`;
 	}
 	if (!process.stdin.isTTY) {
-		console.error(
-			chalk.red(
-				`The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}. ` +
-					`Re-run with --force to proceed.`,
-			),
-		);
+		console.error(chalk.red(`${detail} Re-run with --force to proceed.`));
 		return false;
 	}
-	return promptUpdateConfirm(
-		`The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}. Continue?`,
-	);
+	return promptUpdateConfirm(`${detail} Continue?`);
 }
 
 /**
  * After a successful self-update, retire the now-stale daemon and start the new
- * version immediately so the next session attaches to a current daemon. No-op
- * when no daemon was running.
+ * version immediately so the next session attaches to a current daemon.
  */
 async function restartDaemonAfterSelfUpdate(socketPath: string, daemonWasRunning: boolean): Promise<void> {
 	if (!daemonWasRunning) {
@@ -591,11 +588,10 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						process.exitCode = 1;
 						return true;
 					}
-					// Inspect the running daemon before changing anything on disk: stopping
-					// it to upgrade will terminate any active sessions, so confirm first.
+					// Confirm before the install, since upgrading the daemon afterward stops it.
 					const daemonSocketPath = defaultDaemonSocketPath();
-					const activeSessions = await getRunningDaemonActiveSessions(daemonSocketPath);
-					if (!(await confirmDaemonSessionLossBeforeUpdate(activeSessions, options.force))) {
+					const daemonProbe = await probeRunningDaemonSessions(daemonSocketPath);
+					if (!(await confirmDaemonSessionLossBeforeUpdate(daemonProbe, options.force))) {
 						if (process.stdin.isTTY) {
 							console.log(chalk.dim("Update cancelled."));
 						} else {
@@ -613,7 +609,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						return true;
 					}
 					console.log(chalk.green(`Updated ${APP_NAME}`));
-					await restartDaemonAfterSelfUpdate(daemonSocketPath, activeSessions !== null);
+					await restartDaemonAfterSelfUpdate(daemonSocketPath, daemonProbe.reachable);
 				}
 				return true;
 			}

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -365,17 +365,14 @@ function promptUpdateConfirm(message: string): Promise<boolean> {
 	});
 }
 
-/**
- * Before a self-update, confirm with the user when stopping the daemon would
- * terminate live sessions. Returns false when the update should be aborted.
- */
+// Returns false when the update should be aborted to avoid terminating live sessions.
 async function confirmDaemonSessionLossBeforeUpdate(probe: RunningDaemonProbe, force: boolean): Promise<boolean> {
 	if (!probe.reachable || force) {
 		return true;
 	}
 	let detail: string;
 	if (probe.activeSessions === undefined) {
-		// Reachable but its sessions couldn't be listed: assume work may be lost.
+		// Reachable but couldn't list sessions: assume work may be lost.
 		detail =
 			"A running daemon's sessions could not be listed. Updating will stop the daemon and may terminate active sessions.";
 	} else if (probe.activeSessions.length === 0) {
@@ -393,10 +390,6 @@ async function confirmDaemonSessionLossBeforeUpdate(probe: RunningDaemonProbe, f
 	return promptUpdateConfirm(`${detail} Continue?`);
 }
 
-/**
- * After a successful self-update, retire the now-stale daemon and start the new
- * version immediately so the next session attaches to a current daemon.
- */
 async function restartDaemonAfterSelfUpdate(socketPath: string, daemonWasRunning: boolean): Promise<void> {
 	if (!daemonWasRunning) {
 		return;

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -4,6 +4,7 @@ import { spawn } from "child_process";
 import { selectConfig } from "./cli/config-selector.js";
 import {
 	ensureInteractiveDaemonRunning,
+	isSessionBusy,
 	probeRunningDaemonSessions,
 	type RunningDaemonProbe,
 	shutdownDaemonAndWait,
@@ -366,6 +367,8 @@ function promptUpdateConfirm(message: string): Promise<boolean> {
 }
 
 // Returns false when the update should be aborted to avoid terminating live sessions.
+// Only busy sessions (streaming, compacting, or pending messages) would lose work;
+// idle loaded sessions reload from disk on the fresh daemon.
 async function confirmDaemonSessionLossBeforeUpdate(probe: RunningDaemonProbe, force: boolean): Promise<boolean> {
 	if (!probe.reachable || force) {
 		return true;
@@ -375,13 +378,15 @@ async function confirmDaemonSessionLossBeforeUpdate(probe: RunningDaemonProbe, f
 		// Reachable but couldn't list sessions: assume work may be lost.
 		detail =
 			"A running daemon's sessions could not be listed. Updating will stop the daemon and may terminate active sessions.";
-	} else if (probe.activeSessions.length === 0) {
-		return true;
 	} else {
-		const count = probe.activeSessions.length;
+		const busySessions = probe.activeSessions.filter(isSessionBusy);
+		if (busySessions.length === 0) {
+			return true;
+		}
+		const count = busySessions.length;
 		const noun = count === 1 ? "session" : "sessions";
 		const pronoun = count === 1 ? "it" : "them";
-		detail = `The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}.`;
+		detail = `The running daemon has ${count} busy ${noun}. Updating will stop the daemon and terminate ${pronoun}.`;
 	}
 	if (!process.stdin.isTTY) {
 		console.error(chalk.red(`${detail} Re-run with --force to proceed.`));

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,6 +1,12 @@
+import { createInterface } from "node:readline";
 import chalk from "chalk";
 import { spawn } from "child_process";
 import { selectConfig } from "./cli/config-selector.js";
+import {
+	ensureInteractiveDaemonRunning,
+	getRunningDaemonActiveSessions,
+	shutdownDaemonAndWait,
+} from "./cli/daemon-launch.js";
 import {
 	APP_NAME,
 	CONFIG_DIR_NAME,
@@ -13,6 +19,7 @@ import {
 } from "./config.js";
 import { DefaultPackageManager } from "./core/package-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
+import { defaultDaemonSocketPath } from "./modes/daemon/daemon-socket.js";
 import { shouldUseWindowsShell } from "./utils/child-process.js";
 import { getLatestPiRelease, isNewerPackageVersion } from "./utils/version-check.js";
 
@@ -346,6 +353,76 @@ async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
 	}
 }
 
+function promptUpdateConfirm(message: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = createInterface({ input: process.stdin, output: process.stdout });
+		rl.question(`${message} [y/N] `, (answer) => {
+			rl.close();
+			const normalized = answer.trim().toLowerCase();
+			resolve(normalized === "y" || normalized === "yes");
+		});
+	});
+}
+
+/**
+ * Before a self-update, confirm with the user when stopping the daemon would
+ * terminate live sessions. Returns false when the update should be aborted.
+ */
+async function confirmDaemonSessionLossBeforeUpdate(
+	activeSessions: Awaited<ReturnType<typeof getRunningDaemonActiveSessions>>,
+	force: boolean,
+): Promise<boolean> {
+	const count = activeSessions?.length ?? 0;
+	if (count === 0) {
+		return true;
+	}
+	const noun = count === 1 ? "session" : "sessions";
+	const pronoun = count === 1 ? "it" : "them";
+	if (force) {
+		return true;
+	}
+	if (!process.stdin.isTTY) {
+		console.error(
+			chalk.red(
+				`The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}. ` +
+					`Re-run with --force to proceed.`,
+			),
+		);
+		return false;
+	}
+	return promptUpdateConfirm(
+		`The running daemon has ${count} active ${noun}. Updating will stop the daemon and terminate ${pronoun}. Continue?`,
+	);
+}
+
+/**
+ * After a successful self-update, retire the now-stale daemon and start the new
+ * version immediately so the next session attaches to a current daemon. No-op
+ * when no daemon was running.
+ */
+async function restartDaemonAfterSelfUpdate(socketPath: string, daemonWasRunning: boolean): Promise<void> {
+	if (!daemonWasRunning) {
+		return;
+	}
+	const stopped = await shutdownDaemonAndWait(socketPath);
+	if (!stopped) {
+		console.error(
+			chalk.yellow(`Warning: could not stop the old daemon on ${socketPath}; it will be replaced on next launch.`),
+		);
+		return;
+	}
+	try {
+		await ensureInteractiveDaemonRunning(socketPath);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(
+			chalk.yellow(
+				`Warning: updated, but could not relaunch the daemon (${message}); it will start on next launch.`,
+			),
+		);
+	}
+}
+
 export async function handleConfigCommand(args: string[]): Promise<boolean> {
 	if (args[0] !== "config") {
 		return false;
@@ -514,6 +591,18 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						process.exitCode = 1;
 						return true;
 					}
+					// Inspect the running daemon before changing anything on disk: stopping
+					// it to upgrade will terminate any active sessions, so confirm first.
+					const daemonSocketPath = defaultDaemonSocketPath();
+					const activeSessions = await getRunningDaemonActiveSessions(daemonSocketPath);
+					if (!(await confirmDaemonSessionLossBeforeUpdate(activeSessions, options.force))) {
+						if (process.stdin.isTTY) {
+							console.log(chalk.dim("Update cancelled."));
+						} else {
+							process.exitCode = 1;
+						}
+						return true;
+					}
 					try {
 						await runSelfUpdate(selfUpdateCommand);
 					} catch (error: unknown) {
@@ -524,6 +613,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						return true;
 					}
 					console.log(chalk.green(`Updated ${APP_NAME}`));
+					await restartDaemonAfterSelfUpdate(daemonSocketPath, activeSessions !== null);
 				}
 				return true;
 			}

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -3,11 +3,13 @@ import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getRunningDaemonActiveSessions, shutdownDaemonAndWait } from "../src/cli/daemon-launch.js";
+import { probeRunningDaemonSessions, shutdownDaemonAndWait } from "../src/cli/daemon-launch.js";
 
 interface FakeDaemonOptions {
 	/** Sessions returned for a `list` command. */
 	sessions?: Array<Record<string, unknown>>;
+	/** When true, the `list` command responds with a failure. */
+	failList?: boolean;
 	/** When false, the server ignores `shutdown` and stays up. */
 	respondToShutdown?: boolean;
 }
@@ -43,8 +45,9 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 						type: "response",
 						command: "list",
 						id: command.id,
-						success: true,
-						data: { sessions: options.sessions ?? [] },
+						...(options.failList
+							? { success: false, error: "list failed" }
+							: { success: true, data: { sessions: options.sessions ?? [] } }),
 					});
 				} else if (command.type === "shutdown") {
 					if (options.respondToShutdown === false) {
@@ -68,15 +71,15 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 	};
 }
 
-describe("getRunningDaemonActiveSessions", () => {
+describe("probeRunningDaemonSessions", () => {
 	const cleanups: Array<() => Promise<void>> = [];
 	afterEach(async () => {
 		await Promise.all(cleanups.splice(0).map((fn) => fn()));
 	});
 
-	it("returns null when no daemon is reachable", async () => {
-		const result = await getRunningDaemonActiveSessions(join(tmpdir(), "pa-launch-missing.sock"));
-		expect(result).toBeNull();
+	it("reports unreachable when no daemon is running", async () => {
+		const result = await probeRunningDaemonSessions(join(tmpdir(), "pa-launch-missing.sock"));
+		expect(result).toEqual({ reachable: false });
 	});
 
 	it("returns only sessions that have an activeSessionId", async () => {
@@ -88,14 +91,24 @@ describe("getRunningDaemonActiveSessions", () => {
 			],
 		});
 		cleanups.push(daemon.close);
-		const result = await getRunningDaemonActiveSessions(daemon.socketPath);
-		expect(result?.map((session) => session.activeSessionId)).toEqual(["a", "c"]);
+		const result = await probeRunningDaemonSessions(daemon.socketPath);
+		expect(result.reachable).toBe(true);
+		expect(result.reachable ? result.activeSessions?.map((session) => session.activeSessionId) : undefined).toEqual([
+			"a",
+			"c",
+		]);
 	});
 
-	it("returns an empty array when the daemon is reachable but idle", async () => {
+	it("returns an empty list when the daemon is reachable but idle", async () => {
 		const daemon = await startFakeDaemon({ sessions: [] });
 		cleanups.push(daemon.close);
-		expect(await getRunningDaemonActiveSessions(daemon.socketPath)).toEqual([]);
+		expect(await probeRunningDaemonSessions(daemon.socketPath)).toEqual({ reachable: true, activeSessions: [] });
+	});
+
+	it("leaves activeSessions undefined when reachable but the list fails", async () => {
+		const daemon = await startFakeDaemon({ failList: true });
+		cleanups.push(daemon.close);
+		expect(await probeRunningDaemonSessions(daemon.socketPath)).toEqual({ reachable: true });
 	});
 });
 

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getRunningDaemonActiveSessions, shutdownDaemonAndWait } from "../src/cli/daemon-launch.js";
+
+interface FakeDaemonOptions {
+	/** Sessions returned for a `list` command. */
+	sessions?: Array<Record<string, unknown>>;
+	/** When false, the server ignores `shutdown` and stays up. */
+	respondToShutdown?: boolean;
+}
+
+interface FakeDaemon {
+	socketPath: string;
+	close: () => Promise<void>;
+}
+
+function send(socket: Socket, message: unknown): void {
+	socket.write(`${JSON.stringify(message)}\n`);
+}
+
+async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDaemon> {
+	const dir = mkdtempSync(join(tmpdir(), "pa-launch-"));
+	const socketPath = join(dir, "d.sock");
+	const server: Server = createServer((socket) => {
+		send(socket, { type: "daemon_hello", socketPath, protocol: { name: "prime-agent-daemon", version: 1 } });
+		let buffer = "";
+		socket.on("data", (chunk) => {
+			buffer += chunk.toString();
+			let newline = buffer.indexOf("\n");
+			while (newline !== -1) {
+				const line = buffer.slice(0, newline);
+				buffer = buffer.slice(newline + 1);
+				newline = buffer.indexOf("\n");
+				if (!line.trim()) {
+					continue;
+				}
+				const command = JSON.parse(line) as { type: string; id: string };
+				if (command.type === "list") {
+					send(socket, {
+						type: "response",
+						command: "list",
+						id: command.id,
+						success: true,
+						data: { sessions: options.sessions ?? [] },
+					});
+				} else if (command.type === "shutdown") {
+					if (options.respondToShutdown === false) {
+						continue;
+					}
+					send(socket, { type: "response", command: "shutdown", id: command.id, success: true });
+					server.close();
+					socket.end();
+				}
+			}
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+	return {
+		socketPath,
+		close: () =>
+			new Promise<void>((resolve) => {
+				server.close(() => resolve());
+				rmSync(dir, { recursive: true, force: true });
+			}),
+	};
+}
+
+describe("getRunningDaemonActiveSessions", () => {
+	const cleanups: Array<() => Promise<void>> = [];
+	afterEach(async () => {
+		await Promise.all(cleanups.splice(0).map((fn) => fn()));
+	});
+
+	it("returns null when no daemon is reachable", async () => {
+		const result = await getRunningDaemonActiveSessions(join(tmpdir(), "pa-launch-missing.sock"));
+		expect(result).toBeNull();
+	});
+
+	it("returns only sessions that have an activeSessionId", async () => {
+		const daemon = await startFakeDaemon({
+			sessions: [
+				{ id: "a", activeSessionId: "a", isStreaming: true },
+				{ id: "b" }, // saved-only, no activeSessionId
+				{ id: "c", activeSessionId: "c", isStreaming: false },
+			],
+		});
+		cleanups.push(daemon.close);
+		const result = await getRunningDaemonActiveSessions(daemon.socketPath);
+		expect(result?.map((session) => session.activeSessionId)).toEqual(["a", "c"]);
+	});
+
+	it("returns an empty array when the daemon is reachable but idle", async () => {
+		const daemon = await startFakeDaemon({ sessions: [] });
+		cleanups.push(daemon.close);
+		expect(await getRunningDaemonActiveSessions(daemon.socketPath)).toEqual([]);
+	});
+});
+
+describe("shutdownDaemonAndWait", () => {
+	const cleanups: Array<() => Promise<void>> = [];
+	afterEach(async () => {
+		await Promise.all(cleanups.splice(0).map((fn) => fn()));
+	});
+
+	it("returns true immediately when no daemon is running", async () => {
+		expect(await shutdownDaemonAndWait(join(tmpdir(), "pa-launch-missing2.sock"))).toBe(true);
+	});
+
+	it("stops a running daemon and returns true", async () => {
+		const daemon = await startFakeDaemon({ sessions: [{ id: "a", activeSessionId: "a", isStreaming: false }] });
+		cleanups.push(daemon.close);
+		expect(await shutdownDaemonAndWait(daemon.socketPath)).toBe(true);
+	});
+});


### PR DESCRIPTION
- the long-lived daemon kept serving its original version after an update, so a new tui would attach to a stale daemon and appear stuck with no progress, no subagents, and aborts timing out.
- the update command now stops the running daemon and starts the new version immediately, asking to confirm first when active sessions would be terminated.
- launch only keeps a stale daemon when a turn is actively streaming; idle ones upgrade and reload from disk, and a stale-busy daemon now fails loud with a recovery path instead of silently attaching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon lifecycle during upgrades and interactive startup; wrong busy/idleness checks could interrupt work or block launches, but behavior is conservative when session listing fails.
> 
> **Overview**
> **Self-update** now probes the background daemon before installing a new `prime-agent` version. It prompts when **busy** sessions would be killed (streaming, compacting, or queued steering/follow-ups); non-TTY runs abort unless `--force`. After a successful install, it shuts down the old daemon and starts the current version when one was already running.
> 
> **Stale-daemon replacement** no longer blocks on any loaded session—only on **busy** ones; idle sessions can be replaced and reload from disk. When a stale daemon can’t be replaced, startup throws **`StaleDaemonError`** (red message, exit 1) instead of attaching with a warning.
> 
> Shared helpers (`probeRunningDaemonSessions`, `shutdownDaemonAndWait`, `isSessionBusy`) back both paths; vitest covers probe and shutdown against a fake socket server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82212d70edf0b02628dd3af9abf877227aaa765e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade the daemon automatically when `prime-agent` self-updates
> - Before a self-update, probes the running daemon for active sessions; aborts or prompts interactively if any sessions are streaming, compacting, or have pending messages (bypass with `--force`).
> - After a successful update, stops the old daemon via `shutdownDaemonAndWait` and relaunches it via `ensureInteractiveDaemonRunning`, emitting warnings on non-fatal failures.
> - Stale-daemon replacement during `ensureDaemonRunning` now throws `StaleDaemonError` (exiting with code 1) instead of printing a warning and continuing.
> - Adds `probeRunningDaemonSessions` and `isSessionBusy` helpers used by both the update and daemon-launch paths.
> - Risk: `package update` will now block or abort in non-TTY environments when busy sessions are detected, whereas it previously proceeded unconditionally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82212d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->