### PR TITLE
put the recap status in its own tag and harden parsing

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -22,17 +22,16 @@ export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI 
 
 Output ONLY these two tags, nothing before, between, or after. Do not think out loud, explain, or count words.
 <recap>a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period</recap>
-<status>one of WORKING, NEEDS_INPUT, COMPLETED</status>
+<status>one of NEEDS_INPUT, COMPLETED</status>
 
 STATUS meaning:
-- WORKING: the agent is mid-task and still acting.
 - COMPLETED: the agent finished its turn AND the user's request is fully done with nothing left.
 - NEEDS_INPUT: the agent finished its turn but the task is not fully done — it asked a question, hit a blocker, or needs more prompting.
-When the agent is idle and you are unsure between COMPLETED and NEEDS_INPUT, choose NEEDS_INPUT.
+When you are unsure between COMPLETED and NEEDS_INPUT, choose NEEDS_INPUT.
 
 Example:
 <recap>Refactoring the auth middleware and updating its tests</recap>
-<status>WORKING</status>`;
+<status>NEEDS_INPUT</status>`;
 
 export interface AgentStatusResult {
 	summary: string;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -20,9 +20,9 @@ const SUMMARY_MAX_TOKENS = 400;
 
 export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI coding agent dashboard. You are given the recent conversation between a user and the agent, plus whether the agent is currently working or idle.
 
-Output ONLY these two lines, nothing before or after. Do not think out loud, explain, or count words. Put the summary inside <recap></recap> tags and write nothing after the closing tag.
-SUMMARY: <recap>a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period</recap>
-STATUS: one of WORKING, NEEDS_INPUT, COMPLETED
+Output ONLY these two tags, nothing before, between, or after. Do not think out loud, explain, or count words.
+<recap>a present-tense clause, at most 12 words, saying what the agent is doing or just did, no trailing period</recap>
+<status>one of WORKING, NEEDS_INPUT, COMPLETED</status>
 
 STATUS meaning:
 - WORKING: the agent is mid-task and still acting.
@@ -31,8 +31,8 @@ STATUS meaning:
 When the agent is idle and you are unsure between COMPLETED and NEEDS_INPUT, choose NEEDS_INPUT.
 
 Example:
-SUMMARY: <recap>Refactoring the auth middleware and updating its tests</recap>
-STATUS: WORKING`;
+<recap>Refactoring the auth middleware and updating its tests</recap>
+<status>WORKING</status>`;
 
 export interface AgentStatusResult {
 	summary: string;
@@ -112,7 +112,13 @@ function cleanRecap(raw: string): string | undefined {
 	const value = raw
 		.trim()
 		.replace(REASONING_TRAILER, "")
+		// Drop a leaked label/connector prefix the model narrates before the recap,
+		// e.g. `Recap: . So: Curating…` or `SUMMARY: <recap>Curating…`.
+		.replace(/^(?:summary|recap|status)\s*:\s*/i, "")
+		.replace(/^<\/?recap>\s*/i, "")
+		.replace(/^[.\s]*(?:so|then|thus|therefore)\s*:?\s*/i, "")
 		.replace(/^["“']+|["”']+$/g, "")
+		.replace(/^[.\s]+/, "")
 		.replace(/[.\s]+$/, "")
 		.trim();
 	if (!value || value.startsWith("<") || /present-tense|12 words/i.test(value)) {
@@ -121,42 +127,54 @@ function cleanRecap(raw: string): string | undefined {
 	if (COUNTING_ARTIFACT.test(value) || value.split(/\s+/).length > MAX_RECAP_WORDS) {
 		return undefined;
 	}
+	// A lone word is narration debris, not a recap clause.
+	if (value.split(/\s+/).length < 2) {
+		return undefined;
+	}
 	return value;
 }
 
 /**
- * Parse the two-line reply. The recap is delimited by `<recap></recap>` so
- * trailing chain-of-thought falls outside it; without the close tag we fall back
- * to the `SUMMARY:`/`RECAP:` line and cut inline word-counting. The last clean
- * recap wins. A still-polluted candidate is rejected; idle verdicts default to
- * needs_input.
+ * Parse the tagged reply. Recap and status are delimited by `<recap></recap>`
+ * and `<status></status>` so trailing chain-of-thought falls outside them. The
+ * last well-formed tag wins so a corrected draft resolves. When a tag is missing
+ * or its body is rejected we fall back to the legacy `SUMMARY:`/`RECAP:`/`STATUS:`
+ * lines and cut inline word-counting. A still-polluted candidate is rejected;
+ * idle verdicts default to needs_input.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
+	// Normalize unicode angle-bracket lookalikes (e.g. ‹ › ＜ ＞) the model sometimes
+	// emits instead of < > so a malformed <recap›…</recap> still parses as a tag.
 	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
 	const cleaned = text
+		.replace(/[‹＜]/g, "<")
+		.replace(/[›＞]/g, ">")
 		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
 		.replace(reasoningTag, " ");
 
-	// Prefer the tag (last match wins so a corrected draft resolves). Fall back to
-	// the SUMMARY/RECAP lines only when the tag is missing or its body is rejected;
+	// Prefer the tags (last match wins so a corrected draft resolves). Fall back to
+	// the legacy SUMMARY/RECAP/STATUS lines only when a tag is missing or rejected;
 	// among lines the last clean one wins.
-	const tagMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
-	const tagSummary = tagMatch ? cleanRecap(tagMatch[1]!) : undefined;
+	const recapMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
+	const tagSummary = recapMatch ? cleanRecap(recapMatch[1]!) : undefined;
 	let summary = tagSummary;
 
-	let status: string | undefined;
+	const statusMatch = [...cleaned.matchAll(/<status>\s*([a-z_]+)\s*<\/status>/gi)].at(-1);
+	let status: string | undefined = statusMatch ? statusMatch[1]!.toUpperCase() : undefined;
+	const tagStatus = status;
+
 	for (const rawLine of cleaned.split("\n")) {
 		const line = rawLine.trim();
-		const summaryMatch = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
-		if (summaryMatch) {
+		const summaryLine = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
+		if (summaryLine) {
 			if (!tagSummary) {
-				summary = cleanRecap(summaryMatch[1]!.replace(/<\/?recap>/gi, "")) ?? summary;
+				summary = cleanRecap(summaryLine[1]!.replace(/<\/?recap>/gi, "")) ?? summary;
 			}
 			continue;
 		}
-		const statusMatch = /^status\s*:\s*([a-z_]+)/i.exec(line);
-		if (statusMatch) {
-			status = statusMatch[1]!.toUpperCase();
+		const statusLine = /^status\s*:\s*([a-z_]+)/i.exec(line);
+		if (statusLine && !tagStatus) {
+			status = statusLine[1]!.toUpperCase();
 		}
 	}
 	if (!summary) {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -106,18 +106,12 @@ const REASONING_TRAILER = /\s*(?:["”]\s*)?(?:\bthat['’]?s\s+\d+\s*words?\b|\
 const COUNTING_ARTIFACT = /\(\d+\)|=\s*\d+\s*words?\b/i;
 const MAX_RECAP_WORDS = 16;
 
-/** Strip reasoning trailer and quotes, then reject anything still polluted. */
+/** Trim quotes and trailing punctuation from the tag body, then reject anything still polluted. */
 function cleanRecap(raw: string): string | undefined {
 	const value = raw
 		.trim()
 		.replace(REASONING_TRAILER, "")
-		// Drop a leaked label/connector prefix the model narrates before the recap,
-		// e.g. `Recap: . So: Curating…` or `SUMMARY: <recap>Curating…`.
-		.replace(/^(?:summary|recap|status)\s*:\s*/i, "")
-		.replace(/^<\/?recap>\s*/i, "")
-		.replace(/^[.\s]*(?:so|then|thus|therefore)\s*:?\s*/i, "")
 		.replace(/^["“']+|["”']+$/g, "")
-		.replace(/^[.\s]+/, "")
 		.replace(/[.\s]+$/, "")
 		.trim();
 	if (!value || value.startsWith("<") || /present-tense|12 words/i.test(value)) {
@@ -126,62 +120,30 @@ function cleanRecap(raw: string): string | undefined {
 	if (COUNTING_ARTIFACT.test(value) || value.split(/\s+/).length > MAX_RECAP_WORDS) {
 		return undefined;
 	}
-	// A lone word is narration debris, not a recap clause.
-	if (value.split(/\s+/).length < 2) {
-		return undefined;
-	}
 	return value;
 }
 
 /**
- * Parse the tagged reply. Recap and status are delimited by `<recap></recap>`
- * and `<status></status>` so trailing chain-of-thought falls outside them. The
- * last well-formed tag wins so a corrected draft resolves. When a tag is missing
- * or its body is rejected we fall back to the legacy `SUMMARY:`/`RECAP:`/`STATUS:`
- * lines and cut inline word-counting. A still-polluted candidate is rejected;
- * idle verdicts default to needs_input.
+ * Parse the tagged reply: take the content of `<recap></recap>` and
+ * `<status></status>` and ignore everything else (narration, reasoning, stray
+ * prose). The last well-formed tag wins so a corrected draft resolves. A recap
+ * body that is still polluted is rejected; idle verdicts default to needs_input.
  */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
 	// Normalize unicode angle-bracket lookalikes (e.g. ‹ › ＜ ＞) the model sometimes
 	// emits instead of < > so a malformed <recap›…</recap> still parses as a tag.
-	const reasoningTag = /<\/?(?:think|thinking|reasoning|redacted_thinking)>/gi;
-	const cleaned = text
-		.replace(/[‹＜]/g, "<")
-		.replace(/[›＞]/g, ">")
-		.replace(/<(think|thinking|reasoning|redacted_thinking)>[\s\S]*?<\/\1>/gi, " ")
-		.replace(reasoningTag, " ");
+	const cleaned = text.replace(/[‹＜]/g, "<").replace(/[›＞]/g, ">");
 
-	// Prefer the tags (last match wins so a corrected draft resolves). Fall back to
-	// the legacy SUMMARY/RECAP/STATUS lines only when a tag is missing or rejected;
-	// among lines the last clean one wins.
 	const recapMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);
-	const tagSummary = recapMatch ? cleanRecap(recapMatch[1]!) : undefined;
-	let summary = tagSummary;
-
-	const statusMatch = [...cleaned.matchAll(/<status>\s*([a-z_]+)\s*<\/status>/gi)].at(-1);
-	let status: string | undefined = statusMatch ? statusMatch[1]!.toUpperCase() : undefined;
-	const tagStatus = status;
-
-	for (const rawLine of cleaned.split("\n")) {
-		const line = rawLine.trim();
-		const summaryLine = /^(?:summary|recap)\s*:\s*(.+)$/i.exec(line);
-		if (summaryLine) {
-			if (!tagSummary) {
-				summary = cleanRecap(summaryLine[1]!.replace(/<\/?recap>/gi, "")) ?? summary;
-			}
-			continue;
-		}
-		const statusLine = /^status\s*:\s*([a-z_]+)/i.exec(line);
-		if (statusLine && !tagStatus) {
-			status = statusLine[1]!.toUpperCase();
-		}
-	}
+	const summary = recapMatch ? cleanRecap(recapMatch[1]!) : undefined;
 	if (!summary) {
 		return undefined;
 	}
 	if (isWorking) {
 		return { summary };
 	}
+	const statusMatch = [...cleaned.matchAll(/<status>\s*([a-z_]+)\s*<\/status>/gi)].at(-1);
+	const status = statusMatch ? statusMatch[1]!.toUpperCase() : undefined;
 	const taskState: AgentTaskState = status === "COMPLETED" ? "completed" : "needs_input";
 	return { summary, taskState };
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -15,7 +15,7 @@ const SUMMARY_MODEL_ID = "nvidia/nemotron-3-nano-30b-a3b";
 
 const SUMMARY_CONTEXT_MESSAGES = 8;
 const SUMMARY_MAX_CHARS_PER_MESSAGE = 600;
-// Generous so a chatty model still reaches the SUMMARY line before truncation.
+// Generous so a chatty model still closes the tags before truncation.
 const SUMMARY_MAX_TOKENS = 400;
 
 export const AGENT_STATUS_SYSTEM_PROMPT = `You generate a status line for an AI coding agent dashboard. You are given the recent conversation between a user and the agent, plus whether the agent is currently working or idle.
@@ -99,14 +99,13 @@ export function buildStatusContext(messages: readonly AgentMessage[], isWorking:
 	return `<agent-state>${state}</agent-state>\n<conversation>\n${lines.join("\n")}\n</conversation>`;
 }
 
-// Cuts the word-counting chain-of-thought the model appends on the recap line,
-// e.g. `Sending X. That's 5 words? Count: X(1)... = 6 words.`. Restricted to
-// structural counting markers so plain words ("Waiting for CI") survive.
+// Cuts a word-counting trailer the model sometimes appends, e.g.
+// `Sending X. That's 5 words? Count: X(1)... = 6 words.`. Kept to structural
+// counting markers so plain words ("Waiting for CI") survive.
 const REASONING_TRAILER = /\s*(?:["”]\s*)?(?:\bthat['’]?s\s+\d+\s*words?\b|\bcount\s*:|\(\d+\)|=\s*\d+\s*words?\b).*/i;
 const COUNTING_ARTIFACT = /\(\d+\)|=\s*\d+\s*words?\b/i;
 const MAX_RECAP_WORDS = 16;
 
-/** Trim quotes and trailing punctuation from the tag body, then reject anything still polluted. */
 function cleanRecap(raw: string): string | undefined {
 	const value = raw
 		.trim()
@@ -123,15 +122,9 @@ function cleanRecap(raw: string): string | undefined {
 	return value;
 }
 
-/**
- * Parse the tagged reply: take the content of `<recap></recap>` and
- * `<status></status>` and ignore everything else (narration, reasoning, stray
- * prose). The last well-formed tag wins so a corrected draft resolves. A recap
- * body that is still polluted is rejected; idle verdicts default to needs_input.
- */
+/** Take the content of the last `<recap>` and `<status>` tags; idle verdicts default to needs_input. */
 export function parseAgentStatusResponse(text: string, isWorking: boolean): AgentStatusResult | undefined {
-	// Normalize unicode angle-bracket lookalikes (e.g. ‹ › ＜ ＞) the model sometimes
-	// emits instead of < > so a malformed <recap›…</recap> still parses as a tag.
+	// Normalize unicode angle-bracket lookalikes (‹ › ＜ ＞) so a tag written with them still parses.
 	const cleaned = text.replace(/[‹＜]/g, "<").replace(/[›＞]/g, ">");
 
 	const recapMatch = [...cleaned.matchAll(/<recap>([\s\S]*?)<\/recap>/gi)].at(-1);

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -18,176 +18,116 @@ function assistantMessage(text: string, tools: string[] = []): AgentMessage {
 
 describe("daemon session summarizer", () => {
 	describe("parseAgentStatusResponse", () => {
-		test("parses summary and completion verdict for an idle session", () => {
-			const result = parseAgentStatusResponse("SUMMARY: Added the API reference page.\nSTATUS: COMPLETED", false);
+		test("parses recap and completion verdict for an idle session", () => {
+			const result = parseAgentStatusResponse(
+				"<recap>Added the API reference page</recap>\n<status>COMPLETED</status>",
+				false,
+			);
 			expect(result).toEqual({ summary: "Added the API reference page", taskState: "completed" });
 		});
 
 		test("maps NEEDS_INPUT for idle sessions", () => {
-			const result = parseAgentStatusResponse("SUMMARY: Asked which database to target\nSTATUS: NEEDS_INPUT", false);
+			const result = parseAgentStatusResponse(
+				"<recap>Asked which database to target</recap>\n<status>NEEDS_INPUT</status>",
+				false,
+			);
 			expect(result?.taskState).toBe("needs_input");
 		});
 
-		test("omits the verdict while working", () => {
-			const result = parseAgentStatusResponse("SUMMARY: Refactoring token validation\nSTATUS: WORKING", true);
+		test("omits the verdict while working and ignores any status tag", () => {
+			const result = parseAgentStatusResponse(
+				"<recap>Refactoring token validation</recap>\n<status>COMPLETED</status>",
+				true,
+			);
 			expect(result).toEqual({ summary: "Refactoring token validation" });
 		});
 
-		test("falls back to needs_input on an unrecognized or hedged idle verdict", () => {
-			expect(parseAgentStatusResponse("SUMMARY: Doing something\nSTATUS: WORKING", false)?.taskState).toBe(
-				"needs_input",
-			);
-			expect(parseAgentStatusResponse("SUMMARY: Doing something\nSTATUS: MAYBE", false)?.taskState).toBe(
-				"needs_input",
-			);
-			expect(parseAgentStatusResponse("SUMMARY: Doing something", false)?.taskState).toBe("needs_input");
+		test("falls back to needs_input on a missing or unrecognized idle verdict", () => {
+			expect(
+				parseAgentStatusResponse("<recap>Doing something</recap>\n<status>MAYBE</status>", false)?.taskState,
+			).toBe("needs_input");
+			expect(parseAgentStatusResponse("<recap>Doing something</recap>", false)?.taskState).toBe("needs_input");
 		});
 
-		test("requires the SUMMARY marker and never surfaces free-form text", () => {
-			// A chatty/reasoning model that narrates instead of answering yields no
-			// recap rather than leaking its thinking.
+		test("ignores narration outside the tags and never leaks free-form text", () => {
+			// A chatty/reasoning model that narrates instead of using tags yields no recap.
 			expect(parseAgentStatusResponse("Investigating the failing test.", true)).toBeUndefined();
 			expect(
 				parseAgentStatusResponse(
-					"We need to produce exactly two lines: SUMMARY: <one present-tense clause> and STATUS: with a",
-					false,
+					"Recap: . So: <recap>Curating a niche list of Muon optimizer papers</recap>",
+					true,
 				),
-			).toBeUndefined();
+			).toEqual({ summary: "Curating a niche list of Muon optimizer papers" });
 		});
 
-		test("takes the answer after inline reasoning and strips think tags", () => {
-			const reasoning =
-				"<think>Let me decide. The agent finished editing.</think>\nSUMMARY: Updated the login handler\nSTATUS: COMPLETED";
-			expect(parseAgentStatusResponse(reasoning, false)).toEqual({
+		test("ignores reasoning prose around the tags", () => {
+			const text =
+				"Let me decide. The agent finished editing.\n<recap>Updated the login handler</recap>\n<status>COMPLETED</status>";
+			expect(parseAgentStatusResponse(text, false)).toEqual({
 				summary: "Updated the login handler",
 				taskState: "completed",
 			});
 		});
 
-		test("ignores an echoed prompt template", () => {
-			const echoed = "SUMMARY: <one present-tense clause, at most 12 words, no trailing period>\nSTATUS: WORKING";
+		test("rejects an echoed prompt template", () => {
+			const echoed =
+				"<recap>a present-tense clause, at most 12 words, no trailing period</recap>\n<status>COMPLETED</status>";
 			expect(parseAgentStatusResponse(echoed, true)).toBeUndefined();
 		});
 
-		test("strips reasoning tag variants before parsing", () => {
-			for (const tag of ["think", "thinking", "reasoning", "redacted_thinking"]) {
-				const text = `<${tag}>deliberating about the answer</${tag}>\nSUMMARY: Wired the recap line\nSTATUS: COMPLETED`;
-				expect(parseAgentStatusResponse(text, false)).toEqual({
-					summary: "Wired the recap line",
-					taskState: "completed",
-				});
-			}
-		});
-
-		test("returns undefined when no summary is present", () => {
+		test("returns undefined when no recap tag is present", () => {
 			expect(parseAgentStatusResponse("", false)).toBeUndefined();
-			expect(parseAgentStatusResponse("STATUS: COMPLETED", false)).toBeUndefined();
+			expect(parseAgentStatusResponse("<status>COMPLETED</status>", false)).toBeUndefined();
 		});
 
-		test("extracts the recap from <recap> tags", () => {
-			const text = "SUMMARY: <recap>Sending SSH auth retry to tcg-autoresearch-rl</recap>\nSTATUS: WORKING";
+		test("drops chain-of-thought that falls outside the closing recap tag", () => {
+			const text =
+				"<recap>Sending SSH auth retry to tcg-autoresearch-rl</recap> That's 5 words? Count: Sending(1) SSH(2) = 6 words.\n<status>NEEDS_INPUT</status>";
 			expect(parseAgentStatusResponse(text, true)).toEqual({
 				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
 			});
 		});
 
-		test("drops chain-of-thought after the closing recap tag", () => {
+		test("rejects a recap body that is nothing but counting artifacts", () => {
+			expect(parseAgentStatusResponse("<recap>(1) word(2) count(3) = 3 words</recap>", true)).toBeUndefined();
+		});
+
+		test("rejects a rambling recap that blows past the word ceiling", () => {
 			const text =
-				"SUMMARY: <recap>Sending SSH auth retry to tcg-autoresearch-rl</recap> That's 5 words? Count: Sending(1) SSH(2) auth(3) retry(4) to(5) tcg-autoresearch-rl(6) = 6 words. Under..\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({
-				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
-			});
-		});
-
-		test("cuts inline reasoning when the model omits the closing tag", () => {
-			const text =
-				"SUMMARY: Sending SSH auth retry to tcg-autoresearch-rl. That's 5 words? Count: Sending(1) SSH(2) = 6 words. Under\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({
-				summary: "Sending SSH auth retry to tcg-autoresearch-rl",
-			});
-		});
-
-		test("salvages the clean prefix before counting artifacts begin", () => {
-			const text = "SUMMARY: Counting words(1) two(2) three(3) = 3 words\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Counting words" });
-		});
-
-		test("rejects a candidate whose counting starts at the very first word", () => {
-			// No clean prefix to salvage — the recap is nothing but the artifact.
-			const text = "SUMMARY: (1) word(2) count(3) = 3 words\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toBeUndefined();
-		});
-
-		test("rejects a rambling candidate that blows past the word ceiling", () => {
-			const text =
-				"SUMMARY: this is a very long rambling sentence that just keeps going and going well past any reasonable recap length\nSTATUS: WORKING";
+				"<recap>this is a very long rambling sentence that just keeps going and going well past any reasonable recap length</recap>";
 			expect(parseAgentStatusResponse(text, true)).toBeUndefined();
 		});
 
 		test("strips wrapping quotes the model adds around the recap", () => {
-			const text = 'SUMMARY: <recap>"Wiring the recap line"</recap>\nSTATUS: COMPLETED';
+			const text = '<recap>"Wiring the recap line"</recap>\n<status>COMPLETED</status>';
 			expect(parseAgentStatusResponse(text, false)).toEqual({
 				summary: "Wiring the recap line",
 				taskState: "completed",
 			});
 		});
 
-		test("accepts RECAP: as a synonym for SUMMARY:", () => {
-			const text = "RECAP: Restarting the daemon\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Restarting the daemon" });
-		});
-
 		test("ignores an open recap tag with no close", () => {
-			const text = "SUMMARY: <recap>Editing the parser\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
+			expect(
+				parseAgentStatusResponse("<recap>Editing the parser\n<status>NEEDS_INPUT</status>", true),
+			).toBeUndefined();
 		});
 
-		test("keeps recaps that start with words also used in reasoning", () => {
-			for (const recap of ["Waiting for CI to finish", "Let me know once tests pass", "Under review by the team"]) {
-				expect(parseAgentStatusResponse(`SUMMARY: ${recap}\nSTATUS: WORKING`, true)).toEqual({ summary: recap });
-			}
-		});
-
-		test("takes the last SUMMARY line when a draft is corrected", () => {
-			const text = "SUMMARY: Draft recap\nSUMMARY: Final corrected recap\nSTATUS: WORKING";
+		test("takes the last recap tag when a draft is corrected", () => {
+			const text = "<recap>Draft recap</recap>\n<recap>Final corrected recap</recap>";
 			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Final corrected recap" });
 		});
 
-		test("falls back to a SUMMARY line when the tagged body is rejected", () => {
-			// The tag body is pure counting (rejected); a later valid line must win.
-			const text = "<recap>(1) two(2) = 2 words</recap>\nSUMMARY: Editing the parser\nSTATUS: WORKING";
-			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
-		});
-
-		test("parses recap and status from their tags", () => {
-			const text = "<recap>Updating the login handler</recap>\n<status>COMPLETED</status>";
-			expect(parseAgentStatusResponse(text, false)).toEqual({
-				summary: "Updating the login handler",
-				taskState: "completed",
-			});
-		});
-
-		test("maps NEEDS_INPUT from the status tag", () => {
-			const text = "<recap>Asked which database to target</recap>\n<status>NEEDS_INPUT</status>";
-			expect(parseAgentStatusResponse(text, false)?.taskState).toBe("needs_input");
-		});
-
 		test("takes the last status tag when a draft is corrected", () => {
-			const text = "<recap>Editing the parser</recap>\n<status>WORKING</status>\n<status>COMPLETED</status>";
+			const text = "<recap>Editing the parser</recap>\n<status>NEEDS_INPUT</status>\n<status>COMPLETED</status>";
 			expect(parseAgentStatusResponse(text, false)?.taskState).toBe("completed");
 		});
 
-		test("recovers a recap written with unicode angle-bracket lookalikes", () => {
-			// Real failure: the model narrated, then emitted `<recap›…` with a ›
-			// lookalike and no close tag, leaking "So" as the recap.
-			const text = "Recap: . So:\nSUMMARY: <recap›Curating a niche list of Muon optimizer papers";
+		test("normalizes unicode angle-bracket lookalikes around the tags", () => {
+			// The model sometimes emits › ‹ instead of > < ; normalize so the tag still parses.
+			const text = "‹recap›Curating a niche list of Muon optimizer papers‹/recap›";
 			expect(parseAgentStatusResponse(text, true)).toEqual({
 				summary: "Curating a niche list of Muon optimizer papers",
 			});
-		});
-
-		test("rejects a lone-word narration fragment", () => {
-			expect(parseAgentStatusResponse("Recap: . So:\nSTATUS: WORKING", true)).toBeUndefined();
 		});
 	});
 

--- a/packages/coding-agent/test/daemon-session-summarizer.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer.test.ts
@@ -34,9 +34,13 @@ describe("daemon session summarizer", () => {
 		});
 
 		test("falls back to needs_input on an unrecognized or hedged idle verdict", () => {
-			expect(parseAgentStatusResponse("SUMMARY: Something\nSTATUS: WORKING", false)?.taskState).toBe("needs_input");
-			expect(parseAgentStatusResponse("SUMMARY: Something\nSTATUS: MAYBE", false)?.taskState).toBe("needs_input");
-			expect(parseAgentStatusResponse("SUMMARY: Something", false)?.taskState).toBe("needs_input");
+			expect(parseAgentStatusResponse("SUMMARY: Doing something\nSTATUS: WORKING", false)?.taskState).toBe(
+				"needs_input",
+			);
+			expect(parseAgentStatusResponse("SUMMARY: Doing something\nSTATUS: MAYBE", false)?.taskState).toBe(
+				"needs_input",
+			);
+			expect(parseAgentStatusResponse("SUMMARY: Doing something", false)?.taskState).toBe("needs_input");
 		});
 
 		test("requires the SUMMARY marker and never surfaces free-form text", () => {
@@ -153,6 +157,37 @@ describe("daemon session summarizer", () => {
 			// The tag body is pure counting (rejected); a later valid line must win.
 			const text = "<recap>(1) two(2) = 2 words</recap>\nSUMMARY: Editing the parser\nSTATUS: WORKING";
 			expect(parseAgentStatusResponse(text, true)).toEqual({ summary: "Editing the parser" });
+		});
+
+		test("parses recap and status from their tags", () => {
+			const text = "<recap>Updating the login handler</recap>\n<status>COMPLETED</status>";
+			expect(parseAgentStatusResponse(text, false)).toEqual({
+				summary: "Updating the login handler",
+				taskState: "completed",
+			});
+		});
+
+		test("maps NEEDS_INPUT from the status tag", () => {
+			const text = "<recap>Asked which database to target</recap>\n<status>NEEDS_INPUT</status>";
+			expect(parseAgentStatusResponse(text, false)?.taskState).toBe("needs_input");
+		});
+
+		test("takes the last status tag when a draft is corrected", () => {
+			const text = "<recap>Editing the parser</recap>\n<status>WORKING</status>\n<status>COMPLETED</status>";
+			expect(parseAgentStatusResponse(text, false)?.taskState).toBe("completed");
+		});
+
+		test("recovers a recap written with unicode angle-bracket lookalikes", () => {
+			// Real failure: the model narrated, then emitted `<recap›…` with a ›
+			// lookalike and no close tag, leaking "So" as the recap.
+			const text = "Recap: . So:\nSUMMARY: <recap›Curating a niche list of Muon optimizer papers";
+			expect(parseAgentStatusResponse(text, true)).toEqual({
+				summary: "Curating a niche list of Muon optimizer papers",
+			});
+		});
+
+		test("rejects a lone-word narration fragment", () => {
+			expect(parseAgentStatusResponse("Recap: . So:\nSTATUS: WORKING", true)).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
- the recap status now lives in its own <status> tag alongside <recap>, and the prompt asks for tags only instead of the old summary/status prefixes.
- status is parsed from its tag first with the legacy line format kept as a fallback, and an unrecognized or hallucinated status still defaults to needs_input.
- hardened the parser against a real failure where the model used unicode angle-bracket lookalikes and leaked narration as the recap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter parsing can leave daemon sessions without a dashboard recap if the model still emits the old line format or omits closed tags; impact is limited to status display, not core agent execution.
> 
> **Overview**
> Daemon dashboard status generation now asks the small summary model for **only** `<recap>` and `<status>` tags (no `SUMMARY:`/`STATUS:` lines), and idle `<status>` is limited to **NEEDS_INPUT** or **COMPLETED**—**WORKING** is dropped from the prompt.
> 
> **`parseAgentStatusResponse`** is tag-only: it takes the last `<recap>` and `<status>`, normalizes unicode angle-bracket lookalikes, and still runs `cleanRecap` guards. Legacy line-prefix parsing, think-block stripping, and salvaging recap text without a closing tag are removed, so malformed or old-format replies return **no** summary instead of partial salvage.
> 
> Tests are updated for the XML contract and new edge cases (last tag wins, open `<recap>`, unicode brackets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497d36b1fb2ff6c1cd19dcbcfecc5ef2891e8f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Put recap status in its own `<status>` tag and harden response parsing in daemon session summarizer
> - The system prompt in [daemon-session-summarizer.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/244/files#diff-f7613b331eb488c0bb7d4cd012f97c2bfb45fb01444ab63d0c9378839666625a) now requires the model to emit exactly two tags: `<recap>...</recap>` and `<status>...</status>`, replacing the previous `SUMMARY:`/`STATUS:` prefix format.
> - `WORKING` is removed as a valid status; only `COMPLETED` and `NEEDS_INPUT` are accepted, with `NEEDS_INPUT` as the fallback for missing or unrecognized values.
> - The response parser normalizes Unicode angle-bracket lookalikes to ASCII, strips reasoning trailers, extracts the last `<recap>` and `<status>` values, and ignores the status tag entirely when the agent is still working.
> - Tests in [daemon-session-summarizer.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/244/files#diff-708e542703619791cccbd43dd3b93ecba3fd30452ec64d609f861bcecffbc856) are updated to cover the new tag protocol, including edge cases like multiple tags, echoed templates, and unicode normalization.
> - Behavioral Change: any response without a closing `</recap>` tag now returns `undefined`, and any idle status other than `COMPLETED` maps to `needs_input`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 497d36b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->