### PR TITLE
keep ipython kernel alive across compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2734,15 +2734,20 @@ export class AgentSession {
 	// Appended straight to history (not a nextTurn message) so it also reaches the
 	// continue()-driven auto-compaction resume, which never injects nextTurn messages.
 	private async _notifyKernelStateAfterCompaction(): Promise<void> {
-		const names = await this._ipythonKernelProvisioner?.listNamespaceNames().catch(() => null);
-		if (!names) return;
+		const provisioner = this._ipythonKernelProvisioner;
+		// No kernel means no state to remind about; only stay silent in that case.
+		if (!provisioner?.hasRunningKernel) return;
+		// null here is a listing failure (kernel is up) — still tell the model state persisted.
+		const names = await provisioner.listNamespaceNames().catch(() => null);
 		const detail =
-			names.length > 0
-				? `These names are still defined: ${names.join(", ")}.`
-				: "You have not defined any names yet.";
+			names === null
+				? ""
+				: names.length > 0
+					? ` These names are still defined: ${names.join(", ")}.`
+					: " You have not defined any names yet.";
 		const content = [
 			"<ipython_state>",
-			`Your IPython kernel persisted through compaction; all variables, imports, and helpers you defined remain available. ${detail}`,
+			`Your IPython kernel persisted through compaction; all variables, imports, and helpers you defined remain available.${detail}`,
 			"</ipython_state>",
 		].join("\n");
 		const message = {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -417,6 +417,9 @@ interface RlmChildRun {
 /** Standard thinking levels */
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
 
+/** Cap on the post-compaction kernel namespace probe so a wedged kernel can't stall recovery. */
+const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;
+
 function noopRlmChildAbort(): void {}
 
 function isRlmChildRunCancelled(run: RlmChildRun): boolean {
@@ -2737,8 +2740,16 @@ export class AgentSession {
 		const provisioner = this._ipythonKernelProvisioner;
 		// No kernel means no state to remind about; only stay silent in that case.
 		if (!provisioner?.hasRunningKernel) return;
-		const names = await provisioner.listNamespaceNames().catch(() => null);
-		// null is a listing failure; only claim state survived if the kernel is still up
+		// Bound the listing: a wedged kernel can leave the queued cell unresolved, which would
+		// otherwise hang the compaction path before its continue() retry.
+		const names = await Promise.race([
+			provisioner.listNamespaceNames().catch(() => null),
+			new Promise<null>((resolve) => {
+				const t = setTimeout(() => resolve(null), KERNEL_STATE_LISTING_TIMEOUT_MS);
+				if (typeof t === "object" && "unref" in t) t.unref();
+			}),
+		]);
+		// null is a listing failure/timeout; only claim state survived if the kernel is still up
 		// (it may have died in the window since the check above).
 		if (names === null && !provisioner.hasRunningKernel) return;
 		const detail =

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2731,8 +2731,28 @@ export class AgentSession {
 		return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
 	}
 
-	private async _restartIpythonKernelAfterCompaction(): Promise<void> {
-		await this._ipythonKernelProvisioner?.restart();
+	/**
+	 * Compaction summarizes the conversation but leaves the IPython kernel running,
+	 * so every variable, import, and helper the model defined is still live. The
+	 * cells that defined them are gone from the compacted context, though, so remind
+	 * the model which names remain available. Best-effort and silent on failure.
+	 */
+	private async _notifyKernelStateAfterCompaction(): Promise<void> {
+		const names = await this._ipythonKernelProvisioner?.listNamespaceNames().catch(() => null);
+		if (!names) return;
+		const detail =
+			names.length > 0
+				? `These names are still defined: ${names.join(", ")}.`
+				: "You have not defined any names yet.";
+		const content = [
+			"<ipython_state>",
+			`Your IPython kernel persisted through compaction; all variables, imports, and helpers you defined remain available. ${detail}`,
+			"</ipython_state>",
+		].join("\n");
+		void this.sendCustomMessage(
+			{ customType: "ipython_state", content, display: false },
+			{ deliverAs: "nextTurn" },
+		).catch(() => {});
 	}
 
 	/**
@@ -2902,7 +2922,7 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
-			await this._restartIpythonKernelAfterCompaction();
+			await this._notifyKernelStateAfterCompaction();
 
 			const compactionResult = {
 				summary,
@@ -3240,7 +3260,7 @@ export class AgentSession {
 					fromExtension,
 				});
 			}
-			await this._restartIpythonKernelAfterCompaction();
+			await this._notifyKernelStateAfterCompaction();
 
 			const result: CompactionResult = {
 				summary,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2734,21 +2734,23 @@ export class AgentSession {
 		return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
 	}
 
-	// Appended straight to history (not a nextTurn message) so it also reaches the
-	// continue()-driven auto-compaction resume, which never injects nextTurn messages.
+	// Added to history (not a nextTurn message) so it also reaches the continue()-driven
+	// auto-compaction resume, which never injects nextTurn messages.
 	private async _notifyKernelStateAfterCompaction(): Promise<void> {
 		const provisioner = this._ipythonKernelProvisioner;
 		// No kernel means no state to remind about; only stay silent in that case.
 		if (!provisioner?.hasRunningKernel) return;
-		// Bound the listing: a wedged kernel can leave the queued cell unresolved, which would
-		// otherwise hang the compaction path before its continue() retry.
-		const names = await Promise.race([
-			provisioner.listNamespaceNames().catch(() => null),
-			new Promise<null>((resolve) => {
-				const t = setTimeout(() => resolve(null), KERNEL_STATE_LISTING_TIMEOUT_MS);
-				if (typeof t === "object" && "unref" in t) t.unref();
-			}),
-		]);
+		// Bound the probe so a wedged kernel can't stall recovery, and abort it on timeout so
+		// the kernel's serialized execution queue isn't left occupied by a never-resolving cell.
+		const abort = new AbortController();
+		const timer = setTimeout(() => abort.abort(), KERNEL_STATE_LISTING_TIMEOUT_MS);
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
+		let names: string[] | null;
+		try {
+			names = await provisioner.listNamespaceNames(abort.signal).catch(() => null);
+		} finally {
+			clearTimeout(timer);
+		}
 		// null is a listing failure/timeout; only claim state survived if the kernel is still up
 		// (it may have died in the window since the check above).
 		if (names === null && !provisioner.hasRunningKernel) return;
@@ -2770,7 +2772,15 @@ export class AgentSession {
 			display: false,
 			timestamp: Date.now(),
 		} satisfies CustomMessage;
-		this.agent.state.messages.push(message);
+		// Insert before a trailing assistant error so overflow-retry cleanup can still strip it.
+		const messages = this.agent.state.messages;
+		const last = messages[messages.length - 1];
+		const insertBeforeError = last?.role === "assistant" && (last as AssistantMessage).stopReason === "error";
+		if (insertBeforeError) {
+			messages.splice(messages.length - 1, 0, message);
+		} else {
+			messages.push(message);
+		}
 		this.sessionManager.appendCustomMessageEntry(message.customType, message.content, message.display, undefined);
 		this._emit({ type: "message_start", message });
 		this._emit({ type: "message_end", message });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2737,8 +2737,10 @@ export class AgentSession {
 		const provisioner = this._ipythonKernelProvisioner;
 		// No kernel means no state to remind about; only stay silent in that case.
 		if (!provisioner?.hasRunningKernel) return;
-		// null here is a listing failure (kernel is up) — still tell the model state persisted.
 		const names = await provisioner.listNamespaceNames().catch(() => null);
+		// null is a listing failure; only claim state survived if the kernel is still up
+		// (it may have died in the window since the check above).
+		if (names === null && !provisioner.hasRunningKernel) return;
 		const detail =
 			names === null
 				? ""

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2760,6 +2760,7 @@ export class AgentSession {
 		this.agent.state.messages.push(message);
 		this.sessionManager.appendCustomMessageEntry(message.customType, message.content, message.display, undefined);
 		this._emit({ type: "message_start", message });
+		this._emit({ type: "message_end", message });
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2731,12 +2731,8 @@ export class AgentSession {
 		return this.model ? (clampThinkingLevel(this.model, level) as ThinkingLevel) : "off";
 	}
 
-	/**
-	 * Compaction summarizes the conversation but leaves the IPython kernel running,
-	 * so every variable, import, and helper the model defined is still live. The
-	 * cells that defined them are gone from the compacted context, though, so remind
-	 * the model which names remain available. Best-effort and silent on failure.
-	 */
+	// Appended straight to history (not a nextTurn message) so it also reaches the
+	// continue()-driven auto-compaction resume, which never injects nextTurn messages.
 	private async _notifyKernelStateAfterCompaction(): Promise<void> {
 		const names = await this._ipythonKernelProvisioner?.listNamespaceNames().catch(() => null);
 		if (!names) return;
@@ -2749,10 +2745,16 @@ export class AgentSession {
 			`Your IPython kernel persisted through compaction; all variables, imports, and helpers you defined remain available. ${detail}`,
 			"</ipython_state>",
 		].join("\n");
-		void this.sendCustomMessage(
-			{ customType: "ipython_state", content, display: false },
-			{ deliverAs: "nextTurn" },
-		).catch(() => {});
+		const message = {
+			role: "custom" as const,
+			customType: "ipython_state",
+			content,
+			display: false,
+			timestamp: Date.now(),
+		} satisfies CustomMessage;
+		this.agent.state.messages.push(message);
+		this.sessionManager.appendCustomMessageEntry(message.customType, message.content, message.display, undefined);
+		this._emit({ type: "message_start", message });
 	}
 
 	/**

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -493,8 +493,8 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
-const KERNEL_RESTART_SUMMARY_WARNING =
-	"Note: the IPython kernel will be restarted after this summary. Python variables, imports, and in-memory state will be wiped. Files on disk are preserved — capture file paths and what they contain so the next agent can resume without redoing work.";
+const KERNEL_PERSIST_SUMMARY_NOTE =
+	"Note: the IPython kernel keeps running after this summary — every Python variable, import, and helper you defined stays available. The cells that defined them won't appear above, so record in the summary any names worth remembering so you reuse them instead of redefining them.";
 
 const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
 
@@ -537,14 +537,14 @@ Keep each section concise. Preserve exact file paths, function names, and error 
 
 /**
  * Build the instruction portion of the summarization prompt: the initial or
- * update template, optional user instructions, and the kernel restart warning.
+ * update template, optional user instructions, and the kernel persistence note.
  */
 export function buildSummarizationPrompt(customInstructions?: string, previousSummary?: string): string {
 	let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
 	if (customInstructions) {
 		basePrompt += `\n\n<user-instructions>\nThe user provided these instructions for this summary. Follow them with high priority while keeping the section format above: emphasize what they ask to focus on, and preserve verbatim anything they ask to remember.\n${customInstructions}\n</user-instructions>`;
 	}
-	return `${basePrompt}\n\n${KERNEL_RESTART_SUMMARY_WARNING}`;
+	return `${basePrompt}\n\n${KERNEL_PERSIST_SUMMARY_NOTE}`;
 }
 
 /**

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -10,9 +10,11 @@ import { v4 as uuid } from "uuid";
 import { Dealer, Subscriber } from "zeromq";
 import { ensureKernelPython, type KernelBootstrapProgressHandler, type KernelPythonSkill } from "./bootstrap.js";
 import {
+	buildListNamesCode,
 	buildRestoreCode,
 	buildSnapshotCode,
 	DEFAULT_SNAPSHOT_MAX_BYTES,
+	parseListNamesResult,
 	parseRestoreResult,
 	parseSnapshotResult,
 	type RestoreResult,
@@ -1016,6 +1018,26 @@ export class KernelManager {
 			return parseRestoreResult(r.stdout, cfg.path);
 		} catch (error) {
 			this.appendKernelDiagnostic(`state restore error: ${errorMessage(error)}`);
+			return null;
+		}
+	}
+
+	/**
+	 * List the user-defined top-level names currently live in the namespace,
+	 * using the same filtering as the snapshot. Returns null if the kernel isn't
+	 * running or the listing cell fails. Never throws.
+	 */
+	async listNamespaceNames(): Promise<string[] | null> {
+		if (!this.isRunning) return null;
+		try {
+			const r = await this.enqueueExecute(buildListNamesCode(), { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			if (r.status !== "ok") {
+				this.appendKernelDiagnostic(`namespace listing failed: ${r.error?.evalue ?? r.stderr}`);
+				return null;
+			}
+			return parseListNamesResult(r.stdout);
+		} catch (error) {
+			this.appendKernelDiagnostic(`namespace listing error: ${errorMessage(error)}`);
 			return null;
 		}
 	}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1027,12 +1027,13 @@ export class KernelManager {
 	}
 
 	/** Live user-defined top-level names, or null if the kernel isn't running. Never throws. */
-	async listNamespaceNames(): Promise<string[] | null> {
+	async listNamespaceNames(signal?: AbortSignal): Promise<string[] | null> {
 		if (!this.isRunning) return null;
 		try {
 			const r = await this.enqueueExecute(buildListNamesCode(), {
 				maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS,
 				internal: true,
+				signal,
 			});
 			if (r.status !== "ok") {
 				this.appendKernelDiagnostic(`namespace listing failed: ${r.error?.evalue ?? r.stderr}`);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -84,6 +84,8 @@ export interface ExecuteOptions {
 	onStream?: (chunk: string, name: "stdout" | "stderr") => void;
 	/** Cap stdout / stderr / result at this many characters. Default 65536. */
 	maxOutputChars?: number;
+	/** Synthetic host cell (snapshot/restore/list); excluded from lastCellCode attribution. */
+	internal?: boolean;
 }
 
 /** MIME tag the `edit` skill emits diff payloads under, via `display_data`. */
@@ -655,7 +657,9 @@ export class KernelManager {
 				reject: result.reject,
 			};
 			this.activeExecution = execution;
-			this.lastCellCode = code;
+			if (!opts.internal) {
+				this.lastCellCode = code;
+			}
 			try {
 				await shell.send(encode(msg, conn.key));
 			} catch (error) {
@@ -988,7 +992,7 @@ export class KernelManager {
 		if (!cfg || !this.isRunning) return null;
 		const code = buildSnapshotCode(cfg.path, cfg.manifestPath, cfg.maxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES);
 		try {
-			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS, internal: true });
 			if (r.status !== "ok") {
 				this.appendKernelDiagnostic(`state snapshot failed: ${r.error?.evalue ?? r.stderr}`);
 				return null;
@@ -1010,7 +1014,7 @@ export class KernelManager {
 		if (!cfg) return null;
 		const code = buildRestoreCode(cfg.path);
 		try {
-			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS, internal: true });
 			if (r.status !== "ok") {
 				this.appendKernelDiagnostic(`state restore failed: ${r.error?.evalue ?? r.stderr}`);
 				return null;
@@ -1022,15 +1026,14 @@ export class KernelManager {
 		}
 	}
 
-	/**
-	 * List the user-defined top-level names currently live in the namespace,
-	 * using the same filtering as the snapshot. Returns null if the kernel isn't
-	 * running or the listing cell fails. Never throws.
-	 */
+	/** Live user-defined top-level names, or null if the kernel isn't running. Never throws. */
 	async listNamespaceNames(): Promise<string[] | null> {
 		if (!this.isRunning) return null;
 		try {
-			const r = await this.enqueueExecute(buildListNamesCode(), { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS });
+			const r = await this.enqueueExecute(buildListNamesCode(), {
+				maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS,
+				internal: true,
+			});
 			if (r.status !== "ok") {
 				this.appendKernelDiagnostic(`namespace listing failed: ${r.error?.evalue ?? r.stderr}`);
 				return null;

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -193,12 +193,7 @@ finally:
 `.trim();
 }
 
-/**
- * Python that prints a single marker line listing the user-defined top-level
- * names currently live in the namespace, using the same filtering as the
- * snapshot (skip internals, IPython-injected names, and live handles). Used to
- * remind the model what survived a compaction. Never raises.
- */
+/** Marker-line list of live user-defined names, filtered like the snapshot. Never raises. */
 export function buildListNamesCode(): string {
 	return `
 def _prime_agent_list_state_names():

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -193,6 +193,44 @@ finally:
 `.trim();
 }
 
+/**
+ * Python that prints a single marker line listing the user-defined top-level
+ * names currently live in the namespace, using the same filtering as the
+ * snapshot (skip internals, IPython-injected names, and live handles). Used to
+ * remind the model what survived a compaction. Never raises.
+ */
+export function buildListNamesCode(): string {
+	return `
+def _prime_agent_list_state_names():
+    import builtins as _b, json
+    ip = None
+    try:
+        ip = get_ipython()  # noqa: F821 (injected by IPython)
+    except _b.Exception:
+        ip = None
+    ns = ip.user_ns if ip is not None else _b.globals()
+    hidden = _b.set(_b.getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else _b.set()
+    always_skip = {"rlm", "In", "Out", "get_ipython", "exit", "quit", "open"}
+    names = []
+    for name in _b.list(ns.keys()):
+        if name.startswith("_") or name in hidden or name in always_skip:
+            continue
+        names.append(name)
+    _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"names": _b.sorted(names)}))
+
+
+try:
+    _prime_agent_list_state_names()
+finally:
+    del _prime_agent_list_state_names
+`.trim();
+}
+
+interface RawListNames {
+	names?: unknown;
+	error?: unknown;
+}
+
 interface RawSnapshot {
 	saved?: unknown;
 	skipped?: unknown;
@@ -254,4 +292,11 @@ export function parseRestoreResult(stdout: string, path: string): RestoreResult 
 		failed: asReasonArray(raw.failed),
 		path,
 	};
+}
+
+/** Sorted list of live user-defined names, or null if the marker was absent/invalid. */
+export function parseListNamesResult(stdout: string): string[] | null {
+	const raw = parseMarkerLine<RawListNames>(stdout);
+	if (!raw || raw.error) return null;
+	return asStringArray(raw.names);
 }

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -197,12 +197,7 @@ export class IpythonKernelProvisioner {
 		void this.ensure().catch(() => {});
 	}
 
-	/**
-	 * List the user-defined names currently live in the kernel namespace, or null
-	 * if no kernel is running. Used after compaction to remind the model which
-	 * variables, imports, and helpers survived — the kernel itself is never torn
-	 * down, so the namespace stays intact across compaction.
-	 */
+	/** Live user-defined names in the kernel namespace, or null if no kernel is running. */
 	async listNamespaceNames(): Promise<string[] | null> {
 		const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
 		return (await m?.listNamespaceNames()) ?? null;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -197,7 +197,12 @@ export class IpythonKernelProvisioner {
 		void this.ensure().catch(() => {});
 	}
 
-	/** Live user-defined names in the kernel namespace, or null if no kernel is running. */
+	/** Whether a kernel has finished starting and is currently running. */
+	get hasRunningKernel(): boolean {
+		return this.startedManager?.isRunning ?? false;
+	}
+
+	/** Live user-defined names in the kernel namespace, or null if listing failed / no kernel. */
 	async listNamespaceNames(): Promise<string[] | null> {
 		const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
 		return (await m?.listNamespaceNames()) ?? null;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -203,9 +203,9 @@ export class IpythonKernelProvisioner {
 	}
 
 	/** Live user-defined names in the kernel namespace, or null if listing failed / no kernel. */
-	async listNamespaceNames(): Promise<string[] | null> {
+	async listNamespaceNames(signal?: AbortSignal): Promise<string[] | null> {
 		const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
-		return (await m?.listNamespaceNames()) ?? null;
+		return (await m?.listNamespaceNames(signal)) ?? null;
 	}
 
 	/** Dispose the kernel owned by this provisioner, including one still starting up. */

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -1,6 +1,5 @@
 // TODO: reconsider whether the persistent kernel is needed once RLM-1 weights land.
 import { existsSync } from "node:fs";
-import { rm } from "node:fs/promises";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../extensions/types.js";
@@ -149,7 +148,7 @@ export interface IpythonToolOptions {
 	/** Resolves before this kernel starts — e.g. the previous provisioner's dispose, so a
 	 * /reload's old-kernel snapshot flush can't race the new kernel's restore. */
 	readyGate?: Promise<unknown>;
-	/** Filled after the first kernel start so the owning session can restart it after compaction. */
+	/** Filled with the live KernelManager after the first kernel start; cleared on construction. */
 	kernelManagerRef?: { current?: KernelManager };
 	/**
 	 * Fires once per kernel start when a previous session's namespace was revived
@@ -198,26 +197,15 @@ export class IpythonKernelProvisioner {
 		void this.ensure().catch(() => {});
 	}
 
-	/** Restart the kernel if one is running (e.g. after compaction). */
-	async restart(): Promise<void> {
-		try {
-			// Await any in-flight startup first, so we restart a fully-started kernel and
-			// delete the snapshot after (not during) a concurrent restore.
-			const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
-			await m?.restart();
-		} finally {
-			// Compaction deliberately wipes the namespace and tells the model so. Drop the
-			// stale on-disk snapshot too — even if the restart threw — so a later resume
-			// doesn't revive state the model was told is gone (a fresh cell re-snapshots).
-			this._lastRestore = undefined;
-			const dir = this.options?.snapshotDir;
-			if (dir) {
-				await Promise.allSettled([
-					rm(snapshotPathIn(dir), { force: true }),
-					rm(manifestPathIn(dir), { force: true }),
-				]);
-			}
-		}
+	/**
+	 * List the user-defined names currently live in the kernel namespace, or null
+	 * if no kernel is running. Used after compaction to remind the model which
+	 * variables, imports, and helpers survived — the kernel itself is never torn
+	 * down, so the namespace stays intact across compaction.
+	 */
+	async listNamespaceNames(): Promise<string[] | null> {
+		const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));
+		return (await m?.listNamespaceNames()) ?? null;
 	}
 
 	/** Dispose the kernel owned by this provisioner, including one still starting up. */

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -180,10 +180,12 @@ describe("buildSummarizationPrompt", () => {
 		const prompt = buildSummarizationPrompt();
 		expect(prompt).not.toContain("<user-instructions>");
 		expect(prompt).toContain("## Goal");
-		expect(prompt).toContain("IPython kernel");
+		// The kernel keeps running across compaction — the note must not claim a wipe.
+		expect(prompt).toContain("IPython kernel keeps running");
+		expect(prompt).not.toMatch(/wiped|restarted/);
 	});
 
-	it("includes user instructions in a delimited block before the kernel warning", () => {
+	it("includes user instructions in a delimited block before the kernel note", () => {
 		const prompt = buildSummarizationPrompt("focus on the auth refactor, remember the migration command");
 		expect(prompt).toContain("<user-instructions>");
 		expect(prompt).toContain("focus on the auth refactor, remember the migration command");

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -114,7 +114,12 @@ describe("IpythonKernelProvisioner", () => {
 		expect(countRuns()).toBe(1);
 	});
 
-	it("restart() drops the on-disk snapshot so a compaction wipe isn't revived on resume", async () => {
+	it("listNamespaceNames() returns null when no kernel is running", async () => {
+		const provisioner = new IpythonKernelProvisioner(tempDir, {});
+		expect(await provisioner.listNamespaceNames()).toBeNull();
+	});
+
+	it("does not delete the on-disk snapshot (the kernel survives compaction)", async () => {
 		const snapshotDir = join(tempDir, "artifacts");
 		const provisioner = new IpythonKernelProvisioner(tempDir, { snapshotDir });
 		const dill = join(snapshotDir, "kernel-state.dill");
@@ -123,10 +128,11 @@ describe("IpythonKernelProvisioner", () => {
 		writeFileSync(dill, "payload");
 		writeFileSync(manifest, "{}");
 
-		await provisioner.restart();
+		// listing the namespace must never touch the on-disk snapshot
+		await provisioner.listNamespaceNames();
 
-		expect(existsSync(dill)).toBe(false);
-		expect(existsSync(manifest)).toBe(false);
+		expect(existsSync(dill)).toBe(true);
+		expect(existsSync(manifest)).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -141,6 +141,24 @@ describeIfKernel("kernel state snapshot round-trip (real kernel)", () => {
 		}
 	}, 60_000);
 
+	it("lists live user-defined names, filtering internals and live handles", async () => {
+		const listDir = mkdtempSync(join(tmpdir(), "prime-agent-state-list-"));
+		const manager = new KernelManager({ python: python as string, cwd: listDir });
+		try {
+			// A fresh, unstarted kernel reports no names.
+			expect(await manager.listNamespaceNames()).toBeNull();
+			await manager.execute("alpha = 1\ndef helper(n):\n    return n\n_hidden = 2\nrlm = object()");
+			const names = await manager.listNamespaceNames();
+			expect(names).toEqual(expect.arrayContaining(["alpha", "helper"]));
+			// Underscore-prefixed names and the live rlm handle must be filtered out.
+			expect(names).not.toContain("_hidden");
+			expect(names).not.toContain("rlm");
+		} finally {
+			await manager.dispose();
+			rmSync(listDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+
 	it("auto-snapshots after a successful execution (debounced)", async () => {
 		const autoDir = mkdtempSync(join(tmpdir(), "prime-agent-state-auto-"));
 		const autoPath = join(autoDir, "auto.dill");


### PR DESCRIPTION
- the ipython kernel was torn down and its saved state deleted on every compaction, so any variables, imports, and helpers the agent had defined disappeared and it kept referencing names that no longer existed.
- compaction now leaves the running kernel untouched and instead sends the model a short note listing the names still defined, mirroring how a resumed session reports its revived state.
- also corrects the summarization prompt, which previously told the model its kernel would be wiped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-compaction agent context and kernel lifecycle assumptions; a wedged kernel is mitigated by a 5s listing timeout, but compaction recovery still depends on kernel health.
> 
> **Overview**
> **Compaction no longer restarts the IPython kernel or deletes on-disk snapshots.** Previously each compact wiped in-memory Python state and removed snapshot files so resumed sessions could disagree with what the model was told.
> 
> After manual or auto compaction, the session probes the still-running kernel (5s timeout, abortable) and appends a hidden `ipython_state` custom message to agent history—optionally listing live user-defined names—so the model knows variables survived even though defining cells are gone from context. That path is used instead of `nextTurn` so auto-compaction `continue()` also sees it.
> 
> **Kernel layer:** `listNamespaceNames()` runs a filtered internal cell; snapshot/restore/list executions are marked `internal` so they do not update `lastCellCode`. **Provisioner:** `restart()` and snapshot deletion are removed; `hasRunningKernel` and `listNamespaceNames()` are added.
> 
> **Summarization** now tells the model the kernel **persists** and to record important names in the summary, replacing the old restart/wipe warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd5abce4162155dbd4588955eb0c159cf59ca86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep IPython kernel alive across compaction instead of restarting it
> - After compaction completes, the session now injects a non-displayed `ipython_state` custom message indicating the kernel persisted, optionally listing surviving user-defined names, instead of restarting the kernel.
> - Adds `KernelManager.listNamespaceNames()` in [kernel/index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/267/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac) which executes a Python probe to enumerate user-defined top-level names, filtering out underscore-prefixed identifiers and builtins; the probe is time-bounded to 5000ms via `AbortController`.
> - The summarization prompt now includes a kernel persistence note instead of a restart warning.
> - Internal kernel executions (snapshot, restore, list) are marked with `internal: true` so they no longer overwrite `lastCellCode` attribution.
> - Removes `IpythonKernelProvisioner.restart()` and its on-disk snapshot deletion logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bd5abc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->