### PR TITLE
add /effort to set the thinking level

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 - Added opt-in Prime Agent trace sharing with `/traces` and background uploads of persisted session JSONL files.
 - Added a first draft of daemon-backed cron jobs for scheduling prompts against long-running sessions without using `/goal`.
-- Added `/effort` (alias `/thinking`) to pick the reasoning/thinking level from a selector that lists the levels the current model supports.
+- Added `/effort` (alias `/thinking`) to set the reasoning/thinking level, with argument autocomplete listing the levels the current model supports.
 
 ### Changed
 
-- Replaced the `Shift+Tab` thinking-level cycle with the `/effort` selector.
+- Replaced the `Shift+Tab` thinking-level cycle with the `/effort` command.
 
 ## [0.1.3] - 2026-06-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added opt-in Prime Agent trace sharing with `/traces` and background uploads of persisted session JSONL files.
 - Added a first draft of daemon-backed cron jobs for scheduling prompts against long-running sessions without using `/goal`.
+- Added `/effort` (alias `/thinking`) to pick the reasoning/thinking level from a selector that lists the levels the current model supports.
+
+### Changed
+
+- Replaced the `Shift+Tab` thinking-level cycle with the `/effort` selector.
 
 ## [0.1.3] - 2026-06-12
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -140,6 +140,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 |---------|-------------|
 | `/login`, `/logout` | OAuth authentication |
 | `/model` | Switch models |
