### PR TITLE
fix installer onboarding progress

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ prime_agent_screen_title=
 prime_agent_screen_status=
 prime_agent_screen_detail=
 prime_agent_screen_question=
+prime_agent_animation_frame=0
 
 main() {
 	if [ "$prime_agent_base_url" = "$prime_agent_unconfigured_base_url" ]; then
@@ -679,10 +680,59 @@ prime_agent_pulse() {
 	esac
 }
 
-prime_agent_static_progress_title() {
-	case "$1" in
-		*...) printf '%s' "$1" ;;
-		*) printf '%s...' "$1" ;;
+prime_agent_animation_detail_count() {
+	details="$1"
+	case "$details" in
+		*'
+'*) printf '%s\n' "$details" | wc -l | tr -d ' ' ;;
+		*) printf '1' ;;
+	esac
+}
+
+prime_agent_animation_current_frame() {
+	frame="${prime_agent_animation_frame:-1}"
+	case "$frame" in
+		""|*[!0-9]*) frame=1 ;;
+	esac
+	if [ "$frame" -lt 1 ]; then
+		frame=1
+	fi
+	printf '%s' "$frame"
+}
+
+prime_agent_animation_step_index() {
+	details="$1"
+	detail_count=$(prime_agent_animation_detail_count "$details")
+	frame=$(prime_agent_animation_current_frame)
+	detail_index=$(((frame - 1) / 24 + 1))
+	if [ "$detail_index" -gt "$detail_count" ]; then
+		detail_index="$detail_count"
+	fi
+	printf '%s' "$detail_index"
+}
+
+prime_agent_animation_percent() {
+	details="$1"
+	detail_count=$(prime_agent_animation_detail_count "$details")
+	total_frames=$((detail_count * 24))
+	frame=$(prime_agent_animation_current_frame)
+	percent=$((frame * 100 / total_frames))
+	if [ "$percent" -lt 1 ]; then
+		percent=1
+	fi
+	if [ "$percent" -gt 99 ]; then
+		percent=99
+	fi
+	printf '%s' "$percent"
+}
+
+prime_agent_animation_status() {
+	status="$1"
+	details="$2"
+	status_mode="$3"
+	case "$status_mode" in
+		static) printf '%s · %s%%' "$status" "$(prime_agent_animation_percent "$details")" ;;
+		*) printf '%s%s' "$status" "$(prime_agent_pulse)" ;;
 	esac
 }
 
@@ -691,8 +741,7 @@ prime_agent_animation_detail() {
 	case "$details" in
 		*'
 '*)
-			detail_count=$(printf '%s\n' "$details" | wc -l | tr -d ' ')
-			detail_index=$(((prime_agent_screen_frame / 12) % detail_count + 1))
+			detail_index=$(prime_agent_animation_step_index "$details")
 			printf '%s\n' "$details" | sed -n "${detail_index}p"
 			;;
 		*) printf '%s' "$details" ;;
@@ -734,12 +783,11 @@ prime_agent_run_quiet_with_animation_command() {
 	output_file="$output_dir/output"
 	"$@" >"$output_file" 2>&1 &
 	command_pid=$!
+	prime_agent_animation_frame=0
 
 	while kill -0 "$command_pid" 2>/dev/null; do
-		case "$status_mode" in
-			static) status_display=$(prime_agent_static_progress_title "$status") ;;
-			*) status_display="$status$(prime_agent_pulse)" ;;
-		esac
+		prime_agent_animation_frame=$((prime_agent_animation_frame + 1))
+		status_display=$(prime_agent_animation_status "$status" "$details" "$status_mode")
 		prime_agent_screen "$title" "$status_display" "$(prime_agent_animation_detail "$details")" ""
 		sleep 0.18
 	done

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added daemon-backed user orchestration with agent-to-agent messaging and read-only observation of active sessions.
 - Added an orchestration heartbeat skill for compact multi-session progress, blocker, and action summaries.
 - Added an opt-in auto-refine review hook that can ask whether `/refine` should run after turn intervals or compaction checkpoints.
