### PR TITLE
bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.1.9",
+				"@earendil-works/pi-coding-agent": "^0.2.0",
 				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
@@ -5925,10 +5925,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.1.9",
+				"@earendil-works/pi-ai": "^0.2.0",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5955,7 +5955,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5997,13 +5997,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.1.9",
-				"@earendil-works/pi-ai": "^0.1.9",
-				"@earendil-works/pi-tui": "^0.1.9",
+				"@earendil-works/pi-agent-core": "^0.2.0",
+				"@earendil-works/pi-ai": "^0.2.0",
+				"@earendil-works/pi-tui": "^0.2.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6146,7 +6146,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.1.9",
+		"@earendil-works/pi-coding-agent": "^0.2.0",
 		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.1.9",
+		"@earendil-works/pi-ai": "^0.2.0",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"description": "Coding agent CLI with ipython, bash, edit tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.1.9",
-		"@earendil-works/pi-ai": "^0.1.9",
-		"@earendil-works/pi-tui": "^0.1.9",
+		"@earendil-works/pi-agent-core": "^0.2.0",
+		"@earendil-works/pi-ai": "^0.2.0",
+		"@earendil-works/pi-tui": "^0.2.0",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the root package and all four published packages from 0.1.9 to 0.2.0.
- syncs inter-package dependency ranges and the lockfile to match.
- version-only change with no code or behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no logic, API, or dependency version changes beyond aligned internal package ranges.
> 
> **Overview**
> Bumps **prime-agent** and all published `@earendil-works/pi-*` workspace packages from **0.1.9** to **0.2.0**.
> 
> Updates root and package `package.json` version fields, internal dependency ranges (`^0.2.0`), and `package-lock.json` so the monorepo stays in lockstep. **No application source or runtime behavior changes** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a40b112e34622ac8d1391fdab4faae55467627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all packages to version 0.2.0
> Updates version from 0.1.9 to 0.2.0 across all packages in the monorepo, including internal cross-package dependency ranges.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51a40b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->