### PR TITLE
make resume available in agents view

### DIFF
--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -26,7 +26,7 @@ if (process.env.MY_ANTHROPIC_KEY) {
 // Model registry with no custom models.json
 const modelRegistry = ModelRegistry.inMemory(authStorage);
 
-const model = getModel("anthropic", "claude-sonnet-4-20250514");
+const model = getModel("anthropic", "claude-sonnet-5");
 if (!model) throw new Error("Model not found");
 
 // In-memory settings with overrides

--- a/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-commands.ts
@@ -16,7 +16,7 @@ import {
 	resolveBuiltinSlashCommandName,
 } from "../../core/slash-commands.js";
 
-const AGENTS_VIEW_COMMAND_NAMES = ["login", "logout", "model", "quit"] as const;
+const AGENTS_VIEW_COMMAND_NAMES = ["login", "logout", "model", "resume", "quit"] as const;
 
 export type AgentsViewCommandName = (typeof AGENTS_VIEW_COMMAND_NAMES)[number];
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -18,7 +18,7 @@ import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSI
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { findExactModelReferenceMatch } from "../../core/model-resolver.js";
-import { deleteSessionFile } from "../../core/session-file-actions.js";
+import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { type SessionInfo, SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
@@ -125,6 +125,7 @@ type AgentsViewPersistentState = {
 };
 
 type PromptCommand = Extract<DaemonCommand, { type: "prompt" }>;
+type DeleteSavedSessionCommand = Extract<DaemonCommand, { type: "delete_saved_session" }>;
 type PendingDeleteAgent = {
 	identity: string;
 	activeSessionId?: string;
@@ -164,6 +165,18 @@ export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "l
 	// Omitting `all` returns daemon-resident sessions only; on-disk ones come back
 	// via /resume.
 	return { type: "list" };
+}
+
+export function createAgentsViewDeleteSavedSessionCommand(
+	sessionPath: string,
+	summaries: readonly SessionSummary[],
+): DeleteSavedSessionCommand {
+	const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, summaries);
+	const command: DeleteSavedSessionCommand = { type: "delete_saved_session", sessionPath };
+	if (activeSummary?.activeSessionId) {
+		command.activeSessionId = activeSummary.activeSessionId;
+	}
+	return command;
 }
 
 export function resolveAgentsViewResumeSummary(
@@ -1079,7 +1092,7 @@ class AgentsViewMode implements Component, Focusable {
 						}
 						await this.renameSavedSessionFromSelector(sessionPath, name);
 					},
-					deleteSession: deleteSessionFile,
+					deleteSession: (sessionPath) => this.deleteSavedSessionFromSelector(sessionPath),
 					showRenameHint: true,
 					keybindings: this.keybindings,
 				},
@@ -1106,6 +1119,13 @@ class AgentsViewMode implements Component, Focusable {
 		});
 		requireDaemonData(response);
 		await this.refreshSessions();
+	}
+
+	private async deleteSavedSessionFromSelector(sessionPath: string): Promise<DeleteSessionFileResult> {
+		const response = await this.requireClient().request(
+			createAgentsViewDeleteSavedSessionCommand(sessionPath, this.lastListedSummaries),
+		);
+		return expectDeleteSessionFileResult(requireDaemonData(response));
 	}
 
 	private getDefaultModelForNewAgents(): Model<Api> | undefined {
@@ -2169,6 +2189,22 @@ function expectSessionSummary(value: unknown): SessionSummary {
 		throw new Error("Daemon returned an invalid session summary");
 	}
 	return value;
+}
+
+function expectDeleteSessionFileResult(value: unknown): DeleteSessionFileResult {
+	if (!isRecord(value) || typeof value.ok !== "boolean") {
+		throw new Error("Daemon returned an invalid delete session response");
+	}
+	if (value.ok) {
+		if (value.method !== "trash" && value.method !== "unlink") {
+			throw new Error("Daemon returned an invalid delete session response");
+		}
+		return { ok: true, method: value.method };
+	}
+	if (typeof value.error !== "string") {
+		throw new Error("Daemon returned an invalid delete session response");
+	}
+	return { ok: false, error: value.error };
 }
 
 function isSessionSummary(value: unknown): value is SessionSummary {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -167,16 +167,8 @@ export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "l
 	return { type: "list" };
 }
 
