### PR TITLE
store git commit, ref, and repo url in session traces

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1694,6 +1694,8 @@ export class AgentSession {
 			this.sessionManager.recordGitStateIfChanged();
 			await this._extensionRunner.emit({ type: "agent_start" });
 		} else if (event.type === "agent_end") {
+			// Also capture at end of turn so commits made during the run (e.g. via a bash tool) land.
+			this.sessionManager.recordGitStateIfChanged();
 			await this._extensionRunner.emit({ type: "agent_end", messages: event.messages });
 		} else if (event.type === "turn_start") {
 			const extensionEvent: TurnStartEvent = {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1691,6 +1691,7 @@ export class AgentSession {
 	private async _emitExtensionEvent(event: AgentEvent): Promise<void> {
 		if (event.type === "agent_start") {
 			this._turnIndex = 0;
+			this.sessionManager.recordGitStateIfChanged();
 			await this._extensionRunner.emit({ type: "agent_start" });
 		} else if (event.type === "agent_end") {
 			await this._extensionRunner.emit({ type: "agent_end", messages: event.messages });

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -110,6 +110,28 @@ function readSessionHeader(sessionFile: string): SessionHeader | undefined {
 	}
 }
 
+/**
+ * Most recent git context in the trace: the last git_state entry, falling back to the
+ * session-start header. Keeps the indexing headers consistent with the session body across
+ * re-uploads after the repo moves to a new commit.
+ */
+function latestGitContext(body: string, header: SessionHeader): { repoUrl?: string; commit?: string } | undefined {
+	const lines = body.split("\n");
+	for (let i = lines.length - 1; i >= 0; i -= 1) {
+		const line = lines[i];
+		if (!line || !line.includes('"type":"git_state"')) continue;
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			if (isRecord(parsed) && parsed.type === "git_state" && isRecord(parsed.git)) {
+				return parsed.git as { repoUrl?: string; commit?: string };
+			}
+		} catch {
+			// Skip malformed lines.
+		}
+	}
+	return header.git;
+}
+
 function resolveParentSessionPath(sessionFile: string, parentSession: string): string {
 	return isAbsolute(parentSession) ? parentSession : resolve(dirname(sessionFile), parentSession);
 }
@@ -313,11 +335,12 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	if (traceContext.parentSessionId) {
 		headers["X-Parent-Session"] = traceContext.parentSessionId;
 	}
-	if (header.git?.repoUrl) {
-		headers["X-Git-Repo"] = header.git.repoUrl;
+	const git = latestGitContext(body, header);
+	if (git?.repoUrl) {
+		headers["X-Git-Repo"] = git.repoUrl;
 	}
-	if (header.git?.commit) {
-		headers["X-Git-Commit"] = header.git.commit;
+	if (git?.commit) {
+		headers["X-Git-Commit"] = git.commit;
 	}
 
 	if (!(await getAgentTracesEnabled(options))) {

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -111,23 +111,41 @@ function readSessionHeader(sessionFile: string): SessionHeader | undefined {
 }
 
 /**
- * Most recent git context in the trace: the last git_state entry, falling back to the
- * session-start header. Keeps the indexing headers consistent with the session body across
- * re-uploads after the repo moves to a new commit.
+ * Git context for the active trajectory: the nearest git_state walking the active leaf to
+ * root, falling back to the session-start header. The session is a branched tree, so this
+ * mirrors SessionManager's branch-aware dedup rather than taking the last git_state in file
+ * order (which could belong to a sibling branch). Keeps the indexing headers consistent with
+ * the session body across re-uploads after the repo moves to a new commit.
  */
-function latestGitContext(body: string, header: SessionHeader): { repoUrl?: string; commit?: string } | undefined {
-	const lines = body.split("\n");
-	for (let i = lines.length - 1; i >= 0; i -= 1) {
-		const line = lines[i];
-		if (!line || !line.includes('"type":"git_state"')) continue;
+export function activeGitContext(
+	body: string,
+	header: SessionHeader,
+): { repoUrl?: string; commit?: string } | undefined {
+	const byId = new Map<string, { parentId: string | null; type: string; git?: unknown }>();
+	let leafId: string | null = null;
+	for (const line of body.split("\n")) {
+		if (!line.trim()) continue;
+		let parsed: unknown;
 		try {
-			const parsed = JSON.parse(line) as unknown;
-			if (isRecord(parsed) && parsed.type === "git_state" && isRecord(parsed.git)) {
-				return parsed.git as { repoUrl?: string; commit?: string };
-			}
+			parsed = JSON.parse(line);
 		} catch {
-			// Skip malformed lines.
+			continue;
 		}
+		if (!isRecord(parsed) || parsed.type === "session" || typeof parsed.id !== "string") continue;
+		byId.set(parsed.id, {
+			parentId: typeof parsed.parentId === "string" ? parsed.parentId : null,
+			type: typeof parsed.type === "string" ? parsed.type : "",
+			git: parsed.git,
+		});
+		leafId = parsed.id;
+	}
+
+	let current = leafId ? byId.get(leafId) : undefined;
+	for (let depth = 0; current && depth < byId.size + 1; depth += 1) {
+		if (current.type === "git_state" && isRecord(current.git)) {
+			return current.git as { repoUrl?: string; commit?: string };
+		}
+		current = current.parentId ? byId.get(current.parentId) : undefined;
 	}
 	return header.git;
 }
@@ -335,7 +353,7 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	if (traceContext.parentSessionId) {
 		headers["X-Parent-Session"] = traceContext.parentSessionId;
 	}
-	const git = latestGitContext(body, header);
+	const git = activeGitContext(body, header);
 	if (git?.repoUrl) {
 		headers["X-Git-Repo"] = git.repoUrl;
 	}

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -110,11 +110,8 @@ function readSessionHeader(sessionFile: string): SessionHeader | undefined {
 	}
 }
 
-/**
- * Git context for the active trajectory, for the indexing headers. Sessions are a branched
- * tree, so this walks the active leaf to root (mirroring SessionManager) rather than taking
- * the last git_state in file order, which could belong to a sibling branch.
- */
+/** Active-branch git for the indexing headers: walk leaf to root, not the last git_state in
+ * file order (which may belong to a sibling branch). */
 export function activeGitContext(
 	body: string,
 	header: SessionHeader,

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -313,6 +313,12 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	if (traceContext.parentSessionId) {
 		headers["X-Parent-Session"] = traceContext.parentSessionId;
 	}
+	if (header.git?.repoUrl) {
+		headers["X-Git-Repo"] = header.git.repoUrl;
+	}
+	if (header.git?.commit) {
+		headers["X-Git-Commit"] = header.git.commit;
+	}
 
 	if (!(await getAgentTracesEnabled(options))) {
 		return { status: "disabled" };

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -111,11 +111,9 @@ function readSessionHeader(sessionFile: string): SessionHeader | undefined {
 }
 
 /**
- * Git context for the active trajectory: the nearest git_state walking the active leaf to
- * root, falling back to the session-start header. The session is a branched tree, so this
- * mirrors SessionManager's branch-aware dedup rather than taking the last git_state in file
- * order (which could belong to a sibling branch). Keeps the indexing headers consistent with
- * the session body across re-uploads after the repo moves to a new commit.
+ * Git context for the active trajectory, for the indexing headers. Sessions are a branched
+ * tree, so this walks the active leaf to root (mirroring SessionManager) rather than taking
+ * the last git_state in file order, which could belong to a sibling branch.
  */
 export function activeGitContext(
 	body: string,

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -1,51 +1,8 @@
 import { type ExecFileException, execFile, spawnSync } from "child_process";
-import { existsSync, type FSWatcher, readFileSync, statSync, unwatchFile, watchFile } from "fs";
-import { dirname, join, resolve } from "path";
+import { existsSync, type FSWatcher, readFileSync, unwatchFile, watchFile } from "fs";
+import { dirname, join } from "path";
 import { closeWatcher, FS_WATCH_RETRY_DELAY_MS, watchWithErrorHandler } from "../utils/fs-watch.js";
-
-type GitPaths = {
-	repoDir: string;
-	commonGitDir: string;
-	headPath: string;
-};
-
-/**
- * Find git metadata paths by walking up from cwd.
- * Handles both regular git repos (.git is a directory) and worktrees (.git is a file).
- */
-function findGitPaths(cwd: string): GitPaths | null {
-	let dir = cwd;
-	while (true) {
-		const gitPath = join(dir, ".git");
-		if (existsSync(gitPath)) {
-			try {
-				const stat = statSync(gitPath);
-				if (stat.isFile()) {
-					const content = readFileSync(gitPath, "utf8").trim();
-					if (content.startsWith("gitdir: ")) {
-						const gitDir = resolve(dir, content.slice(8).trim());
-						const headPath = join(gitDir, "HEAD");
-						if (!existsSync(headPath)) return null;
-						const commonDirPath = join(gitDir, "commondir");
-						const commonGitDir = existsSync(commonDirPath)
-							? resolve(gitDir, readFileSync(commonDirPath, "utf8").trim())
-							: gitDir;
-						return { repoDir: dir, commonGitDir, headPath };
-					}
-				} else if (stat.isDirectory()) {
-					const headPath = join(gitPath, "HEAD");
-					if (!existsSync(headPath)) return null;
-					return { repoDir: dir, commonGitDir: gitPath, headPath };
-				}
-			} catch {
-				return null;
-			}
-		}
-		const parent = dirname(dir);
-		if (parent === dir) return null;
-		dir = parent;
-	}
-}
+import { findGitPaths, type GitPaths } from "../utils/git.js";
 
 /** Ask git for the current branch. Returns null on detached HEAD or if git is unavailable. */
 function resolveBranchWithGitSync(repoDir: string): string | null {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -26,7 +26,6 @@ export interface SessionHeader {
 	timestamp: string;
 	cwd: string;
 	parentSession?: string;
-	/** Repo state at session start, for correlating the trajectory with code. */
 	git?: GitContext;
 }
 
@@ -155,10 +154,7 @@ export interface AgentStatusEntry extends SessionEntryBase {
 	status: AgentStatus;
 }
 
-/**
- * Records the repo state at a point in the session, appended when it changes.
- * Append-only; ignored by buildSessionContext (not sent to the LLM).
- */
+/** Append-only repo-state entry; ignored by buildSessionContext and other readers. */
 export interface GitStateEntry extends SessionEntryBase {
 	type: "git_state";
 	git: GitContext;
@@ -1212,12 +1208,7 @@ export class SessionManager {
 		return entry.id;
 	}
 
-	/**
-	 * Capture the repo state and append a git_state entry if it changed since the last
-	 * recorded state on the active branch (or the session-start snapshot in the header).
-	 * No-op when not persisting or outside a git repo. Returns the new entry id, or
-	 * undefined if unchanged.
-	 */
+	/** Appends a git_state entry only when the repo moved since the last state on the active branch. */
 	recordGitStateIfChanged(): string | undefined {
 		if (!this.persist) return undefined;
 		const git = captureGitContext(this.cwd);
@@ -1227,11 +1218,8 @@ export class SessionManager {
 		return this.appendGitState(git);
 	}
 
-	/**
-	 * Most recent git context on the active branch: the nearest git_state walking leaf to
-	 * root, falling back to the session-start snapshot. Branch-aware so dedup doesn't read a
-	 * sibling branch's state that happens to sit later in the file.
-	 */
+	/** Nearest git_state walking leaf to root, else the header snapshot. Walks the active
+	 * branch so dedup ignores a sibling branch's state sitting later in the file. */
 	private getActiveGitContext(): GitContext | undefined {
 		let current = this.leafId ? this.byId.get(this.leafId) : undefined;
 		while (current) {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1208,7 +1208,6 @@ export class SessionManager {
 		return entry.id;
 	}
 
-	/** Appends a git_state entry only when the repo moved since the last state on the active branch. */
 	recordGitStateIfChanged(): string | undefined {
 		if (!this.persist) return undefined;
 		const git = captureGitContext(this.cwd);
@@ -1218,8 +1217,7 @@ export class SessionManager {
 		return this.appendGitState(git);
 	}
 
-	/** Nearest git_state walking leaf to root, else the header snapshot. Walks the active
-	 * branch so dedup ignores a sibling branch's state sitting later in the file. */
+	/** Active-branch git: nearest git_state from leaf to root, else the header snapshot. */
 	private getActiveGitContext(): GitContext | undefined {
 		let current = this.leafId ? this.byId.get(this.leafId) : undefined;
 		while (current) {
@@ -1684,10 +1682,8 @@ export class SessionManager {
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
 
-		// git_state entries record commits made during the source session; the fork begins a new
-		// timeline whose start state is its header, so drop them (re-linking children) and let the
-		// fork record fresh ones as it runs. Otherwise trace uploads resolve git by walking the
-		// active path and would report the source repo instead of the fork's target context.
+		// Drop the source's git_state entries (re-linking children): they describe the source repo,
+		// so the fork would otherwise report the source's git instead of its own target context.
 		const droppedParent = new Map<string, string | null>();
 		for (const entry of sourceEntries) {
 			if (entry.type === "git_state") droppedParent.set(entry.id, entry.parentId);

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -7,6 +7,7 @@ import { dirname, join, resolve } from "path";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import { readFirstLineSync } from "../utils/file-lines.js";
+import { captureGitContext, type GitContext, gitContextsEqual } from "../utils/git.js";
 import {
 	type BashExecutionMessage,
 	type CustomMessage,
@@ -25,6 +26,8 @@ export interface SessionHeader {
 	timestamp: string;
 	cwd: string;
 	parentSession?: string;
+	/** Repo state at session start, for correlating the trajectory with code. */
+	git?: GitContext;
 }
 
 export interface NewSessionOptions {
@@ -153,6 +156,15 @@ export interface AgentStatusEntry extends SessionEntryBase {
 }
 
 /**
+ * Records the repo state at a point in the session, appended when it changes.
+ * Append-only; ignored by buildSessionContext (not sent to the LLM).
+ */
+export interface GitStateEntry extends SessionEntryBase {
+	type: "git_state";
+	git: GitContext;
+}
+
+/**
  * Custom message entry for extensions to inject messages into LLM context.
  * Use customType to identify your extension's entries.
  *
@@ -185,7 +197,8 @@ export type SessionEntry =
 	| LabelEntry
 	| SessionInfoEntry
 	| SessionStateEntry
-	| AgentStatusEntry;
+	| AgentStatusEntry
+	| GitStateEntry;
 
 /** Raw file entry (includes header) */
 export type FileEntry = SessionHeader | SessionEntry;
@@ -821,6 +834,7 @@ export class SessionManager {
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
 	private persistListeners = new Set<SessionPersistListener>();
+	private lastGitContext: GitContext | null = null;
 
 	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
 		this.cwd = cwd;
@@ -888,6 +902,7 @@ export class SessionManager {
 
 		this.sessionId = sessionId;
 		const timestamp = new Date().toISOString();
+		const git = this.persist ? (captureGitContext(this.cwd) ?? undefined) : undefined;
 		const header: SessionHeader = {
 			type: "session",
 			version: CURRENT_SESSION_VERSION,
@@ -895,7 +910,9 @@ export class SessionManager {
 			timestamp,
 			cwd: this.cwd,
 			parentSession: options?.parentSession,
+			git,
 		};
+		this.lastGitContext = git ?? null;
 		this.fileEntries = [header];
 		this.byId.clear();
 		this.labelsById.clear();
@@ -914,10 +931,17 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
+		this.lastGitContext = null;
 		for (const entry of this.fileEntries) {
-			if (entry.type === "session") continue;
+			if (entry.type === "session") {
+				this.lastGitContext = entry.git ?? null;
+				continue;
+			}
 			this.byId.set(entry.id, entry);
 			this.leafId = entry.id;
+			if (entry.type === "git_state") {
+				this.lastGitContext = entry.git;
+			}
 			if (entry.type === "label") {
 				if (entry.label) {
 					this.labelsById.set(entry.targetId, entry.label);
@@ -1182,6 +1206,33 @@ export class SessionManager {
 		};
 		this._appendEntry(entry);
 		return entry.id;
+	}
+
+	/** Append a git state entry as child of current leaf, then advance leaf. Returns entry id. */
+	appendGitState(git: GitContext): string {
+		const entry: GitStateEntry = {
+			type: "git_state",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			git,
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Capture the repo state and append a git_state entry if it changed since the last
+	 * recorded state (including the session-start snapshot in the header). No-op when not
+	 * persisting or outside a git repo. Returns the new entry id, or undefined if unchanged.
+	 */
+	recordGitStateIfChanged(): string | undefined {
+		if (!this.persist) return undefined;
+		const git = captureGitContext(this.cwd);
+		if (!git) return undefined;
+		if (this.lastGitContext && gitContextsEqual(this.lastGitContext, git)) return undefined;
+		this.lastGitContext = git;
+		return this.appendGitState(git);
 	}
 
 	/** Get the latest agent status from the most recent agent_status entry, if any. */

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1518,6 +1518,7 @@ export class SessionManager {
 			timestamp,
 			cwd: this.cwd,
 			parentSession: this.persist ? previousSessionFile : undefined,
+			git: this.persist ? (captureGitContext(this.cwd) ?? undefined) : undefined,
 		};
 
 		// Collect labels for entries in the path

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1680,6 +1680,7 @@ export class SessionManager {
 			timestamp,
 			cwd: targetCwd,
 			parentSession: sourcePath,
+			git: captureGitContext(targetCwd) ?? undefined,
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -834,7 +834,6 @@ export class SessionManager {
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
 	private persistListeners = new Set<SessionPersistListener>();
-	private lastGitContext: GitContext | null = null;
 
 	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
 		this.cwd = cwd;
@@ -912,7 +911,6 @@ export class SessionManager {
 			parentSession: options?.parentSession,
 			git,
 		};
-		this.lastGitContext = git ?? null;
 		this.fileEntries = [header];
 		this.byId.clear();
 		this.labelsById.clear();
@@ -931,17 +929,10 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
-		this.lastGitContext = null;
 		for (const entry of this.fileEntries) {
-			if (entry.type === "session") {
-				this.lastGitContext = entry.git ?? null;
-				continue;
-			}
+			if (entry.type === "session") continue;
 			this.byId.set(entry.id, entry);
 			this.leafId = entry.id;
-			if (entry.type === "git_state") {
-				this.lastGitContext = entry.git;
-			}
 			if (entry.type === "label") {
 				if (entry.label) {
 					this.labelsById.set(entry.targetId, entry.label);
@@ -1223,16 +1214,32 @@ export class SessionManager {
 
 	/**
 	 * Capture the repo state and append a git_state entry if it changed since the last
-	 * recorded state (including the session-start snapshot in the header). No-op when not
-	 * persisting or outside a git repo. Returns the new entry id, or undefined if unchanged.
+	 * recorded state on the active branch (or the session-start snapshot in the header).
+	 * No-op when not persisting or outside a git repo. Returns the new entry id, or
+	 * undefined if unchanged.
 	 */
 	recordGitStateIfChanged(): string | undefined {
 		if (!this.persist) return undefined;
 		const git = captureGitContext(this.cwd);
 		if (!git) return undefined;
-		if (this.lastGitContext && gitContextsEqual(this.lastGitContext, git)) return undefined;
-		this.lastGitContext = git;
+		const last = this.getActiveGitContext();
+		if (last && gitContextsEqual(last, git)) return undefined;
 		return this.appendGitState(git);
+	}
+
+	/**
+	 * Most recent git context on the active branch: the nearest git_state walking leaf to
+	 * root, falling back to the session-start snapshot. Branch-aware so dedup doesn't read a
+	 * sibling branch's state that happens to sit later in the file.
+	 */
+	private getActiveGitContext(): GitContext | undefined {
+		let current = this.leafId ? this.byId.get(this.leafId) : undefined;
+		while (current) {
+			if (current.type === "git_state") return current.git;
+			current = current.parentId ? this.byId.get(current.parentId) : undefined;
+		}
+		const header = this.fileEntries[0];
+		return header?.type === "session" ? header.git : undefined;
 	}
 
 	/** Get the latest agent status from the most recent agent_status entry, if any. */

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1684,11 +1684,24 @@ export class SessionManager {
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
 
-		// Copy all non-header entries from source
+		// git_state entries record commits made during the source session; the fork begins a new
+		// timeline whose start state is its header, so drop them (re-linking children) and let the
+		// fork record fresh ones as it runs. Otherwise trace uploads resolve git by walking the
+		// active path and would report the source repo instead of the fork's target context.
+		const droppedParent = new Map<string, string | null>();
 		for (const entry of sourceEntries) {
-			if (entry.type !== "session") {
-				appendFileSync(newSessionFile, `${JSON.stringify(entry)}\n`);
-			}
+			if (entry.type === "git_state") droppedParent.set(entry.id, entry.parentId);
+		}
+		const liveParent = (parentId: string | null): string | null => {
+			let pid = parentId;
+			while (pid !== null && droppedParent.has(pid)) pid = droppedParent.get(pid) ?? null;
+			return pid;
+		};
+		for (const entry of sourceEntries) {
+			if (entry.type === "session" || entry.type === "git_state") continue;
+			const parentId = liveParent(entry.parentId);
+			const out = parentId === entry.parentId ? entry : { ...entry, parentId };
+			appendFileSync(newSessionFile, `${JSON.stringify(out)}\n`);
 		}
 
 		return new SessionManager(targetCwd, dir, newSessionFile, true);

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -185,6 +185,15 @@ export interface AgentConnectionAgentStatusEntry extends AgentConnectionSessionE
 	};
 }
 
+export interface AgentConnectionGitStateEntry extends AgentConnectionSessionEntryBase {
+	type: "git_state";
+	git: {
+		repoUrl?: string;
+		commit?: string;
+		branch?: string;
+	};
+}
+
 export type AgentConnectionSessionEntry =
 	| AgentConnectionSessionMessageEntry
 	| AgentConnectionThinkingLevelChangeEntry
@@ -197,7 +206,8 @@ export type AgentConnectionSessionEntry =
 	| AgentConnectionLabelEntry
 	| AgentConnectionSessionInfoEntry
 	| AgentConnectionSessionStateEntry
-	| AgentConnectionAgentStatusEntry;
+	| AgentConnectionAgentStatusEntry
+	| AgentConnectionGitStateEntry;
 
 export interface AgentConnectionSessionTreeNode {
 	entry: AgentConnectionSessionEntry;

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -238,16 +238,10 @@ export function findGitPaths(cwd: string): GitPaths | null {
 	}
 }
 
-/**
- * Snapshot of the repo state behind a session/turn, for correlating trajectories with code.
- * Fields are independently optional so partial reads still produce useful data.
- */
 export interface GitContext {
-	/** Normalized clone URL of the `origin` remote, if any. */
 	repoUrl?: string;
-	/** Full SHA of HEAD. */
 	commit?: string;
-	/** Current branch, or undefined on detached HEAD. */
+	/** undefined on detached HEAD */
 	branch?: string;
 }
 
@@ -265,10 +259,7 @@ function runGit(cwd: string, args: string[]): string | null {
 	return result.stdout.trim() || null;
 }
 
-/**
- * Capture the repo's git state by asking git directly.
- * Returns null when cwd is not inside a git repo.
- */
+/** Returns null when cwd is not inside a git repo. */
 export function captureGitContext(cwd: string): GitContext | null {
 	const commit = runGit(cwd, ["rev-parse", "HEAD"]);
 	const branch = runGit(cwd, ["branch", "--show-current"]);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import hostedGitInfo from "hosted-git-info";
@@ -254,91 +255,29 @@ export function gitContextsEqual(a: GitContext, b: GitContext): boolean {
 	return a.repoUrl === b.repoUrl && a.commit === b.commit && a.branch === b.branch;
 }
 
-function readGitHead(headPath: string): { branch?: string; ref?: string; commit?: string } | null {
-	let content: string;
-	try {
-		content = readFileSync(headPath, "utf8").trim();
-	} catch {
-		return null;
-	}
-	if (content.startsWith("ref:")) {
-		const ref = content.slice(4).trim();
-		const branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : undefined;
-		return { ref, branch };
-	}
-	if (/^[0-9a-f]{40,64}$/.test(content)) {
-		return { commit: content };
-	}
-	return null;
-}
-
-function resolveRef(commonGitDir: string, ref: string, depth = 0): string | undefined {
-	if (depth > 8) return undefined;
-	try {
-		const content = readFileSync(join(commonGitDir, ref), "utf8").trim();
-		if (content.startsWith("ref:")) return resolveRef(commonGitDir, content.slice(4).trim(), depth + 1);
-		if (content) return content;
-	} catch {
-		// Loose ref absent; fall back to packed-refs.
-	}
-	try {
-		const packed = readFileSync(join(commonGitDir, "packed-refs"), "utf8");
-		for (const line of packed.split("\n")) {
-			if (!line || line.startsWith("#") || line.startsWith("^")) continue;
-			const sep = line.indexOf(" ");
-			if (sep < 0) continue;
-			if (line.slice(sep + 1).trim() === ref) return line.slice(0, sep).trim();
-		}
-	} catch {
-		// No packed-refs.
-	}
-	return undefined;
-}
-
-function readOriginUrl(commonGitDir: string): string | undefined {
-	let content: string;
-	try {
-		content = readFileSync(join(commonGitDir, "config"), "utf8");
-	} catch {
-		return undefined;
-	}
-	let inOrigin = false;
-	for (const raw of content.split("\n")) {
-		const line = raw.trim();
-		if (line.startsWith("[")) {
-			inOrigin = /^\[remote\s+"origin"\]$/.test(line);
-			continue;
-		}
-		if (inOrigin) {
-			const match = line.match(/^url\s*=\s*(.+)$/);
-			if (match?.[1]) {
-				const url = match[1].trim();
-				return parseGitUrl(url)?.repo ?? url;
-			}
-		}
-	}
-	return undefined;
+function runGit(cwd: string, args: string[]): string | null {
+	const result = spawnSync("git", ["--no-optional-locks", ...args], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	});
+	if (result.status !== 0 || typeof result.stdout !== "string") return null;
+	return result.stdout.trim() || null;
 }
 
 /**
- * Read the repo's git state from .git without spawning git.
- * Returns null when cwd is not inside a git repo or nothing useful could be read.
+ * Capture the repo's git state by asking git directly.
+ * Returns null when cwd is not inside a git repo.
  */
 export function captureGitContext(cwd: string): GitContext | null {
-	const paths = findGitPaths(cwd);
-	if (!paths) return null;
-
-	const head = readGitHead(paths.headPath);
-	if (!head) return null;
-
-	const commit = head.commit ?? (head.ref ? resolveRef(paths.commonGitDir, head.ref) : undefined);
-	const repoUrl = readOriginUrl(paths.commonGitDir);
+	const commit = runGit(cwd, ["rev-parse", "HEAD"]);
+	const branch = runGit(cwd, ["branch", "--show-current"]);
+	const remote = runGit(cwd, ["remote", "get-url", "origin"]);
+	if (!commit && !branch && !remote) return null;
 
 	const context: GitContext = {};
-	if (repoUrl) context.repoUrl = repoUrl;
+	if (remote) context.repoUrl = parseGitUrl(remote)?.repo ?? remote;
 	if (commit) context.commit = commit;
-	if (head.branch) context.branch = head.branch;
-
-	if (!context.repoUrl && !context.commit && !context.branch) return null;
+	if (branch) context.branch = branch;
 	return context;
 }

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -241,7 +241,6 @@ export function findGitPaths(cwd: string): GitPaths | null {
 export interface GitContext {
 	repoUrl?: string;
 	commit?: string;
-	/** undefined on detached HEAD */
 	branch?: string;
 }
 
@@ -259,7 +258,6 @@ function runGit(cwd: string, args: string[]): string | null {
 	return result.stdout.trim() || null;
 }
 
-/** Returns null when cwd is not inside a git repo. */
 export function captureGitContext(cwd: string): GitContext | null {
 	const commit = runGit(cwd, ["rev-parse", "HEAD"]);
 	const branch = runGit(cwd, ["branch", "--show-current"]);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import hostedGitInfo from "hosted-git-info";
 
 /**
@@ -189,4 +191,154 @@ export function parseGitUrl(source: string): GitSource | null {
 	}
 
 	return parseGenericGitUrl(url);
+}
+
+export type GitPaths = {
+	repoDir: string;
+	commonGitDir: string;
+	headPath: string;
+};
+
+/**
+ * Find git metadata paths by walking up from cwd.
+ * Handles both regular git repos (.git is a directory) and worktrees (.git is a file).
+ */
+export function findGitPaths(cwd: string): GitPaths | null {
+	let dir = cwd;
+	while (true) {
+		const gitPath = join(dir, ".git");
+		if (existsSync(gitPath)) {
+			try {
+				const stat = statSync(gitPath);
+				if (stat.isFile()) {
+					const content = readFileSync(gitPath, "utf8").trim();
+					if (content.startsWith("gitdir: ")) {
+						const gitDir = resolve(dir, content.slice(8).trim());
+						const headPath = join(gitDir, "HEAD");
+						if (!existsSync(headPath)) return null;
+						const commonDirPath = join(gitDir, "commondir");
+						const commonGitDir = existsSync(commonDirPath)
+							? resolve(gitDir, readFileSync(commonDirPath, "utf8").trim())
+							: gitDir;
+						return { repoDir: dir, commonGitDir, headPath };
+					}
+				} else if (stat.isDirectory()) {
+					const headPath = join(gitPath, "HEAD");
+					if (!existsSync(headPath)) return null;
+					return { repoDir: dir, commonGitDir: gitPath, headPath };
+				}
+			} catch {
+				return null;
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Snapshot of the repo state behind a session/turn, for correlating trajectories with code.
+ * Fields are independently optional so partial reads still produce useful data.
+ */
+export interface GitContext {
+	/** Normalized clone URL of the `origin` remote, if any. */
+	repoUrl?: string;
+	/** Full SHA of HEAD. */
+	commit?: string;
+	/** Current branch, or undefined on detached HEAD. */
+	branch?: string;
+}
+
+export function gitContextsEqual(a: GitContext, b: GitContext): boolean {
+	return a.repoUrl === b.repoUrl && a.commit === b.commit && a.branch === b.branch;
+}
+
+function readGitHead(headPath: string): { branch?: string; ref?: string; commit?: string } | null {
+	let content: string;
+	try {
+		content = readFileSync(headPath, "utf8").trim();
+	} catch {
+		return null;
+	}
+	if (content.startsWith("ref:")) {
+		const ref = content.slice(4).trim();
+		const branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : undefined;
+		return { ref, branch };
+	}
+	if (/^[0-9a-f]{40,64}$/.test(content)) {
+		return { commit: content };
+	}
+	return null;
+}
+
+function resolveRef(commonGitDir: string, ref: string, depth = 0): string | undefined {
+	if (depth > 8) return undefined;
+	try {
+		const content = readFileSync(join(commonGitDir, ref), "utf8").trim();
+		if (content.startsWith("ref:")) return resolveRef(commonGitDir, content.slice(4).trim(), depth + 1);
+		if (content) return content;
+	} catch {
+		// Loose ref absent; fall back to packed-refs.
+	}
+	try {
+		const packed = readFileSync(join(commonGitDir, "packed-refs"), "utf8");
+		for (const line of packed.split("\n")) {
+			if (!line || line.startsWith("#") || line.startsWith("^")) continue;
+			const sep = line.indexOf(" ");
+			if (sep < 0) continue;
+			if (line.slice(sep + 1).trim() === ref) return line.slice(0, sep).trim();
+		}
+	} catch {
+		// No packed-refs.
+	}
+	return undefined;
+}
+
+function readOriginUrl(commonGitDir: string): string | undefined {
+	let content: string;
+	try {
+		content = readFileSync(join(commonGitDir, "config"), "utf8");
+	} catch {
+		return undefined;
+	}
+	let inOrigin = false;
+	for (const raw of content.split("\n")) {
+		const line = raw.trim();
+		if (line.startsWith("[")) {
+			inOrigin = /^\[remote\s+"origin"\]$/.test(line);
+			continue;
+		}
+		if (inOrigin) {
+			const match = line.match(/^url\s*=\s*(.+)$/);
+			if (match?.[1]) {
+				const url = match[1].trim();
+				return parseGitUrl(url)?.repo ?? url;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Read the repo's git state from .git without spawning git.
+ * Returns null when cwd is not inside a git repo or nothing useful could be read.
+ */
+export function captureGitContext(cwd: string): GitContext | null {
+	const paths = findGitPaths(cwd);
+	if (!paths) return null;
+
+	const head = readGitHead(paths.headPath);
+	if (!head) return null;
+
+	const commit = head.commit ?? (head.ref ? resolveRef(paths.commonGitDir, head.ref) : undefined);
+	const repoUrl = readOriginUrl(paths.commonGitDir);
+
+	const context: GitContext = {};
+	if (repoUrl) context.repoUrl = repoUrl;
+	if (commit) context.commit = commit;
+	if (head.branch) context.branch = head.branch;
+
+	if (!context.repoUrl && !context.commit && !context.branch) return null;
+	return context;
 }

--- a/packages/coding-agent/test/agent-traces-git-context.test.ts
+++ b/packages/coding-agent/test/agent-traces-git-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { activeGitContext } from "../src/core/agent-traces.js";
+import type { SessionHeader } from "../src/core/session-manager.js";
+
+const HEADER: SessionHeader = {
+	type: "session",
+	version: 3,
+	id: "h",
+	timestamp: "2026-01-01T00:00:00.000Z",
+	cwd: "/repo",
+	git: { repoUrl: "https://github.com/acme/widgets.git", commit: "aaa", branch: "main" },
+};
+
+function jsonl(...entries: object[]): string {
+	return [HEADER, ...entries].map((e) => JSON.stringify(e)).join("\n");
+}
+
+describe("activeGitContext", () => {
+	it("returns the header git when there are no git_state entries", () => {
+		const body = jsonl({ type: "message", id: "m1", parentId: null, timestamp: "t", message: {} });
+		expect(activeGitContext(body, HEADER)).toEqual(HEADER.git);
+	});
+
+	it("returns the most recent git_state on a linear path", () => {
+		const body = jsonl(
+			{ type: "message", id: "m1", parentId: null, timestamp: "t", message: {} },
+			{ type: "git_state", id: "g1", parentId: "m1", timestamp: "t", git: { commit: "bbb", branch: "main" } },
+			{ type: "message", id: "m2", parentId: "g1", timestamp: "t", message: {} },
+		);
+		expect(activeGitContext(body, HEADER)).toEqual({ commit: "bbb", branch: "main" });
+	});
+
+	it("ignores a git_state on a sibling branch and uses the active leaf's path", () => {
+		// m1 -> g1(bbb) is one branch; m1 -> m2 -> g2(ccc) is the active branch (g2 is last in file).
+		const body = jsonl(
+			{ type: "message", id: "m1", parentId: null, timestamp: "t", message: {} },
+			{ type: "git_state", id: "g1", parentId: "m1", timestamp: "t", git: { commit: "bbb", branch: "old" } },
+			{ type: "message", id: "m2", parentId: "m1", timestamp: "t", message: {} },
+			{ type: "git_state", id: "g2", parentId: "m2", timestamp: "t", git: { commit: "ccc", branch: "feat" } },
+		);
+		expect(activeGitContext(body, HEADER)).toEqual({ commit: "ccc", branch: "feat" });
+	});
+
+	it("falls back to the header when the active path has no git_state", () => {
+		// Active leaf m2 descends only from the header; g1 lives on an abandoned sibling.
+		const body = jsonl(
+			{ type: "message", id: "m1", parentId: null, timestamp: "t", message: {} },
+			{ type: "git_state", id: "g1", parentId: "m1", timestamp: "t", git: { commit: "bbb", branch: "old" } },
+			{ type: "message", id: "m2", parentId: null, timestamp: "t", message: {} },
+		);
+		expect(activeGitContext(body, HEADER)).toEqual(HEADER.git);
+	});
+});

--- a/packages/coding-agent/test/git-context.test.ts
+++ b/packages/coding-agent/test/git-context.test.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureGitContext, gitContextsEqual } from "../src/utils/git.js";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const SHA2 = "89abcdef0123456789abcdef0123456789abcdef";
+
+function writeGitFile(gitDir: string, relPath: string, content: string): void {
+	const full = join(gitDir, relPath);
+	mkdirSync(join(full, ".."), { recursive: true });
+	writeFileSync(full, content);
+}
+
+describe("captureGitContext", () => {
+	let dir: string;
+	let gitDir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "git-context-"));
+		gitDir = join(dir, ".git");
+		mkdirSync(gitDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("reads branch, commit, and normalized repo url from loose refs", () => {
+		writeGitFile(gitDir, "HEAD", "ref: refs/heads/main\n");
+		writeGitFile(gitDir, "refs/heads/main", `${SHA}\n`);
+		writeGitFile(gitDir, "config", '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n');
+
+		expect(captureGitContext(dir)).toEqual({
+			branch: "main",
+			commit: SHA,
+			repoUrl: "https://github.com/acme/widgets.git",
+		});
+	});
+
+	it("resolves a commit from packed-refs when no loose ref exists", () => {
+		writeGitFile(gitDir, "HEAD", "ref: refs/heads/feature\n");
+		writeGitFile(gitDir, "packed-refs", `# pack-refs with: peeled fully-peeled sorted\n${SHA2} refs/heads/feature\n`);
+
+		expect(captureGitContext(dir)).toMatchObject({ branch: "feature", commit: SHA2 });
+	});
+
+	it("reports a detached HEAD as a commit with no branch", () => {
+		writeGitFile(gitDir, "HEAD", `${SHA}\n`);
+
+		const ctx = captureGitContext(dir);
+		expect(ctx?.commit).toBe(SHA);
+		expect(ctx?.branch).toBeUndefined();
+	});
+
+	it("omits repo url when there is no origin remote", () => {
+		writeGitFile(gitDir, "HEAD", "ref: refs/heads/main\n");
+		writeGitFile(gitDir, "refs/heads/main", `${SHA}\n`);
+
+		const ctx = captureGitContext(dir);
+		expect(ctx?.repoUrl).toBeUndefined();
+		expect(ctx?.commit).toBe(SHA);
+	});
+
+	it("keeps an ssh remote url verbatim when it cannot be normalized", () => {
+		writeGitFile(gitDir, "HEAD", `${SHA}\n`);
+		writeGitFile(gitDir, "config", '[remote "origin"]\n\turl = git@github.com:acme/widgets.git\n');
+
+		expect(captureGitContext(dir)?.repoUrl).toBe("git@github.com:acme/widgets.git");
+	});
+
+	it("returns null outside a git repo", () => {
+		expect(captureGitContext(dir)).toBeNull();
+	});
+});
+
+describe("gitContextsEqual", () => {
+	it("compares all fields", () => {
+		expect(gitContextsEqual({ commit: SHA, branch: "main" }, { commit: SHA, branch: "main" })).toBe(true);
+		expect(gitContextsEqual({ commit: SHA, branch: "main" }, { commit: SHA2, branch: "main" })).toBe(false);
+		expect(gitContextsEqual({ commit: SHA }, { commit: SHA, branch: "main" })).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/git-context.test.ts
+++ b/packages/coding-agent/test/git-context.test.ts
@@ -1,71 +1,73 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureGitContext, gitContextsEqual } from "../src/utils/git.js";
 
-const SHA = "0123456789abcdef0123456789abcdef01234567";
-const SHA2 = "89abcdef0123456789abcdef0123456789abcdef";
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
 
-function writeGitFile(gitDir: string, relPath: string, content: string): void {
-	const full = join(gitDir, relPath);
-	mkdirSync(join(full, ".."), { recursive: true });
-	writeFileSync(full, content);
+function initRepo(dir: string): void {
+	git(dir, "init", "-q", "-b", "main");
+	git(dir, "config", "user.email", "t@t.co");
+	git(dir, "config", "user.name", "t");
+}
+
+function commit(dir: string, message: string): string {
+	writeFileSync(join(dir, "file.txt"), `${message}\n`);
+	git(dir, "add", "-A");
+	git(dir, "commit", "-q", "-m", message);
+	return git(dir, "rev-parse", "HEAD");
 }
 
 describe("captureGitContext", () => {
 	let dir: string;
-	let gitDir: string;
 
 	beforeEach(() => {
 		dir = mkdtempSync(join(tmpdir(), "git-context-"));
-		gitDir = join(dir, ".git");
-		mkdirSync(gitDir, { recursive: true });
 	});
 
 	afterEach(() => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	it("reads branch, commit, and normalized repo url from loose refs", () => {
-		writeGitFile(gitDir, "HEAD", "ref: refs/heads/main\n");
-		writeGitFile(gitDir, "refs/heads/main", `${SHA}\n`);
-		writeGitFile(gitDir, "config", '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n');
+	it("reads branch, commit, and normalized repo url", () => {
+		initRepo(dir);
+		git(dir, "remote", "add", "origin", "https://github.com/acme/widgets.git");
+		const sha = commit(dir, "init");
 
 		expect(captureGitContext(dir)).toEqual({
 			branch: "main",
-			commit: SHA,
+			commit: sha,
 			repoUrl: "https://github.com/acme/widgets.git",
 		});
 	});
 
-	it("resolves a commit from packed-refs when no loose ref exists", () => {
-		writeGitFile(gitDir, "HEAD", "ref: refs/heads/feature\n");
-		writeGitFile(gitDir, "packed-refs", `# pack-refs with: peeled fully-peeled sorted\n${SHA2} refs/heads/feature\n`);
-
-		expect(captureGitContext(dir)).toMatchObject({ branch: "feature", commit: SHA2 });
-	});
-
 	it("reports a detached HEAD as a commit with no branch", () => {
-		writeGitFile(gitDir, "HEAD", `${SHA}\n`);
+		initRepo(dir);
+		const sha = commit(dir, "init");
+		git(dir, "checkout", "-q", sha);
 
 		const ctx = captureGitContext(dir);
-		expect(ctx?.commit).toBe(SHA);
+		expect(ctx?.commit).toBe(sha);
 		expect(ctx?.branch).toBeUndefined();
 	});
 
 	it("omits repo url when there is no origin remote", () => {
-		writeGitFile(gitDir, "HEAD", "ref: refs/heads/main\n");
-		writeGitFile(gitDir, "refs/heads/main", `${SHA}\n`);
+		initRepo(dir);
+		const sha = commit(dir, "init");
 
 		const ctx = captureGitContext(dir);
 		expect(ctx?.repoUrl).toBeUndefined();
-		expect(ctx?.commit).toBe(SHA);
+		expect(ctx?.commit).toBe(sha);
 	});
 
 	it("keeps an ssh remote url verbatim when it cannot be normalized", () => {
-		writeGitFile(gitDir, "HEAD", `${SHA}\n`);
-		writeGitFile(gitDir, "config", '[remote "origin"]\n\turl = git@github.com:acme/widgets.git\n');
+		initRepo(dir);
+		git(dir, "remote", "add", "origin", "git@github.com:acme/widgets.git");
+		commit(dir, "init");
 
 		expect(captureGitContext(dir)?.repoUrl).toBe("git@github.com:acme/widgets.git");
 	});
@@ -76,6 +78,9 @@ describe("captureGitContext", () => {
 });
 
 describe("gitContextsEqual", () => {
+	const SHA = "0123456789abcdef0123456789abcdef01234567";
+	const SHA2 = "89abcdef0123456789abcdef0123456789abcdef";
+
 	it("compares all fields", () => {
 		expect(gitContextsEqual({ commit: SHA, branch: "main" }, { commit: SHA, branch: "main" })).toBe(true);
 		expect(gitContextsEqual({ commit: SHA, branch: "main" }, { commit: SHA2, branch: "main" })).toBe(false);

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -91,12 +91,19 @@ describe("SessionManager git state", () => {
 		});
 	});
 
-	it("captures git context when forking a session file", () => {
+	it("captures target git context when forking and drops the source's git_state", () => {
 		const sourcePath = join(sessionDir, "source.jsonl");
 		writeFileSync(
 			sourcePath,
 			`${[
-				JSON.stringify({ type: "session", version: 3, id: "src", timestamp: "t", cwd: "/old" }),
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "src",
+					timestamp: "t",
+					cwd: "/old",
+					git: { repoUrl: "https://github.com/acme/source.git", commit: "sourcesha", branch: "main" },
+				}),
 				JSON.stringify({
 					type: "message",
 					id: "m1",
@@ -104,15 +111,35 @@ describe("SessionManager git state", () => {
 					timestamp: "t",
 					message: { role: "user", content: "hi", timestamp: 1 },
 				}),
+				JSON.stringify({
+					type: "git_state",
+					id: "g1",
+					parentId: "m1",
+					timestamp: "t",
+					git: { repoUrl: "https://github.com/acme/source.git", commit: "sourcesha", branch: "main" },
+				}),
+				JSON.stringify({
+					type: "message",
+					id: "m2",
+					parentId: "g1",
+					timestamp: "t",
+					message: { role: "user", content: "more", timestamp: 2 },
+				}),
 			].join("\n")}\n`,
 		);
 
 		const forked = SessionManager.forkFrom(sourcePath, repoDir, sessionDir);
+
+		// Header carries the target repo git, not the source's.
 		expect(forked.getHeader()?.git).toEqual({
 			branch: "main",
 			commit: firstSha,
 			repoUrl: "https://github.com/acme/widgets.git",
 		});
+		// Source git_state is dropped and its child re-linked to keep the tree intact.
+		const entries = forked.getEntries();
+		expect(entries.some((e) => e.type === "git_state")).toBe(false);
+		expect(entries.find((e) => e.id === "m2")?.parentId).toBe("m1");
 	});
 
 	it("keeps git_state entries out of the LLM context", () => {

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -91,6 +91,30 @@ describe("SessionManager git state", () => {
 		});
 	});
 
+	it("captures git context when forking a session file", () => {
+		const sourcePath = join(sessionDir, "source.jsonl");
+		writeFileSync(
+			sourcePath,
+			`${[
+				JSON.stringify({ type: "session", version: 3, id: "src", timestamp: "t", cwd: "/old" }),
+				JSON.stringify({
+					type: "message",
+					id: "m1",
+					parentId: null,
+					timestamp: "t",
+					message: { role: "user", content: "hi", timestamp: 1 },
+				}),
+			].join("\n")}\n`,
+		);
+
+		const forked = SessionManager.forkFrom(sourcePath, repoDir, sessionDir);
+		expect(forked.getHeader()?.git).toEqual({
+			branch: "main",
+			commit: firstSha,
+			repoUrl: "https://github.com/acme/widgets.git",
+		});
+	});
+
 	it("keeps git_state entries out of the LLM context", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
 		commit(repoDir, "second");

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -65,6 +65,21 @@ describe("SessionManager git state", () => {
 		expect(sm.recordGitStateIfChanged()).toBeUndefined();
 	});
 
+	it("re-records git state on a branch that lacks it on its active path", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		const msgId = sm.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 });
+		commit(repoDir, "second");
+
+		// On the main path this appends git_state(secondSha).
+		expect(sm.recordGitStateIfChanged()).toBeDefined();
+
+		// Navigate to before that entry: this branch's nearest git context is the header (firstSha),
+		// so even though the file already holds a git_state for the live commit, a new one must be
+		// appended on this path rather than deduped away.
+		sm.branch(msgId);
+		expect(sm.recordGitStateIfChanged()).toBeDefined();
+	});
+
 	it("keeps git_state entries out of the LLM context", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
 		commit(repoDir, "second");

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const SHA2 = "89abcdef0123456789abcdef0123456789abcdef";
+
+function setHead(gitDir: string, sha: string): void {
+	writeFileSync(join(gitDir, "refs", "heads", "main"), `${sha}\n`);
+}
+
+describe("SessionManager git state", () => {
+	let repoDir: string;
+	let gitDir: string;
+	let sessionDir: string;
+
+	beforeEach(() => {
+		repoDir = mkdtempSync(join(tmpdir(), "sm-git-repo-"));
+		sessionDir = mkdtempSync(join(tmpdir(), "sm-git-sessions-"));
+		gitDir = join(repoDir, ".git");
+		mkdirSync(join(gitDir, "refs", "heads"), { recursive: true });
+		writeFileSync(join(gitDir, "HEAD"), "ref: refs/heads/main\n");
+		writeFileSync(join(gitDir, "config"), '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n');
+		setHead(gitDir, SHA);
+	});
+
+	afterEach(() => {
+		rmSync(repoDir, { recursive: true, force: true });
+		rmSync(sessionDir, { recursive: true, force: true });
+	});
+
+	it("captures git context in the session header", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		expect(sm.getHeader()?.git).toEqual({
+			branch: "main",
+			commit: SHA,
+			repoUrl: "https://github.com/acme/widgets.git",
+		});
+	});
+
+	it("does not record a git_state entry when nothing changed", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		expect(sm.recordGitStateIfChanged()).toBeUndefined();
+		expect(sm.getEntries().some((e) => e.type === "git_state")).toBe(false);
+	});
+
+	it("records a git_state entry when the commit changes", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		setHead(gitDir, SHA2);
+
+		const id = sm.recordGitStateIfChanged();
+		expect(id).toBeDefined();
+
+		const entry = sm.getEntries().find((e) => e.type === "git_state");
+		expect(entry).toMatchObject({ type: "git_state", git: { commit: SHA2 } });
+
+		// A second call with no further change is a no-op.
+		expect(sm.recordGitStateIfChanged()).toBeUndefined();
+	});
+
+	it("keeps git_state entries out of the LLM context", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		setHead(gitDir, SHA2);
+		sm.recordGitStateIfChanged();
+		expect(sm.buildSessionContext().messages).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -80,6 +80,17 @@ describe("SessionManager git state", () => {
 		expect(sm.recordGitStateIfChanged()).toBeDefined();
 	});
 
+	it("captures git context in a forked session header", () => {
+		const sm = SessionManager.create(repoDir, sessionDir);
+		const msgId = sm.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 });
+		sm.createBranchedSession(msgId);
+		expect(sm.getHeader()?.git).toEqual({
+			branch: "main",
+			commit: firstSha,
+			repoUrl: "https://github.com/acme/widgets.git",
+		});
+	});
+
 	it("keeps git_state entries out of the LLM context", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
 		commit(repoDir, "second");

--- a/packages/coding-agent/test/session-manager-git-state.test.ts
+++ b/packages/coding-agent/test/session-manager-git-state.test.ts
@@ -1,29 +1,34 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SessionManager } from "../src/core/session-manager.js";
 
-const SHA = "0123456789abcdef0123456789abcdef01234567";
-const SHA2 = "89abcdef0123456789abcdef0123456789abcdef";
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
 
-function setHead(gitDir: string, sha: string): void {
-	writeFileSync(join(gitDir, "refs", "heads", "main"), `${sha}\n`);
+function commit(dir: string, message: string): string {
+	writeFileSync(join(dir, "file.txt"), `${message}\n`);
+	git(dir, "add", "-A");
+	git(dir, "commit", "-q", "-m", message);
+	return git(dir, "rev-parse", "HEAD");
 }
 
 describe("SessionManager git state", () => {
 	let repoDir: string;
-	let gitDir: string;
 	let sessionDir: string;
+	let firstSha: string;
 
 	beforeEach(() => {
 		repoDir = mkdtempSync(join(tmpdir(), "sm-git-repo-"));
 		sessionDir = mkdtempSync(join(tmpdir(), "sm-git-sessions-"));
-		gitDir = join(repoDir, ".git");
-		mkdirSync(join(gitDir, "refs", "heads"), { recursive: true });
-		writeFileSync(join(gitDir, "HEAD"), "ref: refs/heads/main\n");
-		writeFileSync(join(gitDir, "config"), '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n');
-		setHead(gitDir, SHA);
+		git(repoDir, "init", "-q", "-b", "main");
+		git(repoDir, "config", "user.email", "t@t.co");
+		git(repoDir, "config", "user.name", "t");
+		git(repoDir, "remote", "add", "origin", "https://github.com/acme/widgets.git");
+		firstSha = commit(repoDir, "init");
 	});
 
 	afterEach(() => {
@@ -35,7 +40,7 @@ describe("SessionManager git state", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
 		expect(sm.getHeader()?.git).toEqual({
 			branch: "main",
-			commit: SHA,
+			commit: firstSha,
 			repoUrl: "https://github.com/acme/widgets.git",
 		});
 	});
@@ -48,13 +53,13 @@ describe("SessionManager git state", () => {
 
 	it("records a git_state entry when the commit changes", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
-		setHead(gitDir, SHA2);
+		const secondSha = commit(repoDir, "second");
 
 		const id = sm.recordGitStateIfChanged();
 		expect(id).toBeDefined();
 
 		const entry = sm.getEntries().find((e) => e.type === "git_state");
-		expect(entry).toMatchObject({ type: "git_state", git: { commit: SHA2 } });
+		expect(entry).toMatchObject({ type: "git_state", git: { commit: secondSha } });
 
 		// A second call with no further change is a no-op.
 		expect(sm.recordGitStateIfChanged()).toBeUndefined();
@@ -62,7 +67,7 @@ describe("SessionManager git state", () => {
 
 	it("keeps git_state entries out of the LLM context", () => {
 		const sm = SessionManager.create(repoDir, sessionDir);
-		setHead(gitDir, SHA2);
+		commit(repoDir, "second");
 		sm.recordGitStateIfChanged();
 		expect(sm.buildSessionContext().messages).toHaveLength(0);
 	});


### PR DESCRIPTION
- trace transcripts had no link to code state, so stored trajectories couldn't be correlated with the commit they ran against.
- the session now records repo url, commit, and branch read directly from the .git directory, captured at session start and again per user turn whenever it changes.
- commit and repo url are also sent as upload headers so traces can be indexed and curated by code state later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Append-only session metadata and optional trace HTTP headers; no auth or LLM context changes. Fork/parent re-linking is the main behavioral edge case and is covered by tests.
> 
> **Overview**
> **Sessions and trace uploads now tie agent runs to repository state** so stored trajectories can be correlated with the code they ran against.
> 
> New **`git` snapshots** land on the session header when a session is created, branched, or forked (`captureGitContext` in `utils/git.js`: origin URL, `HEAD` commit, current branch). **`git_state` append-only entries** record later changes along the **active branch** only; `recordGitStateIfChanged()` runs at **agent start and agent end** (e.g. commits from bash during a turn). Entries are **not** fed into LLM context.
> 
> **Agent trace uploads** use `activeGitContext` to walk from the session leaf to the nearest `git_state` (not a sibling branch’s last line in the file), then set **`X-Git-Repo`** and **`X-Git-Commit`** on PUT. **Forking** drops source `git_state` rows and re-links parents so the fork header reflects the **target** cwd’s git.
> 
> `findGitPaths` moves from the footer provider into shared **`utils/git.js`**; agent-connection types gain `git_state`. Vitest covers capture, session behavior, and `activeGitContext` branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6d3dee25244be6c77833e02a7a8ce69ff396c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store git commit, ref, and repo URL in session traces
> - Adds a `GitContext` type (repo URL, commit, branch) captured via local git commands in [utils/git.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/208/files#diff-1ce936ff3923877aeedfe1c5195be624868f02c78320d07b7ebdf5c632caed1b) and stored on session headers at creation time.
> - Introduces `git_state` entries appended to the session tree when repo state changes at agent start/end, with deduplication to avoid redundant entries.
> - Adds `activeGitContext` in [agent-traces.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/208/files#diff-80860403dee6901cec0476cf83c00961de058f140b3d95dc92ff3d43c50e64d2) that walks the leaf-to-root path to find the nearest `git_state`, falling back to the header snapshot, and passes `X-Git-Repo` and `X-Git-Commit` headers on trace uploads.
> - When forking a session, `git_state` entries from the source are dropped and children rewired to preserve tree structure; the forked header reflects the target repo's git context.
> - `git_state` entries are excluded from LLM context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac6d3de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->