### PR TITLE
Default thinking level to xhigh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Changed the built-in default thinking level to `xhigh` when no user or project default is configured.
 - Changed the IPython system prompt section to use the upstream rlm-harness IPYTHON_CONTROL_PROMPT: IPython is framed as a persistent control environment, not the target project's runtime. Shell commands should use `%%bash` cells instead of `!cmd` escapes. The agent should not install dependencies into the IPython kernel but use the project's own environment instead.
 - Removed the `.venv` interpreter hint from the system prompt (no longer needed with the control-environment framing).
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -17,7 +17,7 @@ Edit directly or use `/settings` for common options.
 |---------|------|---------|-------------|
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
-| `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
+| `defaultThinkingLevel` | string | `"xhigh"` | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
 
@@ -247,7 +247,7 @@ See [packages.md](packages.md) for package management details.
 {
   "defaultProvider": "anthropic",
   "defaultModel": "claude-sonnet-4-20250514",
-  "defaultThinkingLevel": "medium",
+  "defaultThinkingLevel": "xhigh",
   "theme": "dark",
   "compaction": {
     "enabled": true,

--- a/packages/coding-agent/src/core/defaults.ts
+++ b/packages/coding-agent/src/core/defaults.ts
@@ -1,3 +1,3 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 
-export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "xhigh";

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -407,6 +407,22 @@ describe("default model selection", () => {
 		expect(result.model?.id).toBe("openai/ghost-model");
 	});
 
+	test("findInitialModel uses xhigh as the built-in default thinking level", async () => {
+		const reasoningModel = mockModels[0];
+		const registry = {
+			getAvailable: async () => [reasoningModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: registry,
+		});
+
+		expect(result.model).toBe(reasoningModel);
+		expect(result.thinkingLevel).toBe("xhigh");
+	});
+
 	test("findInitialModel selects ai-gateway default when available", async () => {
 		const aiGatewayModel: Model<"anthropic-messages"> = {
 			id: "anthropic/claude-opus-4-6",


### PR DESCRIPTION
## Summary

- Change the built-in default thinking level from `medium` to `xhigh` when no user or project setting overrides it.
- Document `defaultThinkingLevel` as defaulting to `xhigh`.
- Add a model resolver regression covering the built-in default.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-resolver.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change increases reasoning usage and cost for users who rely on implicit defaults; explicit settings and CLI overrides are unchanged.
> 
> **Overview**
> Raises the **built-in default thinking level** from `medium` to **`xhigh`** when neither user nor project `defaultThinkingLevel` is set. The change is centralized in `DEFAULT_THINKING_LEVEL` in `defaults.ts`, which `findInitialModel` and model-switch paths already use as the fallback.
> 
> Docs and release notes now state that `defaultThinkingLevel` defaults to `xhigh`, including the settings example. A **`findInitialModel` regression test** asserts the built-in default is `xhigh` with no CLI or saved settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa525b56f86122dddf85bddc257bc28a3c4e1c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default thinking level to `xhigh` in coding agent
> Changes `DEFAULT_THINKING_LEVEL` in [defaults.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/266/files#diff-baf665c76df22242fdd06328574fa579e2f045c77316eabd0195470e33f341fb) from `"medium"` to `"xhigh"`. This affects all code paths that fall back to the built-in default when no user or project `defaultThinkingLevel` is configured. Risk: users with no explicit thinking level setting will now consume significantly more tokens per request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa525b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->