### PR TITLE
add claude fable 5 support

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -126,6 +126,7 @@ interface PrimeInferenceModelMetadata {
 const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata> = {
 	// prime-inference proxies Anthropic models through OpenRouter without the
 	// context-1m beta header, so the enforced window is the standard 200k, not 1M.
+	"anthropic/claude-fable-5": { contextWindow: 200000, maxTokens: 128000, vision: true },
 	"anthropic/claude-haiku-4.5": { contextWindow: 200000, maxTokens: 64000, vision: true },
 	"anthropic/claude-opus-4.6": { contextWindow: 200000, maxTokens: 128000, vision: true },
 	"anthropic/claude-opus-4.7": { contextWindow: 200000, maxTokens: 128000, vision: true },
@@ -227,7 +228,8 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 		model.id.includes("opus-4-7") ||
 		model.id.includes("opus-4.7") ||
 		model.id.includes("opus-4-8") ||
-		model.id.includes("opus-4.8")
+		model.id.includes("opus-4.8") ||
+		model.id.includes("sonnet-5")
 	) {
 		mergeThinkingLevelMap(model, { xhigh: "xhigh", max: "max" });
 	}
@@ -348,7 +350,7 @@ function isPrimeInferenceReasoningModel(modelId: string, catalogReasoning?: bool
 		id.startsWith("x-ai/grok-4") ||
 		id.startsWith("z-ai/glm-") ||
 		(id.startsWith("openai/gpt-5") && !id.includes("-chat")) ||
-		/^anthropic\/claude-(?:opus-4|sonnet-4)/.test(id)
+		/^anthropic\/claude-(?:opus-4|sonnet-4|fable-5|mythos-5)/.test(id)
 	);
 }
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -126,7 +126,6 @@ interface PrimeInferenceModelMetadata {
 const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata> = {
 	// prime-inference proxies Anthropic models through OpenRouter without the
 	// context-1m beta header, so the enforced window is the standard 200k, not 1M.
-	"anthropic/claude-fable-5": { contextWindow: 200000, maxTokens: 128000, vision: true },
 	"anthropic/claude-haiku-4.5": { contextWindow: 200000, maxTokens: 64000, vision: true },
 	"anthropic/claude-opus-4.6": { contextWindow: 200000, maxTokens: 128000, vision: true },
 	"anthropic/claude-opus-4.7": { contextWindow: 200000, maxTokens: 128000, vision: true },
@@ -350,7 +349,7 @@ function isPrimeInferenceReasoningModel(modelId: string, catalogReasoning?: bool
 		id.startsWith("x-ai/grok-4") ||
 		id.startsWith("z-ai/glm-") ||
 		(id.startsWith("openai/gpt-5") && !id.includes("-chat")) ||
-		/^anthropic\/claude-(?:opus-4|sonnet-4|fable-5|mythos-5)/.test(id)
+		/^anthropic\/claude-(?:opus-4|sonnet-4)/.test(id)
 	);
 }
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -202,7 +202,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
 				inferenceConfig: {
 					...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
-					...(options.temperature !== undefined && { temperature: options.temperature }),
+					...(options.temperature !== undefined &&
+						!supportsAlwaysOnAdaptiveThinking(model.id, model.name) && { temperature: options.temperature }),
 				},
 				toolConfig: convertToolConfig(context.tools, options.toolChoice),
 				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
@@ -497,10 +498,19 @@ function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean 
 			s.includes("opus-4-7") ||
 			s.includes("opus-4-8") ||
 			s.includes("sonnet-4-6") ||
+			s.includes("sonnet-5") ||
 			s.includes("fable-5") ||
 			s.includes("mythos-5") ||
 			s.includes("mythos-preview"),
 	);
