### PR TITLE
show typed command for local slash commands like /context

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3506,11 +3506,13 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "session" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				await this.handleSessionCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "system-prompt" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				await this.handleSystemPromptCommand();
 				this.editor.setText("");
 				return;
@@ -3521,16 +3523,19 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "context" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				await this.handleContextCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "logs" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				this.handleLogsCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "goal" && (!commandArgs || commandArgs === "status")) {
+				this.echoLocalCommand(canonicalCommandText);
 				this.handleGoalStatusCommand();
 				this.editor.setText("");
 				return;
@@ -3541,11 +3546,13 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "changelog" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				this.handleChangelogCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "hotkeys" && !commandArgs) {
+				this.echoLocalCommand(canonicalCommandText);
 				this.handleHotkeysCommand();
 				this.editor.setText("");
 				return;
@@ -4746,6 +4753,17 @@ export class InteractiveMode {
 		this.lastStatusSpacer = spacer;
 		this.lastStatusText = text;
 		this.ui.requestRender();
+	}
+
+	// Local slash commands (/context, /system-prompt, …) print into the chat
+	// without round-tripping through the agent, so no user message event echoes
+	// the typed command. Render the turn ourselves, mirroring the "user" case
+	// above, so the output is anchored to a visible command instead of floating.
+	private echoLocalCommand(text: string): void {
+		if (this.chatContainer.children.length > 0) {
+			this.chatContainer.addChild(new Spacer(1));
+		}
+		this.chatContainer.addChild(new UserMessageComponent(text, this.getMarkdownThemeWithSettings()));
 	}
 
 	private addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3506,13 +3506,13 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "session" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				await this.handleSessionCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "system-prompt" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				await this.handleSystemPromptCommand();
 				this.editor.setText("");
 				return;
@@ -3523,19 +3523,19 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "context" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				await this.handleContextCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "logs" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				this.handleLogsCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "goal" && (!commandArgs || commandArgs === "status")) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				this.handleGoalStatusCommand();
 				this.editor.setText("");
 				return;
@@ -3546,13 +3546,13 @@ export class InteractiveMode {
 				return;
 			}
 			if (commandName === "changelog" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				this.handleChangelogCommand();
 				this.editor.setText("");
 				return;
 			}
 			if (commandName === "hotkeys" && !commandArgs) {
-				this.echoLocalCommand(canonicalCommandText);
+				this.echoLocalCommand(text);
 				this.handleHotkeysCommand();
 				this.editor.setText("");
 				return;


### PR DESCRIPTION
- local slash commands like /context and /system-prompt printed their output into the chat without echoing the typed command, so the output looked like it appeared at random.
- they run locally without going through the agent, so no user turn was ever rendered; we now render the command as a user-message box before its output.
- also covers /session, /logs, /goal, /changelog, and /hotkeys, and gives /context an anchor so it no longer reads as floating at the bottom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chat-only display change in interactive mode; no agent, auth, or persistence logic is modified.
> 
> **Overview**
> Local slash commands (`/context`, `/system-prompt`, `/session`, `/logs`, `/goal`, `/changelog`, `/hotkeys`) now show the command you typed as a **user message** in the chat before their output appears.
> 
> These handlers run in the interactive UI without sending a turn through the agent, so nothing previously rendered the input line and the response looked unattached. **`echoLocalCommand`** adds a spacer (when needed) and a `UserMessageComponent` using the same styling as normal user turns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60129d1a02f6e032e4912c79f4d43142e736ff40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show typed command in chat for local slash commands like `/context`
> Adds a new `echoLocalCommand` method to `InteractiveMode` that renders the typed command as a user-turn message in the chat transcript before executing it. This applies to local slash commands (`/session`, `/system-prompt`, `/context`, `/logs`, `/goal`, `/changelog`, `/hotkeys`) when invoked with no arguments. A spacer is inserted before the message when the chat already has content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60129d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->