### PR TITLE
Fix daemon OOM when listing saved sessions

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -809,7 +809,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 				if (looksLikeMessageEntry(line)) {
 					messageCount++;
 					const summary = extractOversizedMessageSummary(line);
-					if (typeof summary.timestamp === "number") {
+					if (typeof summary.timestamp === "number" && (summary.role === "user" || summary.role === "assistant")) {
 						lastActivityTime = Math.max(lastActivityTime ?? 0, summary.timestamp);
 					}
 					if (summary.role === "user" && !firstMessage) {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -30,6 +30,7 @@ import { cloneUsage } from "./usage.js";
 export const CURRENT_SESSION_VERSION = 3;
 const SESSION_LIST_SEARCH_TEXT_MAX_CHARS = 64 * 1024;
 const SESSION_LIST_PARSE_MAX_LINE_CHARS = 1024 * 1024;
+const SESSION_LIST_LARGE_MESSAGE_PREVIEW_MAX_CHARS = 256;
 
 export interface SessionHeader {
 	type: "session";
@@ -755,6 +756,74 @@ function looksLikeMessageEntry(line: string): boolean {
 	return line.includes('"type":"message"') || line.includes('"type": "message"');
 }
 
+function extractJsonStringPropertyPrefix(
+	text: string,
+	propertyName: string,
+	maxChars: number,
+	startIndex = 0,
+): string | undefined {
+	const propertyIndex = text.indexOf(`"${propertyName}"`, startIndex);
+	if (propertyIndex < 0) {
+		return undefined;
+	}
+	let index = propertyIndex + propertyName.length + 2;
+	while (index < text.length && /\s/.test(text[index] ?? "")) index++;
+	if (text[index] !== ":") {
+		return undefined;
+	}
+	index++;
+	while (index < text.length && /\s/.test(text[index] ?? "")) index++;
+	if (text[index] !== '"') {
+		return undefined;
+	}
+	index++;
+
+	let result = "";
+	let escaped = false;
+	for (; index < text.length && result.length < maxChars; index++) {
+		const char = text[index];
+		if (escaped) {
+			result += char;
+			escaped = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === '"') {
+			break;
+		}
+		result += char;
+	}
+	return result;
+}
+
+function extractOversizedMessageSummary(line: string): {
+	role?: string;
+	timestamp?: number;
+	textPreview?: string;
+} {
+	const timestampText = extractJsonStringPropertyPrefix(line, "timestamp", 64);
+	const timestamp = timestampText ? new Date(timestampText).getTime() : NaN;
+	const messageIndex = line.indexOf('"message"');
+	const role =
+		messageIndex >= 0
+			? extractJsonStringPropertyPrefix(line, "role", 64, messageIndex)
+			: extractJsonStringPropertyPrefix(line, "role", 64);
+	let textPreview: string | undefined;
+	if (messageIndex >= 0) {
+		textPreview =
+			extractJsonStringPropertyPrefix(line, "content", SESSION_LIST_LARGE_MESSAGE_PREVIEW_MAX_CHARS, messageIndex) ??
+			extractJsonStringPropertyPrefix(line, "text", SESSION_LIST_LARGE_MESSAGE_PREVIEW_MAX_CHARS, messageIndex);
+	}
+	return {
+		role,
+		...(Number.isNaN(timestamp) ? {} : { timestamp }),
+		...(textPreview ? { textPreview } : {}),
+	};
+}
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	try {
 		const stats = await stat(filePath);
@@ -777,6 +846,13 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			if (line.length > SESSION_LIST_PARSE_MAX_LINE_CHARS) {
 				if (looksLikeMessageEntry(line)) {
 					messageCount++;
+					const summary = extractOversizedMessageSummary(line);
+					if (typeof summary.timestamp === "number") {
+						lastActivityTime = Math.max(lastActivityTime ?? 0, summary.timestamp);
+					}
+					if (summary.role === "user" && !firstMessage) {
+						firstMessage = summary.textPreview || "(large message)";
+					}
 				}
 				continue;
 			}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,9 +1,19 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, TextContent, Usage } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "fs";
-import { readdir, readFile, stat } from "fs/promises";
+import {
+	appendFileSync,
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "fs";
+import { readdir, stat } from "fs/promises";
 import { dirname, join, resolve } from "path";
+import { createInterface } from "readline";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import { readFirstLineSync } from "../utils/file-lines.js";
@@ -18,6 +28,8 @@ import {
 import { cloneUsage } from "./usage.js";
 
 export const CURRENT_SESSION_VERSION = 3;
+const SESSION_LIST_SEARCH_TEXT_MAX_CHARS = 64 * 1024;
+const SESSION_LIST_PARSE_MAX_LINE_CHARS = 1024 * 1024;
 
 export interface SessionHeader {
 	type: "session";
@@ -689,33 +701,95 @@ function isSessionStateStatus(value: unknown): value is SessionStateStatus {
 	return value === "active" || value === "sleep" || value === "crash" || value === "hidden";
 }
 
+function updateLastActivityTime(lastActivityTime: number | undefined, entry: FileEntry): number | undefined {
+	if (entry.type !== "message") {
+		return lastActivityTime;
+	}
+
+	const message = (entry as SessionMessageEntry).message;
+	if (!isMessageWithContent(message)) {
+		return lastActivityTime;
+	}
+	if (message.role !== "user" && message.role !== "assistant") {
+		return lastActivityTime;
+	}
+
+	const msgTimestamp = (message as { timestamp?: number }).timestamp;
+	if (typeof msgTimestamp === "number") {
+		return Math.max(lastActivityTime ?? 0, msgTimestamp);
+	}
+
+	const entryTimestamp = (entry as SessionEntryBase).timestamp;
+	if (typeof entryTimestamp === "string") {
+		const t = new Date(entryTimestamp).getTime();
+		if (!Number.isNaN(t)) {
+			return Math.max(lastActivityTime ?? 0, t);
+		}
+	}
+
+	return lastActivityTime;
+}
+
+function getSessionModifiedDateFromLastActivity(
+	lastActivityTime: number | undefined,
+	header: SessionHeader,
+	statsMtime: Date,
+): Date {
+	if (typeof lastActivityTime === "number" && lastActivityTime > 0) {
+		return new Date(lastActivityTime);
+	}
+
+	const headerTime = typeof header.timestamp === "string" ? new Date(header.timestamp).getTime() : NaN;
+	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
+}
+
+function appendCappedSearchText(current: string, text: string): string {
+	if (!text || current.length >= SESSION_LIST_SEARCH_TEXT_MAX_CHARS) {
+		return current;
+	}
+	const next = current ? ` ${text}` : text;
+	return current + next.slice(0, SESSION_LIST_SEARCH_TEXT_MAX_CHARS - current.length);
+}
+
+function looksLikeMessageEntry(line: string): boolean {
+	return line.includes('"type":"message"') || line.includes('"type": "message"');
+}
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	try {
-		const content = await readFile(filePath, "utf8");
-		const entries: FileEntry[] = [];
-		const lines = content.trim().split("\n");
-
-		for (const line of lines) {
-			if (!line.trim()) continue;
-			try {
-				entries.push(JSON.parse(line) as FileEntry);
-			} catch {
-				// Skip malformed lines
-			}
-		}
-
-		if (entries.length === 0) return null;
-		const header = entries[0];
-		if (header.type !== "session") return null;
-
 		const stats = await stat(filePath);
+		const stream = createReadStream(filePath, { encoding: "utf8" });
+		const lines = createInterface({ input: stream, crlfDelay: Infinity });
+		let header: SessionHeader | undefined;
 		let messageCount = 0;
 		let firstMessage = "";
-		const allMessages: string[] = [];
+		let allMessagesText = "";
 		let name: string | undefined;
 		let state: SessionState | undefined;
+		let lastActivityTime: number | undefined;
 
-		for (const entry of entries) {
+		for await (const line of lines) {
+			if (!line.trim()) continue;
+
+			// Large tool-result entries can be many MB. They do not carry the
+			// session-list metadata we need, and parsing them during every refresh
+			// can exhaust the daemon heap.
+			if (line.length > SESSION_LIST_PARSE_MAX_LINE_CHARS) {
+				if (looksLikeMessageEntry(line)) {
+					messageCount++;
+				}
+				continue;
+			}
+
+			const trimmed = line.trim();
+			let entry: FileEntry;
+			try {
+				entry = JSON.parse(trimmed) as FileEntry;
+			} catch {
+				// Skip malformed lines
+				continue;
+			}
+
 			// Extract session name (use latest, including explicit clears)
 			if (entry.type === "session_info") {
 				const infoEntry = entry as SessionInfoEntry;
@@ -728,6 +802,15 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 				}
 			}
 
+			if (!header) {
+				if (entry.type !== "session") {
+					return null;
+				}
+				header = entry as SessionHeader;
+			}
+
+			lastActivityTime = updateLastActivityTime(lastActivityTime, entry);
+
 			if (entry.type !== "message") continue;
 			messageCount++;
 
@@ -738,29 +821,29 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			const textContent = extractTextContent(message);
 			if (!textContent) continue;
 
-			allMessages.push(textContent);
+			allMessagesText = appendCappedSearchText(allMessagesText, textContent);
 			if (!firstMessage && message.role === "user") {
 				firstMessage = textContent;
 			}
 		}
 
-		const cwd = typeof (header as SessionHeader).cwd === "string" ? (header as SessionHeader).cwd : "";
-		const parentSessionPath = (header as SessionHeader).parentSession;
-
-		const modified = getSessionModifiedDate(entries, header as SessionHeader, stats.mtime);
+		if (!header) return null;
+		const cwd = typeof header.cwd === "string" ? header.cwd : "";
+		const parentSessionPath = header.parentSession;
+		const modified = getSessionModifiedDateFromLastActivity(lastActivityTime, header, stats.mtime);
 
 		return {
 			path: filePath,
-			id: (header as SessionHeader).id,
+			id: header.id,
 			cwd,
 			name,
 			state,
 			parentSessionPath,
-			created: new Date((header as SessionHeader).timestamp),
+			created: new Date(header.timestamp),
 			modified,
 			messageCount,
 			firstMessage: firstMessage || "(no messages)",
-			allMessagesText: allMessages.join(" "),
+			allMessagesText,
 		};
 	} catch {
 		return null;
@@ -786,15 +869,10 @@ async function listSessionsFromDir(
 		const total = progressTotal ?? files.length;
 
 		let loaded = 0;
-		const results = await Promise.all(
-			files.map(async (file) => {
-				const info = await buildSessionInfo(file);
-				loaded++;
-				onProgress?.(progressOffset + loaded, total);
-				return info;
-			}),
-		);
-		for (const info of results) {
+		for (const file of files) {
+			const info = await buildSessionInfo(file);
+			loaded++;
+			onProgress?.(progressOffset + loaded, total);
 			if (info) {
 				sessions.push(info);
 			}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -660,44 +660,6 @@ function extractTextContent(message: Message): string {
 		.join(" ");
 }
 
-function getLastActivityTime(entries: FileEntry[]): number | undefined {
-	let lastActivityTime: number | undefined;
-
-	for (const entry of entries) {
-		if (entry.type !== "message") continue;
-
-		const message = (entry as SessionMessageEntry).message;
-		if (!isMessageWithContent(message)) continue;
-		if (message.role !== "user" && message.role !== "assistant") continue;
-
-		const msgTimestamp = (message as { timestamp?: number }).timestamp;
-		if (typeof msgTimestamp === "number") {
-			lastActivityTime = Math.max(lastActivityTime ?? 0, msgTimestamp);
-			continue;
-		}
-
-		const entryTimestamp = (entry as SessionEntryBase).timestamp;
-		if (typeof entryTimestamp === "string") {
-			const t = new Date(entryTimestamp).getTime();
-			if (!Number.isNaN(t)) {
-				lastActivityTime = Math.max(lastActivityTime ?? 0, t);
-			}
-		}
-	}
-
-	return lastActivityTime;
-}
-
-function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, statsMtime: Date): Date {
-	const lastActivityTime = getLastActivityTime(entries);
-	if (typeof lastActivityTime === "number" && lastActivityTime > 0) {
-		return new Date(lastActivityTime);
-	}
-
-	const headerTime = typeof header.timestamp === "string" ? new Date(header.timestamp).getTime() : NaN;
-	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
-}
-
 function isSessionStateStatus(value: unknown): value is SessionStateStatus {
 	return value === "active" || value === "sleep" || value === "crash" || value === "hidden";
 }

--- a/packages/coding-agent/test/session-manager/flat-storage.test.ts
+++ b/packages/coding-agent/test/session-manager/flat-storage.test.ts
@@ -100,6 +100,52 @@ describe("SessionManager flat storage", () => {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("ignores oversized non-conversation rows when computing modified time", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-large-tool-list-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			mkdirSync(sessionDir, { recursive: true });
+			const sessionFile = join(sessionDir, "large-tool.jsonl");
+			const largeText = "z".repeat(2 * 1024 * 1024);
+			writeFileSync(
+				sessionFile,
+				`${JSON.stringify({
+					type: "session",
+					id: "large-tool",
+					timestamp: "2026-01-01T00:00:00.000Z",
+					cwd: join(tempDir, "project"),
+				})}\n${JSON.stringify({
+					type: "message",
+					id: "message-1",
+					parentId: null,
+					timestamp: "2026-01-02T00:00:00.000Z",
+					message: {
+						role: "user",
+						content: "small prompt",
+					},
+				})}\n${JSON.stringify({
+					type: "message",
+					id: "message-2",
+					parentId: "message-1",
+					timestamp: "2026-01-03T00:00:00.000Z",
+					message: {
+						role: "toolResult",
+						content: largeText,
+					},
+				})}\n`,
+			);
+
+			const sessions = await SessionManager.listAll(undefined, sessionDir);
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].messageCount).toBe(2);
+			expect(sessions[0].firstMessage).toBe("small prompt");
+			expect(sessions[0].allMessagesText).toBe("small prompt");
+			expect(sessions[0].modified.toISOString()).toBe("2026-01-02T00:00:00.000Z");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 function createPersistedSession(cwd: string, sessionDir: string, text: string): SessionManager {

--- a/packages/coding-agent/test/session-manager/flat-storage.test.ts
+++ b/packages/coding-agent/test/session-manager/flat-storage.test.ts
@@ -38,6 +38,30 @@ describe("SessionManager flat storage", () => {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("lists sessions without loading large message bodies into search text", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-large-list-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const cwd = join(tempDir, "project");
+			const session = SessionManager.create(cwd, sessionDir);
+			session.appendSessionInfo("large history");
+			session.appendSessionState({ status: "active" });
+			session.appendMessage(userMsg("small prompt"));
+			session.appendMessage(assistantMsg("x".repeat(2 * 1024 * 1024)));
+
+			const sessions = await SessionManager.listAll(undefined, sessionDir);
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].id).toBe(session.getSessionId());
+			expect(sessions[0].name).toBe("large history");
+			expect(sessions[0].state).toEqual({ status: "active" });
+			expect(sessions[0].messageCount).toBe(2);
+			expect(sessions[0].firstMessage).toBe("small prompt");
+			expect(sessions[0].allMessagesText).toBe("small prompt");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 function createPersistedSession(cwd: string, sessionDir: string, text: string): SessionManager {

--- a/packages/coding-agent/test/session-manager/flat-storage.test.ts
+++ b/packages/coding-agent/test/session-manager/flat-storage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -58,6 +58,44 @@ describe("SessionManager flat storage", () => {
 			expect(sessions[0].messageCount).toBe(2);
 			expect(sessions[0].firstMessage).toBe("small prompt");
 			expect(sessions[0].allMessagesText).toBe("small prompt");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves list metadata from oversized user message rows", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-large-user-list-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			mkdirSync(sessionDir, { recursive: true });
+			const sessionFile = join(sessionDir, "large-user.jsonl");
+			const largeText = "y".repeat(2 * 1024 * 1024);
+			writeFileSync(
+				sessionFile,
+				`${JSON.stringify({
+					type: "session",
+					id: "large-user",
+					timestamp: "2026-01-01T00:00:00.000Z",
+					cwd: join(tempDir, "project"),
+				})}\n${JSON.stringify({
+					type: "message",
+					id: "message-1",
+					parentId: null,
+					timestamp: "2026-01-02T00:00:00.000Z",
+					message: {
+						role: "user",
+						content: largeText,
+						timestamp: 1,
+					},
+				})}\n`,
+			);
+
+			const sessions = await SessionManager.listAll(undefined, sessionDir);
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].messageCount).toBe(1);
+			expect(sessions[0].firstMessage).toBe("y".repeat(256));
+			expect(sessions[0].allMessagesText).toBe("");
+			expect(sessions[0].modified.toISOString()).toBe("2026-01-02T00:00:00.000Z");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

Fixes a daemon crash when the agents view refreshes saved sessions with large JSONL histories.

The old session-listing path read each saved session file into one string, parsed every JSONL row into memory, joined all user/assistant text into `allMessagesText`, and did this for all files concurrently. On large local histories this can abort Node/V8 during `JSON.parse`, leaving a stale daemon socket and causing the TUI to show `Failed to refresh agents: Daemon client is not connected`.

## Changes

- Stream saved session files line-by-line in `SessionManager.list/listAll` instead of `readFile` + `split`.
- Cap per-session searchable `allMessagesText` at 64 KiB.
- Skip parsing individual session-list rows over 1 MiB while still counting message entries when detectable.
- Scan session files sequentially instead of via `Promise.all` to avoid parallel heap spikes.
- Add a regression test for listing a session with a multi-megabyte message body.

## Local validation

Ran in `prime-agent-beta` worktree with this exact patch:

- `npm --prefix packages/coding-agent test -- test/session-manager/flat-storage.test.ts`
- `npm --prefix packages/coding-agent test -- test/session-manager`
- `npm --prefix packages/coding-agent run build`
- Real store smoke test against `~/.prime/agent/sessions`: 49 sessions, ~418 MB total session store, scan completed in 971 ms with ~6 MB heap used after GC and max `allMessagesText` capped at 65536 chars.
- Reaped stale default daemon socket, started patched `prime-agent-beta daemon`, restored 10 active sessions, and verified `daemon list -a --json` returned all 49 sessions without crashing.

cc @kevinjosethomas


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon OOM when listing saved sessions by streaming JSONL files instead of loading them into memory
> - Replaces bulk `readFile` reads in `buildSessionInfo` with line-by-line streaming via `createReadStream` and `readline`, so large session files are never fully loaded into memory.
> - Adds size caps (`SESSION_LIST_SEARCH_TEXT_MAX_CHARS`, `SESSION_LIST_PARSE_MAX_LINE_CHARS`, `SESSION_LIST_LARGE_MESSAGE_PREVIEW_MAX_CHARS`) to bound memory use during session listing.
> - Oversized lines (above `SESSION_LIST_PARSE_MAX_LINE_CHARS`) are handled via lightweight string scanning to extract role, timestamp, and a capped preview without full JSON parsing.
> - Changes `listSessionsFromDir` from parallel `Promise.all` to sequential file processing, updating progress after each file.
> - Behavioral Change: large message bodies are excluded from `allMessagesText` (used for search); only a capped preview is stored for oversized messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 688b731.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Listing logic and search metadata semantics change for large sessions; risk is bounded memory and possible incomplete search on very long histories, not security or persistence of full session loads.
> 
> **Overview**
> Fixes daemon crashes when the agents view refreshes sessions whose JSONL histories contain multi‑megabyte rows (e.g. tool results).
> 
> **`buildSessionInfo`** no longer loads each `.jsonl` into memory and parses every line. It **streams** the file with `createReadStream`/`readline`, builds list metadata in one pass, and **caps** `allMessagesText` at **64 KiB** instead of joining all user/assistant text. Lines over **1 MiB** skip full `JSON.parse`; for detectable message rows it still updates counts, `modified`, and a **256‑char** `firstMessage` preview via lightweight string scanning. **`listSessionsFromDir`** processes session files **sequentially** instead of `Promise.all`, reducing parallel heap spikes.
> 
> **Behavioral note:** huge message bodies no longer appear in session search text; oversized first user messages show a truncated preview.
> 
> Regression tests in `flat-storage.test.ts` cover large assistant bodies, oversized user rows, and huge `toolResult` rows for `modified` time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688b731785c37e7f47eaebdec75b6a292e232480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->