### PR TITLE
load sessions off the event loop so a big load doesn't freeze the daemon

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -11,7 +11,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "fs";
-import { readdir, stat } from "fs/promises";
+import { readdir, readFile, stat } from "fs/promises";
 import { dirname, join, resolve } from "path";
 import { createInterface } from "readline";
 import { v7 as uuidv7 } from "uuid";
@@ -542,13 +542,9 @@ export function getDefaultSessionDir(_cwd: string, agentDir: string = getDefault
 	return sessionDir;
 }
 
-/** Exported for testing */
-export function loadEntriesFromFile(filePath: string): FileEntry[] {
-	if (!existsSync(filePath)) return [];
-
-	// Decode per line off a Buffer: readFileSync(path, "utf8") on a large file is far
-	// slower (one giant UTF-16 string). Splitting on 0x0a is UTF-8-safe.
-	const buffer = readFileSync(filePath);
+// Decode per line off a Buffer: toString("utf8") on a whole large file is far slower
+// (one giant UTF-16 string). Splitting on 0x0a is UTF-8-safe.
+function parseEntriesFromBuffer(buffer: Buffer): FileEntry[] {
 	const entries: FileEntry[] = [];
 	const len = buffer.length;
 	let start = 0;
@@ -564,16 +560,53 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		}
 		start = end + 1;
 	}
+	return entries;
+}
 
