### PR TITLE
add /rename, allow renaming from agents view

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -35,6 +35,7 @@ export interface AppKeybindings {
 	"app.agents.reply": true;
 	"app.agents.delete": true;
 	"app.agents.program": true;
+	"app.agents.rename": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
@@ -118,6 +119,7 @@ export const KEYBINDINGS = {
 	"app.agents.reply": { defaultKeys: "space", description: "Reply to selected agent" },
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
+	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],
 		description: "Fold tree branch or move up",
@@ -263,6 +265,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	agentsReply: "app.agents.reply",
 	agentsDelete: "app.agents.delete",
 	agentsProgram: "app.agents.program",
+	agentsRename: "app.agents.rename",
 	treeFoldOrUp: "app.tree.foldOrUp",
 	treeUnfoldOrDown: "app.tree.unfoldOrDown",
 	treeEditLabel: "app.tree.editLabel",

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -79,6 +79,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 const BUILTIN_SLASH_COMMAND_ALIASES: ReadonlyArray<BuiltinSlashCommandAlias> = [
 	{ name: "clear", aliasFor: "new" },
 	{ name: "usage", aliasFor: "context" },
+	{ name: "rename", aliasFor: "name" },
 ];
 
 function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -300,6 +300,7 @@ class AgentsViewMode implements Component, Focusable {
 	private replyHeaderTime = "";
 	private pendingDeleteAgent: PendingDeleteAgent | undefined;
 	private pendingKillSubagent: PendingKillSubagent | undefined;
+	private renameTarget: { activeSessionId: string; identity: string } | undefined;
 	private readonly inactiveAgentIdentities = new Set<string>();
 	private statusMessage: string | undefined;
 	private statusMessageTone: "muted" | "error" | "warning" = "muted";
@@ -398,8 +399,22 @@ class AgentsViewMode implements Component, Focusable {
 
 	handleInput(data: string): void {
 		this.clearStickyStatusMessage();
+		// While renaming, the editor holds the proposed name: Escape cancels, Enter
+		// (via onSubmit) confirms, everything else edits the text.
+		if (this.renameTarget) {
+			if (this.keybindings.matches(data, "tui.select.cancel")) {
+				this.exitRenameMode();
+				return;
+			}
+			this.editor.handleInput(data);
+			return;
+		}
 		if (this.keybindings.matches(data, "app.clear")) {
 			this.handleCtrlC();
+			return;
+		}
+		if (this.keybindings.matches(data, "app.agents.rename") && this.editor.getText().length === 0) {
+			this.enterRenameMode();
 			return;
 		}
 		if (this.keybindings.matches(data, "app.agents.delete") && this.editor.getText().length === 0) {
@@ -722,6 +737,10 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private async submit(value: string): Promise<void> {
+		if (this.renameTarget) {
+			await this.confirmRename(value);
+			return;
+		}
 		const text = value.trim();
 		if (!text) {
 			if (this.replyActiveSessionId) {
@@ -1077,6 +1096,62 @@ class AgentsViewMode implements Component, Focusable {
 		this.ui.requestRender();
 	}
 
+	private enterRenameMode(): void {
+		const row = this.rows[this.selectedIndex];
+		// Only top-level agents carry a renameable session; subagents do not.
+		if (row?.kind !== "agent" || !row.selectable) {
+			return;
+		}
+		const activeSessionId = row.summary.activeSessionId;
+		if (!activeSessionId) {
+			this.setStatusMessage("This agent has no active session to rename");
+			return;
+		}
+		this.setReplyTarget(undefined);
+		this.pendingDeleteAgent = undefined;
+		this.pendingKillSubagent = undefined;
+		this.renameTarget = { activeSessionId, identity: getSummaryIdentity(row.summary) };
+		this.editor.setPlaceholder("Name this agent session");
+		this.editor.setText(row.summary.sessionName ?? "");
+		this.ui.requestRender();
+	}
+
+	private exitRenameMode(): void {
+		this.renameTarget = undefined;
+		this.editor.setText("");
+		this.editor.setPlaceholder(DEFAULT_PROMPT_PLACEHOLDER);
+		this.ui.requestRender();
+	}
+
+	private async confirmRename(value: string): Promise<void> {
+		const target = this.renameTarget;
+		if (!target) {
+			return;
+		}
+		const name = value.trim();
+		if (!name) {
+			this.exitRenameMode();
+			return;
+		}
+		this.exitRenameMode();
+		this.setStatusMessage("Renaming agent...");
+		try {
+			await this.requireClient().request({
+				type: "rename",
+				activeSessionId: target.activeSessionId,
+				name,
+			});
+			this.setStatusMessage(`Renamed to ${name}`, { render: false });
+			await this.refreshSessions();
+		} catch (error) {
+			this.setStatusMessage(
+				isUnknownDaemonCommandError(error, "rename")
+					? "Failed to rename: the daemon is running an older build; restart the daemon and try again"
+					: formatError("Failed to rename agent", error),
+			);
+		}
+	}
+
 	private getReplyHeaderTime(activeSessionId: string): string {
 		const summary = this.findSummaryByActiveSessionId(activeSessionId);
 		return formatAgentsViewRelativeTime(summary?.modified ?? summary?.created);
@@ -1087,6 +1162,9 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private renderReplyHeaderLine(): string | undefined {
+		if (this.renameTarget) {
+			return theme.fg("warning", "Rename agent session");
+		}
 		if (!this.replyActiveSessionId) {
 			return undefined;
 		}
@@ -1644,6 +1722,10 @@ class AgentsViewMode implements Component, Focusable {
 		if (this.statusMessage) {
 			return truncateToWidth(theme.fg(this.statusMessageTone, this.statusMessage), width);
 		}
+		if (this.renameTarget) {
+			const hint = `${keyText("tui.select.confirm")} save   ${keyText("tui.select.cancel")} cancel`;
+			return truncateToWidth(theme.fg("muted", hint), width);
+		}
 		// Replying is reserved for top-level agents; subagents can be stopped.
 		const selectedRow = this.rows[this.selectedIndex];
 		const selectedAgent = selectedRow?.kind === "agent";
@@ -1653,6 +1735,7 @@ class AgentsViewMode implements Component, Focusable {
 			`${keyText("tui.select.confirm")} open/send`,
 			"/ commands",
 			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
+			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
 			selectedAgent ? `${keyText("app.agents.delete")} stop/deactivate` : undefined,
 			selectedSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
 			this.selectedRowCanShowProgram() ? `${keyText("app.agents.program")} program` : undefined,

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -20,6 +20,7 @@ describe("slash command aliases", () => {
 	test("keeps aliases hidden on canonical command entries", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "clear")).toBeUndefined();
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "usage")).toBeUndefined();
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "rename")).toBeUndefined();
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "new")).toMatchObject({
 			description: "Start a new session",
 			aliases: ["clear"],
@@ -27,6 +28,23 @@ describe("slash command aliases", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "context")).toMatchObject({
 			description: "Show token, cost, and context usage for agent and sub-agents",
 			aliases: ["usage"],
+		});
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "name")).toMatchObject({
+			description: "Set session display name",
+			aliases: ["rename"],
+		});
+	});
+
+	test("resolves /rename to /name through the alias path", () => {
+		const parsed = parseSlashCommand("/rename my session");
+
+		expect(isBuiltinSlashCommandName("rename")).toBe(true);
+		expect(resolveBuiltinSlashCommandName("rename")).toBe("name");
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "name",
+			args: "my session",
+			originalName: "rename",
+			isAlias: true,
 		});
 	});
 


### PR DESCRIPTION
- /name already existed, so this adds /rename as an alias for it so either command sets the current session's display name.
- adds a ctrl+r shortcut in the agents view to rename the selected agent session inline, prefilled with its current name, saved on enter and cancelled on escape.
- reuses the existing daemon rename command and the session-name plumbing, so there are no protocol or persistence changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and alias wiring on top of the existing daemon rename path; no auth, data model, or protocol changes.
> 
> **Overview**
> Adds **`/rename`** as a hidden alias for the existing **`/name`** slash command so either form sets the current session display name, with tests covering alias resolution and canonical listing.
> 
> In **agents view**, **`Ctrl+R`** (`app.agents.rename`) opens inline rename for the selected top-level agent: the editor is prefilled with the current session name, **Enter** saves via the existing daemon **`rename`** request, and **Escape** cancels. Subagents and agents without an active session are excluded; UI hints and a rename header line mirror reply-mode behavior. No new protocol or persistence—only client keybindings, slash aliases, and agents-view flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae75c26c62ea9c00ed71a5f7f35272d048d251c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/name` and `/rename` slash commands and `ctrl+r` keybinding to rename the current agent session
> - Adds a rename workflow to `AgentsViewMode`: pressing `ctrl+r` with an empty editor enters rename mode for the selected top-level agent session, pre-filling the editor with the current session name.
> - Submitting while in rename mode sends a `rename` daemon request and refreshes the session list; Escape cancels and restores default editor state.
> - Adds `/name` as a new slash command and `/rename` as an alias for it via [`slash-commands.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/226/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051).
> - Adds the `app.agents.rename` keybinding with a migration from the legacy `agentsRename` config key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae75c26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->