+| `/effort` | Set reasoning/thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |
@@ -174,7 +175,6 @@ See `/hotkeys` for the full list. Customize via `~/.prime/agent/keybindings.json
 | Escape twice | Open `/tree` |
 | Ctrl+L | Open model selector |
 | Ctrl+P / Shift+Ctrl+P | Cycle scoped models forward/backward |
-| Shift+Tab | Cycle thinking level |
 | Ctrl+O | Collapse/expand tool output |
 | Ctrl+T | Collapse/expand thinking blocks |
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -111,7 +111,6 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 |--------|---------|-------------|
 | `app.model.select` | `ctrl+l` | Open model selector |
 | `app.provider.add` | `ctrl+p` | Add provider from the model selector |
-| `app.thinking.cycle` | `shift+tab` | Cycle thinking level |
 | `app.thinking.toggle` | `ctrl+t` | Collapse or expand thinking blocks |
 
 ### Display and Message Queue

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -102,7 +102,7 @@ The command output is sent to the model. Use `!!command` to run a command withou
 
 ### Switch models
 
-Use `/model` or Ctrl+L to choose a model. Use Shift+Tab to cycle thinking level. Use Ctrl+P / Shift+Ctrl+P to cycle through scoped models.
+Use `/model` or Ctrl+L to choose a model. Use `/effort` to set the reasoning/thinking level. Use Ctrl+P / Shift+Ctrl+P to cycle through scoped models.
 
 ### Continue later
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -64,7 +64,6 @@ const RESERVED_KEYBINDINGS_FOR_EXTENSION_CONFLICTS = [
 	"app.clear",
 	"app.exit",
 	"app.suspend",
-	"app.thinking.cycle",
 	"app.model.select",
 	"app.tools.expand",
 	"app.thinking.toggle",

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -16,7 +16,6 @@ export interface AppKeybindings {
 	"app.input.clear": true;
 	"app.exit": true;
 	"app.suspend": true;
-	"app.thinking.cycle": true;
 	"app.model.select": true;
 	"app.provider.add": true;
 	"app.tools.expand": true;
@@ -74,10 +73,6 @@ export const KEYBINDINGS = {
 	"app.suspend": {
 		defaultKeys: process.platform === "win32" ? [] : "ctrl+z",
 		description: "Suspend to background",
-	},
-	"app.thinking.cycle": {
-		defaultKeys: "shift+tab",
-		description: "Cycle thinking level",
 	},
 	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
 	"app.provider.add": { defaultKeys: "ctrl+p", description: "Add provider" },
@@ -245,7 +240,6 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	clearInput: "app.input.clear",
 	exit: "app.exit",
 	suspend: "app.suspend",
-	cycleThinkingLevel: "app.thinking.cycle",
 	selectModel: "app.model.select",
 	expandTools: "app.tools.expand",
 	toggleThinking: "app.thinking.toggle",

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -37,7 +37,7 @@ interface BuiltinSlashCommandAlias {
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
-	{ name: "effort", description: "Select reasoning/thinking level (opens selector UI)" },
+	{ name: "effort", description: "Set reasoning/thinking level", argumentHint: "[level]" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -37,6 +37,7 @@ interface BuiltinSlashCommandAlias {
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
+	{ name: "effort", description: "Select reasoning/thinking level (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },
@@ -79,6 +80,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 const BUILTIN_SLASH_COMMAND_ALIASES: ReadonlyArray<BuiltinSlashCommandAlias> = [
 	{ name: "clear", aliasFor: "new" },
 	{ name: "usage", aliasFor: "context" },
+	{ name: "thinking", aliasFor: "effort" },
 ];
 
 function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { ImageContent, Transport } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels, type ImageContent, type Transport } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
 import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
@@ -189,7 +189,9 @@ export class DeferredAgentConnection implements AgentConnection {
 			cwd: this.seed.cwd,
 			model: this.seed.model,
 			thinkingLevel: this.seed.thinkingLevel,
-			availableThinkingLevels: [],
+			availableThinkingLevels: this.seed.model
+				? (getSupportedThinkingLevels(this.seed.model) as ThinkingLevel[])
+				: [],
 			isStreaming: false,
 			isCompacting: false,
 			isBashRunning: false,

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -68,12 +68,6 @@ export class ThinkingSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 	}
 
-	// Container does not forward input to children; route keys to the list so the
-	// selector works when shown as a focused overlay.
-	handleInput(keyData: string): void {
-		this.selectList.handleInput(keyData);
-	}
-
 	getSelectList(): SelectList {
 		return this.selectList;
 	}

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -68,6 +68,12 @@ export class ThinkingSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 	}
 
+	// Container does not forward input to children; route keys to the list so the
+	// selector works when shown as a focused overlay.
+	handleInput(keyData: string): void {
+		this.selectList.handleInput(keyData);
+	}
+
 	getSelectList(): SelectList {
 		return this.selectList;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -352,11 +352,11 @@ const MODEL_SELECTOR_ACTIONS: readonly ModelSelectorAction[] = [
 
 const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	off: "No reasoning",
-	minimal: "Very brief reasoning (~1k tokens)",
-	low: "Light reasoning (~2k tokens)",
-	medium: "Moderate reasoning (~8k tokens)",
-	high: "Deep reasoning (~16k tokens)",
-	xhigh: "Maximum reasoning (~32k tokens)",
+	minimal: "Very brief reasoning",
+	low: "Light reasoning",
+	medium: "Moderate reasoning",
+	high: "Deep reasoning",
+	xhigh: "Maximum reasoning",
 };
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -802,6 +802,10 @@ export class InteractiveMode {
 		if (effortCommand) {
 			effortCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
 				this.getThinkingLevelCompletions(prefix);
+			const levels = this.getAvailableThinkingLevels();
+			if (levels.length > 0) {
+				effortCommand.argumentHint = `[${levels.join("/")}]`;
+			}
 		}
 
 		const connectionCommands = this.connectionCommands;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5606,6 +5606,8 @@ export class InteractiveMode {
 		});
 		this.footer.invalidate();
 		this.updateEditorBorderColor();
+		// Rebuild so the /effort argument hint reflects the new model's levels.
+		this.setupAutocompleteProvider();
 	}
 
 	private async getConnectionAvailableModels(): Promise<AgentConnectionModel[]> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Api, AssistantMessage, ImageContent, Message, Model, ToolCall } from "@earendil-works/pi-ai";
+import {
+	type Api,
+	type AssistantMessage,
+	getSupportedThinkingLevels,
+	type ImageContent,
+	type Message,
+	type Model,
+	type ToolCall,
+} from "@earendil-works/pi-ai";
 import type {
 	AutocompleteItem,
 	AutocompleteProvider,
@@ -5592,7 +5600,10 @@ export class InteractiveMode {
 	private async applySelectedModel(model: AgentConnectionModel): Promise<void> {
 		await this.agentConnection.setModel(model.provider, model.id);
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
-		this.patchConnectionState({ model });
+		this.patchConnectionState({
+			model,
+			availableThinkingLevels: getSupportedThinkingLevels(model) as ThinkingLevel[],
+		});
 		this.footer.invalidate();
 		this.updateEditorBorderColor();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5674,7 +5674,14 @@ export class InteractiveMode {
 				close();
 			},
 		);
-		handle = this.showFullPaneOverlay(selector, 48);
+		// Anchor a compact popup just above the editor instead of a full-pane
+		// overlay; the picker is only a few rows and blanking the whole terminal
+		// for it is jarring.
+		handle = this.ui.showOverlay(selector, {
+			width: 48,
+			anchor: "bottom-left",
+			margin: { bottom: 1, left: 2 },
+		});
 	}
 
 	private applyThinkingLevel(level: ThinkingLevel): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -140,7 +140,6 @@ import { ScopedModelsSelectorComponent } from "./components/scoped-models-select
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
-import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
 import { ToolExecutionComponent, type ToolExecutionDefinition } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
@@ -342,6 +341,15 @@ type ModelFallbackWarningAction = "show" | "suppress" | "wait";
 const MODEL_SELECTOR_ACTIONS: readonly ModelSelectorAction[] = [
 	{ id: "add_provider", label: "Add provider...", description: "subscription or API key" },
 ];
+
+const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
+	off: "No reasoning",
+	minimal: "Very brief reasoning (~1k tokens)",
+	low: "Light reasoning (~2k tokens)",
+	medium: "Moderate reasoning (~8k tokens)",
+	high: "Deep reasoning (~16k tokens)",
+	xhigh: "Maximum reasoning (~32k tokens)",
+};
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 
@@ -788,6 +796,12 @@ export class InteractiveMode {
 					description: item.provider,
 				}));
 			};
+		}
+
+		const effortCommand = slashCommands.find((command) => command.name === "effort");
+		if (effortCommand) {
+			effortCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
+				this.getThinkingLevelCompletions(prefix);
 		}
 
 		const connectionCommands = this.connectionCommands;
@@ -3257,9 +3271,9 @@ export class InteractiveMode {
 				await this.handleModelCommand(searchTerm);
 				return;
 			}
-			if (commandName === "effort" && !commandArgs) {
+			if (commandName === "effort") {
 				this.editor.setText("");
-				this.showThinkingSelector();
+				this.handleEffortCommand(commandArgs);
 				return;
 			}
 			if (commandName === "export") {
@@ -5647,41 +5661,43 @@ export class InteractiveMode {
 		this.showWarning(warning);
 	}
 
-	private showThinkingSelector(): void {
-		const availableLevels = this.connectionState?.availableThinkingLevels ?? [];
-		const supportsThinking =
-			availableLevels.length > 0 && !(availableLevels.length === 1 && availableLevels[0] === "off");
-		if (!supportsThinking) {
+	private getAvailableThinkingLevels(): ThinkingLevel[] {
+		const levels = this.connectionState?.availableThinkingLevels ?? [];
+		const supportsThinking = levels.length > 0 && !(levels.length === 1 && levels[0] === "off");
+		return supportsThinking ? levels : [];
+	}
+
+	private getThinkingLevelCompletions(prefix: string): AutocompleteItem[] | null {
+		const levels = this.getAvailableThinkingLevels();
+		if (levels.length === 0) return null;
+		const current = this.connectionState?.thinkingLevel;
+		const term = prefix.trim().toLowerCase();
+		const matches = term ? levels.filter((level) => level.startsWith(term)) : levels;
+		if (matches.length === 0) return null;
+		return matches.map((level) => ({
+			value: level,
+			label: level,
+			description:
+				level === current ? `${THINKING_LEVEL_DESCRIPTIONS[level]} (current)` : THINKING_LEVEL_DESCRIPTIONS[level],
+		}));
+	}
+
+	private handleEffortCommand(arg: string): void {
+		const levels = this.getAvailableThinkingLevels();
+		if (levels.length === 0) {
 			this.showStatus("Current model does not support thinking");
 			return;
 		}
-
-		const currentLevel = this.connectionState?.thinkingLevel ?? availableLevels[0];
-		let handle: OverlayHandle | undefined;
-		const close = () => {
-			handle?.hide();
-			this.ui.requestRender();
-		};
-
-		const selector = new ThinkingSelectorComponent(
-			currentLevel,
-			availableLevels,
-			(level) => {
-				close();
-				this.applyThinkingLevel(level);
-			},
-			() => {
-				close();
-			},
-		);
-		// Anchor a compact popup just above the editor instead of a full-pane
-		// overlay; the picker is only a few rows and blanking the whole terminal
-		// for it is jarring.
-		handle = this.ui.showOverlay(selector, {
-			width: 48,
-			anchor: "bottom-left",
-			margin: { bottom: 1, left: 2 },
-		});
+		const requested = arg.trim().toLowerCase();
+		if (!requested) {
+			this.showStatus(`Thinking level: ${this.connectionState?.thinkingLevel} (type a level: ${levels.join(", ")})`);
+			return;
+		}
+		if (!levels.includes(requested as ThinkingLevel)) {
+			this.showError(`Unknown thinking level '${requested}'. Available: ${levels.join(", ")}`);
+			return;
+		}
+		this.applyThinkingLevel(requested as ThinkingLevel);
 	}
 
 	private applyThinkingLevel(level: ThinkingLevel): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6,7 +6,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, AssistantMessage, ImageContent, Message, Model, ToolCall } from "@earendil-works/pi-ai";
 import type {
 	AutocompleteItem,
@@ -140,6 +140,7 @@ import { ScopedModelsSelectorComponent } from "./components/scoped-models-select
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
+import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
 import { ToolExecutionComponent, type ToolExecutionDefinition } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
@@ -874,7 +875,7 @@ export class InteractiveMode {
 						hint("app.exit", "to exit (empty)"),
 						hint("app.suspend", "to suspend"),
 						keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
-						hint("app.thinking.cycle", "to cycle thinking level"),
+						rawKeyHint("/effort", "to set thinking level"),
 						hint("app.model.select", "to select model"),
 						hint("app.tools.expand", "to expand tools"),
 						hint("app.thinking.toggle", "to expand thinking"),
@@ -3089,7 +3090,6 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.interrupt", () => this.handleInterruptKey());
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onAction("app.suspend", () => this.handleCtrlZ());
-		this.defaultEditor.onAction("app.thinking.cycle", () => this.cycleThinkingLevel());
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ui.onDebug = () => {
@@ -3255,6 +3255,11 @@ export class InteractiveMode {
 				const searchTerm = commandArgs || undefined;
 				this.editor.setText("");
 				await this.handleModelCommand(searchTerm);
+				return;
+			}
+			if (commandName === "effort" && !commandArgs) {
+				this.editor.setText("");
+				this.showThinkingSelector();
 				return;
 			}
 			if (commandName === "export") {
@@ -5022,24 +5027,6 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private cycleThinkingLevel(): void {
-		void this.agentConnection
-			.cycleThinkingLevel()
-			.then((newLevel) => {
-				if (newLevel === undefined) {
-					this.showStatus("Current model does not support thinking");
-				} else {
-					this.patchConnectionState({ thinkingLevel: newLevel });
-					this.footer.invalidate();
-					this.updateEditorBorderColor();
-					this.showStatus(`Thinking level: ${newLevel}`);
-				}
-			})
-			.catch((error) => {
-				this.showError(error instanceof Error ? error.message : String(error));
-			});
-	}
-
 	private toggleToolOutputExpansion(): void {
 		this.setToolsExpanded(!this.toolOutputExpanded);
 	}
@@ -5658,6 +5645,50 @@ export class InteractiveMode {
 		}
 		this.anthropicSubscriptionWarningShown = true;
 		this.showWarning(warning);
+	}
+
+	private showThinkingSelector(): void {
+		const availableLevels = this.connectionState?.availableThinkingLevels ?? [];
+		const supportsThinking =
+			availableLevels.length > 0 && !(availableLevels.length === 1 && availableLevels[0] === "off");
+		if (!supportsThinking) {
+			this.showStatus("Current model does not support thinking");
+			return;
+		}
+
+		const currentLevel = this.connectionState?.thinkingLevel ?? availableLevels[0];
+		let handle: OverlayHandle | undefined;
+		const close = () => {
+			handle?.hide();
+			this.ui.requestRender();
+		};
+
+		const selector = new ThinkingSelectorComponent(
+			currentLevel,
+			availableLevels,
+			(level) => {
+				close();
+				this.applyThinkingLevel(level);
+			},
+			() => {
+				close();
+			},
+		);
+		handle = this.showFullPaneOverlay(selector, 48);
+	}
+
+	private applyThinkingLevel(level: ThinkingLevel): void {
+		void this.agentConnection
+			.setThinkingLevel(level)
+			.then(() => {
+				this.patchConnectionState({ thinkingLevel: level });
+				this.footer.invalidate();
+				this.updateEditorBorderColor();
+				this.showStatus(`Thinking level: ${level}`);
+			})
+			.catch((error) => {
+				this.showError(error instanceof Error ? error.message : String(error));
+			});
 	}
 
 	private showModelSelector(initialSearchInput?: string): void {
@@ -6942,7 +6973,6 @@ export class InteractiveMode {
 		const interrupt = this.getAppKeyDisplay("app.interrupt");
 		const exit = this.getAppKeyDisplay("app.exit");
 		const suspend = this.getAppKeyDisplay("app.suspend");
-		const cycleThinkingLevel = this.getAppKeyDisplay("app.thinking.cycle");
 		const selectModel = this.getAppKeyDisplay("app.model.select");
 		const expandTools = this.getAppKeyDisplay("app.tools.expand");
 		const toggleThinking = this.getAppKeyDisplay("app.thinking.toggle");
@@ -6985,7 +7015,6 @@ export class InteractiveMode {
 | \`${clear}\` | Interrupt current operation (first) / exit (second) |
 ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}| \`${exit}\` | Exit (when editor is empty) |
 | \`${suspend}\` | Suspend to background |
-| \`${cycleThinkingLevel}\` | Cycle thinking level |
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |
 | \`${toggleThinking}\` | Toggle thinking block visibility |

--- a/packages/coding-agent/test/deferred-agent-connection.test.ts
+++ b/packages/coding-agent/test/deferred-agent-connection.test.ts
@@ -84,6 +84,31 @@ describe("DeferredAgentConnection", () => {
 		expect(conn.created).toBe(false);
 	});
 
+	test("derives available thinking levels from the seed model before a session exists", async () => {
+		const reasoningModel = {
+			provider: "anthropic",
+			id: "claude-opus",
+			reasoning: true,
+		} as unknown as AgentConnectionModel;
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, { ...SEED, model: reasoningModel });
+
+		const state = await conn.getState();
+
+		expect(state.availableThinkingLevels).toContain("high");
+		expect(state.availableThinkingLevels.length).toBeGreaterThan(1);
+		expect(factory).not.toHaveBeenCalled();
+	});
+
+	test("reports no thinking levels for a non-reasoning seed model", async () => {
+		const { factory } = makeFactory();
+		const conn = new DeferredAgentConnection(factory, SEED);
+
+		const state = await conn.getState();
+
+		expect(state.availableThinkingLevels).toEqual(["off"]);
+	});
+
 	test("creates the session on first prompt and delegates", async () => {
 		const { factory, fake } = makeFactory();
 		const conn = new DeferredAgentConnection(factory, SEED);

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -140,4 +140,37 @@ describe("InteractiveMode /effort", () => {
 			expect(context.patchConnectionState).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("model switch refresh", () => {
+		it("refreshes availableThinkingLevels from the newly selected model", async () => {
+			type ModelContext = {
+				agentConnection: { setModel: (provider: string, id: string) => Promise<void> };
+				settingsManager: { setDefaultModelAndProvider: (provider: string, id: string) => void };
+				patchConnectionState: (patch: Record<string, unknown>) => void;
+				footer: { invalidate: () => void };
+				updateEditorBorderColor: () => void;
+			};
+			const applySelectedModel = (
+				InteractiveMode.prototype as unknown as {
+					applySelectedModel(this: ModelContext, model: unknown): Promise<void>;
+				}
+			).applySelectedModel;
+			const patchConnectionState = vi.fn();
+			const context: ModelContext = {
+				agentConnection: { setModel: vi.fn(async () => {}) },
+				settingsManager: { setDefaultModelAndProvider: vi.fn() },
+				patchConnectionState,
+				footer: { invalidate: vi.fn() },
+				updateEditorBorderColor: vi.fn(),
+			};
+			const model = { provider: "anthropic", id: "claude-opus", reasoning: true };
+
+			await applySelectedModel.call(context, model);
+
+			const patch = patchConnectionState.mock.calls[0][0];
+			expect(patch.model).toBe(model);
+			expect(patch.availableThinkingLevels).toContain("high");
+			expect(patch.availableThinkingLevels.length).toBeGreaterThan(1);
+		});
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -149,6 +149,7 @@ describe("InteractiveMode /effort", () => {
 				patchConnectionState: (patch: Record<string, unknown>) => void;
 				footer: { invalidate: () => void };
 				updateEditorBorderColor: () => void;
+				setupAutocompleteProvider: () => void;
 			};
 			const applySelectedModel = (
 				InteractiveMode.prototype as unknown as {
@@ -156,12 +157,14 @@ describe("InteractiveMode /effort", () => {
 				}
 			).applySelectedModel;
 			const patchConnectionState = vi.fn();
+			const setupAutocompleteProvider = vi.fn();
 			const context: ModelContext = {
 				agentConnection: { setModel: vi.fn(async () => {}) },
 				settingsManager: { setDefaultModelAndProvider: vi.fn() },
 				patchConnectionState,
 				footer: { invalidate: vi.fn() },
 				updateEditorBorderColor: vi.fn(),
+				setupAutocompleteProvider,
 			};
 			const model = { provider: "anthropic", id: "claude-opus", reasoning: true };
 
@@ -171,6 +174,8 @@ describe("InteractiveMode /effort", () => {
 			expect(patch.model).toBe(model);
 			expect(patch.availableThinkingLevels).toContain("high");
 			expect(patch.availableThinkingLevels.length).toBeGreaterThan(1);
+			// Provider rebuild keeps the /effort argument hint in sync with the model.
+			expect(setupAutocompleteProvider).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -1,7 +1,6 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Component, OverlayHandle } from "@earendil-works/pi-tui";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { ThinkingSelectorComponent } from "../src/modes/interactive/components/thinking-selector.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
@@ -12,41 +11,40 @@ type EffortCommandContext = {
 	};
 	agentConnection: { setThinkingLevel: (level: ThinkingLevel) => Promise<void> };
 	footer: { invalidate: () => void };
-	ui: {
-		requestRender: () => void;
-		showOverlay: (component: Component, options?: unknown) => OverlayHandle;
-	};
 	showStatus: (message: string) => void;
 	showError: (message: string) => void;
 	patchConnectionState: (patch: Record<string, unknown>) => void;
 	updateEditorBorderColor: () => void;
+	getAvailableThinkingLevels: () => ThinkingLevel[];
+	applyThinkingLevel: (level: ThinkingLevel) => void;
 };
 
 type InteractiveModePrototype = {
-	showThinkingSelector(this: EffortCommandContext): void;
+	getAvailableThinkingLevels(this: EffortCommandContext): ThinkingLevel[];
+	getThinkingLevelCompletions(this: EffortCommandContext, prefix: string): AutocompleteItem[] | null;
+	handleEffortCommand(this: EffortCommandContext, arg: string): void;
 	applyThinkingLevel(this: EffortCommandContext, level: ThinkingLevel): void;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
 
 function makeContext(overrides: Partial<EffortCommandContext> = {}): EffortCommandContext {
-	return {
+	const context: EffortCommandContext = {
 		connectionState: {
 			thinkingLevel: "medium",
 			availableThinkingLevels: ["off", "low", "medium", "high"],
 		},
 		agentConnection: { setThinkingLevel: vi.fn(async () => {}) },
 		footer: { invalidate: vi.fn() },
-		ui: {
-			requestRender: vi.fn(),
-			showOverlay: vi.fn(() => ({ hide: vi.fn() }) as unknown as OverlayHandle),
-		},
 		showStatus: vi.fn(),
 		showError: vi.fn(),
 		patchConnectionState: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
+		getAvailableThinkingLevels: () => interactiveModePrototype.getAvailableThinkingLevels.call(context),
+		applyThinkingLevel: (level) => interactiveModePrototype.applyThinkingLevel.call(context, level),
 		...overrides,
 	};
+	return context;
 }
 
 describe("InteractiveMode /effort", () => {
@@ -54,55 +52,92 @@ describe("InteractiveMode /effort", () => {
 		initTheme("dark");
 	});
 
-	it("opens a thinking selector preselecting the current level", () => {
-		const context = makeContext();
+	describe("argument autocomplete", () => {
+		it("lists every supported level for an empty prefix and marks the current one", () => {
+			const context = makeContext();
 
-		interactiveModePrototype.showThinkingSelector.call(context);
+			const items = interactiveModePrototype.getThinkingLevelCompletions.call(context, "");
 
-		expect(context.ui.showOverlay).toHaveBeenCalledTimes(1);
-		const [component, options] = (context.ui.showOverlay as ReturnType<typeof vi.fn>).mock.calls[0];
-		expect(component).toBeInstanceOf(ThinkingSelectorComponent);
-		// Compact popup anchored to the editor, not a full-pane overlay that
-		// blanks the terminal.
-		expect(options).toMatchObject({ anchor: "bottom-left" });
-		expect(options?.maxHeight).toBeUndefined();
-		expect(context.showStatus).not.toHaveBeenCalled();
-	});
-
-	it("does not open the selector when the model does not support thinking", () => {
-		const context = makeContext({
-			connectionState: { thinkingLevel: "off", availableThinkingLevels: ["off"] },
+			expect(items?.map((item) => item.value)).toEqual(["off", "low", "medium", "high"]);
+			expect(items?.find((item) => item.value === "medium")?.description).toContain("(current)");
 		});
 
-		interactiveModePrototype.showThinkingSelector.call(context);
+		it("filters by the typed prefix", () => {
+			const context = makeContext();
 
-		expect(context.ui.showOverlay).not.toHaveBeenCalled();
-		expect(context.showStatus).toHaveBeenCalledWith("Current model does not support thinking");
-	});
+			const items = interactiveModePrototype.getThinkingLevelCompletions.call(context, "h");
 
-	it("applies a selected level through the connection and reports it", async () => {
-		const setThinkingLevel = vi.fn(async () => {});
-		const context = makeContext({ agentConnection: { setThinkingLevel } });
-
-		interactiveModePrototype.applyThinkingLevel.call(context, "high");
-		await vi.waitFor(() => expect(context.showStatus).toHaveBeenCalledWith("Thinking level: high"));
-
-		expect(setThinkingLevel).toHaveBeenCalledWith("high");
-		expect(context.patchConnectionState).toHaveBeenCalledWith({ thinkingLevel: "high" });
-		expect(context.footer.invalidate).toHaveBeenCalledWith();
-		expect(context.updateEditorBorderColor).toHaveBeenCalledWith();
-		expect(context.showError).not.toHaveBeenCalled();
-	});
-
-	it("surfaces an error when applying a level fails", async () => {
-		const setThinkingLevel = vi.fn(async () => {
-			throw new Error("nope");
+			expect(items?.map((item) => item.value)).toEqual(["high"]);
 		});
-		const context = makeContext({ agentConnection: { setThinkingLevel } });
 
-		interactiveModePrototype.applyThinkingLevel.call(context, "high");
-		await vi.waitFor(() => expect(context.showError).toHaveBeenCalledWith("nope"));
+		it("offers no completions when the model does not support thinking", () => {
+			const context = makeContext({
+				connectionState: { thinkingLevel: "off", availableThinkingLevels: ["off"] },
+			});
 
-		expect(context.patchConnectionState).not.toHaveBeenCalled();
+			expect(interactiveModePrototype.getThinkingLevelCompletions.call(context, "")).toBeNull();
+		});
+	});
+
+	describe("command handling", () => {
+		it("applies a valid level through the connection and reports it", async () => {
+			const setThinkingLevel = vi.fn(async () => {});
+			const context = makeContext({ agentConnection: { setThinkingLevel } });
+
+			interactiveModePrototype.handleEffortCommand.call(context, "high");
+			await vi.waitFor(() => expect(context.showStatus).toHaveBeenCalledWith("Thinking level: high"));
+
+			expect(setThinkingLevel).toHaveBeenCalledWith("high");
+			expect(context.patchConnectionState).toHaveBeenCalledWith({ thinkingLevel: "high" });
+			expect(context.footer.invalidate).toHaveBeenCalledWith();
+			expect(context.updateEditorBorderColor).toHaveBeenCalledWith();
+			expect(context.showError).not.toHaveBeenCalled();
+		});
+
+		it("rejects an unknown level without touching the connection", () => {
+			const setThinkingLevel = vi.fn(async () => {});
+			const context = makeContext({ agentConnection: { setThinkingLevel } });
+
+			interactiveModePrototype.handleEffortCommand.call(context, "bogus");
+
+			expect(setThinkingLevel).not.toHaveBeenCalled();
+			expect(context.showError).toHaveBeenCalledWith(
+				"Unknown thinking level 'bogus'. Available: off, low, medium, high",
+			);
+		});
+
+		it("shows the current level and choices when called without an argument", () => {
+			const context = makeContext();
+
+			interactiveModePrototype.handleEffortCommand.call(context, "");
+
+			expect(context.agentConnection.setThinkingLevel).not.toHaveBeenCalled();
+			expect(context.showStatus).toHaveBeenCalledWith(
+				"Thinking level: medium (type a level: off, low, medium, high)",
+			);
+		});
+
+		it("reports when the model does not support thinking", () => {
+			const context = makeContext({
+				connectionState: { thinkingLevel: "off", availableThinkingLevels: ["off"] },
+			});
+
+			interactiveModePrototype.handleEffortCommand.call(context, "high");
+
+			expect(context.agentConnection.setThinkingLevel).not.toHaveBeenCalled();
+			expect(context.showStatus).toHaveBeenCalledWith("Current model does not support thinking");
+		});
+
+		it("surfaces an error when applying a level fails", async () => {
+			const setThinkingLevel = vi.fn(async () => {
+				throw new Error("nope");
+			});
+			const context = makeContext({ agentConnection: { setThinkingLevel } });
+
+			interactiveModePrototype.handleEffortCommand.call(context, "high");
+			await vi.waitFor(() => expect(context.showError).toHaveBeenCalledWith("nope"));
+
+			expect(context.patchConnectionState).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -12,12 +12,14 @@ type EffortCommandContext = {
 	};
 	agentConnection: { setThinkingLevel: (level: ThinkingLevel) => Promise<void> };
 	footer: { invalidate: () => void };
-	ui: { requestRender: () => void };
+	ui: {
+		requestRender: () => void;
+		showOverlay: (component: Component, options?: unknown) => OverlayHandle;
+	};
 	showStatus: (message: string) => void;
 	showError: (message: string) => void;
 	patchConnectionState: (patch: Record<string, unknown>) => void;
 	updateEditorBorderColor: () => void;
-	showFullPaneOverlay: (component: Component, maxContentWidth?: number) => OverlayHandle;
 };
 
 type InteractiveModePrototype = {
@@ -35,12 +37,14 @@ function makeContext(overrides: Partial<EffortCommandContext> = {}): EffortComma
 		},
 		agentConnection: { setThinkingLevel: vi.fn(async () => {}) },
 		footer: { invalidate: vi.fn() },
-		ui: { requestRender: vi.fn() },
+		ui: {
+			requestRender: vi.fn(),
+			showOverlay: vi.fn(() => ({ hide: vi.fn() }) as unknown as OverlayHandle),
+		},
 		showStatus: vi.fn(),
 		showError: vi.fn(),
 		patchConnectionState: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
-		showFullPaneOverlay: vi.fn(() => ({ hide: vi.fn() }) as unknown as OverlayHandle),
 		...overrides,
 	};
 }
@@ -55,9 +59,13 @@ describe("InteractiveMode /effort", () => {
 
 		interactiveModePrototype.showThinkingSelector.call(context);
 
-		expect(context.showFullPaneOverlay).toHaveBeenCalledTimes(1);
-		const [component] = (context.showFullPaneOverlay as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(context.ui.showOverlay).toHaveBeenCalledTimes(1);
+		const [component, options] = (context.ui.showOverlay as ReturnType<typeof vi.fn>).mock.calls[0];
 		expect(component).toBeInstanceOf(ThinkingSelectorComponent);
+		// Compact popup anchored to the editor, not a full-pane overlay that
+		// blanks the terminal.
+		expect(options).toMatchObject({ anchor: "bottom-left" });
+		expect(options?.maxHeight).toBeUndefined();
 		expect(context.showStatus).not.toHaveBeenCalled();
 	});
 
@@ -68,7 +76,7 @@ describe("InteractiveMode /effort", () => {
 
 		interactiveModePrototype.showThinkingSelector.call(context);
 
-		expect(context.showFullPaneOverlay).not.toHaveBeenCalled();
+		expect(context.ui.showOverlay).not.toHaveBeenCalled();
 		expect(context.showStatus).toHaveBeenCalledWith("Current model does not support thinking");
 	});
 

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -1,0 +1,100 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Component, OverlayHandle } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { ThinkingSelectorComponent } from "../src/modes/interactive/components/thinking-selector.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+type EffortCommandContext = {
+	connectionState?: {
+		thinkingLevel: ThinkingLevel;
+		availableThinkingLevels: ThinkingLevel[];
+	};
+	agentConnection: { setThinkingLevel: (level: ThinkingLevel) => Promise<void> };
+	footer: { invalidate: () => void };
+	ui: { requestRender: () => void };
+	showStatus: (message: string) => void;
+	showError: (message: string) => void;
+	patchConnectionState: (patch: Record<string, unknown>) => void;
+	updateEditorBorderColor: () => void;
+	showFullPaneOverlay: (component: Component, maxContentWidth?: number) => OverlayHandle;
+};
+
+type InteractiveModePrototype = {
+	showThinkingSelector(this: EffortCommandContext): void;
+	applyThinkingLevel(this: EffortCommandContext, level: ThinkingLevel): void;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+function makeContext(overrides: Partial<EffortCommandContext> = {}): EffortCommandContext {
+	return {
+		connectionState: {
+			thinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		},
+		agentConnection: { setThinkingLevel: vi.fn(async () => {}) },
+		footer: { invalidate: vi.fn() },
+		ui: { requestRender: vi.fn() },
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		patchConnectionState: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		showFullPaneOverlay: vi.fn(() => ({ hide: vi.fn() }) as unknown as OverlayHandle),
+		...overrides,
+	};
+}
+
+describe("InteractiveMode /effort", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("opens a thinking selector preselecting the current level", () => {
+		const context = makeContext();
+
+		interactiveModePrototype.showThinkingSelector.call(context);
+
+		expect(context.showFullPaneOverlay).toHaveBeenCalledTimes(1);
+		const [component] = (context.showFullPaneOverlay as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(component).toBeInstanceOf(ThinkingSelectorComponent);
+		expect(context.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("does not open the selector when the model does not support thinking", () => {
+		const context = makeContext({
+			connectionState: { thinkingLevel: "off", availableThinkingLevels: ["off"] },
+		});
+
+		interactiveModePrototype.showThinkingSelector.call(context);
+
+		expect(context.showFullPaneOverlay).not.toHaveBeenCalled();
+		expect(context.showStatus).toHaveBeenCalledWith("Current model does not support thinking");
+	});
+
+	it("applies a selected level through the connection and reports it", async () => {
+		const setThinkingLevel = vi.fn(async () => {});
+		const context = makeContext({ agentConnection: { setThinkingLevel } });
+
+		interactiveModePrototype.applyThinkingLevel.call(context, "high");
+		await vi.waitFor(() => expect(context.showStatus).toHaveBeenCalledWith("Thinking level: high"));
+
+		expect(setThinkingLevel).toHaveBeenCalledWith("high");
+		expect(context.patchConnectionState).toHaveBeenCalledWith({ thinkingLevel: "high" });
+		expect(context.footer.invalidate).toHaveBeenCalledWith();
+		expect(context.updateEditorBorderColor).toHaveBeenCalledWith();
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("surfaces an error when applying a level fails", async () => {
+		const setThinkingLevel = vi.fn(async () => {
+			throw new Error("nope");
+		});
+		const context = makeContext({ agentConnection: { setThinkingLevel } });
+
+		interactiveModePrototype.applyThinkingLevel.call(context, "high");
+		await vi.waitFor(() => expect(context.showError).toHaveBeenCalledWith("nope"));
+
+		expect(context.patchConnectionState).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -808,6 +808,7 @@ describe("InteractiveMode model selection persistence", () => {
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		handleModelCommand(searchTerm?: string): Promise<void>;
 		completeOnboardingIfCurrentModelReady(): void;
+		setupAutocompleteProvider(): void;
 	};
 
 	const createModel = (provider: string, id: string): AgentConnectionModel =>
@@ -836,6 +837,7 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.footer = { invalidate: vi.fn() };
 		fakeThis.patchConnectionState = vi.fn();
 		fakeThis.updateEditorBorderColor = vi.fn();
+		fakeThis.setupAutocompleteProvider = vi.fn();
 
 		await fakeThis.applySelectedModel(model);
 
@@ -890,6 +892,7 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn(async () => {});
 		fakeThis.checkDaxnutsEasterEgg = vi.fn();
 		fakeThis.completeOnboardingIfCurrentModelReady = vi.fn();
+		fakeThis.setupAutocompleteProvider = vi.fn();
 
 		await fakeThis.handleModelCommand("gpt-5.5");
 
@@ -909,6 +912,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		handleModelCommand(searchTerm?: string): Promise<void>;
 		runOnboardingFlow(): Promise<boolean>;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
+		setupAutocompleteProvider(): void;
 	};
 	type OnboardingFake = OnboardingHarness & {
 		connectionState: AgentConnectionState;
@@ -1037,6 +1041,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn();
 		fakeThis.checkDaxnutsEasterEgg = vi.fn();
 		fakeThis.applySelectedModel = applySelectedModel;
+		fakeThis.setupAutocompleteProvider = vi.fn();
 
 		await handleModelCommand.call(fakeThis, "prime-inference/openai/gpt-5.5");
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -842,7 +842,7 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(fakeThis.uiServices.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(order).toEqual(["connection", "settings"]);
-		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({ model });
+		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({ model, availableThinkingLevels: ["off"] });
 		expect(fakeThis.footer.invalidate).toHaveBeenCalledTimes(1);
 		expect(fakeThis.updateEditorBorderColor).toHaveBeenCalledTimes(1);
 	});
@@ -895,7 +895,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(fakeThis.uiServices.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-5.5");
-		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({ model });
+		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({ model, availableThinkingLevels: ["off"] });
 		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model: gpt-5.5");
 		expect(fakeThis.showError).not.toHaveBeenCalled();
 		expect(fakeThis.completeOnboardingIfCurrentModelReady).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -14,6 +14,13 @@ describe("built-in slash commands", () => {
 		expect(commandNames).toContain("heartbeat");
 		expect(commandNames).not.toContain("cron");
 	});
+
+	test("exposes /effort for selecting the thinking level", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
+			description: "Select reasoning/thinking level (opens selector UI)",
+			aliases: ["thinking"],
+		});
+	});
 });
 
 describe("slash command aliases", () => {
@@ -40,6 +47,19 @@ describe("slash command aliases", () => {
 			name: "new",
 			args: "",
 			originalName: "clear",
+			isAlias: true,
+		});
+	});
+
+	test("resolves /thinking to /effort through the alias path", () => {
+		const parsed = parseSlashCommand("/thinking");
+
+		expect(isBuiltinSlashCommandName("thinking")).toBe(true);
+		expect(resolveBuiltinSlashCommandName("thinking")).toBe("effort");
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "effort",
+			args: "",
+			originalName: "thinking",
 			isAlias: true,
 		});
 	});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -17,7 +17,8 @@ describe("built-in slash commands", () => {
 
 	test("exposes /effort for selecting the thinking level", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
-			description: "Select reasoning/thinking level (opens selector UI)",
+			description: "Set reasoning/thinking level",
+			argumentHint: "[level]",
 			aliases: ["thinking"],
 		});
 	});


### PR DESCRIPTION
- adds an /effort slash command (alias /thinking) to set the reasoning/thinking level, matching the claude code and codex conventions.
- typing /effort offers the levels the current model supports as argument autocomplete in the same list slash commands use, and /effort <level> sets it directly.
- replaces the hard-to-discover shift+tab cycle, and updates the docs, hotkeys, and changelog to point at /effort.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly interactive UX and documentation; behavior change is that Shift+Tab no longer cycles thinking level, but level changes still go through the existing connection API.
> 
> **Overview**
> Adds **`/effort`** (alias **`/thinking`**) as the built-in way to set reasoning/thinking level, with slash-command autocomplete for levels the active model supports and direct **`/effort <level>`** application via **`setThinkingLevel`**.
> 
> **Removes** the **`Shift+Tab`** **`app.thinking.cycle`** keybinding and related interactive wiring; docs, hotkeys, and verbose hints now point users at **`/effort`** instead.
> 
> Connection/UI state now keeps **`availableThinkingLevels`** in sync from the seed model before a session exists, after model changes, and refreshes the **`/effort`** argument hint when the model changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fdd917669cc955152638d01d8540be39b822e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/effort` slash command to set the thinking/reasoning level
> - Replaces the Shift+Tab thinking-level cycle keybinding with a new `/effort` command (aliased as `/thinking`) that gets or sets the thinking level with validation and status feedback.
> - `/effort` provides autocomplete for available thinking levels, annotating the currently active level, with hints that update when the model changes.
> - `DeferredAgentConnection.defaultState` now populates `availableThinkingLevels` from the seed model so UI consumers can show options before a session is created.
> - Behavioral Change: `app.thinking.cycle` (Shift+Tab) is removed from keybindings entirely; existing configs mapping `cycleThinkingLevel` to this action will no longer migrate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7fdd91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->