### PR TITLE
enable the kernel forkserver by default on linux

### DIFF
--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -39,11 +39,8 @@ export class ForkServerUnavailable extends Error {
 	}
 }
 
-/**
- * Fork is a Linux-only, in-process fan-out optimization, on by default there.
- * Any failure auto-falls back to direct spawn, so enabling it can't regress
- * correctness. Set PRIME_AGENT_KERNEL_FORKSERVER=0 to force the direct-spawn path.
- */
+// On by default on Linux (fork-without-exec is unsafe on macOS);
+// PRIME_AGENT_KERNEL_FORKSERVER=0 opts out.
 export function isForkServerEnabled(): boolean {
 	if (process.platform !== "linux") return false;
 	return process.env.PRIME_AGENT_KERNEL_FORKSERVER !== "0";

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -39,9 +39,14 @@ export class ForkServerUnavailable extends Error {
 	}
 }
 
-/** Fork is a Linux-only, in-process fan-out optimization. */
+/**
+ * Fork is a Linux-only, in-process fan-out optimization, on by default there.
+ * Any failure auto-falls back to direct spawn, so enabling it can't regress
+ * correctness. Set PRIME_AGENT_KERNEL_FORKSERVER=0 to force the direct-spawn path.
+ */
 export function isForkServerEnabled(): boolean {
-	return process.platform === "linux" && process.env.PRIME_AGENT_KERNEL_FORKSERVER === "1";
+	if (process.platform !== "linux") return false;
+	return process.env.PRIME_AGENT_KERNEL_FORKSERVER !== "0";
 }
 
 // A forkserver template is defined solely by the interpreter — the imported

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -399,9 +399,7 @@ describe("parseArgs", () => {
 		test("a dash-leading prompt without -- still errors", () => {
 			const result = parseArgs(["- do the thing"]);
 			expect(result.messages).toEqual([]);
-			expect(result.diagnostics).toEqual([
-				{ type: "error", message: "Unknown option: - do the thing" },
-			]);
+			expect(result.diagnostics).toEqual([{ type: "error", message: "Unknown option: - do the thing" }]);
 		});
 
 		test("does not parse flags after -- as options", () => {

--- a/packages/coding-agent/test/boot-gate.test.ts
+++ b/packages/coding-agent/test/boot-gate.test.ts
@@ -18,16 +18,17 @@ describe("resolveKernelBootConcurrency", () => {
 	});
 
 	it("honors a clean positive integer, clamped to the direct-spawn max", () => {
+		// Force the direct-spawn path (forkserver is on by default on linux now).
+		process.env[FORK_ENV] = "0";
 		process.env[ENV] = "8";
 		expect(resolveKernelBootConcurrency()).toBe(8);
 		process.env[ENV] = "999999";
 		expect(resolveKernelBootConcurrency()).toBe(64);
 	});
 
-	it("raises the ceiling when the forkserver is enabled (linux only)", () => {
+	it("raises the ceiling on the forkserver path (linux, default on)", () => {
 		if (process.platform !== "linux") return;
-		process.env[FORK_ENV] = "1";
-		// Auto default is well above the direct-spawn default but still bounded.
+		// Default (flag unset) is now the forkserver path.
 		const auto = resolveKernelBootConcurrency();
 		expect(auto).toBeGreaterThanOrEqual(32);
 		expect(auto).toBeLessThanOrEqual(128);

--- a/packages/coding-agent/test/boot-gate.test.ts
+++ b/packages/coding-agent/test/boot-gate.test.ts
@@ -18,8 +18,7 @@ describe("resolveKernelBootConcurrency", () => {
 	});
 
 	it("honors a clean positive integer, clamped to the direct-spawn max", () => {
-		// Force the direct-spawn path (forkserver is on by default on linux now).
-		process.env[FORK_ENV] = "0";
+		process.env[FORK_ENV] = "0"; // direct-spawn path (forkserver is default-on)
 		process.env[ENV] = "8";
 		expect(resolveKernelBootConcurrency()).toBe(8);
 		process.env[ENV] = "999999";
@@ -28,11 +27,9 @@ describe("resolveKernelBootConcurrency", () => {
 
 	it("raises the ceiling on the forkserver path (linux, default on)", () => {
 		if (process.platform !== "linux") return;
-		// Default (flag unset) is now the forkserver path.
 		const auto = resolveKernelBootConcurrency();
 		expect(auto).toBeGreaterThanOrEqual(32);
 		expect(auto).toBeLessThanOrEqual(128);
-		// A huge override is clamped to the fork backstop, not the direct-spawn cap.
 		process.env[ENV] = "999999";
 		expect(resolveKernelBootConcurrency()).toBe(128);
 	});

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -2,11 +2,24 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupSessionResources } from "@earendil-works/pi-ai";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KernelManager } from "../src/core/kernel/index.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
 let tempDir = "";
+
+// These tests count spawns of a fake python to assert provisioner semantics
+// (memoization, retry, gating) and drive it with a stub interpreter. Pin the
+// direct-spawn path so the on-by-default forkserver's extra spawn/ready handshake
+// doesn't perturb the counts; the fork path has its own coverage.
+const savedForkFlag = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+beforeAll(() => {
+	process.env.PRIME_AGENT_KERNEL_FORKSERVER = "0";
+});
+afterAll(() => {
+	if (savedForkFlag === undefined) delete process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+	else process.env.PRIME_AGENT_KERNEL_FORKSERVER = savedForkFlag;
+});
 
 function writeFakePython(opts: { sleepSeconds?: number } = {}): { python: string; countRuns: () => number } {
 	const python = join(tempDir, "python");

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -8,10 +8,8 @@ import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
 let tempDir = "";
 
-// These tests count spawns of a fake python to assert provisioner semantics
-// (memoization, retry, gating) and drive it with a stub interpreter. Pin the
-// direct-spawn path so the on-by-default forkserver's extra spawn/ready handshake
-// doesn't perturb the counts; the fork path has its own coverage.
+// These tests count spawns of a stub python; the default-on forkserver adds an
+// extra spawn + ready handshake the stub never answers, so pin direct-spawn.
 const savedForkFlag = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
 beforeAll(() => {
 	process.env.PRIME_AGENT_KERNEL_FORKSERVER = "0";

--- a/packages/coding-agent/test/kernel-fork-server.test.ts
+++ b/packages/coding-agent/test/kernel-fork-server.test.ts
@@ -8,15 +8,17 @@ describe("fork-server gating", () => {
 		delete process.env[FORK_ENV];
 	});
 
-	it("is disabled unless the flag is set on linux", () => {
+	it("is on by default on linux, opt-out via the flag", () => {
 		delete process.env[FORK_ENV];
+		expect(isForkServerEnabled()).toBe(process.platform === "linux");
+		process.env[FORK_ENV] = "0";
 		expect(isForkServerEnabled()).toBe(false);
 		process.env[FORK_ENV] = "1";
 		expect(isForkServerEnabled()).toBe(process.platform === "linux");
 	});
 
-	it("rejects with ForkServerUnavailable when disabled so callers fall back", async () => {
-		delete process.env[FORK_ENV];
+	it("rejects with ForkServerUnavailable when opted out so callers fall back", async () => {
+		process.env[FORK_ENV] = "0";
 		await expect(forkKernel("python3", { connectionPath: "/tmp/nope/connection.json" })).rejects.toBeInstanceOf(
 			ForkServerUnavailable,
 		);
@@ -24,7 +26,6 @@ describe("fork-server gating", () => {
 
 	it("degrades to ForkServerUnavailable when the interpreter can't start", async () => {
 		if (process.platform !== "linux") return;
-		process.env[FORK_ENV] = "1";
 		// The spawn errors immediately (ENOENT), so markDead fails the ready promise
 		// fast rather than waiting out the ready timeout.
 		await expect(
@@ -34,7 +35,6 @@ describe("fork-server gating", () => {
 
 	it("falls back to direct spawn for any PYTHON* startup-env override", async () => {
 		if (process.platform !== "linux") return;
-		process.env[FORK_ENV] = "1";
 		// The guard treats the whole PYTHON* family as startup-affecting, so even a var
 		// not explicitly enumerated diverts to direct spawn (no var can be "missed").
 		for (const key of ["PYTHONPATH", "PYTHONUSERBASE", "PYTHONDONTWRITEBYTECODE"]) {

--- a/scripts/boot-bench.mjs
+++ b/scripts/boot-bench.mjs
@@ -32,7 +32,9 @@ function arg(name, def) {
 const mode = arg("mode", "gated");
 const n = Number(arg("n", 50)) || 50;
 
-if (mode === "forkserver") process.env.PRIME_AGENT_KERNEL_FORKSERVER = "1";
+// Forkserver is on by default now, so pin each mode explicitly: enable for the
+// forkserver mode, opt out for the direct-spawn comparison modes.
+process.env.PRIME_AGENT_KERNEL_FORKSERVER = mode === "forkserver" ? "1" : "0";
 
 const { KernelManager } = await import(kernelMod);
 const { ensureKernelPython } = await import(bootstrapMod);

--- a/scripts/boot-bench.mjs
+++ b/scripts/boot-bench.mjs
@@ -32,8 +32,7 @@ function arg(name, def) {
 const mode = arg("mode", "gated");
 const n = Number(arg("n", 50)) || 50;
 
-// Forkserver is on by default now, so pin each mode explicitly: enable for the
-// forkserver mode, opt out for the direct-spawn comparison modes.
+// Pin per-mode so the default-on forkserver doesn't leak into the direct-spawn modes.
 process.env.PRIME_AGENT_KERNEL_FORKSERVER = mode === "forkserver" ? "1" : "0";
 
 const { KernelManager } = await import(kernelMod);


### PR DESCRIPTION
- the forkserver that speeds up subagent kernel fan-out shipped behind an off-by-default env flag, so the speedup never actually reached anyone running prime agent.
- this flips it to on-by-default on linux, with PRIME_AGENT_KERNEL_FORKSERVER=0 as an opt-out escape hatch.
- any fork failure still auto-falls back to the original direct-spawn path, so turning it on can't regress correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on changes kernel startup and boot concurrency on Linux; failures still fall back to direct spawn, but more users will hit the forkserver path in production.
> 
> **Overview**
> **On Linux, the kernel forkserver is now on by default** so subagent kernel fan-out uses the warm-template fork path without setting an env var. Opt out with `PRIME_AGENT_KERNEL_FORKSERVER=0`; macOS/non-Linux behavior is unchanged (fork stays disabled).
> 
> `isForkServerEnabled()` flips from requiring `=1` to treating unset as enabled and only `=0` as disabled. That also means the **higher forkserver boot-gate concurrency** applies by default on Linux when `PRIME_AGENT_MAX_CONCURRENT_KERNEL_BOOTS` isn’t set.
> 
> Tests and `boot-bench.mjs` **pin `PRIME_AGENT_KERNEL_FORKSERVER=0`** for direct-spawn scenarios so stub interpreters and gated/ungated benchmarks aren’t affected by the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27dc250b68bddec20e0112a929f146fb51de13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable kernel forkserver by default on Linux
> - Changes `isForkServerEnabled` in [fork-server.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/300/files#diff-65164112dcd341a9e27f5bbd59aa6b335e99b3c538915cde2701e2afa02a5e36) to return `true` by default on Linux; set `PRIME_AGENT_KERNEL_FORKSERVER=0` to opt out. Non-Linux platforms remain disabled.
> - Updates the boot-bench script to explicitly set `PRIME_AGENT_KERNEL_FORKSERVER=0` for non-forkserver modes so external env defaults no longer affect benchmark runs.
> - Updates affected test suites to pin direct-spawn mode via `PRIME_AGENT_KERNEL_FORKSERVER=0` where needed to keep spawn-counting assertions stable.
> - Behavioral Change: any Linux environment without this env variable set will now use the forkserver path, reversing the previous opt-in default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d27dc25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->