### PR TITLE
fix installer splash flicker

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -241,9 +241,9 @@ prime_agent_screen() {
 	prime_agent_screen_frame_text=$(prime_agent_render_screen)
 
 	if ( : <>/dev/tty ) 2>/dev/null; then
-		printf '%s%s%s\n%s' "$prime_agent_sync_start" "$prime_agent_screen_prefix" "$prime_agent_screen_frame_text" "$prime_agent_sync_end" >/dev/tty
+		printf '%s%s%s%s' "$prime_agent_sync_start" "$prime_agent_screen_prefix" "$prime_agent_screen_frame_text" "$prime_agent_sync_end" >/dev/tty
 	else
-		printf '%s%s%s\n%s' "$prime_agent_sync_start" "$prime_agent_screen_prefix" "$prime_agent_screen_frame_text" "$prime_agent_sync_end" >&2
+		printf '%s%s%s%s' "$prime_agent_sync_start" "$prime_agent_screen_prefix" "$prime_agent_screen_frame_text" "$prime_agent_sync_end" >&2
 	fi
 }
 
@@ -711,19 +711,11 @@ prime_agent_animation_step_index() {
 	printf '%s' "$detail_index"
 }
 
-prime_agent_animation_percent() {
-	details="$1"
-	detail_count=$(prime_agent_animation_detail_count "$details")
-	total_frames=$((detail_count * 24))
-	frame=$(prime_agent_animation_current_frame)
-	percent=$((frame * 100 / total_frames))
-	if [ "$percent" -lt 1 ]; then
-		percent=1
-	fi
-	if [ "$percent" -gt 99 ]; then
-		percent=99
-	fi
-	printf '%s' "$percent"
+prime_agent_static_progress_title() {
+	case "$1" in
+		*...) printf '%s' "$1" ;;
+		*) printf '%s...' "$1" ;;
+	esac
 }
 
 prime_agent_animation_status() {
@@ -731,7 +723,7 @@ prime_agent_animation_status() {
 	details="$2"
 	status_mode="$3"
 	case "$status_mode" in
-		static) printf '%s · %s%%' "$status" "$(prime_agent_animation_percent "$details")" ;;
+		static) prime_agent_static_progress_title "$status" ;;
 		*) printf '%s%s' "$status" "$(prime_agent_pulse)" ;;
 	esac
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the installer splash flickering during animation and resize by stabilizing full-screen redraws and removing misleading synthetic percentages ([ENG-4481](https://linear.app/primeintellect/issue/ENG-4481/installer-screen-is-unstable-and-flickery)).
 - Removed the legacy pi-mono `bash` and `edit` built-in tools; use IPython `%%bash` cells and the Python `edit` skill instead.
 
 ## [0.2.5] - 2026-07-06

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -165,6 +165,7 @@ console.log("Installer render check passed.");
 
 function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
 	const result = spawnSync("sh", [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
+		detached: true,
 		encoding: "utf-8",
 	});
 	if (result.status !== 0) {

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -7,6 +7,7 @@ const installerSource = readFileSync("install.sh", "utf-8");
 const mainCall = '\nmain "$@"';
 const mainCallIndex = installerSource.lastIndexOf(mainCall);
 const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const syncEnd = "\x1b[?2026l";
 const failures = [];
 
 if (mainCallIndex === -1) {
@@ -15,6 +16,14 @@ if (mainCallIndex === -1) {
 }
 
 const harnessSource = `${installerSource.slice(0, mainCallIndex)}
+
+prime_agent_test_cols=80
+prime_agent_test_rows=24
+
+prime_agent_read_terminal_size() {
+	prime_agent_screen_cols="$prime_agent_test_cols"
+	prime_agent_screen_rows="$prime_agent_test_rows"
+}
 
 print_render_meta() {
 	label="$1"
@@ -58,17 +67,43 @@ render_case() {
 	printf '__RENDER_END__ second\\n'
 }
 
+screen_case() {
+	prime_agent_screen_enabled=1
+	prime_agent_screen_drawn=0
+	prime_agent_screen_last_cols=0
+	prime_agent_screen_last_rows=0
+	prime_agent_screen_layout_ready=0
+	prime_agent_screen_layout_show_logo=0
+	prime_agent_screen_layout_lab_width=0
+	prime_agent_screen_render_lab_width=0
+	prime_agent_screen_compact=0
+	prime_agent_screen_frame=0
+
+	prime_agent_test_cols="$1"
+	prime_agent_test_rows="$2"
+	printf '__SCREEN_START__ first\\n' >&2
+	prime_agent_screen "Installing Prime Agent" "Installing Prime Agent" "Fetching the verified package." ""
+	printf '__SCREEN_END__ first\\n' >&2
+
+	prime_agent_test_cols="$3"
+	prime_agent_test_rows="$4"
+	printf '__SCREEN_START__ second\\n' >&2
+	prime_agent_screen "Installing Prime Agent" "Installing Prime Agent" "Fetching the verified package." ""
+	printf '__SCREEN_END__ second\\n' >&2
+}
+
 progress_case() {
 	progress_details="Preparing global install.
 Linking command binaries.
 Finalizing npm install."
 	for progress_frame in 1 24 25 48 49 200; do
 		prime_agent_animation_frame="$progress_frame"
-		printf '__PROGRESS__ %s\t%s\t%s\t%s\\n' "$progress_frame" "$(prime_agent_animation_percent "$progress_details")" "$(prime_agent_animation_status "Installing Prime Agent" "$progress_details" static)" "$(prime_agent_animation_detail "$progress_details")"
+		printf '__PROGRESS__ %s\t%s\t%s\\n' "$progress_frame" "$(prime_agent_animation_status "Installing Prime Agent" "$progress_details" static)" "$(prime_agent_animation_detail "$progress_details")"
 	done
 }
 
 render_case "$@"
+screen_case "$@"
 progress_case
 `;
 
@@ -138,8 +173,11 @@ function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
 	}
 
 	const parsed = parseRenderOutput(result.stdout);
+	parsed.screens = parseScreenOutput(result.stderr);
 	assertLineWidths(name, "first", parsed, initialCols, initialRows);
 	assertLineWidths(name, "second", parsed, resizedCols, resizedRows);
+	assertScreenFrame(name, "first", parsed, initialCols, initialRows);
+	assertScreenFrame(name, "second", parsed, resizedCols, resizedRows);
 	return parsed;
 }
 
@@ -164,8 +202,8 @@ function parseRenderOutput(output) {
 			continue;
 		}
 		if (line.startsWith("__PROGRESS__ ")) {
-			const [frame, percent, status, detail] = line.slice("__PROGRESS__ ".length).split("\t");
-			parsed.progress.push({ frame: Number(frame), percent: Number(percent), status, detail });
+			const [frame, status, detail] = line.slice("__PROGRESS__ ".length).split("\t");
+			parsed.progress.push({ frame: Number(frame), status, detail });
 			continue;
 		}
 		if (activeRender) {
@@ -174,6 +212,27 @@ function parseRenderOutput(output) {
 	}
 
 	return parsed;
+}
+
+function parseScreenOutput(output) {
+	const screens = {};
+	for (const label of ["first", "second"]) {
+		const startToken = `__SCREEN_START__ ${label}\n`;
+		const endToken = `__SCREEN_END__ ${label}\n`;
+		const startIndex = output.indexOf(startToken);
+		if (startIndex === -1) {
+			failures.push(`missing ${label} screen start marker`);
+			continue;
+		}
+		const contentStart = startIndex + startToken.length;
+		const endIndex = output.indexOf(endToken, contentStart);
+		if (endIndex === -1) {
+			failures.push(`missing ${label} screen end marker`);
+			continue;
+		}
+		screens[label] = output.slice(contentStart, endIndex);
+	}
+	return screens;
 }
 
 function assertInstallerProgress(progress) {
@@ -194,19 +253,11 @@ function assertInstallerProgress(progress) {
 			`expected progress sample ${index + 1} to show "${expectedDetail}", got "${progress[index].detail}"`,
 		);
 		check(
-			progress[index].status === `Installing Prime Agent · ${progress[index].percent}%`,
-			`expected progress sample ${index + 1} to include percent in the status`,
+			progress[index].status === "Installing Prime Agent...",
+			`expected progress sample ${index + 1} to use indeterminate status`,
 		);
+		check(!progress[index].status.includes("%"), `expected progress sample ${index + 1} not to include a percent`);
 	}
-
-	for (let index = 1; index < progress.length; index++) {
-		check(
-			progress[index].percent >= progress[index - 1].percent,
-			`expected progress percent to be monotonic between samples ${index} and ${index + 1}`,
-		);
-	}
-	check(progress[0].percent > 0, "expected progress percent to start above zero");
-	check(progress[progress.length - 1].percent === 99, "expected in-flight progress percent to cap at 99");
 }
 
 function assertLineWidths(name, label, parsed, cols, rows) {
@@ -217,6 +268,28 @@ function assertLineWidths(name, label, parsed, cols, rows) {
 	for (const [index, line] of lines.entries()) {
 		check(line.length <= maxWidth, `${name}: ${label} render line ${index + 1} reached ${line.length} columns in a ${cols}-column terminal`);
 	}
+}
+
+function assertScreenFrame(name, label, parsed, cols, rows) {
+	const screen = parsed.screens[label] ?? "";
+	check(screen.endsWith(syncEnd), `${name}: expected ${label} screen frame to end with synchronized update close`);
+	check(!screen.endsWith(`\n${syncEnd}`), `${name}: expected ${label} screen frame not to emit a trailing row newline`);
+	check(countNewlines(screen) === rows - 1, `${name}: expected ${label} screen frame to contain ${rows - 1} line breaks`);
+
+	const lines = screen.replace(ansiPattern, "").split("\n");
+	check(lines.length === rows, `${name}: expected ${label} screen frame to contain ${rows} rows, got ${lines.length}`);
+	const maxWidth = Math.max(cols - 1, 0);
+	for (const [index, line] of lines.entries()) {
+		check(line.length <= maxWidth, `${name}: ${label} screen line ${index + 1} reached ${line.length} columns in a ${cols}-column terminal`);
+	}
+}
+
+function countNewlines(text) {
+	let count = 0;
+	for (const char of text) {
+		if (char === "\n") count++;
+	}
+	return count;
 }
 
 function check(condition, message) {
@@ -235,6 +308,7 @@ function emptyParsedCase() {
 			first: [],
 			second: [],
 		},
+		screens: {},
 		progress: [],
 	};
 }


### PR DESCRIPTION
- installer redraws no longer add an extra bottom-row newline, which stops the splash from scrolling each frame.
- quiet install phases now use honest indeterminate status text instead of synthetic percentages.
- the installer render check now covers full-screen output and resize-bounded redraws.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer UX and test-harness changes only; no auth, install logic, or package runtime behavior changes.
> 
> **Overview**
> Fixes **installer splash flicker** during animation and terminal resize by changing how `prime_agent_screen` writes synchronized full-screen updates: the frame is printed without an extra trailing newline before the sync-end sequence, so redraws no longer scroll or jitter each frame.
> 
> **Quiet install progress** in static animation mode no longer shows synthetic `· N%` values. `prime_agent_animation_percent` is removed in favor of `prime_agent_static_progress_title`, which shows an honest indeterminate title (e.g. `Installing Prime Agent...`).
> 
> **`scripts/check-installer-render.mjs`** now exercises full `prime_agent_screen` output (including resize), asserts sync-end framing and row bounds, and expects indeterminate status without percent signs. Changelog documents ENG-4481.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafc785bfd4cd929a8456f17e2d3f02ec0abbbcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix installer splash screen flicker by removing trailing newlines from screen frames
> - Removes the extra newline between the rendered frame and the synchronized update close token (`\x1b[?2026l`) in `prime_agent_screen`, stabilizing full-screen redraws across frames and resizes.
> - Replaces the synthetic progress percentage in static mode with an indeterminate title (e.g. `Installing Prime Agent...`) via a new `prime_agent_static_progress_title` helper.
> - Adds test coverage in [check-installer-render.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/329/files#diff-22dc1ee148ea8609089fbf10f9465e8ca5e6375523e99bb314a55b9c0381ae5e) that validates frame boundaries, newline discipline, line width/height constraints, and the absence of percent values in static progress output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aafc785.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->