### PR TITLE
stop tool results with no output from claiming an image is attached

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -925,7 +925,7 @@ export function convertMessages(
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+					content: sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : ""),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -246,7 +246,7 @@ export function convertResponsesMessages<TApi extends Api>(
 
 				output = contentParts;
 			} else {
-				output = sanitizeSurrogates(hasText ? textResult : "(see attached image)");
+				output = sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "");
 			}
 
 			messages.push({

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -99,4 +99,43 @@ describe("openai-completions convertMessages", () => {
 		);
 		expect(imageParts.length).toBe(2);
 	});
+
+	it("does not emit the image placeholder for empty-text tool results with no image", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text", "image"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { cmd: "true" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tool-1",
+			toolName: "bash",
+			content: [{ type: "text", text: "" }],
+			isError: false,
+			timestamp: now + 1,
+		};
+
+		const context: Context = {
+			messages: [{ role: "user", content: "Run it", timestamp: now - 2 }, assistantMessage, toolResult],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((message) => message.role === "tool");
+		expect(toolMessage?.content).toBe("");
+		expect(toolMessage?.content).not.toBe("(see attached image)");
+	});
 });

--- a/packages/ai/test/openai-responses-empty-tool-result.test.ts
+++ b/packages/ai/test/openai-responses-empty-tool-result.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, Context, Model, ToolResultMessage, Usage } from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function buildContext(toolResult: ToolResultMessage, now: number): Context {
+	const assistantMessage: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { cmd: "true" } }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp: now,
+	};
+	return {
+		messages: [{ role: "user", content: "Run it", timestamp: now - 2 }, assistantMessage, toolResult],
+	};
+}
+
+describe("openai-responses convertResponsesMessages", () => {
+	const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+	const model: Model<"openai-responses"> = {
+		...baseModel,
+		api: "openai-responses",
+		input: ["text", "image"],
+	};
+
+	it("does not emit the image placeholder for empty-text tool results with no image", () => {
+		const now = Date.now();
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tool-1",
+			toolName: "bash",
+			content: [{ type: "text", text: "" }],
+			isError: false,
+			timestamp: now + 1,
+		};
+
+		const messages = convertResponsesMessages(model, buildContext(toolResult, now), new Set(["openai"]));
+		const output = messages.find((m) => m.type === "function_call_output");
+		expect(output?.output).toBe("");
+		expect(output?.output).not.toBe("(see attached image)");
+	});
+
+	it("still attaches images for tool results that contain an image", () => {
+		const now = Date.now();
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tool-1",
+			toolName: "read",
+			content: [{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" }],
+			isError: false,
+			timestamp: now + 1,
+		};
+
+		const messages = convertResponsesMessages(model, buildContext(toolResult, now), new Set(["openai"]));
+		const output = messages.find((m) => m.type === "function_call_output");
+		expect(Array.isArray(output?.output)).toBe(true);
+		const parts = output?.output as Array<{ type?: string }>;
+		expect(parts.some((p) => p.type === "input_image")).toBe(true);
+	});
+});


### PR DESCRIPTION
- empty-output tool results (aborted cells, commands with no stdout) were being sent to the model as the literal text "(see attached image)" on openai-completions and openai-responses providers, making the model hallucinate a nonexistent image and derail.
- the placeholder was keyed only on whether text was present, ignoring whether an image actually existed; now it only appears when there really is an image, matching the google and mistral providers.
- added regression tests covering both providers for the empty-text, no-image case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to provider message serialization for edge-case tool outputs, with regression tests and no auth or data-path impact.
> 
> **Overview**
> Fixes **misleading tool-result text** on OpenAI chat-completions and Responses message conversion when a tool returns no stdout (empty text) and no image blocks—cases like aborted cells or silent commands.
> 
> Previously, missing text always became the literal `"(see attached image)"`, which could make the model invent images. The conversion now uses that placeholder **only when `hasImages` is true**; otherwise it sends an empty string, consistent with Google/Mistral-style handling.
> 
> Regression tests cover empty-text/no-image tool results for both `convertMessages` and `convertResponsesMessages`, plus a check that image-only tool results still attach images on Responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9156768137f3c8ee137c657302a7e4705bf917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tool result messages from claiming an image is attached when no image exists
> In both `convertMessages` ([openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/290/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246)) and `convertResponsesMessages` ([openai-responses-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/290/files#diff-75a92c85369ffe30444d6da4b398bb4fd5b852ff45a5eea02f95b3b2fa48df48)), the fallback content for tool results with no text was always `'(see attached image)'`, even when no image was present. The content now falls back to `'(see attached image)'` only when images are present, and to an empty string otherwise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e91567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->