### PR TITLE
make install progress line descriptive with percentage

### DIFF
--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -263,6 +263,43 @@ function reportProgress(options: EnsureKernelPythonOptions, message: string): vo
 	process.stderr.write(`${message}\n`);
 }
 
+// Drives the single setup line shown during first-run bootstrap: each step
+// replaces the line with what's actually running plus a cumulative percentage.
+// Weights are rough wall-clock shares (the package install dwarfs the rest) so
+// the percentage tracks real work, not a flat 1/N. The caller builds the step
+// list from only the steps that will run, so the denominator stays honest.
+interface BootstrapStep {
+	label: string;
+	weight: number;
+}
+
+class BootstrapProgress {
+	private readonly total: number;
+	private completedWeight = 0;
+
+	constructor(
+		private readonly options: EnsureKernelPythonOptions,
+		steps: readonly BootstrapStep[],
+	) {
+		this.total = steps.reduce((sum, step) => sum + step.weight, 0) || 1;
+	}
+
+	// Announce a step as it begins; the percentage reflects work done before it.
+	begin(step: BootstrapStep): void {
+		const percent = Math.min(99, Math.round((this.completedWeight / this.total) * 100));
+		this.completedWeight += step.weight;
+		reportProgress(this.options, `${step.label} · ${percent}%`);
+	}
+}
+
+const BOOTSTRAP_STEP = {
+	uv: { label: "installing uv", weight: 3 },
+	python: { label: "installing Python 3.11", weight: 4 },
+	venv: { label: "creating virtual environment", weight: 2 },
+	packages: { label: "installing packages (ipykernel, numpy, pandas, …)", weight: 10 },
+	skills: { label: "installing Python skills", weight: 2 },
+} satisfies Record<string, BootstrapStep>;
+
 function bootstrapLockDir(venv: string): string {
 	return path.join(path.dirname(venv), `${path.basename(venv)}${BOOTSTRAP_LOCK_NAME}`);
 }
@@ -332,13 +369,23 @@ async function findExecutable(name: string): Promise<string | null> {
 	return null;
 }
 
-async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
+function localUvPath(): string {
+	return path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
+}
+
+// Resolve an existing uv without installing one. Returns null if uv is absent.
+async function locateUv(): Promise<string | null> {
 	const fromPath = await findExecutable("uv");
 	if (fromPath) return fromPath;
+	const localUv = localUvPath();
+	return (await isExecutable(localUv)) ? localUv : null;
+}
 
-	const localUv = path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
-	if (await isExecutable(localUv)) return localUv;
+async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
+	const existing = await locateUv();
+	if (existing) return existing;
 
+	const localUv = localUvPath();
 	const shouldInstallUv =
 		process.env.PRIME_AGENT_INSTALL_UV === "1" || (!options.onProgress && (await confirmUvInstall()));
 	if (!shouldInstallUv) {
@@ -348,7 +395,6 @@ async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 		);
 	}
 
