### PR TITLE
pre-import asyncio in the repl kernel

### DIFF
--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -73,9 +73,9 @@ def _prime_agent_snapshot_state():
         ip = None
     ns = ip.user_ns if ip is not None else _b.globals()
     hidden = _b.set(_b.getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else _b.set()
-    # rlm and the wrapped skill modules are live, connection-bound handles that
-    # the bootstrap re-creates on restore; never snapshot them.
-    always_skip = {"rlm", "In", "Out", "get_ipython", "exit", "quit", "open"}
+    # rlm and asyncio are re-created by the kernel bootstrap on every start;
+    # never snapshot them.
+    always_skip = {"rlm", "asyncio", "In", "Out", "get_ipython", "exit", "quit", "open"}
 
     payload = {}
     skipped = []
@@ -205,7 +205,7 @@ def _prime_agent_list_state_names():
         ip = None
     ns = ip.user_ns if ip is not None else _b.globals()
     hidden = _b.set(_b.getattr(ip, "user_ns_hidden", {}) or {}) if ip is not None else _b.set()
-    always_skip = {"rlm", "In", "Out", "get_ipython", "exit", "quit", "open"}
+    always_skip = {"rlm", "asyncio", "In", "Out", "get_ipython", "exit", "quit", "open"}
     names = []
     for name in _b.list(ns.keys()):
         if name.startswith("_") or name in hidden or name in always_skip:

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -76,7 +76,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
-			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
+			"For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`; `asyncio` is already imported.",
 			"For sub-agent work that can run in the background, keep the task handle from `asyncio.create_task(rlm('sub-task'))` so you do not block the main execution path; use normal task callbacks, `task.done()`, or `await task` later to observe completion and read the returned `RLMResult.answer`.",
 		);
 	}

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -18,6 +18,8 @@ import type { PythonSkillRuntimeInfo } from "../skills.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const RLM_BOOTSTRAP_BASE_CODE = `
+import asyncio
+
 try:
     import nest_asyncio as _prime_agent_nest_asyncio
     _prime_agent_nest_asyncio.apply()

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
 import { buildRlmBootstrapCode } from "../src/core/tools/ipython.js";
 
 describe("IPython RLM bootstrap", () => {
+	it("pre-imports asyncio so the prompt's subagent patterns work without a manual import", () => {
+		expect(buildRlmBootstrapCode()).toMatch(/^import asyncio$/m);
+	});
+
 	it("guards Python skill imports so a broken skill does not abort bootstrap", () => {
 		const code = buildRlmBootstrapCode([
 			{
@@ -17,4 +26,44 @@ describe("IPython RLM bootstrap", () => {
 		expect(code).toContain("_PRIME_AGENT_SKILL_IMPORT_ERRORS");
 		expect(code).toContain("globals()[_prime_agent_skill_name] = _PrimeAgentUnavailableSkill");
 	});
+});
+
+/** Find a python that can launch an ipykernel, or null to skip. */
+function resolveKernelPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((p): p is string => Boolean(p));
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import ipykernel"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+const python = resolveKernelPython();
+const describeIfKernel = python ? describe : describe.skip;
+
+describeIfKernel("IPython RLM bootstrap (real kernel)", () => {
+	const dir = mkdtempSync(join(tmpdir(), "prime-agent-bootstrap-"));
+
+	afterAll(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("binds asyncio in the user namespace", async () => {
+		const manager = new KernelManager({ python: python as string, cwd: dir });
+		try {
+			await manager.start();
+			const bootstrap = await manager.execute(buildRlmBootstrapCode());
+			expect(bootstrap.status).toBe("ok");
+
+			const result = await manager.execute("_t = asyncio.create_task(asyncio.sleep(0))\nprint(type(_t).__name__)");
+			expect(result.status).toBe("ok");
+			expect(result.stdout).toContain("Task");
+		} finally {
+			await manager.dispose();
+		}
+	}, 60_000);
 });


### PR DESCRIPTION
- the system prompt tells the model to use asyncio.gather and asyncio.create_task for parallel and background subagents, but the kernel bootstrap never imported asyncio, so the first fan-out hit a NameError.
- the bootstrap now binds asyncio on every kernel start, the prompt notes it is pre-imported, and the snapshot/live-name filters skip it like rlm since the bootstrap recreates it.
- added a live-kernel test asserting asyncio.create_task works right after bootstrap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bootstrap and snapshot filter changes only; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **NameError** when the model follows RLM guidance to use `asyncio.gather` or `asyncio.create_task` for parallel or background sub-agents: the prompt assumed `asyncio` was available, but the kernel bootstrap never imported it.
> 
> The bootstrap now runs **`import asyncio`** on every kernel start (alongside `rlm`). The RLM prompt explicitly states that **`asyncio` is already imported**. Kernel state snapshot/list logic **excludes `asyncio` from persistence** (same treatment as `rlm`), since bootstrap recreates it on restore.
> 
> Tests assert the generated bootstrap includes the import and, when a real ipykernel Python is available, that **`asyncio.create_task` works immediately after bootstrap**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a0ecfd26b2311db49ff8ace0bad9595a4de8842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-import `asyncio` in the IPython REPL kernel bootstrap
> - Prepends `import asyncio` to `RLM_BOOTSTRAP_BASE_CODE` in [`ipython.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/315/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d) so `asyncio` is available in the kernel user namespace without an explicit import.
> - Excludes `asyncio` from the state snapshot and state name listing in [`state-snapshot.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/315/files#diff-a753754f120d668228b1d45376c92f81aaa31900e3479c20d12d07dfde49b324) so it is not persisted as user state.
> - Updates the RLM prompt to note that `asyncio` is already imported when describing parallel sub-agent usage via `asyncio.gather`.
> - Adds a unit assertion and an optional integration test (real `KernelManager`) in [`ipython-bootstrap.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/315/files#diff-8a40d8041aabcb786cecc38b59b3da8cbcca731229f222a72eb193078d09af22) that verifies `asyncio` is bound and usable after bootstrap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a0ecfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->