### PR TITLE
Encourage prime-agent to do sub-agent calling

### DIFF
--- a/packages/coding-agent/src/core/prompts/index.ts
+++ b/packages/coding-agent/src/core/prompts/index.ts
@@ -1,1 +1,1 @@
-export { buildRlmPrompt, type RlmPromptOptions } from "./rlm.js";
+export { buildRlmPrompt, buildSubagentGuidance, type RlmPromptOptions } from "./rlm.js";

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -85,3 +85,48 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 
 	return parts.join("\n");
 }
+
+/**
+ * Supplemental sub-agent delegation guidance, appended AFTER the trained
+ * `buildRlmPrompt` prefix (see system-prompt.ts). This is intentionally NOT part of
+ * `buildRlmPrompt`'s `parts` array: the text that function emits is frozen as the v1
+ * training prefix and must stay byte-identical. The trained recursion block already
+ * covers the mechanics (`await rlm(...)`, `asyncio.gather`, `asyncio.create_task`);
+ * this block adds the *when* and *why* — the decision guidance the trained prefix
+ * lacks — in the same When -> Why -> (menu) order Claude Code's Agent tool uses. The
+ * subagent-spec "menu" itself renders just after this, inside the harness-state block.
+ */
+export function buildSubagentGuidance(): string {
+	return [
+		"# Delegating to sub-agents",
+		"",
+		"You already have `rlm` in scope. This is about *when* to spawn one — which matters as much as how.",
+		"",
+		"Reach for `await rlm(...)` when:",
+		"- you have independent sub-tasks that can run in parallel — fan them out with `await asyncio.gather(rlm('task1'), rlm('task2'))` rather than working them one after another;",
+		"- a sub-task would mean reading across many files, outputs, or sources you don't need to keep — delegate it and you keep the answer, not the raw material;",
+		"- the sub-task matches one of your saved subagent specs (listed in the harness state below) — turn the spec into a concise task prompt and call `rlm` with it.",
+		"",
+		"Do it inline instead when the step is a single known lookup, edit, or command — there, a sub-agent just adds latency. Once you've delegated a sub-task, await its handle and use the result instead of redoing the work yourself.",
+		"",
+		"For example:",
+		"```python",
+		"# Independent sub-tasks in parallel — each returns just its conclusion, not the files it read",
+		"auth, api = await asyncio.gather(",
+		"    rlm('Summarize how authentication works in this repo: entrypoints, token flow, and key files.'),",
+		"    rlm('Summarize the HTTP API layer: routes, middleware, and error handling.'),",
+		")",
+		"",
+		"# Context isolation — a sub-agent digests a large file and hands back only the answer",
+		"res = await rlm('Read build.log, find the failing step and its root cause, and report it in 3 lines.')",
+		"print(res.answer)",
+		"",
+		"# Background — kick off a slow sub-task, keep working, collect it later",
+		"task = asyncio.create_task(rlm('Run the full test suite and report any failures with root causes.'))",
+		"# ... continue with other work while it runs ...",
+		"failures = (await task).answer",
+		"```",
+		"",
+		"These are illustrations, not a fixed menu: delegate any self-contained sub-task that fits the cases above.",
+	].join("\n");
+}

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -319,7 +319,16 @@ export function formatHarnessStateForPrompt(
 			[a.path, a.title, a.id].join("\0").localeCompare([b.path, b.title, b.id].join("\0")),
 		);
 		totalEntries += entries.length;
-		lines.push(`${kind}: ${entries.length}`);
+		// Render subagent specs as a task-shaped roster the model can match against — the
+		// analogue of Claude Code's agent-type menu — rather than a bare count. The
+		// invocation hint makes clear each spec is reached through the single `rlm` entrypoint.
+		if (kind === "subagent" && entries.length > 0) {
+			lines.push(
+				`${kind}: ${entries.length} (invoke a spec by turning it into a concise task prompt and calling \`await rlm('<task>')\`)`,
+			);
+		} else {
+			lines.push(`${kind}: ${entries.length}`);
+		}
 		for (const entry of entries.slice(0, maxEntriesPerKind)) {
 			const argumentsText =
 				entry.kind === "skill" && Object.keys(entry.arguments).length > 0

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -2,7 +2,7 @@
  * System prompt construction and project context loading
  */
 
-import { buildRlmPrompt } from "./prompts/index.js";
+import { buildRlmPrompt, buildSubagentGuidance } from "./prompts/index.js";
 import { formatHarnessStateForPrompt, type HarnessState } from "./refinement/index.js";
 import { formatSkillsForPrompt, getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
 
@@ -102,6 +102,13 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		activeTools: tools.filter((name) => name === "ipython" || name === "bash" || name === "edit"),
 		allowRecursion,
 	});
+
+	// Appended AFTER the trained buildRlmPrompt prefix, and before the harness-state
+	// menu, so the model reads when/why to delegate and then sees the concrete subagent
+	// specs it can match against — the same ordering as Claude Code's Agent tool.
+	if (allowRecursion ?? true) {
+		prompt += `\n\n${buildSubagentGuidance()}`;
+	}
 
 	if (harnessState) {
 		prompt += `\n\n${formatHarnessStateForPrompt(harnessState)}`;


### PR DESCRIPTION
We append to the base system prompt (to not go OOD from what we train) with a re-written version of the Agent tool prompt that Claude Code uses. 

Useful for encouraging sub-agent calling behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to default system text and harness formatting; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`buildSubagentGuidance()`** as a separate prompt block (not inside the byte-frozen **`buildRlmPrompt`** prefix) so the prime agent gets **when/why** guidance for **`await rlm(...)`**, parallel **`asyncio.gather`**, and background **`asyncio.create_task`**, with short Python examples—mirroring Claude Code–style Agent-tool ordering.
> 
> **`buildSystemPrompt`** now appends that block when recursion is allowed, **before** the harness-state section, so delegation advice sits immediately ahead of saved subagent specs.
> 
> Harness prompt formatting for **subagent** entries now includes an explicit **invoke via `await rlm('<task>')`** hint on the kind header instead of only a bare count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f48f4cecb47c64b9d4f99c10f3f788d3dabf0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Encourage prime-agent to delegate work to sub-agents via `rlm`
> - Adds `buildSubagentGuidance()` in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/306/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) that returns a standardized guidance block describing when and how to delegate tasks to sub-agents (e.g. parallel async work, context isolation, background tasks).
> - Injects this guidance into the system prompt in [system-prompt.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/306/files#diff-db1412afec77d3c6d261173c97d9073fabd7f40adb493137581377a806e8b529) after the RLM prompt section, whenever recursion is allowed (default: true).
> - Updates [refinement.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/306/files#diff-17b614d876315ad8ac0165562a8f07a5c4ada3b28928eb02d90f6b93a96ea91d) to append an invocation hint to non-empty subagent harness state sections, prompting the agent to call `await rlm('<task>')`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f48f4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->