### PR TITLE
fix trace upload failing with und_err_invalid_arg on undici 7.28

### DIFF
--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -442,8 +442,6 @@ async function performAgentTraceUpload(options: AgentTraceUploadOptions): Promis
 
 	const traceContext = resolveTraceContext(options.sessionFile, header);
 	const bodyBytes = Buffer.byteLength(body, "utf8");
-	// No manual Content-Length: fetch derives it from the body, and undici >=7.28
-	// rejects the explicit header on a string body with UND_ERR_INVALID_ARG.
 	const headers: Record<string, string> = {
 		Authorization: `Bearer ${credential.apiKey}`,
 		"Content-Type": "application/x-ndjson",

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -442,11 +442,12 @@ async function performAgentTraceUpload(options: AgentTraceUploadOptions): Promis
 
 	const traceContext = resolveTraceContext(options.sessionFile, header);
 	const bodyBytes = Buffer.byteLength(body, "utf8");
+	// No manual Content-Length: fetch derives it from the body, and undici >=7.28
+	// rejects the explicit header on a string body with UND_ERR_INVALID_ARG.
 	const headers: Record<string, string> = {
 		Authorization: `Bearer ${credential.apiKey}`,
 		"Content-Type": "application/x-ndjson",
 		Accept: "application/json",
-		"Content-Length": String(bodyBytes),
 		"X-Trace-Id": traceContext.traceId,
 		"X-Cwd": header.cwd,
 		"X-Agent-Version": VERSION,

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -226,7 +225,9 @@ describe("agent trace upload", () => {
 		expect(headers.get("x-parent-session")).toBe("parent-session");
 		expect(headers.get("x-cwd")).toBe(cwd);
 		expect(headers.get("x-agent-version")).toBeTruthy();
-		expect(headers.get("content-length")).toBe(String(Buffer.byteLength(call.init.body as string, "utf8")));
+		// Content-Length is left for fetch to derive; setting it explicitly trips
+		// UND_ERR_INVALID_ARG on undici >=7.28 with a string body.
+		expect(headers.get("content-length")).toBeNull();
 	});
 
 	it("uses the production trace API unless a trace-specific base URL is configured", async () => {

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -225,8 +225,6 @@ describe("agent trace upload", () => {
 		expect(headers.get("x-parent-session")).toBe("parent-session");
 		expect(headers.get("x-cwd")).toBe(cwd);
 		expect(headers.get("x-agent-version")).toBeTruthy();
-		// Content-Length is left for fetch to derive; setting it explicitly trips
-		// UND_ERR_INVALID_ARG on undici >=7.28 with a string body.
 		expect(headers.get("content-length")).toBeNull();
 	});
 


### PR DESCRIPTION
- trace uploads started failing with a fetch error because the uploader set a content-length header by hand alongside a string body.
- undici 7.28 now rejects that combination before the request is sent, so every upload aborted with und_err_invalid_arg.
- dropped the manual header and let fetch derive content-length itself, which works on both the old and new undici.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-header change on outbound trace uploads with no auth or payload format changes; behavior matches letting fetch set Content-Length automatically.
> 
> **Overview**
> Fixes agent trace uploads that fail with **`und_err_invalid_arg`** on undici 7.28 by no longer setting **`Content-Length`** on the PUT in `performAgentTraceUpload` when the body is a string. Fetch/undici now rejects that combination; length is left for the runtime to derive.
> 
> The trace upload test now expects **`content-length`** to be absent on the recorded request headers instead of matching the UTF-8 byte length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805f634262d6f1e36ca2261337474330a88822f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix trace upload failure by removing explicit `Content-Length` header in `performAgentTraceUpload`
> undici 7.28 throws `und_err_invalid_arg` when a request sets `Content-Length` explicitly alongside a body. The fix removes the `Content-Length` header from the outgoing request in [agent-traces.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/243/files#diff-80860403dee6901cec0476cf83c00961de058f140b3d95dc92ff3d43c50e64d2); undici computes it automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 805f634.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->