### PR TITLE
show edit diffs in the collapsed ipython view

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -240,7 +240,8 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 				...buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
-					gutter: "",
+					// Leading space keeps the text off the edge while the bg still reaches it.
+					gutter: " ",
 					content: replaceTabs(rawLine),
 					language,
 					width,
@@ -249,7 +250,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			continue;
 		}
 		const { prefix, lineNum, content } = parsed;
-		const gutter = `${lineNum} ${prefix === " " ? " " : prefix} `;
+		const gutter = ` ${lineNum} ${prefix === " " ? " " : prefix} `;
 		const text = replaceTabs(content);
 		if (prefix === "+") {
 			rows.push(

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -171,6 +171,8 @@ function highlightContent(content: string, language: string | undefined): string
 interface DiffLineSpec {
 	bg: ThemeBg;
 	gutter: string;
+	/** Gutter for wrapped continuation rows; defaults to blanks. */
+	contGutter?: string;
 	gutterFg: ThemeColor;
 	content: string;
 	language: string | undefined;
@@ -204,9 +206,10 @@ function buildRichDiffLine(spec: DiffLineSpec): string[] {
 	}
 
 	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
-	const blankGutter = theme.fg(spec.gutterFg, " ".repeat(gutterWidth));
+	const cont = spec.contGutter ?? " ".repeat(gutterWidth);
+	const styledCont = theme.fg(spec.gutterFg, cont);
 	return contentRows.map((row, index) => {
-		const gutter = index === 0 ? styledGutter : blankGutter;
+		const gutter = index === 0 ? styledGutter : styledCont;
 		return theme.bg(spec.bg, padToWidth(`${gutter}${row}\x1b[39m`, spec.width));
 	});
 }
@@ -251,6 +254,8 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		}
 		const { prefix, lineNum, content } = parsed;
 		const gutter = ` ${lineNum} ${prefix === " " ? " " : prefix} `;
+		// Wrapped rows keep the +/- sign but drop the line number.
+		const contGutter = ` ${" ".repeat(lineNum.length)} ${prefix === " " ? " " : prefix} `;
 		const text = replaceTabs(content);
 		if (prefix === "+") {
 			rows.push(
@@ -258,10 +263,11 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 					bg: useBlocks ? "toolDiffAddedBg" : "toolPanelBg",
 					gutterFg: "toolDiffAdded",
 					gutter,
+					contGutter,
 					content: text,
 					language,
 					width,
-					contentFg: useBlocks ? undefined : "toolDiffAdded",
+					contentFg: useBlocks ? "toolDiffText" : "toolDiffAdded",
 				}),
 			);
 		} else if (prefix === "-") {
@@ -270,10 +276,11 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 					bg: useBlocks ? "toolDiffRemovedBg" : "toolPanelBg",
 					gutterFg: "toolDiffRemoved",
 					gutter,
+					contGutter,
 					content: text,
 					language,
 					width,
-					contentFg: useBlocks ? undefined : "toolDiffRemoved",
+					contentFg: useBlocks ? "toolDiffText" : "toolDiffRemoved",
 				}),
 			);
 		} else {

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
 import { highlightCode, theme } from "../theme/theme.js";
 
@@ -179,23 +179,36 @@ interface DiffLineSpec {
 	contentFg?: ThemeColor;
 }
 
-/** Build one diff row filling `width` on a single background block. */
-function buildRichDiffLine(spec: DiffLineSpec): string {
-	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
-	const renderedContent = spec.contentFg
-		? theme.fg(spec.contentFg, spec.content)
-		: highlightContent(spec.content, spec.language);
-	let inner = `${styledGutter}${renderedContent}\x1b[39m`;
-	if (visibleWidth(inner) > spec.width) {
-		inner = truncateToWidth(inner, spec.width, "");
+function padToWidth(inner: string, width: number): string {
+	if (visibleWidth(inner) > width) {
+		inner = truncateToWidth(inner, width, "");
 	}
 	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
 	// the result a cell short.
-	const pad = spec.width - visibleWidth(inner);
-	if (pad > 0) {
-		inner += " ".repeat(pad);
+	const pad = width - visibleWidth(inner);
+	return pad > 0 ? inner + " ".repeat(pad) : inner;
+}
+
+// One diff line as one-or-more full-width background rows. Content wider than the
+// row wraps onto continuation rows with a blank gutter, so nothing is truncated.
+function buildRichDiffLine(spec: DiffLineSpec): string[] {
+	const renderedContent = spec.contentFg
+		? theme.fg(spec.contentFg, spec.content)
+		: highlightContent(spec.content, spec.language);
+
+	const gutterWidth = visibleWidth(spec.gutter);
+	const contentWidth = Math.max(1, spec.width - gutterWidth);
+	const contentRows = wrapTextWithAnsi(renderedContent, contentWidth);
+	if (contentRows.length === 0) {
+		contentRows.push("");
 	}
-	return theme.bg(spec.bg, inner);
+
+	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
+	const blankGutter = theme.fg(spec.gutterFg, " ".repeat(gutterWidth));
+	return contentRows.map((row, index) => {
+		const gutter = index === 0 ? styledGutter : blankGutter;
+		return theme.bg(spec.bg, padToWidth(`${gutter}${row}\x1b[39m`, spec.width));
+	});
 }
 
 export interface RichDiffOptions {
@@ -224,7 +237,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const parsed = parseDiffLine(rawLine);
 		if (!parsed) {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter: "",
@@ -240,7 +253,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const text = replaceTabs(content);
 		if (prefix === "+") {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: useBlocks ? "toolDiffAddedBg" : "toolPanelBg",
 					gutterFg: "toolDiffAdded",
 					gutter,
@@ -252,7 +265,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else if (prefix === "-") {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: useBlocks ? "toolDiffRemovedBg" : "toolPanelBg",
 					gutterFg: "toolDiffRemoved",
 					gutter,
@@ -264,7 +277,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter,

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
 import { highlightCode, theme } from "../theme/theme.js";
 
@@ -179,44 +179,23 @@ interface DiffLineSpec {
 	contentFg?: ThemeColor;
 }
 
-/** Pad `inner` to exactly `width` cells (truncating a straddling wide char if over). */
-function fillToWidth(inner: string, width: number): string {
-	if (visibleWidth(inner) > width) {
-		inner = truncateToWidth(inner, width, "");
-	}
-	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
-	// the result a cell short.
-	const pad = width - visibleWidth(inner);
-	if (pad > 0) {
-		inner += " ".repeat(pad);
-	}
-	return inner;
-}
-
-/**
- * Build the row(s) for one diff line, each filling `width` on a single background
- * block. Content wider than the gutter's remaining space wraps onto continuation
- * rows whose gutter is blank, so long lines stay fully visible instead of truncating.
- */
-function buildRichDiffLine(spec: DiffLineSpec): string[] {
+/** Build one diff row filling `width` on a single background block. */
+function buildRichDiffLine(spec: DiffLineSpec): string {
 	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
 	const renderedContent = spec.contentFg
 		? theme.fg(spec.contentFg, spec.content)
 		: highlightContent(spec.content, spec.language);
-
-	const gutterWidth = visibleWidth(spec.gutter);
-	const contentWidth = Math.max(1, spec.width - gutterWidth);
-	const contentRows = wrapTextWithAnsi(renderedContent, contentWidth);
-	if (contentRows.length === 0) {
-		contentRows.push("");
+	let inner = `${styledGutter}${renderedContent}\x1b[39m`;
+	if (visibleWidth(inner) > spec.width) {
+		inner = truncateToWidth(inner, spec.width, "");
 	}
-
-	const blankGutter = theme.fg(spec.gutterFg, " ".repeat(gutterWidth));
-	return contentRows.map((row, index) => {
-		const gutter = index === 0 ? styledGutter : blankGutter;
-		const inner = fillToWidth(`${gutter}${row}\x1b[39m`, spec.width);
-		return theme.bg(spec.bg, inner);
-	});
+	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
+	// the result a cell short.
+	const pad = spec.width - visibleWidth(inner);
+	if (pad > 0) {
+		inner += " ".repeat(pad);
+	}
+	return theme.bg(spec.bg, inner);
 }
 
 export interface RichDiffOptions {
@@ -245,7 +224,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const parsed = parseDiffLine(rawLine);
 		if (!parsed) {
 			rows.push(
-				...buildRichDiffLine({
+				buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter: "",
@@ -261,7 +240,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const text = replaceTabs(content);
 		if (prefix === "+") {
 			rows.push(
-				...buildRichDiffLine({
+				buildRichDiffLine({
 					bg: useBlocks ? "toolDiffAddedBg" : "toolPanelBg",
 					gutterFg: "toolDiffAdded",
 					gutter,
@@ -273,7 +252,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else if (prefix === "-") {
 			rows.push(
-				...buildRichDiffLine({
+				buildRichDiffLine({
 					bg: useBlocks ? "toolDiffRemovedBg" : "toolPanelBg",
 					gutterFg: "toolDiffRemoved",
 					gutter,
@@ -285,7 +264,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else {
 			rows.push(
-				...buildRichDiffLine({
+				buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter,

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
 import { highlightCode, theme } from "../theme/theme.js";
 
@@ -179,23 +179,44 @@ interface DiffLineSpec {
 	contentFg?: ThemeColor;
 }
 
-/** Build one diff row filling `width` on a single background block. */
-function buildRichDiffLine(spec: DiffLineSpec): string {
+/** Pad `inner` to exactly `width` cells (truncating a straddling wide char if over). */
+function fillToWidth(inner: string, width: number): string {
+	if (visibleWidth(inner) > width) {
+		inner = truncateToWidth(inner, width, "");
+	}
+	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
+	// the result a cell short.
+	const pad = width - visibleWidth(inner);
+	if (pad > 0) {
+		inner += " ".repeat(pad);
+	}
+	return inner;
+}
+
+/**
+ * Build the row(s) for one diff line, each filling `width` on a single background
+ * block. Content wider than the gutter's remaining space wraps onto continuation
+ * rows whose gutter is blank, so long lines stay fully visible instead of truncating.
+ */
+function buildRichDiffLine(spec: DiffLineSpec): string[] {
 	const styledGutter = theme.fg(spec.gutterFg, spec.gutter);
 	const renderedContent = spec.contentFg
 		? theme.fg(spec.contentFg, spec.content)
 		: highlightContent(spec.content, spec.language);
-	let inner = `${styledGutter}${renderedContent}\x1b[39m`;
-	if (visibleWidth(inner) > spec.width) {
-		inner = truncateToWidth(inner, spec.width, "");
+
+	const gutterWidth = visibleWidth(spec.gutter);
+	const contentWidth = Math.max(1, spec.width - gutterWidth);
+	const contentRows = wrapTextWithAnsi(renderedContent, contentWidth);
+	if (contentRows.length === 0) {
+		contentRows.push("");
 	}
-	// Pad after truncating too: a 2-cell character straddling the cutoff leaves
-	// the result a cell short.
-	const pad = spec.width - visibleWidth(inner);
-	if (pad > 0) {
-		inner += " ".repeat(pad);
-	}
-	return theme.bg(spec.bg, inner);
+
+	const blankGutter = theme.fg(spec.gutterFg, " ".repeat(gutterWidth));
+	return contentRows.map((row, index) => {
+		const gutter = index === 0 ? styledGutter : blankGutter;
+		const inner = fillToWidth(`${gutter}${row}\x1b[39m`, spec.width);
+		return theme.bg(spec.bg, inner);
+	});
 }
 
 export interface RichDiffOptions {
@@ -224,7 +245,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const parsed = parseDiffLine(rawLine);
 		if (!parsed) {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter: "",
@@ -240,7 +261,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 		const text = replaceTabs(content);
 		if (prefix === "+") {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: useBlocks ? "toolDiffAddedBg" : "toolPanelBg",
 					gutterFg: "toolDiffAdded",
 					gutter,
@@ -252,7 +273,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else if (prefix === "-") {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: useBlocks ? "toolDiffRemovedBg" : "toolPanelBg",
 					gutterFg: "toolDiffRemoved",
 					gutter,
@@ -264,7 +285,7 @@ export function renderRichDiff(diffText: string, contentWidth: number, options: 
 			);
 		} else {
 			rows.push(
-				buildRichDiffLine({
+				...buildRichDiffLine({
 					bg: "toolPanelBg",
 					gutterFg: "toolDiffContext",
 					gutter,

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -668,7 +668,7 @@ export class IPythonCellComponent implements Component {
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		const displayPath = displayEditPath(path, this.state.cwd);
-		this.addPlain(lines, `${marker} ${theme.fg("accent", displayPath)}  ${counts}`);
+		this.addPlain(lines, `${marker} ${displayPath}  ${counts}`);
 
 		// Colored rows already fill the full width; emit them flush, no panel inset.
 		lines.push(...rows);

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -292,7 +292,7 @@ export class IPythonCellComponent implements Component {
 				return this.renderCache.set(safeWidth, this.stateVersion, [summary]);
 			}
 			const lines = [summary];
-			this.renderDiffs(lines, safeWidth, details.diffs ?? []);
+			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
 			return this.renderCache.set(safeWidth, this.stateVersion, lines);
 		}
 
@@ -529,7 +529,7 @@ export class IPythonCellComponent implements Component {
 			// renderDiffs adds its own leading blank, so skip startOutput's to avoid
 			// a double gap; mark output started for the trailing text below.
 			outputStarted = true;
-			this.renderDiffs(lines, width, diffs);
+			this.renderDiffs(lines, width, diffs, this.marker(details));
 			renderedTextOutput = true;
 		}
 
@@ -616,7 +616,7 @@ export class IPythonCellComponent implements Component {
 	// Edit diffs render in full regardless of expand state — file changes must be
 	// visible without expanding. Grouped by file: one block per file, edits shown
 	// as `⋮`-separated hunks.
-	private renderDiffs(lines: string[], width: number, diffs: readonly DiffDisplay[]): void {
+	private renderDiffs(lines: string[], width: number, diffs: readonly DiffDisplay[], marker: string): void {
 		const diffsByPath = new Map<string, DiffDisplay[]>();
 		for (const diff of diffs) {
 			const existing = diffsByPath.get(diff.path);
@@ -627,11 +627,17 @@ export class IPythonCellComponent implements Component {
 			// Blank line before every file block, including the first, so the diff
 			// stands clear of the summary line above it.
 			this.addBlank(lines, width);
-			this.renderFileDiff(lines, width, path, edits);
+			this.renderFileDiff(lines, width, path, edits, marker);
 		}
 	}
 
-	private renderFileDiff(lines: string[], width: number, path: string, edits: readonly DiffDisplay[]): void {
+	private renderFileDiff(
+		lines: string[],
+		width: number,
+		path: string,
+		edits: readonly DiffDisplay[],
+		marker: string,
+	): void {
 		// Diff rows span the full cli width — no panel side padding — so they read
 		// as one continuous block like the prompt bar.
 		const contentWidth = Math.max(1, width);
@@ -653,7 +659,7 @@ export class IPythonCellComponent implements Component {
 		});
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
-		this.addWrapped(lines, "", `${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
+		this.addWrapped(lines, "", `${marker} ${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
 
 		lines.push(...rows);
 	}

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -10,7 +10,7 @@ import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
 import { renderDiffSeparator, renderRichDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
-import { TOOL_PANEL_PADDING_X, toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
+import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
 export interface IPythonCellContentBlock {
 	type: string;
@@ -526,7 +526,9 @@ export class IPythonCellComponent implements Component {
 		};
 
 		if (diffs.length > 0) {
-			startOutput();
+			// renderDiffs adds its own leading blank, so skip startOutput's to avoid
+			// a double gap; mark output started for the trailing text below.
+			outputStarted = true;
 			this.renderDiffs(lines, width, diffs);
 			renderedTextOutput = true;
 		}
@@ -621,18 +623,18 @@ export class IPythonCellComponent implements Component {
 			if (existing) existing.push(diff);
 			else diffsByPath.set(diff.path, [diff]);
 		}
-		let fileIndex = 0;
 		for (const [path, edits] of diffsByPath) {
-			if (fileIndex > 0) {
-				this.addBlank(lines, width);
-			}
-			fileIndex++;
+			// Blank line before every file block, including the first, so the diff
+			// stands clear of the summary line above it.
+			this.addBlank(lines, width);
 			this.renderFileDiff(lines, width, path, edits);
 		}
 	}
 
 	private renderFileDiff(lines: string[], width: number, path: string, edits: readonly DiffDisplay[]): void {
-		const contentWidth = toolPanelContentWidth(width);
+		// Diff rows span the full cli width — no panel side padding — so they read
+		// as one continuous block like the prompt bar.
+		const contentWidth = Math.max(1, width);
 		const language = getLanguageFromPath(path);
 
 		const rows: string[] = [];
@@ -653,11 +655,7 @@ export class IPythonCellComponent implements Component {
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		this.addWrapped(lines, "", `${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
 
-		// Rows already fill the content width; just add the panel side padding.
-		const sidePad = theme.bg("toolPanelBg", " ".repeat(TOOL_PANEL_PADDING_X));
-		for (const row of rows) {
-			lines.push(sidePad + row + sidePad);
-		}
+		lines.push(...rows);
 	}
 
 	private renderOutputText(

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative } from "node:path";
 import {
 	type Component,
 	truncateToWidth,
@@ -5,10 +6,12 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
-import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
+import { shortenPath } from "../../../core/tools/render-utils.js";
+import { highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
-import { renderDiffSeparator, renderRichDiff } from "./diff.js";
+import { renderDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
 import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
@@ -29,6 +32,8 @@ export interface IPythonCellState {
 	executionStarted?: boolean;
 	argsComplete?: boolean;
 	showImages?: boolean;
+	/** Session cwd — edit paths nested under it render relative, else absolute. */
+	cwd?: string;
 }
 
 interface DiffDisplay {
@@ -206,6 +211,18 @@ function formatDuration(durationMs: number | undefined): string | undefined {
 
 function hiddenLinesLabel(hidden: number): string {
 	return `… +${hidden} line${hidden === 1 ? "" : "s"}`;
+}
+
+// Relative to the session cwd when nested under it, else the absolute path.
+function displayEditPath(path: string, cwd: string | undefined): string {
+	if (cwd && isAbsolute(path)) {
+		const rel = relative(cwd, path);
+		if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+			return rel;
+		}
+		return shortenPath(path);
+	}
+	return path;
 }
 
 function isImageBlock(block: IPythonCellContentBlock): boolean {
@@ -613,9 +630,7 @@ export class IPythonCellComponent implements Component {
 		}
 	}
 
-	// Edit diffs render in full regardless of expand state — file changes must be
-	// visible without expanding. Grouped by file: one block per file, edits shown
-	// as `⋮`-separated hunks.
+	// Edits always render in full, regardless of expand state. Grouped by file.
 	private renderDiffs(lines: string[], width: number, diffs: readonly DiffDisplay[], marker: string): void {
 		const diffsByPath = new Map<string, DiffDisplay[]>();
 		for (const diff of diffs) {
@@ -624,9 +639,7 @@ export class IPythonCellComponent implements Component {
 			else diffsByPath.set(diff.path, [diff]);
 		}
 		for (const [path, edits] of diffsByPath) {
-			// Blank line before every file block, including the first, so the diff
-			// stands clear of the summary line above it.
-			this.addBlank(lines, width);
+			this.addPlain(lines, "");
 			this.renderFileDiff(lines, width, path, edits, marker);
 		}
 	}
@@ -638,30 +651,30 @@ export class IPythonCellComponent implements Component {
 		edits: readonly DiffDisplay[],
 		marker: string,
 	): void {
-		// Diff rows span the full cli width — no panel side padding — so they read
-		// as one continuous block like the prompt bar.
-		const contentWidth = Math.max(1, width);
-		const language = getLanguageFromPath(path);
-
-		const rows: string[] = [];
 		let added = 0;
 		let removed = 0;
-		edits.forEach((edit, index) => {
+		const diffTexts: string[] = [];
+		edits.forEach((edit) => {
 			const { diff: diffText } = generateDiffString(edit.oldStr, edit.newStr, 4, edit.startLine ?? 1);
 			for (const row of diffText.split("\n")) {
 				if (row.startsWith("+")) added++;
 				else if (row.startsWith("-")) removed++;
 			}
-			if (index > 0) {
-				rows.push(renderDiffSeparator(contentWidth));
-			}
-			rows.push(...renderRichDiff(diffText, contentWidth, { language }));
+			diffTexts.push(diffText);
 		});
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
-		this.addWrapped(lines, "", `${marker} ${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
+		const displayPath = displayEditPath(path, this.state.cwd);
+		this.addPlainWrapped(lines, `${marker} ${theme.fg("accent", displayPath)}  ${counts}`, width);
 
-		lines.push(...rows);
+		diffTexts.forEach((diffText, index) => {
+			if (index > 0) {
+				this.addPlain(lines, theme.fg("toolDiffContext", "⋮"));
+			}
+			for (const row of renderDiff(diffText).split("\n")) {
+				this.addPlainWrapped(lines, row, width);
+			}
+		});
 	}
 
 	private renderOutputText(
@@ -704,5 +717,22 @@ export class IPythonCellComponent implements Component {
 
 	private addBlank(lines: string[], width: number): void {
 		lines.push(toolPanelLine("", width));
+	}
+
+	// No-background line, indented one space to align with the summary line above.
+	private addPlain(lines: string[], text: string): void {
+		lines.push(` ${text}`);
+	}
+
+	private addPlainWrapped(lines: string[], text: string, width: number): void {
+		const indent = 1;
+		// Align wrapped rows under the `±N ` diff gutter so code stays under its line.
+		const gutter = stripAnsi(text).match(/^[+\- ]\s*\d+\s/)?.[0]?.length ?? 0;
+		const available = Math.max(1, width - indent);
+		const wrapped = wrapTextWithAnsi(text, available);
+		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
+			const pad = index === 0 ? indent : indent + gutter;
+			lines.push(`${" ".repeat(pad)}${line}`);
+		}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -6,12 +6,11 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import stripAnsi from "strip-ansi";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import { shortenPath } from "../../../core/tools/render-utils.js";
-import { highlightCode, theme } from "../theme/theme.js";
+import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
-import { renderDiff } from "./diff.js";
+import { renderDiffSeparator, renderRichDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
 import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
@@ -651,30 +650,28 @@ export class IPythonCellComponent implements Component {
 		edits: readonly DiffDisplay[],
 		marker: string,
 	): void {
+		const language = getLanguageFromPath(path);
 		let added = 0;
 		let removed = 0;
-		const diffTexts: string[] = [];
-		edits.forEach((edit) => {
+		const rows: string[] = [];
+		edits.forEach((edit, index) => {
 			const { diff: diffText } = generateDiffString(edit.oldStr, edit.newStr, 4, edit.startLine ?? 1);
 			for (const row of diffText.split("\n")) {
 				if (row.startsWith("+")) added++;
 				else if (row.startsWith("-")) removed++;
 			}
-			diffTexts.push(diffText);
+			if (index > 0) {
+				rows.push(renderDiffSeparator(width));
+			}
+			rows.push(...renderRichDiff(diffText, width, { language }));
 		});
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		const displayPath = displayEditPath(path, this.state.cwd);
-		this.addPlainWrapped(lines, `${marker} ${theme.fg("accent", displayPath)}  ${counts}`, width);
+		this.addPlain(lines, `${marker} ${theme.fg("accent", displayPath)}  ${counts}`);
 
-		diffTexts.forEach((diffText, index) => {
-			if (index > 0) {
-				this.addPlain(lines, theme.fg("toolDiffContext", "⋮"));
-			}
-			for (const row of renderDiff(diffText).split("\n")) {
-				this.addPlainWrapped(lines, row, width);
-			}
-		});
+		// Colored rows already fill the full width; emit them flush, no panel inset.
+		lines.push(...rows);
 	}
 
 	private renderOutputText(
@@ -722,17 +719,5 @@ export class IPythonCellComponent implements Component {
 	// No-background line, indented one space to align with the summary line above.
 	private addPlain(lines: string[], text: string): void {
 		lines.push(` ${text}`);
-	}
-
-	private addPlainWrapped(lines: string[], text: string, width: number): void {
-		const indent = 1;
-		// Align wrapped rows under the `±N ` diff gutter so code stays under its line.
-		const gutter = stripAnsi(text).match(/^[+\- ]\s*\d+\s/)?.[0]?.length ?? 0;
-		const available = Math.max(1, width - indent);
-		const wrapped = wrapTextWithAnsi(text, available);
-		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
-			const pad = index === 0 ? indent : indent + gutter;
-			lines.push(`${" ".repeat(pad)}${line}`);
-		}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -68,7 +68,6 @@ const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 
 const OUTPUT_PREVIEW_LINES = 5;
 const INPUT_PREVIEW_LINES = 3;
-const DIFF_PREVIEW_LINES = 12;
 
 // Cap so the trailing duration/counts stay visible on narrow widths.
 const DESCRIPTOR_MAX_WIDTH = 64;
@@ -285,9 +284,16 @@ export class IPythonCellComponent implements Component {
 
 		// Collapsed default: one line, indented to match message text. Cached by
 		// state version so it never re-renders on unrelated repaints (would flicker).
+		// Edits are the exception: the diff always shows in full under the summary
+		// line so file changes are visible without expanding.
 		if (!this.state.expanded) {
-			const line = truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "");
-			return this.renderCache.set(safeWidth, this.stateVersion, [line]);
+			const summary = truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "");
+			if ((details.diffs?.length ?? 0) === 0) {
+				return this.renderCache.set(safeWidth, this.stateVersion, [summary]);
+			}
+			const lines = [summary];
+			this.renderDiffs(lines, safeWidth, details.diffs ?? []);
+			return this.renderCache.set(safeWidth, this.stateVersion, lines);
 		}
 
 		const lines: string[] = [];
@@ -519,21 +525,9 @@ export class IPythonCellComponent implements Component {
 			}
 		};
 
-		// Group edits by file: one block per file, edits shown as `⋮`-separated hunks.
-		const diffsByPath = new Map<string, DiffDisplay[]>();
-		for (const diff of diffs) {
-			const existing = diffsByPath.get(diff.path);
-			if (existing) existing.push(diff);
-			else diffsByPath.set(diff.path, [diff]);
-		}
-		let fileIndex = 0;
-		for (const [path, edits] of diffsByPath) {
+		if (diffs.length > 0) {
 			startOutput();
-			if (fileIndex > 0) {
-				this.addBlank(lines, width);
-			}
-			fileIndex++;
-			this.renderFileDiff(lines, width, path, edits, withExpandHint);
+			this.renderDiffs(lines, width, diffs);
 			renderedTextOutput = true;
 		}
 
@@ -617,13 +611,27 @@ export class IPythonCellComponent implements Component {
 		}
 	}
 
-	private renderFileDiff(
-		lines: string[],
-		width: number,
-		path: string,
-		edits: readonly DiffDisplay[],
-		withExpandHint: ExpandHintFormatter,
-	): void {
+	// Edit diffs render in full regardless of expand state — file changes must be
+	// visible without expanding. Grouped by file: one block per file, edits shown
+	// as `⋮`-separated hunks.
+	private renderDiffs(lines: string[], width: number, diffs: readonly DiffDisplay[]): void {
+		const diffsByPath = new Map<string, DiffDisplay[]>();
+		for (const diff of diffs) {
+			const existing = diffsByPath.get(diff.path);
+			if (existing) existing.push(diff);
+			else diffsByPath.set(diff.path, [diff]);
+		}
+		let fileIndex = 0;
+		for (const [path, edits] of diffsByPath) {
+			if (fileIndex > 0) {
+				this.addBlank(lines, width);
+			}
+			fileIndex++;
+			this.renderFileDiff(lines, width, path, edits);
+		}
+	}
+
+	private renderFileDiff(lines: string[], width: number, path: string, edits: readonly DiffDisplay[]): void {
 		const contentWidth = toolPanelContentWidth(width);
 		const language = getLanguageFromPath(path);
 
@@ -645,17 +653,10 @@ export class IPythonCellComponent implements Component {
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		this.addWrapped(lines, "", `${theme.fg("muted", "edit")} ${path}  ${counts}`, width);
 
-		const expanded = this.state.expanded ?? false;
-		const showCollapsed = !expanded && rows.length > DIFF_PREVIEW_LINES;
-		const visibleRows = showCollapsed ? rows.slice(0, DIFF_PREVIEW_LINES) : rows;
 		// Rows already fill the content width; just add the panel side padding.
 		const sidePad = theme.bg("toolPanelBg", " ".repeat(TOOL_PANEL_PADDING_X));
-		for (const row of visibleRows) {
+		for (const row of rows) {
 			lines.push(sidePad + row + sidePad);
-		}
-		if (showCollapsed) {
-			const hidden = rows.length - DIFF_PREVIEW_LINES;
-			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -663,20 +663,22 @@ export class IPythonCellComponent implements Component {
 			if (index > 0) {
 				rows.push(renderDiffSeparator(width));
 			}
-			rows.push(...renderRichDiff(diffText, width, { language }));
+			// Append, not spread: a huge edit's diff can exceed the JS arg-count limit.
+			for (const row of renderRichDiff(diffText, width, { language })) {
+				rows.push(row);
+			}
 		});
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		const displayPath = displayEditPath(path, this.state.cwd);
-		// Truncate the path (not the counts) so a long path can't push the header
-		// past the render width and trip the TUI's overflow guard.
+		// Truncate the path (not the counts) so it can't push the header past width.
 		const fixed = visibleWidth(marker) + 1 + 2 + visibleWidth(counts);
-		const pathBudget = Math.max(1, width - 1 - fixed);
-		const shownPath = truncateToWidth(displayPath, pathBudget, "…");
+		const shownPath = truncateToWidth(displayPath, Math.max(1, width - 1 - fixed), "…");
 		this.addPlain(lines, `${marker} ${shownPath}  ${counts}`);
 
-		// Colored rows already fill the full width; emit them flush, no panel inset.
-		lines.push(...rows);
+		for (const row of rows) {
+			lines.push(row);
+		}
 	}
 
 	private renderOutputText(

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -668,7 +668,12 @@ export class IPythonCellComponent implements Component {
 
 		const counts = `${theme.fg("toolDiffAdded", `+${added}`)} ${theme.fg("toolDiffRemoved", `-${removed}`)}`;
 		const displayPath = displayEditPath(path, this.state.cwd);
-		this.addPlain(lines, `${marker} ${displayPath}  ${counts}`);
+		// Truncate the path (not the counts) so a long path can't push the header
+		// past the render width and trip the TUI's overflow guard.
+		const fixed = visibleWidth(marker) + 1 + 2 + visibleWidth(counts);
+		const pathBudget = Math.max(1, width - 1 - fixed);
+		const shownPath = truncateToWidth(displayPath, pathBudget, "…");
+		this.addPlain(lines, `${marker} ${shownPath}  ${counts}`);
 
 		// Colored rows already fill the full width; emit them flush, no panel inset.
 		lines.push(...rows);

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -265,6 +265,7 @@ export class ToolExecutionComponent extends Container {
 					executionStarted: this.executionStarted,
 					argsComplete: this.argsComplete,
 					showImages: this.showImages,
+					cwd: this.cwd,
 				};
 				if (!this.ipythonCellComponent) {
 					this.ipythonCellComponent = new IPythonCellComponent(state);

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -61,6 +61,7 @@
 
 		"toolDiffAdded": "#3fb950",
 		"toolDiffRemoved": "#f85149",
+		"toolDiffText": "#9aa0a6",
 		"toolDiffContext": "gray",
 
 		"syntaxComment": "#6A9955",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -60,6 +60,7 @@
 
 		"toolDiffAdded": "green",
 		"toolDiffRemoved": "red",
+		"toolDiffText": "#57606a",
 		"toolDiffContext": "mediumGray",
 
 		"syntaxComment": "#008000",

--- a/packages/coding-agent/src/modes/interactive/theme/prime.json
+++ b/packages/coding-agent/src/modes/interactive/theme/prime.json
@@ -65,6 +65,7 @@
 		"mdListBullet": "muted",
 		"toolDiffAdded": "#3fb950",
 		"toolDiffRemoved": "#f85149",
+		"toolDiffText": "#9aa0a6",
 		"toolDiffContext": "muted",
 		"syntaxComment": "muted",
 		"syntaxKeyword": "info",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -72,6 +72,7 @@
 				"mdListBullet",
 				"toolDiffAdded",
 				"toolDiffRemoved",
+				"toolDiffText",
 				"toolDiffContext",
 				"syntaxComment",
 				"syntaxKeyword",
@@ -238,6 +239,10 @@
 				"toolDiffRemoved": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Removed lines in tool diffs"
+				},
+				"toolDiffText": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Diff line content on colored add/remove blocks"
 				},
 				"toolDiffContext": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -77,6 +77,7 @@ const ThemeJsonSchema = Type.Object({
 		// Tool Diffs (3 colors)
 		toolDiffAdded: ColorValueSchema,
 		toolDiffRemoved: ColorValueSchema,
+		toolDiffText: ColorValueSchema,
 		toolDiffContext: ColorValueSchema,
 		// Syntax Highlighting (9 colors)
 		syntaxComment: ColorValueSchema,
@@ -152,6 +153,7 @@ export type ThemeColor =
 	| "mdListBullet"
 	| "toolDiffAdded"
 	| "toolDiffRemoved"
+	| "toolDiffText"
 	| "toolDiffContext"
 	| "syntaxComment"
 	| "syntaxKeyword"

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -151,6 +151,21 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(header).toMatch(/\+1 -1\s*$/);
 	});
 
+	it("renders a large diff without spreading the row array (no RangeError)", () => {
+		const n = 5000;
+		const oldStr = Array.from({ length: n }, (_, i) => `line ${i}`).join("\n");
+		const newStr = Array.from({ length: n }, (_, i) => `LINE ${i}`).join("\n");
+		expect(() =>
+			new IPythonCellComponent({
+				code: "await edit(...)",
+				details: { status: "ok", diffs: [{ path: "big.txt", oldStr, newStr, startLine: 1 }] },
+				executionStarted: true,
+				argsComplete: true,
+				expanded: false,
+			}).render(80),
+		).not.toThrow();
+	});
+
 	it("repeats the +/- sign on wrapped continuation rows", () => {
 		const longLine = `const x = ${Array.from({ length: 20 }, (_, i) => `arg${i}`).join(", ")};`;
 		const out = renderCell({

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -151,6 +151,21 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(header).toMatch(/\+1 -1\s*$/);
 	});
 
+	it("repeats the +/- sign on wrapped continuation rows", () => {
+		const longLine = `const x = ${Array.from({ length: 20 }, (_, i) => `arg${i}`).join(", ")};`;
+		const out = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "const x = 1;", newStr: longLine, startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		}).split("\n");
+		// The added line wraps; every row carrying its content shows a "+" gutter.
+		const addedRows = out.filter((line) => /arg\d/.test(line));
+		expect(addedRows.length).toBeGreaterThan(1);
+		expect(addedRows.every((line) => /^\s*\+ /.test(line) || /\d+ \+ /.test(line))).toBe(true);
+	});
+
 	it("separates the diff from the summary line with a blank line", () => {
 		const out = renderCell({
 			code: "await edit(...)",

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -74,6 +74,56 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(out.every((line) => visibleWidth(line) === 40)).toBe(true);
 	});
 
+	it("wraps a long diff line onto gutter-aligned continuation rows instead of truncating", () => {
+		const longLine = `const x = ${Array.from({ length: 20 }, (_, i) => `arg${i}`).join(", ")};`;
+		const out = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "const x = 1;", newStr: longLine, startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		}).split("\n");
+
+		// The full content survives across the wrapped rows (nothing truncated away).
+		const joined = out.join("");
+		expect(joined).toContain("arg0");
+		expect(joined).toContain("arg19");
+		// The added line spilled onto at least one continuation row.
+		const addedRows = out.filter((line) => /arg\d/.test(line));
+		expect(addedRows.length).toBeGreaterThan(1);
+	});
+
+	it("renders diff rows at the full cli width with no side padding", () => {
+		const width = 50;
+		const out = new IPythonCellComponent({
+			code: "await edit(...)",
+			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "alpha", newStr: "ALPHA", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		}).render(width);
+		// The colored diff rows fill the whole width — no 2-col panel inset.
+		const diffRows = out.filter((line) => /alpha|ALPHA/i.test(stripAnsi(line)));
+		expect(diffRows.length).toBeGreaterThan(0);
+		expect(diffRows.every((line) => visibleWidth(line) === width)).toBe(true);
+		// The row starts at column 0, not behind two spaces of panel padding.
+		expect(diffRows.every((line) => !stripAnsi(line).startsWith("  "))).toBe(true);
+	});
+
+	it("separates the diff from the summary line with a blank line", () => {
+		const out = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", durationMs: 4, diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		}).split("\n");
+		// Line 0 is the summary; line 1 is blank; the edit header follows.
+		expect(out[0]).toContain("to expand");
+		expect(out[1].trim()).toBe("");
+		expect(out[2]).toContain("edit a.ts");
+	});
+
 	it("shows the full diff in the collapsed view so file changes never hide behind expand", () => {
 		const oldStr = Array.from({ length: 30 }, (_, i) => `row ${i}`).join("\n");
 		const newStr = oldStr

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -1,10 +1,13 @@
-import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 function stripAnsi(text: string): string {
 	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function hasBackground(line: string): boolean {
+	return /\x1b\[4[0-9]m|\x1b\[48[;:]/.test(line);
 }
 
 function renderCell(state: ConstructorParameters<typeof IPythonCellComponent>[0]): string {
@@ -16,7 +19,7 @@ describe("IPythonCellComponent diff rendering", () => {
 		initTheme("dark");
 	});
 
-	it("renders a streamed diff with absolute line numbers and suppresses the Edited confirmation", () => {
+	it("renders a diff with absolute line numbers and suppresses the Edited confirmation", () => {
 		const out = renderCell({
 			code: 'await edit(path="sample.py", old_str="gamma", new_str="GAMMA")',
 			details: {
@@ -31,19 +34,20 @@ describe("IPythonCellComponent diff rendering", () => {
 			expanded: true,
 		});
 
-		// Header carries the path and the +/- line counts.
-		expect(out).toContain("edit sample.py");
+		// Header carries the path (no "edit" label) and the +/- line counts.
+		expect(out).toContain("sample.py");
+		expect(out).not.toMatch(/edit sample\.py/);
 		expect(out).toMatch(/\+1\s+-1/);
-		// Removed line keeps the old line number + content; added line the new one.
-		expect(out).toMatch(/11 -.*gamma/);
-		expect(out).toMatch(/11 \+.*GAMMA/);
+		// Removed line keeps the old line number; added line the new one.
+		expect(out).toMatch(/-11 .*gamma/);
+		expect(out).toMatch(/\+11 .*GAMMA/);
 		expect(out).toMatch(/10 .*alpha/);
 		// The redundant "Edited sample.py" confirmation must not render as its own line.
 		expect(out.split("\n").some((line) => /^\s*'?Edited sample\.py'?\s*$/.test(line.trim()))).toBe(false);
 	});
 
-	it("pads every diff row to the full content width on a single background block", () => {
-		const out = new IPythonCellComponent({
+	it("renders diffs as foreground text with no background block", () => {
+		const lines = new IPythonCellComponent({
 			code: "await edit(...)",
 			details: {
 				status: "ok",
@@ -53,36 +57,22 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: true,
 		}).render(72);
-		// Every rendered line is exactly the panel width (no ragged backgrounds).
-		expect(out.every((line) => stripAnsi(line).length === 72)).toBe(true);
+		const diffRows = lines.filter((line) => /alpha|gamma|GAMMA/.test(stripAnsi(line)));
+		expect(diffRows.length).toBeGreaterThan(0);
+		expect(diffRows.some(hasBackground)).toBe(false);
 	});
 
-	it("keeps full width when a wide character straddles the truncation boundary", () => {
-		// CJK chars are 2 cells wide; a narrow render forces truncation mid-character.
-		const wide = "値".repeat(60);
-		const out = new IPythonCellComponent({
-			code: "await edit(...)",
-			details: {
-				status: "ok",
-				diffs: [{ path: "a.py", oldStr: "x = 1", newStr: `x = "${wide}"`, startLine: 1 }],
-			},
-			executionStarted: true,
-			argsComplete: true,
-			expanded: true,
-		}).render(40);
-		// Measure display cells, not code units (CJK chars are 2 cells wide).
-		expect(out.every((line) => visibleWidth(line) === 40)).toBe(true);
-	});
-
-	it("prefixes the edit header with the cell's status marker", () => {
+	it("prefixes the header with the cell's status marker and aligns it with the summary line", () => {
 		const done = renderCell({
 			code: "await edit(...)",
 			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
 			executionStarted: true,
 			argsComplete: true,
 			expanded: false,
-		});
-		expect(done).toMatch(/✓ edit a\.ts/);
+		}).split("\n");
+		// Summary line and header share the same single-space indent.
+		expect(done[0]).toMatch(/^ ✓ python/);
+		expect(done.find((l) => l.includes("a.ts"))).toMatch(/^ ✓ a\.ts/);
 
 		const failed = renderCell({
 			code: "await edit(...)",
@@ -92,7 +82,31 @@ describe("IPythonCellComponent diff rendering", () => {
 			expanded: false,
 			isError: true,
 		});
-		expect(failed).toMatch(/✗ edit a\.ts/);
+		expect(failed).toMatch(/✗ a\.ts/);
+	});
+
+	it("renders an edit path relative to the session cwd, or absolute when outside it", () => {
+		const cwd = "/home/me/project";
+		const inside = renderCell({
+			code: "await edit(...)",
+			cwd,
+			details: { status: "ok", diffs: [{ path: `${cwd}/src/app.ts`, oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+		expect(inside).toContain("src/app.ts");
+		expect(inside).not.toContain(`${cwd}/src/app.ts`);
+
+		const outside = renderCell({
+			code: "await edit(...)",
+			cwd,
+			details: { status: "ok", diffs: [{ path: "/etc/hosts", oldStr: "a", newStr: "b", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+		expect(outside).toContain("/etc/hosts");
 	});
 
 	it("wraps a long diff line onto gutter-aligned continuation rows instead of truncating", () => {
@@ -114,23 +128,6 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(addedRows.length).toBeGreaterThan(1);
 	});
 
-	it("renders diff rows at the full cli width with no side padding", () => {
-		const width = 50;
-		const out = new IPythonCellComponent({
-			code: "await edit(...)",
-			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "alpha", newStr: "ALPHA", startLine: 1 }] },
-			executionStarted: true,
-			argsComplete: true,
-			expanded: false,
-		}).render(width);
-		// The colored diff rows fill the whole width — no 2-col panel inset.
-		const diffRows = out.filter((line) => /alpha|ALPHA/i.test(stripAnsi(line)));
-		expect(diffRows.length).toBeGreaterThan(0);
-		expect(diffRows.every((line) => visibleWidth(line) === width)).toBe(true);
-		// The row starts at column 0, not behind two spaces of panel padding.
-		expect(diffRows.every((line) => !stripAnsi(line).startsWith("  "))).toBe(true);
-	});
-
 	it("separates the diff from the summary line with a blank line", () => {
 		const out = renderCell({
 			code: "await edit(...)",
@@ -139,10 +136,9 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: false,
 		}).split("\n");
-		// Line 0 is the summary; line 1 is blank; the edit header follows.
 		expect(out[0]).toContain("to expand");
 		expect(out[1].trim()).toBe("");
-		expect(out[2]).toContain("edit a.ts");
+		expect(out[2]).toContain("a.ts");
 	});
 
 	it("shows the full diff in the collapsed view so file changes never hide behind expand", () => {
@@ -159,9 +155,8 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: false,
 		});
-		// Collapsed keeps the one-line summary but renders the diff under it, in full.
 		expect(collapsed).toContain("to expand");
-		expect(collapsed).toContain("edit big.py");
+		expect(collapsed).toContain("big.py");
 		expect(collapsed).toContain("ROW");
 		// Every changed row is present — the diff is never truncated when collapsed.
 		expect((collapsed.match(/\+.*ROW \d+/g) ?? []).length).toBe(15);
@@ -181,8 +176,8 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: false,
 		});
-		expect(collapsed).toContain("edit a.py");
-		expect(collapsed).toContain("edit b.py");
+		expect(collapsed).toContain("a.py");
+		expect(collapsed).toContain("b.py");
 		expect(collapsed).toContain("ONE");
 		expect(collapsed).toContain("TWO");
 	});
@@ -201,25 +196,6 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(collapsed).not.toContain("world");
 	});
 
-	it("renders multiple diffs from a single cell", () => {
-		const out = renderCell({
-			code: "await edit(...); await edit(...)",
-			details: {
-				status: "ok",
-				durationMs: 5,
-				diffs: [
-					{ path: "a.py", oldStr: "one", newStr: "ONE", startLine: 1 },
-					{ path: "b.py", oldStr: "two", newStr: "TWO", startLine: 2 },
-				],
-			},
-			executionStarted: true,
-			argsComplete: true,
-			expanded: true,
-		});
-		expect(out).toContain("edit a.py");
-		expect(out).toContain("edit b.py");
-	});
-
 	it("coalesces multiple edits to one file into a single block with hunk separators", () => {
 		const out = renderCell({
 			code: "await edit(...); await edit(...); await edit(...)",
@@ -236,10 +212,9 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 		});
 		// One consolidated header for the file, with summed counts.
-		expect(out.split("\n").filter((l) => l.includes("edit app.py")).length).toBe(1);
-		expect(out).toMatch(/edit app\.py\s+\+3\s+-3/);
-		// Non-adjacent hunks are separated by the vertical-ellipsis marker.
-		expect(out).toContain("⋮");
+		expect(out.split("\n").filter((l) => l.includes("app.py")).length).toBe(1);
+		expect(out).toMatch(/app\.py\s+\+3\s+-3/);
+		// Hunks are separated by the vertical-ellipsis marker.
 		expect((out.match(/⋮/g) ?? []).length).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -74,7 +74,7 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(out.every((line) => visibleWidth(line) === 40)).toBe(true);
 	});
 
-	it("collapses a long diff and shows an expand hint", () => {
+	it("shows the full diff in the collapsed view so file changes never hide behind expand", () => {
 		const oldStr = Array.from({ length: 30 }, (_, i) => `row ${i}`).join("\n");
 		const newStr = oldStr
 			.split("\n")
@@ -88,18 +88,46 @@ describe("IPythonCellComponent diff rendering", () => {
 			argsComplete: true,
 			expanded: false,
 		});
-		// Collapsed is a single line: the diff itself is hidden behind the expand hint.
+		// Collapsed keeps the one-line summary but renders the diff under it, in full.
 		expect(collapsed).toContain("to expand");
-		expect(collapsed).not.toContain("ROW");
+		expect(collapsed).toContain("edit big.py");
+		expect(collapsed).toContain("ROW");
+		// Every changed row is present — the diff is never truncated when collapsed.
+		expect((collapsed.match(/\+.*ROW \d+/g) ?? []).length).toBe(15);
+	});
 
-		const expanded = renderCell({
-			code: "await edit(...)",
-			details: { status: "ok", durationMs: 9, diffs: [{ path: "big.py", oldStr, newStr, startLine: 1 }] },
+	it("renders multiple files' diffs in the collapsed view", () => {
+		const collapsed = renderCell({
+			code: "await edit(...); await edit(...)",
+			details: {
+				status: "ok",
+				diffs: [
+					{ path: "a.py", oldStr: "one", newStr: "ONE", startLine: 1 },
+					{ path: "b.py", oldStr: "two", newStr: "TWO", startLine: 2 },
+				],
+			},
 			executionStarted: true,
 			argsComplete: true,
-			expanded: true,
+			expanded: false,
 		});
-		expect(expanded).toContain("ROW");
+		expect(collapsed).toContain("edit a.py");
+		expect(collapsed).toContain("edit b.py");
+		expect(collapsed).toContain("ONE");
+		expect(collapsed).toContain("TWO");
+	});
+
+	it("keeps non-edit cells collapsed to a single summary line", () => {
+		const collapsed = renderCell({
+			code: "print('hello')",
+			details: { status: "ok", durationMs: 3, stdout: "hello\nworld\nmore\noutput\nlines" },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+		// No diffs → the collapsed view stays a single line; output hides behind expand.
+		expect(collapsed.split("\n")).toHaveLength(1);
+		expect(collapsed).toContain("to expand");
+		expect(collapsed).not.toContain("world");
 	});
 
 	it("renders multiple diffs from a single cell", () => {

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -74,6 +74,27 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(out.every((line) => visibleWidth(line) === 40)).toBe(true);
 	});
 
+	it("prefixes the edit header with the cell's status marker", () => {
+		const done = renderCell({
+			code: "await edit(...)",
+			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		});
+		expect(done).toMatch(/✓ edit a\.ts/);
+
+		const failed = renderCell({
+			code: "await edit(...)",
+			details: { status: "error", diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+			isError: true,
+		});
+		expect(failed).toMatch(/✗ edit a\.ts/);
+	});
+
 	it("wraps a long diff line onto gutter-aligned continuation rows instead of truncating", () => {
 		const longLine = `const x = ${Array.from({ length: 20 }, (_, i) => `arg${i}`).join(", ")};`;
 		const out = renderCell({

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -39,14 +40,15 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(out).not.toMatch(/edit sample\.py/);
 		expect(out).toMatch(/\+1\s+-1/);
 		// Removed line keeps the old line number; added line the new one.
-		expect(out).toMatch(/-11 .*gamma/);
-		expect(out).toMatch(/\+11 .*GAMMA/);
+		expect(out).toMatch(/11 - .*gamma/);
+		expect(out).toMatch(/11 \+ .*GAMMA/);
 		expect(out).toMatch(/10 .*alpha/);
 		// The redundant "Edited sample.py" confirmation must not render as its own line.
 		expect(out.split("\n").some((line) => /^\s*'?Edited sample\.py'?\s*$/.test(line.trim()))).toBe(false);
 	});
 
-	it("renders diffs as foreground text with no background block", () => {
+	it("renders diff rows as full-width colored blocks", () => {
+		const width = 72;
 		const lines = new IPythonCellComponent({
 			code: "await edit(...)",
 			details: {
@@ -56,10 +58,12 @@ describe("IPythonCellComponent diff rendering", () => {
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
-		}).render(72);
+		}).render(width);
 		const diffRows = lines.filter((line) => /alpha|gamma|GAMMA/.test(stripAnsi(line)));
 		expect(diffRows.length).toBeGreaterThan(0);
-		expect(diffRows.some(hasBackground)).toBe(false);
+		// Each changed row is a background block spanning the full width.
+		expect(diffRows.every((line) => visibleWidth(line) === width)).toBe(true);
+		expect(diffRows.some(hasBackground)).toBe(true);
 	});
 
 	it("prefixes the header with the cell's status marker and aligns it with the summary line", () => {
@@ -109,23 +113,25 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(outside).toContain("/etc/hosts");
 	});
 
-	it("wraps a long diff line onto gutter-aligned continuation rows instead of truncating", () => {
-		const longLine = `const x = ${Array.from({ length: 20 }, (_, i) => `arg${i}`).join(", ")};`;
-		const out = renderCell({
+	it("wraps a long diff line across rows without truncating or overflowing the width", () => {
+		const width = 92;
+		const longLine = `const x = ${Array.from({ length: 30 }, (_, i) => `arg${i}`).join(", ")};`;
+		const lines = new IPythonCellComponent({
 			code: "await edit(...)",
 			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "const x = 1;", newStr: longLine, startLine: 1 }] },
 			executionStarted: true,
 			argsComplete: true,
 			expanded: false,
-		}).split("\n");
+		}).render(width);
 
+		// No rendered row may exceed the terminal width (the TUI throws if one does).
+		expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
 		// The full content survives across the wrapped rows (nothing truncated away).
-		const joined = out.join("");
+		const joined = lines.map(stripAnsi).join("");
 		expect(joined).toContain("arg0");
-		expect(joined).toContain("arg19");
+		expect(joined).toContain("arg29");
 		// The added line spilled onto at least one continuation row.
-		const addedRows = out.filter((line) => /arg\d/.test(line));
-		expect(addedRows.length).toBeGreaterThan(1);
+		expect(lines.filter((line) => /arg\d/.test(stripAnsi(line))).length).toBeGreaterThan(1);
 	});
 
 	it("separates the diff from the summary line with a blank line", () => {

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -134,6 +134,23 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(lines.filter((line) => /arg\d/.test(stripAnsi(line))).length).toBeGreaterThan(1);
 	});
 
+	it("truncates a long header path so it never overflows the width, keeping the counts", () => {
+		const width = 40;
+		const longPath = `src/${"very-long-directory-name/".repeat(8)}file.ts`;
+		const lines = new IPythonCellComponent({
+			code: "await edit(...)",
+			details: { status: "ok", diffs: [{ path: longPath, oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: false,
+		}).render(width);
+		expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+		const header = lines.map(stripAnsi).find((line) => line.includes("…"));
+		expect(header).toBeDefined();
+		// The +/- counts survive truncation; only the path is shortened.
+		expect(header).toMatch(/\+1 -1\s*$/);
+	});
+
 	it("separates the diff from the summary line with a blank line", () => {
 		const out = renderCell({
 			code: "await edit(...)",


### PR DESCRIPTION
- when the agent edits a file it does so through the edit helper inside the ipython tool, but the collapsed cell only showed a one-line summary so the diff stayed hidden until you expanded.
- the collapsed view now renders the full colored diff under the summary line, and the per-file diff is never truncated.
- non-edit cells still collapse to a single line, and the existing expanded view is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to interactive TUI rendering and theme tokens; no auth, persistence, or tool execution logic is modified.
> 
> **Overview**
> **Collapsed IPython cells that include file edits now render the complete colored diff under the one-line summary**, so changes are visible without expanding. Cells without edits still collapse to a single summary line.
> 
> **Rich diff rendering** no longer truncates wide lines: content wraps onto extra full-width background rows via `wrapTextWithAnsi`, with continuation gutters that keep the `+`/`-` sign but omit line numbers. In truecolor mode, add/remove block text uses the new **`toolDiffText`** theme token instead of full syntax highlight on the tint.
> 
> **Per-file diff headers** use the cell status marker (`✓`/`✗`), show paths relative to session **`cwd`** when under it (otherwise shortened absolute), drop the `edit` label, and truncate only the path so `+`/`-` counts stay on screen. Diff rows render at terminal width without the old panel side padding; very large diffs append rows in a loop to avoid JS spread `RangeError`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894b28287a91ec891770e49971c320d76e782bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show full edit diffs in the collapsed IPython cell view
> - In collapsed view, diff blocks now render in full below the summary line instead of being hidden until expanded.
> - Long diff lines wrap across multiple full-width background rows with continuation gutters that repeat the `+`/`-` prefix; truncation is removed.
> - Diff headers show the file path relative to the session `cwd` when nested under it, dropping the `edit` label, and preserve added/removed counts when truncating long paths.
> - Adds a `toolDiffText` theme color (`#9aa0a6` dark, `#57606a` light) used for diff text on truecolor terminals.
> - Behavioral Change: collapsed cells with edits now produce multiple output rows instead of a single summary line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 894b282.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->