### PR TITLE
rebind built-in tools to the live extension runner

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3446,6 +3446,10 @@ export class AgentSession {
 		);
 		const runner = this._extensionRunner;
 		const wrappedExtensionTools = wrapRegisteredTools(allCustomTools, runner);
+		// Built-in tools belong to the session, not any single runner instance. Bind them
+		// to a getter that resolves the current runner at execution time so a rebuild/reload
+		// (which invalidates the old runner) rebinds them to the live one instead of wedging
+		// every subsequent call on the stale-ctx guard.
 		const wrappedBuiltInTools = wrapRegisteredTools(
 			Array.from(this._baseToolDefinitions.values())
 				.filter((definition) => isAllowedTool(definition.name))
@@ -3453,7 +3457,7 @@ export class AgentSession {
 					definition,
 					sourceInfo: createSyntheticSourceInfo(`<builtin:${definition.name}>`, { source: "builtin" }),
 				})),
-			runner,
+			() => this._extensionRunner,
 		);
 
 		const toolRegistry = new Map(wrappedBuiltInTools.map((tool) => [tool.name, tool]));

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3446,10 +3446,8 @@ export class AgentSession {
 		);
 		const runner = this._extensionRunner;
 		const wrappedExtensionTools = wrapRegisteredTools(allCustomTools, runner);
-		// Built-in tools belong to the session, not any single runner instance. Bind them
-		// to a getter that resolves the current runner at execution time so a rebuild/reload
-		// (which invalidates the old runner) rebinds them to the live one instead of wedging
-		// every subsequent call on the stale-ctx guard.
+		// Resolve the runner at call time so a rebuild/reload rebinds built-in tools to the
+		// live runner instead of wedging them on the invalidated one's stale-ctx guard.
 		const wrappedBuiltInTools = wrapRegisteredTools(
 			Array.from(this._baseToolDefinitions.values())
 				.filter((definition) => isAllowedTool(definition.name))

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -11,20 +11,33 @@ import type { ExtensionRunner } from "./runner.js";
 import type { RegisteredTool } from "./types.js";
 
 /**
+ * A runner or a getter that resolves the current runner at execution time.
+ * Built-in tools pass a getter so a session rebuild/reload rebinds them to the
+ * live runner instead of leaving them wired to an invalidated one.
+ */
+type RunnerSource = ExtensionRunner | (() => ExtensionRunner);
+
+function toRunnerGetter(source: RunnerSource): () => ExtensionRunner {
+	return typeof source === "function" ? source : () => source;
+}
+
+/**
  * Wrap a RegisteredTool into an AgentTool.
  * Uses the runner's createContext() for consistent context across tools and event handlers.
  */
-export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: ExtensionRunner): AgentTool {
-	return wrapToolDefinition(registeredTool.definition, () => runner.createContext());
+export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: RunnerSource): AgentTool {
+	const getRunner = toRunnerGetter(runner);
+	return wrapToolDefinition(registeredTool.definition, () => getRunner().createContext());
 }
 
 /**
  * Wrap all registered tools into AgentTools.
  * Uses the runner's createContext() for consistent context across tools and event handlers.
  */
