### PR TITLE
bound subagent kernel-boot concurrency

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,7 +15,7 @@
 
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { cpus, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
 	Agent,
@@ -39,6 +39,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
+import { Semaphore } from "../utils/semaphore.js";
 import { sleep } from "../utils/sleep.js";
 import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../utils/tools-manager.js";
 import { flushAgentTraceUpload } from "./agent-traces.js";
@@ -386,6 +387,37 @@ const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "hi
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;
 
 function noopRlmChildAbort(): void {}
+
+/**
+ * Bounds how many subagent kernels boot at once. Each boot spawns a Python
+ * process and binds 5 ZeroMQ ports, so an unbounded fan-out (e.g. 100 rlm.run
+ * calls) starves the box and most kernels fail to start. The limiter is
+ * process-wide because kernels contend for the same OS resources regardless of
+ * which session in the tree spawned them. Excess runs sit in "queued" until a
+ * slot frees, rather than racing and dying.
+ */
+const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.max(2, (cpus().length || 4) - 2);
+
+function resolveKernelBootConcurrency(): number {
+	const raw = process.env.PRIME_AGENT_MAX_CONCURRENT_SUBAGENT_BOOTS;
+	if (raw === undefined || raw === "") {
+		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
+	}
+	return parsed;
+}
+
+let kernelBootSemaphore: Semaphore | undefined;
+
+function getKernelBootSemaphore(): Semaphore {
+	if (!kernelBootSemaphore) {
+		kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
+	}
+	return kernelBootSemaphore;
+}
 
 function isRlmChildRunCancelled(run: RlmChildRun): boolean {
 	return run.status === "cancelled";
@@ -4039,7 +4071,8 @@ export class AgentSession {
 			id: childNodeId,
 			prompt,
 			sessionDir: childSessionDir,
-			status: "running",
+			// Boots are gated; the run is "queued" until it acquires a kernel-boot slot.
+			status: "queued",
 			abort: noopRlmChildAbort,
 		};
 		this._activeRlmChildRuns.set(run.id, run);
@@ -4081,7 +4114,16 @@ export class AgentSession {
 				if (!(await ensureTool("rg", true))) {
 					throw new Error(MISSING_RIPGREP_MESSAGE);
 				}
-				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
+				// Gate the kernel boot so a large fan-out doesn't spawn every Python
+				// process at once. The permit covers only the boot, not the run.
+				childRuntime = await getKernelBootSemaphore().run(async () => {
+					if (isRlmChildRunCancelled(run)) {
+						throw new Error(run.error ?? "RLM child cancelled");
+					}
+					run.status = "running";
+					emitChildUpdate();
+					return this._createRlmSubagentRuntime(subagentOptions);
+				});
 				const child = childRuntime.session;
 				childSession = child;
 				run.session = child;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,7 +15,7 @@
 
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { cpus, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
 	Agent,
@@ -39,7 +39,6 @@ import {
 } from "@earendil-works/pi-ai";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
-import { Semaphore } from "../utils/semaphore.js";
 import { sleep } from "../utils/sleep.js";
 import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../utils/tools-manager.js";
 import { flushAgentTraceUpload } from "./agent-traces.js";
@@ -387,37 +386,6 @@ const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "hi
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;
 
 function noopRlmChildAbort(): void {}
-
-/**
- * Bounds how many subagent kernels boot at once. Each boot spawns a Python
- * process and binds 5 ZeroMQ ports, so an unbounded fan-out (e.g. 100 rlm.run
- * calls) starves the box and most kernels fail to start. The limiter is
- * process-wide because kernels contend for the same OS resources regardless of
- * which session in the tree spawned them. Excess runs sit in "queued" until a
- * slot frees, rather than racing and dying.
- */
-const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.max(2, (cpus().length || 4) - 2);
-
-function resolveKernelBootConcurrency(): number {
-	const raw = process.env.PRIME_AGENT_MAX_CONCURRENT_SUBAGENT_BOOTS;
-	if (raw === undefined || raw === "") {
-		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
-	}
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed < 1) {
-		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
-	}
-	return parsed;
-}
-
-let kernelBootSemaphore: Semaphore | undefined;
-
-function getKernelBootSemaphore(): Semaphore {
-	if (!kernelBootSemaphore) {
-		kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
-	}
-	return kernelBootSemaphore;
-}
 
 function isRlmChildRunCancelled(run: RlmChildRun): boolean {
 	return run.status === "cancelled";
@@ -4071,8 +4039,7 @@ export class AgentSession {
 			id: childNodeId,
 			prompt,
 			sessionDir: childSessionDir,
-			// Boots are gated; the run is "queued" until it acquires a kernel-boot slot.
-			status: "queued",
+			status: "running",
 			abort: noopRlmChildAbort,
 		};
 		this._activeRlmChildRuns.set(run.id, run);
@@ -4114,16 +4081,10 @@ export class AgentSession {
 				if (!(await ensureTool("rg", true))) {
 					throw new Error(MISSING_RIPGREP_MESSAGE);
 				}
-				// Gate the kernel boot so a large fan-out doesn't spawn every Python
-				// process at once. The permit covers only the boot, not the run.
-				childRuntime = await getKernelBootSemaphore().run(async () => {
-					if (isRlmChildRunCancelled(run)) {
-						throw new Error(run.error ?? "RLM child cancelled");
-					}
-					run.status = "running";
-					emitChildUpdate();
-					return this._createRlmSubagentRuntime(subagentOptions);
-				});
+				if (isRlmChildRunCancelled(run)) {
+					throw new Error(run.error ?? "RLM child cancelled");
+				}
+				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
 				childSession = child;
 				run.session = child;

--- a/packages/coding-agent/src/core/kernel/boot-gate.ts
+++ b/packages/coding-agent/src/core/kernel/boot-gate.ts
@@ -1,14 +1,8 @@
 import { cpus } from "node:os";
 import { Semaphore } from "../../utils/semaphore.js";
 
-/**
- * Bounds how many IPython kernels boot at once. The weight of a boot is the cold
- * Python interpreter + ipykernel/IPython import graph (not the ports); spawning
- * too many at once makes them thrash during import and miss the port-resolve
- * window, so most fail to start. Boots are spawn/IO-bound rather than CPU-bound,
- * so we oversubscribe cores, but keep a conservative cap until warm-kernel reuse
- * makes a boot cheap enough to raise it. Override with the env var below.
- */
+// Above core count because boots are IO-bound (cold imports), but capped so a
+// fan-out can't thrash the FS past the port-resolve window.
 const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.min(16, Math.max(4, (cpus().length || 4) * 2));
 
 function resolveKernelBootConcurrency(): number {
@@ -32,7 +26,6 @@ function getKernelBootSemaphore(): Semaphore {
 	return kernelBootSemaphore;
 }
 
-/** Run `boot` while holding a kernel-boot permit, releasing it once the kernel is live (or boot throws). */
 export function withKernelBootPermit<T>(boot: () => Promise<T>): Promise<T> {
 	return getKernelBootSemaphore().run(boot);
 }

--- a/packages/coding-agent/src/core/kernel/boot-gate.ts
+++ b/packages/coding-agent/src/core/kernel/boot-gate.ts
@@ -18,6 +18,6 @@ function resolveKernelBootConcurrency(): number {
 
 const kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
 
-export function withKernelBootPermit<T>(boot: () => Promise<T>): Promise<T> {
-	return kernelBootSemaphore.run(boot);
+export function withKernelBootPermit<T>(boot: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+	return kernelBootSemaphore.run(boot, signal);
 }

--- a/packages/coding-agent/src/core/kernel/boot-gate.ts
+++ b/packages/coding-agent/src/core/kernel/boot-gate.ts
@@ -1,0 +1,38 @@
+import { cpus } from "node:os";
+import { Semaphore } from "../../utils/semaphore.js";
+
+/**
+ * Bounds how many IPython kernels boot at once. The weight of a boot is the cold
+ * Python interpreter + ipykernel/IPython import graph (not the ports); spawning
+ * too many at once makes them thrash during import and miss the port-resolve
+ * window, so most fail to start. Boots are spawn/IO-bound rather than CPU-bound,
+ * so we oversubscribe cores, but keep a conservative cap until warm-kernel reuse
+ * makes a boot cheap enough to raise it. Override with the env var below.
+ */
+const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.min(16, Math.max(4, (cpus().length || 4) * 2));
+
+function resolveKernelBootConcurrency(): number {
+	const raw = process.env.PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS;
+	if (raw === undefined || raw === "") {
+		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
+	}
+	return parsed;
+}
+
+let kernelBootSemaphore: Semaphore | undefined;
+
+function getKernelBootSemaphore(): Semaphore {
+	if (!kernelBootSemaphore) {
+		kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
+	}
+	return kernelBootSemaphore;
+}
+
+/** Run `boot` while holding a kernel-boot permit, releasing it once the kernel is live (or boot throws). */
+export function withKernelBootPermit<T>(boot: () => Promise<T>): Promise<T> {
+	return getKernelBootSemaphore().run(boot);
+}

--- a/packages/coding-agent/src/core/kernel/boot-gate.ts
+++ b/packages/coding-agent/src/core/kernel/boot-gate.ts
@@ -4,28 +4,20 @@ import { Semaphore } from "../../utils/semaphore.js";
 // Above core count because boots are IO-bound (cold imports), but capped so a
 // fan-out can't thrash the FS past the port-resolve window.
 const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.min(16, Math.max(4, (cpus().length || 4) * 2));
+const MAX_KERNEL_BOOT_CONCURRENCY = 64;
 
 function resolveKernelBootConcurrency(): number {
 	const raw = process.env.PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS;
-	if (raw === undefined || raw === "") {
+	// Only a clean positive integer overrides; anything malformed falls back to
+	// the default rather than silently mis-bounding the gate.
+	if (raw === undefined || !/^\d+$/.test(raw) || raw === "0") {
 		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
 	}
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed < 1) {
-		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
-	}
-	return parsed;
+	return Math.min(MAX_KERNEL_BOOT_CONCURRENCY, Number.parseInt(raw, 10));
 }
 
-let kernelBootSemaphore: Semaphore | undefined;
-
-function getKernelBootSemaphore(): Semaphore {
-	if (!kernelBootSemaphore) {
-		kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
-	}
-	return kernelBootSemaphore;
-}
+const kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());
 
 export function withKernelBootPermit<T>(boot: () => Promise<T>): Promise<T> {
-	return getKernelBootSemaphore().run(boot);
+	return kernelBootSemaphore.run(boot);
 }

--- a/packages/coding-agent/src/core/kernel/boot-gate.ts
+++ b/packages/coding-agent/src/core/kernel/boot-gate.ts
@@ -6,14 +6,18 @@ import { Semaphore } from "../../utils/semaphore.js";
 const DEFAULT_KERNEL_BOOT_CONCURRENCY = Math.min(16, Math.max(4, (cpus().length || 4) * 2));
 const MAX_KERNEL_BOOT_CONCURRENCY = 64;
 
-function resolveKernelBootConcurrency(): number {
+export function resolveKernelBootConcurrency(): number {
 	const raw = process.env.PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS;
-	// Only a clean positive integer overrides; anything malformed falls back to
-	// the default rather than silently mis-bounding the gate.
-	if (raw === undefined || !/^\d+$/.test(raw) || raw === "0") {
+	if (raw === undefined || !/^\d+$/.test(raw)) {
 		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
 	}
-	return Math.min(MAX_KERNEL_BOOT_CONCURRENCY, Number.parseInt(raw, 10));
+	const parsed = Number.parseInt(raw, 10);
+	// A malformed or out-of-range value (incl. 0, e.g. "00") falls back to the
+	// default rather than mis-bounding the gate or throwing at module load.
+	if (parsed < 1) {
+		return DEFAULT_KERNEL_BOOT_CONCURRENCY;
+	}
+	return Math.min(MAX_KERNEL_BOOT_CONCURRENCY, parsed);
 }
 
 const kernelBootSemaphore = new Semaphore(resolveKernelBootConcurrency());

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -5,6 +5,7 @@ import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { IMAGE_MIME_TYPES } from "../../utils/mime.js";
 import type { ToolDefinition } from "../extensions/types.js";
+import { withKernelBootPermit } from "../kernel/boot-gate.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
 import {
 	type HostRequestHandlers,
@@ -295,32 +296,38 @@ export class IpythonKernelProvisioner {
 				? { path: snapshotPathIn(snapshotDir), manifestPath: manifestPathIn(snapshotDir) }
 				: undefined,
 		});
+		// Emitted synchronously (before the permit await) so a listener attaching
+		// mid-flight can replay the current stage.
 		this.emitStartupProgress("Starting IPython kernel...");
-		await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
-		// Whether a snapshot existed decides if we notify the model on success.
+		// Hold a boot permit across the actual process spawn + restore + bootstrap so a
+		// large fan-out can't start every kernel at once. Acquired after readyGate above
+		// so a kernel waiting on a prior dispose never occupies a slot while idle.
 		let pendingRestore: RestoreResult | undefined;
-		try {
-			// Revive a prior session's namespace before the bootstrap, so the bootstrap
-			// then overwrites live handles (rlm, skills) on top of anything restored.
-			if (snapshotDir) {
-				const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
-				this.emitStartupProgress("Restoring IPython state...");
-				const restore = await m.restoreState();
-				if (snapshotExisted) {
-					pendingRestore = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
+		await withKernelBootPermit(async () => {
+			await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
+			try {
+				// Revive a prior session's namespace before the bootstrap, so the bootstrap
+				// then overwrites live handles (rlm, skills) on top of anything restored.
+				if (snapshotDir) {
+					const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
+					this.emitStartupProgress("Restoring IPython state...");
+					const restore = await m.restoreState();
+					if (snapshotExisted) {
+						pendingRestore = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
+					}
 				}
+				this.emitStartupProgress("Preparing IPython runtime...");
+				const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
+				if (bootstrap.status !== "ok") {
+					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+					throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+				}
+			} catch (error) {
+				// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
+				void m.dispose();
+				throw error;
 			}
-			this.emitStartupProgress("Preparing IPython runtime...");
-			const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
-			if (bootstrap.status !== "ok") {
-				const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
-				throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
-			}
-		} catch (error) {
-			// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
-			void m.dispose();
-			throw error;
-		}
+		});
 		// Only tell the model what was revived once the kernel is actually usable —
 		// a notice claiming restored state must never outlive a failed bootstrap.
 		if (pendingRestore) {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -182,6 +182,7 @@ export class IpythonKernelProvisioner {
 	private readonly startupListeners = new Set<KernelBootstrapProgressHandler>();
 	private lastStartupMessage?: string;
 	private _lastRestore?: RestoreResult;
+	private readonly disposeController = new AbortController();
 
 	constructor(
 		private readonly cwd: string,
@@ -220,6 +221,10 @@ export class IpythonKernelProvisioner {
 
 	/** Dispose the kernel owned by this provisioner, including one still starting up. */
 	async dispose(): Promise<void> {
+		// Drops a still-queued boot out of the semaphore and short-circuits an
+		// in-flight startKernel before it spawns, so a disposed session's boot
+		// doesn't waste a slot during a fan-out.
+		this.disposeController.abort();
 		const pending = this.managerPromise;
 		this.managerPromise = undefined;
 		this.startedManager = undefined;
@@ -304,9 +309,12 @@ export class IpythonKernelProvisioner {
 		// covers only start(). Restore/bootstrap run per-kernel afterwards and are
 		// unbounded execute()s; holding the global permit across them could pin it
 		// forever on a wedged bootstrap and starve every other session's boot.
-		await withKernelBootPermit(() =>
-			m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) }),
-		);
+		const signal = this.disposeController.signal;
+		await withKernelBootPermit(() => {
+			// Disposed while queued for the permit — don't spawn a kernel nobody wants.
+			if (signal.aborted) throw new Error("Kernel provisioner disposed before start");
+			return m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
+		}, signal);
 		let pendingRestore: RestoreResult | undefined;
 		try {
 			// Revive a prior session's namespace before the bootstrap, so the bootstrap

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -299,32 +299,37 @@ export class IpythonKernelProvisioner {
 		// Emitted synchronously (before the permit await) so a listener attaching
 		// mid-flight can replay the current stage.
 		this.emitStartupProgress("Starting IPython kernel...");
+		// Only the process spawn + port resolve contends for OS resources under a
+		// fan-out, and it is bounded by start()'s own timeouts — so the permit
+		// covers only start(). Restore/bootstrap run per-kernel afterwards and are
+		// unbounded execute()s; holding the global permit across them could pin it
+		// forever on a wedged bootstrap and starve every other session's boot.
+		await withKernelBootPermit(() =>
+			m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) }),
+		);
 		let pendingRestore: RestoreResult | undefined;
-		await withKernelBootPermit(async () => {
-			await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });
-			try {
-				// Revive a prior session's namespace before the bootstrap, so the bootstrap
-				// then overwrites live handles (rlm, skills) on top of anything restored.
-				if (snapshotDir) {
-					const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
-					this.emitStartupProgress("Restoring IPython state...");
-					const restore = await m.restoreState();
-					if (snapshotExisted) {
-						pendingRestore = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
-					}
+		try {
+			// Revive a prior session's namespace before the bootstrap, so the bootstrap
+			// then overwrites live handles (rlm, skills) on top of anything restored.
+			if (snapshotDir) {
+				const snapshotExisted = existsSync(snapshotPathIn(snapshotDir));
+				this.emitStartupProgress("Restoring IPython state...");
+				const restore = await m.restoreState();
+				if (snapshotExisted) {
+					pendingRestore = restore ?? { restored: [], failed: [], path: snapshotPathIn(snapshotDir) };
 				}
-				this.emitStartupProgress("Preparing IPython runtime...");
-				const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
-				if (bootstrap.status !== "ok") {
-					const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
-					throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
-				}
-			} catch (error) {
-				// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
-				void m.dispose();
-				throw error;
 			}
-		});
+			this.emitStartupProgress("Preparing IPython runtime...");
+			const bootstrap = await m.execute(buildRlmBootstrapCode(this.options?.pythonSkills));
+			if (bootstrap.status !== "ok") {
+				const details = [bootstrap.stderr, bootstrap.error?.traceback.join("\n")].filter(Boolean).join("\n");
+				throw new Error(`Failed to initialize rlm runtime in the IPython kernel:\n${details}`);
+			}
+		} catch (error) {
+			// Never leak the kernel's ZMQ sockets / temp dir if startup fails after spawn.
+			void m.dispose();
+			throw error;
+		}
 		// Only tell the model what was revived once the kernel is actually usable —
 		// a notice claiming restored state must never outlive a failed bootstrap.
 		if (pendingRestore) {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -299,9 +299,6 @@ export class IpythonKernelProvisioner {
 		// Emitted synchronously (before the permit await) so a listener attaching
 		// mid-flight can replay the current stage.
 		this.emitStartupProgress("Starting IPython kernel...");
-		// Hold a boot permit across the actual process spawn + restore + bootstrap so a
-		// large fan-out can't start every kernel at once. Acquired after readyGate above
-		// so a kernel waiting on a prior dispose never occupies a slot while idle.
 		let pendingRestore: RestoreResult | undefined;
 		await withKernelBootPermit(async () => {
 			await m.start({ onBootstrapProgress: (message) => this.emitStartupProgress(message) });

--- a/packages/coding-agent/src/utils/semaphore.ts
+++ b/packages/coding-agent/src/utils/semaphore.ts
@@ -1,0 +1,47 @@
+/**
+ * Counting semaphore for bounding async concurrency. FIFO: waiters acquire in
+ * the order they queued.
+ */
+export class Semaphore {
+	private available: number;
+	private readonly waiters: Array<() => void> = [];
+
+	constructor(permits: number) {
+		if (!Number.isInteger(permits) || permits < 1) {
+			throw new Error(`Semaphore permits must be a positive integer, got ${permits}`);
+		}
+		this.available = permits;
+	}
+
+	/** Number of callers currently waiting for a permit. */
+	get queueLength(): number {
+		return this.waiters.length;
+	}
+
+	private async acquire(): Promise<void> {
+		if (this.available > 0) {
+			this.available -= 1;
+			return;
+		}
+		await new Promise<void>((resolve) => this.waiters.push(resolve));
+	}
+
+	private release(): void {
+		const next = this.waiters.shift();
+		if (next) {
+			next();
+		} else {
+			this.available += 1;
+		}
+	}
+
+	/** Run `fn` while holding a permit, releasing it even if `fn` throws. */
+	async run<T>(fn: () => Promise<T>): Promise<T> {
+		await this.acquire();
+		try {
+			return await fn();
+		} finally {
+			this.release();
+		}
+	}
+}

--- a/packages/coding-agent/src/utils/semaphore.ts
+++ b/packages/coding-agent/src/utils/semaphore.ts
@@ -13,7 +13,6 @@ export class Semaphore {
 		this.available = permits;
 	}
 
-	/** Number of callers currently waiting for a permit. */
 	get queueLength(): number {
 		return this.waiters.length;
 	}

--- a/packages/coding-agent/src/utils/semaphore.ts
+++ b/packages/coding-agent/src/utils/semaphore.ts
@@ -17,12 +17,29 @@ export class Semaphore {
 		return this.waiters.length;
 	}
 
-	private async acquire(): Promise<void> {
+	private async acquire(signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) {
+			throw signal.reason ?? new Error("aborted");
+		}
 		if (this.available > 0) {
 			this.available -= 1;
 			return;
 		}
-		await new Promise<void>((resolve) => this.waiters.push(resolve));
+		// A queued waiter can be aborted before it gets a permit; on abort it
+		// removes itself from the queue so it never consumes a slot.
+		await new Promise<void>((resolve, reject) => {
+			const waiter = (): void => {
+				signal?.removeEventListener("abort", onAbort);
+				resolve();
+			};
+			const onAbort = (): void => {
+				const i = this.waiters.indexOf(waiter);
+				if (i !== -1) this.waiters.splice(i, 1);
+				reject(signal?.reason ?? new Error("aborted"));
+			};
+			this.waiters.push(waiter);
+			signal?.addEventListener("abort", onAbort, { once: true });
+		});
 	}
 
 	private release(): void {
@@ -34,9 +51,9 @@ export class Semaphore {
 		}
 	}
 
-	/** Run `fn` while holding a permit, releasing it even if `fn` throws. */
-	async run<T>(fn: () => Promise<T>): Promise<T> {
-		await this.acquire();
+	/** Run `fn` while holding a permit, releasing it even if `fn` throws. Rejects without running if `signal` aborts while queued. */
+	async run<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.acquire(signal);
 		try {
 			return await fn();
 		} finally {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -272,11 +272,8 @@ describe("AgentSession rlm recursion", () => {
 		expect(dirname(result.session_dir!)).toBe(root.sessionManager.getSessionArtifactDir());
 		expect(existsSync(result.session_dir!)).toBe(true);
 		expect(readdirSync(result.session_dir!).some((name) => name.endsWith(".jsonl"))).toBe(true);
-		// Boots are gated: the run is emitted "queued" first, then flips to "running"
-		// once it acquires a kernel-boot slot.
-		expect(childUpdates[0]?.status).toBe("queued");
+		expect(childUpdates[0]?.status).toBe("running");
 		expect(childUpdates[0]?.label).toBe("summarize shard 1");
-		expect(childUpdates.some((update) => update.status === "running")).toBe(true);
 		const doneUpdate = [...childUpdates].reverse().find((update) => update.status === "done");
 		expect(doneUpdate?.answerPreview).toBe("child answer: summarize shard 1");
 		// Context tokens from the child's own assistant usage (input 7 + output 3); no tools ran.

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -272,8 +272,11 @@ describe("AgentSession rlm recursion", () => {
 		expect(dirname(result.session_dir!)).toBe(root.sessionManager.getSessionArtifactDir());
 		expect(existsSync(result.session_dir!)).toBe(true);
 		expect(readdirSync(result.session_dir!).some((name) => name.endsWith(".jsonl"))).toBe(true);
-		expect(childUpdates[0]?.status).toBe("running");
+		// Boots are gated: the run is emitted "queued" first, then flips to "running"
+		// once it acquires a kernel-boot slot.
+		expect(childUpdates[0]?.status).toBe("queued");
 		expect(childUpdates[0]?.label).toBe("summarize shard 1");
+		expect(childUpdates.some((update) => update.status === "running")).toBe(true);
 		const doneUpdate = [...childUpdates].reverse().find((update) => update.status === "done");
 		expect(doneUpdate?.answerPreview).toBe("child answer: summarize shard 1");
 		// Context tokens from the child's own assistant usage (input 7 + output 3); no tools ran.

--- a/packages/coding-agent/test/boot-gate.test.ts
+++ b/packages/coding-agent/test/boot-gate.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveKernelBootConcurrency } from "../src/core/kernel/boot-gate.js";
+
+const ENV = "PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS";
+
+describe("resolveKernelBootConcurrency", () => {
+	afterEach(() => {
+		delete process.env[ENV];
+	});
+
+	it("never returns a value below 1 (so the semaphore can't throw at load)", () => {
+		for (const bad of ["0", "00", "000", "abc", "3.9", "-1", "8 junk", ""]) {
+			process.env[ENV] = bad;
+			expect(resolveKernelBootConcurrency()).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("honors a clean positive integer, clamped to the max", () => {
+		process.env[ENV] = "8";
+		expect(resolveKernelBootConcurrency()).toBe(8);
+		process.env[ENV] = "999999";
+		expect(resolveKernelBootConcurrency()).toBe(64);
+	});
+});

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -97,6 +97,21 @@ describe("IpythonKernelProvisioner", () => {
 		expect(provisioner.manager).toBeUndefined();
 	});
 
+	it("dispose() before the boot slot prevents the kernel from spawning", async () => {
+		const { python, countRuns } = writeFakePython();
+		let release: () => void = () => {};
+		const gate = new Promise<void>((r) => {
+			release = r;
+		});
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python, readyGate: gate });
+
+		const started = provisioner.ensure().catch(() => {});
+		const disposed = provisioner.dispose(); // aborts while the boot waits on readyGate
+		release();
+		await Promise.all([started, disposed]);
+		expect(countRuns()).toBe(0); // disposed boot must never spawn a kernel
+	});
+
 	it("waits for readyGate before starting the kernel", async () => {
 		const { python, countRuns } = writeFakePython();
 		let release: () => void = () => {};

--- a/packages/coding-agent/test/semaphore.test.ts
+++ b/packages/coding-agent/test/semaphore.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the async Semaphore used to bound subagent kernel-boot concurrency.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Semaphore } from "../src/utils/semaphore.js";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+describe("Semaphore", () => {
+	it("rejects non-positive permit counts", () => {
+		expect(() => new Semaphore(0)).toThrow();
+		expect(() => new Semaphore(-1)).toThrow();
+		expect(() => new Semaphore(1.5)).toThrow();
+	});
+
+	it("never exceeds the permit count under heavy fan-out", async () => {
+		const limit = 3;
+		const total = 50;
+		const sem = new Semaphore(limit);
+		let active = 0;
+		let peak = 0;
+		let completed = 0;
+
+		await Promise.all(
+			Array.from({ length: total }, () =>
+				sem.run(async () => {
+					active += 1;
+					peak = Math.max(peak, active);
+					await new Promise((r) => setTimeout(r, 1));
+					active -= 1;
+					completed += 1;
+				}),
+			),
+		);
+
+		expect(peak).toBeLessThanOrEqual(limit);
+		expect(completed).toBe(total);
+	});
+
+	it("releases the permit when the task throws", async () => {
+		const sem = new Semaphore(1);
+		await expect(sem.run(async () => Promise.reject(new Error("boom")))).rejects.toThrow("boom");
+		// If the permit leaked, this second acquire would hang forever.
+		await expect(sem.run(async () => "ok")).resolves.toBe("ok");
+	});
+
+	it("hands permits to waiters in FIFO order", async () => {
+		const sem = new Semaphore(1);
+		const order: number[] = [];
+		const gate = deferred<void>();
+
+		// Holder occupies the single permit until we release `gate`.
+		const holder = sem.run(async () => {
+			await gate.promise;
+		});
+
+		// Queue three waiters; they should run in the order they queued.
+		const waiters = [0, 1, 2].map((i) =>
+			sem.run(async () => {
+				order.push(i);
+			}),
+		);
+
+		expect(sem.queueLength).toBe(3);
+		gate.resolve();
+		await Promise.all([holder, ...waiters]);
+		expect(order).toEqual([0, 1, 2]);
+	});
+});

--- a/packages/coding-agent/test/semaphore.test.ts
+++ b/packages/coding-agent/test/semaphore.test.ts
@@ -73,4 +73,34 @@ describe("Semaphore", () => {
 		await Promise.all([holder, ...waiters]);
 		expect(order).toEqual([0, 1, 2]);
 	});
+
+	it("a queued waiter aborts out of the queue without consuming a permit", async () => {
+		const sem = new Semaphore(1);
+		const gate = deferred<void>();
+		const holder = sem.run(async () => {
+			await gate.promise;
+		});
+
+		const ac = new AbortController();
+		const queued = sem.run(async () => "ran", ac.signal);
+		expect(sem.queueLength).toBe(1);
+
+		ac.abort();
+		await expect(queued).rejects.toBeTruthy();
+		expect(sem.queueLength).toBe(0);
+
+		// The aborted waiter must not have stolen the permit: once the holder
+		// releases, a fresh acquire runs immediately.
+		gate.resolve();
+		await holder;
+		await expect(sem.run(async () => "ok")).resolves.toBe("ok");
+	});
+
+	it("rejects immediately if the signal is already aborted", async () => {
+		const sem = new Semaphore(1);
+		const ac = new AbortController();
+		ac.abort();
+		await expect(sem.run(async () => "ran", ac.signal)).rejects.toBeTruthy();
+		await expect(sem.run(async () => "ok")).resolves.toBe("ok");
+	});
 });


### PR DESCRIPTION
- spawning a large subagent fan-out tried to boot every ipython kernel at once and starved the box, so a micro-benchmark booted only 6/100 and 16/200 kernels before the change.
- gates the actual kernel boot inside the lazy ipython provisioner, so session creation is never delayed and only the first ipython block waits for a free slot; the same benchmark now boots all of them with zero failures.
- the boot weight is the cold python interpreter and import graph rather than the ports, so the default limit is two per core capped at sixteen (overridable by env var); kernel reuse and agents-view listing lag are tracked in eng-4384 and eng-4385.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes kernel startup ordering and concurrency under heavy RLM fan-out; dispose now rejects queued `ensure()` calls instead of eventually spawning, which is intentional but behavior-changing.
> 
> **Overview**
> Large RLM subagent fan-outs no longer try to spawn every IPython kernel at once. A global **FIFO semaphore** (`withKernelBootPermit`) limits concurrent kernel **process start + port resolve** only; restore and RLM bootstrap still run per kernel afterward so a wedged bootstrap cannot hold the global slot forever.
> 
> Default concurrency is **2× CPU count**, floored at 4 and capped at 16, overridable via `PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS` (clamped to 64; invalid env values fall back to the default). `IpythonKernelProvisioner` acquires a permit around `manager.start()` and uses an **abort on dispose** so queued boots drop out of the semaphore and never spawn after the session is torn down.
> 
> Also fixes an RLM child race: if a run is already **cancelled** before `_createRlmSubagentRuntime`, the task throws immediately instead of booting a child nobody wants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eaa6ddbd12723e5b7b275d13e0441bd417118ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound IPython kernel boot concurrency with an abort-aware semaphore
> - Adds a new [`Semaphore`](https://github.com/PrimeIntellect-ai/prime-agent/pull/294/files#diff-9d6c85692e2e42bbd80a35a43a61448e4342f5cc695a2b21a4a8f7fbd8c92193) class (FIFO, abort-aware) and a [`boot-gate`](https://github.com/PrimeIntellect-ai/prime-agent/pull/294/files#diff-0c89be5534f4b7883db2454056a62dd517cd928b648295e0e24391c294ea0211) module that exposes a process-wide semaphore for kernel boots.
> - Concurrency defaults to `min(max(cpuCount, 4), 16)` and can be overridden via `PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS` (clamped to [1, 64]).
> - [`IpythonKernelProvisioner`](https://github.com/PrimeIntellect-ai/prime-agent/pull/294/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d) wraps `m.start()` with `withKernelBootPermit()`, holding the permit only for the spawn step, not the restore/bootstrap phase.
> - Disposing the provisioner before a permit is acquired aborts the queued boot and causes `ensure()` to reject without spawning a process.
> - Adds a cancellation guard in the RLM subagent start path to immediately reject if the child run is already cancelled before runtime creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7eaa6dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->