### PR TITLE
fix ci after model catalog refresh

### DIFF
--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -30,7 +30,6 @@ describe("Prime Inference models", () => {
 				"nvidia/nemotron-3-super-120b-a12b",
 				"openai/gpt-5.4",
 				"openai/gpt-5.5",
-				"prime-intellect/intellect-3",
 				"qwen/qwen3-coder-next",
 				"qwen/qwen3-vl-235b-a22b-thinking",
 				"x-ai/grok-4.20",

--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -26,7 +26,7 @@ if (process.env.MY_ANTHROPIC_KEY) {
 // Model registry with no custom models.json
 const modelRegistry = ModelRegistry.inMemory(authStorage);
 
-const model = getModel("anthropic", "claude-sonnet-4-20250514");
+const model = getModel("anthropic", "claude-sonnet-5");
 if (!model) throw new Error("Model not found");
 
 // In-memory settings with overrides

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -237,6 +237,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 	it("should trigger threshold compaction for error messages using last successful usage", async () => {
 		const model = session.model!;
+		const highUsageTokens = model.contextWindow;
 
 		// A successful assistant message with high token usage (near context limit)
 		const successfulAssistant: AssistantMessage = {
@@ -246,11 +247,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 			provider: model.provider,
 			model: model.id,
 			usage: {
-				input: 180_000,
-				output: 10_000,
+				input: highUsageTokens,
+				output: 0,
 				cacheRead: 0,
 				cacheWrite: 0,
-				totalTokens: 190_000,
+				totalTokens: highUsageTokens,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "stop",

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -51,13 +51,12 @@ describeIfKernel("kernel state snapshot round-trip (real kernel)", () => {
 			await writer.execute("x = 42");
 			await writer.execute("df = [1, 2, 3]");
 			await writer.execute("def double(n):\n    return n * 2");
-			await writer.execute("import socket\nsock = socket.socket()");
+			await writer.execute("gen = (n for n in range(3))");
 
 			const snap = await writer.snapshotState();
 			expect(snap).not.toBeNull();
 			expect(snap?.saved).toEqual(expect.arrayContaining(["x", "df", "double"]));
-			// A live socket cannot be pickled and must be reported, not silently dropped.
-			expect(snap?.skipped.map((s) => s.name)).toContain("sock");
+			expect(snap?.skipped.map((s) => s.name)).toContain("gen");
 			expect(existsSync(snapshotPath)).toBe(true);
 			expect(existsSync(manifestPath)).toBe(true);
 		} finally {


### PR DESCRIPTION
- updates the sdk example to use a model id that exists after catalog regeneration.
- relaxes live prime inference catalog assertions so removed models do not break tests.
- makes brittle ci tests scale with generated metadata and avoid slow unpicklable fixtures.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI tests after model catalog refresh
> - Removes `prime-intellect/intellect-3` from the expected model IDs in the Prime Inference catalog test in [prime-inference-models.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/324/files#diff-6462d25872f543c52f27cfe6c81089527799a97772aba030f15340bd33bf77b2)
> - Updates the Anthropic model identifier in the full-control example from `claude-sonnet-4-20250514` to `claude-sonnet-5`
> - Replaces hardcoded token values in the auto-compaction threshold test with values derived from `model.contextWindow`
> - Replaces a live socket with a generator as the unpicklable object in the kernel state snapshot test
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 254a23c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->