### PR TITLE
support -- end-of-options separator in cli arg parsing

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -68,8 +68,21 @@ export function parseArgs(args: string[]): Args {
 		diagnostics: [],
 	};
 
+	let endOfOptions = false;
+
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
+
+		// POSIX end-of-options: everything after a standalone "--" is a positional
+		// message, even if it starts with a dash (e.g. a Markdown-bullet prompt).
+		if (endOfOptions) {
+			result.messages.push(arg);
+			continue;
+		}
+		if (arg === "--") {
+			endOfOptions = true;
+			continue;
+		}
 
 		if (arg === "--help" || arg === "-h") {
 			result.help = true;
@@ -268,6 +281,7 @@ ${chalk.bold("Options:")}
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
   --help, -h                     Show this help
   --version, -v                  Show version number
+  --                             End of options; treat all following args as messages
 
 Extensions can register additional flags (e.g., --plan from plan-mode extension).${extensionFlagsText}
 
@@ -286,6 +300,9 @@ ${chalk.bold("Examples:")}
 
   # Multiple messages (interactive)
   ${APP_NAME} "Read package.json" "What dependencies do we have?"
+
+  # Prompt that starts with a dash (use -- to end option parsing)
+  ${APP_NAME} -- "- You are given a state dictionary..."
 
   # Continue previous session
   ${APP_NAME} --continue "What did we discuss?"

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -387,4 +387,43 @@ describe("parseArgs", () => {
 			expect(result.messages).toEqual(["Do the task"]);
 		});
 	});
+
+	describe("-- end-of-options separator", () => {
+		test("treats a dash-leading prompt after -- as a positional message", () => {
+			const result = parseArgs(["--", "- You are given a state dictionary (/app/weights.pt)..."]);
+			expect(result.messages).toEqual(["- You are given a state dictionary (/app/weights.pt)..."]);
+			expect(result.diagnostics).toEqual([]);
+			expect(result.unknownFlags.size).toBe(0);
+		});
+
+		test("a dash-leading prompt without -- still errors", () => {
+			const result = parseArgs(["- do the thing"]);
+			expect(result.messages).toEqual([]);
+			expect(result.diagnostics).toEqual([
+				{ type: "error", message: "Unknown option: - do the thing" },
+			]);
+		});
+
+		test("does not parse flags after -- as options", () => {
+			const result = parseArgs(["--", "--provider", "openai"]);
+			expect(result.provider).toBeUndefined();
+			expect(result.messages).toEqual(["--provider", "openai"]);
+			expect(result.unknownFlags.size).toBe(0);
+		});
+
+		test("parses flags before -- and treats the rest as messages", () => {
+			const result = parseArgs(["--provider", "openai", "--", "-p", "@file"]);
+			expect(result.provider).toBe("openai");
+			expect(result.print).toBeUndefined();
+			expect(result.fileArgs).toEqual([]);
+			expect(result.messages).toEqual(["-p", "@file"]);
+		});
+
+		test("a lone -- produces no messages and no diagnostics", () => {
+			const result = parseArgs(["--"]);
+			expect(result.messages).toEqual([]);
+			expect(result.diagnostics).toEqual([]);
+			expect(result.unknownFlags.size).toBe(0);
+		});
+	});
 });


### PR DESCRIPTION
- a prompt starting with a dash was rejected as an unknown option, so tasks whose instruction begins with a markdown bullet failed before the agent ran.
- added standard posix -- handling so everything after it is taken as a positional message, giving callers a way to pass dash-leading prompts literally.
- eval harnesses can now insert -- before the prompt instead of hitting a non-zero exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI argument parsing with tests; no auth, data, or runtime agent logic affected.
> 
> **Overview**
> Adds **POSIX `--` end-of-options** handling in `parseArgs` so arguments after a standalone `--` are always treated as positional messages, including prompts that start with `-` (e.g. Markdown bullets) that previously failed as “unknown option”.
> 
> Help documents the new `--` flag and an example; tests cover dash-leading prompts, flags not parsed after `--`, mixed flags-before/`--`/messages, and a lone `--`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb2a04f4d4db2be07ecb31fe616fb8a1e136151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `--` end-of-options separator in CLI argument parsing
> Adds POSIX-standard `--` handling to `parseArgs` in [args.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/296/files#diff-3b284fa108abd7559ef709f343eddfe521198102aa818df139fbff7dec918924). Arguments after `--` are pushed directly to `result.messages` regardless of whether they start with a dash, preventing unknown-option errors for dash-prefixed prompts. The help text is updated with documentation and an example for this usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8eb2a04. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->