### PR TITLE
fix onboarding showing no models after entering provider key

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1336,7 +1336,7 @@ export async function main(args: string[], options?: MainOptions) {
 					model: startupModel.model,
 					thinkingLevel: prepared.sessionOptions.thinkingLevel ?? defaultSessionConfig.thinking ?? "off",
 					scopedModels: prepared.sessionOptions.scopedModels ?? [],
-					availableModels: services.modelRegistry.getAvailable(),
+					availableModels: () => services.modelRegistry.getAvailable(),
 					steeringMode: settingsManager.getSteeringMode(),
 					followUpMode: settingsManager.getFollowUpMode(),
 					autoCompactionEnabled: settingsManager.getCompactionEnabled(),

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -47,7 +47,9 @@ export interface DeferredAgentConnectionSeed {
 	model?: AgentConnectionModel;
 	thinkingLevel: ThinkingLevel;
 	scopedModels: AgentConnectionScopedModel[];
-	availableModels: AgentConnectionModel[];
+	// A thunk, not a frozen array: the available set changes pre-session when the
+	// user logs in during onboarding, so it must reflect the current registry.
+	availableModels: () => AgentConnectionModel[];
 	steeringMode: AgentConnectionQueueMode;
 	followUpMode: AgentConnectionQueueMode;
 	autoCompactionEnabled: boolean;
@@ -237,7 +239,7 @@ export class DeferredAgentConnection implements AgentConnection {
 	}
 
 	async getAvailableModels(): Promise<AgentConnectionModel[]> {
-		return this.real ? this.real.getAvailableModels() : this.seed.availableModels;
+		return this.real ? this.real.getAvailableModels() : this.seed.availableModels();
 	}
 
 	async getSessionStats(): Promise<SessionStats> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -47,8 +47,6 @@ export interface DeferredAgentConnectionSeed {
 	model?: AgentConnectionModel;
 	thinkingLevel: ThinkingLevel;
 	scopedModels: AgentConnectionScopedModel[];
-	// A thunk, not a frozen array: the available set changes pre-session when the
-	// user logs in during onboarding, so it must reflect the current registry.
 	availableModels: () => AgentConnectionModel[];
 	steeringMode: AgentConnectionQueueMode;
 	followUpMode: AgentConnectionQueueMode;

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -182,7 +182,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		// Load available models (built-in models still work even if models.json failed)
 		let availableModels: ReadonlyArray<Model<any>>;
 		try {
-			availableModels = this.availableModels ?? (await this.modelRegistry.getAvailable());
+			// An empty passed-in snapshot must not beat a live query: a caller may
+			// have captured it before auth was configured (e.g. during onboarding).
+			availableModels = this.availableModels?.length
+				? this.availableModels
+				: await this.modelRegistry.getAvailable();
 			models = availableModels.map((model: Model<any>) => ({
 				provider: model.provider,
 				id: model.id,

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -206,7 +206,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			const scopedModelId = `${scoped.model.provider}/${scoped.model.id}`;
 			const refreshed =
 				availableModelsById.get(scopedModelId) ??
-				(this.availableModels ? undefined : this.modelRegistry.find(scoped.model.provider, scoped.model.id));
+				(this.availableModels?.length
+					? undefined
+					: this.modelRegistry.find(scoped.model.provider, scoped.model.id));
 			return refreshed ? { ...scoped, model: refreshed } : scoped;
 		});
 		this.scopedModelItems = this.scopedModels.map((scoped) => ({

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -182,8 +182,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		// Load available models (built-in models still work even if models.json failed)
 		let availableModels: ReadonlyArray<Model<any>>;
 		try {
-			// An empty passed-in snapshot must not beat a live query: a caller may
-			// have captured it before auth was configured (e.g. during onboarding).
+			// An empty snapshot may predate login; prefer a live query.
 			availableModels = this.availableModels?.length
 				? this.availableModels
 				: await this.modelRegistry.getAvailable();

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -85,8 +85,6 @@ describe("DeferredAgentConnection", () => {
 	});
 
 	test("re-evaluates availableModels on each read so login during onboarding shows models", async () => {
-		// Regression: ENG-4206. The seed list is empty before the user logs in;
-		// after login (no session promotion yet) the next read must reflect it.
 		const { factory } = makeFactory();
 		let models: AgentConnectionModel[] = [];
 		const conn = new DeferredAgentConnection(factory, { ...SEED, availableModels: () => models });

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -17,7 +17,7 @@ const SEED: DeferredAgentConnectionSeed = {
 	model: MODEL,
 	thinkingLevel: "off",
 	scopedModels: [],
-	availableModels: [MODEL],
+	availableModels: () => [MODEL],
 	steeringMode: "all",
 	followUpMode: "all",
 	autoCompactionEnabled: true,
@@ -82,6 +82,20 @@ describe("DeferredAgentConnection", () => {
 		await conn.dispose();
 		expect(factory).not.toHaveBeenCalled();
 		expect(conn.created).toBe(false);
+	});
+
+	test("re-evaluates availableModels on each read so login during onboarding shows models", async () => {
+		// Regression: ENG-4206. The seed list is empty before the user logs in;
+		// after login (no session promotion yet) the next read must reflect it.
+		const { factory } = makeFactory();
+		let models: AgentConnectionModel[] = [];
+		const conn = new DeferredAgentConnection(factory, { ...SEED, availableModels: () => models });
+
+		expect(await conn.getAvailableModels()).toEqual([]);
+
+		models = [MODEL];
+		expect(await conn.getAvailableModels()).toEqual([MODEL]);
+		expect(factory).not.toHaveBeenCalled();
 	});
 
 	test("creates the session on first prompt and delegates", async () => {


### PR DESCRIPTION
- during first-run onboarding, logging in with a provider key showed an empty model list until the app was restarted.
- the pre-session connection served a model list snapshotted at startup, before any credentials existed, and never recomputed it after login.
- it now reads the live model registry on each request, so models appear as soon as a key is added, which also lets onboarding complete instead of looping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to pre-session UI model listing and selector loading; no auth or session persistence changes beyond fresher reads.
> 
> **Overview**
> Fixes first-run onboarding showing an **empty model list** after entering a provider key, which could block completing setup until restart.
> 
> The pre-session **`DeferredAgentConnection`** no longer freezes `availableModels` at startup. The seed now supplies a **getter** (`() => modelRegistry.getAvailable()`), and **`getAvailableModels`** invokes it on every read so credentials added during onboarding are reflected immediately.
> 
> **`ModelSelectorComponent`** treats a passed-in empty list as a stale pre-login snapshot and **falls back to a live** `modelRegistry.getAvailable()` call (and only skips `find()` for scoped refresh when a non-empty snapshot was provided).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22210b7d3fdf756c9378e87e83fc7df5f7ac0ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding model selector showing no models after entering a provider key
> - Changes `availableModels` in `DeferredAgentConnectionSeed` from a pre-evaluated array to a thunk (`() => Promise<AgentConnectionModel[]>`), so each call to `getAvailableModels` re-queries the registry instead of returning a stale snapshot.
> - Updates `ModelSelectorComponent` to fall back to a live `modelRegistry.getAvailable()` call when the provided `availableModels` snapshot is empty, covering the case where models become available after the key is entered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22210b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->