### PR TITLE
retry transient provider stream errors instead of ending the run

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4220,8 +4220,8 @@ export class AgentSession {
 		if (isContextOverflow(message, contextWindow)) return false;
 
 		const err = message.errorMessage;
-		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
+		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded, transient content_filter finish_reason, provider policy-flag prose, and prose-form transient 5xx ("an error occurred while processing your request. you can retry")
+		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay|content.?filter|flagged .*(cybersecurity|usage polic|violat)|error occurred while processing|you can retry/i.test(
 			err,
 		);
 	}

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -129,6 +129,53 @@ describe("AgentSession retry", () => {
 		return { session, getCallCount: () => callCount };
 	}
 
+	// Build a session whose stream fails `failCount` times with `errorMessage`, then succeeds.
+	function createSessionWithError(errorMessage: string, options?: { failCount?: number; maxRetries?: number }) {
+		const failCount = options?.failCount ?? 1;
+		const maxRetries = options?.maxRetries ?? 3;
+		let callCount = 0;
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				callCount++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (callCount <= failCount) {
+						const msg = createAssistantMessage("", { stopReason: "error", errorMessage });
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "error", reason: "error", error: msg });
+					} else {
+						const msg = createAssistantMessage("Recovered after retry");
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "done", reason: "stop", message: msg });
+					}
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		return { session, getCallCount: () => callCount };
+	}
+
 	it("retries after a transient error and succeeds", async () => {
 		const created = createSession({ failCount: 1 });
 		const events: string[] = [];
@@ -314,5 +361,50 @@ describe("AgentSession retry", () => {
 		// A follow-up prompt must work (no "Agent is already processing" error)
 		await session.prompt("Follow-up");
 		expect(callCount).toBe(4);
+	});
+
+	// Transient provider stream artifacts the classifier previously missed (ENG-4390).
+	const transientProviderErrors: Array<[string, string]> = [
+		["content_filter finish_reason", "Provider finish_reason: content_filter"],
+		["cybersecurity policy flag", "Your request was flagged for cybersecurity risk and cannot be processed."],
+		["usage policy flag", "flagged as potentially violating our usage policy"],
+		["prose-form transient 5xx", "An error occurred while processing your request. You can retry your request."],
+	];
+
+	for (const [name, errorMessage] of transientProviderErrors) {
+		it(`retries transient provider error: ${name}`, async () => {
+			const created = createSessionWithError(errorMessage, { failCount: 1 });
+			const events: string[] = [];
+			created.session.subscribe((event) => {
+				if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+				if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+			});
+
+			await created.session.prompt("Test");
+
+			expect(created.getCallCount()).toBe(2);
+			expect(events).toEqual(["start:1", "end:success=true"]);
+			expect(created.session.isRetrying).toBe(false);
+		});
+	}
+
+	it("bounds retries on a persistent content_filter block", async () => {
+		const created = createSessionWithError("Provider finish_reason: content_filter", {
+			failCount: 99,
+			maxRetries: 2,
+		});
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.getCallCount()).toBe(3);
+		expect(events).toContain("start:1");
+		expect(events).toContain("start:2");
+		expect(events).toContain("end:success=false");
+		expect(created.session.isRetrying).toBe(false);
 	});
 });


### PR DESCRIPTION
- a single transient provider event (openai content_filter, a policy-flag message, or a prose-form transient 5xx) was ending the whole run because the auto-retry classifier didn't recognize those error strings.
- extended the existing retryable-error matcher so these transient events flow into the retry-with-backoff path that already exists, matching how codex recovers from them.
- persistent blocks are still bounded by the normal retry cap, so a genuine content policy failure won't loop forever.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error-string classification and tests; may cause extra retries on messages that look transient but are permanent policy blocks, still bounded by maxRetries.
> 
> **Overview**
> **Auto-retry** no longer treats some provider stream failures as terminal when the existing backoff path could recover.
> 
> `_isRetryableError` in `AgentSession` now classifies additional assistant error strings as retryable: **`content_filter`** finish reasons, policy-flag prose (cybersecurity / usage policy), and generic “error occurred while processing … you can retry” messages. Context overflow stays non-retryable; the same **max retry** cap still applies when a block persists.
> 
> Tests add `createSessionWithError`, cover the four previously missed transient cases, and assert repeated `content_filter` errors stop after the configured retry limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9250012d3f3a040a4b5cd606ddaa06bec9b754ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient provider stream errors in `AgentSession` instead of ending the run
> - Expands `AgentSession._isRetryableError` to match additional transient provider conditions: `content_filter` finish reason, cybersecurity/usage policy flags, and prose-form 5xx messages containing 'you can retry your request'.
> - Adds tests covering each new error pattern, asserting a single retry occurs and the run succeeds, plus a test that caps retries when a persistent `content_filter` block repeats.
> - Behavioral Change: errors previously classified as fatal (content filter, policy flags, prose 5xx) now trigger automatic retries up to `maxRetries` before failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9250012. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->