### PR TITLE
bump version to 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.1.7",
+				"@earendil-works/pi-coding-agent": "^0.1.8",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5913,10 +5913,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.1.7",
+				"@earendil-works/pi-ai": "^0.1.8",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5943,7 +5943,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5985,13 +5985,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.1.7",
-				"@earendil-works/pi-ai": "^0.1.7",
-				"@earendil-works/pi-tui": "^0.1.7",
+				"@earendil-works/pi-agent-core": "^0.1.8",
+				"@earendil-works/pi-ai": "^0.1.8",
+				"@earendil-works/pi-tui": "^0.1.8",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6134,7 +6134,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.1.7",
+		"@earendil-works/pi-coding-agent": "^0.1.8",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.1.7",
+		"@earendil-works/pi-ai": "^0.1.8",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.1.7",
-		"@earendil-works/pi-ai": "^0.1.7",
-		"@earendil-works/pi-tui": "^0.1.7",
+		"@earendil-works/pi-agent-core": "^0.1.8",
+		"@earendil-works/pi-ai": "^0.1.8",
+		"@earendil-works/pi-tui": "^0.1.8",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the root package and published packages (agent, ai, coding-agent, tui) from 0.1.7 to 0.1.8.
- syncs internal dependency ranges and refreshes the lockfile to match.
- version-only patch bump, no functional changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no runtime, auth, or logic changes in the diff.
> 
> **Overview**
> Bumps the **prime-agent** monorepo and published `@earendil-works/pi-*` packages from **0.1.7** to **0.1.8**, including root `package.json`, workspace `package.json` files (`pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`), and internal dependency ranges (`^0.1.8`). **`package-lock.json`** is refreshed so lockfile workspace entries match the new versions.
> 
> There are **no application or library source changes** in this diff—only version metadata for a coordinated patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877879234ea6a6ace257d148c5ce84d6d0680e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all package versions from 0.1.7 to 0.1.8
> Updates the version field in all workspace packages and aligns internal dependency ranges to `^0.1.8`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8778792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->