### PR TITLE
Defer heartbeat delivery while sessions are active

### DIFF
--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -33,6 +33,7 @@ export interface AgentCronJob {
 	updatedAt: string;
 	nextRunAt?: string;
 	lastRunAt?: string;
+	lastSkippedAt?: string;
 	lastError?: string;
 	runCount: number;
 }
@@ -489,7 +490,12 @@ export class AgentCronJobStore {
 				return job;
 			}
 			const nextRunAt = nextRunAtForSchedule(job.schedule, now);
-			updated = { ...job, nextRunAt: nextRunAt?.toISOString(), updatedAt: now.toISOString() };
+			updated = {
+				...job,
+				nextRunAt: nextRunAt?.toISOString(),
+				lastSkippedAt: now.toISOString(),
+				updatedAt: now.toISOString(),
+			};
 			return updated;
 		});
 		if (updated) {
@@ -766,7 +772,8 @@ export function formatAgentCronJob(job: AgentCronJob): string {
 	const preview = job.prompt.replace(/\s+/g, " ").slice(0, 80);
 	const error = job.lastError ? ` error=${job.lastError}` : "";
 	const label = job.label ? ` label="${job.label}"` : "";
-	return `${job.id} ${job.status}${label} next=${next} last=${last} runs=${job.runCount} schedule="${job.schedule.expression}" prompt="${preview}"${error}`;
+	const skipped = job.lastSkippedAt ? ` skipped=${new Date(job.lastSkippedAt).toLocaleString()}` : "";
+	return `${job.id} ${job.status}${label} next=${next} last=${last}${skipped} runs=${job.runCount} schedule="${job.schedule.expression}" prompt="${preview}"${error}`;
 }
 
 export function createAgentHeartbeatToolDefinitions(controller: AgentCronToolController): ToolDefinition[] {

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -58,6 +58,12 @@ export interface AgentCronSchedulerHooks {
 	onError?: (job: AgentCronJob, error: unknown) => void;
 }
 
+export interface HeartbeatCronSessionActivity {
+	isStreaming: boolean;
+	isBashRunning: boolean;
+	pendingMessageCount: number;
+}
+
 interface CronJobsFile {
 	jobs?: unknown;
 }
@@ -812,6 +818,16 @@ function consumeLeadingEverySchedule(text: string): { interval: string; rest: st
 			.replace(/^--\s*/, "")
 			.trim(),
 	};
+}
+
+export function isHeartbeatCronJob(job: AgentCronJob): boolean {
+	return job.source === "heartbeat" || job.source === "rlm_heartbeat";
+}
+
+export function shouldDeferHeartbeatCronJob(job: AgentCronJob, activity: HeartbeatCronSessionActivity): boolean {
+	return (
+		isHeartbeatCronJob(job) && (activity.isStreaming || activity.isBashRunning || activity.pendingMessageCount > 0)
+	);
 }
 
 function nextCronRunAfter(expression: string, after: Date): Date {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -476,16 +476,14 @@ export class AgentDaemon {
 		if (shouldDeferHeartbeatCronJob(job, state.runtime.session)) {
 			return "skipped";
 		}
-		const followUpQueueKey = isHeartbeatCronJob(job) ? `heartbeat:${job.id}` : undefined;
-		if (!followUpQueueKey && (state.runtime.session.isStreaming || state.runtime.session.pendingMessageCount > 0)) {
+		if (
+			!isHeartbeatCronJob(job) &&
+			(state.runtime.session.isStreaming || state.runtime.session.pendingMessageCount > 0)
+		) {
 			await state.runtime.session.followUp(job.prompt);
 			return;
 		}
-		await state.runtime.session.prompt(job.prompt, {
-			streamingBehavior: state.runtime.session.isStreaming ? "followUp" : undefined,
-			followUpQueueKey,
-			source: "rpc",
-		});
+		await state.runtime.session.prompt(job.prompt, { source: "rpc" });
 	}
 
 	private createCronJobForState(state: ActiveSessionState, schedule: string, prompt: string): AgentCronJob {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -483,7 +483,10 @@ export class AgentDaemon {
 			await state.runtime.session.followUp(job.prompt);
 			return;
 		}
-		await state.runtime.session.prompt(job.prompt, { source: "rpc" });
+		await state.runtime.session.prompt(job.prompt, {
+			streamingBehavior: "followUp",
+			source: "rpc",
+		});
 	}
 
 	private createCronJobForState(state: ActiveSessionState, schedule: string, prompt: string): AgentCronJob {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -485,6 +485,7 @@ export class AgentDaemon {
 		}
 		await state.runtime.session.prompt(job.prompt, {
 			streamingBehavior: "followUp",
+			followUpQueueKey: isHeartbeatCronJob(job) ? `heartbeat:${job.id}` : undefined,
 			source: "rpc",
 		});
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -22,7 +22,9 @@ import {
 	type AgentHeartbeatUpdateAction,
 	createAgentHeartbeatToolDefinitions,
 	DEFAULT_HEARTBEAT_SCHEDULE,
+	isHeartbeatCronJob,
 	normalizeHeartbeatSchedule,
+	shouldDeferHeartbeatCronJob,
 } from "../../core/cron-jobs.js";
 import type {
 	CreateRlmSubagentRuntimeOptions,
@@ -471,11 +473,10 @@ export class AgentDaemon {
 		if (!state) {
 			return;
 		}
-		const followUpQueueKey = isHeartbeatCronJob(job) ? `heartbeat:${job.id}` : undefined;
-		if (followUpQueueKey && (state.runtime.session.isStreaming || state.runtime.session.pendingMessageCount > 0)) {
-			const didQueue = await state.runtime.session.followUp(job.prompt, undefined, { queueKey: followUpQueueKey });
-			return didQueue ? undefined : "skipped";
+		if (shouldDeferHeartbeatCronJob(job, state.runtime.session)) {
+			return "skipped";
 		}
+		const followUpQueueKey = isHeartbeatCronJob(job) ? `heartbeat:${job.id}` : undefined;
 		if (!followUpQueueKey && (state.runtime.session.isStreaming || state.runtime.session.pendingMessageCount > 0)) {
 			await state.runtime.session.followUp(job.prompt);
 			return;
@@ -1668,10 +1669,6 @@ export class AgentDaemon {
 		this.cleanupSocketPath();
 		process.exit(exitCode);
 	}
-}
-
-function isHeartbeatCronJob(job: AgentCronJob): boolean {
-	return job.source === "heartbeat" || job.source === "rlm_heartbeat";
 }
 
 function serializeSavedSessionInfo(session: SessionInfo): DaemonSavedSessionInfo {

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -703,6 +703,7 @@ describe("AgentCronScheduler", () => {
 			id: job.id,
 			status: "active",
 			nextRunAt: "2026-01-01T12:45:00.000Z",
+			lastSkippedAt: "2026-01-01T12:40:00.000Z",
 			runCount: 0,
 		});
 		expect(store.getHeartbeat("active-1")).not.toHaveProperty("lastRunAt");

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -9,6 +9,7 @@ import {
 	createAgentHeartbeatToolDefinitions,
 	parseAgentCronSchedule,
 	parseHeartbeatCommand,
+	shouldDeferHeartbeatCronJob,
 } from "../src/core/cron-jobs.js";
 
 const start = new Date("2026-01-01T12:34:00.000Z");
@@ -749,6 +750,69 @@ describe("AgentCronScheduler", () => {
 				expect.objectContaining({ id: second.id, status: "cancelled", runCount: 0 }),
 			]),
 		);
+	});
+});
+
+describe("shouldDeferHeartbeatCronJob", () => {
+	const baseJob: AgentCronJob = {
+		id: "job-1",
+		status: "active",
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		prompt: "check progress",
+		schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+		createdAt: "2026-01-01T12:34:00.000Z",
+		updatedAt: "2026-01-01T12:34:00.000Z",
+		nextRunAt: "2026-01-01T12:39:00.000Z",
+		runCount: 0,
+	};
+
+	it("defers user and RLM heartbeats while the target session is working", () => {
+		for (const source of ["heartbeat", "rlm_heartbeat"] as const) {
+			const job = { ...baseJob, source };
+
+			expect(
+				shouldDeferHeartbeatCronJob(job, {
+					isStreaming: true,
+					isBashRunning: false,
+					pendingMessageCount: 0,
+				}),
+			).toBe(true);
+			expect(
+				shouldDeferHeartbeatCronJob(job, {
+					isStreaming: false,
+					isBashRunning: true,
+					pendingMessageCount: 0,
+				}),
+			).toBe(true);
+			expect(
+				shouldDeferHeartbeatCronJob(job, {
+					isStreaming: false,
+					isBashRunning: false,
+					pendingMessageCount: 1,
+				}),
+			).toBe(true);
+		}
+	});
+
+	it("allows heartbeats when the target session is idle", () => {
+		expect(
+			shouldDeferHeartbeatCronJob(
+				{ ...baseJob, source: "heartbeat" },
+				{ isStreaming: false, isBashRunning: false, pendingMessageCount: 0 },
+			),
+		).toBe(false);
+	});
+
+	it("does not defer ordinary cron jobs", () => {
+		expect(
+			shouldDeferHeartbeatCronJob(
+				{ ...baseJob, source: "cron" },
+				{ isStreaming: true, isBashRunning: true, pendingMessageCount: 2 },
+			),
+		).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -383,10 +383,55 @@ describe("daemon mode helpers", () => {
 		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
 
 		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
+			makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }),
+		);
+
+		expect(prompt).toHaveBeenCalledWith("heartbeat prompt", {
+			streamingBehavior: "followUp",
+			followUpQueueKey: "heartbeat:heartbeat-1",
+			source: "rpc",
+		});
+		expect(followUp).not.toHaveBeenCalled();
+	});
+
+	it("prompts idle generic cron jobs without a heartbeat coalescing key", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const prompt = vi.fn(async () => {});
+		const followUp = vi.fn(async () => true);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					isStreaming: boolean;
+					isBashRunning: boolean;
+					pendingMessageCount: number;
+					prompt: typeof prompt;
+					followUp: typeof followUp;
+				};
+			};
+		};
+		state.runtime.session = {
+			isStreaming: false,
+			isBashRunning: false,
+			pendingMessageCount: 0,
+			prompt,
+			followUp,
+		} as never;
+		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
+
+		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
 			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }),
 		);
 