-export function createAgentsViewDeleteSavedSessionCommand(
-	sessionPath: string,
-	summaries: readonly SessionSummary[],
-): DeleteSavedSessionCommand {
-	const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, summaries);
-	const command: DeleteSavedSessionCommand = { type: "delete_saved_session", sessionPath };
-	if (activeSummary?.activeSessionId) {
-		command.activeSessionId = activeSummary.activeSessionId;
-	}
-	return command;
+export function createAgentsViewDeleteSavedSessionCommand(sessionPath: string): DeleteSavedSessionCommand {
+	return { type: "delete_saved_session", sessionPath };
 }
 
 export function resolveAgentsViewResumeSummary(
@@ -1122,9 +1114,7 @@ class AgentsViewMode implements Component, Focusable {
 	}
 
 	private async deleteSavedSessionFromSelector(sessionPath: string): Promise<DeleteSessionFileResult> {
-		const response = await this.requireClient().request(
-			createAgentsViewDeleteSavedSessionCommand(sessionPath, this.lastListedSummaries),
-		);
+		const response = await this.requireClient().request(createAgentsViewDeleteSavedSessionCommand(sessionPath));
 		return expectDeleteSessionFileResult(requireDaemonData(response));
 	}
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -171,15 +171,26 @@ export function resolveAgentsViewResumeSummary(
 	savedSessions: readonly SessionInfo[],
 	visibleSummaries: readonly SessionSummary[],
 ): SessionSummary | undefined {
-	const selectedPath = resolvePath(sessionPath);
-	const activeSummary = visibleSummaries.find(
-		(summary) => summary.sessionFile !== undefined && resolvePath(summary.sessionFile) === selectedPath,
-	);
+	const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, visibleSummaries);
 	if (activeSummary) {
 		return activeSummary;
 	}
+	const selectedPath = resolvePath(sessionPath);
 	const savedSession = savedSessions.find((session) => resolvePath(session.path) === selectedPath);
 	return savedSession ? summaryForInactiveSession(savedSession) : undefined;
+}
+
+export function resolveAgentsViewActiveSummaryForPath(
+	sessionPath: string,
+	summaries: readonly SessionSummary[],
+): SessionSummary | undefined {
+	const selectedPath = resolvePath(sessionPath);
+	return summaries.find(
+		(summary) =>
+			summary.activeSessionId !== undefined &&
+			summary.sessionFile !== undefined &&
+			resolvePath(summary.sessionFile) === selectedPath,
+	);
 }
 
 // Status messages render in a single-row hint slot below the editor; embedded
@@ -1066,7 +1077,7 @@ class AgentsViewMode implements Component, Focusable {
 						if (!name) {
 							return;
 						}
-						SessionManager.open(sessionPath).appendSessionInfo(name);
+						await this.renameSavedSessionFromSelector(sessionPath, name);
 					},
 					deleteSession: deleteSessionFile,
 					showRenameHint: true,
