### PR TITLE
cancel background subagents when the parent kernel is reloaded

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3508,6 +3508,11 @@ export class AgentSession {
 			// kernel so the session never holds two live kernels. Gate the new kernel's
 			// startup on the old one's dispose (which flushes a final snapshot), so a
 			// reload can't restore from a snapshot the old kernel is still writing.
+			// Child runs bound to the old kernel can never complete once it's gone, so
+			// cancel them first — otherwise they hang as "running" forever.
+			if (this._ipythonKernelProvisioner) {
+				this._cancelActiveRlmChildRuns("Parent kernel was reloaded");
+			}
 			const previousDispose = this._ipythonKernelProvisioner?.dispose();
 			this._ipythonKernelSnapshotDir = this.sessionManager.getSessionArtifactDir();
 			// Only surface the "revived from your previous session" notice on the first


### PR DESCRIPTION
- background subagents spawned via asyncio.create_task could hang as "running" forever after a /reload, because reloading disposes the old kernel while their run loops were still awaiting it.
- the kernel-rebuild path now cancels in-flight child runs before dropping the old kernel, so they settle and emit a terminal status instead of getting stranded.
- verified with a reload-mid-run repro: previously three children stayed stuck running, now all settle to cancelled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded call on an existing cancellation helper during kernel rebuild; no auth or data-path changes.
> 
> **Overview**
> **Fixes background RLM subagents stuck as "running" after `/reload`.**
> 
> When the runtime rebuilds the IPython kernel, it now calls `_cancelActiveRlmChildRuns("Parent kernel was reloaded")` **before** disposing the old provisioner. Child runs tied to the disposed kernel cannot finish, so they are cancelled up front and emit a terminal **cancelled** status instead of hanging indefinitely.
> 
> This matches the existing cancel-on-abort and cancel-on-dispose behavior; only the kernel-rebuild path was missing it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcaec6f1f0cd3f36913f963f5c35df9624761b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel active background subagents when parent kernel is reloaded
> When a kernel rebuild occurs and a previous kernel provisioner exists, all active RLM child runs bound to the old kernel are now cancelled with the reason "Parent kernel was reloaded" before the old kernel is disposed. This prevents subagents from remaining in a running state indefinitely after a kernel reload. The cancellation step is added in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/289/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) before the old provisioner is disposed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcaec6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->