### PR TITLE
add prompt stashing for draft prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added daemon-backed user orchestration with agent-to-agent messaging and read-only observation of active sessions.
 - Added an orchestration heartbeat skill for compact multi-session progress, blocker, and action summaries.
 - Added an opt-in auto-refine review hook that can ask whether `/refine` should run after turn intervals or compaction checkpoints.
+- Added prompt stashing so a draft can be temporarily saved, a separate prompt or command can run, and the draft is restored afterward.
 
 ## [0.2.4] - 2026-07-01
 

--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -26,7 +26,7 @@ if (process.env.MY_ANTHROPIC_KEY) {
 // Model registry with no custom models.json
 const modelRegistry = ModelRegistry.inMemory(authStorage);
 
-const model = getModel("anthropic", "claude-sonnet-4-20250514");
+const model = getModel("anthropic", "claude-sonnet-5");
 if (!model) throw new Error("Model not found");
 
 // In-memory settings with overrides

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -23,6 +23,7 @@ export interface AppKeybindings {
 	"app.subagents.focus": true;
 	"app.session.toggleNamedFilter": true;
 	"app.editor.external": true;
+	"app.prompt.stash": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
@@ -95,6 +96,10 @@ export const KEYBINDINGS = {
 	"app.editor.external": {
 		defaultKeys: "ctrl+g",
 		description: "Open external editor",
+	},
+	"app.prompt.stash": {
+		defaultKeys: "ctrl+s",
+		description: "Stash or restore draft prompt",
 	},
 	"app.message.followUp": {
 		defaultKeys: "alt+enter",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -501,6 +501,7 @@ export class InteractiveMode {
 	private queuedMessagesContainer: Container;
 	private defaultEditor: CustomEditor;
 	private editor: EditorComponent;
+	private promptStash: string | undefined;
 	private editorComponentFactory: EditorFactory | undefined;
 	private autocompleteProvider: AutocompleteProvider | undefined;
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
@@ -949,6 +950,7 @@ export class InteractiveMode {
 						hint("app.thinking.toggle", "to expand thinking"),
 						hint("app.subagents.focus", "to inspect subagents"),
 						hint("app.editor.external", "for external editor"),
+						hint("app.prompt.stash", "to stash prompt"),
 						rawKeyHint("/", "for commands"),
 						hint("app.message.followUp", "to queue follow-up"),
 						hint("app.message.dequeue", "to edit all queued messages"),
@@ -2286,6 +2288,7 @@ export class InteractiveMode {
 		// stays monotonic so a new paste never reuses an id that may still appear in
 		// restored text.
 		this.pastedImages.clear();
+		this.promptStash = undefined;
 		this.defaultEditor.clearHistory?.();
 		this.defaultEditor.setText("");
 		if (this.editor !== this.defaultEditor) {
@@ -3362,6 +3365,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
 		this.defaultEditor.onAction("app.subagents.focus", () => this.focusChildAgentSummary());
 		this.defaultEditor.onAction("app.editor.external", () => this.openExternalEditor());
+		this.defaultEditor.onAction("app.prompt.stash", () => this.handlePromptStash());
 		this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 		this.defaultEditor.onAction("app.message.dequeue", () => {
 			void this.handleDequeue();
@@ -3395,6 +3399,34 @@ export class InteractiveMode {
 		this.defaultEditor.onPasteImage = () => {
 			this.handleClipboardImagePaste();
 		};
+	}
+
+	private handlePromptStash(): void {
+		const text = this.editor.getExpandedText?.() ?? this.editor.getText();
+		if (!text.trim()) {
+			if (!this.restorePromptStashIfEditorEmpty()) {
+				this.showStatus("No prompt to stash");
+			}
+			return;
+		}
+		if (this.promptStash !== undefined) {
+			this.showStatus("Prompt stash already has a draft");
+			return;
+		}
+		this.promptStash = text;
+		this.editor.setText("");
+		this.showStatus("Stashed prompt");
+	}
+
+	private restorePromptStashIfEditorEmpty(): boolean {
+		if (this.promptStash === undefined || this.editor.getText().trim()) {
+			return false;
+		}
+		const text = this.promptStash;
+		this.promptStash = undefined;
+		this.editor.setText(text);
+		this.showStatus("Restored stashed prompt");
+		return true;
 	}
 
 	private async handleClipboardImagePaste(): Promise<void> {
@@ -3460,6 +3492,9 @@ export class InteractiveMode {
 			}
 		};
 		add(this.editor.getText());
+		if (this.promptStash !== undefined) {
+			add(this.promptStash);
+		}
 		for (const entry of this.editor.getHistory?.() ?? []) {
 			add(entry);
 		}
@@ -3496,265 +3531,274 @@ export class InteractiveMode {
 		this.defaultEditor.onSubmit = async (text: string) => {
 			text = text.trim();
 			if (!text) return;
+			const shouldRestorePromptStash = this.promptStash !== undefined;
 
-			const slashCommand = parseSlashCommand(text);
-			const commandName = slashCommand ? resolveBuiltinSlashCommandName(slashCommand.name) : undefined;
-			const commandArgs = slashCommand?.args ?? "";
-			const canonicalCommandText = commandName ? `/${commandName}${commandArgs ? ` ${commandArgs}` : ""}` : text;
+			try {
+				const slashCommand = parseSlashCommand(text);
+				const commandName = slashCommand ? resolveBuiltinSlashCommandName(slashCommand.name) : undefined;
+				const commandArgs = slashCommand?.args ?? "";
+				const canonicalCommandText = commandName ? `/${commandName}${commandArgs ? ` ${commandArgs}` : ""}` : text;
 
-			// Handle commands
-			if (commandName === "settings" && !commandArgs) {
-				await this.showSettingsSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "scoped-models" && !commandArgs) {
-				this.editor.setText("");
-				await this.showModelsSelector();
-				return;
-			}
-			if (commandName === "model") {
-				const searchTerm = commandArgs || undefined;
-				this.editor.setText("");
-				await this.handleModelCommand(searchTerm);
-				return;
-			}
-			if (commandName === "effort") {
-				this.editor.setText("");
-				this.handleEffortCommand(commandArgs);
-				return;
-			}
-			if (commandName === "export") {
-				await this.handleExportCommand(canonicalCommandText);
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "import") {
-				await this.handleImportCommand(canonicalCommandText);
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "share" && !commandArgs) {
-				await this.handleShareCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "copy" && !commandArgs) {
-				await this.handleCopyCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "name") {
-				await this.handleNameCommand(canonicalCommandText);
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "session" && !commandArgs) {
-				this.echoLocalCommand(text);
-				await this.handleSessionCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "system-prompt" && !commandArgs) {
-				this.echoLocalCommand(text);
-				await this.handleSystemPromptCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "traces") {
-				await this.handleTracesCommand(canonicalCommandText);
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "context" && !commandArgs) {
-				this.echoLocalCommand(text);
-				await this.handleContextCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "logs" && !commandArgs) {
-				this.echoLocalCommand(text);
-				this.handleLogsCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "goal" && (!commandArgs || commandArgs === "status")) {
-				this.echoLocalCommand(text);
-				this.handleGoalStatusCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "heartbeat") {
-				await this.handleHeartbeatCommand(canonicalCommandText);
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "changelog" && !commandArgs) {
-				this.echoLocalCommand(text);
-				this.handleChangelogCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "hotkeys" && !commandArgs) {
-				this.echoLocalCommand(text);
-				this.handleHotkeysCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "fork" && !commandArgs) {
-				void this.showUserMessageSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "clone" && !commandArgs) {
-				this.editor.setText("");
-				await this.handleCloneCommand();
-				return;
-			}
-			if (commandName === "tree" && !commandArgs) {
-				void this.showTreeSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (commandName === "login" && !commandArgs) {
-				this.editor.setText("");
-				await this.showOAuthSelector("login");
-				return;
-			}
-			if (commandName === "logout" && !commandArgs) {
-				this.editor.setText("");
-				await this.showOAuthSelector("logout");
-				return;
-			}
-			if (commandName === "mcp") {
-				this.editor.setText("");
-				await this.handleMcpCommand(commandArgs);
-				return;
-			}
-			if (commandName === "new" && !commandArgs) {
-				this.editor.setText("");
-				await this.handleClearCommand();
-				return;
-			}
-			if (commandName === "compact") {
-				const customInstructions = commandArgs || undefined;
-				this.editor.setText("");
-				await this.handleCompactCommand(customInstructions);
-				return;
-			}
-			if (commandName === "refine") {
-				const refineArgs = commandArgs || undefined;
-				this.editor.setText("");
-				await this.handleRefineCommand(refineArgs);
-				return;
-			}
-			if (commandName === "reload" && !commandArgs) {
-				this.editor.setText("");
-				await this.handleReloadCommand();
-				return;
-			}
-			if (commandName === "fullscreen") {
-				this.editor.setText("");
-				const arg = commandArgs?.trim().toLowerCase();
-				if (arg && arg !== "on" && arg !== "off") {
-					this.showError("Usage: /fullscreen [on|off]");
+				// Handle commands
+				if (commandName === "settings" && !commandArgs) {
+					await this.showSettingsSelector();
+					this.editor.setText("");
 					return;
 				}
-				const enable = arg === "on" ? true : arg === "off" ? false : !this.fullscreenEnabled;
-				this.setFullscreenMode(enable);
-				return;
-			}
-			if (commandName === "debug" && !commandArgs) {
-				await this.handleDebugCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/arminsayshi") {
-				this.handleArminSaysHi();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/dementedelves") {
-				this.handleDementedDelves();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/resume") {
-				void this.showSessionSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/quit") {
-				this.editor.setText("");
-				await this.shutdown();
-				return;
-			}
-
-			// Handle bash command (! for normal, !! for excluded from context)
-			if (text.startsWith("!")) {
-				const isExcluded = text.startsWith("!!");
-				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
-				if (!command) {
-					// Bare ! / !! is bash mode with nothing to run; don't send it as a prompt
+				if (commandName === "scoped-models" && !commandArgs) {
+					this.editor.setText("");
+					await this.showModelsSelector();
 					return;
 				}
-				if (this.isBashRunning()) {
-					this.showWarning(`A bash command is already running. Press ${keyText("app.clear")} to cancel it first.`);
+				if (commandName === "model") {
+					const searchTerm = commandArgs || undefined;
+					this.editor.setText("");
+					await this.handleModelCommand(searchTerm);
 					return;
 				}
-				this.editor.addToHistory?.(text);
-				this.editor.setText("");
-				// Optimistic: bash_start only fires after extension dispatch, and the
-				// clear key must already route to abortBash in that window.
-				this.patchConnectionState({ isBashRunning: true });
-				try {
-					await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
-				} catch (error) {
-					// Re-sync rather than assume idle: the rejection may mean another
-					// client's bash run already holds the slot.
-					try {
-						const state = await this.agentConnection.getState();
-						this.patchConnectionState({ isBashRunning: state.isBashRunning });
-					} catch {
-						this.patchConnectionState({ isBashRunning: false });
+				if (commandName === "effort") {
+					this.editor.setText("");
+					this.handleEffortCommand(commandArgs);
+					return;
+				}
+				if (commandName === "export") {
+					await this.handleExportCommand(canonicalCommandText);
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "import") {
+					await this.handleImportCommand(canonicalCommandText);
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "share" && !commandArgs) {
+					await this.handleShareCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "copy" && !commandArgs) {
+					await this.handleCopyCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "name") {
+					await this.handleNameCommand(canonicalCommandText);
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "session" && !commandArgs) {
+					this.echoLocalCommand(text);
+					await this.handleSessionCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "system-prompt" && !commandArgs) {
+					this.echoLocalCommand(text);
+					await this.handleSystemPromptCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "traces") {
+					await this.handleTracesCommand(canonicalCommandText);
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "context" && !commandArgs) {
+					this.echoLocalCommand(text);
+					await this.handleContextCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "logs" && !commandArgs) {
+					this.echoLocalCommand(text);
+					this.handleLogsCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "goal" && (!commandArgs || commandArgs === "status")) {
+					this.echoLocalCommand(text);
+					this.handleGoalStatusCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "heartbeat") {
+					await this.handleHeartbeatCommand(canonicalCommandText);
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "changelog" && !commandArgs) {
+					this.echoLocalCommand(text);
+					this.handleChangelogCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "hotkeys" && !commandArgs) {
+					this.echoLocalCommand(text);
+					this.handleHotkeysCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "fork" && !commandArgs) {
+					void this.showUserMessageSelector();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "clone" && !commandArgs) {
+					this.editor.setText("");
+					await this.handleCloneCommand();
+					return;
+				}
+				if (commandName === "tree" && !commandArgs) {
+					void this.showTreeSelector();
+					this.editor.setText("");
+					return;
+				}
+				if (commandName === "login" && !commandArgs) {
+					this.editor.setText("");
+					await this.showOAuthSelector("login");
+					return;
+				}
+				if (commandName === "logout" && !commandArgs) {
+					this.editor.setText("");
+					await this.showOAuthSelector("logout");
+					return;
+				}
+				if (commandName === "mcp") {
+					this.editor.setText("");
+					await this.handleMcpCommand(commandArgs);
+					return;
+				}
+				if (commandName === "new" && !commandArgs) {
+					this.editor.setText("");
+					await this.handleClearCommand();
+					return;
+				}
+				if (commandName === "compact") {
+					const customInstructions = commandArgs || undefined;
+					this.editor.setText("");
+					await this.handleCompactCommand(customInstructions);
+					return;
+				}
+				if (commandName === "refine") {
+					const refineArgs = commandArgs || undefined;
+					this.editor.setText("");
+					await this.handleRefineCommand(refineArgs);
+					return;
+				}
+				if (commandName === "reload" && !commandArgs) {
+					this.editor.setText("");
+					await this.handleReloadCommand();
+					return;
+				}
+				if (commandName === "fullscreen") {
+					this.editor.setText("");
+					const arg = commandArgs?.trim().toLowerCase();
+					if (arg && arg !== "on" && arg !== "off") {
+						this.showError("Usage: /fullscreen [on|off]");
+						return;
 					}
-					this.showError(error instanceof Error ? error.message : String(error));
+					const enable = arg === "on" ? true : arg === "off" ? false : !this.fullscreenEnabled;
+					this.setFullscreenMode(enable);
+					return;
 				}
-				return;
-			}
+				if (commandName === "debug" && !commandArgs) {
+					await this.handleDebugCommand();
+					this.editor.setText("");
+					return;
+				}
+				if (text === "/arminsayshi") {
+					this.handleArminSaysHi();
+					this.editor.setText("");
+					return;
+				}
+				if (text === "/dementedelves") {
+					this.handleDementedDelves();
+					this.editor.setText("");
+					return;
+				}
+				if (text === "/resume") {
+					void this.showSessionSelector();
+					this.editor.setText("");
+					return;
+				}
+				if (text === "/quit") {
+					this.editor.setText("");
+					await this.shutdown();
+					return;
+				}
 
-			// Queue input during compaction (extension commands execute immediately)
-			if (this.isAgentCompacting()) {
-				if (this.isExtensionCommand(text)) {
+				// Handle bash command (! for normal, !! for excluded from context)
+				if (text.startsWith("!")) {
+					const isExcluded = text.startsWith("!!");
+					const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
+					if (!command) {
+						// Bare ! / !! is bash mode with nothing to run; don't send it as a prompt
+						return;
+					}
+					if (this.isBashRunning()) {
+						this.showWarning(
+							`A bash command is already running. Press ${keyText("app.clear")} to cancel it first.`,
+						);
+						return;
+					}
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
-				} else {
-					this.queueCompactionMessage(text, "steer");
+					// Optimistic: bash_start only fires after extension dispatch, and the
+					// clear key must already route to abortBash in that window.
+					this.patchConnectionState({ isBashRunning: true });
+					try {
+						await this.agentConnection.executeBash(command, { excludeFromContext: isExcluded });
+					} catch (error) {
+						// Re-sync rather than assume idle: the rejection may mean another
+						// client's bash run already holds the slot.
+						try {
+							const state = await this.agentConnection.getState();
+							this.patchConnectionState({ isBashRunning: state.isBashRunning });
+						} catch {
+							this.patchConnectionState({ isBashRunning: false });
+						}
+						this.showError(error instanceof Error ? error.message : String(error));
+					}
+					return;
 				}
-				return;
-			}
 
-			// If streaming, use prompt() with steer behavior
-			// This handles extension commands (execute immediately), prompt template expansion, and queueing
-			if (this.isAgentStreaming()) {
-				const images = this.collectImagesFor(text);
+				// Queue input during compaction (extension commands execute immediately)
+				if (this.isAgentCompacting()) {
+					if (this.isExtensionCommand(text)) {
+						this.editor.addToHistory?.(text);
+						this.editor.setText("");
+						await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
+					} else {
+						this.queueCompactionMessage(text, "steer");
+					}
+					return;
+				}
+
+				// If streaming, use prompt() with steer behavior
+				// This handles extension commands (execute immediately), prompt template expansion, and queueing
+				if (this.isAgentStreaming()) {
+					const images = this.collectImagesFor(text);
+					this.editor.addToHistory?.(text);
+					this.editor.setText("");
+					await this.agentConnection.prompt(text, { streamingBehavior: "steer", images });
+					this.updatePendingMessagesDisplay();
+					this.ui.requestRender();
+					return;
+				}
+
+				// Normal message submission
+				// First, move any pending bash components to chat
+				this.flushPendingBashComponents();
+
+				if (this.onInputCallback) {
+					this.onInputCallback(text);
+				}
 				this.editor.addToHistory?.(text);
-				this.editor.setText("");
-				await this.agentConnection.prompt(text, { streamingBehavior: "steer", images });
-				this.updatePendingMessagesDisplay();
-				this.ui.requestRender();
-				return;
+			} finally {
+				if (shouldRestorePromptStash) {
+					this.restorePromptStashIfEditorEmpty();
+				}
 			}
-
-			// Normal message submission
-			// First, move any pending bash components to chat
-			this.flushPendingBashComponents();
-
-			if (this.onInputCallback) {
-				this.onInputCallback(text);
-			}
-			this.editor.addToHistory?.(text);
 		};
 	}
 
@@ -5441,33 +5485,40 @@ export class InteractiveMode {
 	private async handleFollowUp(): Promise<void> {
 		const text = (this.editor.getExpandedText?.() ?? this.editor.getText()).trim();
 		if (!text) return;
+		const shouldRestorePromptStash = this.promptStash !== undefined;
 
-		// Queue input during compaction (extension commands execute immediately)
-		if (this.isAgentCompacting()) {
-			if (this.isExtensionCommand(text)) {
+		try {
+			// Queue input during compaction (extension commands execute immediately)
+			if (this.isAgentCompacting()) {
+				if (this.isExtensionCommand(text)) {
+					this.editor.addToHistory?.(text);
+					this.editor.setText("");
+					await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
+				} else {
+					this.queueCompactionMessage(text, "followUp");
+				}
+				return;
+			}
+
+			// Alt+Enter queues a follow-up message (waits until agent finishes)
+			// This handles extension commands (execute immediately), prompt template expansion, and queueing
+			if (this.isAgentStreaming()) {
+				const images = this.collectImagesFor(text);
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
-			} else {
-				this.queueCompactionMessage(text, "followUp");
+				await this.agentConnection.prompt(text, { streamingBehavior: "followUp", images });
+				this.updatePendingMessagesDisplay();
+				this.ui.requestRender();
 			}
-			return;
-		}
-
-		// Alt+Enter queues a follow-up message (waits until agent finishes)
-		// This handles extension commands (execute immediately), prompt template expansion, and queueing
-		if (this.isAgentStreaming()) {
-			const images = this.collectImagesFor(text);
-			this.editor.addToHistory?.(text);
-			this.editor.setText("");
-			await this.agentConnection.prompt(text, { streamingBehavior: "followUp", images });
-			this.updatePendingMessagesDisplay();
-			this.ui.requestRender();
-		}
-		// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
-		else if (this.editor.onSubmit) {
-			this.editor.setText("");
-			this.editor.onSubmit(text);
+			// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
+			else if (this.editor.onSubmit) {
+				this.editor.setText("");
+				this.editor.onSubmit(text);
+			}
+		} finally {
+			if (shouldRestorePromptStash) {
+				this.restorePromptStashIfEditorEmpty();
+			}
 		}
 	}
 
@@ -7599,6 +7650,7 @@ export class InteractiveMode {
 		const toggleThinking = this.getAppKeyDisplay("app.thinking.toggle");
 		const focusSubagents = this.getAppKeyDisplay("app.subagents.focus");
 		const externalEditor = this.getAppKeyDisplay("app.editor.external");
+		const promptStash = this.getAppKeyDisplay("app.prompt.stash");
 		const followUp = this.getAppKeyDisplay("app.message.followUp");
 		const dequeue = this.getAppKeyDisplay("app.message.dequeue");
 		const pasteImage = this.getAppKeyDisplay("app.clipboard.pasteImage");
@@ -7647,6 +7699,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}| \`${
 | \`${toggleThinking}\` | Toggle thinking block visibility |
 | \`${focusSubagents}\` | Open subagent inspector |
 | \`${externalEditor}\` | Edit message in external editor |
+| \`${promptStash}\` | Stash or restore draft prompt |
 | \`${followUp}\` | Queue follow-up message |
 | \`${dequeue}\` | Restore queued messages |
 | \`${pasteImage}\` | Paste image from clipboard |

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5513,7 +5513,7 @@ export class InteractiveMode {
 			// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
 			else if (this.editor.onSubmit) {
 				this.editor.setText("");
-				this.editor.onSubmit(text);
+				await this.editor.onSubmit(text);
 			}
 		} finally {
 			if (shouldRestorePromptStash) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3435,6 +3435,9 @@ export class InteractiveMode {
 		if (stash === undefined || this.editor.getText().trim()) {
 			return false;
 		}
+		if (this.promptStash !== stash) {
+			return false;
+		}
 		this.promptStash = undefined;
 		this.editor.setText(stash.text);
 		if (stash.pasteSnapshot) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2276,12 +2276,15 @@ export class InteractiveMode {
 		process.exit(1);
 	}
 
-	private resetCurrentSessionRenderState(): void {
+	private resetCurrentSessionRenderState(options?: { clearPromptStash?: boolean }): void {
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
 		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
 		this.connectionQueue = { steering: [], followUp: [] };
+		if (options?.clearPromptStash) {
+			this.promptStash = undefined;
+		}
 		// Clear every editor's prompt history, draft text, and queues, then prune
 		// any pasted images no longer referenced by the remaining stashed draft.
 		this.defaultEditor.clearHistory?.();
@@ -3815,7 +3818,7 @@ export class InteractiveMode {
 				} else if (event.type === "session_replaced") {
 					this.resetExtensionUI();
 					this.applyConnectionStateSnapshot(event.state);
-					this.resetCurrentSessionRenderState();
+					this.resetCurrentSessionRenderState({ clearPromptStash: true });
 					await this.rebindCurrentSession();
 					await this.renderInitialMessages();
 					this.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -21,6 +21,7 @@ import type {
 	AutocompleteItem,
 	AutocompleteProvider,
 	EditorComponent,
+	EditorPasteSnapshot,
 	Keybinding,
 	KeyId,
 	MarkdownTheme,
@@ -199,6 +200,11 @@ import { setWorkingPulseFrame, WORKING_ICON_INTERVAL_MS } from "./theme/working-
 interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
+
+type PromptStash = {
+	text: string;
+	pasteSnapshot?: EditorPasteSnapshot;
+};
 
 interface PendingToolCallRenderInput {
 	id: string;
@@ -501,7 +507,7 @@ export class InteractiveMode {
 	private queuedMessagesContainer: Container;
 	private defaultEditor: CustomEditor;
 	private editor: EditorComponent;
-	private promptStash: string | undefined;
+	private promptStash: PromptStash | undefined;
 	private editorComponentFactory: EditorFactory | undefined;
 	private autocompleteProvider: AutocompleteProvider | undefined;
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
@@ -3417,17 +3423,23 @@ export class InteractiveMode {
 			this.showStatus("Prompt stash already has a draft");
 			return;
 		}
-		this.promptStash = text;
+		this.promptStash = {
+			text,
+			pasteSnapshot: this.editor.getPasteSnapshot?.(),
+		};
 		this.editor.setText("");
 		this.showStatus("Stashed prompt");
 	}
 
-	private restorePromptStashIfEditorEmpty(text = this.promptStash): boolean {
-		if (text === undefined || this.editor.getText().trim()) {
+	private restorePromptStashIfEditorEmpty(stash = this.promptStash): boolean {
+		if (stash === undefined || this.editor.getText().trim()) {
 			return false;
 		}
 		this.promptStash = undefined;
-		this.editor.setText(text);
+		this.editor.setText(stash.text);
+		if (stash.pasteSnapshot) {
+			this.editor.restorePasteSnapshot?.(stash.pasteSnapshot);
+		}
 		this.showStatus("Restored stashed prompt");
 		return true;
 	}
@@ -3496,7 +3508,7 @@ export class InteractiveMode {
 		};
 		add(this.editor.getText());
 		if (this.promptStash !== undefined) {
-			add(this.promptStash);
+			add(this.promptStash.text);
 		}
 		for (const entry of this.editor.getHistory?.() ?? []) {
 			add(entry);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3638,8 +3638,8 @@ export class InteractiveMode {
 					return;
 				}
 				if (commandName === "fork" && !commandArgs) {
-					void this.showUserMessageSelector();
 					this.editor.setText("");
+					await this.showUserMessageSelector();
 					return;
 				}
 				if (commandName === "clone" && !commandArgs) {
@@ -3648,8 +3648,8 @@ export class InteractiveMode {
 					return;
 				}
 				if (commandName === "tree" && !commandArgs) {
-					void this.showTreeSelector();
 					this.editor.setText("");
+					await this.showTreeSelector();
 					return;
 				}
 				if (commandName === "login" && !commandArgs) {
@@ -3716,8 +3716,8 @@ export class InteractiveMode {
 					return;
 				}
 				if (text === "/resume") {
-					void this.showSessionSelector();
 					this.editor.setText("");
+					await this.showSessionSelector();
 					return;
 				}
 				if (text === "/quit") {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2281,8 +2281,9 @@ export class InteractiveMode {
 		this.pendingMessagesContainer.clear();
 		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
-		// Clear every editor's prompt history and draft text, then prune any pasted
-		// images no longer referenced by the remaining stashed draft.
+		this.connectionQueue = { steering: [], followUp: [] };
+		// Clear every editor's prompt history, draft text, and queues, then prune
+		// any pasted images no longer referenced by the remaining stashed draft.
 		this.defaultEditor.clearHistory?.();
 		this.defaultEditor.setText("");
 		if (this.editor !== this.defaultEditor) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -203,6 +203,7 @@ interface Expandable {
 
 type PromptStash = {
 	text: string;
+	expandedText?: string;
 	pasteSnapshot?: EditorPasteSnapshot;
 };
 
@@ -3423,9 +3424,11 @@ export class InteractiveMode {
 			this.showStatus("Prompt stash already has a draft");
 			return;
 		}
+		const pasteSnapshot = this.editor.getPasteSnapshot?.();
 		this.promptStash = {
 			text,
-			pasteSnapshot: this.editor.getPasteSnapshot?.(),
+			expandedText: pasteSnapshot ? (this.editor.getExpandedText?.() ?? text) : undefined,
+			pasteSnapshot,
 		};
 		this.editor.setText("");
 		this.showStatus("Stashed prompt");
@@ -3439,9 +3442,11 @@ export class InteractiveMode {
 			return false;
 		}
 		this.promptStash = undefined;
-		this.editor.setText(stash.text);
-		if (stash.pasteSnapshot) {
-			this.editor.restorePasteSnapshot?.(stash.pasteSnapshot);
+		const canRestorePasteSnapshot =
+			stash.pasteSnapshot === undefined || this.editor.restorePasteSnapshot !== undefined;
+		this.editor.setText(canRestorePasteSnapshot ? stash.text : (stash.expandedText ?? stash.text));
+		if (stash.pasteSnapshot && this.editor.restorePasteSnapshot) {
+			this.editor.restorePasteSnapshot(stash.pasteSnapshot);
 		}
 		this.showStatus("Restored stashed prompt");
 		return true;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2281,19 +2281,19 @@ export class InteractiveMode {
 		this.pendingMessagesContainer.clear();
 		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
-		// Pasted images belong to the session being torn down; drop them so markers
-		// in a newly loaded session can't resolve to the previous session's bytes.
-		// Clear every editor's prompt history and draft text alongside them so no
-		// `[image #N]` marker survives without a backing image. nextImageMarkerId
-		// stays monotonic so a new paste never reuses an id that may still appear in
-		// restored text.
-		this.pastedImages.clear();
-		this.promptStash = undefined;
+		// Clear every editor's prompt history and draft text, then prune any pasted
+		// images no longer referenced by the remaining stashed draft.
 		this.defaultEditor.clearHistory?.();
 		this.defaultEditor.setText("");
 		if (this.editor !== this.defaultEditor) {
 			this.editor.clearHistory?.();
 			this.editor.setText("");
+		}
+		const keepImageIds = this.liveImageMarkerIds();
+		for (const markerId of this.pastedImages.keys()) {
+			if (!keepImageIds.has(markerId)) {
+				this.pastedImages.delete(markerId);
+			}
 		}
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
@@ -3402,7 +3402,7 @@ export class InteractiveMode {
 	}
 
 	private handlePromptStash(): void {
-		const text = this.editor.getExpandedText?.() ?? this.editor.getText();
+		const text = this.editor.getText();
 		if (!text.trim()) {
 			if (!this.restorePromptStashIfEditorEmpty()) {
 				this.showStatus("No prompt to stash");
@@ -3418,11 +3418,10 @@ export class InteractiveMode {
 		this.showStatus("Stashed prompt");
 	}
 
-	private restorePromptStashIfEditorEmpty(): boolean {
-		if (this.promptStash === undefined || this.editor.getText().trim()) {
+	private restorePromptStashIfEditorEmpty(text = this.promptStash): boolean {
+		if (text === undefined || this.editor.getText().trim()) {
 			return false;
 		}
-		const text = this.promptStash;
 		this.promptStash = undefined;
 		this.editor.setText(text);
 		this.showStatus("Restored stashed prompt");
@@ -3531,7 +3530,7 @@ export class InteractiveMode {
 		this.defaultEditor.onSubmit = async (text: string) => {
 			text = text.trim();
 			if (!text) return;
-			const shouldRestorePromptStash = this.promptStash !== undefined;
+			const promptStashToRestore = this.promptStash;
 
 			try {
 				const slashCommand = parseSlashCommand(text);
@@ -3795,8 +3794,8 @@ export class InteractiveMode {
 				}
 				this.editor.addToHistory?.(text);
 			} finally {
-				if (shouldRestorePromptStash) {
-					this.restorePromptStashIfEditorEmpty();
+				if (promptStashToRestore !== undefined) {
+					this.restorePromptStashIfEditorEmpty(promptStashToRestore);
 				}
 			}
 		};
@@ -5485,15 +5484,18 @@ export class InteractiveMode {
 	private async handleFollowUp(): Promise<void> {
 		const text = (this.editor.getExpandedText?.() ?? this.editor.getText()).trim();
 		if (!text) return;
-		const shouldRestorePromptStash = this.promptStash !== undefined;
+		const promptStashToRestore = this.promptStash;
+		let clearedSubmittedText: string | undefined;
 
 		try {
 			// Queue input during compaction (extension commands execute immediately)
 			if (this.isAgentCompacting()) {
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
+					clearedSubmittedText = text;
 					this.editor.setText("");
 					await this.agentConnection.prompt(text, { images: this.collectImagesFor(text) });
+					clearedSubmittedText = undefined;
 				} else {
 					this.queueCompactionMessage(text, "followUp");
 				}
@@ -5505,19 +5507,29 @@ export class InteractiveMode {
 			if (this.isAgentStreaming()) {
 				const images = this.collectImagesFor(text);
 				this.editor.addToHistory?.(text);
+				clearedSubmittedText = text;
 				this.editor.setText("");
 				await this.agentConnection.prompt(text, { streamingBehavior: "followUp", images });
+				clearedSubmittedText = undefined;
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 			}
 			// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
 			else if (this.editor.onSubmit) {
+				clearedSubmittedText = text;
 				this.editor.setText("");
 				await this.editor.onSubmit(text);
+				clearedSubmittedText = undefined;
 			}
+		} catch (error) {
+			if (clearedSubmittedText !== undefined) {
+				this.editor.setText(clearedSubmittedText);
+				this.promptStash = promptStashToRestore;
+			}
+			throw error;
 		} finally {
-			if (shouldRestorePromptStash) {
-				this.restorePromptStashIfEditorEmpty();
+			if (promptStashToRestore !== undefined && clearedSubmittedText === undefined) {
+				this.restorePromptStashIfEditorEmpty(promptStashToRestore);
 			}
 		}
 	}

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -36,7 +36,7 @@ type SubmitHarness = PromptStashHarness & {
 type PromptStashMethods = {
 	handleFollowUp: (this: SubmitHarness) => Promise<void>;
 	handlePromptStash: (this: PromptStashHarness) => void;
-	restorePromptStashIfEditorEmpty: (this: PromptStashHarness) => boolean;
+	restorePromptStashIfEditorEmpty: (this: PromptStashHarness, text?: string) => boolean;
 	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
 	setupEditorSubmitHandler: (this: SubmitHarness) => void;
 };
@@ -83,7 +83,7 @@ describe("InteractiveMode prompt stash", () => {
 		expect(keybindings.getKeys("app.prompt.stash")).toEqual(["ctrl+s"]);
 	});
 
-	it("stashes expanded editor text and clears the editor", () => {
+	it("stashes editor text without expanding paste markers", () => {
 		const mode = createPromptStashHarness({
 			text: "[paste #1 +12 lines]",
 			expandedText: "line one\nline two",
@@ -91,7 +91,7 @@ describe("InteractiveMode prompt stash", () => {
 
 		interactiveModeMethods.handlePromptStash.call(mode);
 
-		expect(mode.promptStash).toBe("line one\nline two");
+		expect(mode.promptStash).toBe("[paste #1 +12 lines]");
 		expect(mode.editor.getText()).toBe("");
 		expect(mode.showStatus).toHaveBeenCalledWith("Stashed prompt");
 	});
@@ -136,6 +136,30 @@ describe("InteractiveMode prompt stash", () => {
 		expect(mode.editor.getText()).toBe("half-written draft");
 	});
 
+	it("restores a stashed prompt after a session reset clears prompt state", async () => {
+		let mode: SubmitHarness & { handleClearCommand: Mock<() => Promise<void>> };
+		mode = {
+			...createPromptStashHarness({ stash: "half-written draft" }),
+			defaultEditor: {},
+			isAgentCompacting: () => false,
+			isAgentStreaming: () => false,
+			flushPendingBashComponents: vi.fn(),
+			onInputCallback: vi.fn(),
+			handleClearCommand: vi.fn(async () => {
+				mode.promptStash = undefined;
+				mode.editor.setText("");
+			}),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+		interactiveModeMethods.setupEditorSubmitHandler.call(mode);
+
+		await mode.defaultEditor.onSubmit?.("/new");
+
+		expect(mode.handleClearCommand).toHaveBeenCalled();
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
 	it("restores a stashed prompt after idle follow-up slash commands clear the editor", async () => {
 		let resolveSettings: () => void = () => {};
 		const settingsDone = new Promise<void>((resolve) => {
@@ -162,6 +186,37 @@ describe("InteractiveMode prompt stash", () => {
 		expect(mode.showSettingsSelector).toHaveBeenCalled();
 		expect(mode.promptStash).toBeUndefined();
 		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
+	it("restores failed follow-up text without dropping the stashed prompt", async () => {
+		const error = new Error("send failed");
+		const mode: SubmitHarness & {
+			agentConnection: { prompt: Mock<() => Promise<void>> };
+			collectImagesFor: Mock;
+			updatePendingMessagesDisplay: Mock;
+			ui: { requestRender: Mock };
+		} = {
+			...createPromptStashHarness({ text: "quick follow-up", stash: "half-written draft" }),
+			defaultEditor: {},
+			isAgentCompacting: () => false,
+			isAgentStreaming: () => true,
+			flushPendingBashComponents: vi.fn(),
+			onInputCallback: vi.fn(),
+			agentConnection: {
+				prompt: vi.fn(async () => {
+					throw error;
+				}),
+			},
+			collectImagesFor: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			ui: { requestRender: vi.fn() },
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+
+		await expect(interactiveModeMethods.handleFollowUp.call(mode)).rejects.toThrow(error);
+
+		expect(mode.editor.getText()).toBe("quick follow-up");
+		expect(mode.promptStash).toBe("half-written draft");
 	});
 
 	it("keeps image markers in a stashed prompt live", () => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -6,6 +6,7 @@ type FakeEditor = {
 	text: string;
 	expandedText: string;
 	history: string[];
+	onSubmit?: (text: string) => void | Promise<void>;
 	getText: () => string;
 	getExpandedText: () => string;
 	setText: (text: string) => void;
@@ -33,6 +34,7 @@ type SubmitHarness = PromptStashHarness & {
 };
 
 type PromptStashMethods = {
+	handleFollowUp: (this: SubmitHarness) => Promise<void>;
 	handlePromptStash: (this: PromptStashHarness) => void;
 	restorePromptStashIfEditorEmpty: (this: PromptStashHarness) => boolean;
 	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
@@ -130,6 +132,34 @@ describe("InteractiveMode prompt stash", () => {
 
 		expect(mode.onInputCallback).toHaveBeenCalledWith("temporary prompt");
 		expect(mode.editor.addToHistory).toHaveBeenCalledWith("temporary prompt");
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
+	it("restores a stashed prompt after idle follow-up slash commands clear the editor", async () => {
+		let resolveSettings: () => void = () => {};
+		const settingsDone = new Promise<void>((resolve) => {
+			resolveSettings = resolve;
+		});
+		const mode: SubmitHarness & { showSettingsSelector: Mock<() => Promise<void>> } = {
+			...createPromptStashHarness({ text: "/settings", stash: "half-written draft" }),
+			defaultEditor: {},
+			isAgentCompacting: () => false,
+			isAgentStreaming: () => false,
+			flushPendingBashComponents: vi.fn(),
+			onInputCallback: vi.fn(),
+			showSettingsSelector: vi.fn(() => settingsDone),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+		interactiveModeMethods.setupEditorSubmitHandler.call(mode);
+		mode.editor.onSubmit = mode.defaultEditor.onSubmit;
+
+		const followUp = interactiveModeMethods.handleFollowUp.call(mode);
+		await Promise.resolve();
+		resolveSettings();
+		await followUp;
+
+		expect(mode.showSettingsSelector).toHaveBeenCalled();
 		expect(mode.promptStash).toBeUndefined();
 		expect(mode.editor.getText()).toBe("half-written draft");
 	});

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -160,6 +160,38 @@ describe("InteractiveMode prompt stash", () => {
 		expect(mode.editor.getText()).toBe("half-written draft");
 	});
 
+	it("waits for async session selectors before restoring a stashed prompt", async () => {
+		let resolveSelector: () => void = () => {};
+		const selectorDone = new Promise<void>((resolve) => {
+			resolveSelector = resolve;
+		});
+		let mode: SubmitHarness & { showUserMessageSelector: Mock<() => Promise<void>> };
+		mode = {
+			...createPromptStashHarness({ stash: "half-written draft" }),
+			defaultEditor: {},
+			isAgentCompacting: () => false,
+			isAgentStreaming: () => false,
+			flushPendingBashComponents: vi.fn(),
+			onInputCallback: vi.fn(),
+			showUserMessageSelector: vi.fn(async () => {
+				await selectorDone;
+				mode.promptStash = undefined;
+				mode.editor.setText("");
+			}),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+		interactiveModeMethods.setupEditorSubmitHandler.call(mode);
+
+		const submit = mode.defaultEditor.onSubmit?.("/fork");
+		await Promise.resolve();
+		resolveSelector();
+		await submit;
+
+		expect(mode.showUserMessageSelector).toHaveBeenCalled();
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
 	it("restores a stashed prompt after idle follow-up slash commands clear the editor", async () => {
 		let resolveSettings: () => void = () => {};
 		const settingsDone = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -7,6 +7,7 @@ type FakeEditor = {
 	expandedText: string;
 	history: string[];
 	onSubmit?: (text: string) => void | Promise<void>;
+	clearHistory?: Mock;
 	getText: () => string;
 	getExpandedText: () => string;
 	setText: (text: string) => void;
@@ -25,6 +26,25 @@ type PromptStashLiveMarkerHarness = PromptStashHarness & {
 	connectionQueue: { steering: string[]; followUp: string[] };
 };
 
+type ResetHarness = PromptStashLiveMarkerHarness & {
+	chatContainer: { clear: Mock };
+	pendingMessagesContainer: { clear: Mock };
+	queuedMessagesContainer: { clear: Mock };
+	defaultEditor: FakeEditor;
+	pastedImages: Map<number, unknown>;
+	streamingComponent?: unknown;
+	streamingMessage?: unknown;
+	activeBashComponent?: { setComplete: Mock };
+	pendingBashComponents: unknown[];
+	activityTracker: { reset: Mock };
+	contextUsageTokenBaseline: number;
+	resetPendingToolState: Mock;
+	resetChildAgentInspector: Mock;
+	setGoalAnnouncementBaseline: Mock;
+	getGoalState: Mock<() => unknown>;
+	syncGoalTray: Mock;
+};
+
 type SubmitHarness = PromptStashHarness & {
 	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
 	isAgentCompacting: () => boolean;
@@ -36,6 +56,7 @@ type SubmitHarness = PromptStashHarness & {
 type PromptStashMethods = {
 	handleFollowUp: (this: SubmitHarness) => Promise<void>;
 	handlePromptStash: (this: PromptStashHarness) => void;
+	resetCurrentSessionRenderState: (this: ResetHarness) => void;
 	restorePromptStashIfEditorEmpty: (this: PromptStashHarness, text?: string) => boolean;
 	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
 	setupEditorSubmitHandler: (this: SubmitHarness) => void;
@@ -62,6 +83,9 @@ function createEditor(options: { text?: string; expandedText?: string; history?:
 		getHistory() {
 			return this.history;
 		},
+		clearHistory: vi.fn(function (this: FakeEditor) {
+			this.history = [];
+		}),
 	};
 	return editor;
 }
@@ -218,6 +242,38 @@ describe("InteractiveMode prompt stash", () => {
 		expect(mode.showSettingsSelector).toHaveBeenCalled();
 		expect(mode.promptStash).toBeUndefined();
 		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
+	it("drops queued image references from old sessions while keeping stashed images", () => {
+		const base = createPromptStashHarness({ stash: "keep [image #1]" });
+		const mode: ResetHarness = {
+			...base,
+			defaultEditor: base.editor,
+			compactionQueuedMessages: [],
+			connectionQueue: { steering: ["old [image #2]"], followUp: [] },
+			chatContainer: { clear: vi.fn() },
+			pendingMessagesContainer: { clear: vi.fn() },
+			queuedMessagesContainer: { clear: vi.fn() },
+			pastedImages: new Map<number, unknown>([
+				[1, {}],
+				[2, {}],
+			]),
+			pendingBashComponents: [],
+			activityTracker: { reset: vi.fn() },
+			contextUsageTokenBaseline: 1,
+			resetPendingToolState: vi.fn(),
+			resetChildAgentInspector: vi.fn(),
+			setGoalAnnouncementBaseline: vi.fn(),
+			getGoalState: vi.fn(() => undefined),
+			syncGoalTray: vi.fn(),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+
+		interactiveModeMethods.resetCurrentSessionRenderState.call(mode);
+
+		expect(mode.connectionQueue).toEqual({ steering: [], followUp: [] });
+		expect(mode.pastedImages.has(1)).toBe(true);
+		expect(mode.pastedImages.has(2)).toBe(false);
 	});
 
 	it("restores failed follow-up text without dropping the stashed prompt", async () => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -56,7 +56,7 @@ type SubmitHarness = PromptStashHarness & {
 type PromptStashMethods = {
 	handleFollowUp: (this: SubmitHarness) => Promise<void>;
 	handlePromptStash: (this: PromptStashHarness) => void;
-	resetCurrentSessionRenderState: (this: ResetHarness) => void;
+	resetCurrentSessionRenderState: (this: ResetHarness, options?: { clearPromptStash?: boolean }) => void;
 	restorePromptStashIfEditorEmpty: (this: PromptStashHarness, text?: string) => boolean;
 	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
 	setupEditorSubmitHandler: (this: SubmitHarness) => void;
@@ -272,8 +272,37 @@ describe("InteractiveMode prompt stash", () => {
 		interactiveModeMethods.resetCurrentSessionRenderState.call(mode);
 
 		expect(mode.connectionQueue).toEqual({ steering: [], followUp: [] });
+		expect(mode.promptStash).toBe("keep [image #1]");
 		expect(mode.pastedImages.has(1)).toBe(true);
 		expect(mode.pastedImages.has(2)).toBe(false);
+	});
+
+	it("clears stashed prompt state on external session replacement resets", () => {
+		const base = createPromptStashHarness({ stash: "drop [image #1]" });
+		const mode: ResetHarness = {
+			...base,
+			defaultEditor: base.editor,
+			compactionQueuedMessages: [],
+			connectionQueue: { steering: [], followUp: [] },
+			chatContainer: { clear: vi.fn() },
+			pendingMessagesContainer: { clear: vi.fn() },
+			queuedMessagesContainer: { clear: vi.fn() },
+			pastedImages: new Map<number, unknown>([[1, {}]]),
+			pendingBashComponents: [],
+			activityTracker: { reset: vi.fn() },
+			contextUsageTokenBaseline: 1,
+			resetPendingToolState: vi.fn(),
+			resetChildAgentInspector: vi.fn(),
+			setGoalAnnouncementBaseline: vi.fn(),
+			getGoalState: vi.fn(() => undefined),
+			syncGoalTray: vi.fn(),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+
+		interactiveModeMethods.resetCurrentSessionRenderState.call(mode, { clearPromptStash: true });
+
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.pastedImages.has(1)).toBe(false);
 	});
 
 	it("restores failed follow-up text without dropping the stashed prompt", async () => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -170,6 +170,20 @@ describe("InteractiveMode prompt stash", () => {
 		expect(mode.showStatus).toHaveBeenCalledWith("Restored stashed prompt");
 	});
 
+	it("does not restore an older captured stash after a newer stash is created", () => {
+		const mode = createPromptStashHarness({ stash: "older draft" });
+		const olderStash = mode.promptStash;
+		const newerStash = { text: "newer draft" };
+		mode.promptStash = newerStash;
+
+		const restored = interactiveModeMethods.restorePromptStashIfEditorEmpty.call(mode, olderStash);
+
+		expect(restored).toBe(false);
+		expect(mode.promptStash).toBe(newerStash);
+		expect(mode.editor.getText()).toBe("");
+		expect(mode.showStatus).not.toHaveBeenCalledWith("Restored stashed prompt");
+	});
+
 	it("does not overwrite an existing stash", () => {
 		const mode = createPromptStashHarness({ text: "second draft", stash: "first draft" });
 
@@ -210,7 +224,6 @@ describe("InteractiveMode prompt stash", () => {
 			flushPendingBashComponents: vi.fn(),
 			onInputCallback: vi.fn(),
 			handleClearCommand: vi.fn(async () => {
-				mode.promptStash = undefined;
 				mode.editor.setText("");
 			}),
 		};
@@ -239,7 +252,6 @@ describe("InteractiveMode prompt stash", () => {
 			onInputCallback: vi.fn(),
 			showUserMessageSelector: vi.fn(async () => {
 				await selectorDone;
-				mode.promptStash = undefined;
 				mode.editor.setText("");
 			}),
 		};

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, type Mock, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+type FakeEditor = {
+	text: string;
+	expandedText: string;
+	history: string[];
+	getText: () => string;
+	getExpandedText: () => string;
+	setText: (text: string) => void;
+	addToHistory: Mock;
+	getHistory: () => readonly string[];
+};
+
+type PromptStashHarness = {
+	promptStash?: string;
+	editor: FakeEditor;
+	showStatus: Mock;
+};
+
+type PromptStashLiveMarkerHarness = PromptStashHarness & {
+	compactionQueuedMessages: Array<{ text: string; mode: "steer" | "followUp" }>;
+	connectionQueue: { steering: string[]; followUp: string[] };
+};
+
+type SubmitHarness = PromptStashHarness & {
+	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
+	isAgentCompacting: () => boolean;
+	isAgentStreaming: () => boolean;
+	flushPendingBashComponents: Mock;
+	onInputCallback: Mock;
+};
+
+type PromptStashMethods = {
+	handlePromptStash: (this: PromptStashHarness) => void;
+	restorePromptStashIfEditorEmpty: (this: PromptStashHarness) => boolean;
+	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
+	setupEditorSubmitHandler: (this: SubmitHarness) => void;
+};
+
+const interactiveModeMethods = InteractiveMode.prototype as unknown as PromptStashMethods;
+
+function createEditor(options: { text?: string; expandedText?: string; history?: string[] } = {}): FakeEditor {
+	const editor: FakeEditor = {
+		text: options.text ?? "",
+		expandedText: options.expandedText ?? options.text ?? "",
+		history: options.history ?? [],
+		getText() {
+			return this.text;
+		},
+		getExpandedText() {
+			return this.expandedText;
+		},
+		setText(nextText: string) {
+			this.text = nextText;
+			this.expandedText = nextText;
+		},
+		addToHistory: vi.fn(),
+		getHistory() {
+			return this.history;
+		},
+	};
+	return editor;
+}
+
+function createPromptStashHarness(options: { text?: string; expandedText?: string; stash?: string } = {}) {
+	const harness: PromptStashHarness = {
+		promptStash: options.stash,
+		editor: createEditor({ text: options.text, expandedText: options.expandedText }),
+		showStatus: vi.fn(),
+	};
+	Object.setPrototypeOf(harness, InteractiveMode.prototype);
+	return harness;
+}
+
+describe("InteractiveMode prompt stash", () => {
+	it("uses Ctrl+S as the default configurable stash keybinding", () => {
+		const keybindings = new KeybindingsManager();
+
+		expect(keybindings.getKeys("app.prompt.stash")).toEqual(["ctrl+s"]);
+	});
+
+	it("stashes expanded editor text and clears the editor", () => {
+		const mode = createPromptStashHarness({
+			text: "[paste #1 +12 lines]",
+			expandedText: "line one\nline two",
+		});
+
+		interactiveModeMethods.handlePromptStash.call(mode);
+
+		expect(mode.promptStash).toBe("line one\nline two");
+		expect(mode.editor.getText()).toBe("");
+		expect(mode.showStatus).toHaveBeenCalledWith("Stashed prompt");
+	});
+
+	it("restores a stashed prompt when the editor is empty", () => {
+		const mode = createPromptStashHarness({ stash: "half-written draft" });
+
+		interactiveModeMethods.handlePromptStash.call(mode);
+
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.editor.getText()).toBe("half-written draft");
+		expect(mode.showStatus).toHaveBeenCalledWith("Restored stashed prompt");
+	});
+
+	it("does not overwrite an existing stash", () => {
+		const mode = createPromptStashHarness({ text: "second draft", stash: "first draft" });
+
+		interactiveModeMethods.handlePromptStash.call(mode);
+
+		expect(mode.promptStash).toBe("first draft");
+		expect(mode.editor.getText()).toBe("second draft");
+		expect(mode.showStatus).toHaveBeenCalledWith("Prompt stash already has a draft");
+	});
+
+	it("restores a stashed prompt after normal message submission clears the editor", async () => {
+		const mode: SubmitHarness = {
+			...createPromptStashHarness({ stash: "half-written draft" }),
+			defaultEditor: {},
+			isAgentCompacting: () => false,
+			isAgentStreaming: () => false,
+			flushPendingBashComponents: vi.fn(),
+			onInputCallback: vi.fn(),
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+		interactiveModeMethods.setupEditorSubmitHandler.call(mode);
+
+		await mode.defaultEditor.onSubmit?.("temporary prompt");
+
+		expect(mode.onInputCallback).toHaveBeenCalledWith("temporary prompt");
+		expect(mode.editor.addToHistory).toHaveBeenCalledWith("temporary prompt");
+		expect(mode.promptStash).toBeUndefined();
+		expect(mode.editor.getText()).toBe("half-written draft");
+	});
+
+	it("keeps image markers in a stashed prompt live", () => {
+		const mode: PromptStashLiveMarkerHarness = {
+			...createPromptStashHarness({ stash: "look at [image #7]" }),
+			compactionQueuedMessages: [],
+			connectionQueue: { steering: [], followUp: [] },
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+
+		expect(interactiveModeMethods.liveImageMarkerIds.call(mode)).toEqual(new Set([7]));
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -2,21 +2,35 @@ import { describe, expect, it, type Mock, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 
+type FakePasteSnapshot = {
+	pastes: readonly (readonly [number, string])[];
+	pasteCounter: number;
+};
+
+type PromptStash = {
+	text: string;
+	pasteSnapshot?: FakePasteSnapshot;
+};
+
 type FakeEditor = {
 	text: string;
 	expandedText: string;
 	history: string[];
+	pasteSnapshot?: FakePasteSnapshot;
+	restoredPasteSnapshot?: FakePasteSnapshot;
 	onSubmit?: (text: string) => void | Promise<void>;
 	clearHistory?: Mock;
 	getText: () => string;
 	getExpandedText: () => string;
+	getPasteSnapshot: () => FakePasteSnapshot | undefined;
+	restorePasteSnapshot: (snapshot: FakePasteSnapshot) => void;
 	setText: (text: string) => void;
 	addToHistory: Mock;
 	getHistory: () => readonly string[];
 };
 
 type PromptStashHarness = {
-	promptStash?: string;
+	promptStash?: PromptStash;
 	editor: FakeEditor;
 	showStatus: Mock;
 };
@@ -57,23 +71,33 @@ type PromptStashMethods = {
 	handleFollowUp: (this: SubmitHarness) => Promise<void>;
 	handlePromptStash: (this: PromptStashHarness) => void;
 	resetCurrentSessionRenderState: (this: ResetHarness, options?: { clearPromptStash?: boolean }) => void;
-	restorePromptStashIfEditorEmpty: (this: PromptStashHarness, text?: string) => boolean;
+	restorePromptStashIfEditorEmpty: (this: PromptStashHarness, stash?: PromptStash) => boolean;
 	liveImageMarkerIds: (this: PromptStashLiveMarkerHarness) => Set<number>;
 	setupEditorSubmitHandler: (this: SubmitHarness) => void;
 };
 
 const interactiveModeMethods = InteractiveMode.prototype as unknown as PromptStashMethods;
 
-function createEditor(options: { text?: string; expandedText?: string; history?: string[] } = {}): FakeEditor {
+function createEditor(
+	options: { text?: string; expandedText?: string; history?: string[]; pasteSnapshot?: FakePasteSnapshot } = {},
+): FakeEditor {
 	const editor: FakeEditor = {
 		text: options.text ?? "",
 		expandedText: options.expandedText ?? options.text ?? "",
 		history: options.history ?? [],
+		pasteSnapshot: options.pasteSnapshot,
 		getText() {
 			return this.text;
 		},
 		getExpandedText() {
 			return this.expandedText;
+		},
+		getPasteSnapshot() {
+			return this.pasteSnapshot;
+		},
+		restorePasteSnapshot(snapshot: FakePasteSnapshot) {
+			this.restoredPasteSnapshot = snapshot;
+			this.pasteSnapshot = snapshot;
 		},
 		setText(nextText: string) {
 			this.text = nextText;
@@ -90,10 +114,16 @@ function createEditor(options: { text?: string; expandedText?: string; history?:
 	return editor;
 }
 
-function createPromptStashHarness(options: { text?: string; expandedText?: string; stash?: string } = {}) {
+function createPromptStashHarness(
+	options: { text?: string; expandedText?: string; stash?: string; pasteSnapshot?: FakePasteSnapshot } = {},
+) {
 	const harness: PromptStashHarness = {
-		promptStash: options.stash,
-		editor: createEditor({ text: options.text, expandedText: options.expandedText }),
+		promptStash: options.stash ? { text: options.stash, pasteSnapshot: options.pasteSnapshot } : undefined,
+		editor: createEditor({
+			text: options.text,
+			expandedText: options.expandedText,
+			pasteSnapshot: options.pasteSnapshot,
+		}),
 		showStatus: vi.fn(),
 	};
 	Object.setPrototypeOf(harness, InteractiveMode.prototype);
@@ -108,16 +138,26 @@ describe("InteractiveMode prompt stash", () => {
 	});
 
 	it("stashes editor text without expanding paste markers", () => {
+		const pasteSnapshot: FakePasteSnapshot = {
+			pastes: [[1, "line one\nline two"]],
+			pasteCounter: 1,
+		};
 		const mode = createPromptStashHarness({
 			text: "[paste #1 +12 lines]",
 			expandedText: "line one\nline two",
+			pasteSnapshot,
 		});
 
 		interactiveModeMethods.handlePromptStash.call(mode);
 
-		expect(mode.promptStash).toBe("[paste #1 +12 lines]");
+		expect(mode.promptStash).toEqual({ text: "[paste #1 +12 lines]", pasteSnapshot });
 		expect(mode.editor.getText()).toBe("");
 		expect(mode.showStatus).toHaveBeenCalledWith("Stashed prompt");
+
+		interactiveModeMethods.restorePromptStashIfEditorEmpty.call(mode);
+
+		expect(mode.editor.getText()).toBe("[paste #1 +12 lines]");
+		expect(mode.editor.restoredPasteSnapshot).toBe(pasteSnapshot);
 	});
 
 	it("restores a stashed prompt when the editor is empty", () => {
@@ -135,7 +175,7 @@ describe("InteractiveMode prompt stash", () => {
 
 		interactiveModeMethods.handlePromptStash.call(mode);
 
-		expect(mode.promptStash).toBe("first draft");
+		expect(mode.promptStash?.text).toBe("first draft");
 		expect(mode.editor.getText()).toBe("second draft");
 		expect(mode.showStatus).toHaveBeenCalledWith("Prompt stash already has a draft");
 	});
@@ -272,7 +312,7 @@ describe("InteractiveMode prompt stash", () => {
 		interactiveModeMethods.resetCurrentSessionRenderState.call(mode);
 
 		expect(mode.connectionQueue).toEqual({ steering: [], followUp: [] });
-		expect(mode.promptStash).toBe("keep [image #1]");
+		expect(mode.promptStash?.text).toBe("keep [image #1]");
 		expect(mode.pastedImages.has(1)).toBe(true);
 		expect(mode.pastedImages.has(2)).toBe(false);
 	});
@@ -333,7 +373,7 @@ describe("InteractiveMode prompt stash", () => {
 		await expect(interactiveModeMethods.handleFollowUp.call(mode)).rejects.toThrow(error);
 
 		expect(mode.editor.getText()).toBe("quick follow-up");
-		expect(mode.promptStash).toBe("half-written draft");
+		expect(mode.promptStash?.text).toBe("half-written draft");
 	});
 
 	it("keeps image markers in a stashed prompt live", () => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -9,6 +9,7 @@ type FakePasteSnapshot = {
 
 type PromptStash = {
 	text: string;
+	expandedText?: string;
 	pasteSnapshot?: FakePasteSnapshot;
 };
 
@@ -23,7 +24,7 @@ type FakeEditor = {
 	getText: () => string;
 	getExpandedText: () => string;
 	getPasteSnapshot: () => FakePasteSnapshot | undefined;
-	restorePasteSnapshot: (snapshot: FakePasteSnapshot) => void;
+	restorePasteSnapshot?: (snapshot: FakePasteSnapshot) => void;
 	setText: (text: string) => void;
 	addToHistory: Mock;
 	getHistory: () => readonly string[];
@@ -150,7 +151,11 @@ describe("InteractiveMode prompt stash", () => {
 
 		interactiveModeMethods.handlePromptStash.call(mode);
 
-		expect(mode.promptStash).toEqual({ text: "[paste #1 +12 lines]", pasteSnapshot });
+		expect(mode.promptStash).toEqual({
+			text: "[paste #1 +12 lines]",
+			expandedText: "line one\nline two",
+			pasteSnapshot,
+		});
 		expect(mode.editor.getText()).toBe("");
 		expect(mode.showStatus).toHaveBeenCalledWith("Stashed prompt");
 
@@ -158,6 +163,27 @@ describe("InteractiveMode prompt stash", () => {
 
 		expect(mode.editor.getText()).toBe("[paste #1 +12 lines]");
 		expect(mode.editor.restoredPasteSnapshot).toBe(pasteSnapshot);
+	});
+
+	it("restores expanded paste text when paste snapshots are unsupported", () => {
+		const pasteSnapshot: FakePasteSnapshot = {
+			pastes: [[1, "line one\nline two"]],
+			pasteCounter: 1,
+		};
+		const mode = createPromptStashHarness({
+			text: "[paste #1 +12 lines]",
+			expandedText: "line one\nline two",
+			pasteSnapshot,
+		});
+
+		interactiveModeMethods.handlePromptStash.call(mode);
+		mode.editor.restorePasteSnapshot = undefined;
+
+		const restored = interactiveModeMethods.restorePromptStashIfEditorEmpty.call(mode);
+
+		expect(restored).toBe(true);
+		expect(mode.editor.getText()).toBe("line one\nline two");
+		expect(mode.editor.restoredPasteSnapshot).toBeUndefined();
 	});
 
 	it("restores a stashed prompt when the editor is empty", () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -480,6 +480,7 @@ describe("InteractiveMode pending bash components", () => {
 			queuedMessagesContainer: new Container(),
 			compactionQueuedMessages: [],
 			pastedImages: new Map(),
+			liveImageMarkerIds: () => new Set(),
 			defaultEditor: editorStub,
 			editor: editorStub,
 			streamingComponent: undefined,

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,4 +1,5 @@
 import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocomplete.js";
+import type { EditorPasteSnapshot } from "../editor-component.js";
 import { getKeybindings } from "../keybindings.js";
 import { decodePrintableKey, matchesKey } from "../keys.js";
 import { KillRing } from "../kill-ring.js";
@@ -1063,6 +1064,18 @@ export class Editor implements Component, Focusable {
 	 */
 	getExpandedText(): string {
 		return this.expandPasteMarkers(this.state.lines.join("\n"));
+	}
+
+	getPasteSnapshot(): EditorPasteSnapshot {
+		return {
+			pastes: [...this.pastes],
+			pasteCounter: this.pasteCounter,
+		};
+	}
+
+	restorePasteSnapshot(snapshot: EditorPasteSnapshot): void {
+		this.pastes = new Map(snapshot.pastes);
+		this.pasteCounter = snapshot.pasteCounter;
 	}
 
 	getLines(): string[] {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -217,7 +217,7 @@ interface EditorState {
 }
 
 interface EditorUndoSnapshot extends EditorState {
-	pastes: readonly (readonly [number, string])[];
+	pastes: Map<number, string>;
 	pasteCounter: number;
 }
 
@@ -315,7 +315,13 @@ export class Editor implements Component, Focusable {
 	private snappedFromCursorCol: number | null = null;
 
 	// Undo support
-	private undoStack = new UndoStack<EditorUndoSnapshot>();
+	private undoStack = new UndoStack<EditorUndoSnapshot>((snapshot) => ({
+		lines: [...snapshot.lines],
+		cursorLine: snapshot.cursorLine,
+		cursorCol: snapshot.cursorCol,
+		pastes: new Map(snapshot.pastes),
+		pasteCounter: snapshot.pasteCounter,
+	}));
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -2107,10 +2113,10 @@ export class Editor implements Component, Focusable {
 
 	private pushUndoSnapshot(): void {
 		this.undoStack.push({
-			lines: [...this.state.lines],
+			lines: this.state.lines,
 			cursorLine: this.state.cursorLine,
 			cursorCol: this.state.cursorCol,
-			pastes: [...this.pastes],
+			pastes: this.pastes,
 			pasteCounter: this.pasteCounter,
 		});
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -216,6 +216,11 @@ interface EditorState {
 	cursorCol: number;
 }
 
+interface EditorUndoSnapshot extends EditorState {
+	pastes: readonly (readonly [number, string])[];
+	pasteCounter: number;
+}
+
 interface LayoutLine {
 	text: string;
 	hasCursor: boolean;
@@ -310,7 +315,7 @@ export class Editor implements Component, Focusable {
 	private snappedFromCursorCol: number | null = null;
 
 	// Undo support
-	private undoStack = new UndoStack<EditorState>();
+	private undoStack = new UndoStack<EditorUndoSnapshot>();
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -2101,14 +2106,26 @@ export class Editor implements Component, Focusable {
 	}
 
 	private pushUndoSnapshot(): void {
-		this.undoStack.push(this.state);
+		this.undoStack.push({
+			lines: [...this.state.lines],
+			cursorLine: this.state.cursorLine,
+			cursorCol: this.state.cursorCol,
+			pastes: [...this.pastes],
+			pasteCounter: this.pasteCounter,
+		});
 	}
 
 	private undo(): void {
 		this.historyIndex = -1; // Exit history browsing mode
 		const snapshot = this.undoStack.pop();
 		if (!snapshot) return;
-		Object.assign(this.state, snapshot);
+		this.state = {
+			lines: snapshot.lines,
+			cursorLine: snapshot.cursorLine,
+			cursorCol: snapshot.cursorCol,
+		};
+		this.pastes = new Map(snapshot.pastes);
+		this.pasteCounter = snapshot.pasteCounter;
 		this.lastAction = null;
 		this.preferredVisualCol = null;
 		if (this.onChange) {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -1,6 +1,11 @@
 import type { AutocompleteProvider } from "./autocomplete.js";
 import type { Component } from "./tui.js";
 
+export interface EditorPasteSnapshot {
+	pastes: readonly (readonly [number, string])[];
+	pasteCounter: number;
+}
+
 /**
  * Interface for custom editor components.
  *
@@ -57,6 +62,10 @@ export interface EditorComponent extends Component {
 	 * Falls back to getText() if not implemented.
 	 */
 	getExpandedText?(): string;
+
+	getPasteSnapshot?(): EditorPasteSnapshot;
+
+	restorePasteSnapshot?(snapshot: EditorPasteSnapshot): void;
 
 	// =========================================================================
 	// Autocomplete support (optional)

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -28,7 +28,7 @@ export { Spacer } from "./components/spacer.js";
 export { Text } from "./components/text.js";
 export { TruncatedText } from "./components/truncated-text.js";
 // Editor component interface (for custom editors)
-export type { EditorComponent } from "./editor-component.js";
+export type { EditorComponent, EditorPasteSnapshot } from "./editor-component.js";
 // Fullscreen (alternate-screen) viewport
 export { FullscreenViewport, type ScrollInfo } from "./fullscreen.js";
 // Fuzzy matching

--- a/packages/tui/src/undo-stack.ts
+++ b/packages/tui/src/undo-stack.ts
@@ -1,15 +1,17 @@
 /**
  * Generic undo stack with clone-on-push semantics.
  *
- * Stores deep clones of state snapshots. Popped snapshots are returned
- * directly (no re-cloning) since they are already detached.
+ * Stores cloned state snapshots. Popped snapshots are returned directly
+ * since they are already detached.
  */
 export class UndoStack<S> {
 	private stack: S[] = [];
 
-	/** Push a deep clone of the given state onto the stack. */
+	constructor(private readonly clone: (state: S) => S = structuredClone) {}
+
+	/** Push a clone of the given state onto the stack. */
 	push(state: S): void {
-		this.stack.push(structuredClone(state));
+		this.stack.push(this.clone(state));
 	}
 
 	/** Pop and return the most recent snapshot, or undefined if empty. */

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3692,6 +3692,51 @@ describe("Editor component", () => {
 			assert.strictEqual(restored.getExpandedText(), pastedText);
 		});
 
+		it("restores paste snapshot state on undo", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const originalText = [
+				"original 1",
+				"original 2",
+				"original 3",
+				"original 4",
+				"original 5",
+				"original 6",
+				"original 7",
+				"original 8",
+				"original 9",
+				"original 10",
+				"original 11",
+			].join("\n");
+			const restoredText = [
+				"restored 1",
+				"restored 2",
+				"restored 3",
+				"restored 4",
+				"restored 5",
+				"restored 6",
+				"restored 7",
+				"restored 8",
+				"restored 9",
+				"restored 10",
+				"restored 11",
+				"restored 12",
+			].join("\n");
+			const restoredSource = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.handleInput(`\x1b[200~${originalText}\x1b[201~`);
+			const originalMarker = editor.getText();
+			restoredSource.handleInput(`\x1b[200~${restoredText}\x1b[201~`);
+
+			editor.setText(restoredSource.getText());
+			editor.restorePasteSnapshot(restoredSource.getPasteSnapshot());
+			assert.strictEqual(editor.getExpandedText(), restoredText);
+
+			editor.handleInput("\x1b[45;5u");
+
+			assert.strictEqual(editor.getText(), originalMarker);
+			assert.strictEqual(editor.getExpandedText(), originalText);
+		});
+
 		it("snaps to the paste marker start when navigating down into it", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3658,6 +3658,40 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getExpandedText(), pastedText);
 		});
 
+		it("restores expanded pasted content from a paste snapshot", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const pastedText = [
+				"line 1",
+				"line 2",
+				"line 3",
+				"line 4",
+				"line 5",
+				"line 6",
+				"line 7",
+				"line 8",
+				"line 9",
+				"line 10",
+				"line 11",
+			].join("\n");
+			let submitted = "";
+			editor.onSubmit = (text) => {
+				submitted = text;
+			};
+
+			editor.handleInput(`\x1b[200~${pastedText}\x1b[201~`);
+			const markerText = editor.getText();
+			const snapshot = editor.getPasteSnapshot();
+			editor.handleInput("\r");
+
+			const restored = new Editor(createTestTUI(), defaultEditorTheme);
+			restored.setText(markerText);
+			restored.restorePasteSnapshot(snapshot);
+
+			assert.match(markerText, /\[paste #\d+ \+\d+ lines\]/);
+			assert.strictEqual(submitted, pastedText);
+			assert.strictEqual(restored.getExpandedText(), pastedText);
+		});
+
 		it("snaps to the paste marker start when navigating down into it", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
- prompt drafts can now be stashed from the editor and restored after sending a separate prompt or command.
- the stash preserves expanded paste text and keeps referenced image attachments alive while the draft is hidden.
- ctrl+s is registered as a configurable app keybinding and documented in hotkey hints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized interactive editor and TUI changes with broad test coverage; no auth, persistence, or agent-runtime behavior changes beyond draft lifecycle.
> 
> **Overview**
> Adds **prompt stashing** in interactive mode so you can park a draft, run another prompt or slash command, then get the draft back in the editor.
> 
> **Ctrl+S** (`app.prompt.stash`) saves the current editor text (including paste-marker snapshots when supported), clears the input, and restores the stash when the editor is empty or after submit/follow-up handlers finish—including async selectors like `/fork` and `/settings`. Only one stash at a time; **session replacement** clears it.
> 
> The TUI **Editor** gains optional `getPasteSnapshot` / `restorePasteSnapshot`, with undo snapshots extended so paste maps survive undo. Session render resets keep stashed drafts and their **image markers** alive while pruning orphaned pasted images from cleared queues.
> 
> Changelog, header hints, and hotkeys help document the binding; new tests cover stash/restore, image retention, and follow-up error rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3610e792e816946488d00f351338080fb804aca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prompt stashing to interactive mode with `ctrl+s` keybinding
> - Adds a stash/restore flow for draft prompts in `InteractiveMode`: pressing `ctrl+s` saves the current editor text (including paste snapshot) and clears the editor; pressing again restores the stash when the editor is empty.
> - After a stashed prompt is cleared to run a different command or follow-up, it is automatically restored into the editor once that submission completes.
> - Pasted image markers referenced only by a stashed draft are now kept live and not pruned on session reset.
> - External session replacement (via `session_replaced`) clears the stash, preventing stale drafts from reappearing.
> - The editor's `UndoStack` now deep-copies paste state on push and restores it on undo, enabling accurate snapshot round-trips.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3610e79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->