### PR TITLE
backfill changelogs for all releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## Conversational Style
 
+- No fluff or cheerful filler text
 - Keep answers short and concise
 - No emojis in commits, issues, PR comments, or code
-- No fluff or cheerful filler text
 - Technical prose only, be kind but direct (e.g., "Thanks @user" not "Thanks so much @user!")
 
 ## Code Quality
 
 - Read files in full before making wide-ranging changes, before editing files you have not already fully inspected, and when the user asks you to investigate or audit something. Do not rely only on search snippets for broad changes.
+- Don't be too verbose with comments in the code. Only write comments when there is serious ambiguity
 - No `any` types unless absolutely necessary
 - Check node_modules for external API type definitions instead of guessing
 - **NEVER use inline imports** - no `await import("./foo.js")`, no `import("pkg").Type` in type positions, no dynamic imports for types. Always use standard top-level imports.
@@ -30,7 +31,6 @@
 - When writing tests, run them, identify issues in either the test or implementation, and iterate until fixed.
 - For `packages/coding-agent/test/suite/`, use `test/suite/harness.ts` plus the faux provider. Do not use real provider APIs, real API keys, or paid tokens.
 - Put issue-specific regressions under `packages/coding-agent/test/suite/regressions/` and name them `<issue-number>-<short-slug>.test.ts`.
-- NEVER commit unless user asks
 
 ## Dependencies
 
@@ -64,7 +64,7 @@ When closing issues via commit:
 
 - Analyze PRs without pulling locally first
 - If the user approves: create a feature branch, pull PR, rebase on main, apply adjustments, commit, merge into main, push, close PR, and leave a comment in the user's tone
-- You never open PRs yourself. We work in feature branches until everything is according to the user's requirements, then merge into main, and push.
+- We work in feature branches until everything is according to the user's requirements. Never merge PRs by yourself.
 
 ## Testing Prime Agent Interactive Mode with tmux
 
