### PR TITLE
mark stale provider auth after repeated failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed provider auth failures leaving stale credentials shown as connected in `/login` ([ENG-4491](https://linear.app/primeintellect/issue/ENG-4491/mark-provider-stale-after-repeated-401s)).
+
 ## [0.2.6] - 2026-07-06
 
 - Fixed the installer splash flickering during animation and resize by stabilizing full-screen redraws and removing misleading synthetic percentages ([ENG-4481](https://linear.app/primeintellect/issue/ENG-4481/installer-screen-is-unstable-and-flickery)).

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -1415,6 +1415,7 @@ class DaemonAttachTerminal {
 			case "turn_end":
 			case "message_start":
 			case "tool_execution_update":
+			case "auth_stale":
 				return;
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -589,7 +589,7 @@ export class AgentSession {
 	private _retryAttempt = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
-	private _retryAuthFailureSource: AuthSourceToken | undefined = undefined;
+	private _retryAuthFailureSources: AuthSourceToken[] = [];
 	private _acceptedPromptCompletions = new Set<Promise<void>>();
 	private _acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined = undefined;
 	private _agentMessageDeliveryWaiters = new Map<string, AgentMessageDeliveryWaiter>();
@@ -1752,7 +1752,7 @@ export class AgentSession {
 						attempt: this._retryAttempt,
 					});
 					this._retryAttempt = 0;
-					this._retryAuthFailureSource = undefined;
+					this._retryAuthFailureSources = [];
 				}
 				if (this._accountGoalUsageForAssistantMessage(assistantMsg)) {
 					this.agent.steer(createGoalContextMessage(this._goalState, "budget_limit"));
@@ -1783,7 +1783,7 @@ export class AgentSession {
 				}
 				const didRetry = await this._handleRetryableError(msg, {
 					markAuthStaleOnFailure: concreteAuthFailure,
-					authSourceToken: concreteAuthFailure ? this._retryAuthFailureSource : undefined,
+					authSourceTokens: concreteAuthFailure ? this._retryAuthFailureSources : undefined,
 				});
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
@@ -5405,16 +5405,29 @@ export class AgentSession {
 	}
 
 	private _captureRetryAuthFailureSource(message: AssistantMessage): AuthSourceToken | undefined {
-		if (this._retryAuthFailureSource) {
-			return this._retryAuthFailureSource;
+		const token = this._modelRegistry.getCurrentProviderAuthSourceToken(message.provider);
+		if (!token) {
+			return undefined;
 		}
-		this._retryAuthFailureSource = this._modelRegistry.getCurrentProviderAuthSourceToken(message.provider);
-		return this._retryAuthFailureSource;
+		if (
+			!this._retryAuthFailureSources.some(
+				(existing) =>
+					existing.provider === token.provider &&
+					existing.source === token.source &&
+					existing.identityFingerprint === token.identityFingerprint &&
+					existing.valueFingerprint === token.valueFingerprint,
+			)
+		) {
+			this._retryAuthFailureSources.push(token);
+		}
+		return token;
 	}
 
-	private _markProviderAuthStale(message: AssistantMessage, authSourceToken?: AuthSourceToken): void {
-		if (authSourceToken) {
-			this._modelRegistry.markProviderAuthSourceStale(authSourceToken);
+	private _markProviderAuthStale(message: AssistantMessage, authSourceTokens?: readonly AuthSourceToken[]): void {
+		if (authSourceTokens && authSourceTokens.length > 0) {
+			for (const token of authSourceTokens) {
+				this._modelRegistry.markProviderAuthSourceStale(token);
+			}
 			return;
 		}
 		this._modelRegistry.markProviderAuthStale(message.provider);
@@ -5426,11 +5439,14 @@ export class AgentSession {
 	 */
 	private async _handleRetryableError(
 		message: AssistantMessage,
-		options?: { markAuthStaleOnFailure?: boolean; authSourceToken?: AuthSourceToken },
+		options?: { markAuthStaleOnFailure?: boolean; authSourceTokens?: readonly AuthSourceToken[] },
 	): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
-			this._retryAuthFailureSource = undefined;
+			if (options?.markAuthStaleOnFailure) {
+				this._markProviderAuthStale(message, options.authSourceTokens);
+			}
+			this._retryAuthFailureSources = [];
 			this._resolveRetry();
 			return false;
 		}
@@ -5447,7 +5463,7 @@ export class AgentSession {
 
 		if (this._retryAttempt > settings.maxRetries) {
 			if (options?.markAuthStaleOnFailure) {
-				this._markProviderAuthStale(message, options.authSourceToken);
+				this._markProviderAuthStale(message, options.authSourceTokens);
 			}
 			// Max retries exceeded, emit final failure and reset
 			this._emit({
@@ -5457,7 +5473,7 @@ export class AgentSession {
 				finalError: message.errorMessage,
 			});
 			this._retryAttempt = 0;
-			this._retryAuthFailureSource = undefined;
+			this._retryAuthFailureSources = [];
 			this._resolveRetry(); // Resolve so waitForRetry() completes
 			return false;
 		}
@@ -5494,7 +5510,7 @@ export class AgentSession {
 				finalError: "Retry cancelled",
 			});
 			this._resolveRetry();
-			this._retryAuthFailureSource = undefined;
+			this._retryAuthFailureSources = [];
 			return false;
 		}
 		this._retryAbortController = undefined;
@@ -5515,7 +5531,7 @@ export class AgentSession {
 	abortRetry(): void {
 		this._retryAbortController?.abort();
 		// Note: _retryAttempt is reset in the catch block of _autoRetry
-		this._retryAuthFailureSource = undefined;
+		this._retryAuthFailureSources = [];
 		this._resolveRetry();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5423,25 +5423,31 @@ export class AgentSession {
 		return token;
 	}
 
-	private _markProviderAuthStale(message: AssistantMessage, authSourceTokens?: readonly AuthSourceToken[]): void {
+	private _markProviderAuthStale(message: AssistantMessage, authSourceTokens?: readonly AuthSourceToken[]): boolean {
 		if (authSourceTokens && authSourceTokens.length > 0) {
+			let marked = false;
 			for (const token of authSourceTokens) {
-				this._modelRegistry.markProviderAuthSourceStale(token);
+				marked = this._modelRegistry.markProviderAuthSourceStale(token) || marked;
 			}
-			return;
+			return marked;
 		}
-		this._modelRegistry.markProviderAuthStale(message.provider);
+		return this._modelRegistry.markProviderAuthStale(message.provider);
 	}
 
 	private _markProviderAuthStaleForRetryFailure(
 		message: AssistantMessage,
 		options?: { markAuthStaleOnFailure?: boolean; authSourceTokens?: readonly AuthSourceToken[] },
-	): void {
+	): boolean {
 		const authSourceTokens =
 			this._retryAuthFailureSources.length > 0 ? this._retryAuthFailureSources : options?.authSourceTokens;
 		if ((authSourceTokens?.length ?? 0) > 0 || options?.markAuthStaleOnFailure) {
-			this._markProviderAuthStale(message, authSourceTokens);
+			const marked = this._markProviderAuthStale(message, authSourceTokens);
+			if (marked && message.errorMessage) {
+				message.errorMessage = addLoginGuidanceToAuthError(message.errorMessage);
+			}
+			return marked;
 		}
+		return false;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1594,7 +1594,10 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
-		if (!lastAssistant || !this._isRetryableError(lastAssistant)) {
+		if (
+			!lastAssistant ||
+			(!this._isRetryableError(lastAssistant) && !this._isConcreteProviderAuthFailure(lastAssistant))
+		) {
 			return;
 		}
 
@@ -1760,8 +1763,9 @@ export class AgentSession {
 			this._lastAssistantMessage = undefined;
 
 			// Check for retryable errors first (overloaded, rate limit, server errors)
-			if (this._isRetryableError(msg)) {
-				const didRetry = await this._handleRetryableError(msg);
+			const concreteAuthFailure = this._isConcreteProviderAuthFailure(msg);
+			if (this._isRetryableError(msg) || concreteAuthFailure) {
+				const didRetry = await this._handleRetryableError(msg, { markAuthStaleOnFailure: concreteAuthFailure });
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
@@ -5344,11 +5348,55 @@ export class AgentSession {
 		);
 	}
 
+	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {
+		const failure = message.diagnostics?.find((diagnostic) => diagnostic.type === "provider_stream_failure");
+		const details = failure?.details;
+		if (!details || typeof details !== "object") {
+			return undefined;
+		}
+
+		const kind = "kind" in details ? details.kind : undefined;
+		if (kind !== "auth") {
+			return undefined;
+		}
+
+		const status = "status" in details ? details.status : undefined;
+		if (typeof status === "number") {
+			return status;
+		}
+		if (typeof status === "string") {
+			const parsed = Number(status);
+			return Number.isInteger(parsed) ? parsed : undefined;
+		}
+		return undefined;
+	}
+
+	private _isConcreteProviderAuthFailure(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error" || !message.errorMessage) return false;
+
+		const structuredStatus = this._getProviderStreamFailureAuthStatus(message);
+		if (structuredStatus === 401 || structuredStatus === 403) {
+			return true;
+		}
+
+		return (
+			/\b(?:401|403)\b/.test(message.errorMessage) &&
+			/auth|unauthori[sz]ed|forbidden|api.?key|token|credential/i.test(message.errorMessage)
+		);
+	}
+
+	private _markProviderAuthStale(message: AssistantMessage): void {
+		this._modelRegistry.markProviderAuthStale(message.provider);
+	}
+
 	/**
 	 * Handle retryable errors with exponential backoff.
 	 * @returns true if retry was initiated, false if max retries exceeded or disabled
 	 */
-	private async _handleRetryableError(message: AssistantMessage): Promise<boolean> {
+	private async _handleRetryableError(
+		message: AssistantMessage,
+		options?: { markAuthStaleOnFailure?: boolean },
+	): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
 			this._resolveRetry();
@@ -5366,6 +5414,9 @@ export class AgentSession {
 		this._retryAttempt++;
 
 		if (this._retryAttempt > settings.maxRetries) {
+			if (options?.markAuthStaleOnFailure) {
+				this._markProviderAuthStale(message);
+			}
 			// Max retries exceeded, emit final failure and reset
 			this._emit({
 				type: "auto_retry_end",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -71,6 +71,7 @@ import {
 	formatNoModelSelectedMessage,
 	isLikelyAuthenticationError,
 } from "./auth-guidance.js";
+import type { AuthSourceToken } from "./auth-storage.js";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
 import {
 	type CompactionResult,
@@ -588,6 +589,7 @@ export class AgentSession {
 	private _retryAttempt = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
+	private _retryAuthFailureSource: AuthSourceToken | undefined = undefined;
 	private _acceptedPromptCompletions = new Set<Promise<void>>();
 	private _acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined = undefined;
 	private _agentMessageDeliveryWaiters = new Map<string, AgentMessageDeliveryWaiter>();
@@ -1594,11 +1596,12 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
-		if (
-			!lastAssistant ||
-			(!this._isRetryableError(lastAssistant) && !this._isConcreteProviderAuthFailure(lastAssistant))
-		) {
+		const concreteAuthFailure = lastAssistant ? this._isConcreteProviderAuthFailure(lastAssistant) : false;
+		if (!lastAssistant || (!this._isRetryableError(lastAssistant) && !concreteAuthFailure)) {
 			return;
+		}
+		if (concreteAuthFailure) {
+			this._captureRetryAuthFailureSource(lastAssistant);
 		}
 
 		this._retryPromise = new Promise((resolve) => {
@@ -1736,6 +1739,9 @@ export class AgentSession {
 				if (assistantMsg.stopReason !== "error") {
 					this._overflowRecoveryAttempted = false;
 				}
+				if (this._isConcreteProviderAuthFailure(assistantMsg)) {
+					this._captureRetryAuthFailureSource(assistantMsg);
+				}
 
 				// Reset retry counter immediately on successful assistant response
 				// This prevents accumulation across multiple LLM calls within a turn
@@ -1746,6 +1752,7 @@ export class AgentSession {
 						attempt: this._retryAttempt,
 					});
 					this._retryAttempt = 0;
+					this._retryAuthFailureSource = undefined;
 				}
 				if (this._accountGoalUsageForAssistantMessage(assistantMsg)) {
 					this.agent.steer(createGoalContextMessage(this._goalState, "budget_limit"));
@@ -1758,14 +1765,26 @@ export class AgentSession {
 		}
 
 		// Check auto-retry and auto-compaction after agent completes
-		if (event.type === "agent_end" && this._lastAssistantMessage) {
-			const msg = this._lastAssistantMessage;
+		if (event.type === "agent_end") {
+			const msg =
+				this._lastAssistantMessage ??
+				(this._retryPromise ? this._findLastAssistantInMessages(event.messages) : undefined);
 			this._lastAssistantMessage = undefined;
+			if (!msg) {
+				this._resolveRetry();
+				return;
+			}
 
 			// Check for retryable errors first (overloaded, rate limit, server errors)
 			const concreteAuthFailure = this._isConcreteProviderAuthFailure(msg);
 			if (this._isRetryableError(msg) || concreteAuthFailure) {
-				const didRetry = await this._handleRetryableError(msg, { markAuthStaleOnFailure: concreteAuthFailure });
+				if (concreteAuthFailure) {
+					this._captureRetryAuthFailureSource(msg);
+				}
+				const didRetry = await this._handleRetryableError(msg, {
+					markAuthStaleOnFailure: concreteAuthFailure,
+					authSourceToken: concreteAuthFailure ? this._retryAuthFailureSource : undefined,
+				});
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
@@ -5385,7 +5404,19 @@ export class AgentSession {
 		);
 	}
 
-	private _markProviderAuthStale(message: AssistantMessage): void {
+	private _captureRetryAuthFailureSource(message: AssistantMessage): AuthSourceToken | undefined {
+		if (this._retryAuthFailureSource) {
+			return this._retryAuthFailureSource;
+		}
+		this._retryAuthFailureSource = this._modelRegistry.getCurrentProviderAuthSourceToken(message.provider);
+		return this._retryAuthFailureSource;
+	}
+
+	private _markProviderAuthStale(message: AssistantMessage, authSourceToken?: AuthSourceToken): void {
+		if (authSourceToken) {
+			this._modelRegistry.markProviderAuthSourceStale(authSourceToken);
+			return;
+		}
 		this._modelRegistry.markProviderAuthStale(message.provider);
 	}
 
@@ -5395,10 +5426,11 @@ export class AgentSession {
 	 */
 	private async _handleRetryableError(
 		message: AssistantMessage,
-		options?: { markAuthStaleOnFailure?: boolean },
+		options?: { markAuthStaleOnFailure?: boolean; authSourceToken?: AuthSourceToken },
 	): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
+			this._retryAuthFailureSource = undefined;
 			this._resolveRetry();
 			return false;
 		}
@@ -5415,7 +5447,7 @@ export class AgentSession {
 
 		if (this._retryAttempt > settings.maxRetries) {
 			if (options?.markAuthStaleOnFailure) {
-				this._markProviderAuthStale(message);
+				this._markProviderAuthStale(message, options.authSourceToken);
 			}
 			// Max retries exceeded, emit final failure and reset
 			this._emit({
@@ -5425,6 +5457,7 @@ export class AgentSession {
 				finalError: message.errorMessage,
 			});
 			this._retryAttempt = 0;
+			this._retryAuthFailureSource = undefined;
 			this._resolveRetry(); // Resolve so waitForRetry() completes
 			return false;
 		}
@@ -5461,6 +5494,7 @@ export class AgentSession {
 				finalError: "Retry cancelled",
 			});
 			this._resolveRetry();
+			this._retryAuthFailureSource = undefined;
 			return false;
 		}
 		this._retryAbortController = undefined;
@@ -5481,6 +5515,7 @@ export class AgentSession {
 	abortRetry(): void {
 		this._retryAbortController?.abort();
 		// Note: _retryAttempt is reset in the catch block of _autoRetry
+		this._retryAuthFailureSource = undefined;
 		this._resolveRetry();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5433,6 +5433,17 @@ export class AgentSession {
 		this._modelRegistry.markProviderAuthStale(message.provider);
 	}
 
+	private _markProviderAuthStaleForRetryFailure(
+		message: AssistantMessage,
+		options?: { markAuthStaleOnFailure?: boolean; authSourceTokens?: readonly AuthSourceToken[] },
+	): void {
+		const authSourceTokens =
+			this._retryAuthFailureSources.length > 0 ? this._retryAuthFailureSources : options?.authSourceTokens;
+		if ((authSourceTokens?.length ?? 0) > 0 || options?.markAuthStaleOnFailure) {
+			this._markProviderAuthStale(message, authSourceTokens);
+		}
+	}
+
 	/**
 	 * Handle retryable errors with exponential backoff.
 	 * @returns true if retry was initiated, false if max retries exceeded or disabled
@@ -5443,9 +5454,7 @@ export class AgentSession {
 	): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
-			if (options?.markAuthStaleOnFailure) {
-				this._markProviderAuthStale(message, options.authSourceTokens);
-			}
+			this._markProviderAuthStaleForRetryFailure(message, options);
 			this._retryAuthFailureSources = [];
 			this._resolveRetry();
 			return false;
@@ -5462,9 +5471,7 @@ export class AgentSession {
 		this._retryAttempt++;
 
 		if (this._retryAttempt > settings.maxRetries) {
-			if (options?.markAuthStaleOnFailure) {
-				this._markProviderAuthStale(message, options.authSourceTokens);
-			}
+			this._markProviderAuthStaleForRetryFailure(message, options);
 			// Max retries exceeded, emit final failure and reset
 			this._emit({
 				type: "auto_retry_end",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5399,6 +5399,10 @@ export class AgentSession {
 			return true;
 		}
 
+		if (/\b(?:401|403)\b/.test(message.errorMessage) && /\bstatus code\b/i.test(message.errorMessage)) {
+			return true;
+		}
+
 		return (
 			/\b(?:401|403)\b/.test(message.errorMessage) &&
 			/auth|unauthori[sz]ed|forbidden|api.?key|token|credential/i.test(message.errorMessage)
@@ -5522,6 +5526,7 @@ export class AgentSession {
 		} catch {
 			// Aborted during sleep - emit end event so UI can clean up
 			const attempt = this._retryAttempt;
+			this._markProviderAuthStaleForRetryFailure(message, options);
 			this._retryAttempt = 0;
 			this._retryAbortController = undefined;
 			this._emit({
@@ -5550,8 +5555,10 @@ export class AgentSession {
 	 * Cancel in-progress retry.
 	 */
 	abortRetry(): void {
-		this._retryAbortController?.abort();
-		// Note: _retryAttempt is reset in the catch block of _autoRetry
+		if (this._retryAbortController) {
+			this._retryAbortController.abort();
+			return;
+		}
 		this._retryAuthFailureSources = [];
 		this._resolveRetry();
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -247,6 +247,7 @@ export type AgentSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| { type: "auth_stale"; provider: string; sourceTokens?: readonly AuthSourceToken[] }
 	| { type: "rlm_child_update"; child: RlmChildAgentSnapshot }
 	| { type: "recap_update"; recap: string | undefined }
 	| { type: "goal_update"; goal: GoalState }
@@ -5429,9 +5430,16 @@ export class AgentSession {
 			for (const token of authSourceTokens) {
 				marked = this._modelRegistry.markProviderAuthSourceStale(token) || marked;
 			}
+			if (marked) {
+				this._emit({ type: "auth_stale", provider: message.provider, sourceTokens: authSourceTokens });
+			}
 			return marked;
 		}
-		return this._modelRegistry.markProviderAuthStale(message.provider);
+		const marked = this._modelRegistry.markProviderAuthStale(message.provider);
+		if (marked) {
+			this._emit({ type: "auth_stale", provider: message.provider });
+		}
+		return marked;
 	}
 
 	private _markProviderAuthStaleForRetryFailure(

--- a/packages/coding-agent/src/core/auth-guidance.ts
+++ b/packages/coding-agent/src/core/auth-guidance.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { getDocsPath } from "../config.js";
 
 const UNKNOWN_PROVIDER = "unknown";
-const LOGIN_RECOVERY_MESSAGE = "Run /login to update credentials.";
+export const LOGIN_RECOVERY_MESSAGE = "Run /login to update credentials.";
 
 export function getProviderLoginHelp(): string {
 	return [

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -265,7 +265,7 @@ export class AuthStorage {
 	 * Used for CLI --api-key flag.
 	 */
 	setRuntimeApiKey(provider: string, apiKey: string): void {
-		this.clearStaleAuth(provider);
+		this.clearStaleAuthSource(provider, "runtime");
 		this.runtimeOverrides.set(provider, apiKey);
 	}
 
@@ -273,7 +273,7 @@ export class AuthStorage {
 	 * Remove a runtime API key override.
 	 */
 	removeRuntimeApiKey(provider: string): void {
-		this.clearStaleAuth(provider);
+		this.clearStaleAuthSource(provider, "runtime");
 		this.runtimeOverrides.delete(provider);
 	}
 
@@ -436,8 +436,19 @@ export class AuthStorage {
 		return true;
 	}
 
-	private clearStaleAuth(provider: string): void {
-		this.staleAuthSources.delete(provider);
+	private clearStaleAuthSource(provider: string, source: ActiveAuthStatusSource): void {
+		const stale = this.staleAuthSources.get(provider);
+		if (!stale) {
+			return;
+		}
+		for (const fingerprint of stale) {
+			if (fingerprint.startsWith(`${source}:`)) {
+				stale.delete(fingerprint);
+			}
+		}
+		if (stale.size === 0) {
+			this.staleAuthSources.delete(provider);
+		}
 	}
 
 	private parseStorageData(content: string | undefined): AuthStorageData {
@@ -497,7 +508,7 @@ export class AuthStorage {
 	 * Set credential for a provider.
 	 */
 	set(provider: string, credential: AuthCredential): void {
-		this.clearStaleAuth(provider);
+		this.clearStaleAuthSource(provider, "stored");
 		this.data[provider] = credential;
 		this.persistProviderChange(provider, credential);
 	}
@@ -506,7 +517,7 @@ export class AuthStorage {
 	 * Remove credential for a provider.
 	 */
 	remove(provider: string): void {
-		this.clearStaleAuth(provider);
+		this.clearStaleAuthSource(provider, "stored");
 		delete this.data[provider];
 		this.persistProviderChange(provider, undefined);
 	}
@@ -570,10 +581,10 @@ export class AuthStorage {
 	 * Logout from a provider.
 	 */
 	logout(provider: string): void {
-		this.clearStaleAuth(provider);
 		if (provider === PRIME_INFERENCE_PROVIDER_ID && this.isPrimeCliConfigEnabled()) {
 			try {
 				clearPrimeCliCredentials(this.getEnabledPrimeCliConfigPath());
+				this.clearStaleAuthSource(provider, "prime_cli");
 			} catch (error) {
 				this.recordError(error);
 				throw error;
@@ -752,7 +763,6 @@ export class AuthStorage {
 	}
 
 	setPrimeInferenceApiKey(apiKey: string): void {
-		this.clearStaleAuth(PRIME_INFERENCE_PROVIDER_ID);
 		if (this.isPrimeCliConfigEnabled()) {
 			try {
 				const configPath = this.getEnabledPrimeCliConfigPath();
@@ -764,6 +774,7 @@ export class AuthStorage {
 				} else if (!config.teamIdFromEnv && (legacyPrimeTeam === null || (!config.teamId && legacyPrimeTeam))) {
 					savePrimeCliTeamSelection(legacyPrimeTeam, configPath);
 				}
+				this.clearStaleAuthSource(PRIME_INFERENCE_PROVIDER_ID, "prime_cli");
 			} catch (error) {
 				this.recordError(error);
 				throw error;

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -418,13 +418,42 @@ export class AuthStorage {
 			return undefined;
 		}
 		const label = envKey ?? "ambient credentials";
+		const identityMaterial = envKey ?? this.getAmbientEnvironmentIdentityMaterial(provider);
 		return this.createAuthSourceCandidate({
 			configured: false,
 			source: "environment",
 			label,
-			identityMaterial: envKey ?? provider,
-			valueMaterial: `${envKey ?? provider}\0${apiKey}`,
+			identityMaterial,
+			valueMaterial: `${identityMaterial}\0${apiKey}`,
 		});
+	}
+
+	private getAmbientEnvironmentIdentityMaterial(provider: string): string {
+		if (provider === "amazon-bedrock") {
+			if (process.env.AWS_PROFILE) return `amazon-bedrock:profile:${process.env.AWS_PROFILE}`;
+			if (process.env.AWS_ACCESS_KEY_ID) {
+				return `amazon-bedrock:access-key:${process.env.AWS_ACCESS_KEY_ID}:${process.env.AWS_SECRET_ACCESS_KEY ?? ""}:${process.env.AWS_SESSION_TOKEN ?? ""}`;
+			}
+			if (process.env.AWS_BEARER_TOKEN_BEDROCK) {
+				return `amazon-bedrock:bearer:${process.env.AWS_BEARER_TOKEN_BEDROCK}`;
+			}
+			if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
+				return `amazon-bedrock:ecs-relative:${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`;
+			}
+			if (process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI) {
+				return `amazon-bedrock:ecs-full:${process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI}`;
+			}
+			if (process.env.AWS_WEB_IDENTITY_TOKEN_FILE) {
+				return `amazon-bedrock:web-identity:${process.env.AWS_WEB_IDENTITY_TOKEN_FILE}`;
+			}
+		}
+		if (provider === "google-vertex") {
+			const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT ?? "";
+			const location = process.env.GOOGLE_CLOUD_LOCATION ?? "";
+			const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS ?? "application-default";
+			return `google-vertex:${project}:${location}:${credentialsPath}`;
+		}
+		return provider;
 	}
 
 	private getFallbackAuthCandidate(provider: string): AuthSourceCandidate | undefined {

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -29,7 +29,7 @@ import {
 	savePrimeCliApiKey,
 	savePrimeCliTeamSelection,
 } from "./prime-inference-auth.js";
-import { resolveConfigValue } from "./resolve-config-value.js";
+import { resolveConfigValue, resolveConfigValueUncached } from "./resolve-config-value.js";
 
 export type PrimeTeamCredential = {
 	teamId: string;
@@ -79,11 +79,20 @@ type LockResult<T> = {
 
 type ActiveAuthStatusSource = Exclude<NonNullable<AuthStatus["source"]>, "stale">;
 
+export type AuthSourceToken = {
+	provider: string;
+	source: ActiveAuthStatusSource;
+	identityFingerprint: string;
+	valueFingerprint: string;
+};
+
 type AuthSourceCandidate = {
 	source: ActiveAuthStatusSource;
 	configured: boolean;
 	label?: string;
-	fingerprint: string;
+	identityFingerprint: string;
+	valueFingerprint?: string;
+	resolveValueFingerprint?: () => string | undefined;
 };
 
 export interface AuthStorageBackend {
@@ -233,7 +242,7 @@ export class InMemoryAuthStorageBackend implements AuthStorageBackend {
 export class AuthStorage {
 	private data: AuthStorageData = {};
 	private runtimeOverrides: Map<string, string> = new Map();
-	private staleAuthSources: Map<string, Set<string>> = new Map();
+	private staleAuthSources: Map<string, AuthSourceToken[]> = new Map();
 	private fallbackResolver?: (provider: string) => string | undefined;
 	private loadError: Error | null = null;
 	private errors: Error[] = [];
@@ -295,10 +304,48 @@ export class AuthStorage {
 		return `${source}:${digest}`;
 	}
 
-	private getStoredCredentialFingerprintMaterial(providerId: string, credential: AuthCredential): string {
+	private createAuthSourceCandidate(options: {
+		source: ActiveAuthStatusSource;
+		configured: boolean;
+		identityMaterial: string;
+		valueMaterial?: string;
+		label?: string;
+		resolveValueMaterial?: () => string | undefined;
+	}): AuthSourceCandidate {
+		return {
+			configured: options.configured,
+			source: options.source,
+			...(options.label ? { label: options.label } : {}),
+			identityFingerprint: this.fingerprintAuthSource(options.source, `identity:${options.identityMaterial}`),
+			...(options.valueMaterial !== undefined
+				? {
+						valueFingerprint: this.fingerprintAuthSource(
+							options.source,
+							`value:${options.identityMaterial}\0${options.valueMaterial}`,
+						),
+					}
+				: {}),
+			...(options.resolveValueMaterial
+				? {
+						resolveValueFingerprint: () => {
+							const valueMaterial = options.resolveValueMaterial?.();
+							return valueMaterial === undefined
+								? undefined
+								: this.fingerprintAuthSource(
+										options.source,
+										`value:${options.identityMaterial}\0${valueMaterial}`,
+									);
+						},
+					}
+				: {}),
+		};
+	}
+
+	private getStoredCredentialValueMaterial(providerId: string, credential: AuthCredential): string | undefined {
 		if (credential.type === "api_key") {
 			if (credential.key.startsWith("!")) {
-				return `api_key:command:${credential.key}`;
+				const resolvedKey = resolveConfigValueUncached(credential.key);
+				return resolvedKey === undefined ? undefined : `api_key:command:${credential.key}\0${resolvedKey}`;
 			}
 			return `api_key:${credential.key}\0${resolveConfigValue(credential.key) ?? ""}`;
 		}
@@ -313,10 +360,13 @@ export class AuthStorage {
 			return undefined;
 		}
 		return {
-			configured: false,
-			source: "runtime",
 			label: "--api-key",
-			fingerprint: this.fingerprintAuthSource("runtime", apiKey),
+			...this.createAuthSourceCandidate({
+				configured: false,
+				source: "runtime",
+				identityMaterial: provider,
+				valueMaterial: apiKey,
+			}),
 		};
 	}
 
@@ -326,41 +376,55 @@ export class AuthStorage {
 			return undefined;
 		}
 		return {
-			configured: false,
-			source: "prime_cli",
 			label: "Prime CLI",
-			fingerprint: this.fingerprintAuthSource("prime_cli", apiKey),
+			...this.createAuthSourceCandidate({
+				configured: false,
+				source: "prime_cli",
+				identityMaterial: provider,
+				valueMaterial: apiKey,
+			}),
 		};
 	}
 
-	private getStoredAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+	private getStoredAuthCandidate(
+		provider: string,
+		options?: { resolveCommandValue?: boolean },
+	): AuthSourceCandidate | undefined {
 		const credential = this.data[provider];
 		if (!credential) {
 			return undefined;
 		}
-		return {
+		const isCommandApiKey = credential.type === "api_key" && credential.key.startsWith("!");
+		const identityMaterial = isCommandApiKey ? `api_key:command:${credential.key}` : `${provider}:${credential.type}`;
+		return this.createAuthSourceCandidate({
 			configured: true,
 			source: "stored",
-			fingerprint: this.fingerprintAuthSource(
-				"stored",
-				this.getStoredCredentialFingerprintMaterial(provider, credential),
-			),
-		};
+			identityMaterial,
+			valueMaterial:
+				isCommandApiKey && !options?.resolveCommandValue
+					? undefined
+					: this.getStoredCredentialValueMaterial(provider, credential),
+			resolveValueMaterial: isCommandApiKey
+				? () => this.getStoredCredentialValueMaterial(provider, credential)
+				: undefined,
+		});
 	}
 
 	private getEnvironmentAuthCandidate(provider: string): AuthSourceCandidate | undefined {
 		const envKeys = findEnvKeys(provider);
 		const envKey = envKeys?.[0];
 		const apiKey = getEnvApiKey(provider);
-		if (!envKey || !apiKey) {
+		if (!apiKey) {
 			return undefined;
 		}
-		return {
+		const label = envKey ?? "ambient credentials";
+		return this.createAuthSourceCandidate({
 			configured: false,
 			source: "environment",
-			label: envKey,
-			fingerprint: this.fingerprintAuthSource("environment", `${envKey}\0${apiKey}`),
-		};
+			label,
+			identityMaterial: envKey ?? provider,
+			valueMaterial: `${envKey ?? provider}\0${apiKey}`,
+		});
 	}
 
 	private getFallbackAuthCandidate(provider: string): AuthSourceCandidate | undefined {
@@ -368,12 +432,13 @@ export class AuthStorage {
 		if (!apiKey) {
 			return undefined;
 		}
-		return {
+		return this.createAuthSourceCandidate({
 			configured: false,
 			source: "fallback",
 			label: "custom provider config",
-			fingerprint: this.fingerprintAuthSource("fallback", apiKey),
-		};
+			identityMaterial: provider,
+			valueMaterial: apiKey,
+		});
 	}
 
 	private getAuthSourceCandidates(provider: string, options?: { includeFallback?: boolean }): AuthSourceCandidate[] {
@@ -388,7 +453,22 @@ export class AuthStorage {
 	}
 
 	private isAuthSourceStale(provider: string, candidate: AuthSourceCandidate): boolean {
-		return this.staleAuthSources.get(provider)?.has(candidate.fingerprint) ?? false;
+		const matchingStale = this.getMatchingStaleAuthSources(provider, candidate);
+		if (matchingStale.length === 0) {
+			return false;
+		}
+		const valueFingerprint = candidate.valueFingerprint ?? candidate.resolveValueFingerprint?.();
+		return Boolean(valueFingerprint && matchingStale.some((token) => token.valueFingerprint === valueFingerprint));
+	}
+
+	private getMatchingStaleAuthSources(provider: string, candidate: AuthSourceCandidate): AuthSourceToken[] {
+		const stale = this.staleAuthSources.get(provider);
+		if (!stale) {
+			return [];
+		}
+		return stale.filter(
+			(token) => token.source === candidate.source && token.identityFingerprint === candidate.identityFingerprint,
+		);
 	}
 
 	private getAvailableAuthCandidate(
@@ -426,13 +506,43 @@ export class AuthStorage {
 	}
 
 	markAuthStale(provider: string): boolean {
+		const token = this.getCurrentAuthSourceToken(provider);
+		return token ? this.markAuthSourceStale(token) : false;
+	}
+
+	getCurrentAuthSourceToken(provider: string): AuthSourceToken | undefined {
 		const { candidate } = this.getAvailableAuthCandidate(provider);
 		if (!candidate) {
+			return undefined;
+		}
+		const valueFingerprint = candidate.valueFingerprint ?? candidate.resolveValueFingerprint?.();
+		if (!valueFingerprint) {
+			return undefined;
+		}
+		return {
+			provider,
+			source: candidate.source,
+			identityFingerprint: candidate.identityFingerprint,
+			valueFingerprint,
+		};
+	}
+
+	markAuthSourceStale(token: AuthSourceToken): boolean {
+		if (token.provider.length === 0) {
 			return false;
 		}
-		const stale = this.staleAuthSources.get(provider) ?? new Set<string>();
-		stale.add(candidate.fingerprint);
-		this.staleAuthSources.set(provider, stale);
+		const stale = this.staleAuthSources.get(token.provider) ?? [];
+		if (
+			!stale.some(
+				(existing) =>
+					existing.source === token.source &&
+					existing.identityFingerprint === token.identityFingerprint &&
+					existing.valueFingerprint === token.valueFingerprint,
+			)
+		) {
+			stale.push(token);
+		}
+		this.staleAuthSources.set(token.provider, stale);
 		return true;
 	}
 
@@ -441,13 +551,11 @@ export class AuthStorage {
 		if (!stale) {
 			return;
 		}
-		for (const fingerprint of stale) {
-			if (fingerprint.startsWith(`${source}:`)) {
-				stale.delete(fingerprint);
-			}
-		}
-		if (stale.size === 0) {
+		const next = stale.filter((token) => token.source !== source);
+		if (next.length === 0) {
 			this.staleAuthSources.delete(provider);
+		} else {
+			this.staleAuthSources.set(provider, next);
 		}
 	}
 
@@ -673,7 +781,10 @@ export class AuthStorage {
 		if (cred?.type === "api_key") {
 			const storedCandidate = this.getStoredAuthCandidate(providerId);
 			if (storedCandidate && !this.isAuthSourceStale(providerId, storedCandidate)) {
-				return resolveConfigValue(cred.key);
+				const hasStaleRecord = this.getMatchingStaleAuthSources(providerId, storedCandidate).length > 0;
+				return cred.key.startsWith("!") && hasStaleRecord
+					? resolveConfigValueUncached(cred.key)
+					: resolveConfigValue(cred.key);
 			}
 		}
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -6,6 +6,7 @@
  * try to refresh tokens simultaneously.
  */
 
+import { createHash } from "node:crypto";
 import {
 	findEnvKeys,
 	getEnvApiKey,
@@ -54,7 +55,15 @@ export type AuthStorageData = Record<string, AuthCredential>;
 
 export type AuthStatus = {
 	configured: boolean;
-	source?: "stored" | "runtime" | "environment" | "prime_cli" | "fallback" | "models_json_key" | "models_json_command";
+	source?:
+		| "stored"
+		| "runtime"
+		| "environment"
+		| "prime_cli"
+		| "fallback"
+		| "models_json_key"
+		| "models_json_command"
+		| "stale";
 	label?: string;
 };
 
@@ -66,6 +75,15 @@ export type AuthStorageOptions = {
 type LockResult<T> = {
 	result: T;
 	next?: string;
+};
+
+type ActiveAuthStatusSource = Exclude<NonNullable<AuthStatus["source"]>, "stale">;
+
+type AuthSourceCandidate = {
+	source: ActiveAuthStatusSource;
+	configured: boolean;
+	label?: string;
+	fingerprint: string;
 };
 
 export interface AuthStorageBackend {
@@ -215,6 +233,7 @@ export class InMemoryAuthStorageBackend implements AuthStorageBackend {
 export class AuthStorage {
 	private data: AuthStorageData = {};
 	private runtimeOverrides: Map<string, string> = new Map();
+	private staleAuthSources: Map<string, Set<string>> = new Map();
 	private fallbackResolver?: (provider: string) => string | undefined;
 	private loadError: Error | null = null;
 	private errors: Error[] = [];
@@ -246,6 +265,7 @@ export class AuthStorage {
 	 * Used for CLI --api-key flag.
 	 */
 	setRuntimeApiKey(provider: string, apiKey: string): void {
+		this.clearStaleAuth(provider);
 		this.runtimeOverrides.set(provider, apiKey);
 	}
 
@@ -253,6 +273,7 @@ export class AuthStorage {
 	 * Remove a runtime API key override.
 	 */
 	removeRuntimeApiKey(provider: string): void {
+		this.clearStaleAuth(provider);
 		this.runtimeOverrides.delete(provider);
 	}
 
@@ -267,6 +288,156 @@ export class AuthStorage {
 	private recordError(error: unknown): void {
 		const normalizedError = error instanceof Error ? error : new Error(String(error));
 		this.errors.push(normalizedError);
+	}
+
+	private fingerprintAuthSource(source: ActiveAuthStatusSource, material: string): string {
+		const digest = createHash("sha256").update(source).update("\0").update(material).digest("hex");
+		return `${source}:${digest}`;
+	}
+
+	private getStoredCredentialFingerprintMaterial(providerId: string, credential: AuthCredential): string {
+		if (credential.type === "api_key") {
+			if (credential.key.startsWith("!")) {
+				return `api_key:command:${credential.key}`;
+			}
+			return `api_key:${credential.key}\0${resolveConfigValue(credential.key) ?? ""}`;
+		}
+		const provider = getOAuthProvider(providerId);
+		const apiKey = provider?.getApiKey(credential) ?? credential.access;
+		return `oauth:${apiKey}\0${credential.refresh}\0${credential.expires}`;
+	}
+
+	private getRuntimeAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+		const apiKey = this.runtimeOverrides.get(provider);
+		if (!apiKey) {
+			return undefined;
+		}
+		return {
+			configured: false,
+			source: "runtime",
+			label: "--api-key",
+			fingerprint: this.fingerprintAuthSource("runtime", apiKey),
+		};
+	}
+
+	private getPrimeCliAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+		const apiKey = this.getPrimeCliApiKey(provider);
+		if (!apiKey) {
+			return undefined;
+		}
+		return {
+			configured: false,
+			source: "prime_cli",
+			label: "Prime CLI",
+			fingerprint: this.fingerprintAuthSource("prime_cli", apiKey),
+		};
+	}
+
+	private getStoredAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+		const credential = this.data[provider];
+		if (!credential) {
+			return undefined;
+		}
+		return {
+			configured: true,
+			source: "stored",
+			fingerprint: this.fingerprintAuthSource(
+				"stored",
+				this.getStoredCredentialFingerprintMaterial(provider, credential),
+			),
+		};
+	}
+
+	private getEnvironmentAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+		const envKeys = findEnvKeys(provider);
+		const envKey = envKeys?.[0];
+		const apiKey = getEnvApiKey(provider);
+		if (!envKey || !apiKey) {
+			return undefined;
+		}
+		return {
+			configured: false,
+			source: "environment",
+			label: envKey,
+			fingerprint: this.fingerprintAuthSource("environment", `${envKey}\0${apiKey}`),
+		};
+	}
+
+	private getFallbackAuthCandidate(provider: string): AuthSourceCandidate | undefined {
+		const apiKey = this.fallbackResolver?.(provider);
+		if (!apiKey) {
+			return undefined;
+		}
+		return {
+			configured: false,
+			source: "fallback",
+			label: "custom provider config",
+			fingerprint: this.fingerprintAuthSource("fallback", apiKey),
+		};
+	}
+
+	private getAuthSourceCandidates(provider: string, options?: { includeFallback?: boolean }): AuthSourceCandidate[] {
+		const candidates = [
+			this.getRuntimeAuthCandidate(provider),
+			provider === PRIME_INFERENCE_PROVIDER_ID ? this.getPrimeCliAuthCandidate(provider) : undefined,
+			this.getStoredAuthCandidate(provider),
+			this.getEnvironmentAuthCandidate(provider),
+			options?.includeFallback === false ? undefined : this.getFallbackAuthCandidate(provider),
+		];
+		return candidates.filter((candidate): candidate is AuthSourceCandidate => candidate !== undefined);
+	}
+
+	private isAuthSourceStale(provider: string, candidate: AuthSourceCandidate): boolean {
+		return this.staleAuthSources.get(provider)?.has(candidate.fingerprint) ?? false;
+	}
+
+	private getAvailableAuthCandidate(
+		provider: string,
+		options?: { includeFallback?: boolean },
+	): { candidate?: AuthSourceCandidate; hasStaleCandidate: boolean } {
+		let hasStaleCandidate = false;
+		for (const candidate of this.getAuthSourceCandidates(provider, options)) {
+			if (this.isAuthSourceStale(provider, candidate)) {
+				hasStaleCandidate = true;
+				continue;
+			}
+			return { candidate, hasStaleCandidate };
+		}
+		return { hasStaleCandidate };
+	}
+
+	private toAuthStatus(candidate: AuthSourceCandidate): AuthStatus {
+		return {
+			configured: candidate.configured,
+			source: candidate.source,
+			...(candidate.label ? { label: candidate.label } : {}),
+		};
+	}
+
+	private getAuthStatusFromCandidates(provider: string): AuthStatus {
+		const { candidate, hasStaleCandidate } = this.getAvailableAuthCandidate(provider);
+		if (candidate) {
+			return this.toAuthStatus(candidate);
+		}
+		if (hasStaleCandidate) {
+			return { configured: false, source: "stale", label: "expired" };
+		}
+		return { configured: false };
+	}
+
+	markAuthStale(provider: string): boolean {
+		const { candidate } = this.getAvailableAuthCandidate(provider);
+		if (!candidate) {
+			return false;
+		}
+		const stale = this.staleAuthSources.get(provider) ?? new Set<string>();
+		stale.add(candidate.fingerprint);
+		this.staleAuthSources.set(provider, stale);
+		return true;
+	}
+
+	private clearStaleAuth(provider: string): void {
+		this.staleAuthSources.delete(provider);
 	}
 
 	private parseStorageData(content: string | undefined): AuthStorageData {
@@ -326,6 +497,7 @@ export class AuthStorage {
 	 * Set credential for a provider.
 	 */
 	set(provider: string, credential: AuthCredential): void {
+		this.clearStaleAuth(provider);
 		this.data[provider] = credential;
 		this.persistProviderChange(provider, credential);
 	}
@@ -334,6 +506,7 @@ export class AuthStorage {
 	 * Remove credential for a provider.
 	 */
 	remove(provider: string): void {
+		this.clearStaleAuth(provider);
 		delete this.data[provider];
 		this.persistProviderChange(provider, undefined);
 	}
@@ -357,46 +530,14 @@ export class AuthStorage {
 	 * Unlike getApiKey(), this doesn't refresh OAuth tokens.
 	 */
 	hasAuth(provider: string): boolean {
-		if (this.runtimeOverrides.has(provider)) return true;
-		if (provider === PRIME_INFERENCE_PROVIDER_ID) {
-			if (this.getPrimeCliApiKey(provider)) return true;
-			if (this.data[provider]) return true;
-			if (getEnvApiKey(provider)) return true;
-			if (this.fallbackResolver?.(provider)) return true;
-			return false;
-		}
-		if (this.data[provider]) return true;
-		if (getEnvApiKey(provider)) return true;
-		if (this.fallbackResolver?.(provider)) return true;
-		return false;
+		return this.getAvailableAuthCandidate(provider).candidate !== undefined;
 	}
 
 	/**
 	 * Return auth status without exposing credential values or refreshing tokens.
 	 */
 	getAuthStatus(provider: string): AuthStatus {
-		if (provider === PRIME_INFERENCE_PROVIDER_ID) {
-			return this.getPrimeInferenceAuthStatus();
-		}
-
-		if (this.data[provider]) {
-			return { configured: true, source: "stored" };
-		}
-
-		if (this.runtimeOverrides.has(provider)) {
-			return { configured: false, source: "runtime", label: "--api-key" };
-		}
-
-		const envKeys = findEnvKeys(provider);
-		if (envKeys?.[0]) {
-			return { configured: false, source: "environment", label: envKeys[0] };
-		}
-
-		if (this.fallbackResolver?.(provider)) {
-			return { configured: false, source: "fallback", label: "custom provider config" };
-		}
-
-		return { configured: false };
+		return this.getAuthStatusFromCandidates(provider);
 	}
 
 	/**
@@ -429,6 +570,7 @@ export class AuthStorage {
 	 * Logout from a provider.
 	 */
 	logout(provider: string): void {
+		this.clearStaleAuth(provider);
 		if (provider === PRIME_INFERENCE_PROVIDER_ID && this.isPrimeCliConfigEnabled()) {
 			try {
 				clearPrimeCliCredentials(this.getEnabledPrimeCliConfigPath());
@@ -501,70 +643,81 @@ export class AuthStorage {
 	 */
 	async getApiKey(providerId: string, options?: { includeFallback?: boolean }): Promise<string | undefined> {
 		// Runtime override takes highest priority
+		const runtimeCandidate = this.getRuntimeAuthCandidate(providerId);
 		const runtimeKey = this.runtimeOverrides.get(providerId);
-		if (runtimeKey) {
+		if (runtimeKey && runtimeCandidate && !this.isAuthSourceStale(providerId, runtimeCandidate)) {
 			return runtimeKey;
 		}
 
 		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
+			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
 			const primeCliKey = this.getPrimeCliApiKey(providerId);
-			if (primeCliKey) return primeCliKey;
+			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
+				return primeCliKey;
+			}
 		}
 
 		const cred = this.data[providerId];
 
 		if (cred?.type === "api_key") {
-			return resolveConfigValue(cred.key);
+			const storedCandidate = this.getStoredAuthCandidate(providerId);
+			if (storedCandidate && !this.isAuthSourceStale(providerId, storedCandidate)) {
+				return resolveConfigValue(cred.key);
+			}
 		}
 
 		if (cred?.type === "oauth") {
-			const provider = getOAuthProvider(providerId);
-			if (!provider) {
-				// Unknown OAuth provider, can't get API key
-				return undefined;
-			}
-
-			// Check if token needs refresh
-			const needsRefresh = Date.now() >= cred.expires;
-
-			if (needsRefresh) {
-				// Use locked refresh to prevent race conditions
-				try {
-					const result = await this.refreshOAuthTokenWithLock(providerId);
-					if (result) {
-						return result.apiKey;
-					}
-				} catch (error) {
-					this.recordError(error);
-					// Refresh failed - re-read file to check if another instance succeeded
-					this.reload();
-					const updatedCred = this.data[providerId];
-
-					if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
-						// Another instance refreshed successfully, use those credentials
-						return provider.getApiKey(updatedCred);
-					}
-
-					// Refresh truly failed - return undefined so model discovery skips this provider
-					// User can /login to re-authenticate (credentials preserved for retry)
+			const storedCandidate = this.getStoredAuthCandidate(providerId);
+			if (storedCandidate && !this.isAuthSourceStale(providerId, storedCandidate)) {
+				const provider = getOAuthProvider(providerId);
+				if (!provider) {
+					// Unknown OAuth provider, can't get API key
 					return undefined;
 				}
-			} else {
-				// Token not expired, use current access token
-				return provider.getApiKey(cred);
+
+				// Check if token needs refresh
+				const needsRefresh = Date.now() >= cred.expires;
+
+				if (needsRefresh) {
+					// Use locked refresh to prevent race conditions
+					try {
+						const result = await this.refreshOAuthTokenWithLock(providerId);
+						if (result) {
+							return result.apiKey;
+						}
+					} catch (error) {
+						this.recordError(error);
+						// Refresh failed - re-read file to check if another instance succeeded
+						this.reload();
+						const updatedCred = this.data[providerId];
+
+						if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
+							// Another instance refreshed successfully, use those credentials
+							return provider.getApiKey(updatedCred);
+						}
+
+						// Refresh truly failed - return undefined so model discovery skips this provider
+						// User can /login to re-authenticate (credentials preserved for retry)
+						return undefined;
+					}
+				} else {
+					// Token not expired, use current access token
+					return provider.getApiKey(cred);
+				}
 			}
 		}
 
 		// Fall back to environment variable
+		const envCandidate = this.getEnvironmentAuthCandidate(providerId);
 		const envKey = getEnvApiKey(providerId);
-		if (envKey) return envKey;
-
-		const primeCliKey = this.getPrimeCliApiKey(providerId);
-		if (primeCliKey) return primeCliKey;
+		if (envKey && envCandidate && !this.isAuthSourceStale(providerId, envCandidate)) return envKey;
 
 		// Fall back to custom resolver (e.g., models.json custom providers)
 		if (options?.includeFallback !== false) {
-			return this.fallbackResolver?.(providerId) ?? undefined;
+			const fallbackCandidate = this.getFallbackAuthCandidate(providerId);
+			if (fallbackCandidate && !this.isAuthSourceStale(providerId, fallbackCandidate)) {
+				return this.fallbackResolver?.(providerId) ?? undefined;
+			}
 		}
 
 		return undefined;
@@ -599,6 +752,7 @@ export class AuthStorage {
 	}
 
 	setPrimeInferenceApiKey(apiKey: string): void {
+		this.clearStaleAuth(PRIME_INFERENCE_PROVIDER_ID);
 		if (this.isPrimeCliConfigEnabled()) {
 			try {
 				const configPath = this.getEnabledPrimeCliConfigPath();
@@ -750,31 +904,6 @@ export class AuthStorage {
 			throw new Error("Prime CLI config is not enabled");
 		}
 		return configPath;
-	}
-
-	private getPrimeInferenceAuthStatus(): AuthStatus {
-		if (this.runtimeOverrides.has(PRIME_INFERENCE_PROVIDER_ID)) {
-			return { configured: false, source: "runtime", label: "--api-key" };
-		}
-
-		if (this.getPrimeCliApiKey(PRIME_INFERENCE_PROVIDER_ID)) {
-			return { configured: false, source: "prime_cli", label: "Prime CLI" };
-		}
-
-		if (this.data[PRIME_INFERENCE_PROVIDER_ID]) {
-			return { configured: true, source: "stored" };
-		}
-
-		const envKeys = findEnvKeys(PRIME_INFERENCE_PROVIDER_ID);
-		if (envKeys?.[0]) {
-			return { configured: false, source: "environment", label: envKeys[0] };
-		}
-
-		if (this.fallbackResolver?.(PRIME_INFERENCE_PROVIDER_ID)) {
-			return { configured: false, source: "fallback", label: "custom provider config" };
-		}
-
-		return { configured: false };
 	}
 
 	private isPrimeCliConfigEnabled(): boolean {

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -95,6 +95,11 @@ type AuthSourceCandidate = {
 	resolveValueFingerprint?: () => string | undefined;
 };
 
+type AuthApiKeyResult = {
+	apiKey?: string;
+	sourceToken?: AuthSourceToken;
+};
+
 export interface AuthStorageBackend {
 	withLock<T>(fn: (current: string | undefined) => LockResult<T>): T;
 	withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T>;
@@ -388,7 +393,7 @@ export class AuthStorage {
 
 	private getStoredAuthCandidate(
 		provider: string,
-		options?: { resolveCommandValue?: boolean },
+		options?: { resolveCommandValue?: boolean; resolvedCommandValue?: string },
 	): AuthSourceCandidate | undefined {
 		const credential = this.data[provider];
 		if (!credential) {
@@ -396,14 +401,19 @@ export class AuthStorage {
 		}
 		const isCommandApiKey = credential.type === "api_key" && credential.key.startsWith("!");
 		const identityMaterial = isCommandApiKey ? `api_key:command:${credential.key}` : `${provider}:${credential.type}`;
+		const commandValueMaterial =
+			isCommandApiKey && options?.resolvedCommandValue !== undefined
+				? `api_key:command:${credential.key}\0${options.resolvedCommandValue}`
+				: undefined;
 		return this.createAuthSourceCandidate({
 			configured: true,
 			source: "stored",
 			identityMaterial,
 			valueMaterial:
-				isCommandApiKey && !options?.resolveCommandValue
+				commandValueMaterial ??
+				(isCommandApiKey && !options?.resolveCommandValue
 					? undefined
-					: this.getStoredCredentialValueMaterial(provider, credential),
+					: this.getStoredCredentialValueMaterial(provider, credential)),
 			resolveValueMaterial: isCommandApiKey
 				? () => this.getStoredCredentialValueMaterial(provider, credential)
 				: undefined,
@@ -539,11 +549,10 @@ export class AuthStorage {
 		return token ? this.markAuthSourceStale(token) : false;
 	}
 
-	getCurrentAuthSourceToken(provider: string): AuthSourceToken | undefined {
-		const { candidate } = this.getAvailableAuthCandidate(provider);
-		if (!candidate) {
-			return undefined;
-		}
+	private getAuthSourceTokenForCandidate(
+		provider: string,
+		candidate: AuthSourceCandidate,
+	): AuthSourceToken | undefined {
 		const valueFingerprint = candidate.valueFingerprint ?? candidate.resolveValueFingerprint?.();
 		if (!valueFingerprint) {
 			return undefined;
@@ -554,6 +563,14 @@ export class AuthStorage {
 			identityFingerprint: candidate.identityFingerprint,
 			valueFingerprint,
 		};
+	}
+
+	getCurrentAuthSourceToken(provider: string): AuthSourceToken | undefined {
+		const { candidate } = this.getAvailableAuthCandidate(provider);
+		if (!candidate) {
+			return undefined;
+		}
+		return this.getAuthSourceTokenForCandidate(provider, candidate);
 	}
 
 	markAuthSourceStale(token: AuthSourceToken): boolean {
@@ -789,19 +806,28 @@ export class AuthStorage {
 	 * 4. Environment variable
 	 * 5. Fallback resolver (models.json custom providers)
 	 */
-	async getApiKey(providerId: string, options?: { includeFallback?: boolean }): Promise<string | undefined> {
+	async getApiKeyWithSourceToken(
+		providerId: string,
+		options?: { includeFallback?: boolean },
+	): Promise<AuthApiKeyResult> {
 		// Runtime override takes highest priority
 		const runtimeCandidate = this.getRuntimeAuthCandidate(providerId);
 		const runtimeKey = this.runtimeOverrides.get(providerId);
 		if (runtimeKey && runtimeCandidate && !this.isAuthSourceStale(providerId, runtimeCandidate)) {
-			return runtimeKey;
+			return {
+				apiKey: runtimeKey,
+				sourceToken: this.getAuthSourceTokenForCandidate(providerId, runtimeCandidate),
+			};
 		}
 
 		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
 			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
 			const primeCliKey = this.getPrimeCliApiKey(providerId);
 			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
-				return primeCliKey;
+				return {
+					apiKey: primeCliKey,
+					sourceToken: this.getAuthSourceTokenForCandidate(providerId, primeCliCandidate),
+				};
 			}
 		}
 
@@ -811,9 +837,21 @@ export class AuthStorage {
 			const storedCandidate = this.getStoredAuthCandidate(providerId);
 			if (storedCandidate && !this.isAuthSourceStale(providerId, storedCandidate)) {
 				const hasStaleRecord = this.getMatchingStaleAuthSources(providerId, storedCandidate).length > 0;
-				return cred.key.startsWith("!") && hasStaleRecord
-					? resolveConfigValueUncached(cred.key)
-					: resolveConfigValue(cred.key);
+				const apiKey =
+					cred.key.startsWith("!") && hasStaleRecord
+						? resolveConfigValueUncached(cred.key)
+						: resolveConfigValue(cred.key);
+				const sourceToken =
+					apiKey === undefined
+						? undefined
+						: this.getAuthSourceTokenForCandidate(
+								providerId,
+								cred.key.startsWith("!")
+									? (this.getStoredAuthCandidate(providerId, { resolvedCommandValue: apiKey }) ??
+											storedCandidate)
+									: storedCandidate,
+							);
+				return { apiKey, sourceToken };
 			}
 		}
 
@@ -823,7 +861,7 @@ export class AuthStorage {
 				const provider = getOAuthProvider(providerId);
 				if (!provider) {
 					// Unknown OAuth provider, can't get API key
-					return undefined;
+					return {};
 				}
 
 				// Check if token needs refresh
@@ -834,7 +872,13 @@ export class AuthStorage {
 					try {
 						const result = await this.refreshOAuthTokenWithLock(providerId);
 						if (result) {
-							return result.apiKey;
+							const refreshedCandidate = this.getStoredAuthCandidate(providerId);
+							return {
+								apiKey: result.apiKey,
+								sourceToken: refreshedCandidate
+									? this.getAuthSourceTokenForCandidate(providerId, refreshedCandidate)
+									: undefined,
+							};
 						}
 					} catch (error) {
 						this.recordError(error);
@@ -844,16 +888,25 @@ export class AuthStorage {
 
 						if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
 							// Another instance refreshed successfully, use those credentials
-							return provider.getApiKey(updatedCred);
+							const updatedCandidate = this.getStoredAuthCandidate(providerId);
+							return {
+								apiKey: provider.getApiKey(updatedCred),
+								sourceToken: updatedCandidate
+									? this.getAuthSourceTokenForCandidate(providerId, updatedCandidate)
+									: undefined,
+							};
 						}
 
 						// Refresh truly failed - return undefined so model discovery skips this provider
 						// User can /login to re-authenticate (credentials preserved for retry)
-						return undefined;
+						return {};
 					}
 				} else {
 					// Token not expired, use current access token
-					return provider.getApiKey(cred);
+					return {
+						apiKey: provider.getApiKey(cred),
+						sourceToken: this.getAuthSourceTokenForCandidate(providerId, storedCandidate),
+					};
 				}
 			}
 		}
@@ -861,17 +914,30 @@ export class AuthStorage {
 		// Fall back to environment variable
 		const envCandidate = this.getEnvironmentAuthCandidate(providerId);
 		const envKey = getEnvApiKey(providerId);
-		if (envKey && envCandidate && !this.isAuthSourceStale(providerId, envCandidate)) return envKey;
+		if (envKey && envCandidate && !this.isAuthSourceStale(providerId, envCandidate)) {
+			return {
+				apiKey: envKey,
+				sourceToken: this.getAuthSourceTokenForCandidate(providerId, envCandidate),
+			};
+		}
 
 		// Fall back to custom resolver (e.g., models.json custom providers)
 		if (options?.includeFallback !== false) {
 			const fallbackCandidate = this.getFallbackAuthCandidate(providerId);
 			if (fallbackCandidate && !this.isAuthSourceStale(providerId, fallbackCandidate)) {
-				return this.fallbackResolver?.(providerId) ?? undefined;
+				return {
+					apiKey: this.fallbackResolver?.(providerId) ?? undefined,
+					sourceToken: this.getAuthSourceTokenForCandidate(providerId, fallbackCandidate),
+				};
 			}
 		}
 
-		return undefined;
+		return {};
+	}
+
+	async getApiKey(providerId: string, options?: { includeFallback?: boolean }): Promise<string | undefined> {
+		const result = await this.getApiKeyWithSourceToken(providerId, options);
+		return result.apiKey;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -355,6 +355,7 @@ export class ModelRegistry {
 	private models: Model<Api>[] = [];
 	private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
 	private staleProviderRequestAuthSources: Map<string, AuthSourceToken[]> = new Map();
+	private lastProviderAuthSourceTokens: Map<string, AuthSourceToken> = new Map();
 	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
@@ -387,6 +388,7 @@ export class ModelRegistry {
 	refresh(): void {
 		this.providerRequestConfigs.clear();
 		this.modelRequestHeaders.clear();
+		this.lastProviderAuthSourceTokens.clear();
 		this.loadError = undefined;
 
 		// Credentials may have been written by another process (e.g. the UI
@@ -817,6 +819,30 @@ export class ModelRegistry {
 		}
 	}
 
+	private getProviderRequestAuthSourceToken(
+		provider: string,
+		source: ProviderRequestAuthSource,
+	): AuthSourceToken | undefined {
+		const valueFingerprint = source.valueFingerprint ?? source.resolveValueFingerprint?.();
+		if (!valueFingerprint) {
+			return undefined;
+		}
+		return {
+			provider,
+			source: source.source,
+			identityFingerprint: source.identityFingerprint,
+			valueFingerprint,
+		};
+	}
+
+	private setLastProviderAuthSourceToken(provider: string, token: AuthSourceToken | undefined): void {
+		if (token) {
+			this.lastProviderAuthSourceTokens.set(provider, token);
+		} else {
+			this.lastProviderAuthSourceTokens.delete(provider);
+		}
+	}
+
 	private hasConfiguredProviderRequestAuth(provider: string): boolean {
 		const source = this.getProviderRequestAuthSource(provider);
 		return source !== undefined && this.getMatchingStaleProviderRequestAuthSources(provider, source).length === 0;
@@ -832,6 +858,11 @@ export class ModelRegistry {
 	}
 
 	getCurrentProviderAuthSourceToken(provider: string): AuthSourceToken | undefined {
+		const lastRequestToken = this.lastProviderAuthSourceTokens.get(provider);
+		if (lastRequestToken) {
+			return lastRequestToken;
+		}
+
 		const authStorageToken = this.authStorage.getCurrentAuthSourceToken(provider);
 		if (authStorageToken) {
 			return authStorageToken;
@@ -923,8 +954,11 @@ export class ModelRegistry {
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
-			const apiKeyFromAuthStorage = await this.authStorage.getApiKey(model.provider, { includeFallback: false });
-			let apiKey = apiKeyFromAuthStorage;
+			const authStorageAuth = await this.authStorage.getApiKeyWithSourceToken(model.provider, {
+				includeFallback: false,
+			});
+			let apiKey = authStorageAuth.apiKey;
+			let authSourceToken = authStorageAuth.sourceToken;
 			if (apiKey === undefined && providerConfig?.apiKey) {
 				const resolvedApiKey = resolveConfigValueOrThrow(
 					providerConfig.apiKey,
@@ -937,8 +971,10 @@ export class ModelRegistry {
 				) {
 					this.clearStaleProviderRequestAuthSource(model.provider, providerRequestAuthSource);
 					apiKey = resolvedApiKey;
+					authSourceToken = this.getProviderRequestAuthSourceToken(model.provider, providerRequestAuthSource);
 				}
 			}
+			this.setLastProviderAuthSourceToken(model.provider, apiKey === undefined ? undefined : authSourceToken);
 
 			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
 			const authStorageHeaders = this.authStorage.getProviderHeaders(model.provider);
@@ -1018,22 +1054,30 @@ export class ModelRegistry {
 	 * Get API key for a provider.
 	 */
 	async getApiKeyForProvider(provider: string): Promise<string | undefined> {
-		const apiKey = await this.authStorage.getApiKey(provider, { includeFallback: false });
-		if (apiKey !== undefined) {
-			return apiKey;
+		const authStorageAuth = await this.authStorage.getApiKeyWithSourceToken(provider, { includeFallback: false });
+		if (authStorageAuth.apiKey !== undefined) {
+			this.setLastProviderAuthSourceToken(provider, authStorageAuth.sourceToken);
+			return authStorageAuth.apiKey;
 		}
 
 		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
 		if (!providerApiKey) {
+			this.setLastProviderAuthSourceToken(provider, undefined);
 			return undefined;
 		}
 
 		const resolvedApiKey = resolveConfigValueUncached(providerApiKey);
+		if (resolvedApiKey === undefined) {
+			this.setLastProviderAuthSourceToken(provider, undefined);
+			return undefined;
+		}
 		const source = this.getProviderRequestAuthSource(provider, { resolvedApiKey });
 		if (!source || this.isProviderRequestAuthStale(provider, source)) {
+			this.setLastProviderAuthSourceToken(provider, undefined);
 			return undefined;
 		}
 		this.clearStaleProviderRequestAuthSource(provider, source);
+		this.setLastProviderAuthSourceToken(provider, this.getProviderRequestAuthSourceToken(provider, source));
 
 		return resolvedApiKey;
 	}

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -354,7 +354,7 @@ export const clearApiKeyCache = clearConfigValueCache;
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
 	private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
-	private staleProviderRequestAuthSources: Map<string, Set<string>> = new Map();
+	private staleProviderRequestAuthSources: Map<string, AuthSourceToken[]> = new Map();
 	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
@@ -781,22 +781,45 @@ export class ModelRegistry {
 	}
 
 	private isProviderRequestAuthStale(provider: string, source: ProviderRequestAuthSource): boolean {
-		const stale = this.staleProviderRequestAuthSources.get(provider);
-		if (!stale) {
+		const matchingStale = this.getMatchingStaleProviderRequestAuthSources(provider, source);
+		if (matchingStale.length === 0) {
 			return false;
 		}
-		for (const fingerprint of stale) {
-			const valueFingerprint = source.valueFingerprint ?? source.resolveValueFingerprint?.();
-			if (valueFingerprint && valueFingerprint === fingerprint) {
-				return true;
-			}
+		const valueFingerprint = source.valueFingerprint ?? source.resolveValueFingerprint?.();
+		return Boolean(valueFingerprint && matchingStale.some((token) => token.valueFingerprint === valueFingerprint));
+	}
+
+	private getMatchingStaleProviderRequestAuthSources(
+		provider: string,
+		source: ProviderRequestAuthSource,
+	): AuthSourceToken[] {
+		const stale = this.staleProviderRequestAuthSources.get(provider);
+		if (!stale) {
+			return [];
 		}
-		return false;
+		return stale.filter(
+			(token) => token.source === source.source && token.identityFingerprint === source.identityFingerprint,
+		);
+	}
+
+	private clearStaleProviderRequestAuthSource(provider: string, source: ProviderRequestAuthSource): void {
+		const stale = this.staleProviderRequestAuthSources.get(provider);
+		if (!stale) {
+			return;
+		}
+		const next = stale.filter(
+			(token) => token.source !== source.source || token.identityFingerprint !== source.identityFingerprint,
+		);
+		if (next.length === 0) {
+			this.staleProviderRequestAuthSources.delete(provider);
+		} else {
+			this.staleProviderRequestAuthSources.set(provider, next);
+		}
 	}
 
 	private hasConfiguredProviderRequestAuth(provider: string): boolean {
 		const source = this.getProviderRequestAuthSource(provider);
-		return source !== undefined && !this.isProviderRequestAuthStale(provider, source);
+		return source !== undefined && this.getMatchingStaleProviderRequestAuthSources(provider, source).length === 0;
 	}
 
 	markProviderAuthStale(provider: string): boolean {
@@ -840,8 +863,17 @@ export class ModelRegistry {
 			providerRequestSource?.source === token.source &&
 			providerRequestSource.identityFingerprint === token.identityFingerprint
 		) {
-			const stale = this.staleProviderRequestAuthSources.get(token.provider) ?? new Set<string>();
-			stale.add(token.valueFingerprint);
+			const stale = this.staleProviderRequestAuthSources.get(token.provider) ?? [];
+			if (
+				!stale.some(
+					(existing) =>
+						existing.source === token.source &&
+						existing.identityFingerprint === token.identityFingerprint &&
+						existing.valueFingerprint === token.valueFingerprint,
+				)
+			) {
+				stale.push(token);
+			}
 			this.staleProviderRequestAuthSources.set(token.provider, stale);
 			marked = true;
 		}
@@ -903,6 +935,7 @@ export class ModelRegistry {
 					providerRequestAuthSource &&
 					!this.isProviderRequestAuthStale(model.provider, providerRequestAuthSource)
 				) {
+					this.clearStaleProviderRequestAuthSource(model.provider, providerRequestAuthSource);
 					apiKey = resolvedApiKey;
 				}
 			}
@@ -954,7 +987,7 @@ export class ModelRegistry {
 			return authStatus;
 		}
 
-		if (this.isProviderRequestAuthStale(provider, source)) {
+		if (this.getMatchingStaleProviderRequestAuthSources(provider, source).length > 0) {
 			return { configured: false, source: "stale", label: "expired" };
 		}
 
@@ -1000,6 +1033,7 @@ export class ModelRegistry {
 		if (!source || this.isProviderRequestAuthStale(provider, source)) {
 			return undefined;
 		}
+		this.clearStaleProviderRequestAuthSource(provider, source);
 
 		return resolvedApiKey;
 	}

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -27,7 +27,7 @@ import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import { getAgentDir } from "../config.js";
-import type { AuthStatus, AuthStorage } from "./auth-storage.js";
+import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "./provider-display-names.js";
 import {
 	clearConfigValueCache,
@@ -251,7 +251,9 @@ type ProviderRequestAuthSource = {
 	source: "environment" | "models_json_key" | "models_json_command";
 	configured: true;
 	label?: string;
-	fingerprint: string;
+	identityFingerprint: string;
+	valueFingerprint?: string;
+	resolveValueFingerprint?: () => string | undefined;
 };
 
 export type ResolvedRequestAuth =
@@ -700,39 +702,96 @@ export class ModelRegistry {
 		return `${source}:${digest}`;
 	}
 
-	private getProviderRequestAuthSource(provider: string): ProviderRequestAuthSource | undefined {
+	private createProviderRequestAuthSource(options: {
+		source: ProviderRequestAuthSource["source"];
+		identityMaterial: string;
+		valueMaterial?: string;
+		label?: string;
+		resolveValueMaterial?: () => string | undefined;
+	}): ProviderRequestAuthSource {
+		return {
+			configured: true,
+			source: options.source,
+			...(options.label ? { label: options.label } : {}),
+			identityFingerprint: this.fingerprintProviderRequestAuthSource(
+				options.source,
+				`identity:${options.identityMaterial}`,
+			),
+			...(options.valueMaterial !== undefined
+				? {
+						valueFingerprint: this.fingerprintProviderRequestAuthSource(
+							options.source,
+							`value:${options.identityMaterial}\0${options.valueMaterial}`,
+						),
+					}
+				: {}),
+			...(options.resolveValueMaterial
+				? {
+						resolveValueFingerprint: () => {
+							const valueMaterial = options.resolveValueMaterial?.();
+							return valueMaterial === undefined
+								? undefined
+								: this.fingerprintProviderRequestAuthSource(
+										options.source,
+										`value:${options.identityMaterial}\0${valueMaterial}`,
+									);
+						},
+					}
+				: {}),
+		};
+	}
+
+	private getProviderRequestAuthSource(
+		provider: string,
+		options?: { resolvedApiKey?: string },
+	): ProviderRequestAuthSource | undefined {
 		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
 		if (!providerApiKey) {
 			return undefined;
 		}
 
 		if (providerApiKey.startsWith("!")) {
-			return {
-				configured: true,
+			return this.createProviderRequestAuthSource({
 				source: "models_json_command",
-				fingerprint: this.fingerprintProviderRequestAuthSource("models_json_command", providerApiKey),
-			};
+				identityMaterial: providerApiKey,
+				valueMaterial:
+					options?.resolvedApiKey === undefined ? undefined : `${providerApiKey}\0${options.resolvedApiKey}`,
+				resolveValueMaterial: () => {
+					const resolved = resolveConfigValueUncached(providerApiKey);
+					return resolved === undefined ? undefined : `${providerApiKey}\0${resolved}`;
+				},
+			});
 		}
 
 		const envValue = process.env[providerApiKey];
 		if (envValue) {
-			return {
-				configured: true,
+			return this.createProviderRequestAuthSource({
 				source: "environment",
 				label: providerApiKey,
-				fingerprint: this.fingerprintProviderRequestAuthSource("environment", `${providerApiKey}\0${envValue}`),
-			};
+				identityMaterial: providerApiKey,
+				valueMaterial: `${providerApiKey}\0${envValue}`,
+			});
 		}
 
-		return {
-			configured: true,
+		return this.createProviderRequestAuthSource({
 			source: "models_json_key",
-			fingerprint: this.fingerprintProviderRequestAuthSource("models_json_key", providerApiKey),
-		};
+			identityMaterial: provider,
+			valueMaterial: providerApiKey,
+		});
 	}
 
 	private isProviderRequestAuthStale(provider: string, source: ProviderRequestAuthSource): boolean {
-		return this.staleProviderRequestAuthSources.get(provider)?.has(source.fingerprint) ?? false;
+		const stale = this.staleProviderRequestAuthSources.get(provider);
+		if (!stale) {
+			return false;
+		}
+		for (const fingerprint of stale) {
+			const valueFingerprint = source.valueFingerprint ?? source.resolveValueFingerprint?.();
+			if (valueFingerprint && valueFingerprint === fingerprint) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private hasConfiguredProviderRequestAuth(provider: string): boolean {
@@ -745,15 +804,53 @@ export class ModelRegistry {
 			return true;
 		}
 
-		const source = this.getProviderRequestAuthSource(provider);
-		if (!source || this.isProviderRequestAuthStale(provider, source)) {
-			return false;
+		const token = this.getCurrentProviderAuthSourceToken(provider);
+		return token ? this.markProviderAuthSourceStale(token) : false;
+	}
+
+	getCurrentProviderAuthSourceToken(provider: string): AuthSourceToken | undefined {
+		const authStorageToken = this.authStorage.getCurrentAuthSourceToken(provider);
+		if (authStorageToken) {
+			return authStorageToken;
 		}
 
-		const stale = this.staleProviderRequestAuthSources.get(provider) ?? new Set<string>();
-		stale.add(source.fingerprint);
-		this.staleProviderRequestAuthSources.set(provider, stale);
-		return true;
+		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
+		if (!providerApiKey) {
+			return undefined;
+		}
+		const resolvedApiKey = resolveConfigValueUncached(providerApiKey);
+		const source = this.getProviderRequestAuthSource(provider, { resolvedApiKey });
+		const valueFingerprint = source?.valueFingerprint ?? source?.resolveValueFingerprint?.();
+		if (!source || !valueFingerprint || this.isProviderRequestAuthStale(provider, source)) {
+			return undefined;
+		}
+
+		return {
+			provider,
+			source: source.source,
+			identityFingerprint: source.identityFingerprint,
+			valueFingerprint,
+		};
+	}
+
+	markProviderAuthSourceStale(token: AuthSourceToken): boolean {
+		let marked = false;
+		const providerRequestSource = this.getProviderRequestAuthSource(token.provider);
+		if (
+			providerRequestSource?.source === token.source &&
+			providerRequestSource.identityFingerprint === token.identityFingerprint
+		) {
+			const stale = this.staleProviderRequestAuthSources.get(token.provider) ?? new Set<string>();
+			stale.add(token.valueFingerprint);
+			this.staleProviderRequestAuthSources.set(token.provider, stale);
+			marked = true;
+		}
+
+		if (token.source !== "models_json_key" && token.source !== "models_json_command") {
+			marked = this.authStorage.markAuthSourceStale(token) || marked;
+		}
+
+		return marked;
 	}
 
 	private getModelRequestKey(provider: string, modelId: string): string {
@@ -794,15 +891,21 @@ export class ModelRegistry {
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
-			const providerRequestAuthSource = this.getProviderRequestAuthSource(model.provider);
 			const apiKeyFromAuthStorage = await this.authStorage.getApiKey(model.provider, { includeFallback: false });
-			const apiKey =
-				apiKeyFromAuthStorage ??
-				(providerConfig?.apiKey &&
-				providerRequestAuthSource &&
-				!this.isProviderRequestAuthStale(model.provider, providerRequestAuthSource)
-					? resolveConfigValueOrThrow(providerConfig.apiKey, `API key for provider "${model.provider}"`)
-					: undefined);
+			let apiKey = apiKeyFromAuthStorage;
+			if (apiKey === undefined && providerConfig?.apiKey) {
+				const resolvedApiKey = resolveConfigValueOrThrow(
+					providerConfig.apiKey,
+					`API key for provider "${model.provider}"`,
+				);
+				const providerRequestAuthSource = this.getProviderRequestAuthSource(model.provider, { resolvedApiKey });
+				if (
+					providerRequestAuthSource &&
+					!this.isProviderRequestAuthStale(model.provider, providerRequestAuthSource)
+				) {
+					apiKey = resolvedApiKey;
+				}
+			}
 
 			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
 			const authStorageHeaders = this.authStorage.getProviderHeaders(model.provider);
@@ -887,13 +990,18 @@ export class ModelRegistry {
 			return apiKey;
 		}
 
-		const source = this.getProviderRequestAuthSource(provider);
+		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
+		if (!providerApiKey) {
+			return undefined;
+		}
+
+		const resolvedApiKey = resolveConfigValueUncached(providerApiKey);
+		const source = this.getProviderRequestAuthSource(provider, { resolvedApiKey });
 		if (!source || this.isProviderRequestAuthStale(provider, source)) {
 			return undefined;
 		}
 
-		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
-		return providerApiKey ? resolveConfigValueUncached(providerApiKey) : undefined;
+		return resolvedApiKey;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -2,6 +2,7 @@
  * Model registry - manages built-in and custom models, provides API key resolution.
  */
 
+import { createHash } from "node:crypto";
 import {
 	type AnthropicMessagesCompat,
 	type Api,
@@ -246,6 +247,13 @@ interface ProviderRequestConfig {
 	authHeader?: boolean;
 }
 
+type ProviderRequestAuthSource = {
+	source: "environment" | "models_json_key" | "models_json_command";
+	configured: true;
+	label?: string;
+	fingerprint: string;
+};
+
 export type ResolvedRequestAuth =
 	| {
 			ok: true;
@@ -344,6 +352,7 @@ export const clearApiKeyCache = clearConfigValueCache;
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
 	private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
+	private staleProviderRequestAuthSources: Map<string, Set<string>> = new Map();
 	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
@@ -683,10 +692,68 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
-		return (
-			this.authStorage.hasAuth(model.provider) ||
-			this.providerRequestConfigs.get(model.provider)?.apiKey !== undefined
-		);
+		return this.authStorage.hasAuth(model.provider) || this.hasConfiguredProviderRequestAuth(model.provider);
+	}
+
+	private fingerprintProviderRequestAuthSource(source: ProviderRequestAuthSource["source"], material: string): string {
+		const digest = createHash("sha256").update(source).update("\0").update(material).digest("hex");
+		return `${source}:${digest}`;
+	}
+
+	private getProviderRequestAuthSource(provider: string): ProviderRequestAuthSource | undefined {
+		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
+		if (!providerApiKey) {
+			return undefined;
+		}
+
+		if (providerApiKey.startsWith("!")) {
+			return {
+				configured: true,
+				source: "models_json_command",
+				fingerprint: this.fingerprintProviderRequestAuthSource("models_json_command", providerApiKey),
+			};
+		}
+
+		const envValue = process.env[providerApiKey];
+		if (envValue) {
+			return {
+				configured: true,
+				source: "environment",
+				label: providerApiKey,
+				fingerprint: this.fingerprintProviderRequestAuthSource("environment", `${providerApiKey}\0${envValue}`),
+			};
+		}
+
+		return {
+			configured: true,
+			source: "models_json_key",
+			fingerprint: this.fingerprintProviderRequestAuthSource("models_json_key", providerApiKey),
+		};
+	}
+
+	private isProviderRequestAuthStale(provider: string, source: ProviderRequestAuthSource): boolean {
+		return this.staleProviderRequestAuthSources.get(provider)?.has(source.fingerprint) ?? false;
+	}
+
+	private hasConfiguredProviderRequestAuth(provider: string): boolean {
+		const source = this.getProviderRequestAuthSource(provider);
+		return source !== undefined && !this.isProviderRequestAuthStale(provider, source);
+	}
+
+	markProviderAuthStale(provider: string): boolean {
+		if (this.authStorage.markAuthStale(provider)) {
+			return true;
+		}
+
+		const source = this.getProviderRequestAuthSource(provider);
+		if (!source || this.isProviderRequestAuthStale(provider, source)) {
+			return false;
+		}
+
+		const stale = this.staleProviderRequestAuthSources.get(provider) ?? new Set<string>();
+		stale.add(source.fingerprint);
+		this.staleProviderRequestAuthSources.set(provider, stale);
+		return true;
 	}
 
 	private getModelRequestKey(provider: string, modelId: string): string {
@@ -727,10 +794,13 @@ export class ModelRegistry {
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
+			const providerRequestAuthSource = this.getProviderRequestAuthSource(model.provider);
 			const apiKeyFromAuthStorage = await this.authStorage.getApiKey(model.provider, { includeFallback: false });
 			const apiKey =
 				apiKeyFromAuthStorage ??
-				(providerConfig?.apiKey
+				(providerConfig?.apiKey &&
+				providerRequestAuthSource &&
+				!this.isProviderRequestAuthStale(model.provider, providerRequestAuthSource)
 					? resolveConfigValueOrThrow(providerConfig.apiKey, `API key for provider "${model.provider}"`)
 					: undefined);
 
@@ -776,20 +846,20 @@ export class ModelRegistry {
 			return authStatus;
 		}
 
-		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
-		if (!providerApiKey) {
+		const source = this.getProviderRequestAuthSource(provider);
+		if (!source) {
 			return authStatus;
 		}
 
-		if (providerApiKey.startsWith("!")) {
-			return { configured: true, source: "models_json_command" };
+		if (this.isProviderRequestAuthStale(provider, source)) {
+			return { configured: false, source: "stale", label: "expired" };
 		}
 
-		if (process.env[providerApiKey]) {
-			return { configured: true, source: "environment", label: providerApiKey };
-		}
-
-		return { configured: true, source: "models_json_key" };
+		return {
+			configured: true,
+			source: source.source,
+			...(source.label ? { label: source.label } : {}),
+		};
 	}
 
 	/**
@@ -815,6 +885,11 @@ export class ModelRegistry {
 		const apiKey = await this.authStorage.getApiKey(provider, { includeFallback: false });
 		if (apiKey !== undefined) {
 			return apiKey;
+		}
+
+		const source = this.getProviderRequestAuthSource(provider);
+		if (!source || this.isProviderRequestAuthStale(provider, source)) {
+			return undefined;
 		}
 
 		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -791,6 +791,21 @@ export class ModelRegistry {
 		return Boolean(valueFingerprint && matchingStale.some((token) => token.valueFingerprint === valueFingerprint));
 	}
 
+	private isProviderRequestAuthStaleForStatus(provider: string, source: ProviderRequestAuthSource): boolean {
+		const matchingStale = this.getMatchingStaleProviderRequestAuthSources(provider, source);
+		if (matchingStale.length === 0) {
+			return false;
+		}
+		if (!source.valueFingerprint) {
+			return true;
+		}
+		const isStale = matchingStale.some((token) => token.valueFingerprint === source.valueFingerprint);
+		if (!isStale) {
+			this.clearStaleProviderRequestAuthSource(provider, source);
+		}
+		return isStale;
+	}
+
 	private getMatchingStaleProviderRequestAuthSources(
 		provider: string,
 		source: ProviderRequestAuthSource,
@@ -845,7 +860,7 @@ export class ModelRegistry {
 
 	private hasConfiguredProviderRequestAuth(provider: string): boolean {
 		const source = this.getProviderRequestAuthSource(provider);
-		return source !== undefined && this.getMatchingStaleProviderRequestAuthSources(provider, source).length === 0;
+		return source !== undefined && !this.isProviderRequestAuthStaleForStatus(provider, source);
 	}
 
 	markProviderAuthStale(provider: string): boolean {
@@ -1023,7 +1038,7 @@ export class ModelRegistry {
 			return authStatus;
 		}
 
-		if (this.getMatchingStaleProviderRequestAuthSources(provider, source).length > 0) {
+		if (this.isProviderRequestAuthStaleForStatus(provider, source)) {
 			return { configured: false, source: "stale", label: "expired" };
 		}
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -842,7 +842,7 @@ export class ModelRegistry {
 	 */
 	getProviderAuthStatus(provider: string): AuthStatus {
 		const authStatus = this.authStorage.getAuthStatus(provider);
-		if (authStatus.source) {
+		if (authStatus.source && authStatus.source !== "stale") {
 			return authStatus;
 		}
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent, Transport, Usage } from "@earendil-works/pi-ai";
+import type { AuthSourceToken } from "../../core/auth-storage.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
 import type { AgentCronJob, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
@@ -467,6 +468,7 @@ export type AgentConnectionSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| { type: "auth_stale"; provider: string; sourceTokens?: readonly AuthSourceToken[] }
 	| { type: "rlm_child_update"; child: AgentConnectionRlmChildAgentSnapshot }
 	| { type: "recap_update"; recap: string | undefined }
 	| { type: "goal_update"; goal: GoalState }

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,11 +1,18 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { type Component, Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { LOGIN_RECOVERY_MESSAGE } from "../../../core/auth-guidance.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
-import { CollapsibleErrorComponent, shouldCollapseErrorDetails, summarizeErrorDetails } from "./collapsible-error.js";
+import {
+	CollapsibleErrorComponent,
+	normalizeErrorDetails,
+	shouldCollapseErrorDetails,
+	summarizeErrorDetails,
+} from "./collapsible-error.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+const LOGIN_RECOVERY_SUFFIX = `\n\n${LOGIN_RECOVERY_MESSAGE}`;
 
 export interface AssistantMessageComponentOptions {
 	expanded?: boolean;
@@ -27,6 +34,18 @@ function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
 		listBullet: quiet,
 		highlightCode: (code: string) => code.split("\n").map((line) => quiet(line)),
 	};
+}
+
+function formatInlineLoginRecoveryMessage(message: string): string | undefined {
+	const normalized = normalizeErrorDetails(message);
+	if (!normalized.endsWith(LOGIN_RECOVERY_SUFFIX)) {
+		return undefined;
+	}
+	const base = normalized.slice(0, -LOGIN_RECOVERY_SUFFIX.length).trimEnd();
+	if (!base || shouldCollapseErrorDetails(base)) {
+		return undefined;
+	}
+	return `${base} · ${LOGIN_RECOVERY_MESSAGE}`;
 }
 
 /**
@@ -252,6 +271,12 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	private createErrorComponent(message: string, prefix?: string): Component {
+		const inlineLoginRecovery = formatInlineLoginRecoveryMessage(message);
+		if (inlineLoginRecovery) {
+			const text = prefix ? `${prefix}: ${inlineLoginRecovery}` : inlineLoginRecovery;
+			return new Text(theme.fg("error", text), 1, 0);
+		}
+
 		if (!shouldCollapseErrorDetails(message)) {
 			const text = prefix ? `${prefix}: ${message}` : message;
 			return new Text(theme.fg("error", text), 1, 0);

--- a/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
+++ b/packages/coding-agent/src/modes/interactive/components/collapsible-error.ts
@@ -103,7 +103,7 @@ export class CollapsibleErrorComponent implements Component {
 
 		const summary = normalizeErrorDetails(this.options.summary ?? summarizeErrorDetails(text));
 		const inlineHint = `${summary} ${theme.fg("dim", "·")} ${keyHint("app.tools.expand", "to expand")}`;
-		return this.renderText(inlineHint, width, "muted");
+		return this.renderText(inlineHint, width, "error");
 	}
 
 	private renderText(text: string, width: number, color: "error" | "muted" = "error"): string[] {

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -173,11 +173,16 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 	private isProviderConfigured(provider: AuthSelectorProvider): boolean {
 		const status = this.getAuthStatus(provider.id);
-		if (status.source === "stale") {
+		const credential = this.authStorage.get(provider.id);
+		const storageStatus = this.authStorage.getAuthStatus(provider.id);
+		if (status.source === "stale" || (storageStatus.source === "stale" && credential?.type === provider.authType)) {
 			return false;
 		}
 
-		const credential = this.authStorage.get(provider.id);
+		if (status.source && status.source !== "stored") {
+			return provider.authType === "api_key";
+		}
+
 		if (credential) {
 			return true;
 		}
@@ -245,11 +250,18 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 	private formatStatusIndicator(provider: AuthSelectorProvider): string {
 		const status = this.getAuthStatus(provider.id);
-		if (status.source === "stale") {
+		const credential = this.authStorage.get(provider.id);
+		const storageStatus = this.authStorage.getAuthStatus(provider.id);
+		if (status.source === "stale" || (storageStatus.source === "stale" && credential?.type === provider.authType)) {
 			return theme.fg("warning", status.label ?? "expired");
 		}
 
-		const credential = this.authStorage.get(provider.id);
+		if (status.source && status.source !== "stored") {
+			return provider.authType === "api_key"
+				? this.formatApiKeyStatusIndicator(status)
+				: theme.fg("muted", "unconfigured");
+		}
+
 		if (credential?.type === provider.authType) return theme.fg("success", "configured");
 		if (credential) {
 			const label = credential.type === "oauth" ? "subscription configured" : "API key configured";
@@ -257,6 +269,10 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		}
 		if (provider.authType !== "api_key") return theme.fg("muted", "unconfigured");
 
+		return this.formatApiKeyStatusIndicator(status);
+	}
+
+	private formatApiKeyStatusIndicator(status: AuthStatus): string {
 		switch (status.source) {
 			case "environment":
 				return theme.fg("success", `env: ${status.label ?? "API key"}`);

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -163,19 +163,35 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 	private sortProviders(providers: AuthSelectorProvider[]): AuthSelectorProvider[] {
 		return [...providers].sort((a, b) => {
-			const configuredDelta = Number(this.isProviderConfigured(b)) - Number(this.isProviderConfigured(a));
-			if (configuredDelta !== 0) {
-				return configuredDelta;
+			const rankDelta = this.getProviderSortRank(a) - this.getProviderSortRank(b);
+			if (rankDelta !== 0) {
+				return rankDelta;
 			}
 			return compareAuthSelectorProviders(a, b);
 		});
 	}
 
-	private isProviderConfigured(provider: AuthSelectorProvider): boolean {
+	private getProviderSortRank(provider: AuthSelectorProvider): number {
+		if (this.isProviderConfigured(provider)) {
+			return 0;
+		}
+		if (this.isProviderStale(provider)) {
+			return 1;
+		}
+		return 2;
+	}
+
+	private isProviderStale(provider: AuthSelectorProvider): boolean {
 		const status = this.getAuthStatus(provider.id);
 		const credential = this.authStorage.get(provider.id);
 		const storageStatus = this.authStorage.getAuthStatus(provider.id);
-		if (status.source === "stale" || (storageStatus.source === "stale" && credential?.type === provider.authType)) {
+		return status.source === "stale" || (storageStatus.source === "stale" && credential?.type === provider.authType);
+	}
+
+	private isProviderConfigured(provider: AuthSelectorProvider): boolean {
+		const status = this.getAuthStatus(provider.id);
+		const credential = this.authStorage.get(provider.id);
+		if (this.isProviderStale(provider)) {
 			return false;
 		}
 
@@ -251,8 +267,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	private formatStatusIndicator(provider: AuthSelectorProvider): string {
 		const status = this.getAuthStatus(provider.id);
 		const credential = this.authStorage.get(provider.id);
-		const storageStatus = this.authStorage.getAuthStatus(provider.id);
-		if (status.source === "stale" || (storageStatus.source === "stale" && credential?.type === provider.authType)) {
+		if (this.isProviderStale(provider)) {
 			return theme.fg("warning", status.label ?? "expired");
 		}
 

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -172,6 +172,11 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	}
 
 	private isProviderConfigured(provider: AuthSelectorProvider): boolean {
+		const status = this.getAuthStatus(provider.id);
+		if (status.source === "stale") {
+			return false;
+		}
+
 		const credential = this.authStorage.get(provider.id);
 		if (credential) {
 			return true;
@@ -179,7 +184,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		if (provider.authType !== "api_key") {
 			return false;
 		}
-		return this.getAuthStatus(provider.id).source !== undefined;
+		return status.source !== undefined;
 	}
 
 	override render(width: number): string[] {
@@ -239,6 +244,11 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	}
 
 	private formatStatusIndicator(provider: AuthSelectorProvider): string {
+		const status = this.getAuthStatus(provider.id);
+		if (status.source === "stale") {
+			return theme.fg("warning", status.label ?? "expired");
+		}
+
 		const credential = this.authStorage.get(provider.id);
 		if (credential?.type === provider.authType) return theme.fg("success", "configured");
 		if (credential) {
@@ -247,7 +257,6 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		}
 		if (provider.authType !== "api_key") return theme.fg("muted", "unconfigured");
 
-		const status = this.getAuthStatus(provider.id);
 		switch (status.source) {
 			case "environment":
 				return theme.fg("success", `env: ${status.label ?? "API key"}`);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2191,6 +2191,18 @@ export class InteractiveMode {
 		return this.connectionState?.sessionName ?? this.uiServices.getInitialSessionName();
 	}
 
+	private applyAuthStaleEvent(event: Extract<AgentConnectionSessionEvent, { type: "auth_stale" }>): void {
+		let marked = false;
+		for (const token of event.sourceTokens ?? []) {
+			marked = this.modelRegistry.markProviderAuthSourceStale(token) || marked;
+		}
+		if (!marked) {
+			this.modelRegistry.markProviderAuthStale(event.provider);
+		}
+		this.footer.invalidate();
+		this.updateEditorBorderColor();
+	}
+
 	private getCurrentModel(): AgentConnectionModel | undefined {
 		return this.connectionState?.model;
 	}
@@ -4381,6 +4393,12 @@ export class InteractiveMode {
 				if (!event.success) {
 					this.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 				}
+				this.ui.requestRender();
+				break;
+			}
+
+			case "auth_stale": {
+				this.applyAuthStaleEvent(event);
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import stripAnsi from "strip-ansi";
 import { describe, expect, test } from "vitest";
 import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -74,6 +74,45 @@ describe("AssistantMessageComponent", () => {
 
 		expect(rendered).toContain("/tmp/internal.py");
 		expect(rendered).not.toContain("Ctrl+O to expand");
+	});
+
+	test("renders auth recovery guidance inline for simple provider errors", () => {
+		initTheme("dark");
+
+		const message = {
+			...createAssistantMessage([]),
+			stopReason: "error" as const,
+			errorMessage: "401 status code (no body)\n\nRun /login to update credentials.",
+		};
+		const component = new AssistantMessageComponent(message);
+		const raw = component.render(120).join("\n");
+		const rendered = stripAnsi(raw);
+
+		expect(rendered).toContain("Error: 401 status code (no body) · Run /login to update credentials.");
+		expect(rendered).not.toContain("Ctrl+O to expand");
+		expect(raw).toContain(theme.getFgAnsi("error"));
+	});
+
+	test("renders collapsed multiline assistant errors as errors", () => {
+		initTheme("dark");
+
+		const message = {
+			...createAssistantMessage([]),
+			stopReason: "error" as const,
+			errorMessage: [
+				"Provider request failed",
+				"Traceback (most recent call last):",
+				'  File "/tmp/internal.py", line 12, in run',
+				"RuntimeError: backend crashed",
+			].join("\n"),
+		};
+		const component = new AssistantMessageComponent(message);
+		const raw = component.render(100).join("\n");
+		const rendered = stripAnsi(raw);
+
+		expect(rendered).toContain("Error: Provider request failed");
+		expect(rendered).toContain("to expand");
+		expect(raw).toContain(theme.getFgAnsi("error"));
 	});
 });
 

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -134,6 +134,29 @@ describe("AuthStorage", () => {
 			}
 		});
 
+		test("ambient environment credentials count as available auth", async () => {
+			const originalAwsProfile = process.env.AWS_PROFILE;
+			process.env.AWS_PROFILE = "pi-test-profile";
+
+			try {
+				authStorage = AuthStorage.inMemory();
+
+				expect(authStorage.hasAuth("amazon-bedrock")).toBe(true);
+				await expect(authStorage.getApiKey("amazon-bedrock")).resolves.toBe("<authenticated>");
+				expect(authStorage.getAuthStatus("amazon-bedrock")).toEqual({
+					configured: false,
+					source: "environment",
+					label: "ambient credentials",
+				});
+			} finally {
+				if (originalAwsProfile === undefined) {
+					delete process.env.AWS_PROFILE;
+				} else {
+					process.env.AWS_PROFILE = originalAwsProfile;
+				}
+			}
+		});
+
 		test("apiKey as literal value is used directly when not an env var", async () => {
 			// Make sure this isn't an env var
 			delete process.env.literal_api_key_value;
@@ -265,6 +288,27 @@ describe("AuthStorage", () => {
 				label: "expired",
 			});
 			await expect(authStorage.getApiKey("anthropic")).resolves.toBeUndefined();
+		});
+
+		test("changed command-backed stored key no longer matches stale auth marker", async () => {
+			const tokenFile = join(tempDir, "command-token");
+			writeFileSync(tokenFile, "stale-key");
+			const tokenPath = toShPath(tokenFile);
+			writeAuthJson({
+				anthropic: { type: "api_key", key: `!sh -c 'cat "${tokenPath}"'` },
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBe("stale-key");
+			expect(authStorage.markAuthStale("anthropic")).toBe(true);
+			expect(authStorage.hasAuth("anthropic")).toBe(false);
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBeUndefined();
+
+			writeFileSync(tokenFile, "fresh-key");
+
+			expect(authStorage.hasAuth("anthropic")).toBe(true);
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBe("fresh-key");
+			expect(authStorage.getAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
 		});
 
 		test("prime inference uses Prime CLI auth over legacy Prime Agent auth", async () => {

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -182,6 +182,71 @@ describe("AuthStorage", () => {
 			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("changed-prime-key");
 		});
 
+		test("prime inference marks current Prime CLI auth stale", async () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+
+			expect(authStorage.markAuthStale("prime-inference")).toBe(true);
+
+			expect(authStorage.hasAuth("prime-inference")).toBe(false);
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBeUndefined();
+			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
+				configured: false,
+				source: "stale",
+				label: "expired",
+			});
+		});
+
+		test("changed Prime CLI key no longer matches stale auth marker", async () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+			authStorage.markAuthStale("prime-inference");
+
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "changed-prime-key" }));
+
+			expect(authStorage.hasAuth("prime-inference")).toBe(true);
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("changed-prime-key");
+			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
+				configured: false,
+				source: "prime_cli",
+				label: "Prime CLI",
+			});
+		});
+
+		test("setPrimeInferenceApiKey clears stale Prime CLI auth marker", async () => {
+			const primeConfigPath = join(tempDir, "prime-config.json");
+			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+			writeAuthJson({});
+
+			authStorage = AuthStorage.create(authJsonPath, {
+				primeCliConfigPath: primeConfigPath,
+				usePrimeCliConfig: true,
+			});
+			authStorage.markAuthStale("prime-inference");
+
+			authStorage.setPrimeInferenceApiKey("new-prime-key");
+
+			expect(authStorage.hasAuth("prime-inference")).toBe(true);
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("new-prime-key");
+			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
+				configured: false,
+				source: "prime_cli",
+				label: "Prime CLI",
+			});
+		});
+
 		test("prime inference uses Prime CLI auth over legacy Prime Agent auth", async () => {
 			const primeConfigPath = join(tempDir, "prime-config.json");
 			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -247,6 +247,26 @@ describe("AuthStorage", () => {
 			});
 		});
 
+		test("stored credential updates do not revive stale runtime auth", async () => {
+			authStorage = AuthStorage.inMemory();
+			authStorage.setRuntimeApiKey("anthropic", "runtime-key");
+			expect(authStorage.markAuthStale("anthropic")).toBe(true);
+
+			authStorage.set("anthropic", { type: "api_key", key: "stored-key" });
+
+			expect(authStorage.getAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBe("stored-key");
+
+			authStorage.remove("anthropic");
+
+			expect(authStorage.getAuthStatus("anthropic")).toEqual({
+				configured: false,
+				source: "stale",
+				label: "expired",
+			});
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBeUndefined();
+		});
+
 		test("prime inference uses Prime CLI auth over legacy Prime Agent auth", async () => {
 			const primeConfigPath = join(tempDir, "prime-config.json");
 			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -157,6 +157,29 @@ describe("AuthStorage", () => {
 			}
 		});
 
+		test("changed ambient environment credential no longer matches stale auth marker", async () => {
+			const originalAwsProfile = process.env.AWS_PROFILE;
+			process.env.AWS_PROFILE = "stale-profile";
+
+			try {
+				authStorage = AuthStorage.inMemory();
+				expect(authStorage.markAuthStale("amazon-bedrock")).toBe(true);
+				expect(authStorage.hasAuth("amazon-bedrock")).toBe(false);
+				await expect(authStorage.getApiKey("amazon-bedrock")).resolves.toBeUndefined();
+
+				process.env.AWS_PROFILE = "fresh-profile";
+
+				expect(authStorage.hasAuth("amazon-bedrock")).toBe(true);
+				await expect(authStorage.getApiKey("amazon-bedrock")).resolves.toBe("<authenticated>");
+			} finally {
+				if (originalAwsProfile === undefined) {
+					delete process.env.AWS_PROFILE;
+				} else {
+					process.env.AWS_PROFILE = originalAwsProfile;
+				}
+			}
+		});
+
 		test("apiKey as literal value is used directly when not an env var", async () => {
 			// Make sure this isn't an env var
 			delete process.env.literal_api_key_value;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1393,6 +1393,28 @@ describe("ModelRegistry", () => {
 				});
 			});
 
+			test("provider auth status reports models.json auth when stored auth is stale", async () => {
+				authStorage.setRuntimeApiKey("custom-provider", "stale-runtime-key");
+				expect(authStorage.markAuthStale("custom-provider")).toBe(true);
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey("literal_api_key_value"),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+				const model = registry.find("custom-provider", "test-model");
+				expect(model).toBeDefined();
+
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: true,
+					source: "models_json_key",
+				});
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBe("literal_api_key_value");
+				await expect(registry.getApiKeyAndHeaders(model!)).resolves.toMatchObject({
+					ok: true,
+					apiKey: "literal_api_key_value",
+				});
+			});
+
 			test("provider auth status reports command apiKey values from models.json without executing them", () => {
 				const counterFile = join(tempDir, "status-counter");
 				writeFileSync(counterFile, "0");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AnthropicMessagesCompat, Api, Context, Model, OpenAICompletionsCompat } from "@earendil-works/pi-ai";
 import { getApiProvider } from "@earendil-works/pi-ai";
-import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import { getOAuthProvider, registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
@@ -1412,6 +1412,46 @@ describe("ModelRegistry", () => {
 				await expect(registry.getApiKeyAndHeaders(model!)).resolves.toMatchObject({
 					ok: true,
 					apiKey: "literal_api_key_value",
+				});
+			});
+
+			test("stale marking uses the auth source resolved for the last request", async () => {
+				const providerId = `test-oauth-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+				registerOAuthProvider({
+					id: providerId,
+					name: "Test OAuth Fallback",
+					async login() {
+						throw new Error("Not used in this test");
+					},
+					async refreshToken() {
+						throw new Error("refresh failed");
+					},
+					getApiKey(credentials) {
+						return `Bearer ${credentials.access}`;
+					},
+				});
+				authStorage.set(providerId, {
+					type: "oauth",
+					refresh: "refresh-token",
+					access: "expired-access-token",
+					expires: Date.now() - 10_000,
+				});
+				writeRawModelsJson({
+					[providerId]: providerWithApiKey("literal_api_key_value"),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				await expect(registry.getApiKeyForProvider(providerId)).resolves.toBe("literal_api_key_value");
+				const token = registry.getCurrentProviderAuthSourceToken(providerId);
+				expect(token?.source).toBe("models_json_key");
+				expect(token).toBeDefined();
+				expect(registry.markProviderAuthSourceStale(token!)).toBe(true);
+
+				await expect(registry.getApiKeyForProvider(providerId)).resolves.toBeUndefined();
+				expect(authStorage.getAuthStatus(providerId)).toEqual({
+					configured: true,
+					source: "stored",
 				});
 			});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1480,6 +1480,35 @@ describe("ModelRegistry", () => {
 				expect(count).toBe(0);
 			});
 
+			test("changed command-backed apiKey no longer matches stale models.json marker", async () => {
+				const tokenFile = join(tempDir, "models-json-token");
+				writeFileSync(tokenFile, "stale-key");
+				const tokenPath = toShPath(tokenFile);
+
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey(`!sh -c 'cat "${tokenPath}"'`),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBe("stale-key");
+				expect(registry.markProviderAuthStale("custom-provider")).toBe(true);
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBeUndefined();
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: false,
+					source: "stale",
+					label: "expired",
+				});
+
+				writeFileSync(tokenFile, "fresh-key");
+
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBe("fresh-key");
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: true,
+					source: "models_json_command",
+				});
+			});
+
 			test("getApiKeyAndHeaders resolves authHeader on every request", async () => {
 				const tokenFile = join(tempDir, "token");
 				writeFileSync(tokenFile, "token-1");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1455,6 +1455,35 @@ describe("ModelRegistry", () => {
 				});
 			});
 
+			test("changed literal models.json apiKey no longer matches stale provider marker", async () => {
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey("stale-key"),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBe("stale-key");
+				expect(registry.markProviderAuthStale("custom-provider")).toBe(true);
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: false,
+					source: "stale",
+					label: "expired",
+				});
+				expect(registry.getAvailable().some((model) => model.provider === "custom-provider")).toBe(false);
+
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey("fresh-key"),
+				});
+				registry.refresh();
+
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: true,
+					source: "models_json_key",
+				});
+				expect(registry.getAvailable().some((model) => model.provider === "custom-provider")).toBe(true);
+				await expect(registry.getApiKeyForProvider("custom-provider")).resolves.toBe("fresh-key");
+			});
+
 			test("provider auth status reports command apiKey values from models.json without executing them", () => {
 				const counterFile = join(tempDir, "status-counter");
 				writeFileSync(counterFile, "0");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1433,6 +1433,29 @@ describe("ModelRegistry", () => {
 				expect(readFileSync(counterFile, "utf-8")).toBe("0");
 			});
 
+			test("provider auth status reports stale command auth without executing it", () => {
+				const counterFile = join(tempDir, "stale-status-counter");
+				writeFileSync(counterFile, "0");
+				const counterPath = toShPath(counterFile);
+				const command = `!sh -c 'count=$(cat "${counterPath}"); echo $((count + 1)) > "${counterPath}"; echo key-value'`;
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey(command),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				expect(registry.markProviderAuthStale("custom-provider")).toBe(true);
+				expect(readFileSync(counterFile, "utf-8").trim()).toBe("1");
+				writeFileSync(counterFile, "0");
+
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: false,
+					source: "stale",
+					label: "expired",
+				});
+				expect(readFileSync(counterFile, "utf-8").trim()).toBe("0");
+			});
+
 			test("environment variables are not cached (changes are picked up)", async () => {
 				const envVarName = "TEST_API_KEY_CACHE_TEST_98765";
 				const originalEnv = process.env[envVarName];

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -196,6 +196,36 @@ describe("OAuthSelectorComponent", () => {
 		expect(output).toContain("expired");
 	});
 
+	it("sorts stale auth ahead of unconfigured providers", () => {
+		process.env.OPENAI_API_KEY = "test-openai-key";
+		const authStorage = AuthStorage.inMemory({
+			"prime-inference": {
+				type: "api_key",
+				key: "stale-prime-key",
+			},
+		});
+		authStorage.markAuthStale("prime-inference");
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[
+				{ id: "github-copilot", name: "GitHub Copilot", authType: "oauth" },
+				{ id: "amazon-bedrock", name: "Amazon Bedrock", authType: "api_key" },
+				{ id: "prime-inference", name: "Prime Inference", authType: "api_key" },
+				{ id: "openai", name: "OpenAI", authType: "api_key" },
+			],
+			() => {},
+			() => {},
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output.indexOf("OpenAI")).toBeLessThan(output.indexOf("Prime Inference"));
+		expect(output.indexOf("Prime Inference")).toBeLessThan(output.indexOf("GitHub Copilot"));
+		expect(output.indexOf("Prime Inference")).toBeLessThan(output.indexOf("Amazon Bedrock"));
+		expect(output).toContain("expired");
+	});
+
 	it("shows models.json auth instead of stale stored auth on API key rows", () => {
 		const authStorage = AuthStorage.inMemory({
 			anthropic: {

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -143,6 +143,59 @@ describe("OAuthSelectorComponent", () => {
 		expect(output).not.toContain("unconfigured");
 	});
 
+	it("shows stale auth as expired instead of configured", () => {
+		const authStorage = AuthStorage.inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "stale-access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			},
+		});
+		authStorage.markAuthStale("anthropic");
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[{ id: "anthropic", name: "Anthropic", authType: "oauth" }],
+			() => {},
+			() => {},
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output).toContain("Anthropic");
+		expect(output).toContain("expired");
+		expect(output).not.toContain("configured");
+	});
+
+	it("does not sort stale auth ahead of configured providers", () => {
+		process.env.OPENAI_API_KEY = "test-openai-key";
+		const authStorage = AuthStorage.inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "stale-access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			},
+		});
+		authStorage.markAuthStale("anthropic");
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[
+				{ id: "anthropic", name: "Anthropic", authType: "oauth" },
+				{ id: "openai", name: "OpenAI", authType: "api_key" },
+			],
+			() => {},
+			() => {},
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output.indexOf("OpenAI")).toBeLessThan(output.indexOf("Anthropic"));
+		expect(output).toContain("expired");
+	});
+
 	it("shows custom provider environment API key auth from status resolver", () => {
 		const authStorage = AuthStorage.inMemory();
 		const selector = new OAuthSelectorComponent(

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -196,6 +196,59 @@ describe("OAuthSelectorComponent", () => {
 		expect(output).toContain("expired");
 	});
 
+	it("shows models.json auth instead of stale stored auth on API key rows", () => {
+		const authStorage = AuthStorage.inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "stale-access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			},
+		});
+		authStorage.markAuthStale("anthropic");
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[{ id: "anthropic", name: "Anthropic", authType: "api_key" }],
+			() => {},
+			() => {},
+			() => ({ configured: true, source: "models_json_key" }),
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output).toContain("Anthropic");
+		expect(output).toContain("key in models.json");
+		expect(output).not.toContain("subscription configured");
+		expect(output).not.toContain("expired");
+	});
+
+	it("shows stale stored auth as expired when models.json auth is active for the provider", () => {
+		const authStorage = AuthStorage.inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "stale-access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			},
+		});
+		authStorage.markAuthStale("anthropic");
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[{ id: "anthropic", name: "Anthropic", authType: "oauth" }],
+			() => {},
+			() => {},
+			() => ({ configured: true, source: "models_json_key" }),
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output).toContain("Anthropic");
+		expect(output).toContain("expired");
+		expect(output).not.toContain("configured");
+	});
+
 	it("shows custom provider environment API key auth from status resolver", () => {
 		const authStorage = AuthStorage.inMemory();
 		const selector = new OAuthSelectorComponent(

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -57,6 +57,7 @@ export function getAssistantTexts(harness: Harness): string[] {
 }
 
 export interface HarnessOptions {
+	provider?: string;
 	models?: FauxModelDefinition[];
 	settings?: Partial<Settings>;
 	systemPrompt?: string;
@@ -97,6 +98,7 @@ function createTempDir(): string {
 export async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
 	const tempDir = createTempDir();
 	const fauxProvider: FauxProviderRegistration = registerFauxProvider({
+		provider: options.provider,
 		models: options.models,
 	});
 	fauxProvider.setResponses([]);

--- a/packages/coding-agent/test/suite/regressions/4435-auth-error-login-guidance.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4435-auth-error-login-guidance.test.ts
@@ -13,7 +13,7 @@ describe("issue #4435 auth error login guidance", () => {
 	});
 
 	it("adds /login guidance to provider authentication errors", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
 		harnesses.push(harness);
 		harness.setResponses([
 			fauxAssistantMessage("", {

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -57,7 +57,7 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		expect(finalAssistant?.errorMessage).toContain("Run /login to update credentials.");
 	});
 
-	it("marks the failed auth source stale when credentials change during retry backoff", async () => {
+	it("marks each failed auth source stale when credentials change during retry backoff", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 5 } },
 		});
@@ -76,13 +76,28 @@ describe("issue #4491 provider stale after repeated 401", () => {
 
 		expect(changedCredentials).toBe(true);
 		expect(harness.faux.state.callCount).toBe(2);
-		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(true);
-		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBe("fresh-key");
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
+		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBeUndefined();
 		expect(harness.authStorage.getAuthStatus(harness.getModel().provider)).toEqual({
 			configured: false,
-			source: "runtime",
-			label: "--api-key",
+			source: "stale",
+			label: "expired",
 		});
+	});
+
+	it("marks concrete auth failures stale when retry is disabled", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([provider401Message()]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toHaveLength(0);
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
+		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBeUndefined();
 	});
 
 	it("resolves retry state for auth failures surfaced only on agent_end", async () => {

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -19,6 +19,13 @@ function provider401Message(): AssistantMessage {
 	};
 }
 
+function bareProvider401Message(): AssistantMessage {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: "401 status code (no body)",
+	});
+}
+
 function provider500Message(): AssistantMessage {
 	return {
 		...fauxAssistantMessage("", {
@@ -56,6 +63,7 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		expect(harness.faux.state.callCount).toBe(3);
 		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1, 2]);
 		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+		expect(harness.eventsOfType("auth_stale")).toHaveLength(1);
 
 		const provider = harness.getModel().provider;
 		expect(harness.authStorage.hasAuth(provider)).toBe(false);
@@ -71,6 +79,32 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		const finalAssistant = assistantMessages[assistantMessages.length - 1];
 		expect(finalAssistant?.errorMessage).toContain("401 Unauthorized");
 		expect(finalAssistant?.errorMessage).toContain("Run /login to update credentials.");
+	});
+
+	it("emits stale auth source tokens for daemon clients after bare 401 auth failures", async () => {
+		const harness = await createHarness({
+			provider: "prime-inference",
+			settings: { retry: { enabled: true, maxRetries: 0, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([bareProvider401Message()]);
+
+		await harness.session.prompt("hello");
+
+		const authStaleEvents = harness.eventsOfType("auth_stale");
+		expect(authStaleEvents).toHaveLength(1);
+		expect(authStaleEvents[0]?.provider).toBe("prime-inference");
+		expect(authStaleEvents[0]?.sourceTokens).toMatchObject([
+			{
+				provider: "prime-inference",
+				source: "runtime",
+			},
+		]);
+		expect(harness.authStorage.getAuthStatus("prime-inference")).toEqual({
+			configured: false,
+			source: "stale",
+			label: "expired",
+		});
 	});
 
 	it("marks each failed auth source stale when credentials change during retry backoff", async () => {

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -115,6 +115,13 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
 		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
 		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBeUndefined();
+
+		const assistantMessages = harness.session.messages.filter(
+			(message): message is AssistantMessage => message.role === "assistant",
+		);
+		const finalAssistant = assistantMessages[assistantMessages.length - 1];
+		expect(finalAssistant?.errorMessage).toContain("500 Internal Server Error");
+		expect(finalAssistant?.errorMessage).toContain("Run /login to update credentials.");
 	});
 
 	it("marks concrete auth failures stale when retry is disabled", async () => {

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
 import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { createHarness, type Harness } from "../harness.js";
@@ -54,5 +55,54 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		const finalAssistant = assistantMessages[assistantMessages.length - 1];
 		expect(finalAssistant?.errorMessage).toContain("401 Unauthorized");
 		expect(finalAssistant?.errorMessage).toContain("Run /login to update credentials.");
+	});
+
+	it("marks the failed auth source stale when credentials change during retry backoff", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 5 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([provider401Message(), provider401Message()]);
+
+		let changedCredentials = false;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && !changedCredentials) {
+				changedCredentials = true;
+				harness.authStorage.setRuntimeApiKey(harness.getModel().provider, "fresh-key");
+			}
+		});
+
+		await harness.session.prompt("hello");
+
+		expect(changedCredentials).toBe(true);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(true);
+		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBe("fresh-key");
+		expect(harness.authStorage.getAuthStatus(harness.getModel().provider)).toEqual({
+			configured: false,
+			source: "runtime",
+			label: "--api-key",
+		});
+	});
+
+	it("resolves retry state for auth failures surfaced only on agent_end", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 0, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const message = provider401Message();
+		const event = { type: "agent_end", messages: [message] } as AgentEvent;
+		const session = harness.session as unknown as {
+			_createRetryPromiseForAgentEnd(event: AgentEvent): void;
+			_processAgentEvent(event: AgentEvent): Promise<void>;
+		};
+
+		session._createRetryPromiseForAgentEnd(event);
+		await session._processAgentEvent(event);
+
+		expect(harness.session.isRetrying).toBe(false);
+		expect(harness.eventsOfType("auto_retry_end").map((retryEvent) => retryEvent.success)).toEqual([false]);
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
+		expect(message.errorMessage).toContain("Run /login to update credentials.");
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -1,0 +1,58 @@
+import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+function provider401Message(): AssistantMessage {
+	return {
+		...fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: "401 Unauthorized: invalid API key",
+		}),
+		diagnostics: [
+			{
+				type: "provider_stream_failure",
+				timestamp: Date.now(),
+				details: { kind: "auth", status: 401 },
+			},
+		],
+	};
+}
+
+describe("issue #4491 provider stale after repeated 401", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("retries concrete provider auth failures, then marks current auth stale", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([provider401Message(), provider401Message(), provider401Message()]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1, 2]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+
+		const provider = harness.getModel().provider;
+		expect(harness.authStorage.hasAuth(provider)).toBe(false);
+		expect(harness.authStorage.getAuthStatus(provider)).toEqual({
+			configured: false,
+			source: "stale",
+			label: "expired",
+		});
+
+		const assistantMessages = harness.session.messages.filter(
+			(message): message is AssistantMessage => message.role === "assistant",
+		);
+		const finalAssistant = assistantMessages[assistantMessages.length - 1];
+		expect(finalAssistant?.errorMessage).toContain("401 Unauthorized");
+		expect(finalAssistant?.errorMessage).toContain("Run /login to update credentials.");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -107,6 +107,52 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		});
 	});
 
+	it("classifies bare status-code auth failures before login guidance is appended", async () => {
+		const harness = await createHarness({
+			provider: "prime-inference",
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const message = bareProvider401Message();
+		const event = { type: "agent_end", messages: [message] } as AgentEvent;
+		const session = harness.session as unknown as {
+			_createRetryPromiseForAgentEnd(event: AgentEvent): void;
+		};
+
+		session._createRetryPromiseForAgentEnd(event);
+
+		expect(harness.session.isRetrying).toBe(true);
+		harness.session.abortRetry();
+	});
+
+	it("marks captured auth failures stale when retry backoff is cancelled", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([provider401Message(), provider401Message()]);
+
+		const sawRetryStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "auto_retry_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		const promptPromise = harness.session.prompt("hello");
+		await sawRetryStart;
+		harness.session.abortRetry();
+		await promptPromise;
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auth_stale")).toHaveLength(1);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.finalError)).toContain("Retry cancelled");
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
+		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBeUndefined();
+	});
+
 	it("marks each failed auth source stale when credentials change during retry backoff", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 5 } },

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -19,6 +19,22 @@ function provider401Message(): AssistantMessage {
 	};
 }
 
+function provider500Message(): AssistantMessage {
+	return {
+		...fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: "500 Internal Server Error",
+		}),
+		diagnostics: [
+			{
+				type: "provider_stream_failure",
+				timestamp: Date.now(),
+				details: { kind: "server_error", status: 500 },
+			},
+		],
+	};
+}
+
 describe("issue #4491 provider stale after repeated 401", () => {
 	const harnesses: Harness[] = [];
 
@@ -83,6 +99,22 @@ describe("issue #4491 provider stale after repeated 401", () => {
 			source: "stale",
 			label: "expired",
 		});
+	});
+
+	it("marks captured auth failures stale when the final retryable error is not auth", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([provider401Message(), provider401Message(), provider500Message()]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1, 2]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+		expect(harness.authStorage.hasAuth(harness.getModel().provider)).toBe(false);
+		await expect(harness.authStorage.getApiKey(harness.getModel().provider)).resolves.toBeUndefined();
 	});
 
 	it("marks concrete auth failures stale when retry is disabled", async () => {


### PR DESCRIPTION
- repeated provider auth failures now expire the current credential source instead of leaving it shown as connected.
- concrete 401 and 403 failures reuse the existing retry flow before marking credentials stale.
- added focused coverage for stale auth status, login rendering, and repeated provider failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential resolution and retry behavior for all providers; incorrect stale detection could block valid keys or leave bad ones in use, but changes are scoped to explicit 401/403 failures and fingerprint-based invalidation with broad test coverage.
> 
> **Overview**
> Fixes `/login` and related UI still showing a provider as connected after credentials stop working.
> 
> **Stale auth tracking** — `AuthStorage` and `ModelRegistry` fingerprint each credential source (stored, env, runtime, Prime CLI, `models.json`, etc.) and can mark the active source stale. Stale values are skipped for `getApiKey` / `hasAuth`, and status becomes `{ source: 'stale', label: 'expired' }`. Markers clear when that source is updated or its secret changes.
> 
> **Session retry path** — Concrete provider **401/403** failures (structured stream diagnostics or message heuristics) go through the existing auto-retry flow. When retries are exhausted, disabled, or cancelled, the session marks the captured auth source stale, emits **`auth_stale`**, and appends **`Run /login to update credentials.`** to the error. Interactive mode refreshes footer/border on that event; the login selector sorts **expired** between configured and unconfigured.
> 
> **UI polish** — Simple auth errors show inline `/login` guidance; collapsed error summaries use error styling instead of muted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5171c6b1dc83a3680945052ea70e99be5b1047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark provider auth stale after repeated 401/403 failures and surface expired state in the UI
> - `AgentSession` now treats 401/403 provider auth failures as retryable, accumulates the failing auth source tokens, and marks those credentials stale when retries are cancelled or exhausted, emitting a new `auth_stale` session event.
> - `AuthStorage` and `ModelRegistry` track stale credentials using fingerprint-based tokens, suppressing stale sources from `hasAuth`, `getApiKey`, and `getAuthStatus` (which can now return `source: 'stale'`).
> - `InteractiveMode` handles `auth_stale` events by updating the model registry and refreshing the UI footer; the `/login` selector now shows 'expired' for stale providers and sorts them between configured and unconfigured entries.
> - Provider errors appended with login guidance are rendered as a single inline line rather than a collapsible block, and collapsed error summaries now use the error color instead of muted.
> - Risk: `getApiKey` may now return `undefined` for credentials that were previously returned but are now marked stale, which could cause requests to fail until credentials are refreshed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa5171c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->