### PR TITLE
fix broken sessions in agents view from missing directories

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -138,10 +138,8 @@ export async function resolveAgentsViewSessionUiServices(
 	return options.createUiServicesForSession ? await options.createUiServicesForSession(summary) : options.uiServices;
 }
 
-// Stripping cwd lets a session open in its own stored directory rather than
-// wherever the fleet view was launched. When overrideCwd is given (the stored
-// cwd no longer exists), it is sent instead so the daemon resolves the runtime
-// against a real directory rather than throwing MissingSessionCwdError.
+// Stripping cwd opens the session in its own stored directory; overrideCwd is
+// sent when that directory no longer exists so the daemon doesn't reject it.
 export function createAgentsViewResumeConfig(
 	config: AgentSessionRuntimeConfig,
 	overrideCwd?: string,
@@ -185,14 +183,9 @@ export function createAgentsViewReplyHeadline(text: string | undefined): string 
 interface OpenedAgentsViewSession {
 	connection: DaemonAgentConnection;
 	summary: SessionSummary;
-	// Set when the session's stored cwd was missing and we opened it in a
-	// fallback directory; surfaced to the user as a startup notice.
 	cwdFallbackNotice?: string;
 }
 
-// A session created in a now-deleted directory (e.g. a removed worktree) still
-// lists in the fleet view but its stored cwd is gone. Resolve to the launch cwd
-// so the daemon opens it instead of throwing MissingSessionCwdError.
 export function resolveAgentsViewOpenCwd(
 	summary: SessionSummary,
 	fallbackCwd: string | undefined,
@@ -1481,12 +1474,8 @@ class AgentsViewMode implements Component, Focusable {
 				}
 			}
 			if (pending.sessionFile) {
-				// The kill above normally persists the archived state, but it can be
-				// skipped or hit an unknown session (e.g. the daemon died after
-				// listing). Persist archived unless it already is — off-daemon sessions
-				// (and older ones) may carry no session_state entry at all, so a
-				// status===active check would skip them and the row would resurface on
-				// the next scan.
+				// Persist archived unless it already is: sessions with no prior
+				// session_state entry would otherwise resurface on the next scan.
 				const sessionManager = SessionManager.open(pending.sessionFile, this.options.config.sessionDir);
 				if (sessionManager.getSessionState()?.status !== "archived") {
 					sessionManager.appendSessionState({ status: "archived" });

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import type { AutocompleteItem, OverlayHandle, SlashCommand } from "@earendil-works/pi-tui";
 import {
@@ -137,9 +138,20 @@ export async function resolveAgentsViewSessionUiServices(
 	return options.createUiServicesForSession ? await options.createUiServicesForSession(summary) : options.uiServices;
 }
 
-export function createAgentsViewResumeConfig(config: AgentSessionRuntimeConfig): AgentSessionRuntimeConfig {
+// Stripping cwd lets a session open in its own stored directory rather than
+// wherever the fleet view was launched. When overrideCwd is given (the stored
+// cwd no longer exists), it is sent instead so the daemon resolves the runtime
+// against a real directory rather than throwing MissingSessionCwdError.
+export function createAgentsViewResumeConfig(
+	config: AgentSessionRuntimeConfig,
+	overrideCwd?: string,
+): AgentSessionRuntimeConfig {
 	const resumeConfig: AgentSessionRuntimeConfig = { ...config };
-	delete resumeConfig.cwd;
+	if (overrideCwd) {
+		resumeConfig.cwd = overrideCwd;
+	} else {
+		delete resumeConfig.cwd;
+	}
 	return resumeConfig;
 }
 
@@ -170,10 +182,34 @@ export function createAgentsViewReplyHeadline(text: string | undefined): string 
 		.find((line) => line.length > 0);
 }
 
+interface OpenedAgentsViewSession {
+	connection: DaemonAgentConnection;
+	summary: SessionSummary;
+	// Set when the session's stored cwd was missing and we opened it in a
+	// fallback directory; surfaced to the user as a startup notice.
+	cwdFallbackNotice?: string;
+}
+
+// A session created in a now-deleted directory (e.g. a removed worktree) still
+// lists in the fleet view but its stored cwd is gone. Resolve to the launch cwd
+// so the daemon opens it instead of throwing MissingSessionCwdError.
+export function resolveAgentsViewOpenCwd(
+	summary: SessionSummary,
+	fallbackCwd: string | undefined,
+): { overrideCwd?: string; notice?: string } {
+	if (!summary.cwd || existsSync(summary.cwd) || !fallbackCwd) {
+		return {};
+	}
+	return {
+		overrideCwd: fallbackCwd,
+		notice: `Original directory is missing (${summary.cwd}); opened in ${fallbackCwd} instead.`,
+	};
+}
+
 async function openAgentsViewSession(
 	options: AgentsViewModeOptions,
 	summary: SessionSummary,
-): Promise<{ connection: DaemonAgentConnection; summary: SessionSummary }> {
+): Promise<OpenedAgentsViewSession> {
 	let client = await connectAgentsViewDaemonClient(options.socketPath);
 	if (summary.activeSessionId) {
 		try {
@@ -195,10 +231,11 @@ async function openAgentsViewSession(
 		throw new Error("Cannot open agent without an active runtime or saved session file");
 	}
 
+	const { overrideCwd, notice } = resolveAgentsViewOpenCwd(summary, options.config.cwd);
 	try {
 		const response = await client.request({
 			type: "create",
-			config: createAgentsViewResumeConfig(options.config),
+			config: createAgentsViewResumeConfig(options.config, overrideCwd),
 			sessionPath: summary.sessionFile,
 		});
 		const createdSummary = expectSessionSummary(requireDaemonData(response));
@@ -206,7 +243,7 @@ async function openAgentsViewSession(
 		const connection = await DaemonAgentConnection.attach(client, activeSessionId, {
 			closeClientOnDispose: true,
 		});
-		return { connection, summary: createdSummary };
+		return { connection, summary: createdSummary, cwdFallbackNotice: notice };
 	} catch (error) {
 		client.close();
 		throw error;
@@ -256,9 +293,12 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 			persistentState.pendingExpandedAncestorSessionIds = undefined;
 		}
 
-		let opened: { connection: DaemonAgentConnection; summary: SessionSummary } | undefined;
+		let opened: OpenedAgentsViewSession | undefined;
 		try {
 			opened = await openAgentsViewSession(options, result.summary);
+			if (opened.cwdFallbackNotice) {
+				persistentState.statusMessage = opened.cwdFallbackNotice;
+			}
 			const uiServices = await resolveAgentsViewSessionUiServices(options, opened.summary);
 			const interactiveMode = new InteractiveMode({
 				agentConnection: opened.connection,
@@ -266,6 +306,7 @@ export async function runAgentsViewMode(options: AgentsViewModeOptions): Promise
 				bindLocalSessionExtensions: false,
 				migratedProviders: options.migratedProviders,
 				modelFallbackMessage: resolveAttachModelFallbackMessage(opened.summary, options.modelFallbackMessage),
+				startupNotice: opened.cwdFallbackNotice,
 				verbose: options.verbose,
 				returnToAgentsView: true,
 				// The agents view renders the global notices itself, so suppress them in-session.
@@ -1442,10 +1483,12 @@ class AgentsViewMode implements Component, Focusable {
 			if (pending.sessionFile) {
 				// The kill above normally persists the archived state, but it can be
 				// skipped or hit an unknown session (e.g. the daemon died after
-				// listing). Make sure the file is not left marked active, or a
-				// restarted daemon would resurrect a deliberately deactivated agent.
+				// listing). Persist archived unless it already is — off-daemon sessions
+				// (and older ones) may carry no session_state entry at all, so a
+				// status===active check would skip them and the row would resurface on
+				// the next scan.
 				const sessionManager = SessionManager.open(pending.sessionFile, this.options.config.sessionDir);
-				if (sessionManager.getSessionState()?.status === "active") {
+				if (sessionManager.getSessionState()?.status !== "archived") {
 					sessionManager.appendSessionState({ status: "archived" });
 				}
 			}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1473,7 +1473,9 @@ class AgentsViewMode implements Component, Focusable {
 					}
 				}
 			}
-			if (pending.sessionFile) {
+			// Skip a file deleted between listing and now: SessionManager.open would
+			// recreate a stub at the old path instead of loading it.
+			if (pending.sessionFile && existsSync(pending.sessionFile)) {
 				// Persist archived unless it already is: sessions with no prior
 				// session_state entry would otherwise resurface on the next scan.
 				const sessionManager = SessionManager.open(pending.sessionFile, this.options.config.sessionDir);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -450,6 +450,8 @@ export interface InteractiveModeOptions {
 	migratedProviders?: string[];
 	/** Warning message if session model couldn't be restored */
 	modelFallbackMessage?: string;
+	/** One-off warning shown on startup (e.g. session opened in a fallback cwd). */
+	startupNotice?: string;
 	/** Initial message to send on startup (can include @file content) */
 	initialMessage?: string;
 	/** Images to attach to the initial message */
@@ -1057,6 +1059,10 @@ export class InteractiveMode {
 
 		if (migratedProviders && migratedProviders.length > 0) {
 			this.showWarning(`Migrated credentials to auth.json: ${migratedProviders.join(", ")}`);
+		}
+
+		if (this.options.startupNotice) {
+			this.showWarning(this.options.startupNotice);
 		}
 
 		const modelsJsonError = this.modelRegistry.getError();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -450,7 +450,7 @@ export interface InteractiveModeOptions {
 	migratedProviders?: string[];
 	/** Warning message if session model couldn't be restored */
 	modelFallbackMessage?: string;
-	/** One-off warning shown on startup (e.g. session opened in a fallback cwd). */
+	/** One-off warning shown on startup. */
 	startupNotice?: string;
 	/** Initial message to send on startup (can include @file content) */
 	initialMessage?: string;

--- a/packages/coding-agent/test/agents-view-missing-cwd.test.ts
+++ b/packages/coding-agent/test/agents-view-missing-cwd.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createAgentSessionRuntime } from "../src/core/agent-session-runtime.js";
+import { MissingSessionCwdError } from "../src/core/session-cwd.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { createAgentsViewResumeConfig, resolveAgentsViewOpenCwd } from "../src/modes/agents-view/agents-view-mode.js";
+import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+import { assistantMsg, userMsg } from "./utilities.js";
+
+// End-to-end check of the ENG-4369 open path: a session whose stored cwd was
+// deleted must still open instead of failing on the daemon's cwd assertion.
+describe("agents view open with a missing session cwd", () => {
+	it("repros the failure and proves the override opens the session", async () => {
+		const root = mkdtempSync(join(tmpdir(), "agents-view-missing-cwd-"));
+		const launchCwd = join(root, "launch");
+		const worktree = join(root, "worktree");
+		const sessionDir = join(root, "sessions");
+		const agentDir = join(root, "agent");
+		try {
+			mkdirSync(launchCwd, { recursive: true }); // launch dir exists; the session's own dir won't
+			const session = SessionManager.create(worktree, sessionDir);
+			session.appendMessage(userMsg("do the thing"));
+			session.appendMessage(assistantMsg("done"));
+			const sessionFile = session.getSessionFile()!;
+
+			// The worktree the session was created in is removed (the real scenario).
+			rmSync(worktree, { recursive: true, force: true });
+
+			const factory = async () => {
+				throw new Error("runtime factory should not be reached when the cwd is missing");
+			};
+
+			// Bug repro: with cwd stripped, the session resolves against its stored
+			// (now-deleted) cwd and throws before the runtime is ever built — exactly
+			// the flicker users saw.
+			const stripped = await SessionManager.openAsync(sessionFile, sessionDir);
+			await expect(
+				createAgentSessionRuntime(factory, {
+					cwd: stripped.getCwd(),
+					agentDir,
+					sessionManager: stripped,
+				}),
+			).rejects.toThrowError(MissingSessionCwdError);
+
+			// Fix: resolveAgentsViewOpenCwd detects the missing dir and the resume
+			// config carries the launch cwd as an override, so the session opens
+			// against a real directory.
+			const summary: SessionSummary = {
+				id: session.getSessionId(),
+				lifecycle: "live",
+				activity: "idle",
+				sessionId: session.getSessionId(),
+				sessionFile,
+				cwd: worktree,
+				isStreaming: false,
+				isCompacting: false,
+				attachedClients: 0,
+				messageCount: 2,
+				pendingMessageCount: 0,
+			};
+			const { overrideCwd, notice } = resolveAgentsViewOpenCwd(summary, launchCwd);
+			expect(overrideCwd).toBe(launchCwd);
+			expect(notice).toContain(worktree);
+
+			const resumeConfig = createAgentsViewResumeConfig({ cwd: launchCwd, agentDir }, overrideCwd);
+			const overridden = await SessionManager.openAsync(sessionFile, sessionDir, resumeConfig.cwd);
+			expect(overridden.getCwd()).toBe(launchCwd);
+
+			// With the override the session now resolves against the real launch dir,
+			// so the runtime build gets past the cwd guard and into the factory
+			// (which we stop at, having proven the guard no longer fires).
+			let factoryCwd: string | undefined;
+			const okFactory = async (opts: { cwd: string }) => {
+				factoryCwd = opts.cwd;
+				throw new Error("stop after the cwd guard");
+			};
+			await expect(
+				createAgentSessionRuntime(okFactory as never, {
+					cwd: overridden.getCwd(),
+					agentDir,
+					sessionManager: overridden,
+				}),
+			).rejects.toThrow("stop after the cwd guard");
+			expect(factoryCwd).toBe(launchCwd);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/agents-view-missing-cwd.test.ts
+++ b/packages/coding-agent/test/agents-view-missing-cwd.test.ts
@@ -9,8 +9,6 @@ import { createAgentsViewResumeConfig, resolveAgentsViewOpenCwd } from "../src/m
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { assistantMsg, userMsg } from "./utilities.js";
 
-// End-to-end check of the ENG-4369 open path: a session whose stored cwd was
-// deleted must still open instead of failing on the daemon's cwd assertion.
 describe("agents view open with a missing session cwd", () => {
 	it("repros the failure and proves the override opens the session", async () => {
 		const root = mkdtempSync(join(tmpdir(), "agents-view-missing-cwd-"));
@@ -19,22 +17,19 @@ describe("agents view open with a missing session cwd", () => {
 		const sessionDir = join(root, "sessions");
 		const agentDir = join(root, "agent");
 		try {
-			mkdirSync(launchCwd, { recursive: true }); // launch dir exists; the session's own dir won't
+			mkdirSync(launchCwd, { recursive: true });
 			const session = SessionManager.create(worktree, sessionDir);
 			session.appendMessage(userMsg("do the thing"));
 			session.appendMessage(assistantMsg("done"));
 			const sessionFile = session.getSessionFile()!;
 
-			// The worktree the session was created in is removed (the real scenario).
 			rmSync(worktree, { recursive: true, force: true });
 
 			const factory = async () => {
 				throw new Error("runtime factory should not be reached when the cwd is missing");
 			};
 
-			// Bug repro: with cwd stripped, the session resolves against its stored
-			// (now-deleted) cwd and throws before the runtime is ever built — exactly
-			// the flicker users saw.
+			// With cwd stripped, the session resolves against its deleted cwd and throws.
 			const stripped = await SessionManager.openAsync(sessionFile, sessionDir);
 			await expect(
 				createAgentSessionRuntime(factory, {
@@ -44,9 +39,6 @@ describe("agents view open with a missing session cwd", () => {
 				}),
 			).rejects.toThrowError(MissingSessionCwdError);
 
-			// Fix: resolveAgentsViewOpenCwd detects the missing dir and the resume
-			// config carries the launch cwd as an override, so the session opens
-			// against a real directory.
 			const summary: SessionSummary = {
 				id: session.getSessionId(),
 				lifecycle: "live",
@@ -68,9 +60,7 @@ describe("agents view open with a missing session cwd", () => {
 			const overridden = await SessionManager.openAsync(sessionFile, sessionDir, resumeConfig.cwd);
 			expect(overridden.getCwd()).toBe(launchCwd);
 
-			// With the override the session now resolves against the real launch dir,
-			// so the runtime build gets past the cwd guard and into the factory
-			// (which we stop at, having proven the guard no longer fires).
+			// The override gets the build past the cwd guard and into the factory.
 			let factoryCwd: string | undefined;
 			const okFactory = async (opts: { cwd: string }) => {
 				factoryCwd = opts.cwd;

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import type { AgentSessionRuntimeConfig } from "../src/core/agent-session-config.js";
 import type { ModelRegistry } from "../src/core/model-registry.js";
@@ -9,6 +12,7 @@ import {
 	createAgentsViewSessionName,
 	formatAgentsViewRelativeTime,
 	formatAgentsViewStatusLine,
+	resolveAgentsViewOpenCwd,
 	resolveAgentsViewSessionUiServices,
 } from "../src/modes/agents-view/agents-view-mode.js";
 import {
@@ -472,6 +476,34 @@ describe("agents view state", () => {
 		expect(resumeConfig.sessionDir).toBe("/tmp/sessions");
 		expect(resumeConfig.model).toBe("openai/gpt-5");
 		expect(config.cwd).toBe("/tmp/dashboard");
+	});
+
+	test("opens an existing-cwd session in its own directory with no override or notice", () => {
+		const dir = mkdtempSync(join(tmpdir(), "agents-view-cwd-"));
+		try {
+			expect(resolveAgentsViewOpenCwd(makeSummary({ cwd: dir }), "/tmp/launch")).toEqual({});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the launch cwd and explains it when the stored cwd is gone", () => {
+		const missing = join(tmpdir(), "agents-view-missing-worktree-does-not-exist");
+		const { overrideCwd, notice } = resolveAgentsViewOpenCwd(makeSummary({ cwd: missing }), "/tmp/launch");
+		expect(overrideCwd).toBe("/tmp/launch");
+		expect(notice).toContain(missing);
+		expect(notice).toContain("/tmp/launch");
+	});
+
+	test("does not override when there is no fallback cwd to use", () => {
+		const missing = join(tmpdir(), "agents-view-missing-worktree-does-not-exist");
+		expect(resolveAgentsViewOpenCwd(makeSummary({ cwd: missing }), undefined)).toEqual({});
+	});
+
+	test("passes the override cwd through the resume config when the stored cwd is missing", () => {
+		const config: AgentSessionRuntimeConfig = { cwd: "/tmp/launch", agentDir: "/tmp/agents" };
+		const resumeConfig = createAgentsViewResumeConfig(config, "/tmp/launch");
+		expect(resumeConfig.cwd).toBe("/tmp/launch");
 	});
 
 	test("requests all sessions (in-memory + on-disk) for the agents view refresh", () => {

--- a/packages/coding-agent/test/session-manager/session-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-state.test.ts
@@ -92,6 +92,35 @@ describe("SessionManager session state", () => {
 		}
 	});
 
+	// Guards the agents-view deactivate path: opening a deleted file and appending
+	// would recreate a stub session at the old path, so the caller must skip it.
+	it("recreates a stub when archiving a deleted file, which the existsSync guard prevents", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-state-deleted-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(cwd, sessionDir);
+			session.appendMessage(userMsg("hello"));
+			session.appendMessage(assistantMsg("hi")); // forces a flush to disk
+			const sessionFile = session.getSessionFile()!;
+			rmSync(sessionFile);
+			expect(existsSync(sessionFile)).toBe(false);
+
+			// Without the guard, the open+append recreates a fresh stub on disk.
+			SessionManager.open(sessionFile, sessionDir).appendSessionState({ status: "archived" });
+			expect(existsSync(sessionFile)).toBe(true);
+
+			// The guard the caller uses skips a missing file, leaving nothing behind.
+			rmSync(sessionFile);
+			if (existsSync(sessionFile)) {
+				SessionManager.open(sessionFile, sessionDir).appendSessionState({ status: "archived" });
+			}
+			expect(existsSync(sessionFile)).toBe(false);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("coerces legacy sleep and hidden lifecycle state to archived on read", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "session-state-hidden-"));
 		try {

--- a/packages/coding-agent/test/session-manager/session-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-state.test.ts
@@ -67,9 +67,6 @@ describe("SessionManager session state", () => {
 		}
 	});
 
-	// Mirrors the agents-view Ctrl+X deactivate guard: a session that never wrote a
-	// session_state entry (off-daemon / older sessions) must still become archived,
-	// or inactiveLifecycleForSession would re-derive "live" and the row would return.
 	it("archives a deactivated session that has no prior state entry", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "session-state-deactivate-"));
 		try {
@@ -80,7 +77,6 @@ describe("SessionManager session state", () => {
 			session.appendMessage(assistantMsg("hi"));
 			const sessionFile = session.getSessionFile()!;
 
-			// Reopen exactly as deactivatePendingAgent does and apply the guard.
 			const reopened = SessionManager.open(sessionFile, sessionDir);
 			expect(reopened.getSessionState()).toBeUndefined();
 			if (reopened.getSessionState()?.status !== "archived") {

--- a/packages/coding-agent/test/session-manager/session-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-state.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadEntriesFromFile, SessionManager, type SessionStateEntry } from "../../src/core/session-manager.js";
+import { inactiveLifecycleForSession } from "../../src/modes/daemon/daemon-session-list.js";
 import { assistantMsg, userMsg } from "../utilities.js";
 
 describe("SessionManager session state", () => {
@@ -61,6 +62,35 @@ describe("SessionManager session state", () => {
 				messageCount: 0,
 				state: { status: "archived" },
 			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	// Mirrors the agents-view Ctrl+X deactivate guard: a session that never wrote a
+	// session_state entry (off-daemon / older sessions) must still become archived,
+	// or inactiveLifecycleForSession would re-derive "live" and the row would return.
+	it("archives a deactivated session that has no prior state entry", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-state-deactivate-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(cwd, sessionDir);
+			session.appendMessage(userMsg("hello"));
+			session.appendMessage(assistantMsg("hi"));
+			const sessionFile = session.getSessionFile()!;
+
+			// Reopen exactly as deactivatePendingAgent does and apply the guard.
+			const reopened = SessionManager.open(sessionFile, sessionDir);
+			expect(reopened.getSessionState()).toBeUndefined();
+			if (reopened.getSessionState()?.status !== "archived") {
+				reopened.appendSessionState({ status: "archived" });
+			}
+
+			const sessions = await SessionManager.list(cwd, sessionDir);
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0]!.state).toEqual({ status: "archived" });
+			expect(inactiveLifecycleForSession(sessions[0]!)).toBe("archived");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
- sessions created in a directory that no longer exists (like a deleted worktree) showed in the fleet view but only flickered on enter and never opened, because the daemon refused to start a runtime against a missing working directory.
- they now open in the directory the view was launched from, with a notice telling the user the original location is gone.
- deleting one of these with ctrl+x also stuck for good now; previously sessions that never recorded a lifecycle state were only hidden in memory and came back on the next refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted agents-view and session-lifecycle fixes with new tests; no auth or daemon protocol changes beyond optional resume `cwd`.
> 
> **Overview**
> Fixes agents fleet view sessions whose **stored working directory no longer exists** (e.g. deleted worktrees): they could appear in the list but failed to open because the daemon refused a missing `cwd`.
> 
> **Opening:** `resolveAgentsViewOpenCwd` checks `existsSync` on `summary.cwd` and, when it is gone, passes the launch directory through `createAgentsViewResumeConfig` as an override instead of stripping `cwd`. Users see a warning via `startupNotice` in the session and a status line when returning to the fleet list.
> 
> **Deactivating (Ctrl+X):** Deactivation now skips missing session files so `SessionManager.open` does not recreate a stub, and writes `archived` whenever status is not already archived so sessions without a prior `session_state` entry stay hidden after refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d093dd64403e3ba7325457f0addb322d2eed3114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken agent sessions when saved working directory no longer exists
> - When opening a saved agent session, `resolveAgentsViewOpenCwd` checks if the stored `cwd` exists on disk and falls back to an alternative directory when it does not, passing it through `createAgentsViewResumeConfig` to the daemon create request.
> - A one-off startup notice is shown in the interactive session via the new `startupNotice` option on `InteractiveModeOptions` when a fallback `cwd` is used.
> - `AgentsViewMode.deactivate` now guards against missing session files with `existsSync` before appending state, and archives sessions with no prior state instead of leaving them active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d093dd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->