-	reportProgress(options, "› installing uv (one-time)…");
 	try {
 		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
 	} catch (error) {
@@ -495,12 +541,33 @@ async function bootstrapVenv(
 	options: EnsureKernelPythonOptions,
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
-	const uv = await ensureUv(options);
 	const python = path.join(venv, "bin", "python");
 	const runtimeRequirement = await resolveRuntimeRequirement();
 
+	// Build the step list before running so the percentage denominator only
+	// counts work that will actually happen on this machine.
+	const needsUvInstall = (await locateUv()) === null;
+	const steps: BootstrapStep[] = [
+		...(needsUvInstall ? [BOOTSTRAP_STEP.uv] : []),
+		BOOTSTRAP_STEP.python,
+		BOOTSTRAP_STEP.venv,
+		BOOTSTRAP_STEP.packages,
+		...(pythonSkills.length > 0 ? [BOOTSTRAP_STEP.skills] : []),
+	];
+	const progress = new BootstrapProgress(options, steps);
+
+	if (needsUvInstall) {
+		progress.begin(BOOTSTRAP_STEP.uv);
+	}
+	const uv = await ensureUv(options);
+
+	progress.begin(BOOTSTRAP_STEP.python);
 	await run(uv, ["python", "install", PYTHON_VERSION]);
+
+	progress.begin(BOOTSTRAP_STEP.venv);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
+
+	progress.begin(BOOTSTRAP_STEP.packages);
 	await run(uv, [
 		"pip",
 		"install",
@@ -511,6 +578,10 @@ async function bootstrapVenv(
 		STATE_SNAPSHOT_REQUIREMENT,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
+
+	if (pythonSkills.length > 0) {
+		progress.begin(BOOTSTRAP_STEP.skills);
+	}
 	await syncPythonSkills(uv, venv, python, pythonSkills, options);
 }
 
@@ -620,10 +691,7 @@ async function ensureKernelPythonUncached(
 			return python;
 		}
 
-		const hadVenv = existsSync(venv);
-		reportProgress(options, "› setting up python kernel (one-time, ~30s)…");
-		if (hadVenv) {
-			reportProgress(options, "rebuilding kernel venv");
+		if (existsSync(venv)) {
 			await rm(venv, { recursive: true, force: true });
 		}
 
@@ -634,7 +702,7 @@ async function ensureKernelPythonUncached(
 		await releaseLock().catch(() => undefined);
 	}
 
-	reportProgress(options, "✓ ready");
+	reportProgress(options, "✓ ready · 100%");
 	return python;
 }
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -381,7 +381,7 @@ async function locateUv(): Promise<string | null> {
 	return (await isExecutable(localUv)) ? localUv : null;
 }
 
-async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
+async function ensureUv(options: EnsureKernelPythonOptions, onAboutToInstall?: () => void): Promise<string> {
 	const existing = await locateUv();
 	if (existing) return existing;
 
@@ -394,6 +394,10 @@ async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 				"or set PRIME_AGENT_INSTALL_UV=1 to let prime-agent run that installer.",
 		);
 	}
+
+	// Announce only once an install is actually committed, so a refusal here never
+	// leaves a phantom "installing uv" step on screen.
+	onAboutToInstall?.();
 
 	try {
 		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
@@ -556,10 +560,7 @@ async function bootstrapVenv(
 	];
 	const progress = new BootstrapProgress(options, steps);
 
-	if (needsUvInstall) {
-		progress.begin(BOOTSTRAP_STEP.uv);
-	}
-	const uv = await ensureUv(options);
+	const uv = await ensureUv(options, needsUvInstall ? () => progress.begin(BOOTSTRAP_STEP.uv) : undefined);
 
 	progress.begin(BOOTSTRAP_STEP.python);
 	await run(uv, ["python", "install", PYTHON_VERSION]);

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -215,6 +215,21 @@ describe("kernel bootstrap", () => {
 		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("ready"));
 	});
 
+	it("does not show an installing-uv step when uv install is refused", async () => {
+		// uv absent from PATH and from the temp HOME, and install not permitted.
+		const emptyBin = join(tempDir, "empty-bin");
+		mkdirSync(emptyBin, { recursive: true });
+		process.env.PATH = emptyBin;
+		delete process.env.PRIME_AGENT_INSTALL_UV;
+		const venv = join(tempDir, "kernel-venv");
+		const progress: string[] = [];
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+
+		await expect(ensureKernelPython({ onProgress: (message) => progress.push(message) })).rejects.toThrow(/uv/);
+		expect(progress).not.toContain(expect.stringContaining("installing uv"));
+		expect(progress.some((line) => line.startsWith("installing uv"))).toBe(false);
+	});
+
 	it("installs Python skills into the bootstrapped venv", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -201,8 +201,17 @@ describe("kernel bootstrap", () => {
 			stderrWrite.mockRestore();
 		}
 
-		expect(progress).toEqual(expect.arrayContaining(["› setting up python kernel (one-time, ~30s)…", "✓ ready"]));
-		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("setting up python kernel"));
+		// Fake uv is on PATH, so the uv-install step is skipped; the rest describe real steps.
+		expect(progress).toEqual([
+			"installing Python 3.11 · 0%",
+			expect.stringMatching(/^creating virtual environment · \d+%$/),
+			expect.stringMatching(/^installing packages \(.+\) · \d+%$/),
+			"✓ ready · 100%",
+		]);
+
+		const percents = progress.map((line) => Number(line.match(/(\d+)%$/)?.[1] ?? "0"));
+		expect(percents).toEqual([...percents].sort((a, b) => a - b));
+		expect(percents.at(-1)).toBe(100);
 		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("ready"));
 	});
 


### PR DESCRIPTION
- the first-run kernel setup line showed one generic "setting up python kernel" message with no sense of progress, which read as a stuck spinner during the ~30s package install.
- the single line now names the actual step in flight (installing python, creating venv, installing packages, installing skills) and appends a cumulative percentage weighted by how long each step really takes.
- the step list is built from only the steps that will run on the machine, so the percentage denominator stays honest and the bar advances monotonically to 100%.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only changes to bootstrap progress reporting in `bootstrap.ts`; bootstrap behavior and install logic are otherwise unchanged.
> 
> **Overview**
> First-run Python kernel setup no longer shows a single generic **setting up python kernel** line. Progress now reports **named steps** (e.g. installing Python 3.11, creating virtual environment, installing packages) with a **cumulative percentage** on each line, capped below 100% until completion (**✓ ready · 100%**).
> 
> A **`BootstrapProgress`** helper weights steps by rough wall-clock share (package install weighted highest) and only includes steps that will actually run—**uv install** is omitted when `locateUv` finds uv on PATH or `~/.local/bin`, and the skills step only when there are Python skills. **`ensureUv`** defers the installing-uv message until install is committed (after confirm/env), so refusing uv does not flash a phantom step.
> 
> Tests assert monotonic percentages via `onProgress` and add coverage for the refused-uv case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65689c99f10eb58402ccd31c64d0b7bb5f838e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show weighted percentage progress during kernel bootstrap install
> - Replaces generic 'setting up python kernel' messages with per-step progress lines that include cumulative weighted percentages (e.g. 'installing packages · 42%').
> - Adds a `BootstrapProgress` class in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/293/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) that computes percentages from step weights; progress is capped at 99% until completion, then emits '✓ ready · 100%'.
> - The 'installing uv' step is now omitted entirely when uv is already present on PATH or in `~/.local/bin`, and `ensureUv` accepts an `onAboutToInstall` callback to announce the step only when an install actually occurs.
> - Behavioral Change: the bootstrap process no longer emits 'setting up python kernel' or 'rebuilding kernel venv'; existing log parsers or tests relying on those strings will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65689c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->