### PR TITLE
title fresh chats by first prompt instead of session id

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -142,7 +142,13 @@ export function summaryForActiveSession(activeSession: ActiveSessionState, saved
 		modified,
 		// Subagent sessions live in artifact dirs that the saved-session scan
 		// never sees; their spawn prompt is the most identifying title we have.
-		firstMessage: savedSession?.firstMessage ?? (metadata.prompt ? compactRlmText(metadata.prompt, 120) : undefined),
+		// A freshly created top-level session has neither yet — its jsonl is not
+		// scanned until it flushes — so derive from the live first user message to
+		// avoid titling the chat with its session ID until the file lands.
+		firstMessage:
+			savedSession?.firstMessage ??
+			(metadata.prompt ? compactRlmText(metadata.prompt, 120) : undefined) ??
+			firstUserMessageText(session),
 		parentActiveSessionId: metadata.parentActiveSessionId,
 		parentSessionId: metadata.parentSessionId,
 		parentSessionPath: savedSession?.parentSessionPath ?? metadata.parentSessionFile,
@@ -259,6 +265,19 @@ function rlmChildSnapshotForActiveSession(
 		sessionDir: metadata.sessionDir ?? session.sessionManager.getSessionDir(),
 		transcript,
 	};
+}
+
+function firstUserMessageText(session: ActiveSessionState["runtime"]["session"]): string | undefined {
+	for (const message of session.messages) {
+		if (message.role !== "user") {
+			continue;
+		}
+		const text = compactRlmText(readMessageText(message.content), 120).trim();
+		if (text) {
+			return text;
+		}
+	}
+	return undefined;
 }
 
 function readMessageText(content: unknown): string {


### PR DESCRIPTION
- chats started from prime-agent showed their session id as the name because a fresh session has no saved scan or spawn prompt to derive a title from yet.
- the session summary now falls back to the live in-memory first user message, so the chat is titled by its first prompt right away.
- resumed sessions and subagents are unaffected since the saved title and spawn prompt still take precedence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to session list titling with unchanged precedence for saved and subagent sessions.
> 
> **Overview**
> **Fresh top-level chats** no longer show the session ID as the display title when the jsonl has not been scanned or flushed yet.
> 
> `summaryForActiveSession` extends the `firstMessage` chain: saved scan title and subagent spawn prompt still win, but if both are missing the daemon now derives a **120-char compact** label from the **live first user message** in memory via new helper `firstUserMessageText`.
> 
> Resumed sessions and subagents are unchanged because existing precedence rules still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e6f1b1f8e0dc98b8099fa698346ca1ef22745f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Title fresh chats by first user message text when no session title or prompt exists
> In [`daemon-session-list.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/264/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21), `summaryForActiveSession` gains a final fallback for `firstMessage`: when neither `savedSession.firstMessage` nor `metadata.prompt` is available, it calls the new `firstUserMessageText` helper to extract a title from the first user message in the session. The helper scans `session.messages` for the first `role === 'user'` entry, extracts plain text, and truncates it to 120 characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50e6f1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->