-export function wrapRegisteredTools(registeredTools: RegisteredTool[], runner: ExtensionRunner): AgentTool[] {
+export function wrapRegisteredTools(registeredTools: RegisteredTool[], runner: RunnerSource): AgentTool[] {
+	const getRunner = toRunnerGetter(runner);
 	return wrapToolDefinitions(
 		registeredTools.map((registeredTool) => registeredTool.definition),
-		() => runner.createContext(),
+		() => getRunner().createContext(),
 	);
 }

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -10,11 +10,6 @@ import { wrapToolDefinition, wrapToolDefinitions } from "../tools/tool-definitio
 import type { ExtensionRunner } from "./runner.js";
 import type { RegisteredTool } from "./types.js";
 
-/**
- * A runner or a getter that resolves the current runner at execution time.
- * Built-in tools pass a getter so a session rebuild/reload rebinds them to the
- * live runner instead of leaving them wired to an invalidated one.
- */
 type RunnerSource = ExtensionRunner | (() => ExtensionRunner);
 
 function toRunnerGetter(source: RunnerSource): () => ExtensionRunner {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -375,8 +375,7 @@ export function createIpythonToolDefinition(
 		executionMode: "sequential",
 		parameters: ipythonSchema,
 		execute: async (_toolCallId, params, signal, onUpdate, ctx) => {
-			// The working-message update is cosmetic; accessing ctx.ui can throw if the ctx
-			// is stale (a rebind should prevent this, but never let a UI update fail the cell).
+			// Cosmetic; ctx.ui can throw on a stale ctx, but must never fail the cell.
 			const setWorkingMessage = (message?: string) => {
 				try {
 					ctx?.ui.setWorkingMessage(message);

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -375,10 +375,17 @@ export function createIpythonToolDefinition(
 		executionMode: "sequential",
 		parameters: ipythonSchema,
 		execute: async (_toolCallId, params, signal, onUpdate, ctx) => {
+			// The working-message update is cosmetic; accessing ctx.ui can throw if the ctx
+			// is stale (a rebind should prevent this, but never let a UI update fail the cell).
+			const setWorkingMessage = (message?: string) => {
+				try {
+					ctx?.ui.setWorkingMessage(message);
+				} catch {}
+			};
 			let reportedStartupProgress = false;
 			const reportStartupProgress: KernelBootstrapProgressHandler = (message) => {
 				reportedStartupProgress = true;
-				ctx?.ui.setWorkingMessage(message);
+				setWorkingMessage(message);
 				onUpdate?.({
 					content: [{ type: "text", text: message }],
 					details: { status: "starting" },
@@ -424,7 +431,7 @@ export function createIpythonToolDefinition(
 				};
 			} finally {
 				if (reportedStartupProgress) {
-					ctx?.ui.setWorkingMessage();
+					setWorkingMessage();
 				}
 			}
 		},

--- a/packages/coding-agent/test/extension-tool-wrapper-rebind.test.ts
+++ b/packages/coding-agent/test/extension-tool-wrapper-rebind.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { ExtensionRunner } from "../src/core/extensions/runner.js";
+import type { RegisteredTool } from "../src/core/extensions/types.js";
+import { wrapRegisteredTools } from "../src/core/extensions/wrapper.js";
+
+const STALE = "This extension ctx is stale after session replacement or reload.";
+
+// Minimal stand-in for a runner whose createContext() throws once invalidated,
+// mirroring assertActive() on the real ExtensionRunner's guarded ctx getters.
+function makeRunner(id: string): ExtensionRunner & { invalidate(): void } {
+	let stale = false;
+	return {
+		createContext() {
+			if (stale) throw new Error(STALE);
+			return { id } as unknown as ReturnType<ExtensionRunner["createContext"]>;
+		},
+		invalidate() {
+			stale = true;
+		},
+	} as unknown as ExtensionRunner & { invalidate(): void };
+}
+
+function toolThatReturnsCtxId(): RegisteredTool {
+	return {
+		definition: {
+			name: "probe",
+			label: "probe",
+			description: "returns the ctx id",
+			parameters: { type: "object", properties: {} } as never,
+			execute: async (_id: string, _params: unknown, _signal: AbortSignal, _onUpdate: unknown, ctx: unknown) => ({
+				content: [{ type: "text", text: (ctx as { id: string }).id }],
+			}),
+		},
+		sourceInfo: { source: "builtin" },
+	} as unknown as RegisteredTool;
+}
+
+describe("wrapRegisteredTools runner rebinding", () => {
+	it("resolves the current runner at execute time when given a getter", async () => {
+		let runner = makeRunner("first");
+		const [tool] = wrapRegisteredTools([toolThatReturnsCtxId()], () => runner);
+
+		const first = await tool.execute("c1", {}, new AbortController().signal);
+		expect((first.content[0] as { text: string }).text).toBe("first");
+
+		// Session rebuild: old runner invalidated, a fresh one takes its place.
+		runner.invalidate();
+		runner = makeRunner("second");
+
+		const second = await tool.execute("c2", {}, new AbortController().signal);
+		expect((second.content[0] as { text: string }).text).toBe("second");
+	});
+
+	it("stays wedged on a stale runner when bound to a fixed instance (old behavior)", async () => {
+		const runner = makeRunner("only");
+		const [tool] = wrapRegisteredTools([toolThatReturnsCtxId()], runner);
+
+		await expect(tool.execute("c1", {}, new AbortController().signal)).resolves.toBeTruthy();
+
+		runner.invalidate();
+		// The ctx is resolved synchronously as an execute() argument, so a stale runner
+		// throws at call time rather than rejecting.
+		expect(() => tool.execute("c2", {}, new AbortController().signal)).toThrow(STALE);
+	});
+});


### PR DESCRIPTION
- on long runs the ipython tool would wedge and fail every call with a "stale ctx" error for the rest of the run, which was the single largest cause of prime agent task failures in the terminal-bench 2 comparison.
- built-in tools had captured a fixed extension runner, so a session rebuild or replacement invalidated that runner and left the tool permanently tripping the stale-ctx guard instead of using the new live one.
- built-in tools now resolve the current runner at call time, and ipython's cosmetic status-message update is made non-fatal so it can never fail a cell on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool execution and extension context wiring for all built-in tools after reload; behavior change is targeted and covered by tests, but long-run agent reliability depends on this path.
> 
> **Overview**
> Fixes **ipython** (and other built-ins) failing for the rest of a run with stale extension context after **session rebuild** or **`/reload`**, when tool wrappers had captured the old `ExtensionRunner`.
> 
> **`wrapRegisteredTool` / `wrapRegisteredTools`** now take a `RunnerSource` (fixed runner or getter) and resolve `createContext()` at **execute time**. **`AgentSession._refreshToolRegistry`** passes `() => this._extensionRunner` for built-in tools so they always use the current runner; extension-registered tools still bind the runner instance at wrap time.
> 
> **`ipython`** wraps cosmetic `ctx.ui.setWorkingMessage` in try/catch so a stale UI context cannot fail the cell.
> 
> New **`extension-tool-wrapper-rebind.test.ts`** covers getter rebinding vs the old fixed-runner wedge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a10b116b1bdd07be637c3d7e6d96baeb9cef3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rebind built-in tools to the live extension runner at execute time
> - Changes `wrapRegisteredTools` in [wrapper.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/299/files#diff-aab01010dc4af66ffa5d0b2a09d6e298c3fe4a1a92d39a14060e80d06b52e6e5) to accept a lazy getter (`() => ExtensionRunner`) in addition to a fixed instance, resolving the runner at call time instead of session setup.
> - Updates [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/299/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) to pass `() => this._extensionRunner` so tools always bind to the current runner rather than the one captured at construction.
> - Adds error suppression in the IPython tool's `setWorkingMessage` calls to prevent stale UI contexts from failing cell executions.
> - Behavioral Change: tools wrapped with a fixed runner instance continue to behave as before; tools wrapped with a getter now resolve context on every invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64a10b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->