### PR TITLE
enable fullscreen tui by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added daemon-backed user orchestration with agent-to-agent messaging and read-only observation of active sessions.
 - Added an orchestration heartbeat skill for compact multi-session progress, blocker, and action summaries.
 - Added an opt-in auto-refine review hook that can ask whether `/refine` should run after turn intervals or compaction checkpoints.
+- Changed fullscreen TUI rendering to be enabled by default.
 
 ## [0.2.4] - 2026-07-01
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -43,7 +43,7 @@ export interface TerminalSettings {
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
-	fullscreen?: boolean; // default: false (alternate-screen rendering with scrollable transcript)
+	fullscreen?: boolean; // default: true (alternate-screen rendering with scrollable transcript)
 	fullscreenMouse?: boolean; // default: true (wheel scrolling in fullscreen; disable if it breaks selection)
 }
 
@@ -1041,7 +1041,7 @@ export class SettingsManager {
 		if (process.env.PI_FULLSCREEN !== undefined) {
 			return process.env.PI_FULLSCREEN === "1";
 		}
-		return this.settings.terminal?.fullscreen ?? false;
+		return this.settings.terminal?.fullscreen ?? true;
 	}
 
 	setFullscreen(enabled: boolean): void {

--- a/packages/coding-agent/test/fullscreen-mode.test.ts
+++ b/packages/coding-agent/test/fullscreen-mode.test.ts
@@ -31,26 +31,27 @@ describe("fullscreen mode settings", () => {
 		}
 	});
 
-	it("defaults to off with mouse enabled", () => {
+	it("defaults to on with mouse enabled", () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
-		expect(manager.getFullscreen()).toBe(false);
+		expect(manager.getFullscreen()).toBe(true);
 		expect(manager.getFullscreenMouse()).toBe(true);
 	});
 
-	it("persists the fullscreen toggle", async () => {
+	it("persists the fullscreen off toggle", async () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
-		manager.setFullscreen(true);
+		manager.setFullscreen(false);
 		await manager.flush();
 
 		const settings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
-		expect(settings.terminal.fullscreen).toBe(true);
+		expect(settings.terminal.fullscreen).toBe(false);
 
 		const reloaded = SettingsManager.create(projectDir, agentDir);
-		expect(reloaded.getFullscreen()).toBe(true);
+		expect(reloaded.getFullscreen()).toBe(false);
 	});
 
 	it("PI_FULLSCREEN env var overrides the setting in both directions", () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
+		manager.setFullscreen(false);
 
 		process.env.PI_FULLSCREEN = "1";
 		expect(manager.getFullscreen()).toBe(true);


### PR DESCRIPTION
- fullscreen rendering now starts enabled for users without an explicit terminal setting.
- existing slash command and environment overrides still allow users to opt out.
- updated coverage to verify the new default and persisted opt-out path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small default flip in terminal presentation only; explicit settings and `PI_FULLSCREEN` preserve prior behavior for users who configured it.
> 
> **Overview**
> **Fullscreen alternate-screen TUI** now starts **on** when `terminal.fullscreen` is unset: `getFullscreen()` falls back to `true` instead of `false`, and the `TerminalSettings` default comment matches.
> 
> Users who never saved a preference will get scrollable fullscreen rendering on launch. **`PI_FULLSCREEN`** still overrides in both directions, and **`/fullscreen on|off`** plus persisted `settings.json` still opt out. Tests and the unreleased changelog reflect the new default and the persisted off path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c32582a6d172389c3535058c83b911f370c942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable fullscreen TUI mode by default in coding agent
> Changes the default value of `getFullscreen` in [settings-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/325/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab) from `false` to `true` when neither the `PI_FULLSCREEN` env var nor an explicit setting is present. Tests are updated to reflect the new default.
>
> Behavioral Change: existing users who have not explicitly set `fullscreen` will now get fullscreen TUI rendering automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2c3258.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->