### PR TITLE
Clarify IPython state after compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2709,10 +2709,6 @@ export class AgentSession {
 		return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
 	}
 
-	private async _restartIpythonKernelAfterCompaction(): Promise<void> {
-		await this._ipythonKernelProvisioner?.restart();
-	}
-
 	/**
 	 * Tell the model when a resumed session revived its IPython kernel state, so it
 	 * knows which variables are actually available instead of assuming the kernel is
@@ -2880,8 +2876,6 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
-			await this._restartIpythonKernelAfterCompaction();
-
 			const compactionResult = {
 				summary,
 				firstKeptEntryId,
@@ -3218,8 +3212,6 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
-			await this._restartIpythonKernelAfterCompaction();
-
 			const result: CompactionResult = {
 				summary,
 				firstKeptEntryId,

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -10,8 +10,8 @@ export interface RlmPromptOptions {
 }
 
 const IPYTHON_CONTROL_PROMPT = [
-	"IPython is the agent's long-lived notebook during normal turns: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, and write small helper functions.",
-	"Do not rely on Python variables surviving context compaction. Compaction may restart the IPython kernel and clear the live namespace, so persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive compaction.",
+	"IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or normal context compaction.",
+	"Compaction trims the model-visible conversation history; it does not intentionally clear the live IPython namespace. Still persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive an explicit kernel restart, session restart, or reuse across sessions.",
 	"",
 	"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 	"",

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -10,7 +10,8 @@ export interface RlmPromptOptions {
 }
 
 const IPYTHON_CONTROL_PROMPT = [
-	"IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or compaction.",
+	"IPython is the agent's long-lived notebook during normal turns: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, and write small helper functions.",
+	"Do not rely on Python variables surviving context compaction. Compaction may restart the IPython kernel and clear the live namespace, so persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive compaction.",
 	"",
 	"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 	"",

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -149,7 +149,7 @@ export interface IpythonToolOptions {
 	/** Resolves before this kernel starts — e.g. the previous provisioner's dispose, so a
 	 * /reload's old-kernel snapshot flush can't race the new kernel's restore. */
 	readyGate?: Promise<unknown>;
