### PR TITLE
make arrow keys first-class navigation shortcuts

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -31,6 +31,8 @@ export interface AppKeybindings {
 	"app.session.fork": true;
 	"app.session.resume": true;
 	"app.agents.back": true;
+	"app.agents.open": true;
+	"app.modal.back": true;
 	"app.agents.reply": true;
 	"app.agents.delete": true;
 	"app.agents.program": true;
@@ -111,6 +113,8 @@ export const KEYBINDINGS = {
 	"app.session.fork": { defaultKeys: [], description: "Fork current session" },
 	"app.session.resume": { defaultKeys: [], description: "Resume a session" },
 	"app.agents.back": { defaultKeys: "left", description: "Return to agents view" },
+	"app.agents.open": { defaultKeys: "right", description: "Open chat view for selected agent" },
+	"app.modal.back": { defaultKeys: "left", description: "Go back / close the current dialog" },
 	"app.agents.reply": { defaultKeys: "space", description: "Reply to selected agent" },
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -432,7 +432,13 @@ class AgentsViewMode implements Component, Focusable {
 			this.cycleProgramForSelected();
 			return;
 		}
-		if (this.keybindings.matches(data, "app.agents.open") && this.editor.getText().length === 0) {
+		// Mirror the confirm shortcut: open the selected agent only when the prompt
+		// is empty and we are not composing a reply (empty confirm is a no-op then).
+		if (
+			this.keybindings.matches(data, "app.agents.open") &&
+			this.editor.getText().length === 0 &&
+			!this.replyActiveSessionId
+		) {
 			this.openSelected();
 			return;
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -434,9 +434,10 @@ class AgentsViewMode implements Component, Focusable {
 		}
 		// Mirror the confirm shortcut: open the selected agent only when the prompt
 		// is empty and we are not composing a reply (empty confirm is a no-op then).
+		// Match the confirm path's trim() so a whitespace-only prompt still opens.
 		if (
 			this.keybindings.matches(data, "app.agents.open") &&
-			this.editor.getText().length === 0 &&
+			this.editor.getText().trim().length === 0 &&
 			!this.replyActiveSessionId
 		) {
 			this.openSelected();

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -432,6 +432,10 @@ class AgentsViewMode implements Component, Focusable {
 			this.cycleProgramForSelected();
 			return;
 		}
+		if (this.keybindings.matches(data, "app.agents.open") && this.editor.getText().length === 0) {
+			this.openSelected();
+			return;
+		}
 		if (this.editor.getText().length === 0 && this.handleListNavigation(data)) {
 			return;
 		}
@@ -1733,6 +1737,7 @@ class AgentsViewMode implements Component, Focusable {
 		const hints = [
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open/send`,
+			`${keyText("app.agents.open")} open`,
 			"/ commands",
 			selectedAgent ? `${keyText("app.agents.reply")} reply` : undefined,
 			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -16,6 +16,7 @@ import { PRIME_BUTTERFLY_LOGO } from "../../../themes/prime-logo.js";
 import { theme } from "../theme/theme.js";
 import { keyHint } from "./keybinding-hints.js";
 import { MenuPanel, MenuSearchInput } from "./menu-panel.js";
+import { shouldTreatAsBack } from "./modal-back.js";
 
 const PRIME_INFERENCE_PROVIDER_ID = "prime-inference";
 const PRIME_LOGO_LINES = PRIME_BUTTERFLY_LOGO.split("\n");
@@ -307,7 +308,11 @@ export class LoginDialogComponent extends Container implements Focusable {
 	handleInput(data: string): void {
 		const kb = getKeybindings();
 
-		if (kb.matches(data, "tui.select.cancel")) {
+		// Left arrow acts as "back" like Esc. While an editable field is awaiting
+		// input, only treat it as back at the start of the text so left still moves
+		// the cursor mid-edit; on info/continue screens there is no field to guard.
+		const backGuardInput = this.inputResolver ? this.input : undefined;
+		if (kb.matches(data, "tui.select.cancel") || shouldTreatAsBack(data, backGuardInput)) {
 			this.cancel();
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -65,6 +65,10 @@ export class LoginDialogComponent extends Container implements Focusable {
 	private abortController = new AbortController();
 	private inputResolver?: (value: string) => void;
 	private inputRejecter?: (error: Error) => void;
+	// True only while the editable paste field is actually shown in the panel.
+	// Tracks visibility directly rather than inferring it from inputResolver,
+	// which can outlive the field when a new screen clears the content.
+	private inputVisible = false;
 	private continueResolver?: () => void;
 	private continueRejecter?: (error: Error) => void;
 
@@ -165,6 +169,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.addSectionTitle("Manual fallback");
 		this.addMutedText(prompt);
 		this.contentContainer.addChild(this.input);
+		this.inputVisible = true;
 		this.contentContainer.addChild(new Text(theme.fg("muted", keyHint("tui.select.cancel", "cancel")), 0, 0));
 		this.tui.requestRender();
 
@@ -192,6 +197,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 			this.contentContainer.addChild(new Text(theme.fg("muted", `e.g., ${placeholder}`), 0, 0));
 		}
 		this.contentContainer.addChild(this.input);
+		this.inputVisible = true;
 		this.contentContainer.addChild(
 			new Text(
 				theme.fg("muted", `${keyHint("tui.select.confirm", "submit")}  ${keyHint("tui.select.cancel", "cancel")}`),
@@ -266,6 +272,8 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 	private startContent(): void {
 		this.contentContainer.clear();
+		// The cleared panel no longer shows the paste field.
+		this.inputVisible = false;
 		if (this.isPrimeInference) {
 			this.contentContainer.addChild(new PrimeLoginHeader());
 			this.contentContainer.addChild(new Spacer(1));
@@ -308,10 +316,10 @@ export class LoginDialogComponent extends Container implements Focusable {
 	handleInput(data: string): void {
 		const kb = getKeybindings();
 
-		// Left arrow acts as "back" like Esc. While an editable field is awaiting
-		// input, only treat it as back at the start of the text so left still moves
+		// Left arrow acts as "back" like Esc. While the editable field is actually
+		// shown, only treat it as back at the start of the text so left still moves
 		// the cursor mid-edit; on info/continue screens there is no field to guard.
-		const backGuardInput = this.inputResolver ? this.input : undefined;
+		const backGuardInput = this.inputVisible ? this.input : undefined;
 		if (kb.matches(data, "tui.select.cancel") || shouldTreatAsBack(data, backGuardInput)) {
 			this.cancel();
 			return;

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -265,6 +265,10 @@ export class MenuSearchInput implements Component, Focusable, FullWidthMenuCompo
 		return this.input.getValue();
 	}
 
+	getCursor(): number {
+		return this.input.getCursor();
+	}
+
 	setValue(value: string): void {
 		this.input.setValue(value);
 	}

--- a/packages/coding-agent/src/modes/interactive/components/modal-back.ts
+++ b/packages/coding-agent/src/modes/interactive/components/modal-back.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared helper for treating the left arrow as "go back" inside dialogs.
+ *
+ * The left arrow is bound to `app.modal.back` so that, like Esc, it dismisses a
+ * dialog and returns to the previous screen. Dialogs that contain a text field
+ * (model filter, login input, session search) must not steal the left arrow
+ * while the user is editing: it only acts as back when the field is empty or the
+ * cursor is already at the start (column 0). This mirrors the chat editor's
+ * existing `onAgentsBack` guard so behaviour stays consistent across the app.
+ */
+
+import { getKeybindings } from "@earendil-works/pi-tui";
+
+/** A text input whose cursor position can be inspected. */
+export interface BackGuardInput {
+	getCursor(): number;
+}
+
+/**
+ * Returns true when `data` should dismiss the current dialog (act like Esc).
+ *
+ * Pass the dialog's text input to keep the left arrow available for cursor
+ * movement: back only triggers when the cursor sits at column 0. Omit `input`
+ * for dialogs that have no text field, where left is always back.
+ */
+export function shouldTreatAsBack(data: string, input?: BackGuardInput): boolean {
+	if (!getKeybindings().matches(data, "app.modal.back")) {
+		return false;
+	}
+	return input === undefined || input.getCursor() === 0;
+}

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -11,6 +11,7 @@ import {
 	MenuSearchInput,
 	type MenuViewportProvider,
 } from "./menu-panel.js";
+import { shouldTreatAsBack } from "./modal-back.js";
 
 interface ModelItem {
 	provider: string;
@@ -368,8 +369,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			this.handleConfirm();
 		}
-		// Escape or Ctrl+C
-		else if (kb.matches(keyData, "tui.select.cancel")) {
+		// Escape / Ctrl+C, or left arrow when the search field is at its start
+		else if (kb.matches(keyData, "tui.select.cancel") || shouldTreatAsBack(keyData, this.searchInput)) {
 			this.onCancelCallback();
 		}
 		// Pass everything else to search input

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -20,6 +20,7 @@ import type {
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
+import { shouldTreatAsBack } from "./modal-back.js";
 import { filterAndSortSessions, hasSessionName, type NameFilter, type SortMode } from "./session-selector-search.js";
 
 type SessionScope = "current" | "all";
@@ -626,8 +627,8 @@ class SessionList implements Component, Focusable {
 				this.onSelect(selected.session.path);
 			}
 		}
-		// Escape - cancel
-		else if (kb.matches(keyData, "tui.select.cancel")) {
+		// Escape, or left arrow when the search field is at its start - cancel
+		else if (kb.matches(keyData, "tui.select.cancel") || shouldTreatAsBack(keyData, this.searchInput)) {
 			if (this.onCancel) {
 				this.onCancel();
 			}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -544,8 +544,9 @@ class SessionList implements Component, Focusable {
 
 		// Any key other than another delete press cancels an armed confirmation
 		// and is then handled normally, like the agents view.
+		const hadDeleteConfirmation = this.confirmingDeletePath !== null;
 		if (
-			this.confirmingDeletePath !== null &&
+			hadDeleteConfirmation &&
 			!kb.matches(keyData, "app.agents.delete") &&
 			!kb.matches(keyData, "app.session.deleteNoninvasive")
 		) {
@@ -627,8 +628,13 @@ class SessionList implements Component, Focusable {
 				this.onSelect(selected.session.path);
 			}
 		}
-		// Escape, or left arrow when the search field is at its start - cancel
-		else if (kb.matches(keyData, "tui.select.cancel") || shouldTreatAsBack(keyData, this.searchInput)) {
+		// Escape, or left arrow when the search field is at its start - cancel.
+		// If this same keypress just disarmed a delete confirmation, left only
+		// disarms (like other nav keys); Esc still cancels, matching its role.
+		else if (
+			kb.matches(keyData, "tui.select.cancel") ||
+			(!hadDeleteConfirmation && shouldTreatAsBack(keyData, this.searchInput))
+		) {
 			if (this.onCancel) {
 				this.onCancel();
 			}

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -39,6 +39,10 @@ export class Input implements Component, Focusable {
 		return this.value;
 	}
 
+	getCursor(): number {
+		return this.cursor;
+	}
+
 	setValue(value: string): void {
 		this.value = value;
 		this.cursor = Math.min(this.cursor, value.length);


### PR DESCRIPTION
- right arrow in the agents view now opens the selected session's chat view, mirroring the existing left-arrow-goes-back shortcut.
- left arrow now closes the model, login, and session dialogs like esc, but only when the text field is empty or the cursor is at the start so it still moves the cursor mid-edit.
- adds a small shared helper and a cursor-position accessor so the guard behaves consistently across dialogs; the tree navigator is left alone since it already uses left for paging.

ENG-4218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard and hint-only UX changes with no auth, data, or API impact.
> 
> **Overview**
> Adds **Right** and **Left** as first-class TUI shortcuts alongside existing **Left** back in chat.
> 
> **Agents view:** **Right** (`app.agents.open`) opens the selected agent when the prompt is empty (including whitespace-only) and reply mode is off—same conditions as confirm. The hint row documents the binding.
> 
> **Dialogs:** **Left** (`app.modal.back`) dismisses the login, model, and session selectors like Esc. A shared `shouldTreatAsBack` helper applies the back action only when there is no guarded field or the search/paste cursor is at column 0, so **Left** still moves the cursor while editing. Login tracks `inputVisible` so back-guarding matches whether the paste field is actually on screen. Session selector treats **Left** like other nav keys when a delete confirmation was just disarmed (only disarms); Esc still closes the dialog.
> 
> **Plumbing:** `Input.getCursor()` and `MenuSearchInput.getCursor()` expose cursor position for those guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e3ce6d98977635ec4a7a76721449c277397bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make arrow keys first-class navigation shortcuts in agents, model selector, and session selector
> - Adds `app.agents.open` (Right Arrow) and `app.modal.back` (Left Arrow) keybindings in [keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/241/files#diff-f93dc44960592e9f476dd0994e2f5f2f96756644ce1c9ffaa4e45dab0db65739).
> - Right Arrow opens the selected agent's chat in the agents view when the prompt is empty and no reply is being composed.
> - Left Arrow acts as back/cancel in the login dialog, model selector, and session selector, but only when the cursor is at position 0 in any visible text input — otherwise it moves the cursor normally.
> - A shared [modal-back.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/241/files#diff-db8cf7e561006e52f17f7884b85ff6c7ec9279768ac7a326675b6bd72f048552) helper (`shouldTreatAsBack`) centralizes cursor-aware back detection across all dialogs.
> - Behavioral Change: Left Arrow now cancels dialogs (with cursor-position guard) in addition to Esc/Ctrl+C.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7e3ce6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->