@@ -1079,6 +1090,22 @@ class AgentsViewMode implements Component, Focusable {
 
 	private getSavedSessionCwd(): string {
 		return this.options.config.cwd ?? this.options.uiServices.getInitialCwd();
+	}
+
+	private async renameSavedSessionFromSelector(sessionPath: string, name: string): Promise<void> {
+		const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, this.lastListedSummaries);
+		if (!activeSummary?.activeSessionId) {
+			SessionManager.open(sessionPath).appendSessionInfo(name);
+			return;
+		}
+		const response = await this.requireClient().request({
+			type: "rename_saved_session",
+			activeSessionId: activeSummary.activeSessionId,
+			sessionPath,
+			name,
+		});
+		requireDaemonData(response);
+		await this.refreshSessions();
 	}
 
 	private getDefaultModelForNewAgents(): Model<Api> | undefined {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -364,6 +364,7 @@ class AgentsViewMode implements Component, Focusable {
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | undefined;
 	private workingIconFrame = 0;
 	private rows: AgentsViewRow[] = [];
+	private lastListedSummaries: SessionSummary[] = [];
 	private lastVisibleSummaries: SessionSummary[] = [];
 	private expandedSubagentParents = new Set<string>();
 	// Agent row identities whose full spawn program is currently shown.
@@ -1044,7 +1045,7 @@ class AgentsViewMode implements Component, Focusable {
 					const summary = resolveAgentsViewResumeSummary(
 						sessionPath,
 						[...savedSessionsByPath.values()],
-						this.lastVisibleSummaries,
+						this.lastListedSummaries,
 					);
 					close();
 					if (!summary) {
@@ -1667,6 +1668,7 @@ class AgentsViewMode implements Component, Focusable {
 			const response = await client.request(createAgentsViewListCommand());
 			const data = requireDaemonData(response);
 			const sessions = expectSessionList(data);
+			this.lastListedSummaries = sessions;
 			const visibleSessions = sessions.filter((summary) =>
 				shouldShowAgentsViewSession(summary, this.inactiveAgentIdentities.has(getSummaryIdentity(summary))),
 			);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import type { AutocompleteItem, OverlayHandle, SlashCommand } from "@earendil-works/pi-tui";
 import {
@@ -17,16 +18,22 @@ import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSI
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { findExactModelReferenceMatch } from "../../core/model-resolver.js";
-import { SessionManager } from "../../core/session-manager.js";
+import { deleteSessionFile } from "../../core/session-file-actions.js";
+import { type SessionInfo, SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
 import { type DaemonCommand, type DaemonResponse, isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
-import { resolveAttachModelFallbackMessage, type SessionSummary } from "../daemon/daemon-session-list.js";
+import {
+	resolveAttachModelFallbackMessage,
+	type SessionSummary,
+	summaryForInactiveSession,
+} from "../daemon/daemon-session-list.js";
 import { getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "../interactive/auth-flows.js";
 import { showFullPaneOverlay } from "../interactive/components/centered-overlay.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
 import { ModelSelectorComponent } from "../interactive/components/model-selector.js";
+import { SessionSelectorComponent } from "../interactive/components/session-selector.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
 import type { InteractiveModeUiServices } from "../interactive/interactive-mode-services.js";
 import {
@@ -157,6 +164,22 @@ export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "l
 	// Omitting `all` returns daemon-resident sessions only; on-disk ones come back
 	// via /resume.
 	return { type: "list" };
+}
+
+export function resolveAgentsViewResumeSummary(
+	sessionPath: string,
+	savedSessions: readonly SessionInfo[],
+	visibleSummaries: readonly SessionSummary[],
+): SessionSummary | undefined {
+	const selectedPath = resolvePath(sessionPath);
+	const activeSummary = visibleSummaries.find(
+		(summary) => summary.sessionFile !== undefined && resolvePath(summary.sessionFile) === selectedPath,
+	);
+	if (activeSummary) {
+		return activeSummary;
+	}
+	const savedSession = savedSessions.find((session) => resolvePath(session.path) === selectedPath);
+	return savedSession ? summaryForInactiveSession(savedSession) : undefined;
 }
 
 // Status messages render in a single-row hint slot below the editor; embedded
@@ -907,6 +930,9 @@ class AgentsViewMode implements Component, Focusable {
 				await this.showModelSelector(searchTerm);
 				return;
 			}
+			case "resume":
+				await this.showSessionSelector();
+				return;
 			case "quit":
 				this.finish({ type: "exit" });
 				return;
@@ -982,6 +1008,76 @@ class AgentsViewMode implements Component, Focusable {
 			);
 			handle = showFullPaneOverlay(this.ui, selector, 96);
 		});
+	}
+
+	private showSessionSelector(): Promise<void> {
+		return new Promise((done) => {
+			let handle: OverlayHandle | undefined;
+			let settled = false;
+			const savedSessionsByPath = new Map<string, SessionInfo>();
+
+			const rememberSessions = (sessions: SessionInfo[]): SessionInfo[] => {
+				for (const session of sessions) {
+					savedSessionsByPath.set(resolvePath(session.path), session);
+				}
+				return sessions;
+			};
+
+			const close = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				handle?.hide();
+				this.ui.requestRender();
+				done();
+			};
+
+			const selector = new SessionSelectorComponent(
+				async (onProgress) =>
+					rememberSessions(
+						await SessionManager.list(this.getSavedSessionCwd(), this.options.config.sessionDir, onProgress),
+					),
+				async (onProgress) =>
+					rememberSessions(await SessionManager.listAll(onProgress, this.options.config.sessionDir)),
+				(sessionPath) => {
+					const summary = resolveAgentsViewResumeSummary(
+						sessionPath,
+						[...savedSessionsByPath.values()],
+						this.lastVisibleSummaries,
+					);
+					close();
+					if (!summary) {
+						this.setStatusMessage("Failed to resume session: selected session was not found");
+						return;
+					}
+					this.finish({ type: "open", summary });
+				},
+				close,
+				() => {
+					close();
+					this.finish({ type: "exit" });
+				},
+				() => this.ui.requestRender(),
+				{
+					renameSession: async (sessionPath, nextName) => {
+						const name = (nextName ?? "").trim();
+						if (!name) {
+							return;
+						}
+						SessionManager.open(sessionPath).appendSessionInfo(name);
+					},
+					deleteSession: deleteSessionFile,
+					showRenameHint: true,
+					keybindings: this.keybindings,
+				},
+			);
+			handle = showFullPaneOverlay(this.ui, selector, 96);
+		});
+	}
+
+	private getSavedSessionCwd(): string {
+		return this.options.config.cwd ?? this.options.uiServices.getInitialCwd();
 	}
 
 	private getDefaultModelForNewAgents(): Model<Api> | undefined {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -819,33 +819,43 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
+			let result: DeleteSessionFileResult;
 			try {
-				const result = await this.deleteSession(sessionPath);
-
-				if (result.ok) {
-					if (this.currentSessions) {
-						this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
-					}
-					if (this.allSessions) {
-						this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
-					}
-
-					const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
-					const showCwd = this.scope === "all";
-					this.sessionList.setSessions(sessions, showCwd);
-
-					const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
-					this.header.setStatusMessage({ type: "info", message: msg }, 2000);
-					await this.refreshSessionsAfterMutation();
-				} else {
-					const errorMessage = result.error ?? "Unknown error";
-					this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
-				}
+				result = await this.deleteSession(sessionPath);
 			} catch (error) {
 				this.header.setStatusMessage(
 					{ type: "error", message: `Failed to delete: ${formatMutationError(error)}` },
 					3000,
 				);
+				this.requestRender();
+				return;
+			}
+
+			if (result.ok) {
+				if (this.currentSessions) {
+					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+				}
+				if (this.allSessions) {
+					this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
+				}
+
+				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
+				const showCwd = this.scope === "all";
+				this.sessionList.setSessions(sessions, showCwd);
+
+				const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
+				try {
+					await this.refreshSessionsAfterMutation();
+					this.header.setStatusMessage({ type: "info", message: msg }, 2000);
+				} catch (error) {
+					this.header.setStatusMessage(
+						{ type: "error", message: `${msg}; refresh failed: ${formatMutationError(error)}` },
+						3000,
+					);
+				}
+			} else {
+				const errorMessage = result.error ?? "Unknown error";
+				this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
 			}
 
 			this.requestRender();

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -59,6 +59,10 @@ function canonicalizePath(path: string | undefined): string | undefined {
 	return _canonicalizePath(path);
 }
 
+function formatMutationError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 class SessionSelectorHeader implements Component {
 	private scope: SessionScope;
 	private sortMode: SortMode;
@@ -129,6 +133,7 @@ class SessionSelectorHeader implements Component {
 			this.statusTimeout = null;
 			this.requestRender();
 		}, autoHideMs);
+		this.statusTimeout.unref?.();
 	}
 
 	invalidate(): void {}
@@ -814,26 +819,33 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
-			const result = await this.deleteSession(sessionPath);
+			try {
+				const result = await this.deleteSession(sessionPath);
 
-			if (result.ok) {
-				if (this.currentSessions) {
-					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+				if (result.ok) {
+					if (this.currentSessions) {
+						this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+					}
+					if (this.allSessions) {
+						this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
+					}
+
+					const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
+					const showCwd = this.scope === "all";
+					this.sessionList.setSessions(sessions, showCwd);
+
+					const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
+					this.header.setStatusMessage({ type: "info", message: msg }, 2000);
+					await this.refreshSessionsAfterMutation();
+				} else {
+					const errorMessage = result.error ?? "Unknown error";
+					this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
 				}
-				if (this.allSessions) {
-					this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
-				}
-
-				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
-				const showCwd = this.scope === "all";
-				this.sessionList.setSessions(sessions, showCwd);
-
-				const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
-				this.header.setStatusMessage({ type: "info", message: msg }, 2000);
-				await this.refreshSessionsAfterMutation();
-			} else {
-				const errorMessage = result.error ?? "Unknown error";
-				this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
+			} catch (error) {
+				this.header.setStatusMessage(
+					{ type: "error", message: `Failed to delete: ${formatMutationError(error)}` },
+					3000,
+				);
 			}
 
 			this.requestRender();
@@ -898,8 +910,14 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		try {
 			await renameSession(target, next);
 			await this.refreshSessionsAfterMutation();
-		} finally {
 			this.exitRenameMode();
+		} catch (error) {
+			this.exitRenameMode();
+			this.header.setStatusMessage(
+				{ type: "error", message: `Failed to rename: ${formatMutationError(error)}` },
+				4000,
+			);
+			this.requestRender();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -919,8 +919,6 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		try {
 			await renameSession(target, next);
-			await this.refreshSessionsAfterMutation();
-			this.exitRenameMode();
 		} catch (error) {
 			this.exitRenameMode();
 			this.header.setStatusMessage(
@@ -928,7 +926,22 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				4000,
 			);
 			this.requestRender();
+			return;
 		}
+
+		try {
+			await this.refreshSessionsAfterMutation();
+		} catch (error) {
+			this.exitRenameMode();
+			this.header.setStatusMessage(
+				{ type: "error", message: `Session renamed; refresh failed: ${formatMutationError(error)}` },
+				4000,
+			);
+			this.requestRender();
+			return;
+		}
+
+		this.exitRenameMode();
 	}
 
 	private async loadScope(scope: SessionScope, reason: "initial" | "refresh" | "toggle"): Promise<void> {

--- a/packages/coding-agent/test/agents-view-commands.test.ts
+++ b/packages/coding-agent/test/agents-view-commands.test.ts
@@ -33,13 +33,13 @@ describe("parseSlashCommand", () => {
 
 describe("classifyAgentsViewCommand", () => {
 	test("whitelisted global commands run in the agents view", () => {
-		for (const name of ["login", "logout", "model", "quit"]) {
+		for (const name of ["login", "logout", "model", "resume", "quit"]) {
 			expect(classifyAgentsViewCommand(name)).toBe("agents-view");
 		}
 	});
 
 	test("other built-ins are session-only", () => {
-		for (const name of ["compact", "fork", "settings", "resume", "new", "clear", "export"]) {
+		for (const name of ["compact", "fork", "settings", "new", "clear", "export"]) {
 			expect(classifyAgentsViewCommand(name)).toBe("session-only");
 		}
 	});

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import type { AgentSessionRuntimeConfig } from "../src/core/agent-session-config.js";
 import type { ModelRegistry } from "../src/core/model-registry.js";
+import type { SessionInfo } from "../src/core/session-manager.js";
 import type { SettingsManager } from "../src/core/settings-manager.js";
 import {
 	createAgentsViewListCommand,
@@ -13,6 +14,7 @@ import {
 	formatAgentsViewRelativeTime,
 	formatAgentsViewStatusLine,
 	resolveAgentsViewOpenCwd,
+	resolveAgentsViewResumeSummary,
 	resolveAgentsViewSessionUiServices,
 } from "../src/modes/agents-view/agents-view-mode.js";
 import {
@@ -510,6 +512,45 @@ describe("agents view state", () => {
 		expect(createAgentsViewListCommand()).toEqual({ type: "list" });
 	});
 
+	test("creates an inactive summary for a saved session selected from resume", () => {
+		const savedSession = makeSessionInfo({
+			path: "/tmp/sessions/saved.jsonl",
+			id: "saved",
+			name: "Saved session",
+			cwd: "/tmp/project",
+		});
+
+		const summary = resolveAgentsViewResumeSummary(savedSession.path, [savedSession], []);
+
+		expect(summary).toMatchObject({
+			id: "saved",
+			activity: "idle",
+			sessionId: "saved",
+			sessionFile: savedSession.path,
+			sessionName: "Saved session",
+			cwd: "/tmp/project",
+		});
+		expect(summary?.activeSessionId).toBeUndefined();
+		expect(summary?.lifecycle).toBe("live");
+	});
+
+	test("reuses the live daemon summary when resuming an already-active saved session", () => {
+		const savedSession = makeSessionInfo({
+			path: "/tmp/sessions/active.jsonl",
+			id: "saved-active",
+			cwd: "/tmp/project",
+		});
+		const activeSummary = makeSummary({
+			id: "active-runtime",
+			activeSessionId: "active-runtime",
+			sessionId: "saved-active",
+			sessionFile: savedSession.path,
+			sessionName: "Running",
+		});
+
+		expect(resolveAgentsViewResumeSummary(savedSession.path, [savedSession], [activeSummary])).toBe(activeSummary);
+	});
+
 	test("derives the reply headline from the first line of the latest assistant text", () => {
 		expect(createAgentsViewReplyHeadline("  Done.\nNext step?  ")).toBe("Done.");
 		expect(createAgentsViewReplyHeadline("\n\n  spread   over \nlines")).toBe("spread over");
@@ -633,6 +674,23 @@ function makeSummary(overrides: Partial<SessionSummary>): SessionSummary {
 		messageCount: 1,
 		pendingMessageCount: 0,
 		...overrides,
+	};
+}
+
+function makeSessionInfo(overrides: Partial<SessionInfo> & { path: string; id: string }): SessionInfo {
+	return {
+		path: overrides.path,
+		id: overrides.id,
+		cwd: overrides.cwd ?? "/tmp/project",
+		name: overrides.name,
+		state: overrides.state,
+		parentSessionPath: overrides.parentSessionPath,
+		created: overrides.created ?? new Date("2026-01-01T00:00:00Z"),
+		modified: overrides.modified ?? new Date("2026-01-01T00:00:00Z"),
+		messageCount: overrides.messageCount ?? 1,
+		firstMessage: overrides.firstMessage ?? "hello",
+		allMessagesText: overrides.allMessagesText ?? "hello",
+		agentStatus: overrides.agentStatus,
 	};
 }
 

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -13,6 +13,7 @@ import {
 	createAgentsViewSessionName,
 	formatAgentsViewRelativeTime,
 	formatAgentsViewStatusLine,
+	resolveAgentsViewActiveSummaryForPath,
 	resolveAgentsViewOpenCwd,
 	resolveAgentsViewResumeSummary,
 	resolveAgentsViewSessionUiServices,
@@ -549,6 +550,27 @@ describe("agents view state", () => {
 		});
 
 		expect(resolveAgentsViewResumeSummary(savedSession.path, [savedSession], [activeSummary])).toBe(activeSummary);
+	});
+
+	test("resolves active summaries by session file path", () => {
+		const activeSummary = makeSummary({
+			id: "active-runtime",
+			activeSessionId: "active-runtime",
+			sessionId: "saved-active",
+			sessionFile: "/tmp/sessions/active.jsonl",
+			sessionName: "Running",
+		});
+		const inactiveSummary = makeSummary({
+			id: "inactive",
+			activeSessionId: undefined,
+			sessionId: "inactive",
+			sessionFile: "/tmp/sessions/inactive.jsonl",
+		});
+
+		expect(
+			resolveAgentsViewActiveSummaryForPath("/tmp/sessions/active.jsonl", [inactiveSummary, activeSummary]),
+		).toBe(activeSummary);
+		expect(resolveAgentsViewActiveSummaryForPath("/tmp/sessions/inactive.jsonl", [inactiveSummary])).toBeUndefined();
 	});
 
 	test("derives the reply headline from the first line of the latest assistant text", () => {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -574,21 +574,12 @@ describe("agents view state", () => {
 		expect(resolveAgentsViewActiveSummaryForPath("/tmp/sessions/inactive.jsonl", [inactiveSummary])).toBeUndefined();
 	});
 
-	test("routes saved session deletes through the active daemon session when present", () => {
-		const activeSummary = makeSummary({
-			id: "active-runtime",
-			activeSessionId: "active-runtime",
-			sessionId: "saved-active",
-			sessionFile: "/tmp/sessions/active.jsonl",
-			sessionName: "Running",
-		});
-
-		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/active.jsonl", [activeSummary])).toEqual({
+	test("routes saved session deletes through the daemon file guard", () => {
+		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/active.jsonl")).toEqual({
 			type: "delete_saved_session",
-			activeSessionId: "active-runtime",
 			sessionPath: "/tmp/sessions/active.jsonl",
 		});
-		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/inactive.jsonl", [activeSummary])).toEqual({
+		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/inactive.jsonl")).toEqual({
 			type: "delete_saved_session",
 			sessionPath: "/tmp/sessions/inactive.jsonl",
 		});

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -7,6 +7,7 @@ import type { ModelRegistry } from "../src/core/model-registry.js";
 import type { SessionInfo } from "../src/core/session-manager.js";
 import type { SettingsManager } from "../src/core/settings-manager.js";
 import {
+	createAgentsViewDeleteSavedSessionCommand,
 	createAgentsViewListCommand,
 	createAgentsViewReplyHeadline,
 	createAgentsViewResumeConfig,
@@ -571,6 +572,26 @@ describe("agents view state", () => {
 			resolveAgentsViewActiveSummaryForPath("/tmp/sessions/active.jsonl", [inactiveSummary, activeSummary]),
 		).toBe(activeSummary);
 		expect(resolveAgentsViewActiveSummaryForPath("/tmp/sessions/inactive.jsonl", [inactiveSummary])).toBeUndefined();
+	});
+
+	test("routes saved session deletes through the active daemon session when present", () => {
+		const activeSummary = makeSummary({
+			id: "active-runtime",
+			activeSessionId: "active-runtime",
+			sessionId: "saved-active",
+			sessionFile: "/tmp/sessions/active.jsonl",
+			sessionName: "Running",
+		});
+
+		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/active.jsonl", [activeSummary])).toEqual({
+			type: "delete_saved_session",
+			activeSessionId: "active-runtime",
+			sessionPath: "/tmp/sessions/active.jsonl",
+		});
+		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/inactive.jsonl", [activeSummary])).toEqual({
+			type: "delete_saved_session",
+			sessionPath: "/tmp/sessions/inactive.jsonl",
+		});
 	});
 
 	test("derives the reply headline from the first line of the latest assistant text", () => {

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -238,6 +238,39 @@ describe("session selector path/delete interactions", () => {
 		expect(output).toContain("Failed to delete: Cannot delete the currently active session");
 	});
 
+	it("keeps delete success visible when refresh after deletion fails", async () => {
+		const sessions = [makeSession({ id: "a" })];
+		const deleteSession = vi.fn(async () => ({ ok: true as const, method: "unlink" as const }));
+		let loadCalls = 0;
+
+		const selector = new SessionSelectorComponent(
+			async () => {
+				loadCalls++;
+				if (loadCalls > 1) {
+					throw new Error("refresh unavailable");
+				}
+				return sessions;
+			},
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings, deleteSession },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput(CTRL_X);
+		list.handleInput(CTRL_X);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(deleteSession).toHaveBeenCalledTimes(1);
+		expect(output).toContain("Session deleted");
+		expect(output).not.toContain("Failed to delete");
+	});
+
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
 		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { AgentConnectionSavedSessionInfo } from "../src/modes/agent-connection/index.js";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { initTheme, preloadCodeHighlighter } from "../src/modes/interactive/theme/theme.js";
 
 type Deferred<T> = {
 	promise: Promise<T>;
@@ -103,9 +103,10 @@ describe("session selector path/delete interactions", () => {
 		setKeybindings(new KeybindingsManager());
 	});
 
-	beforeAll(() => {
+	beforeAll(async () => {
 		// session selector uses the global theme instance
 		initTheme("dark");
+		await preloadCodeHighlighter();
 	});
 	it("does not treat Ctrl+Backspace as delete when search query is non-empty", async () => {
 		const sessions = [makeSession({ id: "a" }), makeSession({ id: "b" })];
@@ -208,6 +209,33 @@ describe("session selector path/delete interactions", () => {
 
 		expect(deleteSession).toHaveBeenCalledTimes(1);
 		expect(deleteSession).toHaveBeenCalledWith(sessions[0]!.path);
+	});
+
+	it("shows an error when the injected delete handler rejects", async () => {
+		const sessions = [makeSession({ id: "a" })];
+		const deleteSession = vi.fn(async () => {
+			throw new Error("Cannot delete the currently active session");
+		});
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings, deleteSession },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput(CTRL_X);
+		list.handleInput(CTRL_X);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(deleteSession).toHaveBeenCalledTimes(1);
+		expect(output).toContain("Failed to delete: Cannot delete the currently active session");
 	});
 
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -141,4 +141,39 @@ describe("session selector rename", () => {
 		expect(output).toContain("Resume Session");
 		expect(output).toContain("Failed to rename: daemon unavailable");
 	});
+
+	it("does not report rename failure when refresh after rename fails", async () => {
+		const sessions = [makeSession({ id: "a", name: "Old" })];
+		const renameSession = vi.fn(async () => {});
+		let loadCalls = 0;
+
+		const keybindings = new KeybindingsManager();
+		const selector = new SessionSelectorComponent(
+			async () => {
+				loadCalls++;
+				if (loadCalls > 1) {
+					throw new Error("refresh unavailable");
+				}
+				return sessions;
+			},
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ renameSession, showRenameHint: true, keybindings },
+		);
+		await flushPromises();
+
+		selector.getSessionList().handleInput(CTRL_R);
+		await flushPromises();
+
+		selector.handleInput("\r");
+		await flushPromises();
+
+		const output = selector.render(120).join("\n");
+		expect(renameSession).toHaveBeenCalledTimes(1);
+		expect(output).toContain("Resume Session");
+		expect(output).not.toContain("Failed to rename");
+	});
 });

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { AgentConnectionSavedSessionInfo } from "../src/modes/agent-connection/index.js";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { initTheme, preloadCodeHighlighter } from "../src/modes/interactive/theme/theme.js";
 
 async function flushPromises(): Promise<void> {
 	await new Promise<void>((resolve) => {
@@ -31,8 +31,9 @@ function makeSession(
 const CTRL_R = "\x1b[114;5u";
 
 describe("session selector rename", () => {
-	beforeAll(() => {
+	beforeAll(async () => {
 		initTheme("dark");
+		await preloadCodeHighlighter();
 	});
 
 	beforeEach(() => {
@@ -109,5 +110,35 @@ describe("session selector rename", () => {
 
 		expect(renameSession).toHaveBeenCalledTimes(1);
 		expect(renameSession).toHaveBeenCalledWith(sessions[0]!.path, "XOld");
+	});
+
+	it("shows an error when rename fails", async () => {
+		const sessions = [makeSession({ id: "a", name: "Old" })];
+		const renameSession = vi.fn(async () => {
+			throw new Error("daemon unavailable");
+		});
+
+		const keybindings = new KeybindingsManager();
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ renameSession, showRenameHint: true, keybindings },
+		);
+		await flushPromises();
+
+		selector.getSessionList().handleInput(CTRL_R);
+		await flushPromises();
+
+		selector.handleInput("\r");
+		await flushPromises();
+
+		const output = selector.render(120).join("\n");
+		expect(renameSession).toHaveBeenCalledTimes(1);
+		expect(output).toContain("Resume Session");
+		expect(output).toContain("Failed to rename: daemon unavailable");
 	});
 });


### PR DESCRIPTION
- /resume now opens the saved-session picker from agents view before a chat exists.
- selected sessions reuse the existing agents view open flow, including active-session reuse.
- added regression coverage for command classification and saved-session resume resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session open/resume and daemon-mediated delete/rename paths; mistakes could open the wrong session or mishandle active vs on-disk sessions, though behavior is largely reused from in-session flows with new regression tests.
> 
> **Overview**
> **`/resume` is now available from the session-less agents view**, where it was previously treated as session-only.
> 
> Running it opens the same **saved-session picker overlay** (`SessionSelectorComponent`) used in interactive mode. Picking a session exits the overlay and uses the existing **open-agent** flow: live daemon sessions are matched by session file path and reused; on-disk-only sessions get an inactive `SessionSummary` via `summaryForInactiveSession`. The picker supports **rename** (daemon `rename_saved_session` when active, otherwise `SessionManager` on disk) and **delete** (daemon `delete_saved_session`).
> 
> **`SessionSelectorComponent`** now surfaces **rename/delete failures** from injected handlers and still shows success after delete/rename when a post-mutation **refresh** fails. Status auto-hide timers call **`unref`** so they do not keep the process alive.
> 
> Tests cover command whitelisting, resume summary resolution, and selector error/refresh edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313a91664e2697793aa998324f667d5f0a949b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resume command to agents view with session selector for saved sessions
> - Adds `resume` to the agents view command whitelist so `classifyAgentsViewCommand` routes it to the agents view handler.
> - Implements `AgentsViewMode.showSessionSelector` which renders a full-screen `SessionSelectorComponent` overlay listing current and saved sessions, resolved via `SessionManager.list` and `SessionManager.listAll`.
> - Selecting a saved session resolves to either an existing active summary (matched by session file path) or a synthesized inactive summary from saved session metadata.
> - Rename and delete operations are wired through the daemon for active sessions and directly via `SessionManager` for inactive ones; responses are strictly validated.
> - Delete and rename errors in `SessionSelectorComponent` are now caught and surfaced as status messages, with distinct messages when a subsequent session refresh fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 313a916.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->