### PR TITLE
keep /goal command highlighted while typing its argument

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -43,7 +43,7 @@ interface BuiltinSlashCommandAlias {
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
-	{ name: "effort", description: "Set reasoning/thinking level", argumentHint: "[level]" },
+	{ name: "effort", description: "Set reasoning/thinking level", argumentHint: "[level]", takesArgument: true },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -17,6 +17,12 @@ export interface BuiltinSlashCommand {
 	argumentHint?: string;
 	/** Hidden names that resolve to this command without being shown as commands. */
 	aliases?: readonly string[];
+	/**
+	 * The command takes a free-form argument. Confirming it keeps the command
+	 * "selected" (inserts a trailing space, stays in the editor) instead of
+	 * submitting the bare command.
+	 */
+	takesArgument?: boolean;
 }
 
 export interface ParsedSlashCommand {
@@ -66,7 +72,12 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 		argumentHint: "[instructions]",
 	},
 	{ name: "refine", description: "Refine editable harness prompt notes, skills, subagents, and memory" },
-	{ name: "goal", description: "Set or view a persistent goal; supports pause, resume, and clear" },
+	{
+		name: "goal",
+		description: "Set or view a persistent goal; supports pause, resume, and clear",
+		argumentHint: "[objective]",
+		takesArgument: true,
+	},
 	{
 		name: "heartbeat",
 		description: "Set or view a persistent heartbeat; supports pause, resume, and clear",
@@ -130,6 +141,11 @@ export function resolveBuiltinSlashCommandName(name: string): string {
 
 export function isBuiltinSlashCommandName(name: string): boolean {
 	return BUILTIN_SLASH_COMMAND_BY_NAME.has(name) || BUILTIN_SLASH_COMMAND_ALIAS_TO_NAME.has(name);
+}
+
+/** Whether the built-in command (by name or alias) takes a free-form argument. */
+export function builtinSlashCommandTakesArgument(name: string): boolean {
+	return BUILTIN_SLASH_COMMAND_BY_NAME.get(resolveBuiltinSlashCommandName(name))?.takesArgument === true;
 }
 
 export function resolveSlashCommand(command: ParsedSlashCommand): ResolvedSlashCommand {

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -17,11 +17,6 @@ export interface BuiltinSlashCommand {
 	argumentHint?: string;
 	/** Hidden names that resolve to this command without being shown as commands. */
 	aliases?: readonly string[];
-	/**
-	 * The command takes a free-form argument. Confirming it keeps the command
-	 * "selected" (inserts a trailing space, stays in the editor) instead of
-	 * submitting the bare command.
-	 */
 	takesArgument?: boolean;
 }
 
@@ -143,7 +138,6 @@ export function isBuiltinSlashCommandName(name: string): boolean {
 	return BUILTIN_SLASH_COMMAND_BY_NAME.has(name) || BUILTIN_SLASH_COMMAND_ALIAS_TO_NAME.has(name);
 }
 
-/** Whether the built-in command (by name or alias) takes a free-form argument. */
 export function builtinSlashCommandTakesArgument(name: string): boolean {
 	return BUILTIN_SLASH_COMMAND_BY_NAME.get(resolveBuiltinSlashCommandName(name))?.takesArgument === true;
 }

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -11,6 +11,8 @@ import type { AppKeybinding, KeybindingsManager } from "../../../core/keybinding
 export interface CustomEditorOptions extends EditorOptions {
 	placeholder?: string;
 	placeholderColor?: (text: string) => string;
+	/** Whether a slash command (by name) takes a free-form argument and should stay styled. */
+	isArgumentCommand?: (name: string) => boolean;
 }
 
 /**
@@ -22,6 +24,7 @@ export class CustomEditor extends Editor {
 	private readonly configuredPaddingX: number;
 	private placeholder: string | undefined;
 	private readonly placeholderColor: (text: string) => string;
+	private readonly isArgumentCommand: (name: string) => boolean;
 	public actionHandlers: Map<AppKeybinding, () => void> = new Map();
 
 	// Special handlers that can be dynamically replaced
@@ -43,6 +46,7 @@ export class CustomEditor extends Editor {
 		this.configuredPaddingX = options?.paddingX ?? 0;
 		this.placeholder = options?.placeholder;
 		this.placeholderColor = options?.placeholderColor ?? ((text) => text);
+		this.isArgumentCommand = options?.isArgumentCommand ?? (() => false);
 	}
 
 	protected override getPromptPrefix(): string {
@@ -58,6 +62,45 @@ export class CustomEditor extends Editor {
 			return 0;
 		}
 		return this.getBashPromptInfo(line)?.hiddenTextPrefixLength ?? 0;
+	}
+
+	protected override styleDisplayText(
+		displayText: string,
+		layoutLineIndex: number,
+		lineText: string,
+		cursorCol: number | undefined,
+	): string {
+		const commandColor = this.commandColor;
+		if (!commandColor || layoutLineIndex !== 0) {
+			return displayText;
+		}
+
+		// Match a leading slash-command token: optional whitespace, then "/name".
+		const match = /^(\s*)\/(\S+)/.exec(lineText);
+		if (!match) {
+			return displayText;
+		}
+		const [token, leadingWhitespace, name] = match as unknown as [string, string, string];
+		if (!this.isArgumentCommand(name)) {
+			return displayText;
+		}
+
+		const tokenStart = leadingWhitespace.length;
+		const tokenEnd = token.length;
+
+		// The cursor span has been spliced into displayText at cursorCol, which shifts
+		// raw indices. Coloring by raw index is only safe when that splice lands at or
+		// after the token's end. While the cursor is within the token the user is still
+		// typing the command name and the autocomplete dropdown already provides the
+		// highlight, so skipping styling there is also the desired behavior.
+		if (cursorCol !== undefined && cursorCol < tokenEnd) {
+			return displayText;
+		}
+
+		const before = displayText.slice(0, tokenStart);
+		const tokenText = displayText.slice(tokenStart, tokenEnd);
+		const after = displayText.slice(tokenEnd);
+		return `${before}${commandColor(tokenText)}${after}`;
 	}
 
 	private getBashPromptInfo(line: string): { promptPrefix: string; hiddenTextPrefixLength: number } | undefined {

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -11,7 +11,6 @@ import type { AppKeybinding, KeybindingsManager } from "../../../core/keybinding
 export interface CustomEditorOptions extends EditorOptions {
 	placeholder?: string;
 	placeholderColor?: (text: string) => string;
-	/** Whether a slash command (by name) takes a free-form argument and should stay styled. */
 	isArgumentCommand?: (name: string) => boolean;
 }
 
@@ -75,7 +74,6 @@ export class CustomEditor extends Editor {
 			return displayText;
 		}
 
-		// Match a leading slash-command token: optional whitespace, then "/name".
 		const match = /^(\s*)\/(\S+)/.exec(lineText);
 		if (!match) {
 			return displayText;
@@ -88,11 +86,6 @@ export class CustomEditor extends Editor {
 		const tokenStart = leadingWhitespace.length;
 		const tokenEnd = token.length;
 
-		// The cursor span has been spliced into displayText at cursorCol, which shifts
-		// raw indices. Coloring by raw index is only safe when that splice lands at or
-		// after the token's end. While the cursor is within the token the user is still
-		// typing the command name and the autocomplete dropdown already provides the
-		// highlight, so skipping styling there is also the desired behavior.
 		if (cursorCol !== undefined && cursorCol < tokenEnd) {
 			return displayText;
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -83,6 +83,7 @@ import { SessionImportFileNotFoundError } from "../../core/session-import-errors
 import { parseSkillBlock } from "../../core/skill-blocks.js";
 import {
 	BUILTIN_SLASH_COMMANDS,
+	builtinSlashCommandTakesArgument,
 	isBuiltinSlashCommandName,
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
@@ -696,6 +697,7 @@ export class InteractiveMode {
 		this.defaultEditor = new CustomEditor(this.ui, getEditorTheme(), this.keybindings, {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
+			isArgumentCommand: builtinSlashCommandTakesArgument,
 		});
 		this.editor = this.defaultEditor;
 		this.mainContainer = new Container();
@@ -786,6 +788,7 @@ export class InteractiveMode {
 			aliases: command.aliases,
 			description: command.description,
 			argumentHint: command.argumentHint,
+			takesArgument: command.takesArgument,
 		}));
 
 		const modelCommand = slashCommands.find((command) => command.name === "model");

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -1265,6 +1265,7 @@ export function getEditorTheme(): EditorTheme {
 		borderColor: (text: string) => theme.fg("borderMuted", text),
 		backgroundColor: theme.getEditorBackgroundColor(),
 		selectList: getSelectListTheme(),
+		commandColor: (text: string) => theme.fg("accent", text),
 	};
 }
 

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -24,11 +24,16 @@ describe("built-in slash commands", () => {
 		});
 	});
 
-	test("marks /goal as taking a free-form argument", () => {
+	test("marks argument commands as taking a free-form argument", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "goal")).toMatchObject({
 			takesArgument: true,
 		});
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
+			takesArgument: true,
+		});
 		expect(builtinSlashCommandTakesArgument("goal")).toBe(true);
+		expect(builtinSlashCommandTakesArgument("effort")).toBe(true);
+		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true); // alias of /effort
 		// Commands that submit immediately do not take a free-form argument.
 		expect(builtinSlashCommandTakesArgument("new")).toBe(false);
 		expect(builtinSlashCommandTakesArgument("clear")).toBe(false); // alias of /new

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
 	BUILTIN_SLASH_COMMANDS,
+	builtinSlashCommandTakesArgument,
 	isBuiltinSlashCommandName,
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
@@ -21,6 +22,16 @@ describe("built-in slash commands", () => {
 			argumentHint: "[level]",
 			aliases: ["thinking"],
 		});
+	});
+
+	test("marks /goal as taking a free-form argument", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "goal")).toMatchObject({
+			takesArgument: true,
+		});
+		expect(builtinSlashCommandTakesArgument("goal")).toBe(true);
+		// Commands that submit immediately do not take a free-form argument.
+		expect(builtinSlashCommandTakesArgument("new")).toBe(false);
+		expect(builtinSlashCommandTakesArgument("clear")).toBe(false); // alias of /new
 	});
 });
 

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -33,10 +33,9 @@ describe("built-in slash commands", () => {
 		});
 		expect(builtinSlashCommandTakesArgument("goal")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("effort")).toBe(true);