+- Changed the installer onboarding splash to show ordered setup phases with a percentage instead of cycling detail text ([ENG-4376](https://linear.app/primeintellect/issue/ENG-4376/onboarding-instructions-should-be-accurate-to-whats-happening)).
 
 ## [0.2.4] - 2026-07-01
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -442,43 +442,6 @@ function reportProgress(options: EnsureKernelPythonOptions, message: string): vo
 	process.stderr.write(`${message}\n`);
 }
 
-// Drives the single setup line shown during first-run bootstrap: each step
-// replaces the line with what's actually running plus a cumulative percentage.
-// Weights are rough wall-clock shares (the package install dwarfs the rest) so
-// the percentage tracks real work, not a flat 1/N. The caller builds the step
-// list from only the steps that will run, so the denominator stays honest.
-interface BootstrapStep {
-	label: string;
-	weight: number;
-}
-
-class BootstrapProgress {
-	private readonly total: number;
-	private completedWeight = 0;
-
-	constructor(
-		private readonly options: EnsureKernelPythonOptions,
-		steps: readonly BootstrapStep[],
-	) {
-		this.total = steps.reduce((sum, step) => sum + step.weight, 0) || 1;
-	}
-
-	// Announce a step as it begins; the percentage reflects work done before it.
-	begin(step: BootstrapStep): void {
-		const percent = Math.min(99, Math.round((this.completedWeight / this.total) * 100));
-		this.completedWeight += step.weight;
-		reportProgress(this.options, `${step.label} · ${percent}%`);
-	}
-}
-
-const BOOTSTRAP_STEP = {
-	uv: { label: "installing uv", weight: 3 },
-	python: { label: "installing Python 3.11", weight: 4 },
-	venv: { label: "creating virtual environment", weight: 2 },
-	packages: { label: "installing packages (ipykernel, numpy, pandas, …)", weight: 10 },
-	skills: { label: "installing Python skills", weight: 2 },
-} satisfies Record<string, BootstrapStep>;
-
 function bootstrapLockDir(venv: string): string {
 	return path.join(path.dirname(venv), `${path.basename(venv)}${BOOTSTRAP_LOCK_NAME}`);
 }
@@ -548,23 +511,13 @@ async function findExecutable(name: string): Promise<string | null> {
 	return null;
 }
 
-function localUvPath(): string {
-	return path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
-}
-
-// Resolve an existing uv without installing one. Returns null if uv is absent.
-async function locateUv(): Promise<string | null> {
+async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 	const fromPath = await findExecutable("uv");
 	if (fromPath) return fromPath;
-	const localUv = localUvPath();
-	return (await isExecutable(localUv)) ? localUv : null;
-}
 
-async function ensureUv(options: EnsureKernelPythonOptions, onAboutToInstall?: () => void): Promise<string> {
-	const existing = await locateUv();
-	if (existing) return existing;
+	const localUv = path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
+	if (await isExecutable(localUv)) return localUv;
 
-	const localUv = localUvPath();
 	const shouldInstallUv =
 		process.env.PRIME_AGENT_INSTALL_UV === "1" || (!options.onProgress && (await confirmUvInstall()));
 	if (!shouldInstallUv) {
@@ -574,10 +527,7 @@ async function ensureUv(options: EnsureKernelPythonOptions, onAboutToInstall?: (
 		);
 	}
 
-	// Announce only once an install is actually committed, so a refusal here never
-	// leaves a phantom "installing uv" step on screen.
-	onAboutToInstall?.();
-
+	reportProgress(options, "› installing uv (one-time)…");
 	try {
 		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
 	} catch (error) {
@@ -774,32 +724,14 @@ async function bootstrapVenv(
 	options: EnsureKernelPythonOptions,
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
+	const uv = await ensureUv(options);
 	const python = path.join(venv, "bin", "python");
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
 
-	// Build the step list before running so the percentage denominator only
-	// counts work that will actually happen on this machine.
-	const needsUvInstall = (await locateUv()) === null;
-	const steps: BootstrapStep[] = [
-		...(needsUvInstall ? [BOOTSTRAP_STEP.uv] : []),
-		BOOTSTRAP_STEP.python,
-		BOOTSTRAP_STEP.venv,
-		BOOTSTRAP_STEP.packages,
-		...(pythonSkills.length > 0 ? [BOOTSTRAP_STEP.skills] : []),
-	];
-	const progress = new BootstrapProgress(options, steps);
-
-	const uv = await ensureUv(options, needsUvInstall ? () => progress.begin(BOOTSTRAP_STEP.uv) : undefined);
-
-	progress.begin(BOOTSTRAP_STEP.python);
 	await run(uv, ["python", "install", PYTHON_VERSION]);
-
-	progress.begin(BOOTSTRAP_STEP.venv);
 	await run(uv, ["venv", venv, "--python", PYTHON_VERSION, "--seed"]);
-
-	progress.begin(BOOTSTRAP_STEP.packages);
 	await run(uv, [
 		"pip",
 		"install",
@@ -810,9 +742,6 @@ async function bootstrapVenv(
 		STATE_SNAPSHOT_REQUIREMENT,
 		...DEFAULT_RLM_EXTRA_UV_ARGS,
 	]);
-	if (pythonSkills.length > 0) {
-		progress.begin(BOOTSTRAP_STEP.skills);
-	}
 	await syncPythonSkills(uv, venv, python, runtimeIdentity, pythonSkills, options);
 }
 
@@ -969,7 +898,10 @@ async function ensureKernelPythonUncached(
 			return python;
 		}
 
-		if (existsSync(venv)) {
+		const hadVenv = existsSync(venv);
+		reportProgress(options, "› setting up python kernel (one-time, ~30s)…");
+		if (hadVenv) {
+			reportProgress(options, "rebuilding kernel venv");
 			await rm(venv, { recursive: true, force: true });
 		}
 
@@ -980,7 +912,7 @@ async function ensureKernelPythonUncached(
 		await releaseLock().catch(() => undefined);
 	}
 
-	reportProgress(options, "✓ ready · 100%");
+	reportProgress(options, "✓ ready");
 	return python;
 }
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -218,33 +218,9 @@ describe("kernel bootstrap", () => {
 			stderrWrite.mockRestore();
 		}
 
-		// Fake uv is on PATH, so the uv-install step is skipped; the rest describe real steps.
-		expect(progress).toEqual([
-			"installing Python 3.11 · 0%",
-			expect.stringMatching(/^creating virtual environment · \d+%$/),
-			expect.stringMatching(/^installing packages \(.+\) · \d+%$/),
-			"✓ ready · 100%",
-		]);
-
-		const percents = progress.map((line) => Number(line.match(/(\d+)%$/)?.[1] ?? "0"));
-		expect(percents).toEqual([...percents].sort((a, b) => a - b));
-		expect(percents.at(-1)).toBe(100);
+		expect(progress).toEqual(expect.arrayContaining(["› setting up python kernel (one-time, ~30s)…", "✓ ready"]));
+		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("setting up python kernel"));
 		expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining("ready"));
-	});
-
-	it("does not show an installing-uv step when uv install is refused", async () => {
-		// uv absent from PATH and from the temp HOME, and install not permitted.
-		const emptyBin = join(tempDir, "empty-bin");
-		mkdirSync(emptyBin, { recursive: true });
-		process.env.PATH = emptyBin;
-		delete process.env.PRIME_AGENT_INSTALL_UV;
-		const venv = join(tempDir, "kernel-venv");
-		const progress: string[] = [];
-		process.env.PRIME_AGENT_KERNEL_VENV = venv;
-
-		await expect(ensureKernelPython({ onProgress: (message) => progress.push(message) })).rejects.toThrow(/uv/);
-		expect(progress).not.toContain(expect.stringContaining("installing uv"));
-		expect(progress.some((line) => line.startsWith("installing uv"))).toBe(false);
 	});
 
 	it("installs Python skills into the bootstrapped venv", async () => {

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -58,7 +58,18 @@ render_case() {
 	printf '__RENDER_END__ second\\n'
 }
 
+progress_case() {
+	progress_details="Preparing global install.
+Linking command binaries.
+Finalizing npm install."
+	for progress_frame in 1 24 25 48 49 200; do
+		prime_agent_animation_frame="$progress_frame"
+		printf '__PROGRESS__ %s\t%s\t%s\t%s\\n' "$progress_frame" "$(prime_agent_animation_percent "$progress_details")" "$(prime_agent_animation_status "Installing Prime Agent" "$progress_details" static)" "$(prime_agent_animation_detail "$progress_details")"
+	done
+}
+
 render_case "$@"
+progress_case
 `;
 
 const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-installer-render-"));
@@ -74,6 +85,7 @@ try {
 		stableVisible.meta.first.lab_width === stableVisible.meta.second.lab_width,
 		"expected logo lab width to stay stable across a safe resize",
 	);
+	assertInstallerProgress(stableVisible.progress);
 
 	const stableExpand = runCase("stable expanded logo", 60, 24, 120, 32);
 	check(stableExpand.meta.first.visible === "1", "expected the initial medium render to show the logo");
@@ -151,12 +163,50 @@ function parseRenderOutput(output) {
 			activeRender = null;
 			continue;
 		}
+		if (line.startsWith("__PROGRESS__ ")) {
+			const [frame, percent, status, detail] = line.slice("__PROGRESS__ ".length).split("\t");
+			parsed.progress.push({ frame: Number(frame), percent: Number(percent), status, detail });
+			continue;
+		}
 		if (activeRender) {
 			parsed.renders[activeRender].push(line.replace(ansiPattern, ""));
 		}
 	}
 
 	return parsed;
+}
+
+function assertInstallerProgress(progress) {
+	check(progress.length === 6, `expected six progress samples, got ${progress.length}`);
+	if (progress.length !== 6) return;
+
+	const expectedDetails = [
+		"Preparing global install.",
+		"Preparing global install.",
+		"Linking command binaries.",
+		"Linking command binaries.",
+		"Finalizing npm install.",
+		"Finalizing npm install.",
+	];
+	for (const [index, expectedDetail] of expectedDetails.entries()) {
+		check(
+			progress[index].detail === expectedDetail,
+			`expected progress sample ${index + 1} to show "${expectedDetail}", got "${progress[index].detail}"`,
+		);
+		check(
+			progress[index].status === `Installing Prime Agent · ${progress[index].percent}%`,
+			`expected progress sample ${index + 1} to include percent in the status`,
+		);
+	}
+
+	for (let index = 1; index < progress.length; index++) {
+		check(
+			progress[index].percent >= progress[index - 1].percent,
+			`expected progress percent to be monotonic between samples ${index} and ${index + 1}`,
+		);
+	}
+	check(progress[0].percent > 0, "expected progress percent to start above zero");
+	check(progress[progress.length - 1].percent === 99, "expected in-flight progress percent to cap at 99");
 }
 
 function assertLineWidths(name, label, parsed, cols, rows) {
@@ -185,5 +235,6 @@ function emptyParsedCase() {
 			first: [],
 			second: [],
 		},
+		progress: [],
 	};
 }


### PR DESCRIPTION
- reverted the kernel bootstrap progress changes from pr 293 so first-run kernel setup returns to the prior messaging.
- moved eng-4376 to the shell installer splash by showing ordered install phases with an in-flight percentage.
- expanded the installer render check to cover progress ordering and monotonic percentages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only installer animation and simplified bootstrap stderr/onProgress strings; behavior covered by updated unit and installer render checks.
> 
> **Overview**
> **Installer splash (ENG-4376):** Long-running install steps now use **static** mode: multiline phase lists advance in order (one line per 24 animation frames), the status shows **`Title · N%`** with percent clamped to 1–99 while work is in flight, and detail text no longer cycles randomly. Node.js and npm global install paths already pass multiline `*_install_details` into `prime_agent_run_quiet_with_animation_steps`.
> 
> **Kernel bootstrap:** Per-step weighted progress from PR #293 is **removed** (`BootstrapProgress` / step labels with percentages). First-run setup reports a single **`› setting up python kernel (one-time, ~30s)…`**, optional **`rebuilding kernel venv`**, and **`✓ ready`** (no `100%` line). `ensureUv` reports **`› installing uv (one-time)…`** when it actually installs.
> 
> **Tests / CI:** Kernel bootstrap tests no longer assert monotonic step percentages; the installer render harness asserts phase ordering, status formatting, and monotonic capped percentages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8250ddc324d3ab2abb9c9a2405326ff3baf624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix installer onboarding progress to show ordered setup phases with a percentage
> - Replaces cycling detail text in the installer animation with deterministic phase progression: one detail per 24 frames, advancing in order via `prime_agent_animation_step_index` in [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/327/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f)
> - Adds `prime_agent_animation_percent` to display a bounded in-flight percentage (clamped to 1–99) in static mode; removes the old `prime_agent_static_progress_title` ellipsis function
> - Simplifies kernel bootstrap in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/327/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) by removing `BootstrapProgress`/`BootstrapStep` and per-step percentage messages; emits a single setup announcement and a `✓ ready` completion message
> - Extends [check-installer-render.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/327/files#diff-22dc1ee148ea8609089fbf10f9465e8ca5e6375523e99bb314a55b9c0381ae5e) with progress sampling and assertions that verify phase selection, monotonic percent, and the 1–99 cap
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee8250d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->