### PR TITLE
make ctrl+o consistent for ipython cells

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -523,6 +523,7 @@ export class IPythonCellComponent implements Component {
 			!renderedTextOutput &&
 			!traceback &&
 			!details.error &&
+			diffs.length === 0 &&
 			this.state.executionStarted &&
 			imageCount === 0
 		) {
@@ -622,7 +623,8 @@ export class IPythonCellComponent implements Component {
 		const wrapped = wrapTextWithAnsi(text, available);
 		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
 			const linePrefix = index === 0 ? prefix : " ".repeat(visibleWidth(prefix));
-			lines.push(` ${linePrefix}${closeOpenSgr(line)}`);
+			// Truncate the composed line so a narrow pane can't exceed width (fatal in the renderer).
+			lines.push(truncateToWidth(` ${linePrefix}${closeOpenSgr(line)}`, width, ""));
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -14,7 +14,6 @@ import { getWorkingPulseFrame, WORKING_ICON_FRAMES, workingIconFrame } from "../
 import { normalizeErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
 import { renderDiffSeparator, renderRichDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
-import { toolPanelContentWidth, toolPanelLine } from "./tool-panel.js";
 
 export interface IPythonCellContentBlock {
 	type: string;
@@ -67,13 +66,11 @@ interface TracebackParts {
 	preview: string;
 }
 
-type ExpandHintFormatter = (label: string) => string;
-
 const MAGIC_LINE_PATTERN = /^\s*!/;
 const CELL_MAGIC_PATTERN = /^\s*%%bash\b/;
 
-const OUTPUT_PREVIEW_LINES = 5;
-const INPUT_PREVIEW_LINES = 3;
+// Two columns, matching the code body's "› "/"  " gutter so output aligns under it.
+const OUTPUT_INDENT = "  ";
 
 const SGR_PATTERN = /\x1b\[([0-9;]*)m/g;
 
@@ -210,10 +207,6 @@ function formatDuration(durationMs: number | undefined): string | undefined {
 	return `${(durationMs / 1000).toFixed(1)}s`;
 }
 
-function hiddenLinesLabel(hidden: number): string {
-	return `… +${hidden} line${hidden === 1 ? "" : "s"}`;
-}
-
 // Relative to the session cwd when nested under it, else the absolute path.
 function displayEditPath(path: string, cwd: string | undefined): string {
 	if (cwd && isAbsolute(path)) {
@@ -306,34 +299,24 @@ export class IPythonCellComponent implements Component {
 			return cached;
 		}
 
-		// Collapsed default: one line, indented to match message text. Cached by
-		// state version so it never re-renders on unrelated repaints (would flicker).
-		// Edits are the exception: the diff always shows in full under the summary
-		// line so file changes are visible without expanding.
-		if (!this.state.expanded) {
-			const summary = truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "");
-			if ((details.diffs?.length ?? 0) === 0) {
-				return this.renderCache.set(safeWidth, cacheVersion, [summary]);
-			}
-			const lines = [summary];
+		// The top line is identical whether collapsed or expanded — same marker,
+		// counts, duration, and expand hint — so toggling never shifts the layout
+		// or indentation; expanding only attaches code and output below it.
+		// Cached by state version so unrelated repaints don't re-render (flicker).
+		const lines = [truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "")];
+
+		const hasDiffs = (details.diffs?.length ?? 0) > 0;
+		// Edits always show their diff under the top line, regardless of expand state.
+		if (hasDiffs) {
 			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
+		}
+
+		if (!this.state.expanded) {
 			return this.renderCache.set(safeWidth, cacheVersion, lines);
 		}
 
-		const lines: string[] = [];
-		let expandHintShown = false;
-		const withExpandHint: ExpandHintFormatter = (label) => {
-			if (expandHintShown) {
-				return theme.fg("muted", label);
-			}
-			expandHintShown = true;
-			return `${theme.fg("muted", label)} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
-		};
-
-		const hasDiffs = (details.diffs?.length ?? 0) > 0;
-		lines.push(toolPanelLine(this.header(details), safeWidth));
-		const hasCode = this.renderCode(lines, safeWidth, withExpandHint, hasDiffs);
-		this.renderOutput(lines, safeWidth, details, hasCode, withExpandHint);
+		const hasCode = this.renderCode(lines, safeWidth, hasDiffs);
+		this.renderOutput(lines, safeWidth, details, hasCode);
 		return this.renderCache.set(safeWidth, cacheVersion, lines);
 	}
 
@@ -365,7 +348,7 @@ export class IPythonCellComponent implements Component {
 			parts.push(theme.fg("error", errorName));
 		}
 
-		parts.push(keyHint("app.tools.expand", "to expand"));
+		parts.push(keyHint("app.tools.expand", this.state.expanded ? "to collapse" : "to expand"));
 		return parts.join(theme.fg("dim", " · "));
 	}
 
@@ -410,19 +393,6 @@ export class IPythonCellComponent implements Component {
 		return segments.length > 0 ? `${segments.join(" ")} lines` : undefined;
 	}
 
-	private header(details: IpythonDetails): string {
-		// Name the cell so the status reads as part of this tool call instead of
-		// a floating label between the surrounding blocks.
-		const isBashCell = CELL_MAGIC_PATTERN.test(this.state.code.split("\n")[0] ?? "");
-		const status = this.status(details);
-		const duration = formatDuration(details.durationMs);
-		const parts = [theme.fg("muted", isBashCell ? "bash" : "python"), status.label];
-		if (duration) {
-			parts.push(theme.fg("muted", duration));
-		}
-		return parts.join(theme.fg("dim", " · "));
-	}
-
 	private statusKind(details: IpythonDetails): "error" | "aborted" | "running" | "queued" | "done" {
 		const status = details.status;
 		if (this.state.isError || status === "error") {
@@ -453,53 +423,26 @@ export class IPythonCellComponent implements Component {
 		);
 	}
 
-	private status(details: IpythonDetails): { label: string } {
-		switch (this.statusKind(details)) {
-			case "error":
-				return { label: theme.fg("error", "error") };
-			case "aborted":
-				return { label: theme.fg("warning", "aborted") };
-			case "running":
-				return { label: theme.fg("bashMode", "running") };
-			case "queued":
-				return { label: theme.fg("muted", "queued") };
-			default:
-				return { label: theme.fg("success", "done") };
+	// Only runs when expanded — shows the full source below the fixed top line.
+	// Edits skip the source: their diff already renders above and conveys the change.
+	private renderCode(lines: string[], width: number, hasDiffs: boolean): boolean {
+		if (hasDiffs) {
+			return false;
 		}
-	}
-
-	private renderCode(lines: string[], width: number, withExpandHint: ExpandHintFormatter, hasDiffs: boolean): boolean {
 		const code = this.state.code.trimEnd();
 		if (!code) {
 			this.addBlank(lines, width);
-			this.addWrapped(lines, "", theme.fg("muted", "waiting for code"), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", "waiting for code"), width);
 			return false;
 		}
 
 		this.addBlank(lines, width);
 		const isBashCell = CELL_MAGIC_PATTERN.test(code.split("\n")[0] ?? "");
 		const rawLines = code.split("\n");
-		const expanded = this.state.expanded ?? false;
-
-		// With a diff to show below, collapse the (often large) edit source to one bar.
-		if (hasDiffs && !expanded) {
-			const label = `${rawLines.length} line${rawLines.length === 1 ? "" : "s"} of source`;
-			this.addWrapped(lines, theme.fg("dim", "› "), withExpandHint(label), width);
-			return true;
-		}
-
-		const showCollapsed = !expanded && rawLines.length > INPUT_PREVIEW_LINES;
-		const visibleRawLines = showCollapsed ? rawLines.slice(0, INPUT_PREVIEW_LINES) : rawLines;
-		for (const [index, rawLine] of visibleRawLines.entries()) {
+		for (const [index, rawLine] of rawLines.entries()) {
 			const prefix = index === 0 ? theme.fg("dim", "› ") : theme.fg("dim", "  ");
 			const highlighted = this.highlightInputLine(rawLine, isBashCell);
 			this.addWrapped(lines, prefix, highlighted || " ", width);
-		}
-
-		if (showCollapsed) {
-			const hidden = rawLines.length - INPUT_PREVIEW_LINES;
-			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
-			return true;
 		}
 
 		return true;
@@ -513,13 +456,8 @@ export class IPythonCellComponent implements Component {
 		return highlighted[0] ?? theme.fg("mdCodeBlock", line);
 	}
 
-	private renderOutput(
-		lines: string[],
-		width: number,
-		details: IpythonDetails,
-		hasCode: boolean,
-		withExpandHint: ExpandHintFormatter,
-	): void {
+	// Only runs when expanded — shows full output below the code, no previews.
+	private renderOutput(lines: string[], width: number, details: IpythonDetails, hasCode: boolean): void {
 		const blocks = this.state.content ?? [];
 		const text = textFromBlocks(blocks);
 		const imageCount = blocks.filter(isImageBlock).length;
@@ -547,54 +485,40 @@ export class IPythonCellComponent implements Component {
 			}
 		};
 
-		if (diffs.length > 0) {
-			// renderDiffs adds its own leading blank, so skip startOutput's to avoid
-			// a double gap; mark output started for the trailing text below.
-			outputStarted = true;
-			this.renderDiffs(lines, width, diffs, this.marker(details));
-			renderedTextOutput = true;
-		}
-
 		if (hasStructuredOutput) {
 			if (details.stdout?.trim() && !isEditConfirmation(details.stdout, diffs)) {
 				startOutput();
 				renderedTextOutput = true;
-				this.renderOutputText(lines, width, normalizeErrorDetails(details.stdout), "out", withExpandHint);
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.stdout), "out");
 			}
 			if (details.stderr?.trim()) {
 				startOutput();
 				renderedTextOutput = true;
-				this.renderOutputText(lines, width, normalizeErrorDetails(details.stderr), "err", withExpandHint);
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.stderr), "err");
 			}
 			if (details.result?.trim() && !isEditConfirmation(details.result, diffs)) {
 				startOutput();
 				renderedTextOutput = true;
-				this.renderOutputText(lines, width, normalizeErrorDetails(details.result), "out", withExpandHint);
+				this.renderOutputText(lines, width, normalizeErrorDetails(details.result), "out");
 			}
 		} else if (traceback) {
 			if (traceback.output) {
 				startOutput();
 				renderedTextOutput = true;
-				this.renderOutputText(lines, width, traceback.output, "out", withExpandHint);
+				this.renderOutputText(lines, width, traceback.output, "out");
 			}
 		} else if (text.trim()) {
 			startOutput();
 			renderedTextOutput = true;
-			this.renderOutputText(
-				lines,
-				width,
-				normalizeErrorDetails(text),
-				this.state.isError ? "err" : "out",
-				withExpandHint,
-			);
+			this.renderOutputText(lines, width, normalizeErrorDetails(text), this.state.isError ? "err" : "out");
 		}
 
 		if (!renderedTextOutput && this.state.isPartial) {
 			startOutput();
-			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", "waiting for output..."), width);
 		} else if (!renderedTextOutput && this.state.executionStarted && !this.state.argsComplete) {
 			startOutput();
-			this.addWrapped(lines, "", theme.fg("muted", "waiting for output..."), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", "waiting for output..."), width);
 		} else if (
 			!renderedTextOutput &&
 			!traceback &&
@@ -603,27 +527,19 @@ export class IPythonCellComponent implements Component {
 			imageCount === 0
 		) {
 			startOutput();
-			this.addWrapped(lines, "", theme.fg("muted", "no output"), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", "no output"), width);
 		}
 
 		if (details.error) {
 			startOutput();
-			if (this.state.expanded) {
-				this.renderTraceback(
-					lines,
-					width,
-					details.error.traceback.join("\n") || formatIpythonErrorSummary(details.error),
-				);
-			} else {
-				this.addWrapped(lines, "", withExpandHint(formatIpythonErrorSummary(details.error)), width);
-			}
+			this.renderTraceback(
+				lines,
+				width,
+				details.error.traceback.join("\n") || formatIpythonErrorSummary(details.error),
+			);
 		} else if (traceback) {
 			startOutput();
-			if (this.state.expanded) {
-				this.renderTraceback(lines, width, traceback.traceback);
-			} else {
-				this.addWrapped(lines, "", withExpandHint(traceback.preview), width);
-			}
+			this.renderTraceback(lines, width, traceback.traceback);
 		}
 
 		if (imageCount > 0) {
@@ -631,7 +547,7 @@ export class IPythonCellComponent implements Component {
 			const text = this.state.showImages
 				? `${imageCount} image${imageCount === 1 ? "" : "s"} rendered below`
 				: `${imageCount} image${imageCount === 1 ? "" : "s"} hidden`;
-			this.addWrapped(lines, "", theme.fg("muted", text), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", text), width);
 		}
 	}
 
@@ -687,46 +603,31 @@ export class IPythonCellComponent implements Component {
 		}
 	}
 
-	private renderOutputText(
-		lines: string[],
-		width: number,
-		text: string,
-		label: "out" | "err",
-		withExpandHint: ExpandHintFormatter,
-	): void {
+	private renderOutputText(lines: string[], width: number, text: string, label: "out" | "err"): void {
 		const color = label === "err" ? "muted" : "toolOutput";
-		const allLines = text.split("\n");
-		const expanded = this.state.expanded ?? false;
-		const showCollapsed = !expanded && allLines.length > OUTPUT_PREVIEW_LINES;
-		const visibleLines = showCollapsed ? allLines.slice(-OUTPUT_PREVIEW_LINES) : allLines;
-
-		if (showCollapsed) {
-			const hidden = allLines.length - OUTPUT_PREVIEW_LINES;
-			this.addWrapped(lines, "", withExpandHint(hiddenLinesLabel(hidden)), width);
-		}
-
-		for (const line of visibleLines) {
-			this.addWrapped(lines, "", theme.fg(color, line || " "), width);
+		for (const line of text.split("\n")) {
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg(color, line || " "), width);
 		}
 	}
 
 	private renderTraceback(lines: string[], width: number, traceback: string): void {
 		for (const line of traceback.split("\n")) {
-			this.addWrapped(lines, "", theme.fg("muted", line || " "), width);
+			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", line || " "), width);
 		}
 	}
 
+	// Backgroundless line, indented one space to align under the fixed top line.
 	private addWrapped(lines: string[], prefix: string, text: string, width: number): void {
-		const available = Math.max(1, toolPanelContentWidth(width) - visibleWidth(prefix));
+		const available = Math.max(1, width - 1 - visibleWidth(prefix));
 		const wrapped = wrapTextWithAnsi(text, available);
 		for (const [index, line] of (wrapped.length > 0 ? wrapped : [""]).entries()) {
 			const linePrefix = index === 0 ? prefix : " ".repeat(visibleWidth(prefix));
-			lines.push(toolPanelLine(linePrefix + closeOpenSgr(line), width));
+			lines.push(` ${linePrefix}${closeOpenSgr(line)}`);
 		}
 	}
 
-	private addBlank(lines: string[], width: number): void {
-		lines.push(toolPanelLine("", width));
+	private addBlank(lines: string[], _width: number): void {
+		lines.push("");
 	}
 
 	// No-background line, indented one space to align with the summary line above.

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -270,4 +270,32 @@ describe("IPythonCellComponent diff rendering", () => {
 		// Hunks are separated by the vertical-ellipsis marker.
 		expect((out.match(/⋮/g) ?? []).length).toBe(2);
 	});
+
+	it("keeps the top line stable when expanded — only the hint flips, no header line, no layout shift", () => {
+		const state = {
+			code: "print(55)",
+			content: [{ type: "text", text: "55" }],
+			details: { status: "ok", durationMs: 780_000 },
+			executionStarted: true,
+			argsComplete: true,
+		};
+		const collapsed = new IPythonCellComponent({ ...state, expanded: false }).render(80);
+		const expanded = new IPythonCellComponent({ ...state, expanded: true }).render(80);
+
+		// Top line is unchanged through the duration; only the trailing hint flips
+		// "to expand" → "to collapse", so nothing before it can shift.
+		expect(stripAnsi(collapsed[0])).toMatch(/^ ✓ python · .* · ↑ 1 ↓ 1 lines · 780\.0s · .*to expand$/);
+		expect(stripAnsi(expanded[0])).toMatch(/^ ✓ python · .* · ↑ 1 ↓ 1 lines · 780\.0s · .*to collapse$/);
+		const upToHint = (line: string) => stripAnsi(line).replace(/· [^·]*to (expand|collapse)$/, "");
+		expect(upToHint(expanded[0])).toBe(upToHint(collapsed[0]));
+
+		// No separate "python · done · 780.0s" header line below the top line.
+		const stripped = expanded.map(stripAnsi);
+		expect(stripped.filter((l) => /python · done/.test(l)).length).toBe(0);
+
+		// Expanding only attaches code + output below, backgroundless like the top.
+		expect(stripped.join("\n")).toContain("print(55)");
+		expect(stripped.join("\n")).toContain("55");
+		expect(expanded.some(hasBackground)).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -298,4 +298,33 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(stripped.join("\n")).toContain("55");
 		expect(expanded.some(hasBackground)).toBe(false);
 	});
+
+	it("does not show a 'no output' line under an edit-only diff", () => {
+		const out = renderCell({
+			code: 'await edit(path="a.ts", old_str="x", new_str="X")',
+			details: { status: "ok", diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
+			executionStarted: true,
+			argsComplete: true,
+			expanded: true,
+		});
+		expect(out).toContain("a.ts");
+		expect(out).not.toContain("no output");
+	});
+
+	it("never emits a line wider than the viewport, even in a very narrow pane", () => {
+		for (const width of [1, 2, 3, 5, 8]) {
+			const lines = new IPythonCellComponent({
+				code: "import numpy as np\nresult = np.linspace(0, 100, 50)",
+				content: [{ type: "text", text: "a fairly long line of output that must wrap" }],
+				details: { status: "ok", durationMs: 12, stdout: "a fairly long line of output that must wrap" },
+				executionStarted: true,
+				argsComplete: true,
+				expanded: true,
+			}).render(width);
+			expect(
+				lines.every((line) => visibleWidth(line) <= width),
+				`width=${width}`,
+			).toBe(true);
+		}
+	});
 });

--- a/packages/coding-agent/test/ipython-cell-wrap.test.ts
+++ b/packages/coding-agent/test/ipython-cell-wrap.test.ts
@@ -62,11 +62,11 @@ describe("IPythonCellComponent wrapping", () => {
 		}
 	});
 
-	it("pads every wrapped line to exactly the panel width", () => {
+	it("keeps every wrapped line within the available width", () => {
 		for (const width of [20, 30, 40, 50]) {
 			const lines = new IPythonCellComponent(WRAPPING_STATE).render(width);
 			expect(
-				lines.every((line) => visibleWidth(line) === width),
+				lines.every((line) => visibleWidth(line) <= width),
 				`width=${width}`,
 			).toBe(true);
 		}
@@ -85,6 +85,6 @@ describe("IPythonCellComponent wrapping", () => {
 	it("leaves non-wrapping (wide) output untouched", () => {
 		const lines = new IPythonCellComponent(WRAPPING_STATE).render(100);
 		expect(lines.some(foregroundLeftOpen)).toBe(false);
-		expect(lines.every((line) => visibleWidth(line) === 100)).toBe(true);
+		expect(lines.every((line) => visibleWidth(line) <= 100)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -738,23 +738,22 @@ describe("marquee TUI components", () => {
 
 		// Collapsed: routed through the cell renderer (a status line), not the
 		// generic JSON arg dump.
-		const collapsed = stripAnsi(component.render(100).join("\n"));
+		const collapsedLines = component.render(100);
+		const collapsed = stripAnsi(collapsedLines.join("\n"));
 		expect(collapsed).toContain("python");
 		expect(collapsed).toContain("12ms");
 		expect(collapsed).not.toContain("ipython");
 		expect(collapsed).not.toContain('"code"');
 
-		// Expanded: full panel with the code and output on the panel background.
+		// Expanded keeps the identical top line — no restructuring — and just
+		// attaches the code and output below it, backgroundless like the top line.
 		component.setExpanded(true);
-		const rawOutput = component.render(100).join("\n");
-		expect(rawOutput).toMatch(/\x1b\[48;(?:2|5);/);
-		const panelLine = component.render(100).find((line) => line.includes("\x1b[48;")) ?? "";
-		expect(panelLine.startsWith("\x1b[48;")).toBe(true);
-		expect(panelLine.endsWith("\x1b[49m")).toBe(true);
-		expect(visibleWidth(panelLine)).toBe(100);
-		const expanded = stripAnsi(rawOutput);
+		const expandedLines = component.render(100);
+		expect(stripAnsi(expandedLines[0])).toBe(stripAnsi(collapsedLines[0]));
+		const expanded = stripAnsi(expandedLines.join("\n"));
 		expect(expanded).toContain("print(55)");
 		expect(expanded).toContain("55");
 		expect(expanded).not.toContain('"code"');
+		expect(expandedLines.some((line) => /\x1b\[48;/.test(line))).toBe(false);
 	});
 });


### PR DESCRIPTION
- hitting ctrl+o used to restructure the block — the top line changed wording, shifted indentation, and gained a background — so expanding felt jarring.
- the top line is now identical whether collapsed or expanded, and expanding just attaches the code and output beneath it, with the hint flipping to "to collapse".
- aligned the output under the code gutter so stdout, results, and tracebacks line up with the input for both python and bash cells.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation only in `IPythonCellComponent`; behavior is covered by new and updated unit tests with no auth, data, or execution-path changes.
> 
> **Overview**
> **Ctrl+O** on IPython cells no longer restructures the block: the **same summary top line** stays in place when expanding; only the key hint switches between **to expand** and **to collapse**, and full code plus output are appended below.
> 
> Expanded rendering drops the separate **python · done · …** header and **tool panel** background (`toolPanelLine` / `toolPanelContentWidth`). Code, stdout, stderr, tracebacks, and placeholders use a **two-space `OUTPUT_INDENT`** so output lines up with the code gutter. Collapsed cells no longer show truncated input/output previews or per-section expand hints; **edit diffs** still render under the summary in both states.
> 
> Wrapping now **truncates** composed lines to the viewport width (≤ width) instead of padding every line to full panel width, avoiding overflow in narrow panes. Edit-only cells skip the **no output** placeholder when only a diff is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8950bf8a2e922414ce508ac0099b1987d4d492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make ctrl+o expand/collapse consistent for IPython cells
> - Replaces the panel-background rendering model with a backgroundless layout: a single stable top line always appears first, with code and output appended below when expanded.
> - The expand hint on the top line now toggles between 'to expand' and 'to collapse' based on state, instead of always showing 'to expand'.
> - Removes collapsed previews (truncated code/output bars and hidden-line summaries); collapsed view shows only the top line.
> - Edit diffs always render directly under the top line regardless of expand state; cells with only diffs no longer show a spurious 'no output' line.
> - All emitted lines are truncated to the viewport width to prevent overflow in narrow panes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac8950b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->