### PR TITLE
Export benchmark patch artifacts

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -40,6 +40,7 @@ const DAEMON_CLIENT_COMMANDS = new Set([
 	"state",
 	"messages",
 	"stats",
+	"patch-artifact",
 	"commands",
 	"cron",
 	"shutdown",
@@ -232,6 +233,9 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 					{ type: "get_session_stats", activeSessionId: requireActiveSessionId(parsed.positionals) },
 					true,
 				);
+				return;
+			case "patch-artifact":
+				await runPatchArtifact(client, parsed.positionals, parsed.json);
 				return;
 			case "commands":
 				await printResponseData(
@@ -892,6 +896,28 @@ async function runCron(client: DaemonClient, args: string[], json: boolean): Pro
 	throw new Error(`Unknown cron command: ${subcommand}`);
 }
 
+async function runPatchArtifact(client: DaemonClient, args: string[], json: boolean): Promise<void> {
+	const activeSessionId = requireActiveSessionId(args);
+	const outputDir = args.slice(1).join(" ").trim() || undefined;
+	const response = await client.request({ type: "export_patch_artifact", activeSessionId, outputDir }, 120000);
+	const data = requireSuccess(response);
+	if (json) {
+		printJson(data);
+		return;
+	}
+	if (isPatchArtifactData(data)) {
+		console.log(`Patch artifact exported to: ${data.directory}`);
+		if (data.status !== "ready") {
+			console.log(`Status: ${data.status}`);
+		}
+		if (data.rejectedFiles.length > 0) {
+			console.log(`Rejected files: ${data.rejectedFiles.join(", ")}`);
+		}
+		return;
+	}
+	printJson(data);
+}
+
 async function printResponseData(
 	client: DaemonClient,
 	command: Parameters<DaemonClient["request"]>[0],
@@ -919,6 +945,22 @@ function requireSuccess(response: DaemonResponse): unknown {
 		throw new Error(response.error);
 	}
 	return "data" in response ? response.data : undefined;
+}
+
+function isPatchArtifactData(value: unknown): value is {
+	directory: string;
+	status: string;
+	rejectedFiles: string[];
+} {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const candidate = value as { directory?: unknown; status?: unknown; rejectedFiles?: unknown };
+	return (
+		typeof candidate.directory === "string" &&
+		typeof candidate.status === "string" &&
+		Array.isArray(candidate.rejectedFiles)
+	);
 }
 
 async function requireSuccessAsync(responsePromise: Promise<DaemonResponse>): Promise<unknown> {
@@ -1472,6 +1514,7 @@ ${chalk.bold("Commands:")}
   state <session>               Print session state as JSON
   messages <session>            Print messages as JSON
   stats <session>               Print session stats as JSON
+  patch-artifact <session> [dir] Export git patch, metadata, and trajectory
   commands <session>            Print available commands as JSON
   cron list [-a|--all] [session] List scheduled cron jobs
   cron add <session> <schedule> -- <message>
@@ -1502,6 +1545,7 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock create scratch
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock cron add <session> "*/30 * * * *" -- "Check progress"
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock cron list
+  ${APP_NAME} daemon --socket /tmp/prime-agent.sock patch-artifact <session>
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock prompt <session> "Say hello"
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock attach <session>
   ${APP_NAME} daemon --socket /tmp/prime-agent.sock shutdown

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -118,6 +118,7 @@ import type { HostRequestHandlers } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
+import { createPatchArtifact, type PatchArtifactResult } from "./patch-artifact.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import {
 	appendGlobalRefinement,
@@ -5072,6 +5073,20 @@ export class AgentSession {
 
 		writeFileSync(filePath, `${lines.join("\n")}\n`);
 		return filePath;
+	}
+
+	/**
+	 * Export a benchmark-friendly patch artifact with metadata and trajectory.
+	 * @param outputDir Target directory. If omitted, writes beside the session file.
+	 * @returns Paths and status for the generated artifact.
+	 */
+	exportPatchArtifact(outputDir?: string): PatchArtifactResult {
+		return createPatchArtifact({
+			cwd: this.sessionManager.getCwd(),
+			outputDir,
+			sessionFile: this.sessionFile,
+			sessionStats: this.getSessionStats(),
+		});
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -77,6 +77,7 @@ export {
 	type TurnStartEvent,
 	type WorkingIndicatorOptions,
 } from "./extensions/index.js";
+export { createPatchArtifact, type PatchArtifactResult } from "./patch-artifact.js";
 export type { RefinementResult } from "./refinement/index.js";
 export type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
 export { SessionImportFileNotFoundError } from "./session-import-errors.js";

--- a/packages/coding-agent/src/core/patch-artifact.ts
+++ b/packages/coding-agent/src/core/patch-artifact.ts
@@ -1,0 +1,268 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { captureGitContext, type GitContext } from "../utils/git.js";
+import type { SessionStats } from "./session-stats.js";
+
+export type PatchArtifactStatus = "ready" | "empty" | "not_git_repo" | "rejected_setup_churn";
+
+export interface PatchArtifactOptions {
+	cwd: string;
+	outputDir?: string;
+	sessionFile?: string;
+	sessionStats?: SessionStats;
+	testsRun?: string[];
+	failures?: string[];
+	finalStatus?: string;
+	allowSetupChurn?: boolean;
+}
+
+export interface PatchArtifactMetadata {
+	version: 1;
+	createdAt: string;
+	cwd: string;
+	git: GitContext | null;
+	status: PatchArtifactStatus;
+	files: {
+		changed: string[];
+		rejected: string[];
+		untracked: string[];
+	};
+	patch: {
+		path: string;
+		bytes: number;
+	};
+	trajectory?: {
+		path: string;
+		source: string;
+	};
+	session?: SessionStats;
+	testsRun: string[];
+	failures: string[];
+	finalStatus?: string;
+}
+
+export interface PatchArtifactResult {
+	directory: string;
+	patchPath: string;
+	metadataPath: string;
+	summaryPath: string;
+	trajectoryPath?: string;
+	status: PatchArtifactStatus;
+	changedFiles: string[];
+	rejectedFiles: string[];
+	untrackedFiles: string[];
+}
+
+const SETUP_CHURN_FILENAMES = new Set([
+	"bun.lock",
+	"bun.lockb",
+	"Cargo.lock",
+	"Cargo.toml",
+	"composer.json",
+	"composer.lock",
+	"go.mod",
+	"go.sum",
+	"package.json",
+	"package-lock.json",
+	"pnpm-lock.yaml",
+	"poetry.lock",
+	"pyproject.toml",
+	"setup.cfg",
+	"setup.py",
+	"tox.ini",
+	"uv.lock",
+	"yarn.lock",
+	"yarn.lock.yml",
+]);
+
+const SETUP_CHURN_PATH_PATTERNS = [
+	/(^|\/)requirements(?:-[^/]*)?\.txt$/,
+	/(^|\/)environment\.ya?ml$/,
+	/(^|\/)conda\.ya?ml$/,
+	/(^|\/)\.github\/workflows\/[^/]+\.ya?ml$/,
+];
+
+export function createPatchArtifact(options: PatchArtifactOptions): PatchArtifactResult {
+	const cwd = resolve(options.cwd);
+	const createdAt = new Date().toISOString();
+	const artifactDir = resolveArtifactDir({
+		cwd,
+		outputDir: options.outputDir,
+		sessionFile: options.sessionFile,
+		createdAt,
+	});
+
+	const git = captureGitContext(cwd);
+	const trackedPatch = git ? runGit(cwd, ["diff", "--binary", "HEAD", "--"]) : null;
+	const trackedFiles = git ? parseGitLines(runGit(cwd, ["diff", "--name-only", "HEAD", "--"])?.stdout) : [];
+	const untrackedFiles = git ? parseGitLines(runGit(cwd, ["ls-files", "--others", "--exclude-standard"])?.stdout) : [];
+	const untrackedPatch = git ? collectUntrackedPatch(cwd, untrackedFiles) : "";
+	const changedFiles = uniqueSorted([...trackedFiles, ...untrackedFiles]);
+	const rejectedFiles = options.allowSetupChurn ? [] : changedFiles.filter(isSetupChurnPath);
+	const patch = [trackedPatch?.stdout ?? "", untrackedPatch].filter((part) => part.trim().length > 0).join("\n");
+	const status = getPatchStatus({
+		hasGit: Boolean(git),
+		hasPatch: patch.trim().length > 0,
+		rejectedFiles,
+	});
+
+	mkdirSync(artifactDir, { recursive: true });
+	const patchPath = join(artifactDir, "patch.diff");
+	const metadataPath = join(artifactDir, "metadata.json");
+	const summaryPath = join(artifactDir, "summary.md");
+	writeFileSync(patchPath, patch ? `${patch.replace(/\s*$/, "")}\n` : "", "utf8");
+
+	const trajectoryPath = copyTrajectory(options.sessionFile, artifactDir);
+	const metadata: PatchArtifactMetadata = {
+		version: 1,
+		createdAt,
+		cwd,
+		git,
+		status,
+		files: {
+			changed: changedFiles,
+			rejected: rejectedFiles,
+			untracked: untrackedFiles,
+		},
+		patch: {
+			path: relative(artifactDir, patchPath),
+			bytes: Buffer.byteLength(patch, "utf8"),
+		},
+		...(trajectoryPath
+			? {
+					trajectory: {
+						path: relative(artifactDir, trajectoryPath),
+						source: resolve(options.sessionFile!),
+					},
+				}
+			: {}),
+		...(options.sessionStats ? { session: options.sessionStats } : {}),
+		testsRun: options.testsRun ?? [],
+		failures: options.failures ?? [],
+		...(options.finalStatus ? { finalStatus: options.finalStatus } : {}),
+	};
+	writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+	writeFileSync(summaryPath, formatSummary(metadata), "utf8");
+
+	return {
+		directory: artifactDir,
+		patchPath,
+		metadataPath,
+		summaryPath,
+		trajectoryPath,
+		status,
+		changedFiles,
+		rejectedFiles,
+		untrackedFiles,
+	};
+}
+
+function resolveArtifactDir(options: {
+	cwd: string;
+	outputDir?: string;
+	sessionFile?: string;
+	createdAt: string;
+}): string {
+	if (options.outputDir) {
+		return isAbsolute(options.outputDir) ? options.outputDir : resolve(options.cwd, options.outputDir);
+	}
+
+	const safeTimestamp = options.createdAt.replace(/[:.]/g, "-");
+	if (options.sessionFile) {
+		return join(dirname(resolve(options.sessionFile)), "patch-artifacts", safeTimestamp);
+	}
+	return join(options.cwd, ".prime", "patch-artifacts", safeTimestamp);
+}
+
+function runGit(cwd: string, args: string[]): { status: number | null; stdout: string; stderr: string } | null {
+	const result = spawnSync("git", ["--no-optional-locks", ...args], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	const stderr = typeof result.stderr === "string" ? result.stderr : "";
+	if (result.error) {
+		return null;
+	}
+	return { status: result.status, stdout, stderr };
+}
+
+function parseGitLines(value: string | undefined): string[] {
+	return (value ?? "")
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}
+
+function collectUntrackedPatch(cwd: string, files: string[]): string {
+	const parts: string[] = [];
+	for (const file of files) {
+		const fullPath = resolve(cwd, file);
+		if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+			continue;
+		}
+		const diff = runGit(cwd, ["diff", "--no-index", "--binary", "--", "/dev/null", file]);
+		if (!diff || (diff.status !== 0 && diff.status !== 1) || !diff.stdout.trim()) {
+			continue;
+		}
+		parts.push(diff.stdout);
+	}
+	return parts.join("\n");
+}
+
+function uniqueSorted(values: string[]): string[] {
+	return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function isSetupChurnPath(filePath: string): boolean {
+	const normalized = filePath.replace(/\\/g, "/");
+	if (SETUP_CHURN_FILENAMES.has(basename(normalized))) {
+		return true;
+	}
+	return SETUP_CHURN_PATH_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function getPatchStatus(options: { hasGit: boolean; hasPatch: boolean; rejectedFiles: string[] }): PatchArtifactStatus {
+	if (!options.hasGit) {
+		return "not_git_repo";
+	}
+	if (options.rejectedFiles.length > 0) {
+		return "rejected_setup_churn";
+	}
+	if (!options.hasPatch) {
+		return "empty";
+	}
+	return "ready";
+}
+
+function copyTrajectory(sessionFile: string | undefined, artifactDir: string): string | undefined {
+	if (!sessionFile || !existsSync(sessionFile)) {
+		return undefined;
+	}
+	const source = resolve(sessionFile);
+	const target = join(artifactDir, "trajectory.jsonl");
+	copyFileSync(source, target);
+	return target;
+}
+
+function formatSummary(metadata: PatchArtifactMetadata): string {
+	const lines = [
+		"# Prime Agent Patch Artifact",
+		"",
+		`- status: ${metadata.status}`,
+		`- cwd: ${metadata.cwd}`,
+		`- commit: ${metadata.git?.commit ?? "-"}`,
+		`- branch: ${metadata.git?.branch ?? "-"}`,
+		`- changed files: ${metadata.files.changed.length}`,
+		`- rejected setup files: ${metadata.files.rejected.length}`,
+		`- untracked files: ${metadata.files.untracked.length}`,
+		`- patch: ${metadata.patch.path}`,
+		metadata.trajectory ? `- trajectory: ${metadata.trajectory.path}` : "- trajectory: -",
+	];
+	if (metadata.files.rejected.length > 0) {
+		lines.push("", "## Rejected Files", "", ...metadata.files.rejected.map((file) => `- ${file}`));
+	}
+	return `${lines.join("\n")}\n`;
+}

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -38,7 +38,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
-	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
+	{ name: "export", description: "Export session (HTML default, .jsonl, or patch artifact)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -4,6 +4,7 @@ import type { ImageContent, Transport } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
 import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
+import type { PatchArtifactResult } from "../../core/patch-artifact.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type { SessionStats } from "../../core/session-stats.js";
@@ -624,6 +625,14 @@ export class DaemonAgentConnection implements AgentConnection {
 			outputPath,
 		});
 		return data.path;
+	}
+
+	async exportPatchArtifact(outputDir?: string): Promise<PatchArtifactResult> {
+		return this.requestData<PatchArtifactResult>({
+			type: "export_patch_artifact",
+			activeSessionId: this.activeSessionId,
+			outputDir,
+		});
 	}
 
 	async setSessionName(name: string): Promise<void> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -478,6 +478,10 @@ export class DeferredAgentConnection implements AgentConnection {
 		return (await this.ensure()).exportToJsonl(outputPath);
 	}
 
+	async exportPatchArtifact(outputDir?: string) {
+		return (await this.ensure()).exportPatchArtifact(outputDir);
+	}
+
 	async setSessionName(name: string): Promise<void> {
 		return (await this.ensure()).setSessionName(name);
 	}

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -339,6 +339,10 @@ export class InProcessAgentConnection implements AgentConnection {
 		return this.session.exportToJsonl(outputPath);
 	}
 
+	async exportPatchArtifact(outputDir?: string) {
+		return this.session.exportPatchArtifact(outputDir);
+	}
+
 	async setSessionName(name: string): Promise<void> {
 		const trimmedName = name.trim();
 		if (!trimmedName) {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -13,6 +13,7 @@ import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
 import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { GoalState } from "../../core/goals.js";
+import type { PatchArtifactResult } from "../../core/patch-artifact.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type { SessionStats } from "../../core/session-stats.js";
@@ -600,6 +601,7 @@ export interface AgentConnection {
 	importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }>;
 	exportToHtml(outputPath?: string): Promise<string>;
 	exportToJsonl(outputPath?: string): Promise<string>;
+	exportPatchArtifact(outputDir?: string): Promise<PatchArtifactResult>;
 	setSessionName(name: string): Promise<void>;
 	renameSavedSession(sessionPath: string, name: string): Promise<void>;
 	deleteSavedSession(sessionPath: string): Promise<DeleteSessionFileResult>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -143,6 +143,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"import_jsonl",
 	"export_html",
 	"export_jsonl",
+	"export_patch_artifact",
 	"set_session_name",
 	"rename_saved_session",
 	"delete_saved_session",
@@ -1343,6 +1344,12 @@ export class AgentDaemon {
 				const state = this.getSessionState(command.activeSessionId);
 				const path = state.runtime.session.exportToJsonl(command.outputPath);
 				return success(command.id, "export_jsonl", { path });
+			}
+
+			case "export_patch_artifact": {
+				const state = this.getSessionState(command.activeSessionId);
+				const result = state.runtime.session.exportPatchArtifact(command.outputDir);
+				return success(command.id, "export_patch_artifact", result);
 			}
 
 			case "set_session_name": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -2,6 +2,7 @@ import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core"
 import type { ImageContent, Transport } from "@earendil-works/pi-ai";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
+import type { PatchArtifactResult } from "../../core/patch-artifact.js";
 import type { SessionCwdIssue } from "../../core/session-cwd.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type {
@@ -231,6 +232,7 @@ export type DaemonCommand =
 	| { id?: string; type: "import_jsonl"; activeSessionId: string; inputPath: string; cwdOverride?: string }
 	| { id?: string; type: "export_html"; activeSessionId: string; outputPath?: string }
 	| { id?: string; type: "export_jsonl"; activeSessionId: string; outputPath?: string }
+	| { id?: string; type: "export_patch_artifact"; activeSessionId: string; outputDir?: string }
 	| { id?: string; type: "set_session_name"; activeSessionId: string; name: string }
 	| { id?: string; type: "rename_saved_session"; activeSessionId: string; sessionPath: string; name: string }
 	| { id?: string; type: "delete_saved_session"; activeSessionId?: string; sessionPath: string }
@@ -261,6 +263,8 @@ export type DaemonResponse =
 			error: string;
 			errorInfo?: DaemonErrorInfo;
 	  };
+
+export type DaemonPatchArtifactResponse = PatchArtifactResult;
 
 export type DaemonErrorInfo =
 	| { code: "missing_session_cwd"; issue: SessionCwdIssue }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6348,7 +6348,13 @@ export class InteractiveMode {
 		const outputPath = this.getPathCommandArgument(text, "/export");
 
 		try {
-			if (outputPath?.endsWith(".jsonl")) {
+			if (outputPath === "patch" || outputPath?.startsWith("patch ")) {
+				const outputDir =
+					outputPath === "patch" ? undefined : outputPath.slice("patch ".length).trim() || undefined;
+				const result = await this.agentConnection.exportPatchArtifact(outputDir);
+				const statusSuffix = result.status === "ready" ? "" : ` (${result.status})`;
+				this.showStatus(`Patch artifact exported to: ${result.directory}${statusSuffix}`);
+			} else if (outputPath?.endsWith(".jsonl")) {
 				const filePath = await this.agentConnection.exportToJsonl(outputPath);
 				this.showStatus(`Session exported to: ${filePath}`);
 			} else {

--- a/packages/coding-agent/test/patch-artifact.test.ts
+++ b/packages/coding-agent/test/patch-artifact.test.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createPatchArtifact, type PatchArtifactMetadata } from "../src/core/patch-artifact.js";
+import type { SessionStats } from "../src/core/session-stats.js";
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function initRepo(dir: string): void {
+	git(dir, "init", "-q", "-b", "main");
+	git(dir, "config", "user.email", "test@example.com");
+	git(dir, "config", "user.name", "Test User");
+}
+
+function commitAll(dir: string, message: string): void {
+	git(dir, "add", "-A");
+	git(dir, "commit", "-q", "-m", message);
+}
+
+function readJson<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+const sessionStats: SessionStats = {
+	sessionFile: undefined,
+	sessionId: "session-1",
+	userMessages: 1,
+	assistantMessages: 2,
+	toolCalls: 3,
+	toolResults: 4,
+	totalMessages: 7,
+	tokens: {
+		input: 10,
+		output: 20,
+		cacheRead: 30,
+		cacheWrite: 40,
+		total: 100,
+	},
+	cost: 0.12,
+};
+
+describe("createPatchArtifact", () => {
+	let tempDir: string;
+	let repoDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-patch-artifact-"));
+		repoDir = join(tempDir, "repo");
+		mkdirSync(repoDir);
+		initRepo(repoDir);
+		writeFileSync(join(repoDir, "app.txt"), "before\n");
+		commitAll(repoDir, "init");
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("writes patch, metadata, summary, and trajectory files", () => {
+		writeFileSync(join(repoDir, "app.txt"), "after\n");
+		writeFileSync(join(repoDir, "new.txt"), "new file\n");
+		const sessionFile = join(tempDir, "session.jsonl");
+		writeFileSync(sessionFile, '{"type":"session"}\n');
+
+		const result = createPatchArtifact({
+			cwd: repoDir,
+			outputDir: join(tempDir, "artifact"),
+			sessionFile,
+			sessionStats,
+			testsRun: ["npm test"],
+			finalStatus: "tests_passed",
+		});
+
+		expect(result.status).toBe("ready");
+		expect(result.changedFiles).toEqual(["app.txt", "new.txt"]);
+		expect(result.untrackedFiles).toEqual(["new.txt"]);
+		expect(existsSync(result.summaryPath)).toBe(true);
+		expect(readFileSync(result.patchPath, "utf8")).toContain("+after");
+		expect(readFileSync(result.patchPath, "utf8")).toContain("+new file");
+		expect(readFileSync(result.trajectoryPath!, "utf8")).toContain('"type":"session"');
+
+		const metadata = readJson<PatchArtifactMetadata>(result.metadataPath);
+		expect(metadata.status).toBe("ready");
+		expect(metadata.files.changed).toEqual(["app.txt", "new.txt"]);
+		expect(metadata.trajectory?.path).toBe("trajectory.jsonl");
+		expect(metadata.session?.sessionId).toBe("session-1");
+		expect(metadata.testsRun).toEqual(["npm test"]);
+		expect(metadata.finalStatus).toBe("tests_passed");
+	});
+
+	it("rejects dependency and setup churn by default", () => {
+		writeFileSync(join(repoDir, "package.json"), '{"scripts":{"test":"true"}}\n');
+
+		const result = createPatchArtifact({
+			cwd: repoDir,
+			outputDir: join(tempDir, "artifact-rejected"),
+		});
+
+		expect(result.status).toBe("rejected_setup_churn");
+		expect(result.rejectedFiles).toEqual(["package.json"]);
+		expect(readJson<PatchArtifactMetadata>(result.metadataPath).files.rejected).toEqual(["package.json"]);
+		expect(readFileSync(result.patchPath, "utf8")).toContain('+{"scripts"');
+	});
+
+	it("allows setup churn when explicitly requested", () => {
+		writeFileSync(join(repoDir, "requirements-dev.txt"), "pytest\n");
+
+		const result = createPatchArtifact({
+			cwd: repoDir,
+			outputDir: join(tempDir, "artifact-allowed"),
+			allowSetupChurn: true,
+		});
+
+		expect(result.status).toBe("ready");
+		expect(result.rejectedFiles).toEqual([]);
+		expect(result.changedFiles).toEqual(["requirements-dev.txt"]);
+	});
+});


### PR DESCRIPTION
## Summary

- add a benchmark patch artifact exporter that writes `patch.diff`, `metadata.json`, `summary.md`, and optional `trajectory.jsonl`
- capture tracked and untracked git diffs plus commit, branch, file lists, session stats, tests, failures, and final status metadata
- mark dependency/setup churn as `rejected_setup_churn` unless explicitly allowed
- expose the exporter through `AgentSession`, agent connections, `/export patch [dir]`, and `prime-agent daemon patch-artifact <session> [dir]`

## Testing

- `npm --prefix packages/coding-agent test -- patch-artifact.test.ts`
- `./node_modules/.bin/tsgo --noEmit`
- `npm run check`
- isolated daemon smoke with temp socket/session dirs: create git repo, create session, export `daemon patch-artifact`, validate patch and metadata


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `patch-artifact` export command for benchmark patch artifacts
> - Adds [`patch-artifact.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/225/files#diff-335225ea77e270fe7f51bf536adae5ed33eb26e315ed83b781efa9460b10859c), a new module that exports `createPatchArtifact`, which captures git diffs (tracked and untracked), writes `patch.diff`, `metadata.json`, `summary.md`, and optionally `trajectory.jsonl` to an output directory.
> - Adds a `patch-artifact <session> [dir]` CLI subcommand to the daemon client and an `/export patch [dir]` interactive slash command variant.
> - Extends the `AgentConnection` interface and all implementations (daemon, in-process, deferred) with `exportPatchArtifact(outputDir?)`, and adds a corresponding `export_patch_artifact` daemon protocol message.
> - Filters setup/dependency churn files (e.g. lockfiles, `node_modules`) by default, reporting them as `rejectedFiles`; set `allowSetupChurn` to include them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8c719f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->