### PR TITLE
make trace uploads observable and resilient

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -529,7 +529,6 @@ export function getClientErrorLogPath(): string {
 	return join(getLogsDir(), "client-errors.log");
 }
 
-/** Log file capturing agent-trace upload outcomes. */
 export function getAgentTracesLogPath(): string {
 	return join(getLogsDir(), "agent-traces.log");
 }

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -529,6 +529,11 @@ export function getClientErrorLogPath(): string {
 	return join(getLogsDir(), "client-errors.log");
 }
 
+/** Log file capturing agent-trace upload outcomes. */
+export function getAgentTracesLogPath(): string {
+	return join(getLogsDir(), "agent-traces.log");
+}
+
 /**
  * Log file for a daemon. The basename keeps it readable; a hash of the full
  * socket path makes it unique so two sockets that share a basename (e.g.

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -95,7 +95,6 @@ function describeError(error: unknown): string {
 	return error.message;
 }
 
-// A socket-level fetch failure (cause.code set), as opposed to a timeout/user abort.
 function isRetriableNetworkError(error: unknown): boolean {
 	if (!(error instanceof Error) || error.name === "AbortError") {
 		return false;
@@ -350,8 +349,6 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	return result;
 }
 
-// Logs so failures aren't lost in fire-and-forget callers (session teardown).
-// Idle states (disabled, no/empty session) are skipped to keep the log signal-heavy.
 function logAgentTraceOutcome(sessionFile: string | undefined, result: AgentTraceUploadResult): void {
 	let line: string | undefined;
 	switch (result.status) {

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -77,12 +77,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/**
- * Build a human-readable error string that includes the underlying cause.
- * Node's `fetch` rejects with a terse `TypeError: fetch failed` and hides the
- * real reason (DNS, connection refused, reset socket, TLS, ...) on `error.cause`.
- * Surfacing it turns an opaque "fetch failed" into e.g. "fetch failed (ENOTFOUND)".
- */
+// Node's `fetch` hides the real reason on `error.cause`; surface it so a bare
+// "fetch failed" becomes e.g. "fetch failed (ENOTFOUND)".
 function describeError(error: unknown): string {
 	if (!(error instanceof Error)) {
 		return String(error);
@@ -99,11 +95,7 @@ function describeError(error: unknown): string {
 	return error.message;
 }
 
-/**
- * A connection-level failure worth one retry: `fetch` rejected before any HTTP
- * response (DNS, refused, reset, TLS), as opposed to a timeout/user abort. We key
- * off `error.cause.code` since that's where undici puts the socket-level reason.
- */
+// A socket-level fetch failure (cause.code set), as opposed to a timeout/user abort.
 function isRetriableNetworkError(error: unknown): boolean {
 	if (!(error instanceof Error) || error.name === "AbortError") {
 		return false;
@@ -283,11 +275,6 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
 	});
 }
 
-/**
- * `fetchWithTimeout` plus a single retry on transient connection-level failures
- * (DNS/refused/reset/TLS). HTTP error responses, timeouts, and user aborts are not
- * retried — those are returned/thrown as-is on the first attempt.
- */
 async function fetchWithRetry(
 	fetchFn: typeof fetch,
 	url: string,
@@ -363,11 +350,8 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	return result;
 }
 
-/**
- * Record meaningful upload outcomes to a rotating log so failures are not lost in
- * fire-and-forget callers (session teardown). Expected idle states (disabled, no/empty
- * session) are intentionally skipped to keep the file signal-heavy.
- */
+// Logs so failures aren't lost in fire-and-forget callers (session teardown).
+// Idle states (disabled, no/empty session) are skipped to keep the log signal-heavy.
 function logAgentTraceOutcome(sessionFile: string | undefined, result: AgentTraceUploadResult): void {
 	let line: string | undefined;
 	switch (result.status) {

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -93,12 +93,25 @@ function describeError(error: unknown): string {
 	return error.message;
 }
 
+const RETRIABLE_NETWORK_CODES = new Set([
+	"ECONNRESET",
+	"ECONNREFUSED",
+	"ECONNABORTED",
+	"EPIPE",
+	"ETIMEDOUT",
+	"ENETUNREACH",
+	"ENETDOWN",
+	"EAI_AGAIN",
+	"UND_ERR_SOCKET",
+	"UND_ERR_CONNECT_TIMEOUT",
+]);
+
 function isRetriableNetworkError(error: unknown): boolean {
 	if (!(error instanceof Error) || error.name === "AbortError") {
 		return false;
 	}
 	const cause = (error as { cause?: unknown }).cause;
-	return isRecord(cause) && typeof cause.code === "string";
+	return isRecord(cause) && typeof cause.code === "string" && RETRIABLE_NETWORK_CODES.has(cause.code);
 }
 
 function stringField(data: Record<string, unknown>, key: string): string | undefined {

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -282,12 +282,15 @@ async function fetchWithRetry(
 	try {
 		return await fetchWithTimeout(fetchFn, url, init, timeoutMs, signal);
 	} catch (error) {
-		if (signal?.aborted || !isRetriableNetworkError(error)) {
+		if (signal?.aborted) {
+			throw signal.reason ?? error;
+		}
+		if (!isRetriableNetworkError(error)) {
 			throw error;
 		}
 		await delay(TRACE_UPLOAD_RETRY_DELAY_MS, signal);
 		if (signal?.aborted) {
-			throw error;
+			throw signal.reason ?? error;
 		}
 		return await fetchWithTimeout(fetchFn, url, init, timeoutMs, signal);
 	}

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -77,8 +77,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// Node's `fetch` hides the real reason on `error.cause`; surface it so a bare
-// "fetch failed" becomes e.g. "fetch failed (ENOTFOUND)".
 function describeError(error: unknown): string {
 	if (!(error instanceof Error)) {
 		return String(error);

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, isAbsolute, resolve } from "node:path";
-import { VERSION } from "../config.js";
+import { appendRotatingLog, getAgentTracesLogPath, VERSION } from "../config.js";
 import { readFirstLineSync } from "../utils/file-lines.js";
 import type { AuthStorage } from "./auth-storage.js";
 import {
@@ -17,6 +17,7 @@ const MAX_TRACE_BYTES = 20 * 1024 * 1024;
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 const TRACE_UPLOAD_DEBOUNCE_MS = 1_000;
 const TRACE_UPLOAD_MIN_INTERVAL_MS = 60_000;
+const TRACE_UPLOAD_RETRY_DELAY_MS = 500;
 
 export type AgentTraceCredentialSource = "environment" | "stored" | "prime-inference" | "prime-cli";
 
@@ -74,6 +75,41 @@ function stringEnv(name: string): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Build a human-readable error string that includes the underlying cause.
+ * Node's `fetch` rejects with a terse `TypeError: fetch failed` and hides the
+ * real reason (DNS, connection refused, reset socket, TLS, ...) on `error.cause`.
+ * Surfacing it turns an opaque "fetch failed" into e.g. "fetch failed (ENOTFOUND)".
+ */
+function describeError(error: unknown): string {
+	if (!(error instanceof Error)) {
+		return String(error);
+	}
+	const cause = (error as { cause?: unknown }).cause;
+	if (isRecord(cause)) {
+		const code = typeof cause.code === "string" ? cause.code : undefined;
+		const causeMessage = typeof cause.message === "string" ? cause.message : undefined;
+		const detail = code ?? causeMessage;
+		if (detail && detail !== error.message) {
+			return `${error.message} (${detail})`;
+		}
+	}
+	return error.message;
+}
+
+/**
+ * A connection-level failure worth one retry: `fetch` rejected before any HTTP
+ * response (DNS, refused, reset, TLS), as opposed to a timeout/user abort. We key
+ * off `error.cause.code` since that's where undici puts the socket-level reason.
+ */
+function isRetriableNetworkError(error: unknown): boolean {
+	if (!(error instanceof Error) || error.name === "AbortError") {
+		return false;
+	}
+	const cause = (error as { cause?: unknown }).cause;
+	return isRecord(cause) && typeof cause.code === "string";
 }
 
 function stringField(data: Record<string, unknown>, key: string): string | undefined {
@@ -234,6 +270,45 @@ async function fetchWithTimeout(
 	}
 }
 
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const timeout = setTimeout(finish, ms);
+		const onAbort = () => finish();
+		function finish() {
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * `fetchWithTimeout` plus a single retry on transient connection-level failures
+ * (DNS/refused/reset/TLS). HTTP error responses, timeouts, and user aborts are not
+ * retried — those are returned/thrown as-is on the first attempt.
+ */
+async function fetchWithRetry(
+	fetchFn: typeof fetch,
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+	signal?: AbortSignal,
+): Promise<Response> {
+	try {
+		return await fetchWithTimeout(fetchFn, url, init, timeoutMs, signal);
+	} catch (error) {
+		if (signal?.aborted || !isRetriableNetworkError(error)) {
+			throw error;
+		}
+		await delay(TRACE_UPLOAD_RETRY_DELAY_MS, signal);
+		if (signal?.aborted) {
+			throw error;
+		}
+		return await fetchWithTimeout(fetchFn, url, init, timeoutMs, signal);
+	}
+}
+
 export async function getPrimeAgentTraceCredential(
 	authStorage: AuthStorage,
 	options: { reloadAuth?: boolean; configPath?: string } = {},
@@ -283,6 +358,42 @@ async function getAgentTracesEnabled(
 }
 
 export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Promise<AgentTraceUploadResult> {
+	const result = await performAgentTraceUpload(options);
+	logAgentTraceOutcome(options.sessionFile, result);
+	return result;
+}
+
+/**
+ * Record meaningful upload outcomes to a rotating log so failures are not lost in
+ * fire-and-forget callers (session teardown). Expected idle states (disabled, no/empty
+ * session) are intentionally skipped to keep the file signal-heavy.
+ */
+function logAgentTraceOutcome(sessionFile: string | undefined, result: AgentTraceUploadResult): void {
+	let line: string | undefined;
+	switch (result.status) {
+		case "uploaded":
+			line = `uploaded session ${result.sessionId} (${result.bytesStored} bytes)`;
+			break;
+		case "failed":
+			line = `upload failed${result.statusCode ? ` (HTTP ${result.statusCode})` : ""}: ${result.message}`;
+			break;
+		case "too_large":
+			line = `upload skipped: session is ${result.size} bytes (limit ${result.maxBytes})`;
+			break;
+		case "invalid_session":
+			line = `upload skipped: ${result.message}`;
+			break;
+		case "missing_credentials":
+			line = "upload skipped: no Prime credential configured (run /traces login)";
+			break;
+		default:
+			return;
+	}
+	const suffix = sessionFile ? ` [${sessionFile}]` : "";
+	appendRotatingLog(getAgentTracesLogPath(), `[${new Date().toISOString()}] ${line}${suffix}`);
+}
+
+async function performAgentTraceUpload(options: AgentTraceUploadOptions): Promise<AgentTraceUploadResult> {
 	if (!(await getAgentTracesEnabled(options))) {
 		return { status: "disabled" };
 	}
@@ -328,7 +439,7 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 	try {
 		body = await readFile(options.sessionFile, "utf8");
 	} catch (error) {
-		return { status: "failed", message: error instanceof Error ? error.message : String(error) };
+		return { status: "failed", message: describeError(error) };
 	}
 	if (!body.trim()) {
 		return { status: "empty_session" };
@@ -366,7 +477,7 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 
 	let response: Response;
 	try {
-		response = await fetchWithTimeout(
+		response = await fetchWithRetry(
 			fetchFn,
 			url,
 			{
@@ -378,7 +489,7 @@ export async function uploadAgentTraceFile(options: AgentTraceUploadOptions): Pr
 			options.signal,
 		);
 	} catch (error) {
-		return { status: "failed", message: error instanceof Error ? error.message : String(error) };
+		return { status: "failed", message: describeError(error) };
 	}
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -365,7 +365,8 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	low: "Light reasoning",
 	medium: "Moderate reasoning",
 	high: "Deep reasoning",
-	xhigh: "Maximum reasoning",
+	xhigh: "Very deep reasoning",
+	max: "Maximum reasoning",
 };
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -46,7 +46,15 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { spawn, spawnSync } from "child_process";
-import { APP_TITLE, getAgentDir, getDebugLogPath, getLogsDir, getShareViewerUrl, VERSION } from "../../config.js";
+import {
+	APP_TITLE,
+	getAgentDir,
+	getAgentTracesLogPath,
+	getDebugLogPath,
+	getLogsDir,
+	getShareViewerUrl,
+	VERSION,
+} from "../../config.js";
 import {
 	type AgentTraceUploadResult,
 	getPrimeAgentTraceCredential,
@@ -69,6 +77,7 @@ import { emptyGoalState, formatGoalUsage, type GoalState } from "../../core/goal
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
+import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
@@ -6711,7 +6720,7 @@ export class InteractiveMode {
 				if (result.statusCode === 404) {
 					return "Trace upload endpoint was not found. The platform API may not be deployed yet, or PRIME_AGENT_TRACES_BASE_URL points at the wrong API.";
 				}
-				return `Trace upload failed: ${result.statusCode ? `HTTP ${result.statusCode}: ` : ""}${result.message}`;
+				return `Trace upload failed: ${result.statusCode ? `HTTP ${result.statusCode}: ` : ""}${result.message}. See ${getAgentTracesLogPath()} for details.`;
 		}
 	}
 
@@ -6741,6 +6750,7 @@ export class InteractiveMode {
 				"",
 				`${theme.fg("dim", "Status:")} ${this.settingsManager.getAgentTracesEnabled() ? "Enabled" : "Disabled"}`,
 				`${theme.fg("dim", "Credential:")} ${credential?.label ?? "Not configured"}`,
+				`${theme.fg("dim", "Endpoint:")} ${resolvePrimeAgentTracesBaseUrl()}`,
 				`${theme.fg("dim", "Session file:")} ${state.sessionFile ?? "In-memory"}`,
 				"",
 				theme.fg("dim", "Commands: /traces on, /traces off, /traces upload, /traces login"),

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -443,6 +443,38 @@ describe("agent trace upload", () => {
 		expect(calls).toHaveLength(1);
 	});
 
+	it("surfaces the cancellation reason when aborted during the retry backoff", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "aborted-retry-session");
+		const controller = new AbortController();
+		const abortReason = new Error("upload cancelled");
+		let attempts = 0;
+		const flakyFetch: typeof fetch = async () => {
+			attempts += 1;
+			controller.abort(abortReason);
+			const error = new TypeError("fetch failed");
+			(error as { cause?: unknown }).cause = { code: "ECONNRESET" };
+			throw error;
+		};
+
+		const result = await uploadAgentTraceFile({
+			sessionFile: session.getSessionFile(),
+			authStorage: AuthStorage.inMemory({
+				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			fetchFn: flakyFetch,
+			signal: controller.signal,
+			reloadConfig: false,
+		});
+
+		expect(attempts).toBe(1);
+		expect(result.status).toBe("failed");
+		if (result.status === "failed") {
+			expect(result.message).toBe("upload cancelled");
+		}
+	});
+
 	it("does not retry on an HTTP error response", async () => {
 		const session = writeSession(tempDir, join(tempDir, "sessions"), "http-error-session");
 		let attempts = 0;

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -475,6 +475,34 @@ describe("agent trace upload", () => {
 		}
 	});
 
+	it("does not retry a permanent DNS failure", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "dns-failure-session");
+		let attempts = 0;
+		const dnsFailFetch: typeof fetch = async () => {
+			attempts += 1;
+			const error = new TypeError("fetch failed");
+			(error as { cause?: unknown }).cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND host" };
+			throw error;
+		};
+
+		const result = await uploadAgentTraceFile({
+			sessionFile: session.getSessionFile(),
+			authStorage: AuthStorage.inMemory({
+				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			fetchFn: dnsFailFetch,
+			reloadConfig: false,
+		});
+
+		expect(attempts).toBe(1);
+		expect(result.status).toBe("failed");
+		if (result.status === "failed") {
+			expect(result.message).toBe("fetch failed (ENOTFOUND)");
+		}
+	});
+
 	it("does not retry on an HTTP error response", async () => {
 		const session = writeSession(tempDir, join(tempDir, "sessions"), "http-error-session");
 		let attempts = 0;

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR, getAgentTracesLogPath } from "../src/config.js";
 import { flushAgentTraceUpload, installAgentTraceUpload, uploadAgentTraceFile } from "../src/core/agent-traces.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { PRIME_AGENT_TRACES_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
+import { PRIME_AGENT_TRACES_PROVIDER_ID, PRIME_INFERENCE_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 
@@ -72,9 +73,12 @@ describe("agent trace upload", () => {
 	let originalPrimeApiKey: string | undefined;
 	let originalTraceBaseUrl: string | undefined;
 	let originalPrimeBaseUrl: string | undefined;
+	let originalAgentDir: string | undefined;
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "agent-traces-test-"));
+		originalAgentDir = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = tempDir;
 		originalTraceApiKey = process.env.PRIME_AGENT_TRACES_API_KEY;
 		originalPrimeApiKey = process.env.PRIME_API_KEY;
 		originalTraceBaseUrl = process.env.PRIME_AGENT_TRACES_BASE_URL;
@@ -87,6 +91,11 @@ describe("agent trace upload", () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
 		if (originalTraceApiKey === undefined) {
 			delete process.env.PRIME_AGENT_TRACES_API_KEY;
 		} else {
@@ -370,5 +379,119 @@ describe("agent trace upload", () => {
 		setTimeoutSpy.mockClear();
 		sessionManager.appendMessage(createUserMessage("next"));
 		expect(Number(setTimeoutSpy.mock.calls.at(-1)?.[1])).toBe(60_000);
+	});
+
+	it("surfaces the underlying fetch cause and logs the failure", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "failing-session");
+		const sessionFile = session.getSessionFile();
+
+		const failingFetch: typeof fetch = async () => {
+			const error = new TypeError("fetch failed");
+			(error as { cause?: unknown }).cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND host" };
+			throw error;
+		};
+
+		const result = await uploadAgentTraceFile({
+			sessionFile,
+			authStorage: AuthStorage.inMemory({
+				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			fetchFn: failingFetch,
+			reloadConfig: false,
+		});
+
+		expect(result.status).toBe("failed");
+		if (result.status === "failed") {
+			expect(result.message).toBe("fetch failed (ENOTFOUND)");
+		}
+
+		const logContents = readFileSync(getAgentTracesLogPath(), "utf8");
+		expect(logContents).toContain("upload failed");
+		expect(logContents).toContain("fetch failed (ENOTFOUND)");
+		expect(logContents).toContain(sessionFile ?? "");
+	});
+
+	it("retries once on a transient connection failure, then succeeds", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "retry-session");
+		const calls: FetchCall[] = [];
+		let attempts = 0;
+		const flakyFetch: typeof fetch = async (input, init) => {
+			attempts += 1;
+			if (attempts === 1) {
+				const error = new TypeError("fetch failed");
+				(error as { cause?: unknown }).cause = { code: "ECONNRESET" };
+				throw error;
+			}
+			return createFetchRecorder(calls)(input, init);
+		};
+
+		const result = await uploadAgentTraceFile({
+			sessionFile: session.getSessionFile(),
+			authStorage: AuthStorage.inMemory({
+				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			fetchFn: flakyFetch,
+			reloadConfig: false,
+		});
+
+		expect(attempts).toBe(2);
+		expect(result.status).toBe("uploaded");
+		expect(calls).toHaveLength(1);
+	});
+
+	it("does not retry on an HTTP error response", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "http-error-session");
+		let attempts = 0;
+		const erroringFetch: typeof fetch = async () => {
+			attempts += 1;
+			return new Response(JSON.stringify({ detail: "bad request" }), {
+				status: 400,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const result = await uploadAgentTraceFile({
+			sessionFile: session.getSessionFile(),
+			authStorage: AuthStorage.inMemory({
+				[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			fetchFn: erroringFetch,
+			reloadConfig: false,
+		});
+
+		expect(attempts).toBe(1);
+		expect(result.status).toBe("failed");
+		if (result.status === "failed") {
+			expect(result.statusCode).toBe(400);
+		}
+	});
+
+	it("prefers the prime-inference credential over the prime-cli config key", async () => {
+		const session = writeSession(tempDir, join(tempDir, "sessions"), "credential-order-session");
+		const calls: FetchCall[] = [];
+		const configPath = join(tempDir, "prime-config.json");
+		writeFileSync(configPath, JSON.stringify({ api_key: "cli-fallback-key" }));
+
+		const result = await uploadAgentTraceFile({
+			sessionFile: session.getSessionFile(),
+			authStorage: AuthStorage.inMemory({
+				[PRIME_INFERENCE_PROVIDER_ID]: { type: "api_key", key: "inference-key" },
+			}),
+			settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+			baseUrl: "https://api.example.test",
+			configPath,
+			fetchFn: createFetchRecorder(calls),
+			reloadConfig: false,
+		});
+
+		expect(result.status).toBe("uploaded");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.init.headers).toMatchObject({ Authorization: "Bearer inference-key" });
 	});
 });


### PR DESCRIPTION
- trace upload failures were silently swallowed on session teardown and surfaced only a vague "fetch failed", so there was no way to tell whether traces were being sent or why they weren't.
- every meaningful upload outcome is now written to a log file, the underlying network cause is surfaced, and the resolved upload endpoint is shown in the traces status view.
- transient connection failures now retry once, which covers the common case where a single network blip was reported as a hard failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional trace telemetry uploads and local diagnostics; no auth or session data model changes beyond existing upload behavior.
> 
> **Overview**
> Agent trace uploads are easier to debug and slightly more reliable on flaky networks.
> 
> Every meaningful upload outcome (success, HTTP failure, skip reasons) is appended to a rotating **`agent-traces.log`** under the agent logs directory. Failure messages now include underlying network **cause codes** via `describeError`, and the interactive UI points users at that log path when an upload fails. **`/traces status`** also shows the resolved Prime Agent Traces **endpoint** URL.
> 
> Upload HTTP calls use **`fetchWithRetry`**: one extra attempt after 500ms for a defined set of transient connection errors, with abort/cancellation honored during the backoff. HTTP error responses are not retried.
> 
> Tests cover logging, retry success/failure paths, abort during backoff, and credential preference order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d515a2dbe193c0a0b3d3e0903ef7e9e41201a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make agent trace uploads resilient with retry logic and outcome logging
> - Wraps the trace upload fetch in `fetchWithRetry`, which retries once after 500ms on transient network errors (e.g., `ECONNRESET`) and propagates abort reasons during backoff.
> - Logs each upload outcome (success or failure with cause details) to a rotating log file via `getAgentTracesLogPath()`.
> - Surfaces the log file path in the interactive UI on upload failure, and adds the resolved trace endpoint to the `/traces status` output.
> - Adds a `describeError` helper that appends underlying cause code/message to error strings for clearer diagnostics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71d515a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->