-		expect(prompt).toHaveBeenCalledWith("heartbeat prompt", { streamingBehavior: "followUp", source: "rpc" });
+		expect(prompt).toHaveBeenCalledWith("heartbeat prompt", {
+			streamingBehavior: "followUp",
+			followUpQueueKey: undefined,
+			source: "rpc",
+		});
 		expect(followUp).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -353,6 +353,43 @@ describe("daemon mode helpers", () => {
 		expect(prompt).not.toHaveBeenCalled();
 	});
 
+	it("prompts idle sessions with a followUp streaming behavior to survive a mid-call stream start", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const prompt = vi.fn(async () => {});
+		const followUp = vi.fn(async () => true);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					isStreaming: boolean;
+					isBashRunning: boolean;
+					pendingMessageCount: number;
+					prompt: typeof prompt;
+					followUp: typeof followUp;
+				};
+			};
+		};
+		state.runtime.session = {
+			isStreaming: false,
+			isBashRunning: false,
+			pendingMessageCount: 0,
+			prompt,
+			followUp,
+		} as never;
+		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
+
+		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
+			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }),
+		);
+
+		expect(prompt).toHaveBeenCalledWith("heartbeat prompt", { streamingBehavior: "followUp", source: "rpc" });
+		expect(followUp).not.toHaveBeenCalled();
+	});
+
 	it("removes queued heartbeat follow-ups when a heartbeat is cleared", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-heartbeat-clear-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -181,7 +181,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("queues busy heartbeat cron jobs with a per-job coalescing key", async () => {
+	it("defers busy heartbeat cron jobs instead of queueing a follow-up", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: {
 				agentDir: "/tmp/prime-agent-test-agent",
@@ -197,6 +197,7 @@ describe("daemon mode helpers", () => {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
 					isStreaming: boolean;
+					isBashRunning: boolean;
 					pendingMessageCount: number;
 					prompt: typeof prompt;
 					followUp: typeof followUp;
@@ -205,6 +206,7 @@ describe("daemon mode helpers", () => {
 		};
 		state.runtime.session = {
 			isStreaming: true,
+			isBashRunning: false,
 			pendingMessageCount: 0,
 			prompt,
 			followUp,
@@ -216,17 +218,20 @@ describe("daemon mode helpers", () => {
 		).sessions.set(state.activeSessionId, state);
 		const runCronJob = (
 			daemon as unknown as {
-				runCronJob(job: AgentCronJob): Promise<void>;
+				runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 			}
 		).runCronJob.bind(daemon);
 
-		await runCronJob(makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }));
+		const result = await runCronJob(
+			makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }),
+		);
 
-		expect(followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { queueKey: "heartbeat:heartbeat-1" });
+		expect(result).toBe("skipped");
+		expect(followUp).not.toHaveBeenCalled();
 		expect(prompt).not.toHaveBeenCalled();
 	});
 
-	it("uses separate queue keys for separate RLM heartbeat cron jobs", async () => {
+	it("defers separate RLM heartbeat cron jobs while the session is busy", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: {
 				agentDir: "/tmp/prime-agent-test-agent",
@@ -242,6 +247,7 @@ describe("daemon mode helpers", () => {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
 					isStreaming: boolean;
+					isBashRunning: boolean;
 					pendingMessageCount: number;
 					prompt: typeof prompt;
 					followUp: typeof followUp;
@@ -250,6 +256,7 @@ describe("daemon mode helpers", () => {
 		};
 		state.runtime.session = {
 			isStreaming: true,
+			isBashRunning: false,
 			pendingMessageCount: 0,
 			prompt,
 			followUp,
@@ -261,19 +268,24 @@ describe("daemon mode helpers", () => {
 		).sessions.set(state.activeSessionId, state);
 		const runCronJob = (
 			daemon as unknown as {
-				runCronJob(job: AgentCronJob): Promise<void>;
+				runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 			}
 		).runCronJob.bind(daemon);
 
-		await runCronJob(makeCronJob({ id: "rlm-1", source: "rlm_heartbeat", activeSessionId: state.activeSessionId }));
-		await runCronJob(makeCronJob({ id: "rlm-2", source: "rlm_heartbeat", activeSessionId: state.activeSessionId }));
+		const first = await runCronJob(
+			makeCronJob({ id: "rlm-1", source: "rlm_heartbeat", activeSessionId: state.activeSessionId }),
+		);
+		const second = await runCronJob(
+			makeCronJob({ id: "rlm-2", source: "rlm_heartbeat", activeSessionId: state.activeSessionId }),
+		);
 
-		expect(followUp).toHaveBeenNthCalledWith(1, "heartbeat prompt", undefined, { queueKey: "heartbeat:rlm-1" });
-		expect(followUp).toHaveBeenNthCalledWith(2, "heartbeat prompt", undefined, { queueKey: "heartbeat:rlm-2" });
+		expect(first).toBe("skipped");
+		expect(second).toBe("skipped");
+		expect(followUp).not.toHaveBeenCalled();
 		expect(prompt).not.toHaveBeenCalled();
 	});
 
-	it("skips duplicate queued heartbeat cron jobs", async () => {
+	it("does not enqueue another heartbeat when one is already pending", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -284,6 +296,7 @@ describe("daemon mode helpers", () => {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
 					isStreaming: boolean;
+					isBashRunning: boolean;
 					pendingMessageCount: number;
 					prompt: ReturnType<typeof vi.fn>;
 					followUp: ReturnType<typeof vi.fn>;
@@ -294,6 +307,7 @@ describe("daemon mode helpers", () => {
 		const removeQueuedFollowUp = vi.fn(() => true);
 		state.runtime.session = {
 			isStreaming: true,
+			isBashRunning: false,
 			pendingMessageCount: 1,
 			prompt: vi.fn(),
 			followUp,
@@ -305,7 +319,7 @@ describe("daemon mode helpers", () => {
 		).runCronJob(makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }));
 
 		expect(result).toBe("skipped");
-		expect(followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { queueKey: "heartbeat:heartbeat-1" });
+		expect(followUp).not.toHaveBeenCalled();
 		expect(removeQueuedFollowUp).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary

- Defer user `/heartbeat` and internal `rlm_heartbeat` cron jobs when the target session is already active.
- Treat streaming, running bash, or an existing pending follow-up as active work for heartbeat delivery.
- Preserve existing generic cron behavior: non-heartbeat cron jobs still queue behind busy sessions.

## Why

Heartbeat prompts should not pile onto an agent that is already working. If a heartbeat fires while the target session is active, the scheduler now treats that run as skipped and reschedules the next interval instead of enqueueing a follow-up message.

## Tests

- `npm test -- cron-jobs.test.ts daemon-mode.test.ts`
- `npm run build`
- pre-commit `npm run check`
- isolated daemon smoke test: set a heartbeat, queued existing work, waited past the heartbeat interval, and verified no heartbeat follow-up was queued while the job remained scheduled for the next interval

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon scheduling and message delivery for heartbeats versus ordinary crons; misclassification could drop heartbeats or alter queue behavior, but behavior is covered by unit tests.
> 
> **Overview**
> **Heartbeat cron jobs** (`heartbeat` and `rlm_heartbeat`) no longer enqueue follow-ups when the target session is busy. The daemon returns `"skipped"` instead, and the scheduler reschedules the next interval via `recordSkipResult`, which now records **`lastSkippedAt`** (also shown in `formatAgentCronJob`).
> 
> Busy is defined by new **`shouldDeferHeartbeatCronJob`**: streaming, bash running, or any pending follow-up messages. **Generic cron** behavior is unchanged—busy sessions still get `followUp` for non-heartbeat jobs.
> 
> When a cron job actually runs on an idle session, delivery goes through **`session.prompt`** with **`streamingBehavior: "followUp"`** (and heartbeat-specific `followUpQueueKey` when applicable), so a stream that starts mid-dispatch still queues safely instead of colliding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4ff041b7770a0e4d5720a2e69c5863e6c1e94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer heartbeat cron job delivery while sessions are streaming, running bash, or have pending messages
> - Adds `shouldDeferHeartbeatCronJob` and `isHeartbeatCronJob` helpers in [`cron-jobs.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/265/files#diff-fb783dad61580c3b11d0731df2a325b6e3dd852fc430a309a5f3ae7ebcc826dd) that check a `HeartbeatCronSessionActivity` snapshot to decide whether to skip execution.
> - Updates `AgentDaemon.runCronJob` in [`daemon-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/265/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) to call `shouldDeferHeartbeatCronJob` before scheduling; heartbeats return `"skipped"` and no follow-up is queued when the session is busy.
> - Behavioral Change: previously, heartbeats for busy sessions were enqueued as follow-ups; now they are silently dropped until the next scheduled interval.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #265 opened
>
> - Modified `AgentDaemon.runCronJob` method to defer heartbeat job execution when sessions are streaming or have pending messages, and removed follow-up queue key logic for all cron jobs [5a73a9b]
> - Added `lastSkippedAt` timestamp tracking to the `AgentCronJob` interface and `AgentCronJobStore` class to record when cron jobs are skipped [5a73a9b]
> - Modified `AgentDaemon.runCronJob` method to pass `streamingBehavior: 'followUp'` option when prompting idle sessions for non-heartbeat cron jobs [f4501f8]
> - Modified `AgentDaemon.runCronJob` method to pass a `followUpQueueKey` option when invoking `state.runtime.session.prompt`, setting it to `heartbeat:${job.id}` for heartbeat cron jobs and leaving it undefined for non-heartbeat cron jobs [da4ff04]
> - Added test assertions to verify that `session.prompt` is called with the correct `followUpQueueKey` value for both heartbeat and generic cron jobs, and introduced a new test case for idle generic cron jobs [da4ff04]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a73a9b. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->