### PR TITLE
Add autonomous finish contract

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1569,7 +1569,7 @@ export class AgentSession {
 		if (goalMessages.length > 0 || signal?.aborted) {
 			return goalMessages;
 		}
-		const autonomousMessage = nextAutonomousContinuation(this._autonomousState, context.message);
+		const autonomousMessage = nextAutonomousContinuation(this._autonomousState, context.message, { cwd: this._cwd });
 		return autonomousMessage ? [autonomousMessage] : [];
 	}
 

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -1,4 +1,10 @@
+import { spawnSync } from "node:child_process";
 import type { AssistantMessage, TextContent, Usage, UserMessage } from "@earendil-works/pi-ai";
+
+export interface AgentAutonomousFinishContractConfig {
+	enabled?: boolean;
+	continuationPrompt?: string;
+}
 
 export interface AgentAutonomousConfig {
 	enabled?: boolean;
@@ -7,6 +13,7 @@ export interface AgentAutonomousConfig {
 	maxTokens?: number;
 	timeoutMs?: number;
 	continuationPrompt?: string;
+	finishContract?: AgentAutonomousFinishContractConfig;
 }
 
 export interface AgentAutonomousStatus {
@@ -15,13 +22,18 @@ export interface AgentAutonomousStatus {
 	turnsUsed: number;
 	tokensUsed: number;
 	startedAt?: number;
-	limits: Required<Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt">>;
+	limits: Required<Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt" | "finishContract">>;
 }
 
 export const DEFAULT_AUTONOMOUS_CONTINUATION_PROMPT =
 	"Continue autonomously. Make a reasonable assumption, inspect the repo, run tests, and only stop when you have a validated patch or a concrete external blocker. If you are blocked, state the exact blocker and the evidence.";
 
-export const DEFAULT_AUTONOMOUS_LIMITS: Required<Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt">> = {
+export const DEFAULT_AUTONOMOUS_FINISH_PROMPT =
+	"Autonomous finish contract is not satisfied. Do not stop with 'I think it works'. Continue until one of these is true: a clean git patch exists, configured tests passed, an explicit blocker artifact is written, or a no-op is justified with evidence. Inspect the repo and run the relevant checks now.";
+
+export const DEFAULT_AUTONOMOUS_LIMITS: Required<
+	Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt" | "finishContract">
+> = {
 	maxContinuations: 3,
 	maxTurns: 12,
 	maxTokens: 80_000,
@@ -34,13 +46,14 @@ export interface AutonomousRuntimeState {
 	turnsUsed: number;
 	tokensUsed: number;
 	startedAt?: number;
-	limits: Required<Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt">>;
+	limits: Required<Omit<AgentAutonomousConfig, "enabled" | "continuationPrompt" | "finishContract">>;
 	continuationPrompt: string;
+	finishContract: Required<AgentAutonomousFinishContractConfig>;
 }
 
 export interface AutonomousDecision {
 	shouldContinue: boolean;
-	reason: "asks_user" | "soft_blocker" | "real_blocker" | "not_needed" | "limit_reached";
+	reason: "asks_user" | "soft_blocker" | "finish_contract" | "real_blocker" | "not_needed" | "limit_reached";
 }
 
 export function createAutonomousRuntimeState(config?: AgentAutonomousConfig): AutonomousRuntimeState {
@@ -58,6 +71,10 @@ export function createAutonomousRuntimeState(config?: AgentAutonomousConfig): Au
 			timeoutMs: normalizeLimit(config?.timeoutMs, DEFAULT_AUTONOMOUS_LIMITS.timeoutMs),
 		},
 		continuationPrompt: config?.continuationPrompt?.trim() || DEFAULT_AUTONOMOUS_CONTINUATION_PROMPT,
+		finishContract: {
+			enabled: config?.finishContract?.enabled ?? true,
+			continuationPrompt: config?.finishContract?.continuationPrompt?.trim() || DEFAULT_AUTONOMOUS_FINISH_PROMPT,
+		},
 	};
 }
 
@@ -95,19 +112,28 @@ export function addAutonomousUsage(state: AutonomousRuntimeState, usage: Usage |
 export function nextAutonomousContinuation(
 	state: AutonomousRuntimeState,
 	message: AssistantMessage,
+	options: { cwd?: string } = {},
 	now = Date.now(),
 ): UserMessage | undefined {
 	if (!state.enabled) {
 		return undefined;
 	}
-	const decision = shouldAutonomouslyContinue(state, message, now);
+	const decision = shouldAutonomouslyContinue(state, message, options, now);
 	if (!decision.shouldContinue) {
 		return undefined;
 	}
 	state.continuationsUsed++;
 	return {
 		role: "user",
-		content: [{ type: "text", text: state.continuationPrompt }],
+		content: [
+			{
+				type: "text",
+				text:
+					decision.reason === "finish_contract"
+						? state.finishContract.continuationPrompt
+						: state.continuationPrompt,
+			},
+		],
 		timestamp: now,
 	};
 }
@@ -115,6 +141,7 @@ export function nextAutonomousContinuation(
 export function shouldAutonomouslyContinue(
 	state: AutonomousRuntimeState,
 	message: AssistantMessage,
+	options: { cwd?: string } = {},
 	now = Date.now(),
 ): AutonomousDecision {
 	if (!state.enabled || message.stopReason === "error" || message.stopReason === "aborted") {
@@ -135,6 +162,9 @@ export function shouldAutonomouslyContinue(
 	}
 	if (reportsSoftBlocker(text)) {
 		return { shouldContinue: true, reason: "soft_blocker" };
+	}
+	if (state.finishContract.enabled && !hasAutonomousFinishEvidence(text, options.cwd)) {
+		return { shouldContinue: true, reason: "finish_contract" };
 	}
 	return { shouldContinue: false, reason: "not_needed" };
 }
@@ -204,6 +234,28 @@ function isRealExternalBlocker(text: string): boolean {
 		/\bmanual approval\b/,
 		/\bexternal account\b/,
 	].some((pattern) => pattern.test(normalized));
+}
+
+export function hasAutonomousFinishEvidence(text: string, cwd?: string): boolean {
+	if (cwd && hasGitWorktreeChanges(cwd)) {
+		return true;
+	}
+	const normalized = normalize(text);
+	return (
+		/\b(tests?|checks?|lint|typecheck|build)\b.{0,80}\b(pass|passed|green|succeeded|clean)\b/.test(normalized) ||
+		/\b(pass|passed|green|succeeded|clean)\b.{0,80}\b(tests?|checks?|lint|typecheck|build)\b/.test(normalized) ||
+		/\b(blocker artifact|wrote .{0,40}blocker|saved .{0,40}blocker|blocker\.md)\b/.test(normalized) ||
+		/\b(no-op|no op|no changes? needed)\b.{0,120}\b(evidence|because|verified|confirmed)\b/.test(normalized)
+	);
+}
+
+function hasGitWorktreeChanges(cwd: string): boolean {
+	const result = spawnSync("git", ["--no-optional-locks", "status", "--porcelain"], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	});
+	return result.status === 0 && typeof result.stdout === "string" && result.stdout.trim().length > 0;
 }
 
 function normalize(text: string): string {

--- a/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
@@ -1,8 +1,13 @@
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	createAutonomousRuntimeState,
 	DEFAULT_AUTONOMOUS_CONTINUATION_PROMPT,
+	DEFAULT_AUTONOMOUS_FINISH_PROMPT,
+	hasAutonomousFinishEvidence,
 	shouldAutonomouslyContinue,
 } from "../../src/core/autonomous.js";
 import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "./harness.js";
@@ -18,7 +23,7 @@ describe("AgentSession autonomous mode", () => {
 
 	it("injects a host-side continuation when the assistant asks the user for help", async () => {
 		const harness = await createHarness({
-			autonomous: { enabled: true, maxContinuations: 2 },
+			autonomous: { enabled: true, maxContinuations: 2, finishContract: { enabled: false } },
 		});
 		harnesses.push(harness);
 		harness.setResponses([
@@ -59,7 +64,7 @@ describe("AgentSession autonomous mode", () => {
 
 	it("stops after the configured autonomous continuation limit", async () => {
 		const harness = await createHarness({
-			autonomous: { enabled: true, maxContinuations: 1 },
+			autonomous: { enabled: true, maxContinuations: 1, finishContract: { enabled: false } },
 		});
 		harnesses.push(harness);
 		harness.setResponses([
@@ -92,6 +97,44 @@ describe("AgentSession autonomous mode", () => {
 		expect(statusMessages).toHaveLength(2);
 	});
 
+	it("continues when the assistant tries to finish without contract evidence", async () => {
+		const harness = await createHarness({
+			autonomous: { enabled: true, maxContinuations: 2 },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("I think it works."),
+			fauxAssistantMessage("I ran npm test and all tests passed."),
+		]);
+
+		await harness.session.prompt("make the change");
+
+		expect(getUserTexts(harness)).toEqual(["make the change", DEFAULT_AUTONOMOUS_FINISH_PROMPT]);
+		expect(getAssistantTexts(harness)).toEqual(["I think it works.", "I ran npm test and all tests passed."]);
+		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(1);
+	});
+
+	it("accepts an existing git patch as finish evidence", async () => {
+		const harness = await createHarness({
+			autonomous: { enabled: true, maxContinuations: 2 },
+		});
+		harnesses.push(harness);
+		execFileSync("git", ["init"], { cwd: harness.tempDir, stdio: "ignore" });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: harness.tempDir });
+		execFileSync("git", ["config", "user.name", "Test User"], { cwd: harness.tempDir });
+		const path = join(harness.tempDir, "file.txt");
+		writeFileSync(path, "before\n");
+		execFileSync("git", ["add", "file.txt"], { cwd: harness.tempDir });
+		execFileSync("git", ["commit", "-m", "initial"], { cwd: harness.tempDir, stdio: "ignore" });
+		writeFileSync(path, "after\n");
+		harness.setResponses([fauxAssistantMessage("Done.")]);
+
+		await harness.session.prompt("make the change");
+
+		expect(getUserTexts(harness)).toEqual(["make the change"]);
+		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);
+	});
+
 	it("classifies soft blockers separately from real external blockers", () => {
 		const state = createAutonomousRuntimeState({ enabled: true });
 
@@ -107,5 +150,13 @@ describe("AgentSession autonomous mode", () => {
 			shouldContinue: false,
 			reason: "real_blocker",
 		});
+	});
+
+	it("accepts no-op and test evidence in finish classification", () => {
+		expect(
+			hasAutonomousFinishEvidence("No-op: no changes needed because the requested behavior already exists."),
+		).toBe(true);
+		expect(hasAutonomousFinishEvidence("I ran npm test and tests passed.")).toBe(true);
+		expect(hasAutonomousFinishEvidence("I think it works.")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- add an autonomous finish contract that prevents stopping with only "I think it works"
- require evidence before autonomous mode stops: git patch, passing test/check evidence, blocker artifact, or justified no-op
- feed a host-side continuation prompt when the finish contract is not satisfied
- keep the feature scoped to autonomous mode and leave normal sessions unchanged

## Testing

- `npm --prefix packages/coding-agent test -- suite/agent-session-autonomous.test.ts`
- `./node_modules/.bin/tsgo --noEmit`
- `npm run check`
- stacked autonomous suite on `feature/autonomous-quality-gates`: `npm --prefix packages/coding-agent test -- suite/agent-session-autonomous.test.ts args.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add autonomous finish contract to require evidence before stopping autonomous agent sessions
> - Introduces a `finishContract` concept in [autonomous.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/223/files#diff-cef9072ed18a98248d540106d118245ee4a0ffc2474a184e812f705f89245e76): when enabled (default), the agent checks for concrete finish evidence before accepting a stop decision.
> - Evidence is detected via `hasAutonomousFinishEvidence`, which checks for pending git worktree changes (`git status --porcelain`) or text patterns indicating passing tests, a blocker artifact, or a justified no-op.
> - If evidence is missing, `shouldAutonomouslyContinue` returns a new `'finish_contract'` decision reason, and `nextAutonomousContinuation` injects a specific prompt (`DEFAULT_AUTONOMOUS_FINISH_PROMPT`) demanding concrete evidence.
> - `AgentSession._getContinuationMessages` now passes `{ cwd }` to `nextAutonomousContinuation` so git status checks use the correct working directory.
> - Behavioral Change: autonomous sessions enabled by default will no longer stop unless the agent produces a git patch, passes tests, references a blocker, or explicitly justifies a no-op.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f03440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->