### PR TITLE
Remove single built-in tool prompt limit

### DIFF
--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -85,9 +85,5 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push("", IPYTHON_CONTROL_PROMPT);
 	}
 
-	if (activeTools.length > 0) {
-		parts.push("", "Call at most one built-in tool per turn.");
-	}
-
 	return parts.join("\n");
 }

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -82,8 +82,6 @@ describe("buildRlmPrompt", () => {
 				"RLM-native call contract for refined entries: installed Python skills are called from IPython as `await <skill_import>(...)` with keyword arguments, or as `<skill_import> ...` from shell when a CLI exists. Harness skill entries are Python REPL skills with an explicit Python `reference` and `arguments` contract. Harness subagent entries are reusable delegation specs; invoke them by turning the spec into a concise task prompt and calling `await rlm('sub-task')`, or `await asyncio.gather(rlm('task1'), rlm('task2'))` for independent parallel subagents. Do not invent non-native wrappers such as `call_skill(...)`, `run_subagent(...)`, or named subagent registries.",
 				"",
 				"Treat harness refinement as a small, evidence-backed update after observing a repeated failure or reusable tactic: diagnose the issue, update the smallest relevant harness component, validate on the next action, then record the outcome. Do not rewrite the whole harness when a focused memory, skill, prompt note, or subagent spec is enough.",
-				"",
-				"Call at most one built-in tool per turn.",
 			].join("\n"),
 		);
 	});
@@ -367,7 +365,7 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("run it through that project's own environment");
 		expect(prompt).not.toContain("!cd build && make");
 		expect(prompt).not.toContain("out = !cmd");
-		expect(prompt).toContain("Call at most one built-in tool per turn.");
+		expect(prompt).not.toContain("Call at most one built-in tool per turn.");
 		expect(prompt).not.toContain("# IPython Kernel Guidance");
 		expect(prompt).not.toContain("Available tools:");
 		expect(prompt).not.toContain("## Worked example:");
@@ -430,9 +428,10 @@ describe("buildSystemPrompt", () => {
 			cwd: "/repo",
 		});
 
-		expect(prompt.indexOf("Call at most one built-in tool per turn.")).toBeLessThan(
+		expect(prompt.indexOf("Treat harness refinement as a small, evidence-backed update")).toBeLessThan(
 			prompt.indexOf("extra instruction"),
 		);
+		expect(prompt).not.toContain("Call at most one built-in tool per turn.");
 	});
 
 	test("project context files are appended", () => {


### PR DESCRIPTION
## Summary
- remove the RLM prompt sentence that tells agents to call at most one built-in tool per turn
- update system prompt tests to assert the restriction is absent while preserving append-order coverage

## Tests
- npm --workspace @earendil-works/pi-coding-agent test -- test/system-prompt.test.ts
- npm run check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 'Call at most one built-in tool per turn.' restriction from RLM prompt
> Removes the conditional block in `buildRlmPrompt` ([rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/210/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29)) that appended a single built-in tool per turn guidance line when any built-in tools were active. Tests in [system-prompt.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/210/files#diff-3721ab2b979502a9191810d71b1d8900a19e2dc6ffd7b783a3e9de2ba4a39c12) are updated to assert the line is no longer present in the prompt output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b360e24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change with no runtime enforcement removed; may slightly change agent tool-calling behavior but no security or data-path impact.
> 
> **Overview**
> Removes the RLM system prompt line **"Call at most one built-in tool per turn."** from `buildRlmPrompt` in `rlm.ts`. That text was appended whenever any built-in tools were active; agents are no longer instructed to limit themselves to one built-in tool call per turn.
> 
> Tests in `system-prompt.test.ts` are updated to expect the sentence is absent from full prompt snapshots and harness prompts, while still checking that appended system prompt content comes after the RLM harness body (using harness refinement text as the anchor instead of the removed line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b360e24df24f61031292edd4e4b10ecedc9bf148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->