### PR TITLE
generate recap summaries for subagents as well

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -348,9 +348,9 @@ export class AgentDaemon {
 			} catch {
 				// Marking is best-effort; the session still works unrestored.
 			}
-			// Restore the last persisted status so it shows before the first sweep.
-			this.summarizer.seed(state);
 		}
+		// Restore the last persisted status so it shows before the first sweep.
+		this.summarizer.seed(state);
 		return state;
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -180,7 +180,7 @@ export class AgentDaemon {
 	private readonly cronStore: AgentCronJobStore;
 	private readonly cronScheduler: AgentCronScheduler;
 	private readonly summarizer = new DaemonSessionSummarizer(
-		() => [...this.sessions.values()].filter((state) => state.runtime.metadata.kind !== "subagent"),
+		() => [...this.sessions.values()],
 		(state) =>
 			this.broadcastToSession(state, {
 				type: "session_status",

--- a/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-summarizer.ts
@@ -204,9 +204,10 @@ function isSessionWorking(state: ActiveSessionState): boolean {
 }
 
 /**
- * Background status summarization for daemon-hosted top-level sessions. A
- * periodic sweep refreshes working sessions; debounced turn-end activity drives
- * the idle verdict. Status lives in memory; settled idle verdicts are persisted.
+ * Background status summarization for daemon-hosted sessions, top-level and
+ * subagents alike. A periodic sweep refreshes working sessions; debounced
+ * turn-end activity drives the idle verdict. Status lives in memory; settled
+ * idle verdicts are persisted.
  */
 export class DaemonSessionSummarizer {
 	private interval: ReturnType<typeof setInterval> | undefined;
@@ -217,7 +218,7 @@ export class DaemonSessionSummarizer {
 	private readonly rerunRequested = new Set<string>();
 
 	constructor(
-		private readonly listTopLevelSessions: () => readonly ActiveSessionState[],
+		private readonly listSessions: () => readonly ActiveSessionState[],
 		private readonly onStatusChanged?: (state: ActiveSessionState) => void,
 		// Injectable for tests.
 		private readonly generate: (
@@ -230,7 +231,7 @@ export class DaemonSessionSummarizer {
 			return;
 		}
 		this.interval = setInterval(() => {
-			for (const state of this.listTopLevelSessions()) {
+			for (const state of this.listSessions()) {
 				void this.summarize(state);
 			}
 		}, SWEEP_INTERVAL_MS);
@@ -276,9 +277,6 @@ export class DaemonSessionSummarizer {
 
 	/** Called when a session finishes a turn; debounce until the agent settles. */
 	notifyActivity(state: ActiveSessionState): void {
-		if (state.runtime.metadata.kind === "subagent") {
-			return;
-		}
 		const id = state.activeSessionId;
 		const existing = this.debounceTimers.get(id);
 		if (existing) {
@@ -293,9 +291,6 @@ export class DaemonSessionSummarizer {
 	}
 
 	private async summarize(state: ActiveSessionState): Promise<void> {
-		if (state.runtime.metadata.kind === "subagent") {
-			return;
-		}
 		const id = state.activeSessionId;
 		if (this.inFlight.has(id)) {
 			this.rerunRequested.add(id); // run once more after the current pass

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -7,7 +7,7 @@ import { DaemonSessionSummarizer } from "../src/modes/daemon/daemon-session-summ
 const SETTLE_MS = 2000;
 
 function makeState(
-	opts: { working?: boolean; messages?: number; kind?: "top-level" | "subagent" } = {},
+	opts: { working?: boolean; messages?: number; kind?: "top-level" | "subagent"; persisted?: unknown } = {},
 ): ActiveSessionState {
 	const appended: unknown[] = [];
 	const state = {
@@ -22,7 +22,10 @@ function makeState(
 				messages: Array.from({ length: opts.messages ?? 2 }, () => ({ role: "user", content: "hi" })),
 				state: { streamingMessage: undefined },
 				modelRegistry: {},
-				sessionManager: { appendAgentStatus: (s: unknown) => appended.push(s) },
+				sessionManager: {
+					appendAgentStatus: (s: unknown) => appended.push(s),
+					getLatestAgentStatus: () => opts.persisted,
+				},
 			},
 		},
 	} as unknown as ActiveSessionState;
@@ -139,5 +142,14 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		expect(generate).toHaveBeenCalledOnce();
 		expect(state.summaryState).toMatchObject({ summary: "Auditing the migration scripts", taskState: "completed" });
 		expect((state as unknown as { appendedStatuses: unknown[] }).appendedStatuses).toHaveLength(1);
+	});
+
+	test("seeds a subagent's persisted recap into memory", () => {
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, vi.fn());
+		const persisted = { summary: "Reviewing the diff", taskState: "needs_input", basedOnMessageCount: 3 };
+		const state = makeState({ kind: "subagent", persisted });
+
+		summarizer.seed(state);
+		expect(state.summaryState).toEqual(persisted);
 	});
 });

--- a/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
+++ b/packages/coding-agent/test/daemon-session-summarizer-lifecycle.test.ts
@@ -6,13 +6,15 @@ import { DaemonSessionSummarizer } from "../src/modes/daemon/daemon-session-summ
 // SETTLE_DEBOUNCE_MS in the module).
 const SETTLE_MS = 2000;
 
-function makeState(opts: { working?: boolean; messages?: number } = {}): ActiveSessionState {
+function makeState(
+	opts: { working?: boolean; messages?: number; kind?: "top-level" | "subagent" } = {},
+): ActiveSessionState {
 	const appended: unknown[] = [];
-	return {
+	const state = {
 		activeSessionId: "a1",
 		summaryState: undefined,
 		runtime: {
-			metadata: { kind: "top-level" },
+			metadata: { kind: opts.kind ?? "top-level" },
 			session: {
 				isStreaming: opts.working ?? false,
 				isCompacting: false,
@@ -24,6 +26,8 @@ function makeState(opts: { working?: boolean; messages?: number } = {}): ActiveS
 			},
 		},
 	} as unknown as ActiveSessionState;
+	(state as unknown as { appendedStatuses: unknown[] }).appendedStatuses = appended;
+	return state;
 }
 
 describe("DaemonSessionSummarizer lifecycle", () => {
@@ -121,5 +125,19 @@ describe("DaemonSessionSummarizer lifecycle", () => {
 		expect(generate).toHaveBeenCalledOnce();
 		// Result is for an outdated turn → dropped, nothing persisted.
 		expect(state.summaryState).toBeUndefined();
+	});
+
+	test("summarizes a subagent and persists its settled idle verdict", async () => {
+		vi.useFakeTimers();
+		const generate = vi.fn().mockResolvedValue({ summary: "Auditing the migration scripts", taskState: "completed" });
+		const summarizer = new DaemonSessionSummarizer(() => [], undefined, generate);
+		const state = makeState({ working: false, kind: "subagent" });
+
+		summarizer.notifyActivity(state);
+		await vi.advanceTimersByTimeAsync(SETTLE_MS + 500);
+
+		expect(generate).toHaveBeenCalledOnce();
+		expect(state.summaryState).toMatchObject({ summary: "Auditing the migration scripts", taskState: "completed" });
+		expect((state as unknown as { appendedStatuses: unknown[] }).appendedStatuses).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
- recap summaries were only generated for top-level agents because the daemon summarizer explicitly skipped any session marked as a subagent.
- removed those guards so subagents run through the same nemotron status pass, with each subagent persisting its own recap to its session file.
- no ui wiring yet — the generated status is available in memory and on disk for the subagent visualizer to consume later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral extension reuses the existing summarizer path; main impact is extra background model calls for subagent sessions, not security or auth changes.
> 
> **Overview**
> **Subagent sessions now get the same background recap/status pipeline as top-level daemon sessions**, instead of being skipped by `DaemonSessionSummarizer`.
> 
> The daemon passes **all** hosted sessions into the summarizer (periodic sweep and post-turn debounce). Subagent guards in `notifyActivity` and `summarize` are removed, so subagents run the nemotron status pass, update in-memory `summaryState`, emit `session_status` when the recap changes, and **persist settled idle verdicts** via `appendAgentStatus` on their own session files. **`summarizer.seed`** runs for every session on add (including subagents) so persisted recaps show before the first sweep.
> 
> Tests cover subagent debounced summarization/persistence and seeding from disk. **No UI wiring in this PR**—recaps are ready for a future subagent visualizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167167bd957a3b775ed17524d35fd5633623266e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate recap summaries for subagent sessions in `DaemonSessionSummarizer`
> - Extends `DaemonSessionSummarizer` to include subagent sessions in periodic sweeps, debounced activity summarization, and settled idle verdict persistence — previously only top-level sessions were processed.
> - Removes early-return guards that skipped subagent sessions in `notifyActivity` and `summarize`, and replaces `listTopLevelSessions` with `listSessions` throughout.
> - Seeds last persisted status into memory for all sessions (including subagents) at startup, not just top-level ones.
> - Adds tests in [daemon-session-summarizer-lifecycle.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/249/files#diff-a63a61a7ecad607db0a4e5e5ebc23209fbb2dbce622b98b1c05541c79fee3d08) covering subagent summarization and seed behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 167167b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->