-		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true); // alias of /effort
-		// Commands that submit immediately do not take a free-form argument.
+		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("new")).toBe(false);
-		expect(builtinSlashCommandTakesArgument("clear")).toBe(false); // alias of /new
+		expect(builtinSlashCommandTakesArgument("clear")).toBe(false);
 	});
 });
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -220,11 +220,6 @@ export interface AutocompleteItem {
 	value: string;
 	label: string;
 	description?: string;
-	/**
-	 * For slash-command suggestions: the command takes a free-form argument.
-	 * Confirming it should insert a trailing space and keep editing rather than
-	 * submitting the bare command.
-	 */
 	takesArgument?: boolean;
 }
 
@@ -235,11 +230,6 @@ export interface SlashCommand {
 	aliases?: readonly string[];
 	description?: string;
 	argumentHint?: string;
-	/**
-	 * The command takes a free-form argument. Confirming it (Enter/space) keeps the
-	 * command "selected" — inserts a trailing space and stays in the editor — instead
-	 * of submitting the bare command.
-	 */
 	takesArgument?: boolean;
 	// Function to get argument completions for this command
 	// Returns null if no argument completion is available

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -220,6 +220,12 @@ export interface AutocompleteItem {
 	value: string;
 	label: string;
 	description?: string;
+	/**
+	 * For slash-command suggestions: the command takes a free-form argument.
+	 * Confirming it should insert a trailing space and keep editing rather than
+	 * submitting the bare command.
+	 */
+	takesArgument?: boolean;
 }
 
 type Awaitable<T> = T | Promise<T>;
@@ -229,6 +235,12 @@ export interface SlashCommand {
 	aliases?: readonly string[];
 	description?: string;
 	argumentHint?: string;
+	/**
+	 * The command takes a free-form argument. Confirming it (Enter/space) keeps the
+	 * command "selected" — inserts a trailing space and stays in the editor — instead
+	 * of submitting the bare command.
+	 */
+	takesArgument?: boolean;
 	// Function to get argument completions for this command
 	// Returns null if no argument completion is available
 	getArgumentCompletions?(argumentPrefix: string): Awaitable<AutocompleteItem[] | null>;
@@ -314,11 +326,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
 					const desc = cmd.description ?? "";
 					const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+					const takesArgument = "takesArgument" in cmd ? cmd.takesArgument === true : false;
 					return {
 						name,
 						searchText: [name, ...aliases].join(" "),
 						label: name,
 						description: fullDesc || undefined,
+						takesArgument,
 					};
 				});
 
