### PR TITLE
show only daemon-resident sessions in the agents view

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -154,9 +154,8 @@ export function createAgentsViewResumeConfig(
 }
 
 export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "list" }> {
-	// Resident-only: omitting `all` makes the daemon return just its in-memory
-	// sessions. On-disk sessions are reachable via /resume and --resume, never
-	// auto-surfaced here.
+	// Omitting `all` returns daemon-resident sessions only; on-disk ones come back
+	// via /resume.
 	return { type: "list" };
 }
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -153,17 +153,11 @@ export function createAgentsViewResumeConfig(
 	return resumeConfig;
 }
 
-export function createAgentsViewListCommand(
-	config: AgentSessionRuntimeConfig,
-): Extract<DaemonCommand, { type: "list" }> {
-	// `all` makes the daemon merge on-disk sessions with in-memory ones; without it
-	// only daemon-resident sessions return and live sessions saved to disk are lost
-	// from the view. No cwd is set so the fleet view spans every directory.
-	const command: Extract<DaemonCommand, { type: "list" }> = { type: "list", all: true };
-	if (config.sessionDir) {
-		command.sessionDir = config.sessionDir;
-	}
-	return command;
+export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "list" }> {
+	// Resident-only: omitting `all` makes the daemon return just its in-memory
+	// sessions. On-disk sessions are reachable via /resume and --resume, never
+	// auto-surfaced here.
+	return { type: "list" };
 }
 
 // Status messages render in a single-row hint slot below the editor; embedded