-	/** Filled after the first kernel start so the owning session can restart it after compaction. */
+	/** Filled after the first kernel start so the owning session can inspect or manage it. */
 	kernelManagerRef?: { current?: KernelManager };
 	/**
 	 * Fires once per kernel start when a previous session's namespace was revived
@@ -198,7 +198,7 @@ export class IpythonKernelProvisioner {
 		void this.ensure().catch(() => {});
 	}
 
-	/** Restart the kernel if one is running (e.g. after compaction). */
+	/** Restart the kernel if one is running. Used for explicit kernel/session lifecycle resets. */
 	async restart(): Promise<void> {
 		try {
 			// Await any in-flight startup first, so we restart a fully-started kernel and
@@ -206,9 +206,9 @@ export class IpythonKernelProvisioner {
 			const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
 			await m?.restart();
 		} finally {
-			// Compaction deliberately wipes the namespace and tells the model so. Drop the
-			// stale on-disk snapshot too — even if the restart threw — so a later resume
-			// doesn't revive state the model was told is gone (a fresh cell re-snapshots).
+			// A deliberate restart invalidates the live namespace. Drop the stale on-disk
+			// snapshot too, even if the restart threw, so a later resume doesn't revive
+			// state from before the reset (a fresh cell re-snapshots).
 			this._lastRestore = undefined;
 			const dir = this.options?.snapshotDir;
 			if (dir) {

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -114,7 +114,7 @@ describe("IpythonKernelProvisioner", () => {
 		expect(countRuns()).toBe(1);
 	});
 
-	it("restart() drops the on-disk snapshot so a compaction wipe isn't revived on resume", async () => {
+	it("restart() drops the on-disk snapshot so a deliberate kernel reset isn't revived on resume", async () => {
 		const snapshotDir = join(tempDir, "artifacts");
 		const provisioner = new IpythonKernelProvisioner(tempDir, { snapshotDir });
 		const dill = join(snapshotDir, "kernel-state.dill");

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -7,6 +7,7 @@ type SessionWithCompactionInternals = {
 	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
 	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
 	_shouldStopAfterTurn: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+	_ipythonKernelProvisioner?: { restart: () => Promise<void> };
 };
 
 function createUsage(totalTokens: number) {
@@ -81,6 +82,35 @@ describe("AgentSession compaction characterization", () => {
 		expect(result.summary).toBe("summary from extension");
 		expect(compactionEntries).toHaveLength(1);
 		expect(harness.session.messages[0]?.role).toBe("compactionSummary");
+	});
+
+	it("does not restart the IPython kernel during manual compaction", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "summary from extension",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const restart = vi.fn().mockResolvedValue(undefined);
+		(harness.session as unknown as SessionWithCompactionInternals)._ipythonKernelProvisioner = { restart };
+
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		await harness.session.compact();
+
+		expect(restart).not.toHaveBeenCalled();
 	});
 
 	it("throws when compacting without a model", async () => {
@@ -160,6 +190,36 @@ describe("AgentSession compaction characterization", () => {
 		await vi.advanceTimersByTimeAsync(100);
 
 		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not restart the IPython kernel during auto-compaction", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "auto compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const restart = vi.fn().mockResolvedValue(undefined);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		sessionInternals._ipythonKernelProvisioner = { restart };
+
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+
+		await sessionInternals._runAutoCompaction("threshold", false);
+
+		expect(restart).not.toHaveBeenCalled();
 	});
 
 	it("emits a warning when auto-compaction has nothing to summarize", async () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -61,8 +61,8 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
-				"IPython is the agent's long-lived notebook during normal turns: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, and write small helper functions.",
-				"Do not rely on Python variables surviving context compaction. Compaction may restart the IPython kernel and clear the live namespace, so persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive compaction.",
+				"IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or normal context compaction.",
+				"Compaction trims the model-visible conversation history; it does not intentionally clear the live IPython namespace. Still persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive an explicit kernel restart, session restart, or reuse across sessions.",
 				"",
 				"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 				"",
@@ -335,10 +335,13 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");
 		expect(prompt).toContain("IPython is the agent's long-lived notebook");
-		expect(prompt).toContain("Do not rely on Python variables surviving context compaction");
+		expect(prompt).toContain("preserve useful state across turns or normal context compaction");
+		expect(prompt).toContain("Compaction trims the model-visible conversation history");
+		expect(prompt).toContain("does not intentionally clear the live IPython namespace");
 		expect(prompt).toContain("continual harness state via `/refine`");
 		expect(prompt).toContain("prompt addendums/notes, memories, skills, and subagents");
-		expect(prompt).not.toContain("preserve useful state across turns or compaction");
+		expect(prompt).not.toContain("Do not rely on Python variables surviving context compaction");
+		expect(prompt).not.toContain("Compaction may restart the IPython kernel");
 		expect(prompt).toContain("yaml (PyYAML)");
 		expect(prompt).toContain("dotenv (python-dotenv)");
 		expect(prompt).toContain("bs4 (Beautiful Soup)");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -61,7 +61,8 @@ describe("buildRlmPrompt", () => {
 				"Each skill is an async function by the same name. Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`.",
 				"Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.",
 				"",
-				"IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or compaction.",
+				"IPython is the agent's long-lived notebook during normal turns: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, and write small helper functions.",
+				"Do not rely on Python variables surviving context compaction. Compaction may restart the IPython kernel and clear the live namespace, so persist durable facts, procedures, and artifacts in files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when they must survive compaction.",
 				"",
 				"Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.",
 				"",
@@ -334,6 +335,10 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).not.toContain("notify='wake'");
 		expect(prompt).not.toContain("notify='silent'");
 		expect(prompt).toContain("IPython is the agent's long-lived notebook");
+		expect(prompt).toContain("Do not rely on Python variables surviving context compaction");
+		expect(prompt).toContain("continual harness state via `/refine`");
+		expect(prompt).toContain("prompt addendums/notes, memories, skills, and subagents");
+		expect(prompt).not.toContain("preserve useful state across turns or compaction");
 		expect(prompt).toContain("yaml (PyYAML)");
 		expect(prompt).toContain("dotenv (python-dotenv)");
 		expect(prompt).toContain("bs4 (Beautiful Soup)");


### PR DESCRIPTION
## Summary
- Preserve the live IPython kernel across manual and auto context compaction instead of restarting it and clearing the namespace.
- Clarify the RLM prompt: IPython state persists across normal turns and normal context compaction; durable/reusable state should still be written to files, continual harness state via `/refine` (prompt addendums/notes, memories, skills, and subagents), or normal messages when it must survive explicit kernel/session restarts or cross-session reuse.
- Add regression tests that manual and auto compaction do not restart the IPython kernel, and keep restart snapshot cleanup scoped to deliberate kernel resets.

## Tests
- npm --prefix packages/coding-agent test -- system-prompt.test.ts test/suite/agent-session-compaction.test.ts ipython-provisioner.test.ts
- npm run check
