### PR TITLE
track runtime content hash for kernel venv staleness

### DIFF
--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -556,6 +556,9 @@ export async function resolveRuntimeIdentity(): Promise<string> {
 	return hashRuntimeSource(sourceDir);
 }
 
+// Throws if the local source can't be read. A failure here must surface rather than
+// fall back to RUNTIME_REQUIREMENT: that constant is the registry-install identity, and
+// recording it for a local checkout would permanently mask later source changes.
 async function hashRuntimeSource(sourceDir: string): Promise<string> {
 	const rlmDir = path.join(sourceDir, "src", "rlm");
 	const files: string[] = [path.join(sourceDir, "pyproject.toml")];
@@ -570,11 +573,7 @@ async function hashRuntimeSource(sourceDir: string): Promise<string> {
 			}
 		}
 	}
-	try {
-		await collect(rlmDir);
-	} catch {
-		return RUNTIME_REQUIREMENT;
-	}
+	await collect(rlmDir);
 	files.sort();
 	const hash = createHash("sha256");
 	for (const file of files) {

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -529,8 +529,12 @@ async function writeBootstrapVersion(
 
 function runtimeCandidateDirs(): string[] {
 	const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+	// dist/prime-agent-runtime is listed first deliberately: it is the only path stable
+	// across every shipped layout (dist/, dist/bundle/, bun), where import.meta.url-relative
+	// resolution breaks. `npm run build` rebuilds it from live source (copy-assets does
+	// rm -rf + cp), so the staleness hash still refreshes on every build. The relative
+	// paths below cover running from source (tsx) where dist/ hasn't been built.
 	return [
-		// Stable across layouts (dist/, dist/bundle/, tsx): <package>/dist/prime-agent-runtime
 		path.join(getPackageDir(), "dist", "prime-agent-runtime"),
 		path.resolve(moduleDir, "..", "..", "prime-agent-runtime"),
 		path.resolve(moduleDir, "..", "..", "..", "..", "..", "prime-agent-runtime"),

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -547,17 +547,18 @@ async function resolveRuntimeSourceDir(): Promise<string | null> {
 }
 
 // Identity of the runtime to be installed. For a local source checkout this is a
-// content hash of every rlm/*.py file, so any runtime change invalidates an
-// existing venv automatically. Falls back to the bare package name when the
-// runtime resolves to a registry install (no local source to hash).
+// content hash of every rlm/*.py file plus pyproject.toml, so any runtime code or
+// dependency change invalidates an existing venv automatically. Falls back to the
+// bare package name when the runtime resolves to a registry install (no local source).
 export async function resolveRuntimeIdentity(): Promise<string> {
 	const sourceDir = await resolveRuntimeSourceDir();
 	if (!sourceDir) return RUNTIME_REQUIREMENT;
-	return hashRuntimeSource(path.join(sourceDir, "src", "rlm"));
+	return hashRuntimeSource(sourceDir);
 }
 
-async function hashRuntimeSource(rlmDir: string): Promise<string> {
-	const files: string[] = [];
+async function hashRuntimeSource(sourceDir: string): Promise<string> {
+	const rlmDir = path.join(sourceDir, "src", "rlm");
+	const files: string[] = [path.join(sourceDir, "pyproject.toml")];
 	async function collect(dir: string): Promise<void> {
 		const entries = await readdir(dir, { withFileTypes: true });
 		for (const entry of entries) {
@@ -577,7 +578,7 @@ async function hashRuntimeSource(rlmDir: string): Promise<string> {
 	files.sort();
 	const hash = createHash("sha256");
 	for (const file of files) {
-		hash.update(path.relative(rlmDir, file));
+		hash.update(path.relative(sourceDir, file));
 		hash.update("\0");
 		hash.update(await readFile(file));
 		hash.update("\0");

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants, existsSync, readFileSync } from "node:fs";
-import { access, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { stderr, stdin } from "node:process";
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 import { getPackageDir } from "../../config.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 
-const BOOTSTRAP_SCHEMA = 7;
+const BOOTSTRAP_SCHEMA = 8;
 const PYTHON_VERSION = "3.11";
 const IPYKERNEL_REQUIREMENT = "ipykernel";
 const RUNTIME_REQUIREMENT = "prime-agent-runtime";
@@ -51,7 +51,7 @@ const REQUIRED_HARNESS_METHODS = [
 	"delete_prompt_note",
 	"record_refinement",
 ];
-const RUNTIME_READY_CHECK = `import inspect; import rlm; from rlm.harness import HarnessEntry; _harness_methods = ${JSON.stringify(REQUIRED_HARNESS_METHODS)}; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert callable(rlm.host_request); assert hasattr(rlm, 'harness'); assert hasattr(rlm, 'get_harness_state'); assert hasattr(rlm.rlm, 'harness'); assert hasattr(rlm.rlm, 'get_harness_state'); assert all(callable(getattr(_harness, _method, None)) for _harness in (rlm.harness, rlm.rlm.harness) for _method in _harness_methods); assert 'reference' in HarnessEntry.__dataclass_fields__; assert 'reference' in inspect.signature(rlm.harness.create_skill).parameters; assert 'reference' in inspect.signature(rlm.harness.update_skill).parameters; assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')`;
+const RUNTIME_READY_CHECK = `import inspect; import rlm; from rlm import McpIntegration; from rlm.harness import HarnessEntry; _harness_methods = ${JSON.stringify(REQUIRED_HARNESS_METHODS)}; assert hasattr(rlm, 'run'); assert callable(rlm); assert hasattr(rlm, 'rlm'); assert callable(rlm.rlm); assert callable(rlm.host_request); assert hasattr(rlm, 'harness'); assert hasattr(rlm, 'get_harness_state'); assert hasattr(rlm.rlm, 'harness'); assert hasattr(rlm.rlm, 'get_harness_state'); assert all(callable(getattr(_harness, _method, None)) for _harness in (rlm.harness, rlm.rlm.harness) for _method in _harness_methods); assert 'reference' in HarnessEntry.__dataclass_fields__; assert 'reference' in inspect.signature(rlm.harness.create_skill).parameters; assert 'reference' in inspect.signature(rlm.harness.update_skill).parameters; assert not hasattr(rlm, 'background'); assert not hasattr(rlm.rlm, 'background')`;
 const BOOTSTRAP_VERSION_FILE = ".bootstrap-version";
 const BOOTSTRAP_LOCK_NAME = ".bootstrap.lock";
 const BOOTSTRAP_LOCK_RETRY_MS = 100;
@@ -491,28 +491,35 @@ function pythonSkillsMatch(a: BootstrapPythonSkill[] | undefined, b: readonly Bo
 
 function bootstrapVersionCurrent(
 	version: BootstrapVersion | null,
+	runtimeIdentity: string,
 	pythonSkills: readonly BootstrapPythonSkill[],
 ): boolean {
 	return (
-		version !== null && bootstrapBaseVersionCurrent(version) && pythonSkillsMatch(version.pythonSkills, pythonSkills)
+		version !== null &&
+		bootstrapBaseVersionCurrent(version, runtimeIdentity) &&
+		pythonSkillsMatch(version.pythonSkills, pythonSkills)
 	);
 }
 
-function bootstrapBaseVersionCurrent(version: BootstrapVersion | null): boolean {
+function bootstrapBaseVersionCurrent(version: BootstrapVersion | null, runtimeIdentity: string): boolean {
 	return (
 		version?.schema === BOOTSTRAP_SCHEMA &&
 		version.ipykernel === IPYKERNEL_REQUIREMENT &&
-		version.runtime === RUNTIME_REQUIREMENT &&
+		version.runtime === runtimeIdentity &&
 		version.snapshot === STATE_SNAPSHOT_REQUIREMENT &&
 		extraUvArgsMatch(version.extraUvArgs, DEFAULT_RLM_EXTRA_UV_ARGS)
 	);
 }
 
-async function writeBootstrapVersion(venv: string, pythonSkills: readonly BootstrapPythonSkill[]): Promise<void> {
+async function writeBootstrapVersion(
+	venv: string,
+	runtimeIdentity: string,
+	pythonSkills: readonly BootstrapPythonSkill[],
+): Promise<void> {
 	const version: BootstrapVersion = {
 		schema: BOOTSTRAP_SCHEMA,
 		ipykernel: IPYKERNEL_REQUIREMENT,
-		runtime: RUNTIME_REQUIREMENT,
+		runtime: runtimeIdentity,
 		snapshot: STATE_SNAPSHOT_REQUIREMENT,
 		extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 		pythonSkills: [...pythonSkills],
@@ -530,13 +537,52 @@ function runtimeCandidateDirs(): string[] {
 	];
 }
 
-async function resolveRuntimeRequirement(): Promise<string> {
+async function resolveRuntimeSourceDir(): Promise<string | null> {
 	for (const candidate of runtimeCandidateDirs()) {
 		if (await exists(path.join(candidate, "pyproject.toml"))) {
 			return candidate;
 		}
 	}
-	return RUNTIME_REQUIREMENT;
+	return null;
+}
+
+// Identity of the runtime to be installed. For a local source checkout this is a
+// content hash of every rlm/*.py file, so any runtime change invalidates an
+// existing venv automatically. Falls back to the bare package name when the
+// runtime resolves to a registry install (no local source to hash).
+export async function resolveRuntimeIdentity(): Promise<string> {
+	const sourceDir = await resolveRuntimeSourceDir();
+	if (!sourceDir) return RUNTIME_REQUIREMENT;
+	return hashRuntimeSource(path.join(sourceDir, "src", "rlm"));
+}
+
+async function hashRuntimeSource(rlmDir: string): Promise<string> {
+	const files: string[] = [];
+	async function collect(dir: string): Promise<void> {
+		const entries = await readdir(dir, { withFileTypes: true });
+		for (const entry of entries) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await collect(full);
+			} else if (entry.isFile() && entry.name.endsWith(".py")) {
+				files.push(full);
+			}
+		}
+	}
+	try {
+		await collect(rlmDir);
+	} catch {
+		return RUNTIME_REQUIREMENT;
+	}
+	files.sort();
+	const hash = createHash("sha256");
+	for (const file of files) {
+		hash.update(path.relative(rlmDir, file));
+		hash.update("\0");
+		hash.update(await readFile(file));
+		hash.update("\0");
+	}
+	return `sha256:${hash.digest("hex")}`;
 }
 
 async function bootstrapVenv(
@@ -546,7 +592,9 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const python = path.join(venv, "bin", "python");
-	const runtimeRequirement = await resolveRuntimeRequirement();
+	const sourceDir = await resolveRuntimeSourceDir();
+	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
+	const runtimeIdentity = await resolveRuntimeIdentity();
 
 	// Build the step list before running so the percentage denominator only
 	// counts work that will actually happen on this machine.
@@ -579,17 +627,17 @@ async function bootstrapVenv(
 		STATE_SNAPSHOT_REQUIREMENT,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
-
 	if (pythonSkills.length > 0) {
 		progress.begin(BOOTSTRAP_STEP.skills);
 	}
-	await syncPythonSkills(uv, venv, python, pythonSkills, options);
+	await syncPythonSkills(uv, venv, python, runtimeIdentity, pythonSkills, options);
 }
 
 async function syncPythonSkills(
 	uv: string,
 	venv: string,
 	python: string,
+	runtimeIdentity: string,
 	pythonSkills: readonly BootstrapPythonSkill[],
 	options: EnsureKernelPythonOptions,
 ): Promise<void> {
@@ -616,26 +664,27 @@ async function syncPythonSkills(
 			);
 		}
 	}
-	await writeBootstrapVersion(venv, installedPythonSkills);
+	await writeBootstrapVersion(venv, runtimeIdentity, installedPythonSkills);
 }
 
-async function kernelBaseReady(python: string, venv: string): Promise<boolean> {
+async function kernelBaseReady(python: string, venv: string, runtimeIdentity: string): Promise<boolean> {
 	return (
 		(await hasIpykernel(python)) &&
 		(await hasPrimeAgentRuntime(python)) &&
-		bootstrapBaseVersionCurrent(await readBootstrapVersion(venv))
+		bootstrapBaseVersionCurrent(await readBootstrapVersion(venv), runtimeIdentity)
 	);
 }
 
 async function kernelReady(
 	python: string,
 	venv: string,
+	runtimeIdentity: string,
 	pythonSkills: readonly BootstrapPythonSkill[],
 ): Promise<boolean> {
 	return (
 		(await hasIpykernel(python)) &&
 		(await hasPrimeAgentRuntime(python)) &&
-		bootstrapVersionCurrent(await readBootstrapVersion(venv), pythonSkills)
+		bootstrapVersionCurrent(await readBootstrapVersion(venv), runtimeIdentity, pythonSkills)
 	);
 }
 
@@ -682,13 +731,14 @@ async function ensureKernelPythonUncached(
 
 	const venv = await resolveWritableKernelVenvDir();
 	const python = path.join(venv, "bin", "python");
-	if (await kernelReady(python, venv, pythonSkills)) return python;
+	const runtimeIdentity = await resolveRuntimeIdentity();
+	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 
 	const releaseLock = await acquireBootstrapLock(venv);
 	try {
-		if (await kernelReady(python, venv, pythonSkills)) return python;
-		if (await kernelBaseReady(python, venv)) {
-			await syncPythonSkills(await ensureUv(options), venv, python, pythonSkills, options);
+		if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
+		if (await kernelBaseReady(python, venv, runtimeIdentity)) {
+			await syncPythonSkills(await ensureUv(options), venv, python, runtimeIdentity, pythonSkills, options);
 			return python;
 		}
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -9,10 +9,12 @@ import {
 	ensureKernelPython,
 	getKernelVenvDir,
 	type KernelPythonSkill,
+	resolveRuntimeIdentity,
 } from "../src/core/kernel/bootstrap.js";
 
 let tempDir = "";
 let originalEnv: NodeJS.ProcessEnv;
+let runtimeIdentity = "";
 
 function pyprojectHash(pyprojectPath: string): string {
 	return `sha256:${createHash("sha256").update(readFileSync(pyprojectPath)).digest("hex")}`;
@@ -27,9 +29,9 @@ function writeBootstrapVersion(venv: string, pythonSkills: readonly KernelPython
 	writeFileSync(
 		join(venv, ".bootstrap-version"),
 		`${JSON.stringify({
-			schema: 7,
+			schema: 8,
 			ipykernel: "ipykernel",
-			runtime: "prime-agent-runtime",
+			runtime: runtimeIdentity,
 			snapshot: "dill",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: pythonSkills.map((skill) => ({
@@ -133,7 +135,8 @@ function installFakeUv(): string {
 }
 
 describe("kernel bootstrap", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
+		runtimeIdentity = await resolveRuntimeIdentity();
 		originalEnv = { ...process.env };
 		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-kernel-bootstrap-"));
 		process.env.HOME = tempDir;
@@ -177,13 +180,14 @@ describe("kernel bootstrap", () => {
 		}
 		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
 		expect(version).toEqual({
-			schema: 7,
+			schema: 8,
 			ipykernel: "ipykernel",
-			runtime: "prime-agent-runtime",
+			runtime: runtimeIdentity,
 			snapshot: "dill",
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: [],
 		});
+		expect(version.runtime).toMatch(/^sha256:/);
 	});
 
 	it("routes bootstrap progress through the provided callback", async () => {
@@ -365,6 +369,32 @@ dependencies = ["httpx"]
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
 		await expect(ensureKernelPython()).resolves.toBe(python);
+	});
+
+	it("rebuilds a warm venv whose recorded runtime hash no longer matches local source", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const python = join(venv, "bin", "python");
+		mkdirSync(join(venv, "bin"), { recursive: true });
+		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		writeFileSync(
+			join(venv, ".bootstrap-version"),
+			`${JSON.stringify({
+				schema: 8,
+				ipykernel: "ipykernel",
+				runtime: "sha256:stale",
+				snapshot: "dill",
+				extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
+				pythonSkills: [],
+			})}\n`,
+		);
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+
+		await expect(ensureKernelPython()).resolves.toBe(python);
+
+		expect(readFileSync(logPath, "utf8")).toContain(`venv ${venv} --python 3.11 --seed`);
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
+		expect(version.runtime).toBe(runtimeIdentity);
 	});
 
 	it("rebuilds a warm venv with a stale rlm runtime", async () => {


### PR DESCRIPTION
- the kernel venv could keep a stale prime-agent-runtime indefinitely because the staleness check compared a constant against itself, silently breaking mcp skills like linear and notion.
- the venv now records a content hash of the local runtime source and rebuilds automatically whenever that source changes, instead of relying on manual schema bumps.
- also asserts mcp support is importable in the readiness probe and bumps the bootstrap schema so existing stale venvs refresh on next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Python kernel bootstrap and can force full venv rebuilds on upgrade or after local runtime edits; incorrect hashing could cause unnecessary rebuilds or miss staleness.
> 
> **Overview**
> Fixes kernel venvs keeping an outdated **prime-agent-runtime** because staleness only compared the fixed package name `"prime-agent-runtime"` to itself, so local runtime changes never triggered a refresh (breaking MCP-related capabilities).
> 
> **`.bootstrap-version` (schema 8)** now stores a **runtime identity**: a `sha256:` hash over local `pyproject.toml` and all `src/rlm/**/*.py` when a checkout is found via `resolveRuntimeIdentity` / `hashRuntimeSource`; registry-only installs still use the package name. Readiness checks compare that identity on each `ensureKernelPython` run and **rebuild the venv** when it diverges, without relying on manual schema bumps for every runtime edit.
> 
> The runtime readiness probe also requires **`rlm.McpIntegration`** to import. Tests expect the new schema, dynamic runtime identity, and a rebuild when the recorded hash is stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db85a7a36932ae11b6b5d423dc6a30ab889c35d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track runtime content hash to detect kernel venv staleness
> - Adds `resolveRuntimeIdentity` in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/291/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to compute a sha256 hash over `rlm/*.py` files and `pyproject.toml` when a local runtime source dir is present, falling back to `'prime-agent-runtime'` for registry installs.
> - Threads `runtimeIdentity` through `kernelReady`, `kernelBaseReady`, `writeBootstrapVersion`, and `syncPythonSkills` so the `.bootstrap-version` file records the content hash rather than a fixed package name.
> - Any change to runtime source files (names or contents) now causes the venv to be rebuilt automatically on next kernel startup.
> - Bumps `BOOTSTRAP_SCHEMA` from 7 to 8 and adds `from rlm import McpIntegration` to the runtime readiness check.
> - Risk: all existing venvs at schema 7 are immediately considered stale and will be rebuilt on first use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db85a7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->