### PR TITLE
stop asserting an exact prime-inference model count

### DIFF
--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -16,7 +16,10 @@ describe("Prime Inference models", () => {
 	it("registers the Prime Inference catalog", () => {
 		const modelIds = getModels("prime-inference").map((model) => model.id);
 
-		expect(modelIds.length).toBe(28);
+		// Lower bound, not an exact count — the catalog grows with each release and an
+		// exact number breaks on every routine addition. The membership checks below
+		// are the meaningful assertions.
+		expect(modelIds.length).toBeGreaterThanOrEqual(28);
 		expect(modelIds).toEqual(
 			expect.arrayContaining([
 				"anthropic/claude-opus-4.7",


### PR DESCRIPTION
- the prime-inference catalog test hardcoded a model count of 28, which broke ci on main once a 29th model was added to the generated catalog.
- replaces the exact-count assertion with a lower bound, since the catalog grows every release; the membership and exclusion checks remain the meaningful assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or security impact.
> 
> **Overview**
> Fixes flaky CI on **main** when the generated Prime Inference catalog gains models.
> 
> In `prime-inference-models.test.ts`, the catalog registration test no longer asserts an exact model count (`28`). It now requires **at least** 28 entries, with a short comment that the catalog grows each release. **Membership** (`arrayContaining` for known model IDs) and **exclusion** (e.g. no `google/gemini-2.5-pro`) assertions are unchanged and remain the real guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e5f935ba9f236edc0dd318a8ebd80d6a898ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relax Prime Inference model count assertion to a lower-bound check
> Changes the assertion in [prime-inference-models.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/285/files#diff-6462d25872f543c52f27cfe6c81089527799a97772aba030f15340bd33bf77b2) from `toBe(28)` to `toBeGreaterThanOrEqual(28)` so the test passes when new models are added without requiring an exact count update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4e5f93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->