### PR TITLE
show brand splash in the new chat view

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -846,8 +846,10 @@ export class InteractiveMode {
 		this.ui.addChild(this.headerContainer);
 
 		// Brand splash: side-panel layout with structured runtime metadata on the right.
-		// When onboarding is required, the guided onboarding splash owns the first screen.
-		if (!this.shouldRunOnboarding() && (this.options.verbose || !this.settingsManager.getQuietStartup())) {
+		// The model/cwd are read through live getters, so they fill in once the
+		// connection state loads (rebindCurrentSession below). Onboarding, when
+		// required, renders as a full-screen overlay on top of this header.
+		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
 			// Verbose: include the full keybinding cheatsheet under the brand mark.
 			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
 			const verboseInstructions = this.options.verbose


### PR DESCRIPTION
- the default new chat opened with only the input bar because the brand splash was gated on an onboarding check that ran before the connection state (and current model) had loaded, so it always read as "needs onboarding" and got skipped.
- the splash now renders unconditionally for the chat the same way the agents view already does, reading the model and cwd through live getters so they fill in once the session connects.
- onboarding still takes over correctly since its splash draws as a full-screen overlay on top of the header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in interactive startup UI with no auth, data, or execution-path changes.
> 
> **Overview**
> **New chat sessions** no longer open with only the input bar: the **brand splash header** is shown whenever startup is not in quiet mode (or verbose is on), instead of being skipped when `shouldRunOnboarding()` is true at `init()` time.
> 
> That early onboarding check ran **before** connection state (and the current model) loaded, so onboarding was always assumed and the splash never appeared. The splash still uses **live getters** for model and cwd so metadata fills in after `rebindCurrentSession`; onboarding continues to run later as a **full-screen overlay** on top of the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2764fffd4fa49c27ff108930d7a991616d3d73d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show brand splash in the new chat view during onboarding
> Removes the `!this.shouldRunOnboarding()` guard from the brand splash and keybinding hints display condition in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/215/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316). The splash now renders whenever verbose is enabled or quiet startup is disabled, even when onboarding is required. Onboarding continues to appear as an overlay on top of the splash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2764fff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->