### PR TITLE
bump version to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.1.8",
+				"@earendil-works/pi-coding-agent": "^0.1.9",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5913,10 +5913,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.1.8",
+				"@earendil-works/pi-ai": "^0.1.9",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5943,7 +5943,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5985,13 +5985,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.1.8",
-				"@earendil-works/pi-ai": "^0.1.8",
-				"@earendil-works/pi-tui": "^0.1.8",
+				"@earendil-works/pi-agent-core": "^0.1.9",
+				"@earendil-works/pi-ai": "^0.1.9",
+				"@earendil-works/pi-tui": "^0.1.9",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6134,7 +6134,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.1.8",
+		"@earendil-works/pi-coding-agent": "^0.1.9",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.1.8",
+		"@earendil-works/pi-ai": "^0.1.9",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.1.8",
-		"@earendil-works/pi-ai": "^0.1.8",
-		"@earendil-works/pi-tui": "^0.1.8",
+		"@earendil-works/pi-agent-core": "^0.1.9",
+		"@earendil-works/pi-ai": "^0.1.9",
+		"@earendil-works/pi-tui": "^0.1.9",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- version-only patch bump across the published packages (root, agent, ai, coding-agent, tui) from 0.1.8 to 0.1.9.
- synced internal dependency ranges and the root coding-agent dependency to ^0.1.9, plus the lockfile.
- no changelog or release publishing; this only prepares the version numbers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and lockfile updates with no runtime or behavioral changes.
> 
> **Overview**
> Bumps the workspace from **0.1.8** to **0.1.9** with no application or library code changes.
> 
> **`version`** fields are updated on the root `prime-agent` package and the published workspaces `@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent`, and `pi-tui`. Internal semver ranges (`agent` → `pi-ai`, `coding-agent` → agent/ai/tui, root → `pi-coding-agent`) and **`package-lock.json`** are aligned to `^0.1.9` so installs resolve consistently across the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba7a668f1b6fc840e3ebc42ced4501b46659beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all package versions to 0.1.9
> Increments the version field from 0.1.8 to 0.1.9 across all packages (`pi-ai`, `pi-agent-core`, `pi-coding-agent`, `pi-tui`) and updates their inter-dependencies to match the new version range.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ba7a66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->