@@ -1575,7 +1569,7 @@ class AgentsViewMode implements Component, Focusable {
 	private async refreshSessions(): Promise<void> {
 		const client = this.requireClient();
 		try {
-			const response = await client.request(createAgentsViewListCommand(this.options.config));
+			const response = await client.request(createAgentsViewListCommand());
 			const data = requireDaemonData(response);
 			const sessions = expectSessionList(data);
 			const visibleSessions = sessions.filter((summary) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -279,43 +279,10 @@ export class AgentDaemon {
 		this.registerSignalHandlers();
 		this.summarizer.start();
 		this.log(`Prime Agent daemon listening on ${this.socketPath}`);
-		void this.restoreActiveSessions().finally(() => {
-			if (!this.shuttingDown) {
-				this.cronScheduler.start();
-			}
-		});
-	}
-
-	/**
-	 * Reload sessions that were daemon-resident when the previous daemon
-	 * exited (clean shutdown or crash). Runs in the background after the
-	 * socket starts listening so startup latency is unaffected; clients see
-	 * restored sessions appear in list results as each one loads.
-	 */
-	private async restoreActiveSessions(): Promise<void> {
-		let saved: SessionInfo[];
-		try {
-			saved = await SessionManager.listAll(undefined, this.options.defaultSessionConfig.sessionDir);
-		} catch (error) {
-			this.log(`Failed to scan sessions for restore: ${error instanceof Error ? error.message : String(error)}`);
-			return;
-		}
-		for (const info of saved) {
-			// Empty sessions carry no work worth restoring; leaving them out keeps
-			// abandoned create-and-quit sessions from resurrecting on every restart.
-			if (info.state?.status !== "active" || info.messageCount === 0) {
-				continue;
-			}
-			if (this.shuttingDown) {
-				return;
-			}
-			try {
-				await this.createRuntime({ type: "create", sessionPath: info.path });
-			} catch (error) {
-				this.log(
-					`Failed to restore session ${info.path}: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
+		// The daemon starts with no resident sessions: on-disk sessions are
+		// brought back only via explicit /resume or --resume, never auto-restored.
+		if (!this.shuttingDown) {
+			this.cronScheduler.start();
 		}
 	}
 
@@ -352,16 +319,6 @@ export class AgentDaemon {
 		this.rebindCronJobsToState(state);
 		if (name) {
 			state.runtime.session.setSessionName(name);
-		}
-		if (runtime.metadata.kind !== "subagent") {
-			// Mark the session as daemon-resident so a restarted daemon can
-			// restore it. Closes for kill/completed/replaced flip this back to
-			// sleep; clean shutdowns leave it in place on purpose.
-			try {
-				runtime.session.sessionManager.appendSessionState({ status: "active" });
-			} catch {
-				// Marking is best-effort; the session still works unrestored.
-			}
 		}
 		// Restore the last persisted status so it shows before the first sweep.
 		this.summarizer.seed(state);
@@ -1609,6 +1566,9 @@ export class AgentDaemon {
 		// draft closed via kill/completed is never wiped.
 		const isEmptyDraftSession = reason !== "shutdown" && this.isEmptyDraftContent(state);
 		let persistError: unknown;
+		// A clean shutdown leaves the session un-archived on purpose: it stays an
+		// on-disk "live" record reachable via /resume and --resume. Other closes
+		// (kill/completed/replaced) archive it so it drops out of the resume list.
 		if (reason !== "shutdown" && !isEmptyDraftSession) {
 			try {
 				state.runtime.session.sessionManager.appendSessionState({ status: "archived" });

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -279,8 +279,7 @@ export class AgentDaemon {
 		this.registerSignalHandlers();
 		this.summarizer.start();
 		this.log(`Prime Agent daemon listening on ${this.socketPath}`);
-		// The daemon starts with no resident sessions: on-disk sessions are
-		// brought back only via explicit /resume or --resume, never auto-restored.
+		// No startup restore: on-disk sessions return only via /resume or --resume.
 		if (!this.shuttingDown) {
 			this.cronScheduler.start();
 		}
@@ -1566,9 +1565,7 @@ export class AgentDaemon {
 		// draft closed via kill/completed is never wiped.
 		const isEmptyDraftSession = reason !== "shutdown" && this.isEmptyDraftContent(state);
 		let persistError: unknown;
-		// A clean shutdown leaves the session un-archived on purpose: it stays an
-		// on-disk "live" record reachable via /resume and --resume. Other closes
-		// (kill/completed/replaced) archive it so it drops out of the resume list.
+		// Clean shutdown leaves the session un-archived so it stays in the resume list.
 		if (reason !== "shutdown" && !isEmptyDraftSession) {
 			try {
 				state.runtime.session.sessionManager.appendSessionState({ status: "archived" });

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -506,13 +506,8 @@ describe("agents view state", () => {
 		expect(resumeConfig.cwd).toBe("/tmp/launch");
 	});
 
-	test("requests all sessions (in-memory + on-disk) for the agents view refresh", () => {
-		expect(createAgentsViewListCommand({ cwd: "/tmp/project" })).toEqual({ type: "list", all: true });
-		expect(createAgentsViewListCommand({ cwd: "/tmp/project", sessionDir: "/tmp/sessions" })).toEqual({
-			type: "list",
-			all: true,
-			sessionDir: "/tmp/sessions",
-		});
+	test("requests only daemon-resident sessions for the agents view refresh", () => {
+		expect(createAgentsViewListCommand()).toEqual({ type: "list" });
 	});
 
 	test("derives the reply headline from the first line of the latest assistant text", () => {


### PR DESCRIPTION
- the agents view used to merge every saved-on-disk session with live ones, so a restarted daemon surfaced a wall of weeks-old sessions; it now lists only sessions actually resident in the daemon.
- the daemon also no longer auto-restores on-disk sessions into residency on startup, which is what kept refilling that list even after filtering.
- on-disk sessions stay fully reachable through /resume and --resume; note that in-flight background work like running subagents is no longer auto-resumed across a daemon restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core daemon startup and session lifecycle behavior; users lose automatic session restore across restarts, though explicit resume paths remain.
> 
> **Overview**
> The **agents view** no longer merges on-disk sessions into the fleet list. `createAgentsViewListCommand()` now sends a plain `{ type: "list" }` (no `all` or `sessionDir`), so refreshes show only sessions currently loaded in the daemon; saved sessions are expected via **`/resume`** or **`--resume`**.
> 
> The **daemon** stops resurrecting sessions on startup: `restoreActiveSessions()` is removed, the cron scheduler starts immediately, and new runtimes are no longer persisted as `status: "active"` when they become resident—so restarts do not repopulate the agents view from disk.
> 
> **After a daemon restart**, previously running agents disappear from the fleet until explicitly reopened; background work (e.g. subagents) is not auto-resumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6350cc405b5d590e268dc57e214c373bb0f2d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show only daemon-resident sessions in the agents view
> - The agents view now requests only daemon-resident sessions by omitting the `all` flag from the list command in [`agents-view-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/295/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10).
> - The daemon no longer auto-restores previously active on-disk sessions at startup; sessions return only via explicit `/resume` or `--resume` operations.
> - New non-subagent sessions are no longer marked as `active` in persistent storage at creation time, removing the mechanism that previously drove startup restore.
> - Behavioral Change: users who relied on the daemon re-loading active sessions after restart must now explicitly resume them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6350cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->