@@ -326,6 +340,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					value: item.name,
 					label: item.label,
 					...(item.description && { description: item.description }),
+					...(item.takesArgument && { takesArgument: true }),
 				}));
 
 				if (filtered.length === 0) return null;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -225,6 +225,8 @@ export interface EditorTheme {
 	borderColor: (str: string) => string;
 	backgroundColor?: (str: string) => string;
 	selectList: SelectListTheme;
+	/** Color applied to a recognized slash-command token in the input. */
+	commandColor?: (str: string) => string;
 }
 
 export interface EditorOptions {
@@ -264,6 +266,7 @@ export class Editor implements Component, Focusable {
 	// Border color (can be changed dynamically)
 	public borderColor: (str: string) => string;
 	public backgroundColor: ((str: string) => string) | undefined;
+	public commandColor: ((str: string) => string) | undefined;
 
 	// Autocomplete support
 	private autocompleteProvider?: AutocompleteProvider;
@@ -318,6 +321,7 @@ export class Editor implements Component, Focusable {
 		this.theme = theme;
 		this.borderColor = theme.borderColor;
 		this.backgroundColor = theme.backgroundColor;
+		this.commandColor = theme.commandColor;
 		const paddingX = options.paddingX ?? 0;
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
 		this.promptPrefix = options.promptPrefix ?? "";
@@ -369,6 +373,27 @@ export class Editor implements Component, Focusable {
 
 	protected getHiddenTextPrefixLength(_lineIndex: number, _line: string): number {
 		return 0;
+	}
+
+	/**
+	 * Hook to style the display text of a rendered line (e.g. color a slash-command
+	 * token so it stays visually "selected" while the user types its argument).
+	 *
+	 * Called per visible line after the cursor has been composited into `displayText`.
+	 * `lineText` is the unstyled text of this layout line (before the cursor span was
+	 * added); `cursorCol` is the cursor's column within that text, or undefined when
+	 * the cursor is on another line. Implementations must preserve the visible width
+	 * of `displayText` and the embedded cursor span.
+	 *
+	 * Default: no styling.
+	 */
+	protected styleDisplayText(
+		displayText: string,
+		_layoutLineIndex: number,
+		_lineText: string,
+		_cursorCol: number | undefined,
+	): string {
+		return displayText;
 	}
 
 	private getLineHiddenTextPrefixLength(lineIndex: number, line: string): number {
@@ -594,6 +619,14 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
+			// Allow subclasses to style the display text (e.g. color a slash-command token).
+			displayText = this.styleDisplayText(
+				displayText,
+				absoluteLineIndex,
+				layoutLine.text,
+				layoutLine.hasCursor ? layoutLine.cursorPos : undefined,
+			);
+
 			// Calculate padding based on actual visible width
 			const padding = " ".repeat(Math.max(0, inputWidth - lineVisibleWidth));
 			const lineRightPadding = cursorInPadding ? rightPadding.slice(1) : rightPadding;
@@ -745,6 +778,13 @@ export class Editor implements Component, Focusable {
 
 					if (this.autocompletePrefix.startsWith("/")) {
 						this.cancelAutocomplete();
+						// A command that takes a free-form argument stays "selected": the
+						// completion inserted a trailing space, so keep editing instead of
+						// submitting the bare command (matches pressing space).
+						if (selected.takesArgument) {
+							if (this.onChange) this.onChange(this.getText());
+							return;
+						}
 						// Fall through to submit
 					} else {
 						this.cancelAutocomplete();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -225,7 +225,6 @@ export interface EditorTheme {
 	borderColor: (str: string) => string;
 	backgroundColor?: (str: string) => string;
 	selectList: SelectListTheme;
-	/** Color applied to a recognized slash-command token in the input. */
 	commandColor?: (str: string) => string;
 }
 
@@ -375,18 +374,6 @@ export class Editor implements Component, Focusable {
 		return 0;
 	}
 
-	/**
-	 * Hook to style the display text of a rendered line (e.g. color a slash-command
-	 * token so it stays visually "selected" while the user types its argument).
-	 *
-	 * Called per visible line after the cursor has been composited into `displayText`.
-	 * `lineText` is the unstyled text of this layout line (before the cursor span was
-	 * added); `cursorCol` is the cursor's column within that text, or undefined when
-	 * the cursor is on another line. Implementations must preserve the visible width
-	 * of `displayText` and the embedded cursor span.
-	 *
-	 * Default: no styling.
-	 */
 	protected styleDisplayText(
 		displayText: string,
 		_layoutLineIndex: number,
@@ -619,7 +606,6 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
-			// Allow subclasses to style the display text (e.g. color a slash-command token).
 			displayText = this.styleDisplayText(
 				displayText,
 				absoluteLineIndex,
@@ -778,9 +764,6 @@ export class Editor implements Component, Focusable {
 
 					if (this.autocompletePrefix.startsWith("/")) {
 						this.cancelAutocomplete();
-						// A command that takes a free-form argument stays "selected": the
-						// completion inserted a trailing space, so keep editing instead of
-						// submitting the bare command (matches pressing space).
 						if (selected.takesArgument) {
 							if (this.onChange) this.onChange(this.getText());
 							return;

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -13,7 +13,6 @@ export interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
-	/** Slash-command items: the command takes a free-form argument (see AutocompleteItem). */
 	takesArgument?: boolean;
 }
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -13,6 +13,8 @@ export interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
+	/** Slash-command items: the command takes a free-form argument (see AutocompleteItem). */
+	takesArgument?: boolean;
 }
 
 export interface SelectListTheme {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -74,6 +74,24 @@ describe("CombinedAutocompleteProvider", () => {
 				items: [{ value: "new", label: "new", description: "Start a new session" }],
 			});
 		});
+
+		it("surfaces takesArgument on free-form-argument commands and omits it otherwise", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "goal", description: "Set a goal", takesArgument: true },
+					{ name: "new", description: "Start a new session" },
+				],
+				"/tmp",
+			);
+
+			const goal = await getSuggestions(provider, ["/goal"], 0, 5);
+			assert.deepStrictEqual(goal?.items, [
+				{ value: "goal", label: "goal", description: "Set a goal", takesArgument: true },
+			]);
+
+			const fresh = await getSuggestions(provider, ["/new"], 0, 4);
+			assert.deepStrictEqual(fresh?.items, [{ value: "new", label: "new", description: "Start a new session" }]);
+		});
 	});
 
 	describe("extractPathPrefix", () => {


### PR DESCRIPTION
- selecting /goal and pressing space dropped the highlight, leaving it unclear whether the command was still selected, and pressing enter on bare /goal submitted a status message instead of letting you type a goal.
- added a takesArgument flag for commands that take a free-form argument and color the command token inline in the input so it stays highlighted while you type.
- enter on such a command now accepts it and keeps editing, matching how space behaves, rather than submitting immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only input and autocomplete behavior for specific slash commands; no auth, data, or execution-path changes beyond when Enter submits.
> 
> **Overview**
> Improves editing **argument-taking** slash commands (`/goal`, `/effort`, and the `thinking` alias) so the command stays visually selected and autocomplete does not submit too early.
> 
> Adds a **`takesArgument`** flag on built-in slash commands plus `builtinSlashCommandTakesArgument()`, wired through autocomplete items. Choosing such a command from the list **no longer submits on Enter**—focus stays in the input so you can type the argument (same idea as after space).
> 
> The interactive editor passes that metadata into **`CustomEditor`**, which overrides **`styleDisplayText`** to paint the `/command` token with the theme **accent** color while the cursor is past the token. **`EditorTheme`** gains optional **`commandColor`** (set in the coding-agent theme).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa9ed9857bd161c312dc8c53345506acbfdb356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep /goal and /effort commands highlighted while typing their arguments
> - Adds a `takesArgument` flag to the `/goal` and `/effort` slash commands so the editor and autocomplete can treat them differently from commands that submit immediately.
> - When a `takesArgument` command is selected from autocomplete, the editor no longer auto-submits; it keeps focus so the user can type the argument.
> - The command token stays highlighted (using the theme's accent color) while the cursor is positioned after it, implemented via a new `styleDisplayText` override in [`custom-editor.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/236/files#diff-d9bfbf3acb3425b8392c410c8136af3755b8cc08e825ed9312d29a2b15b82203).
> - Behavioral Change: selecting `/goal` or `/effort` from autocomplete no longer submits the input — the user must press Enter after typing the argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fa9ed9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->