### PR TITLE
fix protobufjs vulnerability flagged by npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1489,12 +1489,6 @@
 			"version": "1.0.2",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"license": "BSD-3-Clause"
@@ -4260,9 +4254,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-			"integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4272,7 +4266,6 @@
 				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",


### PR DESCRIPTION
- npm audit flagged a moderate protobufjs advisory on every install; this updates the lockfile to the patched resolution.
- applied via npm audit fix, touching only package-lock.json with no source or direct-dependency changes.
- a low-severity esbuild advisory remains since it is bundled inside the current tsx release and has no upstream fix yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only transitive dependency patch with no direct dependency or application code changes.
> 
> **Overview**
> Resolves a **moderate npm audit advisory** on `protobufjs` by updating the lockfile resolution from **7.6.1** to **7.6.4** (no `package.json` or application source changes).
> 
> The lockfile also drops the nested **`@protobufjs/inquire`** entry as part of the updated `protobufjs` dependency tree. Remaining **esbuild** audit findings are unchanged and still tied to the bundled `tsx` toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e165cb9b640ae136e582c64824525815213c8b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix protobufjs vulnerability flagged by npm audit
> Updates [package-lock.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/275/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519) to resolve a security vulnerability in the `protobufjs` dependency identified by `npm audit`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e165cb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->