### PR TITLE
add full-screen transcript overlay

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -20,6 +20,7 @@ export interface AppKeybindings {
 	"app.provider.add": true;
 	"app.tools.expand": true;
 	"app.thinking.toggle": true;
+	"app.transcript.open": true;
 	"app.subagents.focus": true;
 	"app.session.toggleNamedFilter": true;
 	"app.editor.external": true;
@@ -81,8 +82,12 @@ export const KEYBINDINGS = {
 	"app.provider.add": { defaultKeys: "ctrl+p", description: "Add provider" },
 	"app.tools.expand": { defaultKeys: "ctrl+o", description: "Toggle tool output" },
 	"app.thinking.toggle": {
-		defaultKeys: "ctrl+t",
+		defaultKeys: "alt+t",
 		description: "Toggle thinking blocks",
+	},
+	"app.transcript.open": {
+		defaultKeys: "ctrl+t",
+		description: "Open full transcript",
 	},
 	"app.subagents.focus": {
 		defaultKeys: "alt+a",
@@ -249,6 +254,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	selectModel: "app.model.select",
 	expandTools: "app.tools.expand",
 	toggleThinking: "app.thinking.toggle",
+	openTranscript: "app.transcript.open",
 	focusSubagents: "app.subagents.focus",
 	toggleSessionNamedFilter: "app.session.toggleNamedFilter",
 	externalEditor: "app.editor.external",

--- a/packages/coding-agent/src/modes/interactive/components/transcript-pager.ts
+++ b/packages/coding-agent/src/modes/interactive/components/transcript-pager.ts
@@ -1,0 +1,109 @@
+import { type Component, type Focusable, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+import { shouldTreatAsBack } from "./modal-back.js";
+
+interface TerminalSize {
+	get columns(): number;
+	get rows(): number;
+}
+
+/**
+ * Full-screen scrollable pager for the expanded transcript. Renders a header,
+ * a scrollable content window, and a footer with the scroll position. Content
+ * lines are supplied by `getLines(width)` and recomputed when the width changes
+ * (e.g. on resize) so wrapping stays correct.
+ */
+export class TranscriptPager implements Component, Focusable {
+	focused = false;
+	private scrollOffset = 0;
+	private cachedWidth = -1;
+	private cachedLines: string[] = [];
+
+	constructor(
+		private readonly title: string,
+		private readonly getLines: (width: number) => string[],
+		private readonly size: TerminalSize,
+		private readonly onClose: () => void,
+	) {}
+
+	invalidate(): void {
+		this.cachedWidth = -1;
+	}
+
+	private contentLines(width: number): string[] {
+		if (width !== this.cachedWidth) {
+			this.cachedLines = this.getLines(width);
+			this.cachedWidth = width;
+		}
+		return this.cachedLines;
+	}
+
+	// Content rows available between the header and footer.
+	private contentHeight(): number {
+		return Math.max(1, this.size.rows - 2);
+	}
+
+	private maxScroll(width: number): number {
+		return Math.max(0, this.contentLines(width).length - this.contentHeight());
+	}
+
+	private clampScroll(width: number): void {
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.maxScroll(width)));
+	}
+
+	handleInput(data: string): void {
+		const width = this.size.columns;
+		const page = this.contentHeight();
+		if (matchesKey(data, "esc") || shouldTreatAsBack(data) || matchesKey(data, "ctrl+t") || matchesKey(data, "q")) {
+			this.onClose();
+			return;
+		}
+		if (matchesKey(data, "up") || matchesKey(data, "k")) {
+			this.scrollOffset -= 1;
+		} else if (matchesKey(data, "down") || matchesKey(data, "j")) {
+			this.scrollOffset += 1;
+		} else if (matchesKey(data, "pageUp") || matchesKey(data, "ctrl+b")) {
+			this.scrollOffset -= page;
+		} else if (matchesKey(data, "pageDown") || matchesKey(data, "ctrl+f") || matchesKey(data, "space")) {
+			this.scrollOffset += page;
+		} else if (matchesKey(data, "ctrl+u")) {
+			this.scrollOffset -= Math.max(1, Math.floor(page / 2));
+		} else if (matchesKey(data, "ctrl+d")) {
+			this.scrollOffset += Math.max(1, Math.floor(page / 2));
+		} else if (matchesKey(data, "home") || matchesKey(data, "g")) {
+			this.scrollOffset = 0;
+		} else if (matchesKey(data, "end") || matchesKey(data, "shift+g")) {
+			this.scrollOffset = this.maxScroll(width);
+		}
+		this.clampScroll(width);
+	}
+
+	render(width: number): string[] {
+		this.clampScroll(width);
+		const lines = this.contentLines(width);
+		const contentHeight = this.contentHeight();
+		const out: string[] = [];
+
+		out.push(truncateToWidth(theme.fg("muted", this.title), width, "…"));
+
+		const window = lines.slice(this.scrollOffset, this.scrollOffset + contentHeight);
+		for (const line of window) {
+			out.push(line);
+		}
+		for (let i = window.length; i < contentHeight; i++) {
+			out.push("");
+		}
+
+		out.push(this.footer(width));
+		return out;
+	}
+
+	private footer(width: number): string {
+		const max = this.maxScroll(width);
+		const pct = max === 0 ? 100 : Math.round((this.scrollOffset / max) * 100);
+		const left = `${pct}%`;
+		const right = "↑↓ scroll · esc close";
+		const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+		return theme.fg("dim", `${left}${" ".repeat(gap)}${right}`);
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -159,6 +159,7 @@ import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
 import { ToolExecutionComponent, type ToolExecutionDefinition } from "./components/tool-execution.js";
+import { TranscriptPager } from "./components/transcript-pager.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
@@ -3143,6 +3144,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.model.select", () => this.showModelSelector());
 		this.defaultEditor.onAction("app.tools.expand", () => this.toggleToolOutputExpansion());
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
+		this.defaultEditor.onAction("app.transcript.open", () => this.openTranscriptPager());
 		this.defaultEditor.onAction("app.subagents.focus", () => this.focusChildAgentInspector());
 		this.defaultEditor.onAction("app.editor.external", () => this.openExternalEditor());
 		this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
@@ -5101,6 +5103,36 @@ export class InteractiveMode {
 		// otherwise force a full redraw that scrolls to the top and replays the
 		// whole transcript. Keep the user anchored at their current position.
 		this.ui.requestRenderPreservingViewport();
+	}
+
+	// Render the whole transcript with every block expanded, regardless of the
+	// inline expand state, then restore it. Inline children all track the shared
+	// toolOutputExpanded state, so restoring to it is sufficient.
+	private renderExpandedTranscript(width: number): string[] {
+		const expandables = this.chatContainer.children.filter((c): c is Component & Expandable => isExpandable(c));
+		for (const child of expandables) {
+			child.setExpanded(true);
+		}
+		try {
+			return this.chatContainer.render(width);
+		} finally {
+			for (const child of expandables) {
+				child.setExpanded(this.toolOutputExpanded);
+			}
+		}
+	}
+
+	private openTranscriptPager(): void {
+		if (this.ui.hasPager()) {
+			return;
+		}
+		const pager = new TranscriptPager(
+			"Transcript — full history",
+			(width) => this.renderExpandedTranscript(width),
+			this.ui.terminal,
+			() => this.ui.closePager(),
+		);
+		this.ui.showPager(pager);
 	}
 
 	private toggleThinkingBlockVisibility(): void {

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -26,6 +26,8 @@ class FakeTerminal implements Terminal {
 	clearLine(): void {}
 	clearFromCursor(): void {}
 	clearScreen(): void {}
+	enterAltScreen(): void {}
+	leaveAltScreen(): void {}
 	setTitle(_title: string): void {}
 	setProgress(_active: boolean): void {}
 

--- a/packages/coding-agent/test/transcript-pager.test.ts
+++ b/packages/coding-agent/test/transcript-pager.test.ts
@@ -1,0 +1,69 @@
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, test } from "vitest";
+import { TranscriptPager } from "../src/modes/interactive/components/transcript-pager.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+function makeSize(columns: number, rows: number) {
+	return { columns, rows };
+}
+
+function visibleContent(pager: TranscriptPager, width: number): string[] {
+	// Drop the header (first line) and footer (last line).
+	return pager.render(width).slice(1, -1).map(stripAnsi);
+}
+
+describe("TranscriptPager", () => {
+	const lines = Array.from({ length: 100 }, (_, i) => `content ${i}`);
+	// rows=12 -> contentHeight = 10
+	const makePager = (onClose = () => {}) => new TranscriptPager("Transcript", () => lines, makeSize(40, 12), onClose);
+
+	test("starts at the top of the content", () => {
+		const pager = makePager();
+		const shown = visibleContent(pager, 40);
+		expect(shown[0]).toContain("content 0");
+		expect(shown.at(-1)).toContain("content 9");
+	});
+
+	test("scrolls down one line at a time", () => {
+		const pager = makePager();
+		pager.handleInput("\x1b[B"); // down arrow
+		const shown = visibleContent(pager, 40);
+		expect(shown[0]).toContain("content 1");
+	});
+
+	test("page down advances by a content page", () => {
+		const pager = makePager();
+		pager.handleInput("\x1b[6~"); // page down
+		const shown = visibleContent(pager, 40);
+		expect(shown[0]).toContain("content 10");
+	});
+
+	test("End jumps to the bottom and clamps", () => {
+		const pager = makePager();
+		pager.handleInput("\x1b[F"); // end
+		const shown = visibleContent(pager, 40);
+		// 100 lines, 10 visible -> last window starts at line 90.
+		expect(shown.at(-1)).toContain("content 99");
+		expect(shown[0]).toContain("content 90");
+	});
+
+	test("scrolling up past the top clamps to zero", () => {
+		const pager = makePager();
+		pager.handleInput("\x1b[A"); // up at top
+		const shown = visibleContent(pager, 40);
+		expect(shown[0]).toContain("content 0");
+	});
+
+	test("Esc invokes the close callback", () => {
+		let closed = false;
+		const pager = makePager(() => {
+			closed = true;
+		});
+		pager.handleInput("\x1b"); // escape
+		expect(closed).toBe(true);
+	});
+});

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -57,6 +57,12 @@ export interface Terminal {
 	clearFromCursor(): void; // Clear from cursor to end of screen
 	clearScreen(): void; // Clear entire screen and move cursor to (0,0)
 
+	// Alternate screen buffer. The primary screen (and its scrollback) is left
+	// untouched while the alt screen is active, so a full-screen view can be
+	// shown and dismissed without disturbing the transcript history.
+	enterAltScreen(): void;
+	leaveAltScreen(): void;
+
 	// Title operations
 	setTitle(title: string): void; // Set terminal window title
 
@@ -424,6 +430,14 @@ export class ProcessTerminal implements Terminal {
 
 	clearScreen(): void {
 		process.stdout.write("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
+	}
+
+	enterAltScreen(): void {
+		process.stdout.write("\x1b[?1049h");
+	}
+
+	leaveAltScreen(): void {
+		process.stdout.write("\x1b[?1049l");
 	}
 
 	setTitle(title: string): void {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -273,6 +273,11 @@ export class TUI extends Container {
 		focusOrder: number;
 	}[] = [];
 
+	// Full-screen pager rendered on the alternate screen. While set, doRender
+	// paints only this component and the primary screen (transcript + scrollback)
+	// is left frozen, so the pager can be dismissed without disturbing history.
+	private pager: { component: Component; preFocus: Component | null } | null = null;
+
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
 		super();
 		this.terminal = terminal;
@@ -396,6 +401,40 @@ export class TUI extends Container {
 			},
 			isFocused: () => this.focusedComponent === component,
 		};
+	}
+
+	/**
+	 * Show a full-screen pager on the alternate screen. The primary screen
+	 * (transcript and its scrollback) is preserved untouched until closePager()
+	 * restores it. The component receives focus and all input while active.
+	 */
+	showPager(component: Component): void {
+		if (this.pager) {
+			this.closePager();
+		}
+		this.pager = { component, preFocus: this.focusedComponent };
+		this.terminal.enterAltScreen();
+		this.terminal.hideCursor();
+		this.setFocus(component);
+		// The alt screen starts blank and differs from the primary frame, so the
+		// next render must repaint from scratch rather than diff against it.
+		this.requestRender(true);
+	}
+
+	/** True while a full-screen pager is active. */
+	hasPager(): boolean {
+		return this.pager !== null;
+	}
+
+	/** Dismiss the pager and restore the primary screen and previous focus. */
+	closePager(): void {
+		if (!this.pager) return;
+		const { preFocus } = this.pager;
+		this.pager = null;
+		this.terminal.leaveAltScreen();
+		this.setFocus(preFocus);
+		// Repaint the restored primary screen from scratch.
+		this.requestRender(true);
 	}
 
 	/** Hide the topmost overlay and restore previous focus. */
@@ -969,8 +1008,31 @@ export class TUI extends Container {
 		return null;
 	}
 
+	// Paint the pager full-screen on the alt screen. The pager renders exactly
+	// the visible window for the current size, so this clears and rewrites the
+	// whole screen each frame — cheap on the alt buffer and free of the
+	// transcript's differential/scrollback bookkeeping.
+	private renderPager(): void {
+		if (!this.pager) return;
+		const width = this.terminal.columns;
+		const height = this.terminal.rows;
+		const lines = this.pager.component.render(width).slice(0, height);
+		let buffer = "\x1b[?2026h\x1b[2J\x1b[H";
+		for (let i = 0; i < lines.length; i++) {
+			if (i > 0) buffer += "\r\n";
+			buffer += "\x1b[2K";
+			buffer += lines[i];
+		}
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+	}
+
 	private doRender(): void {
 		if (this.stopped) return;
+		if (this.pager) {
+			this.renderPager();
+			return;
+		}
 		// One-shot: consume here so it never leaks into a later render.
 		const preserveViewport = this.preserveViewportOnNextRender;
 		this.preserveViewportOnNextRender = false;

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -821,3 +821,61 @@ describe("TUI above-viewport changes on a tall transcript", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI full-screen pager", () => {
+	it("enters the alt screen and paints the pager full-screen", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const main = new TestComponent();
+		main.lines = Array.from({ length: 30 }, (_, i) => `Main ${i}`);
+		tui.addChild(main);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		const pager = new TestComponent();
+		pager.lines = ["Pager header", "Pager body"];
+		tui.showPager(pager);
+		await terminal.waitForRender();
+
+		assert.ok(tui.hasPager(), "pager is active");
+		assert.ok(terminal.getWrites().includes("\x1b[?1049h"), "enters the alternate screen");
+		const viewport = terminal.getViewport();
+		assert.ok(
+			viewport.some((l) => l.includes("Pager header")),
+			"pager content is painted",
+		);
+		assert.ok(!viewport.some((l) => l.includes("Main 29")), "main transcript is not painted in the pager");
+
+		tui.stop();
+	});
+
+	it("leaves the alt screen and restores the main view on close", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const main = new TestComponent();
+		main.lines = Array.from({ length: 30 }, (_, i) => `Main ${i}`);
+		tui.addChild(main);
+		tui.start();
+		await terminal.waitForRender();
+
+		const pager = new TestComponent();
+		pager.lines = ["Pager body"];
+		tui.showPager(pager);
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		tui.closePager();
+		await terminal.waitForRender();
+
+		assert.ok(!tui.hasPager(), "pager is dismissed");
+		assert.ok(terminal.getWrites().includes("\x1b[?1049l"), "leaves the alternate screen");
+		const viewport = terminal.getViewport();
+		assert.ok(
+			viewport.some((l) => l.includes("Main 29")),
+			"main transcript is restored",
+		);
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -95,6 +95,14 @@ export class VirtualTerminal implements Terminal {
 		this.xterm.write("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
 	}
 
+	enterAltScreen(): void {
+		this.write("\x1b[?1049h");
+	}
+
+	leaveAltScreen(): void {
+		this.write("\x1b[?1049l");
+	}
+
 	setTitle(title: string): void {
 		// OSC 0;title BEL - set terminal window title
 		this.xterm.write(`\x1b]0;${title}\x07`);


### PR DESCRIPTION
- adds a scrollable full-screen transcript view (ctrl+t) that renders every tool call fully expanded, so you can see what earlier calls did without scrolling the inline view.
- it opens on the terminal's alternate screen and restores the untouched main view on close, avoiding the scrollback reprint flicker that inline expand-in-place caused.
- moves the thinking-block toggle from ctrl+t to alt+t to free up the key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only TUI and keybinding changes with tests; no auth, data, or session persistence changes.
> 
> **Overview**
> Adds a **full-screen scrollable transcript** opened with **ctrl+t**, showing the full chat history with **all expandable blocks forced open** so earlier tool output is readable without disturbing the inline view.
> 
> The view uses the TUI’s new **alternate-screen pager** (`showPager` / `closePager`): the main transcript and scrollback stay frozen while the pager paints on the alt buffer, avoiding scrollback reprint flicker when closing.
> 
> **Thinking-block toggle** moves from ctrl+t to **alt+t** to free the shortcut. New **`TranscriptPager`** component handles vim-style scrolling and a position footer; interactive mode wires **`app.transcript.open`** and temporarily expands chat children only while rendering pager lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148bd2012ffde036a60e44384f434d09f7b0277e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add full-screen transcript overlay with keyboard navigation to interactive mode
> - Adds a `TranscriptPager` component that renders the full chat transcript in a full-screen scrollable overlay with vim-style navigation (j/k, g/G, page up/down, etc.) and closes on Esc or `q`.
> - Wires `TranscriptPager` into `InteractiveMode` via a new `app.transcript.open` keybinding (Ctrl+T); the pager temporarily expands all collapsible blocks while open without altering their inline state.
> - Extends `tui.TUI` with `showPager`/`closePager` methods that switch to the terminal's alternate screen buffer and route focus/rendering exclusively to the pager while active.
> - Adds `enterAltScreen`/`leaveAltScreen` to the `Terminal` interface using ANSI sequences `ESC[?1049h`/`ESC[?1049l`.
> - Behavioral Change: the previous Ctrl+T keybinding for toggling thinking blocks is reassigned to Alt+T.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 148bd20. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->