### PR TITLE
move queued follow-up messages below the execution indicator

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2926,6 +2926,8 @@ export class InteractiveMode {
 		this.editorComponentFactory = factory;
 		if (this.childAgentPanelMode) {
 			this.restoreMainAgentView();
+			// Re-render queued previews cleared on panel entry; the queue may still hold messages.
+			this.updatePendingMessagesDisplay();
 			this.childAgentDetailNodeId = undefined;
 			this.childAgentDetail.setNode(undefined);
 		}
@@ -4408,6 +4410,7 @@ export class InteractiveMode {
 		this.childAgentSummary.setHidden(true);
 		this.childAgentInspector.setNodes(this.childAgentNodes);
 		this.editorContainer.clear();
+		this.queuedMessagesContainer.clear();
 		this.mainViewContainer.clear();
 		this.mainViewContainer.addChild(this.childAgentInspector);
 		this.ui.setFocus(this.childAgentInspector);
@@ -4424,6 +4427,7 @@ export class InteractiveMode {
 		this.childAgentDetail.setNode(node);
 		this.childAgentSummary.setHidden(true);
 		this.editorContainer.clear();
+		this.queuedMessagesContainer.clear();
 		this.mainViewContainer.clear();
 		this.mainViewContainer.addChild(this.childAgentDetail);
 		this.ui.setFocus(this.childAgentDetail);
@@ -4444,6 +4448,8 @@ export class InteractiveMode {
 		this.childAgentDetail.setNode(undefined);
 		this.childAgentSummary.setHidden(false);
 		this.restoreMainAgentView();
+		// Re-render queued previews cleared on panel entry; the queue may still hold messages.
+		this.updatePendingMessagesDisplay();
 		this.editorContainer.clear();
 		this.editorContainer.addChild(this.editor);
 		this.ui.setFocus(this.editor);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -491,6 +491,7 @@ export class InteractiveMode {
 	private chatContainer: Container;
 	private pendingMessagesContainer: Container;
 	private statusContainer: Container;
+	private queuedMessagesContainer: Container;
 	private defaultEditor: CustomEditor;
 	private editor: EditorComponent;
 	private editorComponentFactory: EditorFactory | undefined;
@@ -661,6 +662,7 @@ export class InteractiveMode {
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
+		this.queuedMessagesContainer = new Container();
 		this.childAgentInspector = new ChildAgentInspectorComponent(
 			() => this.getChildAgentPanelRows(),
 			() => this.ui.requestRender(),
@@ -944,6 +946,7 @@ export class InteractiveMode {
 		this.mainContainer.addChild(this.widgetContainerAbove);
 		this.renderRecap();
 		this.mainContainer.addChild(this.recapContainer);
+		this.mainContainer.addChild(this.queuedMessagesContainer);
 		this.mainContainer.addChild(this.editorContainer);
 		this.mainContainer.addChild(this.childAgentSummary);
 		this.mainContainer.addChild(this.widgetContainerBelow);
@@ -2123,6 +2126,7 @@ export class InteractiveMode {
 	private resetCurrentSessionRenderState(): void {
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
+		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
 		// Pasted images belong to the session being torn down; drop them so markers
 		// in a newly loaded session can't resolve to the previous session's bytes.
@@ -5229,26 +5233,30 @@ export class InteractiveMode {
 	}
 
 	private updatePendingMessagesDisplay(): void {
+		// pendingMessagesContainer holds only in-flight bash output for the current
+		// turn, so it stays above the execution indicator. clear() detaches the
+		// components but they stay tracked in pendingBashComponents until flushed.
 		this.pendingMessagesContainer.clear();
-		// Keep in-flight bash output visible across queue refreshes; clear() detaches
-		// the components but they stay tracked in pendingBashComponents until flushed.
 		for (const component of this.pendingBashComponents) {
 			this.pendingMessagesContainer.addChild(component);
 		}
+		// Queued steering/follow-up previews are future turns, so they render in
+		// their own container below the execution indicator and recap.
+		this.queuedMessagesContainer.clear();
 		const { steering: steeringMessages, followUp: followUpMessages } = this.getAllQueuedMessages();
 		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
-			this.pendingMessagesContainer.addChild(new Spacer(1));
+			this.queuedMessagesContainer.addChild(new Spacer(1));
 			for (const message of steeringMessages) {
 				const text = theme.fg("dim", `Steering: ${message}`);
-				this.pendingMessagesContainer.addChild(new TruncatedText(text, 1, 0));
+				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			for (const message of followUpMessages) {
 				const text = theme.fg("dim", `Follow-up: ${message}`);
-				this.pendingMessagesContainer.addChild(new TruncatedText(text, 1, 0));
+				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");
 			const hintText = theme.fg("dim", `↳ ${dequeueHint} to edit all queued messages`);
-			this.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
+			this.queuedMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
 	}
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -293,6 +293,7 @@ describe("InteractiveMode pending bash components", () => {
 		const component = bashComponent();
 		const fakeThis = {
 			pendingMessagesContainer,
+			queuedMessagesContainer: new Container(),
 			pendingBashComponents: [component],
 			getAllQueuedMessages: () => ({ steering: [], followUp: [] }),
 		} as unknown as InteractiveMode;
@@ -370,6 +371,7 @@ describe("InteractiveMode pending bash components", () => {
 		const fakeThis = {
 			chatContainer: new Container(),
 			pendingMessagesContainer: new Container(),
+			queuedMessagesContainer: new Container(),
 			compactionQueuedMessages: [],
 			pastedImages: new Map(),
 			defaultEditor: editorStub,


### PR DESCRIPTION
- queued follow-up and steering previews were rendering above the current turn's execution indicator, which read backwards.
- they now sit in their own container below the indicator and recap line, so the current turn's activity comes first and pending messages follow.
- in-flight bash output stays with the current turn above the indicator, unaffected by the move.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI layout and display refresh only; no agent queue or submission logic changes.
> 
> **Overview**
> **Queued steering/follow-up previews** no longer share `pendingMessagesContainer` with in-flight bash output. They render in a new `queuedMessagesContainer` inserted **after the recap and before the editor**, so the current turn’s activity and execution indicator read first and future queued messages sit below.
> 
> `updatePendingMessagesDisplay` only repopulates `pendingMessagesContainer` with active bash components; queued previews and the dequeue hint move to the new container. Session reset, child-agent panel entry/exit, and custom-editor restore **clear or refresh** that container so previews don’t stick around incorrectly when the main view is torn down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e12c8c7e826c3cbaa5f9a48ce409d36dafc817e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move queued follow-up message previews below the execution indicator in interactive mode
> - Adds a dedicated `queuedMessagesContainer` in `InteractiveMode` to render queued steering/follow-up message previews separately from in-flight bash output in `pendingMessagesContainer`.
> - The new container is positioned below the recap section and above the editor, so previews appear beneath the execution indicator rather than mixed with pending bash output.
> - Queued previews are cleared when entering child agent panels and restored when returning to the main view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e12c8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->