+}
+
+/**
+ * Fable/Mythos models think every turn and reject sampling params with a 400.
+ */
+function supportsAlwaysOnAdaptiveThinking(modelId: string, modelName?: string): boolean {
+	const candidates = getModelMatchCandidates(modelId, modelName);
+	return candidates.some((s) => s.includes("fable-5") || s.includes("mythos-5") || s.includes("mythos-preview"));
 }
 
 function mapThinkingLevelToEffort(

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -676,6 +676,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
+ * Fable/Mythos models think every turn and reject an explicit
+ * `thinking: {type: "disabled"}` (and any sampling params) with a 400.
+ */
+function isAlwaysOnAdaptiveThinkingModel(modelId: string): boolean {
+	return modelId.includes("fable-5") || modelId.includes("mythos-5") || modelId.includes("mythos-preview");
+}
+
+/**
  * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
@@ -689,6 +697,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 		modelId.includes("opus-4.8") ||
 		modelId.includes("sonnet-4-6") ||
 		modelId.includes("sonnet-4.6") ||
+		modelId.includes("sonnet-5") ||
 		modelId.includes("fable-5") ||
 		modelId.includes("mythos-5") ||
 		modelId.includes("mythos-preview")
@@ -920,8 +929,9 @@ function buildParams(
 		];
 	}
 
-	// Temperature is incompatible with extended thinking (adaptive or budget-based).
-	if (options?.temperature !== undefined && !options?.thinkingEnabled) {
+	// Temperature is incompatible with extended thinking (adaptive or budget-based),
+	// and always-on models reject sampling params outright.
+	if (options?.temperature !== undefined && !options?.thinkingEnabled && !isAlwaysOnAdaptiveThinkingModel(model.id)) {
 		params.temperature = options.temperature;
 	}
 
@@ -961,7 +971,7 @@ function buildParams(
 					display,
 				};
 			}
-		} else if (options?.thinkingEnabled === false) {
+		} else if (options?.thinkingEnabled === false && !isAlwaysOnAdaptiveThinkingModel(model.id)) {
 			params.thinking = { type: "disabled" };
 		}
 	}

--- a/packages/ai/test/anthropic-thinking-disable.test.ts
+++ b/packages/ai/test/anthropic-thinking-disable.test.ts
@@ -6,6 +6,7 @@ import type { Context, Model, SimpleStreamOptions } from "../src/types.js";
 interface AnthropicThinkingPayload {
 	thinking?: { type: string; budget_tokens?: number; display?: string };
 	output_config?: { effort?: string };
+	temperature?: number;
 }
 
 function makePayloadCaptureContext(): Context {
@@ -161,6 +162,34 @@ describe("Anthropic thinking disable payload", () => {
 
 	it("maps max reasoning to effort=max for Claude Sonnet 4.6 (no native xhigh)", async () => {
 		const payload = await capturePayload(getModel("anthropic", "claude-sonnet-4-6"), { reasoning: "max" });
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "max" });
+	});
+
+	it("omits the thinking param for Claude Fable 5 when reasoning is off (explicit disabled is a 400)", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"));
+
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config).toBeUndefined();
+	});
+
+	it("drops temperature for Claude Fable 5 (sampling params are rejected)", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), { temperature: 0.5 });
+
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.thinking).toBeUndefined();
+	});
+
+	it("uses adaptive thinking with effort=xhigh for Claude Fable 5", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), { reasoning: "xhigh" });
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "xhigh" });
+	});
+
+	it("maps max reasoning to effort=max for Claude Fable 5", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), { reasoning: "max" });
 
 		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
 		expect(payload.output_config).toEqual({ effort: "max" });

--- a/packages/ai/test/bedrock-thinking-payload.test.ts
+++ b/packages/ai/test/bedrock-thinking-payload.test.ts
@@ -4,6 +4,7 @@ import { type BedrockOptions, streamBedrock } from "../src/providers/amazon-bedr
 import type { Context, Model } from "../src/types.js";
 
 interface BedrockThinkingPayload {
+	inferenceConfig?: { maxTokens?: number; temperature?: number };
 	additionalModelRequestFields?: {
 		thinking?: { type: string; budget_tokens?: number; display?: string };
 		output_config?: { effort?: string };
@@ -87,6 +88,23 @@ describe("Bedrock thinking payload", () => {
 		expect(payload.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
 		expect(payload.additionalModelRequestFields?.output_config).toEqual({ effort: "max" });
 		expect(payload.additionalModelRequestFields?.anthropic_beta).toBeUndefined();
+	});
+
+	it("uses adaptive thinking with effort for Claude Fable 5", async () => {
+		const model = getModel("amazon-bedrock", "global.anthropic.claude-fable-5");
+
+		const payload = await capturePayload(model, { reasoning: "xhigh" });
+
+		expect(payload.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.additionalModelRequestFields?.output_config).toEqual({ effort: "xhigh" });
+	});
+
+	it("drops temperature for Claude Fable 5 (sampling params are rejected)", async () => {
+		const model = getModel("amazon-bedrock", "global.anthropic.claude-fable-5");
+
+		const payload = await capturePayload(model, { reasoning: "high", temperature: 0.5 });
+
+		expect(payload.inferenceConfig?.temperature).toBeUndefined();
 	});
 
 	it("omits display for GovCloud model ids on non-adaptive Claude thinking", async () => {


### PR DESCRIPTION
- fable 5 rejects an explicit disabled-thinking config and any sampling params with a 400, so the anthropic and bedrock providers now omit the thinking param and temperature entirely for always-on models (fable/mythos) instead of sending them.
- fable 5 runs through the anthropic provider using its existing catalog entry; this fixes the no-reasoning path that previously sent disabled thinking and errored.
- recognized sonnet 5 as adaptive-only ahead of the next catalog refresh, since budget-based thinking would 400 on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Anthropic and Bedrock build inference requests for new and always-on thinking models; mistakes could cause 400s or wrong reasoning behavior, but scope is narrow and covered by new payload tests.
> 
> **Overview**
> Adds **Claude Fable 5** and **Sonnet 5** to the adaptive-thinking model paths in the Anthropic and Amazon Bedrock providers, and fixes request shaping so **always-on** Fable/Mythos models stop 400ing the API.
> 
> **Always-on models (Fable 5, Mythos 5, Mythos Preview)** think every turn and reject `thinking: { type: "disabled" }` and sampling params. The Anthropic provider now skips explicit disabled thinking and omits `temperature` for those IDs; Bedrock adds `supportsAlwaysOnAdaptiveThinking` and strips `temperature` from `inferenceConfig` the same way.
> 
> **Sonnet 5** is treated like other adaptive-only Claude families: included in `supportsAdaptiveThinking` on both providers, and in `generate-models.ts` the Opus 4.7+ block now also matches `sonnet-5` so **`xhigh` / `max`** reasoning levels map correctly ahead of catalog refresh.
> 
> Payload tests cover Fable 5 on Anthropic (no thinking param when reasoning is off, no temperature, adaptive + effort when reasoning is on) and Bedrock (adaptive effort, temperature dropped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196b5bb411faffe407ae438b8c588908aea008cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Fable 5 support to Anthropic and Bedrock providers
> - Adds `isAlwaysOnAdaptiveThinkingModel` / `supportsAlwaysOnAdaptiveThinking` helpers in [anthropic.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/302/files#diff-beee73f2e789158a9db5395ff9b504999319d491a77dd9cd523f37ded9b0f954) and [amazon-bedrock.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/302/files#diff-3f2d56a0422dc4ee7e752f4025cae682faf57ec5e2f958e69a3d04c6ffa3de69) to detect always-on adaptive-thinking models (`fable-5`, `mythos-5`, `mythos-preview`).
> - Extends `supportsAdaptiveThinking` to include `sonnet-5` in both providers, and updates `applyThinkingLevelMetadata` to map `xhigh`/`max` reasoning levels for `sonnet-5` models.
> - For always-on models, `buildParams` and `streamBedrock` now omit `temperature` and skip sending `thinking: {type: 'disabled'}` when reasoning is off, as these parameters are incompatible with always-on adaptive thinking.
> - Adds test coverage in [anthropic-thinking-disable.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/302/files#diff-a8b0ddf5c9da13fada198da82ece09c0890e72a670358c55c469d026f3782f54) and [bedrock-thinking-payload.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/302/files#diff-1719c1c2158b094dfd7a830b9bd0907fcbcbf5352f5817c99a17fb3958f48f23) for the new model behavior.
> - Behavioral Change: requests to Fable 5, Mythos 5, and Mythos Preview models will no longer include `temperature` or an explicit `thinking: disabled` param.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 196b5bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->