@@ -91,27 +91,32 @@ tmux send-keys -t prime-agent-test C-o  # ctrl+o
 tmux kill-session -t prime-agent-test
 ```
 
+You, yourself, are often running into a tmux session, so be careful when killing tmux sessions. Lots of other processes can be running on different tmux sessions/
+
 ## Changelog
 
 Location: `packages/*/CHANGELOG.md` (each package has its own)
 
 ### Format
 
-Use these sections under `## [Unreleased]`:
+A flat list of plain bullets under `## [Unreleased]`. No `### Added` / `### Changed` / `### Fixed` / `### Removed` subsections — just one bullet per change, written as a short sentence starting with a past-tense verb (Added, Changed, Fixed, Removed). Keep each bullet to one line; describe the user-visible change, not the implementation.
 
-- `### Breaking Changes` - API changes requiring migration
-- `### Added` - New features
-- `### Changed` - Changes to existing functionality
-- `### Fixed` - Bug fixes
-- `### Removed` - Removed features
+Example of a well-formed `[Unreleased]` section:
+
+```markdown
+## [Unreleased]
+
+- Added `/effort` to set the reasoning level, with autocomplete for the levels the current model supports.
+- Changed `prime-agent` to open a new chat by default instead of resuming the previous session.
+- Fixed onboarding showing no models after entering a provider key.
+- Removed the interactive `!` / `!!` bash shortcuts; use IPython instead.
+```
 
 ### Rules
 
-- Before adding entries, read the full `[Unreleased]` section to see which subsections already exist
-- New entries ALWAYS go under `## [Unreleased]` section
-- Append to existing subsections (e.g., `### Fixed`), do not create duplicates
-- NEVER modify already-released version sections (e.g., `## [0.12.2]`)
-- Each version section is immutable once released
+- Read the full `[Unreleased]` section first so you don't duplicate an existing bullet
+- New entries ALWAYS go under `## [Unreleased]`
+- NEVER modify already-released version sections (e.g., `## [0.2.1]`) — each is immutable once released
 
 ### Attribution
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 - Added `max` to the `ThinkingLevel` union so callers can request the top adaptive-thinking effort on supported Claude models.
 
+## [0.1.9] - 2026-06-22
+
+## [0.1.8] - 2026-06-21
+
+## [0.1.7] - 2026-06-18
+
+## [0.1.6] - 2026-06-17
+
+## [0.1.5] - 2026-06-16
+
+## [0.1.4] - 2026-06-15
+
 ## [0.1.3] - 2026-06-12
 
 ## [0.1.2] - 2026-06-12
@@ -18,6 +30,18 @@
 
 ## [0.1.0] - 2026-06-11
 
+## [0.0.10] - 2026-06-08
+
+## [0.0.9] - 2026-06-04
+
+## [0.0.8] - 2026-06-04
+
+## [0.0.7] - 2026-06-01
+
+## [0.0.6] - 2026-05-27
+
+## [0.0.5] - 2026-05-26
+
 ## [0.0.4] - 2026-05-21
 
 ## [0.0.2] - 2026-05-20
@@ -25,6 +49,8 @@
 ### Added
 
 - Added a continuation-message hook for host-owned policies that should keep the agent loop running after explicit follow-ups are drained.
+
+## [0.0.1] - 2026-05-18
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,26 @@
 
 - Added a `max` thinking level (above `xhigh`) and mapped each adaptive Claude family to the effort levels its API actually supports: Opus 4.6 / Sonnet 4.6 expose `max` (no `xhigh`); Opus 4.7 / Opus 4.8 / Fable 5 / Mythos 5 expose both `xhigh` and `max`; Mythos Preview exposes `max`. Adaptive thinking detection now also covers Opus 4.8 and the Fable/Mythos families on both the Anthropic and Bedrock providers.
 
+### Fixed
+
+- Fixed callers passing `reasoning: "xhigh"` directly from sending an effort the model lacks; the thinking level is now clamped to the model's supported levels before mapping to an Anthropic effort.
+
+## [0.1.9] - 2026-06-22
+
+## [0.1.8] - 2026-06-21
+
+## [0.1.7] - 2026-06-18
+
+### Added
+
+- Added the `glm-5.2`, `minimax-m3`, and `kimi-k2.7-code` models from Prime Inference, and marked the MiniMax `minimax-m*` and Moonshot `kimi*` families as reasoning models in the registry generator.
+
+## [0.1.6] - 2026-06-17
+
+## [0.1.5] - 2026-06-16
+
+## [0.1.4] - 2026-06-15
+
 ## [0.1.3] - 2026-06-12
 
 ## [0.1.2] - 2026-06-12
@@ -22,11 +42,29 @@
 
 - Added Claude Opus 4.8 to the curated Prime Inference model list.
 
+## [0.0.10] - 2026-06-08
+
+## [0.0.9] - 2026-06-04
+
+## [0.0.8] - 2026-06-04
+
+### Removed
+
+- Removed the `x-ai/grok-code-fast-1` model from the Prime Inference catalog.
+
 ## [0.0.7] - 2026-06-01
 
 ### Fixed
 
 - Fixed OAuth callback pages to use Prime butterfly branding on a black background.
+
+## [0.0.6] - 2026-05-27
+
+## [0.0.5] - 2026-05-26
+
+### Changed
+
+- Changed the Fireworks model catalog to point the turbo router at `kimi-k2p6-turbo` and refresh the available Fireworks models.
 
 ## [0.0.4] - 2026-05-21
 
@@ -40,6 +78,8 @@
 ### Fixed
 
 - Fixed OpenAI Responses requests for models that support disabling reasoning to send `reasoning.effort: "none"` when thinking is off.
+
+## [0.0.1] - 2026-05-18
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,14 +13,121 @@
 
 ### Added
 
-- Added a `max` thinking level to the thinking selector, `--thinking` flag, and settings, exposing the top reasoning effort on Claude models that support it (e.g. Opus 4.6+/Sonnet 4.6).
-- Added opt-in Prime Agent trace sharing with `/traces` and background uploads of persisted session JSONL files.
-- Added a first draft of daemon-backed cron jobs for scheduling prompts against long-running sessions without using `/goal`.
-- Added `/effort` (alias `/thinking`) to set the reasoning/thinking level, with argument autocomplete listing the levels the current model supports.
+- Added `/effort` (alias `/thinking`) to set the reasoning level, with argument autocomplete that lists the levels the current model supports.
+- Added a `/system-prompt` command that shows the exact prompt last sent to the model, labelling it honestly when no turn has run yet.
+- Added a `/rename` alias for `/name` and a `Ctrl+R` shortcut in the Agents View to rename the selected session inline.
+- Added support for feeding pasted images into model context: pasted images become atomic editor markers, are validated and resized, held in a bounded registry, and dropped when the active model lacks vision.
+- Added edit diffs to the collapsed IPython view, rendering file edits as a wrapped, full-width relative-path diff prefixed with the cell status marker.
 
 ### Changed
 
-- Replaced the `Shift+Tab` thinking-level cycle with the `/effort` command.
+- Replaced the `Shift+Tab` thinking-level cycle with the `/effort` command, exposing a `max` thinking level on Claude models that support it.
+- Changed the `/goal` and `/effort` commands to stay highlighted in the editor while their argument is being typed.
+- Changed queued follow-up messages to render below the execution indicator.
+- Changed the RLM system prompt to align its shared sections exactly with rlm-harness, including the environment block and pre-installed package hints.
+- Changed trace uploads to be observable and resilient: failures surface the underlying cause, outcomes are logged to `agent-traces.log`, `/traces` shows the resolved endpoint, and transient failures retry once.
+
+### Fixed
+
+- Fixed Prime Agent formatting breaking when resizing to a small screen, where tool-output colors bled into the padding at narrow widths.
+- Fixed onboarding showing no models after entering a provider key by refreshing the scoped model list after login.
+- Fixed silent daemon replacement reading as random crashes by logging shutdown/replacement decisions, and offering to stop a stale-version daemon at startup instead of erroring out.
+
+### Performance
+
+- Improved session load, context building, and listing to scale linearly: file loads decode per line over a raw buffer, and branch/context building uses push+reverse instead of per-entry unshift.
+- Improved daemon responsiveness under large session loads by parsing session files off the event loop, so loading one big session no longer freezes the other sessions the daemon hosts.
+
+## [0.1.9] - 2026-06-22
+
+### Added
+
+- Added the Prime brand splash to the new-chat view.
+
+### Changed
+
+- Changed daemon attach to send slimmer snapshots and to avoid saved-session disk scans in the Agents View, speeding up switching between sessions.
+
+### Fixed
+
+- Fixed daemon out-of-memory crashes when listing saved sessions by streaming the listing, preserving large session row metadata, and ignoring oversized tool rows when computing session activity.
+
+## [0.1.8] - 2026-06-21
+
+### Added
+
+- Added `daemon shutdown --all` to stop every Prime Agent daemon on the machine, hardened against recycled PIDs and able to force-kill wedged daemons.
+- Added git context to session traces: each trace records the repository URL, branch ref, and HEAD commit, captured at end of turn and carried over when a session is forked.
+
+### Changed
+
+- Changed `prime-agent` to open a new chat by default at launch instead of the previous session, with the daemon session created lazily on the first message and empty chats discarded on quit.
+- Changed sending a message from the Agents View to open the chat for that session.
+- Changed model resolution to persist the selected model across updates and default Prime Inference to Claude Opus 4.8 when no model has been chosen.
+
+### Fixed
+
+- Fixed `prime-agent` attaching to a stale daemon left running by a previous version after self-update: `update` now stops the old daemon and starts the new version (confirming first when busy sessions would lose work), and a stale daemon that cannot be replaced fails loudly instead of a silent broken attach. Both shutdown paths now poll the socket until it stops listening, so a transient hiccup cannot spawn a duplicate daemon.
+
+## [0.1.7] - 2026-06-18
+
+### Added
+
+- Added session and RLM heartbeats: a persistent, user-controlled heartbeat re-prompts a long-running session on a schedule via daemon-backed cron jobs, exposed through the `heartbeat` slash command and a bundled `rlm-heartbeat` Python skill, plus a `cron` CLI command to list jobs.
+
+### Changed
+
+- Changed collapsed IPython tool calls in the TUI to render as a single-line summary instead of a multi-line block.
+
+## [0.1.6] - 2026-06-17
+
+### Added
+
+- Added a `daemon ps` CLI command that lists every Prime Agent daemon running on the machine, with confirmation before shutdown and guards against killing a shared or still-reachable daemon.
+- Added opt-in trace uploads: `/traces` enables background upload of persisted session JSONL files to the Prime Inference trace endpoint.
+- Added agent summaries and live status to Agents View, generated daemon-side per session and refreshed on sweep.
+- Added crash-stack capture for the daemon: output routes to a rotating per-socket log file under `<agentDir>/logs/`, client-side crashes write to `client-errors.log`, and a `/logs` command shows the log directory.
+
+### Changed
+
+- Changed startup notices (app-update, extension-update, and tmux warnings) to surface on the Agents View instead of being appended to every chat session.
+
+### Fixed
+
+- Fixed IPython kernel state being lost across session resume: kernel variables are now snapshotted under session-artifacts, restored on resume, deleted with the session, and dropped on compaction.
+- Fixed the viewport jumping when toggling tool-output expansion in the TUI; the viewport now stays anchored across expand/collapse.
+- Fixed non-persisted (e.g. `/tmp`) sessions creating an RLM working directory they did not need.
+
+## [0.1.5] - 2026-06-16
+
+### Added
+
+- Added rich syntax-aware diff rendering for IPython file edits in the TUI: the `edit` Python skill emits structured edit results that the interactive view renders as a colored, full-width unified diff inside the cell.
+- Added a subagent spawn-program panel to Agents View: expand a subagent group and press `Ctrl+O` to toggle a panel showing the IPython cell that called `rlm.run` to spawn them.
+- Added slash-command alias resolution so command aliases resolve to their canonical command consistently across interactive mode and Agents View, including in autocomplete.
+
+### Changed
+
+- Moved goals out of the harness tool surface into a bundled `goal` Python skill (`goal.get` / `goal.create` / `goal.complete`) backed by session state; the only built-in tool is now `ipython`, and the `rlm.run` comm channel is generalized into a typed host bridge.
+- Changed the RLM system prompt to prefer Python for reading and searching files, porting the IPython guidance from rlm-harness.
+- Spaced out the Agents View shortcut hints for readability.
+
+### Fixed
+
+- Fixed slow opening of long agent sessions: the JSONL socket reader is now O(n) instead of O(n^2) on large records, the session tree is fetched lazily instead of embedded in the attach snapshot, `SessionManager.open()` no longer parses the session file twice, and context building avoids copying every entry on the hot path.
+- Fixed `open()` to stay consistent with the full loader when a session file begins with a blank line.
+- Fixed goal-completion usage accounting that could overcount tokens.
+
+## [0.1.4] - 2026-06-15
+
+### Added
+
+- Added a `/refine` command and a session-backed `rlm.harness` continual-learning state (prompt notes, memory, reusable skills, and subagent specs) that persists globally across sessions, with explicit CRUD methods, a refinement log, and global rollback. The compact harness overview is injected into the system prompt, and `/refine` re-reads state before applying so concurrent writes are not clobbered.
+- Added an `edit` built-in Python RLM skill for targeted single-occurrence string replacement in existing files, callable from the kernel or as a shell command.
+
+### Changed
+
+- Changed the IPython control prompt to require `%%bash` as the first line of a shell cell to match the rlm-harness.
 
 ## [0.1.3] - 2026-06-12
 
@@ -104,6 +211,46 @@
 
 - Removed the interactive `!` / `!!` bash shortcuts; use IPython for shell commands.
 
+## [0.0.10] - 2026-06-08
+
+### Added
+
+- Added an inline input prompt indicator to the interactive editor.
+- Added contextual keybinding hints and a visible focused tray marker for child-agent navigation.
+- Added OS-specific shortcut labels in keybinding hints, rendering `Cmd`/`Option` on macOS and capitalized key names elsewhere.
+
+### Changed
+
+- Changed the IPython system prompt to the upstream rlm-harness `IPYTHON_CONTROL_PROMPT`: IPython is framed as a persistent control environment rather than the target project's runtime, shell commands use `%%bash` cells instead of `!cmd`, and project imports, tests, and dependency checks run through the project's own environment. Removed the `.venv` interpreter hint.
+- Changed interactive `Ctrl+C` to interrupt the current operation first and exit only on a second press while the exit hint is visible; `Escape` now clears the input bar without interrupting the agent.
+- Changed the Prime theme to tone down the flashy neon purple and lime green in favor of a calmer dusty lavender and sage green.
+
+### Fixed
+
+- Fixed missing ripgrep to surface a clean inline warning at startup and fail sub-agent runs with a clear message, while routing kernel diagnostics into captured stderr.
+- Fixed IPython kernel startup to avoid blocking the session, cancelling child RLM runs on session abort and reporting bootstrap progress through a start-options handler.
+- Fixed the subagent tool-expansion keybinding so it toggles expanded tool output inside the child-agent detail view.
+- Fixed browser sign-in links to show plain URLs when the terminal does not support hyperlinks.
+- Fixed the auth selector to preserve the selected provider's login type.
+- Stopped showing changelog entries automatically on install, first launch, and update startup.
+
+## [0.0.9] - 2026-06-04
+
+## [0.0.8] - 2026-06-04
+
+### Added
+
+- Added an `onboardingCompleted` setting and a dedicated Prime Inference onboarding splash that prompts users authenticated only via the Prime CLI to choose a model before their first turn.
+
+### Changed
+
+- Changed the system prompt to frame the agent as a general-purpose agent that uses code to solve tasks rather than a pure coding agent, with guidance that shell state does not persist across `!cmd`/`%%bash` cells while Python kernel state does.
+
+### Fixed
+
+- Fixed the onboarding flow so model selection, manual API-key entry, cancellation, and the "model already ready" path all resolve correctly and mark onboarding complete instead of re-prompting on every launch.
+- Fixed the release installer to ask before bootstrapping the IPython kernel runtime during install (defaulting to bootstrap when no terminal is detected) and to avoid stalling on an interactive `uv` prompt.
+
 ## [0.0.7] - 2026-06-01
 
 ### Added
@@ -127,6 +274,32 @@
 ### Removed
 
 - Removed the unused small Prime logo export.
+
+## [0.0.6] - 2026-05-27
+
+### Changed
+
+- Changed installer startup so npm and Node.js setup output stays hidden behind the bounded Prime splash with rotating detail text.
+- Changed `postinstall` to optionally bootstrap the `fd` and `rg` search helpers (gated by an env flag) alongside the kernel, and made search-helper downloads default to silent.
+
+### Fixed
+
+- Fixed Prime Inference auth so credentials from `prime login` are read from the Prime CLI config and surfaced as a `prime_cli` auth source, making Prime Inference models available on startup without a separate login.
+- Fixed initial model selection to skip a saved default model that no longer has configured auth.
+- Fixed first-run search-helper downloads to run quietly instead of printing over onboarding.
+
+## [0.0.5] - 2026-05-26
+
+### Added
+
+- Added a centered-overlay menu system for onboarding and a redesigned Prime onboarding splash and Prime Inference login dialog with browser sign-in plus a manual API-key fallback.
+- Added theme support for adapting interactive surfaces to the detected terminal foreground/background colors.
+
+### Changed
+
+- Changed startup onboarding to guide unauthenticated users through login and model selection before the first agent turn.
+- Changed the model selector and OAuth/provider selectors to render as centered surface menus rather than inline CLI lists.
+- Changed update and package-update notifications to compact one-line alerts pointing at `prime-agent update`.
 
 ## [0.0.4] - 2026-05-21
 
@@ -182,3 +355,9 @@
 - Removed the RLM background API; recursive agents now use `rlm()`/`rlm.run()` with normal Python async tasks for background work.
 - Removed the legacy `read`, `write`, `grep`, `find`, and `ls` built-in tools.
 - Removed the local TPS extension that posted token/cache stats after each agent response.
+
+## [0.0.1] - 2026-05-18
+
+### Added
+
+- Initial Prime Agent release, forked from pi-mono: a persistent `ipython` tool backed by a Jupyter kernel as the default tool set, recursive RLM subagents via `rlm.run`, `/goal` for long-running objectives, an auto-bootstrapped uv-managed kernel runtime, Prime-branded TUI, and an R2-backed tarball release pipeline with a pi-style installer.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,36 @@
 
 ## [0.2.0] - 2026-06-23
 
+### Added
+
+- Added an optional `commandColor` to the editor theme so a leading slash command stays highlighted while its argument is being typed.
+- Added editor support for atomic pasted-image markers, resolving markers by presence so undo and dequeue keep them intact.
+
+## [0.1.9] - 2026-06-22
+
+## [0.1.8] - 2026-06-21
+
+## [0.1.7] - 2026-06-18
+
+### Fixed
+
+- Fixed TUI flicker when attaching to long or streaming sessions by only preserving scrollback when the transcript grows, not when it shrinks.
+
+## [0.1.6] - 2026-06-17
+
+### Fixed
+
+- Fixed the viewport not staying anchored when collapsing or expanding tool output, preserving scrollback images instead of forcing a full redraw.
+
+## [0.1.5] - 2026-06-16
+
+### Fixed
+
+- Fixed `Alt+Up`/`Alt+Down` key matching in non-kitty terminals so the bindings are recognized outside kitty's keyboard protocol.
+- Fixed autocomplete to respect slash-command alias resolution so aliased commands complete to their canonical form.
+
+## [0.1.4] - 2026-06-15
+
 ## [0.1.3] - 2026-06-12
 
 ## [0.1.2] - 2026-06-12
@@ -13,6 +43,30 @@
 ## [0.1.1] - 2026-06-11
 
 ## [0.1.0] - 2026-06-11
+
+## [0.0.10] - 2026-06-08
+
+### Added
+
+- Added an optional `promptPrefix` to the editor that renders a leading prompt indicator with correct wrapping and padding, with overridable hooks for subclasses.
+
+### Changed
+
+- Changed `Editor.cancelAutocomplete` from private to protected so subclasses can cancel autocomplete before handling interrupts.
+
+## [0.0.9] - 2026-06-04
+
+## [0.0.8] - 2026-06-04
+
+## [0.0.7] - 2026-06-01
+
+## [0.0.6] - 2026-05-27
+
+## [0.0.5] - 2026-05-26
+
+### Added
+
+- Added a terminal-colors module that probes the terminal's default foreground/background via OSC queries and exposes helpers to adapt surfaces to dark or light terminals.
 
 ## [0.0.4] - 2026-05-21
 
@@ -27,6 +81,12 @@
 ### Fixed
 
 - Fixed raw tabs in rendered TUI lines to preserve painted backgrounds across indentation.
+
+## [0.0.1] - 2026-05-18
+
+### Added
+
+- Added marquee TUI components and a Prime-branded theme as part of the initial Prime Agent fork from pi-mono.
 
 ## [0.74.0] - 2026-05-07
 


### PR DESCRIPTION
- every prime agent release from v0.0.1 to v0.2.1 now has a changelog entry across the coding-agent, tui, ai, and agent packages, with new versions inserted above the inherited pi-mono history.
- entries are scoped per package so each one only lists changes that actually touched its source, and the stale unreleased section was folded into v0.2.0.
- the matching github release descriptions were also rewritten in a concise, consistent style as part of this backfill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to changelogs and `AGENTS.md`; no runtime or API behavior changes.
> 
> **Overview**
> **Backfills Prime Agent release history** in `packages/agent`, `packages/ai`, `packages/coding-agent`, and `packages/tui` from **v0.0.1 through v0.2.1**, inserting dated version sections above the inherited pi-mono changelog tail. Many intermediate versions are headers only; others carry scoped notes (daemon/Agents View, IPython/RLM, Prime Inference models, TUI editor behavior). In **coding-agent**, material that had been sitting under `[Unreleased]` is **folded into `[0.2.0]`**, while **`[0.2.1]`** keeps the recent daemon recap and bundled-skills fixes.
> 
> **`AGENTS.md`** is updated in the same pass: changelog rules now require a **flat bullet list** under `[Unreleased]` (no Added/Changed/Fixed subsections), plus small edits to code-comment guidance, PR workflow (no self-merge), and a **tmux kill-session** caution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ad0ea7e4ad87a087328dbf8ef59d20551cba1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Backfill changelogs for all packages with historical release entries
> Adds historical release notes across [packages/agent/CHANGELOG.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/245/files#diff-4e4bf6cc2bc562cdfc8034d40f275360f5698d5ed07513dae73047ebc904962c), [packages/ai/CHANGELOG.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/245/files#diff-1a93fd67549d15259de0044dba9e2650cf5e6c41a51de3c4994992c9867ca80b), [packages/coding-agent/CHANGELOG.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/245/files#diff-c6cac40b1364c0a754eeed6b270894091b2fabf42650673820e3b460f0a41d0e), and [packages/tui/CHANGELOG.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/245/files#diff-da406ec084ba0d088085a119022eb77b4cf7f84763b2b30a11a27e947a24bd62), covering versions from initial release through 0.2.0. Also updates [AGENTS.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/245/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to revise changelog contribution rules, replacing subsection-based format with a flat bullet list under `[Unreleased]` and clarifying that released sections should never be modified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69ad0ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->