### PR TITLE
stop recaps from disappearing while a new turn regenerates them

### DIFF
--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -16,7 +16,6 @@ import type {
 function persistedRecap(sessionManager: {
 	getLatestAgentStatus?: () => { summary: string } | undefined;
 }): string | undefined {
-	// Optional-call so a minimal session manager (tests) still works.
 	return sessionManager.getLatestAgentStatus?.()?.summary;
 }
 
@@ -54,9 +53,7 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
-		// Baseline recap; the daemon overlays the live summary on attach. Seeded
-		// even when a turn moved on, so attach shows the last recap instead of a
-		// blank one while the summarizer regenerates.
+		// Baseline recap; the daemon overlays the live summary on attach.
 		recap: persistedRecap(sessionManager),
 	};
 }

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -13,12 +13,11 @@ import type {
 	AgentConnectionState,
 } from "./types.js";
 
-function persistedRecap(
-	sessionManager: { getLatestAgentStatus?: () => { summary: string; basedOnMessageCount: number } | undefined },
-	messageCount: number,
-): string | undefined {
-	const status = sessionManager.getLatestAgentStatus?.();
-	return status && status.basedOnMessageCount === messageCount ? status.summary : undefined;
+function persistedRecap(sessionManager: {
+	getLatestAgentStatus?: () => { summary: string } | undefined;
+}): string | undefined {
+	// Optional-call so a minimal session manager (tests) still works.
+	return sessionManager.getLatestAgentStatus?.()?.summary;
 }
 
 export function createAgentConnectionState(
@@ -55,10 +54,10 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
-		// Baseline recap; the daemon overlays the live summary on attach. Only use it
-		// while it matches the current turn so attach never seeds a stale recap.
-		// Optional-call so a minimal session manager (tests) still works.
-		recap: persistedRecap(sessionManager, session.messages.length),
+		// Baseline recap; the daemon overlays the live summary on attach. Seeded
+		// even when a turn moved on, so attach shows the last recap instead of a
+		// blank one while the summarizer regenerates.
+		recap: persistedRecap(sessionManager),
 	};
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -65,12 +65,7 @@ import {
 	isDaemonDialogExtensionUiRequest,
 	success,
 } from "./daemon-protocol.js";
-import {
-	buildRlmChildSnapshots,
-	buildSessionList,
-	isSummaryCurrent,
-	summaryForActiveSession,
-} from "./daemon-session-list.js";
+import { buildRlmChildSnapshots, buildSessionList, summaryForActiveSession } from "./daemon-session-list.js";
 import { DaemonSessionSummarizer } from "./daemon-session-summarizer.js";
 import {
 	cleanupDaemonSocketPath,
@@ -1459,9 +1454,10 @@ export class AgentDaemon {
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		// Prefer the live in-memory recap over the persisted baseline, but only
-		// while it matches the current turn so we don't seed a stale recap.
-		if (state.summaryState?.summary && isSummaryCurrent(state)) {
+		// Prefer the live in-memory recap over the persisted baseline. Seeded even
+		// when a turn moved on, so attach shows the last recap instead of a blank
+		// one while the summarizer regenerates.
+		if (state.summaryState?.summary) {
 			connectionState.recap = state.summaryState.summary;
 		}
 		return {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1454,9 +1454,7 @@ export class AgentDaemon {
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		// Prefer the live in-memory recap over the persisted baseline. Seeded even
-		// when a turn moved on, so attach shows the last recap instead of a blank
-		// one while the summarizer regenerates.
+		// Prefer the live in-memory recap over the persisted baseline.
 		if (state.summaryState?.summary) {
 			connectionState.recap = state.summaryState.summary;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -153,10 +153,9 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		spawnCode: metadata.spawnCode ? metadata.spawnCode.slice(0, SPAWN_CODE_MAX_CHARS) : undefined,
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
-		// Keep showing the last recap while a new turn regenerates one, so the
-		// agents view never flickers to a blank recap. The completion verdict is
-		// gated on currency, though: a stale "completed" must not show on a turn
-		// that is active again. The summarizer swaps both in within seconds.
+		// Keep the last recap visible across turns so the view never blanks, but
+		// gate the verdict on currency: a stale "completed" must not show on a turn
+		// that is active again.
 		summary: activeSession.summaryState?.summary,
 		...(isSummaryCurrent(activeSession) ? { taskState: activeSession.summaryState?.taskState } : {}),
 	};

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -153,11 +153,12 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		spawnCode: metadata.spawnCode ? metadata.spawnCode.slice(0, SPAWN_CODE_MAX_CHARS) : undefined,
 		modelFallbackMessage: activeSession.runtime.modelFallbackMessage,
 		diagnostics: [...activeSession.runtime.diagnostics],
-		// Drop both summary and verdict once new messages arrive; a stale recap
-		// would describe a prior turn. The summarizer refreshes within seconds.
-		...(isSummaryCurrent(activeSession)
-			? { summary: activeSession.summaryState?.summary, taskState: activeSession.summaryState?.taskState }
-			: {}),
+		// Keep showing the last recap while a new turn regenerates one, so the
+		// agents view never flickers to a blank recap. The completion verdict is
+		// gated on currency, though: a stale "completed" must not show on a turn
+		// that is active again. The summarizer swaps both in within seconds.
+		summary: activeSession.summaryState?.summary,
+		...(isSummaryCurrent(activeSession) ? { taskState: activeSession.summaryState?.taskState } : {}),
 	};
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -20,8 +20,8 @@ const SUMMARY_MAX_TOKENS = 400;
 
 export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI coding agent dashboard. You are given the recent conversation between a user and the agent, plus whether the agent is currently working or idle.
 
-Output ONLY these two lines, nothing before or after. Do not think out loud, explain, or add any other text.
-SUMMARY: a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period
+Output ONLY these two lines, nothing before or after. Do not think out loud, explain, or count words. Put the summary inside <recap></recap> tags and write nothing after the closing tag.
+SUMMARY: <recap>a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period</recap>
 STATUS: one of WORKING, NEEDS_INPUT, COMPLETED
 
 STATUS meaning:
@@ -31,7 +31,7 @@ STATUS meaning:
 When the agent is idle and you are unsure between COMPLETED and NEEDS_INPUT, choose NEEDS_INPUT.
 
 Example:
-SUMMARY: Refactoring the auth middleware and updating its tests
+SUMMARY: <recap>Refactoring the auth middleware and updating its tests</recap>
 STATUS: WORKING`;
 
 export interface AgentStatusResult {
@@ -100,10 +100,39 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
 	return `<agent-state>${state}</agent-state>\n<conversation>\n${lines.join("\n")}\n</conversation>`;
 }
 
+// Inline chain-of-thought the model sometimes appends to the recap on the same
+// line (e.g. `Sending X. That's 5 words? Count: X(1)... = 6 words. Under`).
+// Cut the candidate at the first such marker so reasoning never reaches the UI.
+const REASONING_TRAILER =
+	/\s*(?:["”]\s*)?(?:\bthat['’]?s\b|\bcount\s*:|\(\d+\)|=\s*\d+\s*words?\b|\b(?:under|over|wait|actually|hmm|let me)\b).*/i;
+// Counting artifacts that mark a candidate as polluted beyond salvage.
+const COUNTING_ARTIFACT = /\(\d+\)|=\s*\d+\s*words?\b/i;
+const MAX_RECAP_WORDS = 16;
+
+/** Strip a single layer of wrapping quotes and any trailing punctuation/space. */
+function tidyRecap(raw: string): string {
+	let value = raw.trim().replace(REASONING_TRAILER, "").trim();
+	value = value.replace(/^["“']+|["”']+$/g, "").trim();
+	return value.replace(/[.\s]+$/, "");
+}
+
+/** A candidate that still carries counting artifacts or rambles is discarded. */
+function isCleanRecap(candidate: string): boolean {
+	if (!candidate || candidate.startsWith("<") || /present-tense|12 words/i.test(candidate)) {
+		return false;
+	}
+	if (COUNTING_ARTIFACT.test(candidate)) {
+		return false;
+	}
+	return candidate.split(/\s+/).length <= MAX_RECAP_WORDS;
+}
+
 /**
- * Parse the two-line reply. Requires an explicit `SUMMARY:` line (last one wins,
- * after any reasoning) and never falls back to free text, so a model's
- * chain-of-thought can't leak into the recap. Idle verdicts default to
+ * Parse the two-line reply. The recap is delimited by `<recap></recap>` tags so
+ * trailing chain-of-thought falls structurally outside it; when the model omits
+ * the close tag we fall back to capturing the `SUMMARY:`/`RECAP:` line and
+ * cutting off any inline reasoning. A candidate that still looks polluted is
+ * rejected (returns undefined) rather than surfaced. Idle verdicts default to
  * needs_input on anything unrecognized.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
@@ -111,18 +140,30 @@ export function parseAgentStatusResponse(text: string, isWorking: boolean): Agen
 	const cleaned = text
 		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
 		.replace(reasoningTag, " ");
+
 	let summary: string | undefined;
+	// Prefer the explicit tag; last match wins so reasoning before it is ignored.
+	const tagMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
+	if (tagMatch) {
+		const candidate = tidyRecap(tagMatch[1]!);
+		if (isCleanRecap(candidate)) {
+			summary = candidate;
+		}
+	}
+
 	let status: string | undefined;
 	for (const rawLine of cleaned.split("\n")) {
 		const line = rawLine.trim();
-		const summaryMatch = /^summary\s*:\s*(.+)$/i.exec(line);
-		if (summaryMatch) {
-			const candidate = summaryMatch[1]!.trim().replace(/[.\s]+$/, "");
-			// Skip an echoed prompt template (e.g. "<one present-tense clause…>").
-			if (candidate && !candidate.startsWith("<") && !/present-tense|12 words/i.test(candidate)) {
-				summary = candidate;
+		if (!summary) {
+			const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
+			if (summaryMatch) {
+				// Strip an unclosed `<recap>` tag the model may have left open.
+				const candidate = tidyRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, ""));
+				if (isCleanRecap(candidate)) {
+					summary = candidate;
+				}
+				continue;
 			}
-			continue;
 		}
 		const statusMatch = /^status\s*:\s*([a-z_]+)/i.exec(line);
 		if (statusMatch) {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -100,23 +100,19 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
 	return `<agent-state>${state}</agent-state>\n<conversation>\n${lines.join("\n")}\n</conversation>`;
 }
 
-// Inline chain-of-thought the model sometimes appends to the recap on the same
-// line (e.g. `Sending X. That's 5 words? Count: X(1)... = 6 words. Under`).
-// Cut the candidate at the first such marker so reasoning never reaches the UI.
+// Cuts inline chain-of-thought the model appends on the recap line, e.g.
+// `Sending X. That's 5 words? Count: X(1)... = 6 words. Under`.
 const REASONING_TRAILER =
 	/\s*(?:["”]\s*)?(?:\bthat['’]?s\b|\bcount\s*:|\(\d+\)|=\s*\d+\s*words?\b|\b(?:under|over|wait|actually|hmm|let me)\b).*/i;
-// Counting artifacts that mark a candidate as polluted beyond salvage.
 const COUNTING_ARTIFACT = /\(\d+\)|=\s*\d+\s*words?\b/i;
 const MAX_RECAP_WORDS = 16;
 
-/** Strip a single layer of wrapping quotes and any trailing punctuation/space. */
 function tidyRecap(raw: string): string {
 	let value = raw.trim().replace(REASONING_TRAILER, "").trim();
 	value = value.replace(/^["“']+|["”']+$/g, "").trim();
 	return value.replace(/[.\s]+$/, "");
 }
 
-/** A candidate that still carries counting artifacts or rambles is discarded. */
 function isCleanRecap(candidate: string): boolean {
 	if (!candidate || candidate.startsWith("<") || /present-tense|12 words/i.test(candidate)) {
 		return false;
@@ -128,12 +124,10 @@ function isCleanRecap(candidate: string): boolean {
 }
 
 /**
- * Parse the two-line reply. The recap is delimited by `<recap></recap>` tags so
- * trailing chain-of-thought falls structurally outside it; when the model omits
- * the close tag we fall back to capturing the `SUMMARY:`/`RECAP:` line and
- * cutting off any inline reasoning. A candidate that still looks polluted is
- * rejected (returns undefined) rather than surfaced. Idle verdicts default to
- * needs_input on anything unrecognized.
+ * Parse the two-line reply. The recap is delimited by `<recap></recap>` so
+ * trailing chain-of-thought falls outside it; without the close tag we fall back
+ * to the `SUMMARY:`/`RECAP:` line and cut inline reasoning. A still-polluted
+ * candidate is rejected. Idle verdicts default to needs_input.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
 	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
@@ -142,7 +136,7 @@ export function parseAgentStatusResponse(text: string, isWorking: boolean): Agen
 		.replace(reasoningTag, " ");
 
 	let summary: string | undefined;
-	// Prefer the explicit tag; last match wins so reasoning before it is ignored.
+	// Last match wins so reasoning before the tag is ignored.
 	const tagMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
 	if (tagMatch) {
 		const candidate = tidyRecap(tagMatch[1]!);
@@ -157,7 +151,6 @@ export function parseAgentStatusResponse(text: string, isWorking: boolean): Agen
 		if (!summary) {
 			const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
 			if (summaryMatch) {
-				// Strip an unclosed `<recap>` tag the model may have left open.
 				const candidate = tidyRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, ""));
 				if (isCleanRecap(candidate)) {
 					summary = candidate;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -137,17 +137,19 @@ export function parseAgentStatusResponse(text: string, isWorking: boolean): Agen
 		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
 		.replace(reasoningTag, " ");
 
-	// Last match wins so a draft superseded by a corrected one resolves correctly.
+	// Prefer the tag (last match wins so a corrected draft resolves). Fall back to
+	// the SUMMARY/RECAP lines only when the tag is missing or its body is rejected;
+	// among lines the last clean one wins.
 	const tagMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
-	let summary = tagMatch ? cleanRecap(tagMatch[1]!) : undefined;
+	const tagSummary = tagMatch ? cleanRecap(tagMatch[1]!) : undefined;
+	let summary = tagSummary;
 
 	let status: string | undefined;
 	for (const rawLine of cleaned.split("\n")) {
 		const line = rawLine.trim();
 		const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
 		if (summaryMatch) {
-			// Tag wins over the bare line; otherwise the last clean line wins.
-			if (!tagMatch) {
+			if (!tagSummary) {
 				summary = cleanRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, "")) ?? summary;
 			}
 			continue;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -100,34 +100,36 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
 	return `<agent-state>${state}</agent-state>\n<conversation>\n${lines.join("\n")}\n</conversation>`;
 }
 
-// Cuts inline chain-of-thought the model appends on the recap line, e.g.
-// `Sending X. That's 5 words? Count: X(1)... = 6 words. Under`.
-const REASONING_TRAILER =
-	/\s*(?:["”]\s*)?(?:\bthat['’]?s\b|\bcount\s*:|\(\d+\)|=\s*\d+\s*words?\b|\b(?:under|over|wait|actually|hmm|let me)\b).*/i;
+// Cuts the word-counting chain-of-thought the model appends on the recap line,
+// e.g. `Sending X. That's 5 words? Count: X(1)... = 6 words.`. Restricted to
+// structural counting markers so plain words ("Waiting for CI") survive.
+const REASONING_TRAILER = /\s*(?:["”]\s*)?(?:\bthat['’]?s\s+\d+\s*words?\b|\bcount\s*:|\(\d+\)|=\s*\d+\s*words?\b).*/i;
 const COUNTING_ARTIFACT = /\(\d+\)|=\s*\d+\s*words?\b/i;
 const MAX_RECAP_WORDS = 16;
 
-function tidyRecap(raw: string): string {
-	let value = raw.trim().replace(REASONING_TRAILER, "").trim();
-	value = value.replace(/^["“']+|["”']+$/g, "").trim();
-	return value.replace(/[.\s]+$/, "");
-}
-
-function isCleanRecap(candidate: string): boolean {
-	if (!candidate || candidate.startsWith("<") || /present-tense|12 words/i.test(candidate)) {
-		return false;
+/** Strip reasoning trailer and quotes, then reject anything still polluted. */
+function cleanRecap(raw: string): string | undefined {
+	const value = raw
+		.trim()
+		.replace(REASONING_TRAILER, "")
+		.replace(/^["“']+|["”']+$/g, "")
+		.replace(/[.\s]+$/, "")
+		.trim();
+	if (!value || value.startsWith("<") || /present-tense|12 words/i.test(value)) {
+		return undefined;
 	}
-	if (COUNTING_ARTIFACT.test(candidate)) {
-		return false;
+	if (COUNTING_ARTIFACT.test(value) || value.split(/\s+/).length > MAX_RECAP_WORDS) {
+		return undefined;
 	}
-	return candidate.split(/\s+/).length <= MAX_RECAP_WORDS;
+	return value;
 }
 
 /**
  * Parse the two-line reply. The recap is delimited by `<recap></recap>` so
  * trailing chain-of-thought falls outside it; without the close tag we fall back
- * to the `SUMMARY:`/`RECAP:` line and cut inline reasoning. A still-polluted
- * candidate is rejected. Idle verdicts default to needs_input.
+ * to the `SUMMARY:`/`RECAP:` line and cut inline word-counting. The last clean
+ * recap wins. A still-polluted candidate is rejected; idle verdicts default to
+ * needs_input.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
 	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
@@ -135,28 +137,20 @@ export function parseAgentStatusResponse(text: string, isWorking: boolean): Agen
 		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
 		.replace(reasoningTag, " ");
 
-	let summary: string | undefined;
-	// Last match wins so reasoning before the tag is ignored.
+	// Last match wins so a draft superseded by a corrected one resolves correctly.
 	const tagMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
-	if (tagMatch) {
-		const candidate = tidyRecap(tagMatch[1]!);
-		if (isCleanRecap(candidate)) {
-			summary = candidate;
-		}
-	}
+	let summary = tagMatch ? cleanRecap(tagMatch[1]!) : undefined;
 
 	let status: string | undefined;
 	for (const rawLine of cleaned.split("\n")) {
 		const line = rawLine.trim();
-		if (!summary) {
-			const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
-			if (summaryMatch) {
-				const candidate = tidyRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, ""));
-				if (isCleanRecap(candidate)) {
-					summary = candidate;
-				}
-				continue;
+		const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
+		if (summaryMatch) {
+			// Tag wins over the bare line; otherwise the last clean line wins.
+			if (!tagMatch) {
+				summary = cleanRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, "")) ?? summary;
 			}
+			continue;
 		}
 		const statusMatch = /^status\s*:\s*([a-z_]+)/i.exec(line);
 		if (statusMatch) {

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -8,6 +8,7 @@ import {
 	buildSessionList,
 	resolveAttachModelFallbackMessage,
 	type SessionSummary,
+	summaryForActiveSession,
 } from "../src/modes/daemon/daemon-session-list.js";
 
 describe("buildSessionList", () => {
@@ -92,6 +93,46 @@ describe("buildSessionList", () => {
 			// The spawn prompt doubles as the subagent's display title.
 			firstMessage: "Audit the retry logic for races",
 		});
+	});
+});
+
+describe("summaryForActiveSession recap currency", () => {
+	const twoMessages = [
+		{ role: "user", content: "hi" },
+		{ role: "assistant", content: "ok" },
+	] as AgentMessage[];
+
+	it("surfaces both recap and verdict while the summary matches the turn", () => {
+		const summary = summaryForActiveSession(
+			makeState({
+				activeSessionId: "s1",
+				messages: twoMessages,
+				summaryState: { summary: "Editing the router", taskState: "completed", basedOnMessageCount: 2 },
+			}),
+		);
+		expect(summary.summary).toBe("Editing the router");
+		expect(summary.taskState).toBe("completed");
+	});
+
+	it("keeps showing the prior recap once a new turn outpaces the summary", () => {
+		// New messages arrived (count 3) but the summary is still based on 2; the
+		// recap text must survive so the agents view does not flicker to blank.
+		const summary = summaryForActiveSession(
+			makeState({
+				activeSessionId: "s1",
+				messages: [...twoMessages, { role: "user", content: "next" } as AgentMessage],
+				summaryState: { summary: "Editing the router", taskState: "completed", basedOnMessageCount: 2 },
+			}),
+		);
+		expect(summary.summary).toBe("Editing the router");
+		// ...but a stale "completed" verdict must not show on a turn that is active again.
+		expect(summary.taskState).toBeUndefined();
+	});
+
+	it("omits the recap entirely when there is no summary yet", () => {
+		const summary = summaryForActiveSession(makeState({ activeSessionId: "s1", messages: twoMessages }));
+		expect(summary.summary).toBeUndefined();
+		expect(summary.taskState).toBeUndefined();
 	});
 });
 
@@ -230,6 +271,7 @@ interface StateOptions {
 	pendingToolCalls?: string[];
 	clients?: number;
 	messages?: AgentMessage[];
+	summaryState?: ActiveSessionState["summaryState"];
 	childRunStatuses?: Record<string, "queued" | "running" | "done" | "error" | "cancelled">;
 	metadata?: {
 		kind: "top-level" | "subagent";
@@ -254,6 +296,7 @@ function makeState(options: StateOptions): ActiveSessionState {
 		activeSessionId: options.activeSessionId,
 		clients,
 		lastEventSequence: 0,
+		summaryState: options.summaryState,
 		runtime: {
 			metadata: options.metadata ?? { kind: "top-level", createdAt: 1 },
 			diagnostics: [],

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -148,6 +148,12 @@ describe("daemon session summarizer", () => {
 			const text = "SUMMARY: Draft recap\nSUMMARY: Final corrected recap\nSTATUS: WORKING";
 			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Final corrected recap" });
 		});
+
+		test("falls back to a SUMMARY line when the tagged body is rejected", () => {
+			// The tag body is pure counting (rejected); a later valid line must win.
+			const text = "<recap>(1) two(2) = 2 words</recap>\nSUMMARY: Editing the parser\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
+		});
 	});
 
 	describe("buildStatusContext", () => {

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -137,6 +137,17 @@ describe("daemon session summarizer", () => {
 			const text = "SUMMARY: <recap>Editing the parser\nSTATUS: WORKING";
 			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
 		});
+
+		test("keeps recaps that start with words also used in reasoning", () => {
+			for (const recap of ["Waiting for CI to finish", "Let me know once tests pass", "Under review by the team"]) {
+				expect(parseAgentStatusResponse(`SUMMARY: ${recap}\nSTATUS: WORKING`, true)).toEqual({ summary: recap });
+			}
+		});
+
+		test("takes the last SUMMARY line when a draft is corrected", () => {
+			const text = "SUMMARY: Draft recap\nSUMMARY: Final corrected recap\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Final corrected recap" });
+		});
 	});
 
 	describe("buildStatusContext", () => {

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -79,6 +79,64 @@ describe("daemon session summarizer", () => {
 			expect(parseAgentStatusResponse("", false)).toBeUndefined();
 			expect(parseAgentStatusResponse("STATUS: COMPLETED", false)).toBeUndefined();
 		});
+
+		test("extracts the recap from <recap> tags", () => {
+			const text = "SUMMARY: <recap>Sending SSH auth retry to tcg-autoresearch-rl</recap>\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({
+				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
+			});
+		});
+
+		test("drops chain-of-thought after the closing recap tag", () => {
+			const text =
+				"SUMMARY: <recap>Sending SSH auth retry to tcg-autoresearch-rl</recap> That's 5 words? Count: Sending(1) SSH(2) auth(3) retry(4) to(5) tcg-autoresearch-rl(6) = 6 words. Under..\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({
+				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
+			});
+		});
+
+		test("cuts inline reasoning when the model omits the closing tag", () => {
+			const text =
+				"SUMMARY: Sending SSH auth retry to tcg-autoresearch-rl. That's 5 words? Count: Sending(1) SSH(2) = 6 words. Under\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({
+				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
+			});
+		});
+
+		test("salvages the clean prefix before counting artifacts begin", () => {
+			const text = "SUMMARY: Counting words(1) two(2) three(3) = 3 words\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Counting words" });
+		});
+
+		test("rejects a candidate whose counting starts at the very first word", () => {
+			// No clean prefix to salvage — the recap is nothing but the artifact.
+			const text = "SUMMARY: (1) word(2) count(3) = 3 words\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toBeUndefined();
+		});
+
+		test("rejects a rambling candidate that blows past the word ceiling", () => {
+			const text =
+				"SUMMARY: this is a very long rambling sentence that just keeps going and going well past any reasonable recap length\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toBeUndefined();
+		});
+
+		test("strips wrapping quotes the model adds around the recap", () => {
+			const text = 'SUMMARY: <recap>"Wiring the recap line"</recap>\nSTATUS: COMPLETED';
+			expect(parseAgentStatusResponse(text, false)).toEqual({
+				summary: "Wiring the recap line",
+				taskState: "completed",
+			});
+		});
+
+		test("accepts RECAP: as a synonym for SUMMARY:", () => {
+			const text = "RECAP: Restarting the daemon\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Restarting the daemon" });
+		});
+
+		test("ignores an open recap tag with no close", () => {
+			const text = "SUMMARY: <recap>Editing the parser\nSTATUS: WORKING";
+			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
+		});
 	});
 
 	describe("buildStatusContext", () => {


### PR DESCRIPTION
- recaps in the agents view briefly vanished whenever a new turn started, because the old recap was dropped the instant it went stale and only reappeared once the summarizer produced a fresh one.
- the last recap now stays visible until the new one atomically replaces it, while the completion verdict still clears so a stale "completed" never shows on an active turn.
- the recap model is also asked to wrap its summary in tags and the parser cuts off any trailing chain-of-thought, so its word-counting reasoning no longer leaks into the displayed recap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard display and recap parsing only; no auth, persistence contract changes beyond showing stale recap text until refresh, with task verdict still currency-gated.
> 
> **Overview**
> Fixes **agents view recap flicker** when a new turn starts: the UI no longer drops the last recap while the summarizer catches up.
> 
> **Recap persistence vs verdict:** `summaryForActiveSession` and attach/snapshot paths **always show the last recap text** when one exists. **`taskState` (completed / needs_input) stays gated** on message-count currency via `isSummaryCurrent`, so a stale “completed” does not appear on an active turn. `persistedRecap` and daemon attach similarly stop requiring currency for recap text; live in-memory recap still wins on attach when present.
> 
> **Summarizer output:** The status prompt asks the model to wrap the line in **`<recap>` tags**, and **`parseAgentStatusResponse`** prefers tagged bodies, strips word-count chain-of-thought, rejects polluted/overlong candidates, and accepts **`RECAP:`** as an alias for **`SUMMARY:`**.
> 
> Tests cover recap currency in session lists and the new parser behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bc1912031041595cb7287a8ddd44a51061ee23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop recaps from disappearing while a new turn regenerates them
> - `persistedRecap` in [snapshot.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/239/files#diff-b96224e5973d747681caa3b3b46b10300d0ad88870882a61fd1f8a27397eb2f3) now returns any available recap unconditionally, removing the check that suppressed it when the message count didn't match the current turn.
> - `AgentDaemon` in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/239/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) overlays the live in-memory recap on attach whenever one exists, not only when it is current.
> - [daemon-session-list.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/239/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21) retains recap text across turns but withholds `taskState` (the verdict) until the summary is current again.
> - [daemon-session-summarizer.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/239/files#diff-f7613b331eb488c0bb7d4cd012f97c2bfb45fb01444ab63d0c9378839666625a) updates the system prompt to wrap recaps in `<recap>` tags and improves `parseAgentStatusResponse` to extract from those tags while stripping chain-of-thought artifacts and wrapping quotes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7bc191.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->