### PR TITLE
add /system-prompt command to show the exact prompt sent to the model

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -733,9 +733,6 @@ export class AgentSession {
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
 	private _baseSystemPromptOptions!: BuildSystemPromptOptions;
-	// Exact prompt last sent to the model. Distinct from state.systemPrompt, which is rebuilt
-	// early by tool/resource/refine changes before any request.
-	private _lastSentSystemPrompt: string | undefined;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -1873,17 +1870,6 @@ export class AgentSession {
 		return this.agent.state.systemPrompt;
 	}
 
-	/**
-	 * Returns the exact prompt last sent to the model. Before the first turn, falls back to a
-	 * freshly built base prompt (what would be sent next, before any per-turn extension changes).
-	 */
-	getSystemPromptForDisplay(): { prompt: string; sent: boolean } {
-		if (this._lastSentSystemPrompt !== undefined) {
-			return { prompt: this._lastSentSystemPrompt, sent: true };
-		}
-		return { prompt: this._rebuildSystemPrompt(this.getActiveToolNames()), sent: false };
-	}
-
 	/** Current retry attempt (0 if not retrying) */
 	get retryAttempt(): number {
 		return this._retryAttempt;
@@ -2211,7 +2197,6 @@ export class AgentSession {
 				// Ensure we're using the base prompt (in case previous turn had modifications)
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 			}
-			this._lastSentSystemPrompt = this.agent.state.systemPrompt;
 		} catch (error) {
 			preflightResult?.(false);
 			throw error;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -733,6 +733,9 @@ export class AgentSession {
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
 	private _baseSystemPromptOptions!: BuildSystemPromptOptions;
+	// Exact prompt last sent to the model. Distinct from state.systemPrompt, which is rebuilt
+	// early by tool/resource/refine changes before any request.
+	private _lastSentSystemPrompt: string | undefined;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -1871,12 +1874,14 @@ export class AgentSession {
 	}
 
 	/**
-	 * The system prompt that would be sent to the model right now. Once a turn has run
-	 * this is the exact on-the-wire value (with extension modifications); before the first
-	 * turn `state.systemPrompt` is still empty, so build the current prompt deterministically.
+	 * Returns the exact prompt last sent to the model. Before the first turn, falls back to a
+	 * freshly built base prompt (what would be sent next, before any per-turn extension changes).
 	 */
-	getEffectiveSystemPrompt(): string {
-		return this.agent.state.systemPrompt || this._rebuildSystemPrompt(this.getActiveToolNames());
+	getSystemPromptForDisplay(): { prompt: string; sent: boolean } {
+		if (this._lastSentSystemPrompt !== undefined) {
+			return { prompt: this._lastSentSystemPrompt, sent: true };
+		}
+		return { prompt: this._rebuildSystemPrompt(this.getActiveToolNames()), sent: false };
 	}
 
 	/** Current retry attempt (0 if not retrying) */
@@ -2206,6 +2211,7 @@ export class AgentSession {
 				// Ensure we're using the base prompt (in case previous turn had modifications)
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 			}
+			this._lastSentSystemPrompt = this.agent.state.systemPrompt;
 		} catch (error) {
 			preflightResult?.(false);
 			throw error;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1870,6 +1870,15 @@ export class AgentSession {
 		return this.agent.state.systemPrompt;
 	}
 
+	/**
+	 * The system prompt that would be sent to the model right now. Once a turn has run
+	 * this is the exact on-the-wire value (with extension modifications); before the first
+	 * turn `state.systemPrompt` is still empty, so build the current prompt deterministically.
+	 */
+	getEffectiveSystemPrompt(): string {
+		return this.agent.state.systemPrompt || this._rebuildSystemPrompt(this.getActiveToolNames());
+	}
+
 	/** Current retry attempt (0 if not retrying) */
 	get retryAttempt(): number {
 		return this._retryAttempt;

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -45,6 +45,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info" },
+	{ name: "system-prompt", description: "Show the exact system prompt sent to the model" },
 	{ name: "logs", description: "Show where daemon and client logs are saved" },
 	{
 		name: "traces",

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -366,12 +366,12 @@ export class DaemonAgentConnection implements AgentConnection {
 		return data.text ?? undefined;
 	}
 
-	async getSystemPrompt(): Promise<string> {
-		const data = await this.requestData<{ systemPrompt: string }>({
+	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
+		const data = await this.requestData<{ prompt: string; sent: boolean }>({
 			type: "get_system_prompt",
 			activeSessionId: this.activeSessionId,
 		});
-		return data.systemPrompt;
+		return { prompt: data.prompt, sent: data.sent };
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -366,6 +366,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		return data.text ?? undefined;
 	}
 
+	async getSystemPrompt(): Promise<string> {
+		const data = await this.requestData<{ systemPrompt: string }>({
+			type: "get_system_prompt",
+			activeSessionId: this.activeSessionId,
+		});
+		return data.systemPrompt;
+	}
+
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {
 		const data = await this.requestData<{ toolDefinition?: AgentConnectionToolDefinition }>({
 			type: "get_tool_definition",
@@ -832,6 +840,7 @@ function invalidatesCachedSnapshot(commandType: DaemonCommandBody["type"]): bool
 		case "get_session_tree":
 		case "get_user_messages_for_forking":
 		case "get_last_assistant_text":
+		case "get_system_prompt":
 		case "get_tool_definition":
 		case "export_html":
 		case "export_jsonl":

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -366,12 +366,12 @@ export class DaemonAgentConnection implements AgentConnection {
 		return data.text ?? undefined;
 	}
 
-	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
-		const data = await this.requestData<{ prompt: string; sent: boolean }>({
+	async getSystemPrompt(): Promise<string> {
+		const data = await this.requestData<{ systemPrompt: string }>({
 			type: "get_system_prompt",
 			activeSessionId: this.activeSessionId,
 		});
-		return { prompt: data.prompt, sent: data.sent };
+		return data.systemPrompt;
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -325,6 +325,10 @@ export class DeferredAgentConnection implements AgentConnection {
 		return this.real ? this.real.getLastAssistantText() : undefined;
 	}
 
+	async getSystemPrompt(): Promise<string> {
+		return this.real ? this.real.getSystemPrompt() : "";
+	}
+
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {
 		return this.real ? this.real.getToolDefinition(name) : undefined;
 	}

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -325,8 +325,8 @@ export class DeferredAgentConnection implements AgentConnection {
 		return this.real ? this.real.getLastAssistantText() : undefined;
 	}
 
-	async getSystemPrompt(): Promise<string> {
-		return this.real ? this.real.getSystemPrompt() : "";
+	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
+		return this.real ? this.real.getSystemPrompt() : { prompt: "", sent: false };
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/deferred-agent-connection.ts
@@ -325,8 +325,8 @@ export class DeferredAgentConnection implements AgentConnection {
 		return this.real ? this.real.getLastAssistantText() : undefined;
 	}
 
-	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
-		return this.real ? this.real.getSystemPrompt() : { prompt: "", sent: false };
+	async getSystemPrompt(): Promise<string> {
+		return this.real ? this.real.getSystemPrompt() : "";
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -184,8 +184,8 @@ export class InProcessAgentConnection implements AgentConnection {
 		return this.session.getLastAssistantText();
 	}
 
-	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
-		return this.session.getSystemPromptForDisplay();
+	async getSystemPrompt(): Promise<string> {
+		return this.session.systemPrompt;
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -184,8 +184,8 @@ export class InProcessAgentConnection implements AgentConnection {
 		return this.session.getLastAssistantText();
 	}
 
-	async getSystemPrompt(): Promise<string> {
-		return this.session.getEffectiveSystemPrompt();
+	async getSystemPrompt(): Promise<{ prompt: string; sent: boolean }> {
+		return this.session.getSystemPromptForDisplay();
 	}
 
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -184,6 +184,10 @@ export class InProcessAgentConnection implements AgentConnection {
 		return this.session.getLastAssistantText();
 	}
 
+	async getSystemPrompt(): Promise<string> {
+		return this.session.getEffectiveSystemPrompt();
+	}
+
 	async getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined> {
 		return createAgentConnectionToolDefinition(this.session.getToolDefinition(name));
 	}

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -554,6 +554,8 @@ export interface AgentConnection {
 	updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined>;
 	getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]>;
 	getLastAssistantText(): Promise<string | undefined>;
+	/** The exact system prompt currently sent to the model (post extension modifications). */
+	getSystemPrompt(): Promise<string>;
 	getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined>;
 	setSessionEntryLabel(entryId: string, label: string | undefined): Promise<void>;
 	respondToExtensionUiRequest(requestId: string, response: AgentConnectionExtensionUiResponse): Promise<void>;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -554,8 +554,11 @@ export interface AgentConnection {
 	updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined>;
 	getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]>;
 	getLastAssistantText(): Promise<string | undefined>;
-	/** The exact system prompt currently sent to the model (post extension modifications). */
-	getSystemPrompt(): Promise<string>;
+	/**
+	 * The system prompt for display. `prompt` is the exact string last sent to the model;
+	 * if no turn has run yet, `sent` is false and `prompt` is the freshly built base prompt.
+	 */
+	getSystemPrompt(): Promise<{ prompt: string; sent: boolean }>;
 	getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined>;
 	setSessionEntryLabel(entryId: string, label: string | undefined): Promise<void>;
 	respondToExtensionUiRequest(requestId: string, response: AgentConnectionExtensionUiResponse): Promise<void>;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -554,11 +554,8 @@ export interface AgentConnection {
 	updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined>;
 	getUserMessagesForForking(): Promise<AgentConnectionUserMessage[]>;
 	getLastAssistantText(): Promise<string | undefined>;
-	/**
-	 * The system prompt for display. `prompt` is the exact string last sent to the model;
-	 * if no turn has run yet, `sent` is false and `prompt` is the freshly built base prompt.
-	 */
-	getSystemPrompt(): Promise<{ prompt: string; sent: boolean }>;
+	/** The system prompt currently in effect for the model (with any per-turn extension changes). */
+	getSystemPrompt(): Promise<string>;
 	getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined>;
 	setSessionEntryLabel(entryId: string, label: string | undefined): Promise<void>;
 	respondToExtensionUiRequest(requestId: string, response: AgentConnectionExtensionUiResponse): Promise<void>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1382,7 +1382,9 @@ export class AgentDaemon {
 
 			case "get_system_prompt": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(command.id, "get_system_prompt", state.runtime.session.getSystemPromptForDisplay());
+				return success(command.id, "get_system_prompt", {
+					systemPrompt: state.runtime.session.systemPrompt,
+				});
 			}
 
 			case "get_tool_definition": {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -150,6 +150,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_session_tree",
 	"get_user_messages_for_forking",
 	"get_last_assistant_text",
+	"get_system_prompt",
 	"get_tool_definition",
 	"set_session_entry_label",
 	"extension_ui_response",
@@ -1376,6 +1377,13 @@ export class AgentDaemon {
 				const state = this.getSessionState(command.activeSessionId);
 				return success(command.id, "get_last_assistant_text", {
 					text: state.runtime.session.getLastAssistantText(),
+				});
+			}
+
+			case "get_system_prompt": {
+				const state = this.getSessionState(command.activeSessionId);
+				return success(command.id, "get_system_prompt", {
+					systemPrompt: state.runtime.session.getEffectiveSystemPrompt(),
 				});
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1382,9 +1382,7 @@ export class AgentDaemon {
 
 			case "get_system_prompt": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(command.id, "get_system_prompt", {
-					systemPrompt: state.runtime.session.getEffectiveSystemPrompt(),
-				});
+				return success(command.id, "get_system_prompt", state.runtime.session.getSystemPromptForDisplay());
 			}
 
 			case "get_tool_definition": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -238,6 +238,7 @@ export type DaemonCommand =
 	| { id?: string; type: "get_session_tree"; activeSessionId: string }
 	| { id?: string; type: "get_user_messages_for_forking"; activeSessionId: string }
 	| { id?: string; type: "get_last_assistant_text"; activeSessionId: string }
+	| { id?: string; type: "get_system_prompt"; activeSessionId: string }
 	| { id?: string; type: "get_tool_definition"; activeSessionId: string; name: string }
 	| { id?: string; type: "set_session_entry_label"; activeSessionId: string; entryId: string; label?: string }
 	| {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6721,11 +6721,9 @@ export class InteractiveMode {
 	}
 
 	private async handleSystemPromptCommand(): Promise<void> {
-		// The exact string sent to the model as the system prompt for this session,
-		// including any per-turn extension modifications. Rendered verbatim — the only
-		// transformation is the terminal's soft word-wrap to the viewport width.
-		const prompt = await this.agentConnection.getSystemPrompt();
-		const header = `${theme.bold("System Prompt")} ${theme.fg("dim", `(${prompt.length} chars, exact)`)}`;
+		const { prompt, sent } = await this.agentConnection.getSystemPrompt();
+		const status = sent ? "exact, last sent" : "next turn, not yet sent";
+		const header = `${theme.bold("System Prompt")} ${theme.fg("dim", `(${prompt.length} chars, ${status})`)}`;
 
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(header, 1, 0));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3334,6 +3334,11 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
+			if (commandName === "system-prompt" && !commandArgs) {
+				await this.handleSystemPromptCommand();
+				this.editor.setText("");
+				return;
+			}
 			if (commandName === "traces") {
 				await this.handleTracesCommand(canonicalCommandText);
 				this.editor.setText("");
@@ -6712,6 +6717,20 @@ export class InteractiveMode {
 
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(info, 1, 0));
+		this.ui.requestRender();
+	}
+
+	private async handleSystemPromptCommand(): Promise<void> {
+		// The exact string sent to the model as the system prompt for this session,
+		// including any per-turn extension modifications. Rendered verbatim — the only
+		// transformation is the terminal's soft word-wrap to the viewport width.
+		const prompt = await this.agentConnection.getSystemPrompt();
+		const header = `${theme.bold("System Prompt")} ${theme.fg("dim", `(${prompt.length} chars, exact)`)}`;
+
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new Text(header, 1, 0));
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new Text(prompt, 1, 0));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6721,9 +6721,8 @@ export class InteractiveMode {
 	}
 
 	private async handleSystemPromptCommand(): Promise<void> {
-		const { prompt, sent } = await this.agentConnection.getSystemPrompt();
-		const status = sent ? "exact, last sent" : "next turn, not yet sent";
-		const header = `${theme.bold("System Prompt")} ${theme.fg("dim", `(${prompt.length} chars, ${status})`)}`;
+		const prompt = await this.agentConnection.getSystemPrompt();
+		const header = `${theme.bold("System Prompt")} ${theme.fg("dim", `(${prompt.length} chars)`)}`;
 
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(header, 1, 0));


### PR DESCRIPTION
- adds a /system-prompt slash command that prints the exact system prompt the model receives for the current session, verbatim, so it's easy to see what skills, harness state, and context are actually being sent.
- plumbs a getSystemPrompt call through the in-process, daemon, and deferred connection layers, mirroring the existing getLastAssistantText path.
- falls back to building the current prompt when the session hasn't run a turn yet, since the stored prompt is empty until the first turn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only introspection and a new daemon query command; no changes to prompting, auth, or session mutation paths.
> 
> **Overview**
> Adds a **`/system-prompt`** builtin slash command so you can inspect the **exact system prompt** the model sees for the current session (skills, harness, per-turn extension overrides).
> 
> **`AgentConnection.getSystemPrompt()`** is wired the same way as **`getLastAssistantText`**: in-process reads **`session.systemPrompt`**, the daemon adds **`get_system_prompt`** (read-only, does not invalidate attach snapshots), and **`DeferredAgentConnection`** returns an empty string until a real session exists.
> 
> **Interactive mode** handles the command with no args and prints a titled block in the chat, including character count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddd09eec156f150bf67ba6bb9c7e83a7d765a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/system-prompt` slash command to display the current system prompt in the chat UI
> - Adds a `/system-prompt` command that fetches and displays the active system prompt (with its character count) in the chat UI via `InteractiveMode.handleSystemPromptCommand()`.
> - Extends the `AgentConnection` interface with `getSystemPrompt()`, implemented across in-process, daemon-backed, and deferred connections.
> - The daemon handles a new `get_system_prompt` command type that looks up the prompt by session ID without invalidating the cached snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ddd09e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->