### PR TITLE
preserve session selection when returning to agents view

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -55,8 +55,11 @@ import {
 import {
 	type AgentsViewRow,
 	type AgentsViewSection,
+	type AgentsViewSelectionKey,
 	buildAgentsViewRows,
+	getAgentsViewSelectionKey,
 	getAgentsViewSummaryIdentity as getSummaryIdentity,
+	resolveAgentsViewSelectionIndex,
 	sectionTitle,
 	shouldShowAgentsViewSession,
 } from "./agents-view-state.js";
@@ -92,6 +95,10 @@ export interface AgentsViewModeOptions {
 type AgentsViewRunResult = { type: "exit" } | { type: "open"; summary: SessionSummary; subagent?: SessionSummary };
 type AgentsViewPersistentState = {
 	selectedRowIdentity?: string;
+	// Stable keys for the selected session, used to re-find it when its
+	// identity changes (e.g. persisted, or re-attached with a new active id)
+	// across re-entry into the agents view.
+	selectedSessionKey?: AgentsViewSelectionKey;
 	statusMessage?: string;
 	initialPromptsSent?: boolean;
 	// Gathered once and reused across agents-view instances so the notices survive
@@ -225,7 +232,11 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 		if (result.type === "exit") {
 			return;
 		}
+		// Pin selection to the session being opened so it stays highlighted when
+		// the user returns; the stable key re-finds it even if its identity
+		// changes (persisted / re-attached) while the session was open.
 		persistentState.selectedRowIdentity = getSummaryIdentity(result.summary);
+		persistentState.selectedSessionKey = getAgentsViewSelectionKey(result.summary);
 
 		let opened: { connection: DaemonAgentConnection; summary: SessionSummary } | undefined;
 		try {
@@ -293,6 +304,7 @@ class AgentsViewMode implements Component, Focusable {
 	private selectedIndex = 0;
 	private selectedRowIdentity: string | undefined;
 	private selectedActiveSessionId: string | undefined;
+	private selectedSessionKey: AgentsViewSelectionKey | undefined;
 	private replyActiveSessionId: string | undefined;
 	private replyLastAssistantText: string | undefined;
 	private replyLastAssistantTextLoading = false;
@@ -313,6 +325,8 @@ class AgentsViewMode implements Component, Focusable {
 		private readonly persistentState: AgentsViewPersistentState = {},
 	) {
 		this.selectedRowIdentity = persistentState.selectedRowIdentity;
+		this.selectedSessionKey = persistentState.selectedSessionKey;
+		this.selectedActiveSessionId = persistentState.selectedSessionKey?.activeSessionId;
 		this.keybindings = KeybindingsManager.create();
 		setKeybindings(this.keybindings);
 		setRegisteredThemes(options.uiServices.getThemes());
@@ -1400,7 +1414,9 @@ class AgentsViewMode implements Component, Focusable {
 			await this.refreshSessions();
 			this.selectedRowIdentity = getSummaryIdentity(summary);
 			this.selectedActiveSessionId = activeSessionId;
+			this.selectedSessionKey = getAgentsViewSelectionKey(summary);
 			this.persistentState.selectedRowIdentity = this.selectedRowIdentity;
+			this.persistentState.selectedSessionKey = this.selectedSessionKey;
 			this.restoreSelection();
 			return { summary, activeSessionId };
 		} catch (error) {
@@ -1504,20 +1520,7 @@ class AgentsViewMode implements Component, Focusable {
 			this.selectedActiveSessionId = undefined;
 			return;
 		}
-		const selectedIdentity = this.selectedRowIdentity ?? this.persistentState.selectedRowIdentity;
-		let index =
-			selectedIdentity === undefined
-				? -1
-				: this.rows.findIndex((row) => row.selectable && row.identity === selectedIdentity);
-		const selectedId = this.selectedActiveSessionId;
-		if (index < 0) {
-			index =
-				selectedId === undefined
-					? -1
-					: this.rows.findIndex(
-							(row) => row.selectable && (row.summary.activeSessionId ?? row.summary.id) === selectedId,
-						);
-		}
+		const index = this.findSelectedRowIndex();
 		if (index >= 0) {
 			this.selectedIndex = index;
 		} else if (!this.rows[this.selectedIndex]?.selectable) {
@@ -1528,6 +1531,12 @@ class AgentsViewMode implements Component, Focusable {
 		this.syncSelectedRowState();
 	}
 
+	private findSelectedRowIndex(): number {
+		const identity = this.selectedRowIdentity ?? this.persistentState.selectedRowIdentity;
+		const key = this.selectedSessionKey ?? this.persistentState.selectedSessionKey;
+		return resolveAgentsViewSelectionIndex(this.rows, identity, key);
+	}
+
 	private getSelectableRowIndexes(): number[] {
 		return this.rows.flatMap((row, index) => (row.selectable ? [index] : []));
 	}
@@ -1536,7 +1545,9 @@ class AgentsViewMode implements Component, Focusable {
 		const row = this.rows[this.selectedIndex];
 		this.selectedActiveSessionId = row?.selectable ? (row.summary.activeSessionId ?? row.summary.id) : undefined;
 		this.selectedRowIdentity = getSelectedRowIdentity(row);
+		this.selectedSessionKey = row?.selectable ? getAgentsViewSelectionKey(row.summary) : undefined;
 		this.persistentState.selectedRowIdentity = this.selectedRowIdentity;
+		this.persistentState.selectedSessionKey = this.selectedSessionKey;
 	}
 
 	private finish(result: AgentsViewRunResult): void {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -95,9 +95,6 @@ export interface AgentsViewModeOptions {
 type AgentsViewRunResult = { type: "exit" } | { type: "open"; summary: SessionSummary; subagent?: SessionSummary };
 type AgentsViewPersistentState = {
 	selectedRowIdentity?: string;
-	// Stable keys for the selected session, used to re-find it when its
-	// identity changes (e.g. persisted, or re-attached with a new active id)
-	// across re-entry into the agents view.
 	selectedSessionKey?: AgentsViewSelectionKey;
 	statusMessage?: string;
 	initialPromptsSent?: boolean;
@@ -232,9 +229,6 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 		if (result.type === "exit") {
 			return;
 		}
-		// Pin selection to the session being opened so it stays highlighted when
-		// the user returns; the stable key re-finds it even if its identity
-		// changes (persisted / re-attached) while the session was open.
 		persistentState.selectedRowIdentity = getSummaryIdentity(result.summary);
 		persistentState.selectedSessionKey = getAgentsViewSelectionKey(result.summary);
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -76,6 +76,56 @@ export function getAgentsViewSummaryIdentity(summary: SessionSummary): string {
 	return `session:${summary.sessionId}`;
 }
 
+/**
+ * A row's `identity` keys on `sessionFile` first and falls back to the
+ * runtime-only `activeSessionId`, both of which can change as a session is
+ * persisted or torn down and re-attached. These stable keys let us re-find the
+ * same logical session across those transitions when restoring selection.
+ */
+export interface AgentsViewSelectionKey {
+	sessionId: string;
+	activeSessionId?: string;
+}
+
+export function getAgentsViewSelectionKey(summary: SessionSummary): AgentsViewSelectionKey {
+	return { sessionId: summary.sessionId, activeSessionId: summary.activeSessionId };
+}
+
+/**
+ * Re-find the previously selected session in a rebuilt row list. Tries, in
+ * order: the exact row `identity`, the live `activeSessionId`, then the stable
+ * `sessionId`. The latter two survive transitions that change `identity`
+ * (a session being persisted, or torn down and re-attached with a fresh active
+ * id). Returns -1 when the session is gone so callers fall back to a default.
+ */
+export function resolveAgentsViewSelectionIndex(
+	rows: readonly AgentsViewRow[],
+	identity: string | undefined,
+	key: AgentsViewSelectionKey | undefined,
+): number {
+	const findSelectable = (predicate: (row: AgentsViewRow) => boolean): number =>
+		rows.findIndex((row) => row.selectable && predicate(row));
+
+	if (identity !== undefined) {
+		const index = findSelectable((row) => row.identity === identity);
+		if (index >= 0) {
+			return index;
+		}
+	}
+	if (key?.activeSessionId !== undefined) {
+		const activeSessionId = key.activeSessionId;
+		const index = findSelectable((row) => (row.summary.activeSessionId ?? row.summary.id) === activeSessionId);
+		if (index >= 0) {
+			return index;
+		}
+	}
+	if (key?.sessionId !== undefined) {
+		const sessionId = key.sessionId;
+		return findSelectable((row) => row.summary.sessionId === sessionId);
+	}
+	return -1;
+}
+
 export function buildAgentsViewRows(
 	summaries: readonly SessionSummary[],
 	expandedSubagentParents: ReadonlySet<string> = new Set(),

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -76,12 +76,6 @@ export function getAgentsViewSummaryIdentity(summary: SessionSummary): string {
 	return `session:${summary.sessionId}`;
 }
 
-/**
- * A row's `identity` keys on `sessionFile` first and falls back to the
- * runtime-only `activeSessionId`, both of which can change as a session is
- * persisted or torn down and re-attached. These stable keys let us re-find the
- * same logical session across those transitions when restoring selection.
- */
 export interface AgentsViewSelectionKey {
 	sessionId: string;
 	activeSessionId?: string;
@@ -91,13 +85,9 @@ export function getAgentsViewSelectionKey(summary: SessionSummary): AgentsViewSe
 	return { sessionId: summary.sessionId, activeSessionId: summary.activeSessionId };
 }
 
-/**
- * Re-find the previously selected session in a rebuilt row list. Tries, in
- * order: the exact row `identity`, the live `activeSessionId`, then the stable
- * `sessionId`. The latter two survive transitions that change `identity`
- * (a session being persisted, or torn down and re-attached with a fresh active
- * id). Returns -1 when the session is gone so callers fall back to a default.
- */
+// Matches by identity, then activeSessionId, then sessionId: a row's identity
+// changes when a session is persisted or re-attached, so the latter two keys
+// re-find the same session across those transitions. Returns -1 when gone.
 export function resolveAgentsViewSelectionIndex(
 	rows: readonly AgentsViewRow[],
 	identity: string | undefined,

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -28,8 +28,11 @@ export { type AgentsViewModeOptions, runAgentsViewMode } from "./agents-view/age
 export {
 	type AgentsViewRow,
 	type AgentsViewSection,
+	type AgentsViewSelectionKey,
 	buildAgentsViewRows,
 	classifyAgentsViewSession,
+	getAgentsViewSelectionKey,
+	resolveAgentsViewSelectionIndex,
 	sectionTitle,
 	shouldShowAgentsViewSession,
 } from "./agents-view/agents-view-state.js";

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -460,7 +460,6 @@ describe("agents view state", () => {
 	});
 
 	describe("restores selection to the previously open session", () => {
-		// The session the user opened, with both a persisted file and a live runtime.
 		const opened = makeSummary({
 			id: "active-open",
 			activeSessionId: "active-open",
@@ -489,8 +488,7 @@ describe("agents view state", () => {
 		});
 
 		test("falls back to activeSessionId when the row identity changed", () => {
-			// The opened session had no file when selected (identity was active:...),
-			// then persisted one while open, so its row identity is now file:...
+			// Selected before the session had a file, so the stored identity is active:...
 			const rows = buildAgentsViewRows([other, opened]);
 			const staleIdentity = "active:active-open";
 			expect(resolveAgentsViewSelectionIndex(rows, staleIdentity, key)).toBe(
@@ -499,8 +497,7 @@ describe("agents view state", () => {
 		});
 
 		test("falls back to sessionId after a daemon re-attach regenerates the active id", () => {
-			// Re-attaching produced a fresh activeSessionId, so neither the stored
-			// identity nor activeSessionId match; the stable sessionId still does.
+			// Re-attach gives a fresh activeSessionId, so only the sessionId still matches.
 			const reattached = { ...opened, id: "active-open-2", activeSessionId: "active-open-2" };
 			const rows = buildAgentsViewRows([other, reattached]);
 			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -14,6 +14,8 @@ import {
 import {
 	buildAgentsViewRows,
 	classifyAgentsViewSession,
+	getAgentsViewSelectionKey,
+	resolveAgentsViewSelectionIndex,
 	type SessionSummary,
 	shouldShowAgentsViewSession,
 } from "../src/modes/index.js";
@@ -455,6 +457,66 @@ describe("agents view state", () => {
 			),
 		).resolves.toBe(sessionServices);
 		expect(createUiServicesForSession).toHaveBeenCalledWith(summary);
+	});
+
+	describe("restores selection to the previously open session", () => {
+		// The session the user opened, with both a persisted file and a live runtime.
+		const opened = makeSummary({
+			id: "active-open",
+			activeSessionId: "active-open",
+			sessionId: "session-open",
+			sessionFile: "/tmp/project/open.jsonl",
+			sessionName: "open",
+		});
+		const other = makeSummary({
+			id: "active-other",
+			activeSessionId: "active-other",
+			sessionId: "session-other",
+			sessionFile: "/tmp/project/other.jsonl",
+			sessionName: "other",
+		});
+		const identity = `file:${opened.sessionFile}`;
+		const key = getAgentsViewSelectionKey(opened);
+
+		test("re-finds the session after the list reorders", () => {
+			// Returning bumps the opened session's modified time so it sorts first.
+			const rows = buildAgentsViewRows([
+				{ ...opened, modified: "2026-01-02T00:00:00Z" },
+				{ ...other, modified: "2026-01-01T00:00:00Z" },
+			]);
+			expect(rows[0]?.summary.sessionId).toBe("session-open");
+			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(0);
+		});
+
+		test("falls back to activeSessionId when the row identity changed", () => {
+			// The opened session had no file when selected (identity was active:...),
+			// then persisted one while open, so its row identity is now file:...
+			const rows = buildAgentsViewRows([other, opened]);
+			const staleIdentity = "active:active-open";
+			expect(resolveAgentsViewSelectionIndex(rows, staleIdentity, key)).toBe(
+				rows.findIndex((row) => row.summary.sessionId === "session-open"),
+			);
+		});
+
+		test("falls back to sessionId after a daemon re-attach regenerates the active id", () => {
+			// Re-attaching produced a fresh activeSessionId, so neither the stored
+			// identity nor activeSessionId match; the stable sessionId still does.
+			const reattached = { ...opened, id: "active-open-2", activeSessionId: "active-open-2" };
+			const rows = buildAgentsViewRows([other, reattached]);
+			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(
+				rows.findIndex((row) => row.summary.sessionId === "session-open"),
+			);
+		});
+
+		test("returns -1 when the session is gone so callers pick a default", () => {
+			const rows = buildAgentsViewRows([other]);
+			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(-1);
+		});
+
+		test("returns -1 with no stored selection", () => {
+			const rows = buildAgentsViewRows([opened, other]);
+			expect(resolveAgentsViewSelectionIndex(rows, undefined, undefined)).toBe(-1);
+		});
 	});
 });
 


### PR DESCRIPTION
- returning to the agents view with the left arrow dropped the highlight to the first row instead of the session you just had open.
- selection was matched only by a row identity that changes when a session is persisted or re-attached, so the match broke and fell through to row zero.
- now persists a stable session key and re-finds the row by identity, then active session id, then session id, so selection sticks across reorders and reattaches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized agents-view selection logic with new unit tests; no auth, daemon protocol, or data-handling changes.
> 
> **Overview**
> Fixes the agents list jumping back to the **first row** after you leave an agent session (e.g. back navigation) when the highlighted session’s **row identity** no longer matches after persist, re-attach, or reorder.
> 
> Adds a stable **`AgentsViewSelectionKey`** (`sessionId` + optional `activeSessionId`) and **`resolveAgentsViewSelectionIndex`**, which re-locates the row by trying **identity**, then **active session id**, then **session id**. **`AgentsViewMode`** persists that key with the existing row identity and uses it in **`restoreSelection()`** (including after creating an agent and when re-entering the view after opening a session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c15589a79302511c0803584e798704a34e6642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve session selection when returning to the agents view
> - Adds a structured `AgentsViewSelectionKey` (sessionId + optional activeSessionId) to complement the existing text-based row identity for tracking which session is selected in the agents view.
> - When a session is opened or the selection changes, the key is persisted alongside the row identity so it survives navigation away and back.
> - On return, `resolveAgentsViewSelectionIndex` restores the correct row by matching identity first, then falling back to activeSessionId, then sessionId.
> - New tests in [`agents-view-state.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/268/files#diff-5af2a63c4fb3846a971096c809753dabe902ca9167f1334df97de89daa78a1ce) cover reordering, identity-change fallbacks, reattach scenarios, and missing-session cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12c1558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->