-	// Validate session header
+function finalizeLoadedEntries(entries: FileEntry[]): FileEntry[] {
 	if (entries.length === 0) return entries;
 	const header = entries[0];
 	if (header.type !== "session" || typeof (header as any).id !== "string") {
 		return [];
 	}
-
 	applyChildUsageAttributions(entries);
 	return entries;
+}
+
+/** Exported for testing */
+export function loadEntriesFromFile(filePath: string): FileEntry[] {
+	if (!existsSync(filePath)) return [];
+	return finalizeLoadedEntries(parseEntriesFromBuffer(readFileSync(filePath)));
+}
+
+// Async loader for the daemon: reads off the event loop and yields while parsing so a
+// large load doesn't freeze other sessions. Identical output to loadEntriesFromFile.
+export async function loadEntriesFromFileAsync(filePath: string): Promise<FileEntry[]> {
+	if (!existsSync(filePath)) return [];
+	const buffer = await readFile(filePath);
+	const entries: FileEntry[] = [];
+	const len = buffer.length;
+	// yield by bytes, not entry count: parse cost scales with bytes (handles a few huge entries too)
+	const YIELD_BYTES = 4 * 1024 * 1024;
+	let start = 0;
+	let lastYield = 0;
+	while (start < len) {
+		let end = buffer.indexOf(0x0a, start);
+		if (end === -1) end = len;
+		if (end > start) {
+			try {
+				entries.push(JSON.parse(buffer.toString("utf8", start, end)) as FileEntry);
+			} catch {
+				// Skip malformed/blank lines (JSON.parse rejects whitespace-only slices)
+			}
+		}
+		start = end + 1;
+		if (start - lastYield >= YIELD_BYTES) {
+			lastYield = start;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+		}
+	}
+	return finalizeLoadedEntries(entries);
 }
 
 function readSessionHeader(filePath: string): Partial<SessionHeader> | undefined {
@@ -986,7 +1019,13 @@ export class SessionManager {
 	private leafId: string | null = null;
 	private persistListeners = new Set<SessionPersistListener>();
 
-	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
+	private constructor(
+		cwd: string,
+		sessionDir: string,
+		sessionFile: string | undefined,
+		persist: boolean,
+		preloadedEntries?: FileEntry[],
+	) {
 		this.cwd = cwd;
 		this.sessionDir = sessionDir;
 		this.persist = persist;
@@ -995,17 +1034,21 @@ export class SessionManager {
 		}
 
 		if (sessionFile) {
-			this.setSessionFile(sessionFile);
+			this.setSessionFile(sessionFile, preloadedEntries);
 		} else {
 			this.newSession();
 		}
 	}
 
-	/** Switch to a different session file (used for resume and branching) */
-	setSessionFile(sessionFile: string): void {
+	/**
+	 * Switch to a different session file (used for resume and branching).
+	 * preloadedEntries must be loadEntriesFromFile(sessionFile) for the same path; it
+	 * lets the async daemon path skip the synchronous re-read.
+	 */
+	setSessionFile(sessionFile: string, preloadedEntries?: FileEntry[]): void {
 		this.sessionFile = resolve(sessionFile);
 		if (existsSync(this.sessionFile)) {
-			this.fileEntries = loadEntriesFromFile(this.sessionFile);
+			this.fileEntries = preloadedEntries ?? loadEntriesFromFile(this.sessionFile);
 
 			// If file was empty or corrupted (no valid header), truncate and start fresh
 			// to avoid appending messages without a session header (which breaks the session)
@@ -1776,6 +1819,25 @@ export class SessionManager {
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ?? resolve(path, "..");
 		return new SessionManager(cwd ?? process.cwd(), dir, path, true);
+	}
+
+	/**
+	 * Non-blocking open() for the daemon: parses off the event loop so a large load
+	 * doesn't freeze other sessions. Falls back to open() for any non-happy path so
+	 * behavior is identical to it.
+	 */
+	static async openAsync(path: string, sessionDir?: string, cwdOverride?: string): Promise<SessionManager> {
+		if (!existsSync(path)) {
+			return SessionManager.open(path, sessionDir, cwdOverride);
+		}
+		const entries = await loadEntriesFromFileAsync(path);
+		// empty/corrupt: defer to open() (finalizeLoadedEntries guarantees entries[0] is a valid header otherwise)
+		if (entries.length === 0) {
+			return SessionManager.open(path, sessionDir, cwdOverride);
+		}
+		const cwd = cwdOverride ?? (entries[0] as SessionHeader).cwd;
+		const dir = sessionDir ?? resolve(path, "..");
+		return new SessionManager(cwd ?? process.cwd(), dir, path, true, entries);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -374,7 +374,7 @@ export class AgentDaemon {
 			? await resolveDaemonSessionPath(command.sessionPath, cwd, config.sessionDir)
 			: undefined;
 		const sessionManager = sessionPath
-			? SessionManager.open(sessionPath, config.sessionDir, cwdOverride)
+			? await SessionManager.openAsync(sessionPath, config.sessionDir, cwdOverride)
 			: command.continueRecent
 				? SessionManager.continueRecent(cwd, config.sessionDir)
 				: SessionManager.create(cwd, config.sessionDir);


### PR DESCRIPTION
- loading a session into the daemon parsed the whole file synchronously, so opening a large session froze every other session the daemon hosts for the duration (~900ms for a 500mb session).
- adds an async loader that reads the file off the event loop and yields every few megabytes while parsing, used by the daemon's session-open path; output is byte-identical to the sync loader and non-existent or corrupt files fall back to the existing path unchanged.
- max event-loop stall while loading a 500mb session drops from ~900ms to ~90ms, so other sessions stay responsive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with explicit fallback to the existing sync open path; only affects daemon session-open latency, not persistence or auth.
> 
> **Overview**
> Opening a session with a large JSONL file no longer blocks the whole daemon while the file is read and parsed.
> 
> **Session loading** is split into shared `parseEntriesFromBuffer` / `finalizeLoadedEntries` helpers. A new `loadEntriesFromFileAsync` uses `fs/promises.readFile` and `setImmediate` every ~4MB of parsed bytes so other hosted sessions can run mid-load. `SessionManager.openAsync` uses that path and passes preloaded entries into `setSessionFile` to avoid a second synchronous read; missing or empty/corrupt files still delegate to `SessionManager.open`.
> 
> The daemon **create** path now `await`s `SessionManager.openAsync` when opening by `sessionPath` instead of synchronous `open`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcb60c878bfdf0b78c1bdd5c4ea5d7624134fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load sessions off the event loop to prevent daemon freezing on large session files
> - Adds `loadEntriesFromFileAsync` in [session-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/220/files#diff-e514ecbe1ca80031cc52600ee3863d993a99616f116355f3fec33c92b532d2cf) that reads session files asynchronously, yielding to the event loop via `setImmediate` every 4MB of parsed data.
> - Adds `SessionManager.openAsync` static method that uses the async loader and passes pre-loaded entries to the constructor to avoid a redundant synchronous re-read.
> - Updates [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/220/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) to call `SessionManager.openAsync` instead of the synchronous `SessionManager.open` when a session path is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dcb60c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->