### PR TITLE
make session load, context, and listing scale linearly with size

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -444,13 +444,14 @@ export function buildSessionContext(
 		return { messages: [], thinkingLevel: "off", model: null };
 	}
 
-	// Walk from leaf to root, collecting path
+	// push+reverse, not unshift-per-entry: unshift is O(n), making this O(n^2) on long sessions.
 	const path: SessionEntry[] = [];
 	let current: SessionEntry | undefined = leaf;
 	while (current) {
-		path.unshift(current);
+		path.push(current);
 		current = current.parentId ? byId.get(current.parentId) : undefined;
 	}
+	path.reverse();
 
 	// Extract settings and find compaction
 	let thinkingLevel = "off";
@@ -545,18 +546,23 @@ export function getDefaultSessionDir(_cwd: string, agentDir: string = getDefault
 export function loadEntriesFromFile(filePath: string): FileEntry[] {
 	if (!existsSync(filePath)) return [];
 
-	const content = readFileSync(filePath, "utf8");
+	// Decode per line off a Buffer: readFileSync(path, "utf8") on a large file is far
+	// slower (one giant UTF-16 string). Splitting on 0x0a is UTF-8-safe.
+	const buffer = readFileSync(filePath);
 	const entries: FileEntry[] = [];
-	const lines = content.trim().split("\n");
-
-	for (const line of lines) {
-		if (!line.trim()) continue;
-		try {
-			const entry = JSON.parse(line) as FileEntry;
-			entries.push(entry);
-		} catch {
-			// Skip malformed lines
+	const len = buffer.length;
+	let start = 0;
+	while (start < len) {
+		let end = buffer.indexOf(0x0a, start);
+		if (end === -1) end = len;
+		if (end > start) {
+			try {
+				entries.push(JSON.parse(buffer.toString("utf8", start, end)) as FileEntry);
+			} catch {
+				// skip malformed/blank lines
+			}
 		}
+		start = end + 1;
 	}
 
 	// Validate session header
@@ -786,9 +792,34 @@ function extractOversizedMessageSummary(line: string): {
 	};
 }
 
+interface SessionInfoCacheEntry {
+	size: number;
+	mtimeMs: number;
+	info: SessionInfo | null;
+}
+
+// Session files are append-only, so an unchanged (size, mtimeMs) means identical
+// content: cache list metadata and rescan only files that changed.
+const sessionInfoCache = new Map<string, SessionInfoCacheEntry>();
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
+	let stats: Awaited<ReturnType<typeof stat>>;
 	try {
-		const stats = await stat(filePath);
+		stats = await stat(filePath);
+	} catch {
+		return null;
+	}
+	const cached = sessionInfoCache.get(filePath);
+	if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
+		return cached.info;
+	}
+	const info = await scanSessionInfo(filePath, stats);
+	sessionInfoCache.set(filePath, { size: stats.size, mtimeMs: stats.mtimeMs, info });
+	return info;
+}
+
+async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeof stat>>): Promise<SessionInfo | null> {
+	try {
 		const stream = createReadStream(filePath, { encoding: "utf8" });
 		const lines = createInterface({ input: stream, crlfDelay: Infinity });
 		let header: SessionHeader | undefined;
@@ -905,6 +936,14 @@ async function listSessionsFromDir(
 		const dirEntries = await readdir(dir);
 		const files = dirEntries.filter((f) => f.endsWith(".jsonl")).map((f) => join(dir, f));
 		const total = progressTotal ?? files.length;
+
+		// drop cache entries for deleted files so it stays bounded
+		const present = new Set(files);
+		for (const key of sessionInfoCache.keys()) {
+			if (dirname(key) === dir && !present.has(key)) {
+				sessionInfoCache.delete(key);
+			}
+		}
 
 		let loaded = 0;
 		for (const file of files) {
@@ -1456,13 +1495,15 @@ export class SessionManager {
 	 * Use buildSessionContext() to get the resolved messages for the LLM.
 	 */
 	getBranch(fromId?: string): SessionEntry[] {
+		// push+reverse, not unshift-per-entry: unshift is O(n), which makes this O(n^2) on long sessions.
 		const path: SessionEntry[] = [];
 		const startId = fromId ?? this.leafId;
 		let current = startId ? this.byId.get(startId) : undefined;
 		while (current) {
-			path.unshift(current);
+			path.push(current);
 			current = current.parentId ? this.byId.get(current.parentId) : undefined;
 		}
+		path.reverse();
 		return path;
 	}
 


### PR DESCRIPTION
- opening a session read the whole file and utf-8 decoded it into one giant string, and two leaf-to-root walks inserted at the front of an array per entry, so large or long sessions took seconds to open; reads now decode line by line and the walks are linear.
- browsing saved sessions rescanned every file on every open; it now caches per-file metadata keyed by size and modified time, so only sessions that actually changed are re-read.
- no user-facing change and output is byte-identical, with the full test suite passing; in practice a 500mb session opens in ~0.9s instead of ~1.8s and a very long session loads in ~5s instead of ~24s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal performance refactors in session I/O and traversal with byte-identical behavior per PR description; cache invalidation relies on append-only files and stat metadata.
> 
> **Overview**
> Improves **session open and LLM context** performance on large or long histories without changing persisted output.
> 
> **Leaf-to-root walks** in `buildSessionContext` and `SessionManager.getBranch` now **`push` then `reverse`** instead of **`unshift` per entry**, avoiding **O(n²)** path construction on deep branches.
> 
> **`loadEntriesFromFile`** reads the JSONL as a **`Buffer`**, finds newline boundaries, and **`JSON.parse`s each slice**, instead of decoding the whole file to one UTF-16 string and splitting—faster opens and lower peak memory on very large session files.
> 
> **Session browser / listing** adds a module-level **`sessionInfoCache`** keyed by file path with **`(size, mtimeMs)`** (valid because files are append-only), so **`listSessions`** reuses **`SessionInfo`** for unchanged files; **`scanSessionInfo`** holds the full scan logic, and **`listSessionsFromDir`** evicts cache entries for files removed from the directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d069c3c91d5e2c311bf8e2ea09a66a2efdb7bb0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make session load, context, and listing scale linearly with session size
> - Replaces `Array.unshift` with `push` + `reverse` in `buildSessionContext` and `Session.getBranch` to avoid O(n²) path construction for long sessions.
> - Refactors `loadEntriesFromFile` to read a raw `Buffer` and split on `0x0a` byte offsets instead of `readFileSync` + `String.split`, avoiding a full UTF-8 decode and large string allocation upfront.
> - Adds a module-level `sessionInfoCache` Map in [session-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/217/files#diff-e514ecbe1ca80031cc52600ee3863d993a99616f116355f3fec33c92b532d2cf) keyed by file path, storing `size` and `mtimeMs` alongside the parsed `SessionInfo` to skip redundant scans of unchanged append-only files.
> - Extracts session scanning logic into a new `scanSessionInfo` function and adds cache eviction in `listSessionsFromDir` for files that no longer exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d069c3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->