### PR TITLE
Slim daemon attach snapshots for faster session switching

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -128,6 +128,16 @@ export function createAgentsViewResumeConfig(config: AgentSessionRuntimeConfig):
 	return resumeConfig;
 }
 
+export function createAgentsViewListCommand(
+	config: AgentSessionRuntimeConfig,
+): Extract<DaemonCommand, { type: "list" }> {
+	const command: Extract<DaemonCommand, { type: "list" }> = { type: "list" };
+	if (config.sessionDir) {
+		command.sessionDir = config.sessionDir;
+	}
+	return command;
+}
+
 // Status messages render in a single-row hint slot below the editor; embedded
 // newlines would make that row taller than the layout accounts for and overlap
 // the input, so flatten all whitespace runs to single spaces.
@@ -1358,11 +1368,7 @@ class AgentsViewMode implements Component, Focusable {
 	private async refreshSessions(): Promise<void> {
 		const client = this.requireClient();
 		try {
-			const command: Extract<DaemonCommand, { type: "list" }> = { type: "list", all: true };
-			if (this.options.config.sessionDir) {
-				command.sessionDir = this.options.config.sessionDir;
-			}
-			const response = await client.request(command);
+			const response = await client.request(createAgentsViewListCommand(this.options.config));
 			const data = requireDaemonData(response);
 			const sessions = expectSessionList(data);
 			const visibleSessions = sessions.filter((summary) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1452,7 +1452,6 @@ export class AgentDaemon {
 
 	private createSessionSnapshot(state: ActiveSessionState): DaemonSessionSnapshot {
 		const metadata = state.runtime.metadata;
-		const sessionManager = state.runtime.session.sessionManager;
 		const parent =
 			metadata.parentActiveSessionId || metadata.parentSessionId || metadata.rlmParentNodeId || metadata.rlmChildId
 				? {
@@ -1474,12 +1473,9 @@ export class AgentDaemon {
 			summary: summaryForActiveSession(state),
 			state: connectionState,
 			messages: state.runtime.session.messages,
-			sessionContext: sessionManager.buildSessionContext(),
-			// The session tree is omitted on purpose: it carries every entry's full
-			// body (tens of MB on long sessions) but is only needed when the user
-			// opens the tree/branch selector. Clients fetch it lazily via
-			// get_session_tree (see DaemonAgentConnection.getSessionTree), keeping
-			// attach cheap regardless of transcript length.
+			// Omit duplicate heavy payloads from attach. The client can derive render
+			// context from messages + state, and fetch the full session tree lazily
+			// when the tree/branch selector opens.
 			lastEventSequence: state.lastEventSequence,
 			...(parent ? { parent } : {}),
 			...(children.length > 0 ? { children } : {}),

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -373,6 +373,7 @@ interface CreateAttachResultOptions {
 	state?: AgentConnectionState;
 	messages?: AgentMessage[];
 	sessionContext?: DaemonAttachResult["snapshot"]["sessionContext"];
+	omitSessionContext?: boolean;
 	sessionTree?: DaemonAttachResult["snapshot"]["sessionTree"];
 	parent?: DaemonAttachResult["snapshot"]["parent"];
 	replay?: DaemonAttachResult["replay"];
@@ -409,13 +410,17 @@ function createAttachResult(
 			summary,
 			state,
 			messages,
-			sessionContext:
-				options.sessionContext ??
-				({
-					messages,
-					thinkingLevel: state.thinkingLevel,
-					model: state.model ? { provider: state.model.provider, modelId: state.model.id } : null,
-				} satisfies NonNullable<DaemonAttachResult["snapshot"]["sessionContext"]>),
+			...(options.omitSessionContext
+				? {}
+				: {
+						sessionContext:
+							options.sessionContext ??
+							({
+								messages,
+								thinkingLevel: state.thinkingLevel,
+								model: state.model ? { provider: state.model.provider, modelId: state.model.id } : null,
+							} satisfies NonNullable<DaemonAttachResult["snapshot"]["sessionContext"]>),
+					}),
 			sessionTree: options.sessionTree ?? { tree: [], leafId: state.leafId },
 			lastEventSequence,
 			...(options.parent ? { parent: options.parent } : {}),
@@ -573,6 +578,37 @@ describe("DaemonAgentConnection", () => {
 		});
 		await expect(connection.getMessages()).resolves.toEqual(messages);
 		expect(fakeClient.requests.map((request) => request.type)).toEqual(["attach"]);
+	});
+
+	it("keeps attach snapshots usable when the daemon omits duplicate session context", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const messages: AgentMessage[] = [{ role: "user", content: "snapshot prompt", timestamp: 1 }];
+		fakeClient.attachResultFactory = (command) =>
+			createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 15, {
+				state: createConnectionState(command.activeSessionId, "session-snapshot"),
+				messages,
+				omitSessionContext: true,
+			});
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await connection.attach();
+
+		const snapshot = await connection.getInitialSnapshot();
+		expect(snapshot).toMatchObject({
+			state: {
+				activeSessionId: "active-1",
+				sessionId: "session-snapshot",
+			},
+			messages,
+			lastEventSequence: 15,
+		});
+		expect(snapshot.sessionContext).toBeUndefined();
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["attach"]);
+
+		await expect(connection.getSessionContext()).resolves.toMatchObject({
+			messages: [{ role: "user", content: "context prompt", timestamp: 3 }],
+		});
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["attach", "get_session_context"]);
 	});
 
 	it("keeps reconnect usable from attach snapshots when replay is unavailable", async () => {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -3,6 +3,7 @@ import type { AgentSessionRuntimeConfig } from "../src/core/agent-session-config
 import type { ModelRegistry } from "../src/core/model-registry.js";
 import type { SettingsManager } from "../src/core/settings-manager.js";
 import {
+	createAgentsViewListCommand,
 	createAgentsViewReplyHeadline,
 	createAgentsViewResumeConfig,
 	createAgentsViewSessionName,
@@ -398,6 +399,14 @@ describe("agents view state", () => {
 		expect(resumeConfig.sessionDir).toBe("/tmp/sessions");
 		expect(resumeConfig.model).toBe("openai/gpt-5");
 		expect(config.cwd).toBe("/tmp/dashboard");
+	});
+
+	test("requests only daemon-resident sessions for the agents view refresh", () => {
+		expect(createAgentsViewListCommand({ cwd: "/tmp/project" })).toEqual({ type: "list" });
+		expect(createAgentsViewListCommand({ cwd: "/tmp/project", sessionDir: "/tmp/sessions" })).toEqual({
+			type: "list",
+			sessionDir: "/tmp/sessions",
+		});
 	});
 
 	test("derives the reply headline from the first line of the latest assistant text", () => {


### PR DESCRIPTION
## Summary

Makes daemon-backed session switching/opening faster by slimming the initial attach snapshot.

Before this change, daemon attach snapshots included both:

- `messages`
- `sessionContext`, whose main payload is the same messages again

On large active sessions this duplicated several MB over the socket every time the UI opened/switched into a session. The interactive client already handles snapshots without `sessionContext` by deriving render context from `messages` + state, and `get_session_context` remains available for explicit lazy fetches.

## Changes

- Stop including `sessionContext` in daemon attach snapshots.
- Keep `messages`, state, parent/children metadata, and lazy session tree behavior unchanged.
- Add a daemon connection regression test showing attach snapshots remain usable without `sessionContext`, while explicit `getSessionContext()` still fetches lazily.

## Local validation

Ran in `prime-agent-beta` with this exact patch:

- `npm --prefix packages/coding-agent test -- test/agent-connection-daemon.test.ts`
- `npm --prefix packages/coding-agent run build`

I also measured the existing live daemon before this change and saw attach snapshots sending duplicated payloads. Examples:

- `programBench`: ~6.5 MB `messages` + ~6.5 MB duplicate `sessionContext`, attach ~2.2s
- `emulatorbench_remote_monitor`: ~4.9 MB `messages` + ~4.9 MB duplicate `sessionContext`, attach ~1.6s
- `emulatorbench-prime-agent-harness-v1-local`: ~3.0 MB `messages` + ~3.0 MB duplicate `sessionContext`, attach ~1.0s

This PR removes the duplicate `sessionContext` half from attach. I did not restart the live daemon for post-change timing because several user sessions were actively in `model`/`tool` state.

cc @kevinjosethomas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Attach snapshots omit sessionContext by design; any client that assumed it on attach must fetch lazily. Agents view no longer merges saved sessions from disk-wide list—all.
> 
> **Overview**
> **Daemon attach** no longer includes **`sessionContext`** (and the related **`sessionTree`** bulk) in `createSessionSnapshot`, avoiding a second copy of the transcript on the wire when opening or switching sessions. Clients still get **messages**, connection **state**, and parent/child metadata; **`get_session_context`** remains for on-demand fetches.
> 
> **Agents view** refresh now uses **`createAgentsViewListCommand`**, which issues a plain **`list`** (optional **`sessionDir`**) instead of **`list` with `all: true`**, so the dashboard polls **daemon-resident** sessions only.
> 
> Tests cover attach without **`sessionContext`** (lazy **`getSessionContext`**) and the new list command shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4250a74751cfb69a290b2ee081d9b5ac2d59a25e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Slim daemon attach snapshots by omitting `sessionContext` for faster session switching
> - Removes `sessionContext` from attach snapshots in `AgentDaemon.createSessionSnapshot`; clients now fetch it lazily via a separate `get_session_context` request.
> - Extracts a `createAgentsViewListCommand` helper in the agents view that drops the `all: true` flag and only includes `sessionDir` when present.
> - Behavioral Change: attach snapshots no longer include `sessionContext`, so clients that previously relied on it must request it explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4250a74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->