### PR TITLE
fix tui scrolling to bottom when selecting text

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -550,6 +550,23 @@ export function isKeyRelease(data: string): boolean {
 	return false;
 }
 
+// SGR mouse: ESC [ < b ; x ; y (M|m). Legacy X10 mouse: ESC [ M + 3 bytes.
+const SGR_MOUSE_PATTERN = /^\x1b\[<\d+;\d+;\d+[Mm]$/;
+
+/**
+ * Check if a sequence is a mouse event forwarded by the terminal.
+ *
+ * pi-tui never enables mouse tracking, but terminals/multiplexers with their
+ * own mouse mode (e.g. tmux `mouse on`) still relay these during selection and
+ * scrolling. No component consumes them, so they must be treated as no-ops.
+ */
+export function isMouseSequence(data: string): boolean {
+	if (SGR_MOUSE_PATTERN.test(data)) {
+		return true;
+	}
+	return data.length === 6 && data.startsWith("\x1b[M");
+}
+
 /**
  * Check if the last parsed key event was a key repeat.
  * Only meaningful when Kitty keyboard protocol with flag 2 is active.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
-import { isKeyRelease, matchesKey } from "./keys.js";
+import { isKeyRelease, isMouseSequence, matchesKey } from "./keys.js";
 import type { Terminal } from "./terminal.js";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
 import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
@@ -255,6 +255,7 @@ export class TUI extends Container {
 	private static readonly MIN_RENDER_INTERVAL_MS = 16;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
+	private hardwareCursorCol = -1; // Last positioned hardware cursor column (-1 = unknown)
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
@@ -578,6 +579,14 @@ export class TUI extends Container {
 
 		// Consume terminal cell size responses without blocking unrelated input.
 		if (this.consumeCellSizeResponse(data)) {
+			return;
+		}
+
+		// Drop mouse events relayed by the terminal/multiplexer (e.g. tmux
+		// `mouse on`). No component consumes them, and reacting would trigger a
+		// render that repositions the hardware cursor and yanks a scrolled-up
+		// viewport back to the bottom (ENG-4374).
+		if (isMouseSequence(data)) {
 			return;
 		}
 
@@ -1161,9 +1170,9 @@ export class TUI extends Container {
 		}
 		const appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
 
-		// No changes - but still need to update hardware cursor position if it moved
+		// No changes - reposition only if the cursor target actually moved
 		if (firstChanged === -1) {
-			this.positionHardwareCursor(cursorPos, newLines.length);
+			this.positionHardwareCursor(cursorPos, newLines.length, false);
 			this.previousViewportTop = prevViewportTop;
 			this.previousHeight = height;
 			return;
@@ -1384,8 +1393,13 @@ export class TUI extends Container {
 	 * @param cursorPos The cursor position extracted from rendered output, or null
 	 * @param totalLines Total number of rendered lines
 	 */
-	private positionHardwareCursor(cursorPos: { row: number; col: number } | null, totalLines: number): void {
+	private positionHardwareCursor(
+		cursorPos: { row: number; col: number } | null,
+		totalLines: number,
+		contentChanged = true,
+	): void {
 		if (!cursorPos || totalLines <= 0) {
+			this.hardwareCursorCol = -1;
 			this.terminal.hideCursor();
 			return;
 		}
@@ -1393,6 +1407,20 @@ export class TUI extends Container {
 		// Clamp cursor position to valid range
 		const targetRow = Math.max(0, Math.min(cursorPos.row, totalLines - 1));
 		const targetCol = Math.max(0, cursorPos.col);
+
+		// On a render that wrote no content, the hardware cursor is still where we
+		// last left it. Re-emitting the same move would make a scrolled-up terminal
+		// snap to the cursor row (ENG-4374), so skip it when the target is unchanged.
+		// When content changed the cursor was moved by the content writes, so the
+		// tracked column is stale and we must always re-position.
+		if (!contentChanged && targetRow === this.hardwareCursorRow && targetCol === this.hardwareCursorCol) {
+			if (this.showHardwareCursor) {
+				this.terminal.showCursor();
+			} else {
+				this.terminal.hideCursor();
+			}
+			return;
+		}
 
 		// Move cursor from current position to target
 		const rowDelta = targetRow - this.hardwareCursorRow;
@@ -1410,6 +1438,7 @@ export class TUI extends Container {
 		}
 
 		this.hardwareCursorRow = targetRow;
+		this.hardwareCursorCol = targetCol;
 		if (this.showHardwareCursor) {
 			this.terminal.showCursor();
 		} else {

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import {
 	decodeKittyPrintable,
 	decodePrintableKey,
+	isMouseSequence,
 	Key,
 	matchesKey,
 	parseKey,
@@ -612,6 +613,27 @@ describe("parseKey", () => {
 
 		it("should parse double bracket pageUp", () => {
 			assert.strictEqual(parseKey("\x1b[[5~"), "pageUp");
+		});
+	});
+
+	describe("isMouseSequence", () => {
+		it("recognizes SGR mouse press and release", () => {
+			assert.strictEqual(isMouseSequence("\x1b[<0;10;5M"), true);
+			assert.strictEqual(isMouseSequence("\x1b[<0;10;5m"), true);
+			assert.strictEqual(isMouseSequence("\x1b[<64;120;30M"), true);
+		});
+
+		it("recognizes legacy X10 mouse", () => {
+			assert.strictEqual(isMouseSequence("\x1b[M !!"), true);
+			assert.strictEqual(isMouseSequence("\x1b[M"), false);
+		});
+
+		it("rejects non-mouse input", () => {
+			assert.strictEqual(isMouseSequence("a"), false);
+			assert.strictEqual(isMouseSequence("\x1b[A"), false);
+			assert.strictEqual(isMouseSequence("\x1b[97u"), false);
+			assert.strictEqual(isMouseSequence("\x1b[200~text\x1b[201~"), false);
+			assert.strictEqual(isMouseSequence("\x1b[<0;10;5"), false);
 		});
 	});
 });

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -2,13 +2,28 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import { deleteKittyImage, encodeKitty } from "../src/terminal-image.js";
-import { type Component, TUI } from "../src/tui.js";
+import { type Component, CURSOR_MARKER, type Focusable, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
 class TestComponent implements Component {
 	lines: string[] = [];
 	render(_width: number): string[] {
 		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+// A focused component that emits CURSOR_MARKER, like the editor. Tracks any
+// input it receives so tests can assert mouse events are not forwarded.
+class FocusableComponent implements Component, Focusable {
+	focused = false;
+	receivedInput: string[] = [];
+	constructor(private text = "prompt") {}
+	render(_width: number): string[] {
+		return [this.focused ? `${this.text}${CURSOR_MARKER}` : this.text];
+	}
+	handleInput(data: string): void {
+		this.receivedInput.push(data);
 	}
 	invalidate(): void {}
 }
@@ -817,6 +832,68 @@ describe("TUI above-viewport changes on a tall transcript", () => {
 		await terminal.waitForRender();
 
 		assert.ok(terminal.getWrites().includes("\x1b[3J"), "A still-tall shrink clears stale scrollback");
+
+		tui.stop();
+	});
+});
+
+describe("TUI mouse event handling (ENG-4374)", () => {
+	it("ignores relayed mouse events without writing to the terminal", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new FocusableComponent();
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// Simulate the SGR mouse events tmux relays during a drag-select.
+		terminal.sendInput("\x1b[<0;5;3M");
+		terminal.sendInput("\x1b[<32;6;3M");
+		terminal.sendInput("\x1b[<0;8;3m");
+		await terminal.waitForRender();
+
+		assert.strictEqual(terminal.getWrites(), "", "mouse events must not produce any terminal output");
+		assert.deepStrictEqual(component.receivedInput, [], "mouse events must not reach the focused component");
+
+		tui.stop();
+	});
+
+	it("does not reposition the hardware cursor on a no-op render", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new FocusableComponent();
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// A render with identical content and an unchanged cursor target should
+		// emit nothing — re-emitting cursor motion is what scrolls the viewport.
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(terminal.getWrites(), "", "no-op render with unchanged cursor must emit no output");
+
+		tui.stop();
+	});
+
+	it("still forwards normal key input and renders", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new FocusableComponent();
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.sendInput("a");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(component.receivedInput, ["a"], "normal keys must still reach the focused component");
 
 		tui.stop();
 	});


### PR DESCRIPTION
- selecting or copying text scrolled the view back to the bottom under terminals with their own mouse mode, like tmux, which relay mouse events to the app during a drag.
- nothing consumed those events, but reacting to them repositioned the cursor and yanked a scrolled-up view down, so we now drop unconsumed mouse events before they trigger a render.
- also stopped repositioning the cursor on renders that change nothing, as a safeguard against any other source causing the same jump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input and render optimizations with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **ENG-4374**: copying or drag-selecting text in a scrolled-up view (e.g. tmux with `mouse on`) no longer snaps the viewport back to the bottom.
> 
> **Mouse relay:** Adds `isMouseSequence()` for SGR and legacy X10 mouse CSI sequences. `TUI.handleInput` drops these before any component sees them, so they do not trigger renders or cursor moves.
> 
> **Hardware cursor:** Tracks `hardwareCursorCol` and skips re-emitting cursor motion on no-op renders when row/column are unchanged (`contentChanged=false`), avoiding terminal scroll-to-cursor behavior when nothing on screen changed.
> 
> Tests cover mouse detection, ignored mouse input with no terminal writes, no-op render silence, and normal key forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84a951585d8427ee3570ee3741215f33852acee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TUI scrolling to bottom when selecting text by ignoring mouse sequences
> - Adds `isMouseSequence` in [`keys.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/292/files#diff-c4967c48e0748404d8098865b5c26f3cde0386f443cdc0876af23a893ce7774a) to detect SGR and legacy X10 mouse sequences forwarded by terminals like tmux.
> - The TUI input handler now drops mouse events early via `isMouseSequence`, preventing them from triggering renders or being forwarded to components.
> - Adds a `contentChanged` parameter to `positionHardwareCursor` so that no-op renders skip cursor movement sequences when the target position is unchanged.
> - Behavioral Change: Mouse events (e.g. text selection via SGR/X10) no longer cause the TUI to scroll or emit terminal writes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f84a951. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->