### PR TITLE
fix fullscreen overlay selection

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed fullscreen overlay selection so login URLs can be copied.
+
 ## [0.2.5] - 2026-07-06
 
 - Added fullscreen viewport rendering with alternate-screen scrolling, follow controls, mouse selection, and clipboard copy hooks ([#316](https://github.com/PrimeIntellect-ai/prime-agent/pull/316)).

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -121,11 +121,12 @@ export class FullscreenViewport {
 
 	/** Begin a selection at a screen position; false when outside the transcript window. */
 	beginSelection(screenRow: number, screenCol: number): boolean {
-		if (screenRow < 0 || screenRow >= this.lastWindowHeight) {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) {
 			this.clearSelection();
 			return false;
 		}
-		const point = { line: this.scrollTop + screenRow, col: Math.max(0, screenCol) };
+		const point = { line, col: Math.max(0, screenCol) };
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
 		this.selectionMode = "transcript";
@@ -134,8 +135,9 @@ export class FullscreenViewport {
 
 	extendSelection(screenRow: number, screenCol: number): void {
 		if (!this.selectionAnchor || this.selectionMode !== "transcript") return;
-		const row = Math.max(0, Math.min(screenRow, this.lastWindowHeight - 1));
-		this.selectionHead = { line: this.scrollTop + row, col: Math.max(0, screenCol) };
+		const line = this.transcriptLineForScreenRow(screenRow, true);
+		if (line === null) return;
+		this.selectionHead = { line, col: Math.max(0, screenCol) };
 	}
 
 	/** Finish the selection and return its plain text (null when empty). */
@@ -238,6 +240,22 @@ export class FullscreenViewport {
 		const line = this.lastFrameVisibleStart + row;
 		if (line < 0 || line >= this.lastFrame.length) return null;
 		return { line, col: Math.max(0, screenCol) };
+	}
+
+	private transcriptLineForScreenRow(screenRow: number, clamp: boolean): number | null {
+		if (this.lastWindowHeight <= 0) return null;
+		const visibleHeight = this.lastFrameVisibleHeight > 0 ? this.lastFrameVisibleHeight : this.lastWindowHeight;
+		if (visibleHeight <= 0) return null;
+		if (!clamp && (screenRow < 0 || screenRow >= visibleHeight)) return null;
+		const row = clamp ? Math.max(0, Math.min(screenRow, visibleHeight - 1)) : screenRow;
+		const visibleStart = this.lastFrameVisibleHeight > 0 ? this.lastFrameVisibleStart : 0;
+		const visibleEnd = visibleStart + visibleHeight - 1;
+		const transcriptStart = Math.max(0, visibleStart);
+		const transcriptEnd = Math.min(this.lastWindowHeight - 1, visibleEnd);
+		if (transcriptStart > transcriptEnd) return null;
+		const frameLine = visibleStart + row;
+		if (!clamp && (frameLine < transcriptStart || frameLine > transcriptEnd)) return null;
+		return this.scrollTop + Math.max(transcriptStart, Math.min(frameLine, transcriptEnd));
 	}
 
 	private isFrameSelectable(point: SelectionPoint): boolean {

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -26,6 +26,8 @@ interface SelectionPoint {
 	col: number;
 }
 
+type SelectionMode = "transcript" | "frame";
+
 export class FullscreenViewport {
 	private scrollTop = 0;
 	private following = true;
@@ -35,8 +37,10 @@ export class FullscreenViewport {
 	private lastMaxScroll = 0;
 	private lastWindowHeight = 0;
 	private lastTranscript: string[] = [];
+	private lastFrame: string[] = [];
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
+	private selectionMode: SelectionMode | null = null;
 
 	/**
 	 * Compose a frame of exactly `height` lines: scrolled transcript window on
@@ -94,21 +98,13 @@ export class FullscreenViewport {
 	}
 
 	private highlightSelection(window: string[]): void {
+		if (this.selectionMode !== "transcript") return;
 		const sel = this.orderedSelection();
 		if (!sel) return;
 		for (let i = 0; i < window.length; i++) {
 			const span = this.selectionSpan(this.scrollTop + i, sel);
 			if (!span) continue;
-			const width = visibleWidth(window[i]);
-			const from = Math.min(span.from, width);
-			const to = Math.min(span.to, width);
-			if (to <= from) continue;
-			const before = sliceByColumn(window[i], 0, from);
-			// selected span is rendered plain-inverse: SGR codes inside it could
-			// cancel the inverse attribute mid-span
-			const selected = stripAnsi(sliceByColumn(window[i], from, to - from));
-			const after = sliceByColumn(window[i], to, Math.max(0, width - to));
-			window[i] = `${before}\x1b[0m\x1b[7m${selected}\x1b[27m${after}`;
+			window[i] = this.highlightLine(window[i], span);
 		}
 	}
 
@@ -121,23 +117,90 @@ export class FullscreenViewport {
 		const point = { line: this.scrollTop + screenRow, col: Math.max(0, screenCol) };
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
+		this.selectionMode = "transcript";
 		return true;
 	}
 
 	extendSelection(screenRow: number, screenCol: number): void {
-		if (!this.selectionAnchor) return;
+		if (!this.selectionAnchor || this.selectionMode !== "transcript") return;
 		const row = Math.max(0, Math.min(screenRow, this.lastWindowHeight - 1));
 		this.selectionHead = { line: this.scrollTop + row, col: Math.max(0, screenCol) };
 	}
 
 	/** Finish the selection and return its plain text (null when empty). */
 	endSelection(): string | null {
+		if (this.selectionMode !== "transcript") {
+			this.clearSelection();
+			return null;
+		}
 		const sel = this.orderedSelection();
 		this.clearSelection();
 		if (!sel) return null;
+		return this.extractSelectionText(this.lastTranscript, sel);
+	}
+
+	/** Snapshot and highlight the final screen frame for overlay/dock selection. */
+	applyFrameSelection(frame: string[]): void {
+		this.lastFrame = frame;
+		if (this.selectionMode !== "frame") return;
+		const sel = this.orderedSelection();
+		if (!sel) return;
+		for (let lineIndex = sel.start.line; lineIndex <= sel.end.line; lineIndex++) {
+			const line = frame[lineIndex];
+			if (line === undefined) continue;
+			const span = this.selectionSpan(lineIndex, sel);
+			if (!span) continue;
+			frame[lineIndex] = this.highlightLine(line, span);
+		}
+	}
+
+	beginFrameSelection(screenRow: number, screenCol: number): boolean {
+		if (screenRow < 0 || screenRow >= this.lastFrame.length) {
+			this.clearSelection();
+			return false;
+		}
+		const point = { line: screenRow, col: Math.max(0, screenCol) };
+		this.selectionAnchor = point;
+		this.selectionHead = { ...point };
+		this.selectionMode = "frame";
+		return true;
+	}
+
+	extendFrameSelection(screenRow: number, screenCol: number): void {
+		if (!this.selectionAnchor || this.selectionMode !== "frame" || this.lastFrame.length === 0) return;
+		const row = Math.max(0, Math.min(screenRow, this.lastFrame.length - 1));
+		this.selectionHead = { line: row, col: Math.max(0, screenCol) };
+	}
+
+	endFrameSelection(): string | null {
+		if (this.selectionMode !== "frame") {
+			this.clearSelection();
+			return null;
+		}
+		const sel = this.orderedSelection();
+		this.clearSelection();
+		if (!sel) return null;
+		return this.extractSelectionText(this.lastFrame, sel);
+	}
+
+	private highlightLine(line: string, span: { from: number; to: number }): string {
+		const width = visibleWidth(line);
+		const from = Math.min(span.from, width);
+		const to = Math.min(span.to, width);
+		if (to <= from) return line;
+		const before = sliceByColumn(line, 0, from);
+		const selected = stripAnsi(sliceByColumn(line, from, to - from));
+		const after = sliceByColumn(line, to, Math.max(0, width - to));
+		return `${before}\x1b[0m\x1b[7m${selected}\x1b[27m${after}`;
+	}
+
+	private extractSelectionText(
+		sourceLines: string[],
+		sel: { start: SelectionPoint; end: SelectionPoint },
+	): string | null {
 		const lines: string[] = [];
 		for (let lineIndex = sel.start.line; lineIndex <= sel.end.line; lineIndex++) {
-			const line = this.lastTranscript[lineIndex] ?? "";
+			const line = sourceLines[lineIndex] ?? "";
 			const span = this.selectionSpan(lineIndex, sel);
 			if (!span) continue;
 			const width = visibleWidth(line);
@@ -152,6 +215,7 @@ export class FullscreenViewport {
 	clearSelection(): void {
 		this.selectionAnchor = null;
 		this.selectionHead = null;
+		this.selectionMode = null;
 	}
 
 	hasSelection(): boolean {

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -26,6 +26,17 @@ interface SelectionPoint {
 	col: number;
 }
 
+interface FrameSelectionRegion {
+	line: number;
+	col: number;
+	width: number;
+}
+
+interface ColumnSpan {
+	from: number;
+	to: number;
+}
+
 type SelectionMode = "transcript" | "frame";
 
 export class FullscreenViewport {
@@ -40,7 +51,7 @@ export class FullscreenViewport {
 	private lastFrame: string[] = [];
 	private lastFrameVisibleStart = 0;
 	private lastFrameVisibleHeight = 0;
-	private frameSelectionRegions: ReadonlyArray<{ line: number; col: number; width: number }> = [];
+	private frameSelectionRegions: ReadonlyArray<FrameSelectionRegion> = [];
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
 	private selectionMode: SelectionMode | null = null;
@@ -89,10 +100,7 @@ export class FullscreenViewport {
 	}
 
 	// Per-line selected column span, or null when the line is outside the selection.
-	private selectionSpan(
-		lineIndex: number,
-		sel: { start: SelectionPoint; end: SelectionPoint },
-	): { from: number; to: number } | null {
+	private selectionSpan(lineIndex: number, sel: { start: SelectionPoint; end: SelectionPoint }): ColumnSpan | null {
 		if (lineIndex < sel.start.line || lineIndex > sel.end.line) return null;
 		return {
 			from: lineIndex === sel.start.line ? sel.start.col : 0,
@@ -162,11 +170,7 @@ export class FullscreenViewport {
 	}
 
 	/** Snapshot and highlight the final screen frame for overlay/dock selection. */
-	applyFrameSelection(
-		frame: string[],
-		height: number,
-		selectableRegions: ReadonlyArray<{ line: number; col: number; width: number }>,
-	): void {
+	applyFrameSelection(frame: string[], height: number, selectableRegions: ReadonlyArray<FrameSelectionRegion>): void {
 		this.lastFrame = frame;
 		this.lastFrameVisibleHeight = Math.min(Math.max(0, height), frame.length);
 		this.lastFrameVisibleStart = Math.max(0, frame.length - this.lastFrameVisibleHeight);
@@ -175,11 +179,13 @@ export class FullscreenViewport {
 		const sel = this.orderedSelection();
 		if (!sel) return;
 		for (let lineIndex = sel.start.line; lineIndex <= sel.end.line; lineIndex++) {
-			const line = frame[lineIndex];
+			let line = frame[lineIndex];
 			if (line === undefined) continue;
-			const span = this.selectionSpan(lineIndex, sel);
-			if (!span) continue;
-			frame[lineIndex] = this.highlightLine(line, span);
+			const spans = this.selectedFrameSpans(lineIndex, sel);
+			for (let i = spans.length - 1; i >= 0; i--) {
+				line = this.highlightLine(line, spans[i]);
+			}
+			frame[lineIndex] = line;
 		}
 	}
 
@@ -199,7 +205,9 @@ export class FullscreenViewport {
 		if (!this.selectionAnchor || this.selectionMode !== "frame") return;
 		const point = this.framePoint(screenRow, screenCol);
 		if (!point) return;
-		this.selectionHead = point;
+		const clamped = this.clampFrameSelectionPoint(point);
+		if (!clamped) return;
+		this.selectionHead = clamped;
 	}
 
 	endFrameSelection(): string | null {
@@ -210,10 +218,10 @@ export class FullscreenViewport {
 		const sel = this.orderedSelection();
 		this.clearSelection();
 		if (!sel) return null;
-		return this.extractSelectionText(this.lastFrame, sel);
+		return this.extractFrameSelectionText(sel);
 	}
 
-	private highlightLine(line: string, span: { from: number; to: number }): string {
+	private highlightLine(line: string, span: ColumnSpan): string {
 		const width = visibleWidth(line);
 		const from = Math.min(span.from, width);
 		const to = Math.min(span.to, width);
@@ -236,6 +244,62 @@ export class FullscreenViewport {
 		return this.frameSelectionRegions.some(
 			(region) => region.line === point.line && point.col >= region.col && point.col < region.col + region.width,
 		);
+	}
+
+	private frameRegionsForLine(line: number): FrameSelectionRegion[] {
+		return this.frameSelectionRegions
+			.filter((region) => region.line === line && region.width > 0)
+			.sort((a, b) => a.col - b.col);
+	}
+
+	private clampFrameSelectionPoint(point: SelectionPoint): SelectionPoint | null {
+		const regions = this.frameRegionsForLine(point.line);
+		if (regions.length === 0) return null;
+		let closest = regions[0].col;
+		let distance = Number.POSITIVE_INFINITY;
+		for (const region of regions) {
+			const start = region.col;
+			const end = region.col + region.width;
+			if (point.col >= start && point.col <= end) {
+				return { line: point.line, col: Math.max(start, Math.min(point.col, end)) };
+			}
+			for (const col of [start, end]) {
+				const nextDistance = Math.abs(point.col - col);
+				if (nextDistance < distance) {
+					closest = col;
+					distance = nextDistance;
+				}
+			}
+		}
+		return { line: point.line, col: closest };
+	}
+
+	private selectedFrameSpans(lineIndex: number, sel: { start: SelectionPoint; end: SelectionPoint }): ColumnSpan[] {
+		const span = this.selectionSpan(lineIndex, sel);
+		if (!span) return [];
+		const spans: ColumnSpan[] = [];
+		for (const region of this.frameRegionsForLine(lineIndex)) {
+			const from = Math.max(span.from, region.col);
+			const to = Math.min(span.to, region.col + region.width);
+			if (to > from) spans.push({ from, to });
+		}
+		return spans;
+	}
+
+	private extractFrameSelectionText(sel: { start: SelectionPoint; end: SelectionPoint }): string | null {
+		const lines: string[] = [];
+		for (let lineIndex = sel.start.line; lineIndex <= sel.end.line; lineIndex++) {
+			const line = this.lastFrame[lineIndex] ?? "";
+			const spans = this.selectedFrameSpans(lineIndex, sel);
+			if (spans.length === 0) continue;
+			const parts: string[] = [];
+			for (const span of spans) {
+				parts.push(stripAnsi(sliceByColumn(line, span.from, Math.max(0, span.to - span.from))));
+			}
+			lines.push(parts.join("").trimEnd());
+		}
+		const text = lines.join("\n");
+		return text.trim().length > 0 ? text : null;
 	}
 
 	private extractSelectionText(

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -38,6 +38,9 @@ export class FullscreenViewport {
 	private lastWindowHeight = 0;
 	private lastTranscript: string[] = [];
 	private lastFrame: string[] = [];
+	private lastFrameVisibleStart = 0;
+	private lastFrameVisibleHeight = 0;
+	private frameSelectionRegions: ReadonlyArray<{ line: number; col: number; width: number }> = [];
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
 	private selectionMode: SelectionMode | null = null;
@@ -139,9 +142,35 @@ export class FullscreenViewport {
 		return this.extractSelectionText(this.lastTranscript, sel);
 	}
 
+	extendActiveSelection(screenRow: number, screenCol: number): void {
+		if (this.selectionMode === "frame") {
+			this.extendFrameSelection(screenRow, screenCol);
+		} else if (this.selectionMode === "transcript") {
+			this.extendSelection(screenRow, screenCol);
+		}
+	}
+
+	endActiveSelection(): string | null {
+		if (this.selectionMode === "frame") {
+			return this.endFrameSelection();
+		}
+		if (this.selectionMode === "transcript") {
+			return this.endSelection();
+		}
+		this.clearSelection();
+		return null;
+	}
+
 	/** Snapshot and highlight the final screen frame for overlay/dock selection. */
-	applyFrameSelection(frame: string[]): void {
+	applyFrameSelection(
+		frame: string[],
+		height: number,
+		selectableRegions: ReadonlyArray<{ line: number; col: number; width: number }>,
+	): void {
 		this.lastFrame = frame;
+		this.lastFrameVisibleHeight = Math.min(Math.max(0, height), frame.length);
+		this.lastFrameVisibleStart = Math.max(0, frame.length - this.lastFrameVisibleHeight);
+		this.frameSelectionRegions = selectableRegions;
 		if (this.selectionMode !== "frame") return;
 		const sel = this.orderedSelection();
 		if (!sel) return;
@@ -155,11 +184,11 @@ export class FullscreenViewport {
 	}
 
 	beginFrameSelection(screenRow: number, screenCol: number): boolean {
-		if (screenRow < 0 || screenRow >= this.lastFrame.length) {
+		const point = this.framePoint(screenRow, screenCol);
+		if (!point || !this.isFrameSelectable(point)) {
 			this.clearSelection();
 			return false;
 		}
-		const point = { line: screenRow, col: Math.max(0, screenCol) };
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
 		this.selectionMode = "frame";
@@ -167,9 +196,10 @@ export class FullscreenViewport {
 	}
 
 	extendFrameSelection(screenRow: number, screenCol: number): void {
-		if (!this.selectionAnchor || this.selectionMode !== "frame" || this.lastFrame.length === 0) return;
-		const row = Math.max(0, Math.min(screenRow, this.lastFrame.length - 1));
-		this.selectionHead = { line: row, col: Math.max(0, screenCol) };
+		if (!this.selectionAnchor || this.selectionMode !== "frame") return;
+		const point = this.framePoint(screenRow, screenCol);
+		if (!point) return;
+		this.selectionHead = point;
 	}
 
 	endFrameSelection(): string | null {
@@ -192,6 +222,20 @@ export class FullscreenViewport {
 		const selected = stripAnsi(sliceByColumn(line, from, to - from));
 		const after = sliceByColumn(line, to, Math.max(0, width - to));
 		return `${before}\x1b[0m\x1b[7m${selected}\x1b[27m${after}`;
+	}
+
+	private framePoint(screenRow: number, screenCol: number): SelectionPoint | null {
+		if (this.lastFrameVisibleHeight === 0) return null;
+		const row = Math.max(0, Math.min(screenRow, this.lastFrameVisibleHeight - 1));
+		const line = this.lastFrameVisibleStart + row;
+		if (line < 0 || line >= this.lastFrame.length) return null;
+		return { line, col: Math.max(0, screenCol) };
+	}
+
+	private isFrameSelectable(point: SelectionPoint): boolean {
+		return this.frameSelectionRegions.some(
+			(region) => region.line === point.line && point.col >= region.col && point.col < region.col + region.width,
+		);
 	}
 
 	private extractSelectionText(

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -37,6 +37,13 @@ interface ColumnSpan {
 	to: number;
 }
 
+interface FrameSelectionSnapshot {
+	frame: string[];
+	regions: FrameSelectionRegion[];
+	visibleStart: number;
+	visibleHeight: number;
+}
+
 type SelectionMode = "transcript" | "frame";
 
 export class FullscreenViewport {
@@ -52,6 +59,7 @@ export class FullscreenViewport {
 	private lastFrameVisibleStart = 0;
 	private lastFrameVisibleHeight = 0;
 	private frameSelectionRegions: ReadonlyArray<FrameSelectionRegion> = [];
+	private activeFrameSelection: FrameSelectionSnapshot | null = null;
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
 	private selectionMode: SelectionMode | null = null;
@@ -197,6 +205,12 @@ export class FullscreenViewport {
 			this.clearSelection();
 			return false;
 		}
+		this.activeFrameSelection = {
+			frame: [...this.lastFrame],
+			regions: this.frameSelectionRegions.map((region) => ({ ...region })),
+			visibleStart: this.lastFrameVisibleStart,
+			visibleHeight: this.lastFrameVisibleHeight,
+		};
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
 		this.selectionMode = "frame";
@@ -205,7 +219,7 @@ export class FullscreenViewport {
 
 	extendFrameSelection(screenRow: number, screenCol: number): void {
 		if (!this.selectionAnchor || this.selectionMode !== "frame") return;
-		const point = this.framePoint(screenRow, screenCol);
+		const point = this.framePoint(screenRow, screenCol, this.activeFrameSelection);
 		if (!point) return;
 		const clamped = this.clampFrameSelectionPoint(point);
 		if (!clamped) return;
@@ -218,9 +232,12 @@ export class FullscreenViewport {
 			return null;
 		}
 		const sel = this.orderedSelection();
+		const active = this.activeFrameSelection;
+		const sourceLines = active?.frame ?? this.lastFrame;
+		const regions = active?.regions ?? this.frameSelectionRegions;
 		this.clearSelection();
 		if (!sel) return null;
-		return this.extractFrameSelectionText(sel);
+		return this.extractFrameSelectionText(sourceLines, regions, sel);
 	}
 
 	private highlightLine(line: string, span: ColumnSpan): string {
@@ -234,11 +251,18 @@ export class FullscreenViewport {
 		return `${before}\x1b[0m\x1b[7m${selected}\x1b[27m${after}`;
 	}
 
-	private framePoint(screenRow: number, screenCol: number): SelectionPoint | null {
-		if (this.lastFrameVisibleHeight === 0) return null;
-		const row = Math.max(0, Math.min(screenRow, this.lastFrameVisibleHeight - 1));
-		const line = this.lastFrameVisibleStart + row;
-		if (line < 0 || line >= this.lastFrame.length) return null;
+	private framePoint(
+		screenRow: number,
+		screenCol: number,
+		snapshot: FrameSelectionSnapshot | null = null,
+	): SelectionPoint | null {
+		const visibleHeight = snapshot?.visibleHeight ?? this.lastFrameVisibleHeight;
+		if (visibleHeight === 0) return null;
+		const visibleStart = snapshot?.visibleStart ?? this.lastFrameVisibleStart;
+		const frameLength = snapshot?.frame.length ?? this.lastFrame.length;
+		const row = Math.max(0, Math.min(screenRow, visibleHeight - 1));
+		const line = visibleStart + row;
+		if (line < 0 || line >= frameLength) return null;
 		return { line, col: Math.max(0, screenCol) };
 	}
 
@@ -264,10 +288,11 @@ export class FullscreenViewport {
 		);
 	}
 
-	private frameRegionsForLine(line: number): FrameSelectionRegion[] {
-		return this.frameSelectionRegions
-			.filter((region) => region.line === line && region.width > 0)
-			.sort((a, b) => a.col - b.col);
+	private frameRegionsForLine(
+		line: number,
+		regions = this.activeFrameSelection?.regions ?? this.frameSelectionRegions,
+	): FrameSelectionRegion[] {
+		return regions.filter((region) => region.line === line && region.width > 0).sort((a, b) => a.col - b.col);
 	}
 
 	private clampFrameSelectionPoint(point: SelectionPoint): SelectionPoint | null {
@@ -292,11 +317,15 @@ export class FullscreenViewport {
 		return { line: point.line, col: closest };
 	}
 
-	private selectedFrameSpans(lineIndex: number, sel: { start: SelectionPoint; end: SelectionPoint }): ColumnSpan[] {
+	private selectedFrameSpans(
+		lineIndex: number,
+		sel: { start: SelectionPoint; end: SelectionPoint },
+		regions = this.activeFrameSelection?.regions ?? this.frameSelectionRegions,
+	): ColumnSpan[] {
 		const span = this.selectionSpan(lineIndex, sel);
 		if (!span) return [];
 		const spans: ColumnSpan[] = [];
-		for (const region of this.frameRegionsForLine(lineIndex)) {
+		for (const region of this.frameRegionsForLine(lineIndex, regions)) {
 			const from = Math.max(span.from, region.col);
 			const to = Math.min(span.to, region.col + region.width);
 			if (to > from) spans.push({ from, to });
@@ -304,11 +333,15 @@ export class FullscreenViewport {
 		return spans;
 	}
 
-	private extractFrameSelectionText(sel: { start: SelectionPoint; end: SelectionPoint }): string | null {
+	private extractFrameSelectionText(
+		sourceLines: string[],
+		regions: ReadonlyArray<FrameSelectionRegion>,
+		sel: { start: SelectionPoint; end: SelectionPoint },
+	): string | null {
 		const lines: string[] = [];
 		for (let lineIndex = sel.start.line; lineIndex <= sel.end.line; lineIndex++) {
-			const line = this.lastFrame[lineIndex] ?? "";
-			const spans = this.selectedFrameSpans(lineIndex, sel);
+			const line = sourceLines[lineIndex] ?? "";
+			const spans = this.selectedFrameSpans(lineIndex, sel, regions);
 			if (spans.length === 0) continue;
 			const parts: string[] = [];
 			for (const span of spans) {
@@ -342,6 +375,7 @@ export class FullscreenViewport {
 		this.selectionAnchor = null;
 		this.selectionHead = null;
 		this.selectionMode = null;
+		this.activeFrameSelection = null;
 	}
 
 	hasSelection(): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -992,7 +992,14 @@ export class TUI extends Container {
 		const overlaySelectionRegions: FrameSelectionRegion[] = [];
 
 		// Pre-render all visible overlays and calculate positions
-		const rendered: { overlayLines: string[]; row: number; col: number; w: number; scrollback: boolean }[] = [];
+		const rendered: {
+			component: Component;
+			overlayLines: string[];
+			row: number;
+			col: number;
+			w: number;
+			scrollback: boolean;
+		}[] = [];
 		let minLinesNeeded = result.length;
 
 		const visibleEntries = this.overlayStack.filter((e) => this.isOverlayVisible(e));
@@ -1016,7 +1023,7 @@ export class TUI extends Container {
 			// Get final row/col with actual overlay height
 			const { row, col } = this.resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 
-			rendered.push({ overlayLines, row, col, w: width, scrollback });
+			rendered.push({ component, overlayLines, row, col, w: width, scrollback });
 			minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 		}
 
@@ -1033,7 +1040,7 @@ export class TUI extends Container {
 		const viewportStart = Math.max(0, workingHeight - termHeight);
 
 		// Composite each overlay
-		for (const { overlayLines, row, col, w, scrollback } of rendered) {
+		for (const { component, overlayLines, row, col, w, scrollback } of rendered) {
 			const overlayStart = scrollback ? Math.max(0, workingHeight - (row + overlayLines.length)) : viewportStart;
 			for (let i = 0; i < overlayLines.length; i++) {
 				const idx = overlayStart + row + i;
@@ -1044,7 +1051,7 @@ export class TUI extends Container {
 						visibleWidth(overlayLines[i]) > w ? sliceByColumn(overlayLines[i], 0, w, true) : overlayLines[i];
 					result[idx] = this.compositeLineAt(result[idx], truncatedOverlayLine, col, w, termWidth);
 					this.subtractSelectionCoverage(overlaySelectionRegions, idx, col, col + w);
-					const span = this.selectableSpan(truncatedOverlayLine, w);
+					const span = component === this.focusedComponent ? this.selectableSpan(truncatedOverlayLine, w) : null;
 					if (span) {
 						overlaySelectionRegions.push({ line: idx, col: col + span.from, width: span.to - span.from });
 					}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -770,6 +770,21 @@ export class TUI extends Container {
 				} else if (!event.press) {
 					viewport.clearSelection();
 				}
+			} else if (event && overlayFocused) {
+				const viewport = fullscreen.viewport;
+				if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
+					viewport.beginFrameSelection(event.y - 1, event.x - 1);
+					this.requestRender();
+				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && event.motion) {
+					viewport.extendFrameSelection(event.y - 1, event.x - 1);
+					this.requestRender();
+				} else if (!event.press && viewport.hasSelection()) {
+					const text = viewport.endFrameSelection();
+					if (text) this.copySelection(text);
+					this.requestRender();
+				} else if (!event.press) {
+					viewport.clearSelection();
+				}
 			}
 			return true;
 		}
@@ -1184,6 +1199,7 @@ export class TUI extends Container {
 			frame = this.compositeOverlays(frame, width, height);
 		}
 		const cursorPos = this.extractCursorPosition(frame, height);
+		fullscreen.viewport.applyFrameSelection(frame);
 		this.applyLineResets(frame);
 		fullscreen.viewport.paint((data) => this.terminal.write(data), frame, width, height, cursorPos);
 		if (cursorPos && this.showHardwareCursor) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -12,7 +12,14 @@ import { isKeyRelease, matchesKey } from "./keys.js";
 import { isMouseSequence, isWheelDown, isWheelUp, MOUSE_BUTTON_LEFT, parseSgrMouseEvent } from "./mouse.js";
 import type { Terminal } from "./terminal.js";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
+import {
+	extractSegments,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	stripAnsi,
+	visibleWidth,
+} from "./utils.js";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
@@ -67,6 +74,12 @@ export interface Component {
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
 type InputListener = (data: string) => InputListenerResult;
+
+interface FrameSelectionRegion {
+	line: number;
+	col: number;
+	width: number;
+}
 
 /**
  * Interface for components that can receive focus and display a hardware cursor.
@@ -267,6 +280,7 @@ export class TUI extends Container {
 	private fullRedrawCount = 0;
 	private preserveViewportOnNextRender = false; // One-shot: repaint visible viewport in place instead of replaying scrollback
 	private stopped = false;
+	private overlaySelectionRegions: FrameSelectionRegion[] = [];
 
 	// While set, doRender paints fixed frames via the viewport; the inline
 	// differ's bookkeeping stays frozen in `inlineState` until exit.
@@ -761,10 +775,10 @@ export class TUI extends Container {
 					viewport.beginSelection(event.y - 1, event.x - 1);
 					this.requestRender();
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && event.motion) {
-					viewport.extendSelection(event.y - 1, event.x - 1);
+					viewport.extendActiveSelection(event.y - 1, event.x - 1);
 					this.requestRender();
 				} else if (!event.press && viewport.hasSelection()) {
-					const text = viewport.endSelection();
+					const text = viewport.endActiveSelection();
 					if (text) this.copySelection(text);
 					this.requestRender();
 				} else if (!event.press) {
@@ -773,13 +787,15 @@ export class TUI extends Container {
 			} else if (event && overlayFocused) {
 				const viewport = fullscreen.viewport;
 				if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
-					viewport.beginFrameSelection(event.y - 1, event.x - 1);
+					if (!viewport.beginFrameSelection(event.y - 1, event.x - 1)) {
+						viewport.beginSelection(event.y - 1, event.x - 1);
+					}
 					this.requestRender();
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && event.motion) {
-					viewport.extendFrameSelection(event.y - 1, event.x - 1);
+					viewport.extendActiveSelection(event.y - 1, event.x - 1);
 					this.requestRender();
 				} else if (!event.press && viewport.hasSelection()) {
-					const text = viewport.endFrameSelection();
+					const text = viewport.endActiveSelection();
 					if (text) this.copySelection(text);
 					this.requestRender();
 				} else if (!event.press) {
@@ -973,6 +989,7 @@ export class TUI extends Container {
 	private compositeOverlays(lines: string[], termWidth: number, termHeight: number): string[] {
 		if (this.overlayStack.length === 0) return lines;
 		const result = [...lines];
+		const overlaySelectionRegions: FrameSelectionRegion[] = [];
 
 		// Pre-render all visible overlays and calculate positions
 		const rendered: { overlayLines: string[]; row: number; col: number; w: number; scrollback: boolean }[] = [];
@@ -1026,11 +1043,29 @@ export class TUI extends Container {
 					const truncatedOverlayLine =
 						visibleWidth(overlayLines[i]) > w ? sliceByColumn(overlayLines[i], 0, w, true) : overlayLines[i];
 					result[idx] = this.compositeLineAt(result[idx], truncatedOverlayLine, col, w, termWidth);
+					const span = this.selectableSpan(truncatedOverlayLine, w);
+					if (span) {
+						overlaySelectionRegions.push({ line: idx, col: col + span.from, width: span.to - span.from });
+					}
 				}
 			}
 		}
 
+		this.overlaySelectionRegions = overlaySelectionRegions;
 		return result;
+	}
+
+	private selectableSpan(line: string, maxWidth: number): { from: number; to: number } | null {
+		const width = Math.min(maxWidth, visibleWidth(line));
+		let from = -1;
+		let to = -1;
+		for (let col = 0; col < width; col++) {
+			const cell = stripAnsi(sliceByColumn(line, col, 1));
+			if (cell.trim().length === 0) continue;
+			if (from === -1) from = col;
+			to = col + 1;
+		}
+		return from === -1 ? null : { from, to };
 	}
 
 	private static readonly SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
@@ -1172,6 +1207,7 @@ export class TUI extends Container {
 		if (!fullscreen) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
+		this.overlaySelectionRegions = [];
 
 		const transcript: string[] = [];
 		for (const component of fullscreen.scroll) {
@@ -1199,7 +1235,7 @@ export class TUI extends Container {
 			frame = this.compositeOverlays(frame, width, height);
 		}
 		const cursorPos = this.extractCursorPosition(frame, height);
-		fullscreen.viewport.applyFrameSelection(frame);
+		fullscreen.viewport.applyFrameSelection(frame, height, this.overlaySelectionRegions);
 		this.applyLineResets(frame);
 		fullscreen.viewport.paint((data) => this.terminal.write(data), frame, width, height, cursorPos);
 		if (cursorPos && this.showHardwareCursor) {
@@ -1217,6 +1253,7 @@ export class TUI extends Container {
 			return;
 		}
 		// One-shot: consume here so it never leaks into a later render.
+		this.overlaySelectionRegions = [];
 		const preserveViewport = this.preserveViewportOnNextRender;
 		this.preserveViewportOnNextRender = false;
 		const width = this.terminal.columns;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1043,6 +1043,7 @@ export class TUI extends Container {
 					const truncatedOverlayLine =
 						visibleWidth(overlayLines[i]) > w ? sliceByColumn(overlayLines[i], 0, w, true) : overlayLines[i];
 					result[idx] = this.compositeLineAt(result[idx], truncatedOverlayLine, col, w, termWidth);
+					this.subtractSelectionCoverage(overlaySelectionRegions, idx, col, col + w);
 					const span = this.selectableSpan(truncatedOverlayLine, w);
 					if (span) {
 						overlaySelectionRegions.push({ line: idx, col: col + span.from, width: span.to - span.from });
@@ -1066,6 +1067,30 @@ export class TUI extends Container {
 			to = col + 1;
 		}
 		return from === -1 ? null : { from, to };
+	}
+
+	private subtractSelectionCoverage(
+		regions: FrameSelectionRegion[],
+		line: number,
+		coverStart: number,
+		coverEnd: number,
+	): void {
+		for (let i = regions.length - 1; i >= 0; i--) {
+			const region = regions[i];
+			if (region.line !== line) continue;
+			const regionStart = region.col;
+			const regionEnd = region.col + region.width;
+			if (coverEnd <= regionStart || coverStart >= regionEnd) continue;
+
+			const replacements: FrameSelectionRegion[] = [];
+			if (regionStart < coverStart) {
+				replacements.push({ line, col: regionStart, width: coverStart - regionStart });
+			}
+			if (coverEnd < regionEnd) {
+				replacements.push({ line, col: coverEnd, width: regionEnd - coverEnd });
+			}
+			regions.splice(i, 1, ...replacements);
+		}
 	}
 
 	private static readonly SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -346,6 +346,8 @@ describe("TUI fullscreen mode", () => {
 		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
 		terminal.sendInput(`\x1b[<32;${endX};${y}M`);
 		tui.setFocus(chat);
+		tui.requestRender();
+		await terminal.waitForRender();
 		terminal.sendInput(`\x1b[<0;${endX};${y}m`);
 		await terminal.waitForRender();
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -354,6 +354,71 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("keeps focused overlay selection within visible overlay text", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const url = "https://example.com/clamped";
+		const overlay = new InputComponent();
+		overlay.lines = ["Sign-in link", url];
+		tui.showOverlay(overlay, { anchor: "center", width: 44 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		const row = viewport.findIndex((line) => line.includes(url));
+		assert.notStrictEqual(row, -1, "URL is visible in the focused overlay");
+		const outsideRow = viewport.findIndex((line, index) => index !== row && line.includes("Line "));
+		assert.notStrictEqual(outsideRow, -1, "transcript row is visible outside the overlay");
+		const col = viewport[row]!.indexOf(url);
+		const startX = col + 1;
+		const paddedEndX = startX + url.length + 6;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
+		terminal.sendInput(`\x1b[<32;${paddedEndX};${y}M`);
+		terminal.sendInput(`\x1b[<32;1;${outsideRow + 1}M`);
+		terminal.sendInput(`\x1b[<0;1;${outsideRow + 1}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, [url]);
+
+		tui.stop();
+	});
+
+	it("does not select lower overlay text covered by a higher overlay", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const lower = new InputComponent();
+		lower.lines = ["https://lower.example/login"];
+		tui.showOverlay(lower, { anchor: "bottom-left", width: 32 });
+
+		const upper = new InputComponent();
+		upper.lines = ["TOP"];
+		tui.showOverlay(upper, { anchor: "bottom-left", width: 32 });
+		await terminal.waitForRender();
+
+		const row = terminal.getViewport().findIndex((line) => line.startsWith("TOP"));
+		assert.notStrictEqual(row, -1, "higher overlay is visible");
+		const hiddenLowerTextX = 11;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${hiddenLowerTextX};${y}M`);
+		terminal.sendInput(`\x1b[<32;1;${y}M`);
+		terminal.sendInput(`\x1b[<0;1;${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
 	it("exit restores the primary screen and flushes fullscreen-era content into scrollback", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(5));
 		await terminal.waitForRender();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -419,6 +419,68 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("maps focused overlay transcript fallback to the painted viewport slice", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 40, 5);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const overlay = new InputComponent();
+		overlay.lines = ["", "", "", "", "", ""];
+		tui.showOverlay(overlay, { anchor: "top-left", width: 1 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("18"), "top painted row is shifted by the over-tall overlay");
+		const col = viewport[0]!.indexOf("18");
+		const startX = col + 1;
+		const endX = startX + 2;
+
+		terminal.sendInput(`\x1b[<0;${startX};1M`);
+		terminal.sendInput(`\x1b[<32;${endX};1M`);
+		terminal.sendInput(`\x1b[<0;${endX};1m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["18"]);
+
+		tui.stop();
+	});
+
+	it("does not select text from an unfocused visible overlay", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const lowerUrl = "https://lower.example/login";
+		const lower = new InputComponent();
+		lower.lines = [lowerUrl];
+		tui.showOverlay(lower, { anchor: "bottom-left", width: 32 });
+
+		const upper = new InputComponent();
+		upper.lines = ["Focused dialog"];
+		tui.showOverlay(upper, { anchor: "top-right", width: 24 });
+		await terminal.waitForRender();
+
+		const row = terminal.getViewport().findIndex((line) => line.includes(lowerUrl));
+		assert.notStrictEqual(row, -1, "unfocused lower overlay is visible");
+		const col = terminal.getViewport()[row]!.indexOf(lowerUrl);
+		const startX = col + 1;
+		const endX = startX + lowerUrl.length;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
+		terminal.sendInput(`\x1b[<32;${endX};${y}M`);
+		terminal.sendInput(`\x1b[<0;${endX};${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
 	it("exit restores the primary screen and flushes fullscreen-era content into scrollback", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(5));
 		await terminal.waitForRender();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -291,6 +291,69 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("maps focused overlay selection to the painted viewport slice", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 5);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const url = "https://example.com/visible";
+		const overlay = new InputComponent();
+		overlay.lines = [url, "overlay row 1", "overlay row 2", "overlay row 3", "overlay row 4", "overlay row 5"];
+		tui.showOverlay(overlay, { anchor: "top-left", width: 40 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		const row = viewport.findIndex((line) => line.includes(url));
+		assert.notStrictEqual(row, -1, "URL is visible after the over-tall frame is sliced");
+		const col = viewport[row]!.indexOf(url);
+		const startX = col + 1;
+		const endX = startX + url.length;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
+		terminal.sendInput(`\x1b[<32;${endX};${y}M`);
+		terminal.sendInput(`\x1b[<0;${endX};${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, [url]);
+
+		tui.stop();
+	});
+
+	it("copies an active frame selection if focus changes before release", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const url = "https://example.com/focus-change";
+		const overlay = new InputComponent();
+		overlay.lines = ["Sign-in link", url];
+		tui.showOverlay(overlay, { anchor: "center", width: 44 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		const row = viewport.findIndex((line) => line.includes(url));
+		assert.notStrictEqual(row, -1, "URL is visible in the focused overlay");
+		const col = viewport[row]!.indexOf(url);
+		const startX = col + 1;
+		const endX = startX + url.length;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
+		terminal.sendInput(`\x1b[<32;${endX};${y}M`);
+		tui.setFocus(chat);
+		terminal.sendInput(`\x1b[<0;${endX};${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, [url]);
+
+		tui.stop();
+	});
+
 	it("exit restores the primary screen and flushes fullscreen-era content into scrollback", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(5));
 		await terminal.waitForRender();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -11,6 +11,13 @@ class TestComponent implements Component {
 	invalidate(): void {}
 }
 
+class InputComponent extends TestComponent {
+	inputs: string[] = [];
+	handleInput(data: string): void {
+		this.inputs.push(data);
+	}
+}
+
 class LoggingVirtualTerminal extends VirtualTerminal {
 	private writes: string[] = [];
 
@@ -245,6 +252,41 @@ describe("TUI fullscreen mode", () => {
 		handle.hide();
 		await terminal.waitForRender();
 		assert.ok(!terminal.getViewport().some((line) => line.includes("OVERLAY CONTENT")));
+
+		tui.stop();
+	});
+
+	it("drag-selecting focused overlay text copies from the fullscreen frame", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const url = "https://example.com/login";
+		const overlay = new InputComponent();
+		overlay.lines = ["Sign-in link", url];
+		tui.showOverlay(overlay, { anchor: "center", width: 40 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		const row = viewport.findIndex((line) => line.includes(url));
+		assert.notStrictEqual(row, -1, "URL is visible in the focused overlay");
+		const col = viewport[row]!.indexOf(url);
+		const startX = col + 1;
+		const endX = startX + url.length;
+		const y = row + 1;
+
+		terminal.sendInput(`\x1b[<0;${startX};${y}M`);
+		terminal.sendInput(`\x1b[<32;${endX};${y}M`);
+		await terminal.waitForRender();
+		assert.ok(terminal.getWrites().includes("\x1b[7m"), "overlay selection is highlighted while dragging");
+
+		terminal.sendInput(`\x1b[<0;${endX};${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, [url]);
+		assert.deepStrictEqual(overlay.inputs, [], "mouse reports are consumed before overlay input handlers");
 
 		tui.stop();
 	});


### PR DESCRIPTION
- fullscreen login dialogs now support drag selection inside focused overlays.
- selection still uses the existing clipboard path and leaves transcript copying unchanged.
- added regression coverage for copying a visible login url from fullscreen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI fullscreen mouse/clipboard behavior with broad regression tests; no auth, data, or API surface changes beyond copy UX.
> 
> **Overview**
> **Fixes drag-to-copy in fullscreen when a modal overlay (e.g. login) is focused**, so URLs and other visible overlay text reach the clipboard instead of only transcript selection working.
> 
> `FullscreenViewport` gains a **`frame`** selection mode alongside **`transcript`**: frame mode selects against the painted screen using declared column regions, snapshots the frame while dragging (so focus can change before release), and clamps drags to selectable spans. Transcript mouse selection is routed through **`extendActiveSelection`** / **`endActiveSelection`** and maps screen rows via the visible viewport slice when overlays pad or shift the frame.
> 
> In fullscreen, **`TUI.compositeOverlays`** records selectable regions from the **focused** overlay’s non-whitespace text, trims regions occluded by higher overlays, and passes them into **`applyFrameSelection`** on render. Mouse handling with a focused overlay tries **`beginFrameSelection`** first, then falls back to transcript selection; release copies through the existing **`onCopy`** / OSC 52 path. Plain mouse release with no active selection now **clears** selection state.
> 
> Regression tests cover login URL copy, sliced viewports, focus change mid-drag, clamping, stacked overlays, and unfocused overlay text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fcb62a7144635accba545d6522ea407a186b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fullscreen overlay selection to support copying text from focused overlays
> - Adds a second selection mode (`'frame'`) to `FullscreenViewport` alongside the existing `'transcript'` mode, routing mouse events to the correct handler based on where the drag begins.
> - When clicking on a focused overlay in fullscreen, `TUI` starts a frame-bound selection using selectable regions computed during `compositeOverlays`; clicking outside falls back to transcript selection.
> - Selectable regions are limited to visible non-whitespace content in the focused overlay; higher overlays subtract coverage so obscured lower overlay text cannot be selected.
> - Text extraction strips ANSI, trims trailing whitespace, and returns `null` for empty selections, which suppresses clipboard writes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1fcb62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->