### PR TITLE
show model and context usage in the prompt bar

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -428,7 +428,7 @@ function createPrimeInferenceModel(
 ): Model<"openai-completions"> {
 	return {
 		id: entry.id,
-		name: `${getPrimeInferenceDisplayName(entry.id)} (Prime Inference)`,
+		name: getPrimeInferenceDisplayName(entry.id),
 		api: "openai-completions",
 		provider: "prime-inference",
 		baseUrl: PRIME_INFERENCE_BASE_URL,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -12800,7 +12800,7 @@ export const MODELS = {
 	"prime-inference": {
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			id: "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			name: "QWEN3 235B A22B Thinking 2507 (Prime Inference)",
+			name: "QWEN3 235B A22B Thinking 2507",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12818,7 +12818,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-haiku-4.5": {
 			id: "anthropic/claude-haiku-4.5",
-			name: "Claude Haiku 4.5 (Prime Inference)",
+			name: "Claude Haiku 4.5",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12836,7 +12836,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-opus-4.6": {
 			id: "anthropic/claude-opus-4.6",
-			name: "Claude Opus 4.6 (Prime Inference)",
+			name: "Claude Opus 4.6",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12855,7 +12855,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-opus-4.7": {
 			id: "anthropic/claude-opus-4.7",
-			name: "Claude Opus 4.7 (Prime Inference)",
+			name: "Claude Opus 4.7",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12874,7 +12874,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-opus-4.8": {
 			id: "anthropic/claude-opus-4.8",
-			name: "Claude Opus 4.8 (Prime Inference)",
+			name: "Claude Opus 4.8",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12893,7 +12893,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-sonnet-4.5": {
 			id: "anthropic/claude-sonnet-4.5",
-			name: "Claude Sonnet 4.5 (Prime Inference)",
+			name: "Claude Sonnet 4.5",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12911,7 +12911,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"anthropic/claude-sonnet-4.6": {
 			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6 (Prime Inference)",
+			name: "Claude Sonnet 4.6",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12930,7 +12930,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"deepseek/deepseek-v3.2": {
 			id: "deepseek/deepseek-v3.2",
-			name: "Deepseek V3.2 (Prime Inference)",
+			name: "Deepseek V3.2",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12948,7 +12948,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"deepseek/deepseek-v4-flash": {
 			id: "deepseek/deepseek-v4-flash",
-			name: "Deepseek V4 Flash (Prime Inference)",
+			name: "Deepseek V4 Flash",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12967,7 +12967,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"deepseek/deepseek-v4-pro": {
 			id: "deepseek/deepseek-v4-pro",
-			name: "Deepseek V4 PRO (Prime Inference)",
+			name: "Deepseek V4 PRO",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -12986,7 +12986,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"minimax/minimax-m3": {
 			id: "minimax/minimax-m3",
-			name: "Minimax M3 (Prime Inference)",
+			name: "Minimax M3",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13004,7 +13004,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"moonshotai/kimi-k2.7-code": {
 			id: "moonshotai/kimi-k2.7-code",
-			name: "Kimi K2.7 Code (Prime Inference)",
+			name: "Kimi K2.7 Code",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13022,7 +13022,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"nvidia/nemotron-3-nano-30b-a3b": {
 			id: "nvidia/nemotron-3-nano-30b-a3b",
-			name: "Nemotron 3 Nano 30B A3B (Prime Inference)",
+			name: "Nemotron 3 Nano 30B A3B",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13040,7 +13040,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"nvidia/nemotron-3-super-120b-a12b": {
 			id: "nvidia/nemotron-3-super-120b-a12b",
-			name: "Nemotron 3 Super 120B A12B (Prime Inference)",
+			name: "Nemotron 3 Super 120B A12B",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13058,7 +13058,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-5.3-codex": {
 			id: "openai/gpt-5.3-codex",
-			name: "GPT 5.3 Codex (Prime Inference)",
+			name: "GPT 5.3 Codex",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13077,7 +13077,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-5.4": {
 			id: "openai/gpt-5.4",
-			name: "GPT 5.4 (Prime Inference)",
+			name: "GPT 5.4",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13096,7 +13096,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-5.4-mini": {
 			id: "openai/gpt-5.4-mini",
-			name: "GPT 5.4 Mini (Prime Inference)",
+			name: "GPT 5.4 Mini",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13115,7 +13115,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-5.4-pro": {
 			id: "openai/gpt-5.4-pro",
-			name: "GPT 5.4 PRO (Prime Inference)",
+			name: "GPT 5.4 PRO",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13134,7 +13134,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-5.5": {
 			id: "openai/gpt-5.5",
-			name: "GPT 5.5 (Prime Inference)",
+			name: "GPT 5.5",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13153,7 +13153,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"prime-intellect/intellect-3": {
 			id: "prime-intellect/intellect-3",
-			name: "Intellect 3 (Prime Inference)",
+			name: "Intellect 3",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13171,7 +13171,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"qwen/qwen3-coder-next": {
 			id: "qwen/qwen3-coder-next",
-			name: "QWEN3 Coder Next (Prime Inference)",
+			name: "QWEN3 Coder Next",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13189,7 +13189,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"qwen/qwen3-max": {
 			id: "qwen/qwen3-max",
-			name: "QWEN3 MAX (Prime Inference)",
+			name: "QWEN3 MAX",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13207,7 +13207,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"qwen/qwen3-vl-235b-a22b-thinking": {
 			id: "qwen/qwen3-vl-235b-a22b-thinking",
-			name: "QWEN3 VL 235B A22B Thinking (Prime Inference)",
+			name: "QWEN3 VL 235B A22B Thinking",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13225,7 +13225,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"x-ai/grok-4.20": {
 			id: "x-ai/grok-4.20",
-			name: "Grok 4.20 (Prime Inference)",
+			name: "Grok 4.20",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13243,7 +13243,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"x-ai/grok-4.20-multi-agent": {
 			id: "x-ai/grok-4.20-multi-agent",
-			name: "Grok 4.20 Multi Agent (Prime Inference)",
+			name: "Grok 4.20 Multi Agent",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13261,7 +13261,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"z-ai/glm-5": {
 			id: "z-ai/glm-5",
-			name: "GLM 5 (Prime Inference)",
+			name: "GLM 5",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13279,7 +13279,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"z-ai/glm-5.1": {
 			id: "z-ai/glm-5.1",
-			name: "GLM 5.1 (Prime Inference)",
+			name: "GLM 5.1",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",
@@ -13297,7 +13297,7 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 		"z-ai/glm-5.2": {
 			id: "z-ai/glm-5.2",
-			name: "GLM 5.2 (Prime Inference)",
+			name: "GLM 5.2",
 			api: "openai-completions",
 			provider: "prime-inference",
 			baseUrl: "https://api.pinference.ai/api/v1",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4324,9 +4324,20 @@ export class InteractiveMode {
 	}
 
 	private getTrayLocationLabel(): string | undefined {
-		const location = this.footerDataProvider.getGitBranch() ?? formatSplashCwd(this.getCurrentCwd());
 		const agentsHint = this.getAgentsViewTrayHint();
-		return [agentsHint, location].filter((label): label is string => label !== undefined).join("  ");
+		return [agentsHint, this.getModelTrayLabel()].filter((label): label is string => label !== undefined).join("  ");
+	}
+
+	private getModelTrayLabel(): string {
+		const model = this.getCurrentModel();
+		if (!model) {
+			return "—";
+		}
+		if (!model.reasoning) {
+			return model.name;
+		}
+		const level = this.connectionState?.thinkingLevel ?? "off";
+		return level === "off" ? model.name : `${model.name} • ${level}`;
 	}
 
 	private getAgentsViewTrayHint(): string | undefined {
@@ -4342,14 +4353,10 @@ export class InteractiveMode {
 	private getTrayContextLabel(): string | undefined {
 		const goalLabel = this.getTrayGoalLabel();
 		const usage = this.getConnectionContextUsage();
-		if (!usage) {
-			return goalLabel;
-		}
-		if (usage.percent === null) {
-			return goalLabel;
-		}
-		const remainingPercent = Math.max(0, Math.min(100, 100 - usage.percent));
-		const contextLabel = remainingPercent <= 50 ? `${Math.round(remainingPercent)}% context left` : undefined;
+		const contextLabel =
+			usage && usage.tokens !== null && usage.percent !== null
+				? `${formatTokenCount(usage.tokens)} (${Math.round(usage.percent)}%)`
+				: undefined;
 		return [goalLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4354,7 +4354,7 @@ export class InteractiveMode {
 		const goalLabel = this.getTrayGoalLabel();
 		const usage = this.getConnectionContextUsage();
 		const contextLabel =
-			usage && usage.tokens !== null && usage.percent !== null
+			usage && typeof usage.tokens === "number" && typeof usage.percent === "number"
 				? `${formatTokenCount(usage.tokens)} (${Math.round(usage.percent)}%)`
 				: undefined;
 		return [goalLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1155,12 +1155,13 @@ describe("InteractiveMode goal status announcements", () => {
 });
 
 describe("InteractiveMode tray goal label", () => {
+	type TrayUsage = { contextWindow: number; tokens: number | null; percent: number | null };
 	type TrayLabelHarness = {
 		connectionState: {
 			goal: GoalState;
-			contextUsage: { contextWindow: number; percent: number | null } | undefined;
+			contextUsage: TrayUsage | undefined;
 		};
-		uiServices: { getContextUsage(): { contextWindow: number; percent: number | null } | undefined };
+		uiServices: { getContextUsage(): TrayUsage | undefined };
 		getTrayContextLabel(): string | undefined;
 	};
 	const getTrayContextLabel = (InteractiveMode.prototype as unknown as TrayLabelHarness).getTrayContextLabel;
@@ -1183,7 +1184,7 @@ describe("InteractiveMode tray goal label", () => {
 		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s)");
 	});
 
-	test("combines active goals with low-context signal in one lower-tray label", () => {
+	test("combines active goals with token/context usage in one lower-tray label", () => {
 		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
 		fakeThis.connectionState = {
 			goal: {
@@ -1194,11 +1195,29 @@ describe("InteractiveMode tray goal label", () => {
 				timeUsedSeconds: 65,
 				continuationsUsed: 1,
 			} satisfies GoalState,
-			contextUsage: { contextWindow: 100_000, percent: 75 },
+			contextUsage: { contextWindow: 100_000, tokens: 75_000, percent: 75 },
 		};
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
-		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 25% context left");
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 75k (75%)");
+	});
+
+	test("omits the usage segment when token count is unknown", () => {
+		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
+		fakeThis.connectionState = {
+			goal: {
+				active: true,
+				status: "active",
+				objective: "finish the task",
+				tokensUsed: 0,
+				timeUsedSeconds: 65,
+				continuationsUsed: 1,
+			} satisfies GoalState,
+			contextUsage: { contextWindow: 100_000, tokens: null, percent: null },
+		};
+		fakeThis.uiServices = { getContextUsage: () => undefined };
+
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s)");
 	});
 });
 


### PR DESCRIPTION
- the bottom-left of the prompt bar now shows the active model and thinking level instead of the working directory, which was low-value.
- the bottom-right now always shows the token count and percentage of context used, rather than only appearing once usage crossed half the window.
- also drops the redundant " (Prime Inference)" suffix from prime-inference model names at the generator source so the name reads cleanly everywhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and generated model metadata only; no auth, routing, or runtime inference logic changes.
> 
> **Overview**
> The interactive prompt bar **bottom-left tray** now shows the **active model** (and thinking level when reasoning is on) instead of git branch or working directory.
> 
> The **bottom-right tray** always shows context as **`formatTokenCount(tokens) (percent%)`** when both values are known, replacing the old rule that only surfaced “% context left” when remaining context was ≤50%.
> 
> Prime Inference model **`name`** values no longer append **` (Prime Inference)`**; `createPrimeInferenceModel` uses `getPrimeInferenceDisplayName` only, with matching updates in **`models.generated.ts`**. Tests cover the new tray context label behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10cd90c9f3b25142cb488f94ec45f1b6294afad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show model name and token usage in the interactive mode prompt bar
> - The tray location label now shows the active model name (and reasoning level if applicable) instead of the Git branch or working directory.
> - The tray context label now shows consumed token count and percentage (e.g. `1.2k (42%)`) instead of remaining context percentage; the segment is omitted when token data is unavailable.
> - Prime Inference model display names no longer include the ` (Prime Inference)` suffix in [models.generated.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/252/files#diff-ff7c21ac6b779f6c8f30964fa301e7f89a29bfa77866258b05b9be7f35291fdd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10cd90c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->