### PR TITLE
fix prime agent formatting breaking when resizing to a small screen

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -77,15 +77,12 @@ const COMMENT_LINE_PATTERN = /^\s*#/;
 // Strip a leading `cd … &&` to surface the real command.
 const CD_PREFIX_PATTERN = /^\s*cd\s+[^&;|]+(?:&&|;)\s*/;
 
-// Matches a single SGR escape (the only ANSI we emit here): ESC [ … m.
 const SGR_PATTERN = /\x1b\[([0-9;]*)m/g;
 
 /**
- * Append a reset (`ESC[0m`) when `line` ends with foreground or background color
- * still open, so a span that wrapTextWithAnsi split across lines cannot bleed its
- * color into the trailing padding or the next line. Tracks fg and bg separately:
- * theme.fg closes with `39`, theme.bg with `49`, and `0`/empty resets both. A line
- * whose colors already net closed (or that has none) is returned unchanged.
+ * Append `ESC[0m` when `line` ends with a foreground or background color still
+ * open, so a span that wrapTextWithAnsi split across lines cannot bleed into the
+ * trailing padding or the next line.
  */
 function closeOpenSgr(line: string): string {
 	let fgOpen = false;
@@ -98,11 +95,8 @@ function closeOpenSgr(line: string): string {
 				fgOpen = false;
 				bgOpen = false;
 			} else if (code === 38 || code === 48) {
-				// Extended color: `38;5;n` / `38;2;r;g;b` (and 48 for bg). The trailing
-				// parameters are color data, not SGR codes, so consume them here rather
-				// than mis-reading an RGB component (e.g. 38) as a color code.
-				const open = code === 38;
-				if (open) fgOpen = true;
+				// Skip the color data of `38;5;n` / `38;2;r;g;b` so a component (e.g. 38) isn't read as a code.
+				if (code === 38) fgOpen = true;
 				else bgOpen = true;
 				const mode = Number(params[i + 1]);
 				i += mode === 2 ? 4 : mode === 5 ? 2 : 1;
@@ -736,10 +730,6 @@ export class IPythonCellComponent implements Component {
 		const wrapped = wrapTextWithAnsi(text, available);
 		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
 			const linePrefix = index === 0 ? prefix : " ".repeat(visibleWidth(prefix));
-			// wrapTextWithAnsi re-opens active styles at the start of each continuation
-			// line but does not close them at the end, so a colored span split across
-			// lines leaks its foreground into the panel padding toolPanelLine adds (and
-			// into the next line). Close any still-open style so each line stands alone.
 			lines.push(toolPanelLine(linePrefix + closeOpenSgr(line), width));
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -77,6 +77,49 @@ const COMMENT_LINE_PATTERN = /^\s*#/;
 // Strip a leading `cd … &&` to surface the real command.
 const CD_PREFIX_PATTERN = /^\s*cd\s+[^&;|]+(?:&&|;)\s*/;
 
+// Matches a single SGR escape (the only ANSI we emit here): ESC [ … m.
+const SGR_PATTERN = /\x1b\[([0-9;]*)m/g;
+
+/**
+ * Append a reset (`ESC[0m`) when `line` ends with foreground or background color
+ * still open, so a span that wrapTextWithAnsi split across lines cannot bleed its
+ * color into the trailing padding or the next line. Tracks fg and bg separately:
+ * theme.fg closes with `39`, theme.bg with `49`, and `0`/empty resets both. A line
+ * whose colors already net closed (or that has none) is returned unchanged.
+ */
+function closeOpenSgr(line: string): string {
+	let fgOpen = false;
+	let bgOpen = false;
+	for (const match of line.matchAll(SGR_PATTERN)) {
+		const params = match[1] === "" ? ["0"] : match[1].split(";");
+		for (let i = 0; i < params.length; i++) {
+			const code = Number(params[i]);
+			if (code === 0) {
+				fgOpen = false;
+				bgOpen = false;
+			} else if (code === 38 || code === 48) {
+				// Extended color: `38;5;n` / `38;2;r;g;b` (and 48 for bg). The trailing
+				// parameters are color data, not SGR codes, so consume them here rather
+				// than mis-reading an RGB component (e.g. 38) as a color code.
+				const open = code === 38;
+				if (open) fgOpen = true;
+				else bgOpen = true;
+				const mode = Number(params[i + 1]);
+				i += mode === 2 ? 4 : mode === 5 ? 2 : 1;
+			} else if (code === 39) {
+				fgOpen = false;
+			} else if (code === 49) {
+				bgOpen = false;
+			} else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+				fgOpen = true;
+			} else if ((code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+				bgOpen = true;
+			}
+		}
+	}
+	return fgOpen || bgOpen ? `${line}\x1b[0m` : line;
+}
+
 function collapseWhitespace(text: string): string {
 	return text.replace(/\s+/g, " ").trim();
 }
@@ -693,7 +736,11 @@ export class IPythonCellComponent implements Component {
 		const wrapped = wrapTextWithAnsi(text, available);
 		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
 			const linePrefix = index === 0 ? prefix : " ".repeat(visibleWidth(prefix));
-			lines.push(toolPanelLine(linePrefix + line, width));
+			// wrapTextWithAnsi re-opens active styles at the start of each continuation
+			// line but does not close them at the end, so a colored span split across
+			// lines leaks its foreground into the panel padding toolPanelLine adds (and
+			// into the next line). Close any still-open style so each line stands alone.
+			lines.push(toolPanelLine(linePrefix + closeOpenSgr(line), width));
 		}
 	}
 

--- a/packages/coding-agent/test/ipython-cell-wrap.test.ts
+++ b/packages/coding-agent/test/ipython-cell-wrap.test.ts
@@ -5,13 +5,7 @@ import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 type CellState = ConstructorParameters<typeof IPythonCellComponent>[0];
 
-/**
- * Whether `line` ends with a foreground color still open. The panel background
- * legitimately wraps the whole line, so only a dangling *foreground* color
- * indicates a leak into the trailing padding (and, on screen, into the next
- * line). Tracks fg and bg separately the way the theme emits them: `39` closes
- * fg, `49` closes bg, `0`/empty resets both.
- */
+// True when `line` ends with a foreground color still open (a leak into the padding).
 function foregroundLeftOpen(line: string): boolean {
 	let fg = false;
 	for (const match of line.matchAll(/\x1b\[([0-9;]*)m/g)) {
@@ -21,8 +15,7 @@ function foregroundLeftOpen(line: string): boolean {
 			if (code === 0 || code === 39) {
 				fg = false;
 			} else if (code === 38) {
-				// Extended fg color: skip its data params (38;5;n or 38;2;r;g;b) so an
-				// RGB component is not mistaken for an SGR code.
+				// Skip the color data of 38;5;n / 38;2;r;g;b so a component isn't read as a code.
 				fg = true;
 				const mode = Number(params[i + 1]);
 				i += mode === 2 ? 4 : mode === 5 ? 2 : 1;
@@ -37,7 +30,6 @@ function foregroundLeftOpen(line: string): boolean {
 	return fg;
 }
 
-// A long output that is forced to wrap at narrow widths — the original bug.
 const WRAPPING_STATE: CellState = {
 	code: "import numpy as np\nresult = np.linspace(0, 100, 50)\nprint('the first element of the linspace array is', result[0])",
 	content: [
@@ -63,7 +55,6 @@ describe("IPythonCellComponent wrapping", () => {
 	});
 
 	it("never leaves a foreground color open at a wrapped line end", () => {
-		// Sweep the narrow widths that force code and output lines to wrap.
 		for (let width = 20; width <= 60; width++) {
 			const lines = new IPythonCellComponent(WRAPPING_STATE).render(width);
 			const leaks = lines.filter(foregroundLeftOpen);
@@ -82,7 +73,6 @@ describe("IPythonCellComponent wrapping", () => {
 	});
 
 	it("renders the same after a resize as a fresh render at the target width", () => {
-		// Resizing must look identical to having started at the new size.
 		const resized = new IPythonCellComponent(WRAPPING_STATE);
 		resized.render(100);
 		resized.invalidate();
@@ -93,11 +83,8 @@ describe("IPythonCellComponent wrapping", () => {
 	});
 
 	it("leaves non-wrapping (wide) output untouched", () => {
-		// At a wide width nothing wraps, so each styled span is already self-contained
-		// and we must not append spurious resets.
 		const lines = new IPythonCellComponent(WRAPPING_STATE).render(100);
 		expect(lines.some(foregroundLeftOpen)).toBe(false);
-		// No line should carry a redundant full reset followed only by padding.
 		expect(lines.every((line) => visibleWidth(line) === 100)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/ipython-cell-wrap.test.ts
+++ b/packages/coding-agent/test/ipython-cell-wrap.test.ts
@@ -1,0 +1,103 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+type CellState = ConstructorParameters<typeof IPythonCellComponent>[0];
+
+/**
+ * Whether `line` ends with a foreground color still open. The panel background
+ * legitimately wraps the whole line, so only a dangling *foreground* color
+ * indicates a leak into the trailing padding (and, on screen, into the next
+ * line). Tracks fg and bg separately the way the theme emits them: `39` closes
+ * fg, `49` closes bg, `0`/empty resets both.
+ */
+function foregroundLeftOpen(line: string): boolean {
+	let fg = false;
+	for (const match of line.matchAll(/\x1b\[([0-9;]*)m/g)) {
+		const params = match[1] === "" ? ["0"] : match[1].split(";");
+		for (let i = 0; i < params.length; i++) {
+			const code = Number(params[i]);
+			if (code === 0 || code === 39) {
+				fg = false;
+			} else if (code === 38) {
+				// Extended fg color: skip its data params (38;5;n or 38;2;r;g;b) so an
+				// RGB component is not mistaken for an SGR code.
+				fg = true;
+				const mode = Number(params[i + 1]);
+				i += mode === 2 ? 4 : mode === 5 ? 2 : 1;
+			} else if (code === 48) {
+				const mode = Number(params[i + 1]);
+				i += mode === 2 ? 4 : mode === 5 ? 2 : 1;
+			} else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+				fg = true;
+			}
+		}
+	}
+	return fg;
+}
+
+// A long output that is forced to wrap at narrow widths — the original bug.
+const WRAPPING_STATE: CellState = {
+	code: "import numpy as np\nresult = np.linspace(0, 100, 50)\nprint('the first element of the linspace array is', result[0])",
+	content: [
+		{
+			type: "text",
+			text: "the first element of the linspace array is 0.0\nsecond line of output that is also fairly long and will wrap on a small terminal",
+		},
+	],
+	details: {
+		status: "ok",
+		durationMs: 12,
+		stdout:
+			"the first element of the linspace array is 0.0\nsecond line of output that is also fairly long and will wrap on a small terminal",
+	},
+	executionStarted: true,
+	argsComplete: true,
+	expanded: true,
+};
+
+describe("IPythonCellComponent wrapping", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("never leaves a foreground color open at a wrapped line end", () => {
+		// Sweep the narrow widths that force code and output lines to wrap.
+		for (let width = 20; width <= 60; width++) {
+			const lines = new IPythonCellComponent(WRAPPING_STATE).render(width);
+			const leaks = lines.filter(foregroundLeftOpen);
+			expect(leaks, `width=${width} leaked foreground on ${leaks.length} line(s)`).toHaveLength(0);
+		}
+	});
+
+	it("pads every wrapped line to exactly the panel width", () => {
+		for (const width of [20, 30, 40, 50]) {
+			const lines = new IPythonCellComponent(WRAPPING_STATE).render(width);
+			expect(
+				lines.every((line) => visibleWidth(line) === width),
+				`width=${width}`,
+			).toBe(true);
+		}
+	});
+
+	it("renders the same after a resize as a fresh render at the target width", () => {
+		// Resizing must look identical to having started at the new size.
+		const resized = new IPythonCellComponent(WRAPPING_STATE);
+		resized.render(100);
+		resized.invalidate();
+		const afterResize = resized.render(34);
+
+		const fresh = new IPythonCellComponent(WRAPPING_STATE).render(34);
+		expect(afterResize).toEqual(fresh);
+	});
+
+	it("leaves non-wrapping (wide) output untouched", () => {
+		// At a wide width nothing wraps, so each styled span is already self-contained
+		// and we must not append spurious resets.
+		const lines = new IPythonCellComponent(WRAPPING_STATE).render(100);
+		expect(lines.some(foregroundLeftOpen)).toBe(false);
+		// No line should carry a redundant full reset followed only by padding.
+		expect(lines.every((line) => visibleWidth(line) === 100)).toBe(true);
+	});
+});


### PR DESCRIPTION
- when a terminal was resized narrow, tool output and code lines in expanded ipython cells wrapped with their text color left open, bleeding into the surrounding padding and the next line so indentation and backgrounds looked wrong.
- the shared text wrapper re-opens styles on continuation lines but never closes them, so each wrapped line now closes any still-open foreground or background color and stands on its own.
- only showed up at widths narrow enough to force wrapping, which is why it appeared intermittently while resizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI rendering-only change in IPython cell wrapping with regression tests; no security, auth, or data paths affected.
> 
> **Overview**
> Fixes **broken indentation and backgrounds** in expanded IPython/bash tool panels when the terminal is narrow enough that `wrapTextWithAnsi` splits colored spans across lines.
> 
> Adds **`closeOpenSgr`**, which walks SGR sequences on each wrapped segment (including `38`/`48` extended colors) and appends **`ESC[0m`** when foreground or background color would still be open at the line end. **`IPythonCellComponent.addWrapped`** now runs every wrapped line through that helper before **`toolPanelLine`** padding, so color cannot bleed into panel padding or the next line—especially after resize.
> 
> New Vitest coverage in **`ipython-cell-wrap.test.ts`** checks no dangling foreground at wrap boundaries, full panel width padding, resize/invalidate parity with a fresh render, and wide terminals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5a5e1b907022ec1e6240ecac4e9103498301b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ANSI color bleed in prime agent output when wrapping to small screens
> - Adds a `closeOpenSgr` function in [`ipython-cell.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/227/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) that detects unclosed ANSI SGR foreground/background color codes at the end of a line and appends `ESC[0m` to reset them.
> - Applies this reset to each wrapped line in `IPythonCellComponent.addWrapped`, preventing color state from bleeding into line padding or subsequent lines on resize.
> - Adds a test suite in [`ipython-cell-wrap.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/227/files#diff-849f85b0dea7cee6b7d5853a55e3a9ac7bab880467be9f48049e1192af92cb19) covering color bleed, padding width, and resize re-render consistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e5a5e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->