### PR TITLE
fix heartbeat prompt rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed heartbeat and goal continuation prompts rendering like ordinary user messages ([ENG-4482](https://linear.app/primeintellect/issue/ENG-4482/heartbeat-message-should-have-a-different-ui-from-user-message)).
+
 ## [0.2.6] - 2026-07-06
 
 - Fixed the installer splash flickering during animation and resize by stabilizing full-screen redraws and removing misleading synthetic percentages ([ENG-4481](https://linear.app/primeintellect/issue/ENG-4481/installer-screen-is-unstable-and-flickery)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3222,8 +3222,8 @@ export class AgentSession {
 	 * @returns Object with steering and followUp arrays
 	 */
 	clearQueue(): { steering: string[]; followUp: string[] } {
-		const steering = this._steeringMessages.map((message) => message.text);
-		const followUp = this._followUpMessages.map((message) => message.text);
+		const steering = this._steeringMessages.map(queuedMessagePreview);
+		const followUp = this._followUpMessages.map(queuedMessagePreview);
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 		this._steeringMessages = [];
 		this._followUpMessages = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1788,9 +1788,7 @@ export class AgentSession {
 
 	private _isPromptTurnStartMessage(message: AgentMessage): boolean {
 		return (
-			message.role === "user" ||
-			(message.role === "custom" &&
-				(message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE || message.customType === GOAL_CONTEXT_CUSTOM_TYPE))
+			message.role === "user" || (message.role === "custom" && message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE)
 		);
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2279,6 +2279,8 @@ export class AgentSession {
 			}
 		};
 
+		let messages: AgentMessage[] | undefined;
+		let drainedNextTurnMessages: CustomMessage[] = [];
 		try {
 			const shouldQueueForStreaming = this.isStreaming;
 			const shouldQueueForPendingWork =
@@ -2297,16 +2299,12 @@ export class AgentSession {
 						`${stateDescription}. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`,
 					);
 				}
-				let queued = true;
-				if (options.streamingBehavior === "followUp") {
-					queued = await this._queueFollowUp(text, undefined, {
-						queueKey: options.followUpQueueKey,
-						message,
-						previewLabel: "Heartbeat",
-					});
-				} else {
-					await this._queueSteer(text, undefined, { message, previewLabel: "Heartbeat" });
-				}
+				const queued = await this._queueInjectedMessageWithPendingNextTurnMessages(
+					text,
+					message,
+					options.streamingBehavior,
+					{ queueKey: options.followUpQueueKey, previewLabel: "Heartbeat" },
+				);
 				if (!queued) {
 					reportPreflight(false);
 					return;
@@ -2333,20 +2331,80 @@ export class AgentSession {
 				await this._checkCompaction(lastAssistant, false);
 			}
 
-			const pendingNextTurnMessages = this._pendingNextTurnMessages;
+			drainedNextTurnMessages = this._pendingNextTurnMessages;
 			this._pendingNextTurnMessages = [];
-			const promptMessages = [...pendingNextTurnMessages, message];
-			try {
-				await this.agent.prompt(promptMessages);
-			} catch (error) {
-				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages.map((pending) => ({ ...pending })));
-				throw error;
+			messages = [...drainedNextTurnMessages, message];
+
+			const result = await this._extensionRunner.emitBeforeAgentStart(
+				text,
+				undefined,
+				this._baseSystemPrompt,
+				this._baseSystemPromptOptions,
+			);
+			if (result?.messages) {
+				for (const msg of result.messages) {
+					messages.push({
+						role: "custom",
+						customType: msg.customType,
+						content: msg.content,
+						display: msg.display,
+						details: msg.details,
+						timestamp: Date.now(),
+					});
+				}
 			}
-			reportPreflight(true);
+			this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
 		} catch (error) {
 			reportPreflight(false);
 			throw error;
 		}
+
+		if (!messages) {
+			return;
+		}
+
+		if (this._refineInFlight) {
+			await this._waitForRefineIdle();
+		}
+		const shouldQueueAtHandoff =
+			options?.queueIfBusy === true &&
+			(this.isStreaming ||
+				this.pendingMessageCount > 0 ||
+				this.isCompacting ||
+				this.isRetrying ||
+				this.isBashRunning ||
+				this._acceptedPromptCompletions.size > 0 ||
+				this._acceptedAgentMessagePrompt !== undefined);
+		if (shouldQueueAtHandoff) {
+			if (!options?.streamingBehavior) {
+				this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
+				reportPreflight(false);
+				throw new Error(
+					"Agent became busy before prompt delivery. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
+				);
+			}
+			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
+			const queued = await this._queueInjectedMessageWithPendingNextTurnMessages(
+				text,
+				message,
+				options.streamingBehavior,
+				{ queueKey: options.followUpQueueKey, previewLabel: "Heartbeat" },
+			);
+			if (!queued) {
+				reportPreflight(false);
+				return;
+			}
+			reportPreflight(true, true);
+			return;
+		}
+
+		try {
+			await this.agent.prompt(messages);
+		} catch (error) {
+			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
+			throw error;
+		}
+		reportPreflight(true);
 		await this.waitForRetry();
 	}
 
@@ -2831,6 +2889,38 @@ export class AgentSession {
 				return queued;
 			}
 			await this._queueSteer(text, undefined, { agentMessageId: options.agentMessageId, content });
+			return true;
+		} catch (error) {
+			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
+			throw error;
+		}
+	}
+
+	private async _queueInjectedMessageWithPendingNextTurnMessages(
+		text: string,
+		message: CustomMessage,
+		streamingBehavior: "steer" | "followUp",
+		options: { queueKey?: string; previewLabel?: string } = {},
+	): Promise<boolean> {
+		const pendingNextTurnMessages = this._pendingNextTurnMessages;
+		this._pendingNextTurnMessages = [];
+		const queuedMessage: CustomMessage = {
+			...message,
+			content: this._buildPromptContent(text, undefined, pendingNextTurnMessages),
+		};
+		try {
+			if (streamingBehavior === "followUp") {
+				const queued = await this._queueFollowUp(text, undefined, {
+					queueKey: options.queueKey,
+					message: queuedMessage,
+					previewLabel: options.previewLabel,
+				});
+				if (!queued) {
+					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
+				}
+				return queued;
+			}
+			await this._queueSteer(text, undefined, { message: queuedMessage, previewLabel: options.previewLabel });
 			return true;
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -138,7 +138,7 @@ import {
 import type { HostRequestHandlers } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
-import type { BashExecutionMessage, CustomMessage } from "./messages.js";
+import { type BashExecutionMessage, type CustomMessage, createHeartbeatPromptMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import {
@@ -392,15 +392,21 @@ interface InternalPromptOptions extends PromptOptions {
 
 interface QueuedSteeringMessage {
 	text: string;
+	previewLabel?: string;
 	agentMessageId?: string;
 	message: AgentMessage;
 }
 
 interface QueuedFollowUpMessage {
 	text: string;
+	previewLabel?: string;
 	queueKey?: string;
 	agentMessageId?: string;
 	message: AgentMessage;
+}
+
+function queuedMessagePreview(message: { text: string; previewLabel?: string }): string {
+	return message.previewLabel ? `${message.previewLabel}: ${message.text}` : message.text;
 }
 
 interface AcceptedAgentMessagePrompt {
@@ -836,8 +842,8 @@ export class AgentSession {
 	private _emitQueueUpdate(): void {
 		this._emit({
 			type: "queue_update",
-			steering: this._steeringMessages.map((message) => message.text),
-			followUp: this._followUpMessages.map((message) => message.text),
+			steering: this._steeringMessages.map(queuedMessagePreview),
+			followUp: this._followUpMessages.map(queuedMessagePreview),
 		});
 	}
 
@@ -1666,10 +1672,11 @@ export class AgentSession {
 			this._resolveRetry();
 		}
 
-		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
-		// This ensures the UI sees the updated queue state
-		if (event.type === "message_start" && event.message.role === "user") {
-			this._overflowRecoveryAttempted = false;
+		// Remove queued messages before emitting so the UI sees the updated queue.
+		if (event.type === "message_start") {
+			if (event.message.role === "user") {
+				this._overflowRecoveryAttempted = false;
+			}
 			const steeringIndex = this._steeringMessages.findIndex((message) => message.message === event.message);
 			if (steeringIndex !== -1) {
 				const [removed] = this._steeringMessages.splice(steeringIndex, 1);
@@ -2250,6 +2257,99 @@ export class AgentSession {
 		return this._queueFollowUp(text, undefined, { agentMessageId });
 	}
 
+	async promptHeartbeat(job: AgentCronJob, options?: PromptOptions): Promise<void> {
+		const message = createHeartbeatPromptMessage(job);
+		await this._promptInjectedMessage(job.prompt, message, {
+			...options,
+			followUpQueueKey: options?.followUpQueueKey ?? `heartbeat:${job.id}`,
+		});
+	}
+
+	private async _promptInjectedMessage(
+		text: string,
+		message: CustomMessage,
+		options?: InternalPromptOptions,
+	): Promise<void> {
+		const preflightResult = options?.preflightResult;
+		let preflightSettled = false;
+		const reportPreflight = (success: boolean, queued = false) => {
+			if (!preflightSettled) {
+				preflightSettled = true;
+				preflightResult?.(success, queued);
+			}
+		};
+
+		try {
+			const shouldQueueForStreaming = this.isStreaming;
+			const shouldQueueForPendingWork =
+				options?.queueIfBusy === true &&
+				(this.pendingMessageCount > 0 ||
+					this.isCompacting ||
+					this.isRetrying ||
+					this.isBashRunning ||
+					this.hasAcceptedPromptInFlight);
+			if (shouldQueueForStreaming || shouldQueueForPendingWork) {
+				if (!options?.streamingBehavior) {
+					const stateDescription = shouldQueueForStreaming
+						? "Agent is already processing"
+						: "Agent has queued work";
+					throw new Error(
+						`${stateDescription}. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`,
+					);
+				}
+				let queued = true;
+				if (options.streamingBehavior === "followUp") {
+					queued = await this._queueFollowUp(text, undefined, {
+						queueKey: options.followUpQueueKey,
+						message,
+						previewLabel: "Heartbeat",
+					});
+				} else {
+					await this._queueSteer(text, undefined, { message, previewLabel: "Heartbeat" });
+				}
+				if (!queued) {
+					reportPreflight(false);
+					return;
+				}
+				reportPreflight(true, true);
+				return;
+			}
+
+			await this._waitForRefineIdle();
+			this._flushPendingBashMessages();
+			if (!this.model) {
+				throw new Error(formatNoModelSelectedMessage());
+			}
+			if (!this._modelRegistry.hasConfiguredAuth(this.model)) {
+				const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
+				if (isOAuth) {
+					throw new Error(formatAuthenticationFailedMessage(this.model.provider));
+				}
+				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
+			}
+
+			const lastAssistant = this._findLastAssistantMessage();
+			if (lastAssistant) {
+				await this._checkCompaction(lastAssistant, false);
+			}
+
+			const pendingNextTurnMessages = this._pendingNextTurnMessages;
+			this._pendingNextTurnMessages = [];
+			const promptMessages = [...pendingNextTurnMessages, message];
+			try {
+				await this.agent.prompt(promptMessages);
+			} catch (error) {
+				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages.map((pending) => ({ ...pending })));
+				throw error;
+			}
+			reportPreflight(true);
+		} catch (error) {
+			reportPreflight(false);
+			throw error;
+		}
+		await this.waitForRetry();
+	}
+
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
@@ -2744,16 +2844,24 @@ export class AgentSession {
 	private async _queueSteer(
 		text: string,
 		images?: ImageContent[],
-		options: { agentMessageId?: string; content?: (TextContent | ImageContent)[] } = {},
+		options: {
+			agentMessageId?: string;
+			content?: (TextContent | ImageContent)[];
+			message?: AgentMessage;
+			previewLabel?: string;
+		} = {},
 	): Promise<void> {
 		const content = options.content ?? this._buildPromptContent(text, images);
-		const message: AgentMessage = {
-			role: "user",
-			content,
-			timestamp: Date.now(),
-		};
+		const message: AgentMessage =
+			options.message ??
+			({
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			} satisfies AgentMessage);
 		this._steeringMessages.push({
 			text,
+			previewLabel: options.previewLabel,
 			agentMessageId: options.agentMessageId,
 			message,
 		});
@@ -2767,19 +2875,28 @@ export class AgentSession {
 	private async _queueFollowUp(
 		text: string,
 		images?: ImageContent[],
-		options: { queueKey?: string; agentMessageId?: string; content?: (TextContent | ImageContent)[] } = {},
+		options: {
+			queueKey?: string;
+			agentMessageId?: string;
+			content?: (TextContent | ImageContent)[];
+			message?: AgentMessage;
+			previewLabel?: string;
+		} = {},
 	): Promise<boolean> {
 		if (options.queueKey && this._followUpMessages.some((message) => message.queueKey === options.queueKey)) {
 			return false;
 		}
 		const content = options.content ?? this._buildPromptContent(text, images);
-		const message: AgentMessage = {
-			role: "user",
-			content,
-			timestamp: Date.now(),
-		};
+		const message: AgentMessage =
+			options.message ??
+			({
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			} satisfies AgentMessage);
 		this._followUpMessages.push({
 			text,
+			previewLabel: options.previewLabel,
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
 			message,
@@ -2977,9 +3094,17 @@ export class AgentSession {
 		return this._steeringMessages.map((message) => message.text);
 	}
 
+	getSteeringMessagePreviews(): readonly string[] {
+		return this._steeringMessages.map(queuedMessagePreview);
+	}
+
 	/** Get pending follow-up messages (read-only) */
 	getFollowUpMessages(): readonly string[] {
 		return this._followUpMessages.map((message) => message.text);
+	}
+
+	getFollowUpMessagePreviews(): readonly string[] {
+		return this._followUpMessages.map(queuedMessagePreview);
 	}
 
 	hasQueuedFollowUp(queueKey: string): boolean {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -424,6 +424,17 @@ function queuedMessagePreview(message: { text: string; previewLabel?: string }):
 	return message.previewLabel ? `${message.previewLabel}: ${message.text}` : message.text;
 }
 
+function injectedMessagePreviewLabel(message: CustomMessage): string | undefined {
+	switch (message.customType) {
+		case HEARTBEAT_PROMPT_CUSTOM_TYPE:
+			return "Heartbeat prompt";
+		case GOAL_CONTEXT_CUSTOM_TYPE:
+			return "Goal context";
+		default:
+			return undefined;
+	}
+}
+
 interface AcceptedAgentMessagePrompt {
 	text: string;
 	agentMessageId: string;
@@ -2384,6 +2395,7 @@ export class AgentSession {
 
 		let messages: AgentMessage[] | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
+		const previewLabel = injectedMessagePreviewLabel(message);
 		try {
 			const shouldQueueForStreaming = this.isStreaming;
 			const shouldQueueForPendingWork =
@@ -2406,7 +2418,7 @@ export class AgentSession {
 					text,
 					message,
 					options.streamingBehavior,
-					{ queueKey: options.followUpQueueKey, previewLabel: "Heartbeat" },
+					{ queueKey: options.followUpQueueKey, previewLabel },
 				);
 				if (!queued) {
 					reportPreflight(false);
@@ -2491,7 +2503,7 @@ export class AgentSession {
 				text,
 				message,
 				options.streamingBehavior,
-				{ queueKey: options.followUpQueueKey, previewLabel: "Heartbeat" },
+				{ queueKey: options.followUpQueueKey, previewLabel },
 			);
 			if (!queued) {
 				reportPreflight(false);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -138,7 +138,12 @@ import {
 import type { HostRequestHandlers } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
-import { type BashExecutionMessage, type CustomMessage, createHeartbeatPromptMessage } from "./messages.js";
+import {
+	type BashExecutionMessage,
+	type CustomMessage,
+	createHeartbeatPromptMessage,
+	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+} from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import {
@@ -1674,7 +1679,7 @@ export class AgentSession {
 
 		// Remove queued messages before emitting so the UI sees the updated queue.
 		if (event.type === "message_start") {
-			if (event.message.role === "user") {
+			if (this._isPromptTurnStartMessage(event.message)) {
 				this._overflowRecoveryAttempted = false;
 			}
 			const steeringIndex = this._steeringMessages.findIndex((message) => message.message === event.message);
@@ -1779,6 +1784,14 @@ export class AgentSession {
 				this._scheduleAutoRefineAfterAgentEnd();
 			}
 		}
+	}
+
+	private _isPromptTurnStartMessage(message: AgentMessage): boolean {
+		return (
+			message.role === "user" ||
+			(message.role === "custom" &&
+				(message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE || message.customType === GOAL_CONTEXT_CUSTOM_TYPE))
+		);
 	}
 
 	/** Resolve the pending retry promise */

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -125,6 +125,7 @@ import {
 	createGoalContextMessage,
 	emptyGoalState,
 	GOAL_CONTEXT_CUSTOM_TYPE,
+	GOAL_CONTEXT_PREVIEW_LABEL,
 	GOAL_SKILL_NAME,
 	GOAL_STATE_CUSTOM_TYPE,
 	type GoalHostResponse,
@@ -145,6 +146,7 @@ import {
 	type CustomMessage,
 	createHeartbeatPromptMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -427,9 +429,9 @@ function queuedMessagePreview(message: { text: string; previewLabel?: string }):
 function injectedMessagePreviewLabel(message: CustomMessage): string | undefined {
 	switch (message.customType) {
 		case HEARTBEAT_PROMPT_CUSTOM_TYPE:
-			return "Heartbeat prompt";
+			return HEARTBEAT_PROMPT_PREVIEW_LABEL;
 		case GOAL_CONTEXT_CUSTOM_TYPE:
-			return "Goal context";
+			return GOAL_CONTEXT_PREVIEW_LABEL;
 		default:
 			return undefined;
 	}

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -192,6 +192,12 @@ export class AgentCronJobStore {
 			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
 	}
 
+	getLatestHeartbeat(activeSessionId: string): AgentCronJob | undefined {
+		return this.readJobs()
+			.filter((job) => job.activeSessionId === activeSessionId && job.source === "heartbeat")
+			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+	}
+
 	createHeartbeat(input: CreateAgentCronJobInput): AgentCronJob {
 		const now = input.now ?? new Date();
 		const parsed = parseAgentCronSchedule(input.scheduleText, now);

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -3,6 +3,7 @@ import type { CustomMessage } from "./messages.js";
 
 export const GOAL_STATE_CUSTOM_TYPE = "thread_goal_state";
 export const GOAL_CONTEXT_CUSTOM_TYPE = "goal_context";
+export const GOAL_CONTEXT_PREVIEW_LABEL = "Goal context";
 export const GOAL_SKILL_NAME = "goal";
 export const MAX_THREAD_GOAL_OBJECTIVE_CHARS = 4000;
 

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -166,7 +166,7 @@ export function createGoalContextMessage(
 		role: "custom",
 		customType: GOAL_CONTEXT_CUSTOM_TYPE,
 		content,
-		display: false,
+		display: true,
 		details: {
 			kind,
 			goalId: goal.goalId,

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -7,6 +7,7 @@
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import type { AgentCronJob } from "./cron-jobs.js";
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
 
@@ -22,6 +23,8 @@ export const BRANCH_SUMMARY_PREFIX = `The following is a summary of a branch tha
 `;
 
 export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
+
+export const HEARTBEAT_PROMPT_CUSTOM_TYPE = "heartbeat_prompt";
 
 /**
  * Message type for bash executions via the ! command.
@@ -50,6 +53,15 @@ export interface CustomMessage<T = unknown> {
 	display: boolean;
 	details?: T;
 	timestamp: number;
+}
+
+export interface HeartbeatPromptDetails {
+	jobId: string;
+	schedule: string;
+	status: AgentCronJob["status"];
+	runCount: number;
+	nextRunAt?: string;
+	lastRunAt?: string;
 }
 
 export interface BranchSummaryMessage {
@@ -138,6 +150,27 @@ export function createCustomMessage(
 		display,
 		details,
 		timestamp: new Date(timestamp).getTime(),
+	};
+}
+
+export function createHeartbeatPromptMessage(
+	job: AgentCronJob,
+	timestamp = Date.now(),
+): CustomMessage<HeartbeatPromptDetails> {
+	return {
+		role: "custom",
+		customType: HEARTBEAT_PROMPT_CUSTOM_TYPE,
+		content: job.prompt,
+		display: true,
+		details: {
+			jobId: job.id,
+			schedule: job.schedule.expression,
+			status: job.status,
+			runCount: job.runCount,
+			nextRunAt: job.nextRunAt,
+			lastRunAt: job.lastRunAt,
+		},
+		timestamp,
 	};
 }
 

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -25,6 +25,7 @@ export const BRANCH_SUMMARY_PREFIX = `The following is a summary of a branch tha
 export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
 
 export const HEARTBEAT_PROMPT_CUSTOM_TYPE = "heartbeat_prompt";
+export const HEARTBEAT_PROMPT_PREVIEW_LABEL = "Heartbeat prompt";
 
 /**
  * Message type for bash executions via the ! command.

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -144,8 +144,8 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async getQueue(): Promise<AgentConnectionQueueState> {
 		return {
-			steering: [...this.session.getSteeringMessages()],
-			followUp: [...this.session.getFollowUpMessages()],
+			steering: [...this.session.getSteeringMessagePreviews()],
+			followUp: [...this.session.getFollowUpMessagePreviews()],
 		};
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -275,6 +275,7 @@ export interface AgentConnectionState {
 	pendingMessageCount: number;
 	compactionCount: number;
 	goal: GoalState;
+	heartbeat?: AgentCronJob | null;
 	scopedModels: AgentConnectionScopedModel[];
 	activeToolNames: string[];
 	contextUsage: SessionStats["contextUsage"];

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -21,6 +21,7 @@ import {
 export interface ActiveSessionBindingCallbacks {
 	broadcast: (state: ActiveSessionState, message: DaemonOutbound) => void;
 	createConnectionState?: (state: ActiveSessionState) => AgentConnectionState;
+	sessionReplaced?: (state: ActiveSessionState) => void;
 	shutdown: () => void;
 	subagentRuntimeHost?: SubagentRuntimeHost;
 }
@@ -67,6 +68,7 @@ export async function bindActiveSessionState(
 	});
 
 	state.runtime.setRebindSession(async () => {
+		callbacks.sessionReplaced?.(state);
 		await bindActiveSessionState(state, callbacks);
 		callbacks.broadcast(state, {
 			type: "session_replaced",

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../core/extensions/index.js";
 import type { SubagentRuntimeHost } from "../../core/rlm-runtime.js";
 import { createAgentConnectionState } from "../agent-connection/snapshot.js";
+import type { AgentConnectionState } from "../agent-connection/types.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import type { ActiveSessionState } from "./active-session-state.js";
 import { execEnvForSession, withClientEnv } from "./daemon-client-env.js";
@@ -19,6 +20,7 @@ import {
 
 export interface ActiveSessionBindingCallbacks {
 	broadcast: (state: ActiveSessionState, message: DaemonOutbound) => void;
+	createConnectionState?: (state: ActiveSessionState) => AgentConnectionState;
 	shutdown: () => void;
 	subagentRuntimeHost?: SubagentRuntimeHost;
 }
@@ -69,7 +71,9 @@ export async function bindActiveSessionState(
 		callbacks.broadcast(state, {
 			type: "session_replaced",
 			activeSessionId: state.activeSessionId,
-			state: createAgentConnectionState(state.runtime, state.activeSessionId),
+			state:
+				callbacks.createConnectionState?.(state) ??
+				createAgentConnectionState(state.runtime, state.activeSessionId),
 			messages: state.runtime.session.messages,
 		});
 	});

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -68,8 +68,8 @@ export async function bindActiveSessionState(
 	});
 
 	state.runtime.setRebindSession(async () => {
-		callbacks.sessionReplaced?.(state);
 		await bindActiveSessionState(state, callbacks);
+		callbacks.sessionReplaced?.(state);
 		callbacks.broadcast(state, {
 			type: "session_replaced",
 			activeSessionId: state.activeSessionId,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -44,7 +44,7 @@ import {
 	normalizeObserveLimit,
 	normalizeObserveMaxChars,
 } from "../../core/agent-observe.js";
-import type { PromptOptions } from "../../core/agent-session.js";
+import type { AgentSession, PromptOptions } from "../../core/agent-session.js";
 import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import {
 	AgentSessionRuntime,
@@ -588,9 +588,16 @@ export class AgentDaemon {
 			await session.followUp(job.prompt);
 			return;
 		}
+		if (isHeartbeatCronJob(job)) {
+			await this.promptHeartbeatWithAgentMessagePreparingGuard(state, job, {
+				streamingBehavior: "followUp",
+				followUpQueueKey: `heartbeat:${job.id}`,
+				source: "rpc",
+			});
+			return;
+		}
 		await this.promptWithAgentMessagePreparingGuard(state, job.prompt, {
 			streamingBehavior: "followUp",
-			followUpQueueKey: isHeartbeatCronJob(job) ? `heartbeat:${job.id}` : undefined,
 			source: "rpc",
 		});
 	}
@@ -603,6 +610,35 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		message: string,
 		options?: PromptOptions,
+	): Promise<void> {
+		await this.withAgentMessagePreparingGuard(state, (session) =>
+			session.prompt(message, {
+				...options,
+				preflightResult: (didSucceed) => {
+					options?.preflightResult?.(didSucceed);
+				},
+			}),
+		);
+	}
+
+	private async promptHeartbeatWithAgentMessagePreparingGuard(
+		state: ActiveSessionState,
+		job: AgentCronJob,
+		options?: PromptOptions,
+	): Promise<void> {
+		await this.withAgentMessagePreparingGuard(state, (session) =>
+			session.promptHeartbeat(job, {
+				...options,
+				preflightResult: (didSucceed) => {
+					options?.preflightResult?.(didSucceed);
+				},
+			}),
+		);
+	}
+
+	private async withAgentMessagePreparingGuard(
+		state: ActiveSessionState,
+		run: (session: AgentSession) => Promise<void>,
 	): Promise<void> {
 		const activeSessionId = state.activeSessionId;
 		const session = state.runtime.session;
@@ -625,12 +661,7 @@ export class AgentDaemon {
 		};
 		try {
 			await this.agentMessageTargetLocks.get(activeSessionId)?.catch(() => undefined);
-			await session.prompt(message, {
-				...options,
-				preflightResult: (didSucceed) => {
-					options?.preflightResult?.(didSucceed);
-				},
-			});
+			await run(session);
 		} finally {
 			clearPreparing();
 		}
@@ -1394,11 +1425,7 @@ export class AgentDaemon {
 
 			case "get_connection_state": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(
-					command.id,
-					"get_connection_state",
-					createAgentConnectionState(state.runtime, state.activeSessionId),
-				);
+				return success(command.id, "get_connection_state", this.createConnectionState(state));
 			}
 
 			case "get_messages": {
@@ -1444,8 +1471,8 @@ export class AgentDaemon {
 			case "get_queue": {
 				const state = this.getSessionState(command.activeSessionId);
 				return success(command.id, "get_queue", {
-					steering: [...state.runtime.session.getSteeringMessages()],
-					followUp: [...state.runtime.session.getFollowUpMessages()],
+					steering: [...state.runtime.session.getSteeringMessagePreviews()],
+					followUp: [...state.runtime.session.getFollowUpMessagePreviews()],
 				});
 			}
 
@@ -1789,11 +1816,7 @@ export class AgentDaemon {
 					}
 				: undefined;
 		const children = buildRlmChildSnapshots(state.activeSessionId, [...this.sessions.values()]);
-		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		// Prefer the live in-memory recap over the persisted baseline.
-		if (state.summaryState?.summary) {
-			connectionState.recap = state.summaryState.summary;
-		}
+		const connectionState = this.createConnectionState(state);
 		return {
 			activeSessionId: state.activeSessionId,
 			summary: summaryForActiveSession(state),
@@ -1806,6 +1829,15 @@ export class AgentDaemon {
 			...(parent ? { parent } : {}),
 			...(children.length > 0 ? { children } : {}),
 		};
+	}
+
+	private createConnectionState(state: ActiveSessionState): ReturnType<typeof createAgentConnectionState> {
+		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
+		connectionState.heartbeat = this.cronStore.getHeartbeat(state.activeSessionId) ?? null;
+		if (state.summaryState?.summary) {
+			connectionState.recap = state.summaryState.summary;
+		}
+		return connectionState;
 	}
 
 	private createAgentSessionMessageEndpoint(state: ActiveSessionState): AgentSessionMessageEndpoint {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -392,6 +392,7 @@ export class AgentDaemon {
 			await bindActiveSessionState(state, {
 				broadcast: (targetSessionState, message) => this.broadcastToSession(targetSessionState, message),
 				createConnectionState: (targetSessionState) => this.createConnectionState(targetSessionState),
+				sessionReplaced: (targetSessionState) => this.refreshReplacedSessionState(targetSessionState),
 				shutdown: () => {
 					void this.shutdown(0);
 				},
@@ -419,6 +420,18 @@ export class AgentDaemon {
 		// Restore the last persisted status so it shows before the first sweep.
 		this.summarizer.seed(state);
 		return state;
+	}
+
+	private refreshReplacedSessionState(state: ActiveSessionState): void {
+		this.summarizer.forget(state.activeSessionId);
+		state.summaryState = undefined;
+		state.runtime.session.setCurrentRecap(undefined);
+		this.summarizer.seed(state);
+		if (state.runtime.metadata.kind === "subagent") {
+			const summaryState = state.summaryState as ActiveSessionState["summaryState"];
+			state.runtime.session.setCurrentRecap(summaryState?.summary);
+		}
+		this.rebindCronJobsToState(state);
 	}
 
 	private async createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState> {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -391,6 +391,7 @@ export class AgentDaemon {
 		try {
 			await bindActiveSessionState(state, {
 				broadcast: (targetSessionState, message) => this.broadcastToSession(targetSessionState, message),
+				createConnectionState: (targetSessionState) => this.createConnectionState(targetSessionState),
 				shutdown: () => {
 					void this.shutdown(0);
 				},
@@ -1833,7 +1834,7 @@ export class AgentDaemon {
 
 	private createConnectionState(state: ActiveSessionState): ReturnType<typeof createAgentConnectionState> {
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
-		connectionState.heartbeat = this.cronStore.getHeartbeat(state.activeSessionId) ?? null;
+		connectionState.heartbeat = this.cronStore.getLatestHeartbeat(state.activeSessionId) ?? null;
 		if (state.summaryState?.summary) {
 			connectionState.recap = state.summaryState.summary;
 		}

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Component, MarkdownTheme, TUI } from "@earendil-works/pi-tui";
 import { AssistantMessageComponent } from "./assistant-message.js";
+import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
 import { ToolExecutionComponent, type ToolExecutionDefinition, type ToolExecutionOptions } from "./tool-execution.js";
 import { UserMessageComponent } from "./user-message.js";
 
@@ -77,6 +78,10 @@ export function buildConversationComponents(
 		} else if (message.role === "toolResult") {
 			pendingTools.get(message.toolCallId)?.updateResult(message);
 			pendingTools.delete(message.toolCallId);
+		} else if (isInjectedPromptMessage(message) && message.display) {
+			const component = new InjectedPromptMessageComponent(message, options.markdownTheme);
+			component.setExpanded(expanded);
+			components.push(component);
 		} else if (message.role === "user") {
 			const text = readUserText(message.content);
 			const hasContent =
@@ -87,7 +92,7 @@ export function buildConversationComponents(
 				components.push(new UserMessageComponent(display, options.markdownTheme));
 			}
 		}
-		// Non-conversational messages (bash/branch-summary/compaction/custom) aren't shown.
+		// Non-conversational messages (bash/branch-summary/compaction/other custom) aren't shown.
 	}
 	return components;
 }

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -20,6 +20,7 @@ export { ExtensionEditorComponent } from "./extension-editor.js";
 export { ExtensionInputComponent } from "./extension-input.js";
 export { ExtensionSelectorComponent } from "./extension-selector.js";
 export { FooterComponent } from "./footer.js";
+export { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
 export {
 	getIpythonCodeFromArgs,
 	IPythonCellComponent,

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -1,0 +1,144 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { TextContent } from "@earendil-works/pi-ai";
+import {
+	Container,
+	Markdown,
+	type MarkdownTheme,
+	Spacer,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import { GOAL_CONTEXT_CUSTOM_TYPE, type GoalContextDetails } from "../../../core/goals.js";
+import {
+	type CustomMessage,
+	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+	type HeartbeatPromptDetails,
+} from "../../../core/messages.js";
+import { getMarkdownTheme, theme } from "../theme/theme.js";
+import { keyText } from "./keybinding-hints.js";
+
+type InjectedPromptDetails = GoalContextDetails | HeartbeatPromptDetails;
+type InjectedPromptMessage = CustomMessage<InjectedPromptDetails>;
+
+export function isInjectedPromptMessage(message: AgentMessage): message is InjectedPromptMessage {
+	return (
+		message.role === "custom" &&
+		(message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE || message.customType === GOAL_CONTEXT_CUSTOM_TYPE)
+	);
+}
+
+function readCustomText(message: CustomMessage): string {
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+	return message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+function collapseText(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function goalLabel(details: GoalContextDetails | undefined): string {
+	switch (details?.kind) {
+		case "continuation":
+			return "Goal continuation";
+		case "budget_limit":
+			return "Goal budget limit";
+		case "objective_updated":
+			return "Goal updated";
+		default:
+			return "Goal context";
+	}
+}
+
+function compactHeartbeatSchedule(schedule: string | undefined): string {
+	const trimmed = schedule?.trim();
+	if (!trimmed) {
+		return "prompt";
+	}
+	return trimmed.replace(/^every\s+/i, "");
+}
+
+export class InjectedPromptMessageComponent extends Container {
+	private readonly content = new Container();
+	private readonly header = new Text("", 1, 0);
+	private expanded = false;
+
+	constructor(
+		private readonly message: InjectedPromptMessage,
+		private readonly markdownTheme: MarkdownTheme = getMarkdownTheme(),
+	) {
+		super();
+		this.addChild(new Spacer(1));
+		this.addChild(this.content);
+		this.updateDisplay();
+	}
+
+	setExpanded(expanded: boolean): void {
+		if (this.expanded === expanded) {
+			return;
+		}
+		this.expanded = expanded;
+		this.updateDisplay();
+	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.updateDisplay();
+	}
+
+	private updateDisplay(): void {
+		this.content.clear();
+		this.header.setText(this.headerText());
+		this.content.addChild(this.header);
+		if (this.expanded) {
+			this.content.addChild(
+				new Markdown(readCustomText(this.message), 1, 0, this.markdownTheme, {
+					color: (text: string) => theme.fg("customMessageText", text),
+				}),
+			);
+			return;
+		}
+	}
+
+	private headerText(): string {
+		if (this.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
+			return this.heartbeatHeaderText();
+		}
+
+		const details = this.message.details;
+		const title = goalLabel(details as GoalContextDetails | undefined);
+		const meta = this.metaText();
+		const hint = this.expanded ? "" : ` (${keyText("app.tools.expand")} to expand)`;
+		return theme.fg("muted", title) + meta + theme.fg("dim", hint);
+	}
+
+	private heartbeatHeaderText(): string {
+		const details = this.message.details as HeartbeatPromptDetails | undefined;
+		const pulse = theme.fg("error", "♥");
+		const schedule = theme.fg("muted", compactHeartbeatSchedule(details?.schedule));
+		const hint = this.expanded ? "" : ` (${keyText("app.tools.expand")} to expand)`;
+		return `${pulse} ${theme.fg("muted", "Heartbeat prompt")}${theme.fg("dim", " · ")}${schedule}${theme.fg("dim", hint)}`;
+	}
+
+	private metaText(): string {
+		const details = this.message.details;
+		if (this.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
+			const heartbeat = details as HeartbeatPromptDetails | undefined;
+			if (!heartbeat?.schedule) {
+				return "";
+			}
+			return theme.fg("muted", ` · ${heartbeat.schedule}`);
+		}
+		const goal = details as GoalContextDetails | undefined;
+		if (!goal?.objective) {
+			return "";
+		}
+		const prefixWidth = visibleWidth("Goal continuation · ");
+		return theme.fg("muted", ` · ${truncateToWidth(collapseText(goal.objective), Math.max(20, 90 - prefixWidth))}`);
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -63,6 +63,11 @@ function compactHeartbeatSchedule(schedule: string | undefined): string {
 	return trimmed.replace(/^every\s+/i, "");
 }
 
+function heartbeatPromptSchedule(schedule: string | undefined): string {
+	const compact = compactHeartbeatSchedule(schedule);
+	return compact === "prompt" ? "scheduled" : `every ${compact}`;
+}
+
 export class InjectedPromptMessageComponent extends Container {
 	private readonly content = new Container();
 	private readonly header = new Text("", 1, 0);
@@ -120,7 +125,7 @@ export class InjectedPromptMessageComponent extends Container {
 	private heartbeatHeaderText(): string {
 		const details = this.message.details as HeartbeatPromptDetails | undefined;
 		const pulse = theme.fg("error", "♥");
-		const schedule = theme.fg("muted", compactHeartbeatSchedule(details?.schedule));
+		const schedule = theme.fg("muted", heartbeatPromptSchedule(details?.schedule));
 		const hint = this.expanded ? "" : ` (${keyText("app.tools.expand")} to expand)`;
 		return `${pulse} ${theme.fg("muted", "Heartbeat prompt")}${theme.fg("dim", " · ")}${schedule}${theme.fg("dim", hint)}`;
 	}

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -1,5 +1,4 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { TextContent } from "@earendil-works/pi-ai";
 import {
 	Container,
 	Markdown,
@@ -32,10 +31,7 @@ function readCustomText(message: CustomMessage): string {
 	if (typeof message.content === "string") {
 		return message.content;
 	}
-	return message.content
-		.filter((block): block is TextContent => block.type === "text")
-		.map((block) => block.text)
-		.join("\n");
+	return message.content.map((block) => (block.type === "text" ? block.text : "[image]")).join("\n");
 }
 
 function collapseText(text: string): string {

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -128,13 +128,6 @@ export class InjectedPromptMessageComponent extends Container {
 
 	private metaText(): string {
 		const details = this.message.details;
-		if (this.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
-			const heartbeat = details as HeartbeatPromptDetails | undefined;
-			if (!heartbeat?.schedule) {
-				return "";
-			}
-			return theme.fg("muted", ` · ${heartbeat.schedule}`);
-		}
 		const goal = details as GoalContextDetails | undefined;
 		if (!goal?.objective) {
 			return "";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -222,7 +222,7 @@ interface PendingToolCallRenderInput {
 const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
 const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
 
-function isLabeledQueuedFollowUpPreview(message: string): boolean {
+function isLabeledQueuedPreview(message: string): boolean {
 	return (
 		message.startsWith(`${HEARTBEAT_PROMPT_PREVIEW_LABEL}: `) || message.startsWith(`${GOAL_CONTEXT_PREVIEW_LABEL}: `)
 	);
@@ -5958,11 +5958,11 @@ export class InteractiveMode {
 		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
 			this.queuedMessagesContainer.addChild(new Spacer(1));
 			for (const message of steeringMessages) {
-				const text = theme.fg("dim", `Steering: ${message}`);
+				const text = theme.fg("dim", isLabeledQueuedPreview(message) ? message : `Steering: ${message}`);
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			for (const message of followUpMessages) {
-				const text = theme.fg("dim", isLabeledQueuedFollowUpPreview(message) ? message : `Follow-up: ${message}`);
+				const text = theme.fg("dim", isLabeledQueuedPreview(message) ? message : `Follow-up: ${message}`);
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5014,7 +5014,6 @@ export class InteractiveMode {
 		if (
 			message.role !== "user" ||
 			!heartbeat ||
-			(heartbeat.status !== "active" && heartbeat.status !== "paused") ||
 			!this.isTextOnlyUserMessage(message) ||
 			textContent.trim() !== heartbeat.prompt.trim() ||
 			!this.isLikelyHeartbeatPromptTimestamp(heartbeat, message.timestamp)
@@ -7680,7 +7679,7 @@ export class InteractiveMode {
 						this.showStatus("No active heartbeat");
 						return;
 					}
-					this.patchConnectionState({ heartbeat: null });
+					this.patchConnectionState({ heartbeat });
 					this.showStatus("Heartbeat cleared");
 					return;
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -78,7 +78,7 @@ import type {
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { emptyGoalState, formatGoalUsage, type GoalState } from "../../core/goals.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
-import { createCompactionSummaryMessage } from "../../core/messages.js";
+import { createCompactionSummaryMessage, createHeartbeatPromptMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
@@ -153,6 +153,7 @@ import { ExtensionEditorComponent } from "./components/extension-editor.js";
 import { ExtensionInputComponent } from "./components/extension-input.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
 import { FooterComponent } from "./components/footer.js";
+import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./components/injected-prompt-message.js";
 import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import { type ModelSelectorAction, ModelSelectorComponent } from "./components/model-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
@@ -212,6 +213,9 @@ interface PendingToolCallRenderInput {
 	name: string;
 	arguments: ToolCall["arguments"];
 }
+
+const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
+const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
 
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
@@ -4704,12 +4708,40 @@ export class InteractiveMode {
 
 	private getTrayContextLabel(): string | undefined {
 		const goalLabel = this.getTrayGoalLabel();
+		const heartbeatLabel = this.getTrayHeartbeatLabel();
 		const usage = this.getConnectionContextUsage();
 		const contextLabel =
 			usage && typeof usage.tokens === "number" && typeof usage.percent === "number"
 				? `${formatTokenCount(usage.tokens)} (${Math.round(usage.percent)}%)`
 				: undefined;
-		return [goalLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;
+		return [goalLabel, heartbeatLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;
+	}
+
+	private getTrayHeartbeatLabel(): string | undefined {
+		const heartbeat = this.connectionState?.heartbeat;
+		if (!heartbeat) {
+			return undefined;
+		}
+		const schedule = this.formatHeartbeatScheduleLabel(heartbeat);
+		const suffix = schedule ? ` (${schedule})` : "";
+		switch (heartbeat.status) {
+			case "active":
+				return `Heartbeat active${suffix}`;
+			case "paused":
+				return `Heartbeat paused${suffix}`;
+			case "completed":
+			case "cancelled":
+				return undefined;
+			default: {
+				const _exhaustive: never = heartbeat.status;
+				return _exhaustive;
+			}
+		}
+	}
+
+	private formatHeartbeatScheduleLabel(heartbeat: AgentCronJob): string | undefined {
+		const schedule = heartbeat.schedule.expression.trim().replace(/^every\s+/i, "");
+		return schedule || undefined;
 	}
 
 	private getTrayGoalLabel(): string | undefined {
@@ -4974,6 +5006,67 @@ export class InteractiveMode {
 		return textBlocks.map((c) => (c as { text: string }).text).join("");
 	}
 
+	private createLegacyHeartbeatPromptMessage(
+		message: Message,
+		textContent: string,
+	): ReturnType<typeof createHeartbeatPromptMessage> | undefined {
+		const heartbeat = this.connectionState?.heartbeat;
+		if (
+			message.role !== "user" ||
+			!heartbeat ||
+			(heartbeat.status !== "active" && heartbeat.status !== "paused") ||
+			!this.isTextOnlyUserMessage(message) ||
+			textContent.trim() !== heartbeat.prompt.trim() ||
+			!this.isLikelyHeartbeatPromptTimestamp(heartbeat, message.timestamp)
+		) {
+			return undefined;
+		}
+
+		return createHeartbeatPromptMessage(heartbeat, message.timestamp);
+	}
+
+	private isTextOnlyUserMessage(message: Message): boolean {
+		if (message.role !== "user") {
+			return false;
+		}
+		if (typeof message.content === "string") {
+			return true;
+		}
+		return message.content.every((content) => content.type === "text");
+	}
+
+	private isLikelyHeartbeatPromptTimestamp(job: AgentCronJob, timestamp: number): boolean {
+		const directRunTimes = [job.lastRunAt, job.nextRunAt]
+			.map((value) => (value ? Date.parse(value) : Number.NaN))
+			.filter((value) => Number.isFinite(value));
+		const tolerance = this.heartbeatLegacyPromptToleranceMs(job);
+		if (directRunTimes.some((runAt) => Math.abs(timestamp - runAt) <= tolerance)) {
+			return true;
+		}
+
+		const intervalMs = job.schedule.intervalMs;
+		const nextRunAt = job.nextRunAt ? Date.parse(job.nextRunAt) : Number.NaN;
+		if (job.schedule.kind !== "interval" || !intervalMs || intervalMs <= 0 || !Number.isFinite(nextRunAt)) {
+			return false;
+		}
+
+		const distanceFromReference = Math.abs(timestamp - nextRunAt);
+		const remainder = distanceFromReference % intervalMs;
+		const nearestRunDistance = Math.min(remainder, intervalMs - remainder);
+		return nearestRunDistance <= Math.min(tolerance, intervalMs / 2);
+	}
+
+	private heartbeatLegacyPromptToleranceMs(job: AgentCronJob): number {
+		const intervalMs = job.schedule.intervalMs;
+		if (!intervalMs || intervalMs <= 0) {
+			return HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS;
+		}
+		return Math.min(
+			HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS,
+			Math.max(HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS, intervalMs / 3),
+		);
+	}
+
 	/**
 	 * Show a status message in the chat.
 	 *
@@ -5029,10 +5122,15 @@ export class InteractiveMode {
 			}
 			case "custom": {
 				if (message.display) {
-					const renderer = this.bindLocalSessionExtensions
-						? this.getLocalSessionHost().getExtensionRunner().getMessageRenderer(message.customType)
-						: undefined;
-					const component = new CustomMessageComponent(message, renderer, this.getMarkdownThemeWithSettings());
+					const component = isInjectedPromptMessage(message)
+						? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
+						: new CustomMessageComponent(
+								message,
+								this.bindLocalSessionExtensions
+									? this.getLocalSessionHost().getExtensionRunner().getMessageRenderer(message.customType)
+									: undefined,
+								this.getMarkdownThemeWithSettings(),
+							);
 					component.setExpanded(this.toolOutputExpanded);
 					this.chatContainer.addChild(component);
 				}
@@ -5055,6 +5153,20 @@ export class InteractiveMode {
 			case "user": {
 				const textContent = this.getUserMessageText(message);
 				if (textContent) {
+					const heartbeatMessage = this.createLegacyHeartbeatPromptMessage(message, textContent);
+					if (heartbeatMessage) {
+						if (this.chatContainer.children.length > 0) {
+							this.chatContainer.addChild(new Spacer(1));
+						}
+						const component = new InjectedPromptMessageComponent(
+							heartbeatMessage,
+							this.getMarkdownThemeWithSettings(),
+						);
+						component.setExpanded(this.toolOutputExpanded);
+						this.chatContainer.addChild(component);
+						break;
+					}
+
 					if (this.chatContainer.children.length > 0) {
 						this.chatContainer.addChild(new Spacer(1));
 					}
@@ -5810,7 +5922,7 @@ export class InteractiveMode {
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			for (const message of followUpMessages) {
-				const text = theme.fg("dim", `Follow-up: ${message}`);
+				const text = theme.fg("dim", message.startsWith("Heartbeat: ") ? message : `Follow-up: ${message}`);
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");
@@ -7532,11 +7644,13 @@ export class InteractiveMode {
 			switch (command.type) {
 				case "status": {
 					const heartbeat = await this.agentConnection.getHeartbeat();
+					this.patchConnectionState({ heartbeat: heartbeat ?? null });
 					this.showHeartbeat(heartbeat);
 					return;
 				}
 				case "set": {
 					const heartbeat = await this.agentConnection.setHeartbeat(command.schedule, command.instruction);
+					this.patchConnectionState({ heartbeat });
 					this.showStatus(`Heartbeat set\nNext run: ${heartbeat.nextRunAt ?? "-"}`);
 					return;
 				}
@@ -7546,6 +7660,7 @@ export class InteractiveMode {
 						this.showStatus("No active heartbeat");
 						return;
 					}
+					this.patchConnectionState({ heartbeat });
 					this.showStatus("Heartbeat paused");
 					return;
 				}
@@ -7555,6 +7670,7 @@ export class InteractiveMode {
 						this.showStatus("No active heartbeat");
 						return;
 					}
+					this.patchConnectionState({ heartbeat });
 					this.showStatus(`Heartbeat resumed\nNext run: ${heartbeat.nextRunAt ?? "-"}`);
 					return;
 				}
@@ -7564,6 +7680,7 @@ export class InteractiveMode {
 						this.showStatus("No active heartbeat");
 						return;
 					}
+					this.patchConnectionState({ heartbeat: null });
 					this.showStatus("Heartbeat cleared");
 					return;
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -78,7 +78,11 @@ import type {
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { emptyGoalState, formatGoalUsage, type GoalState } from "../../core/goals.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
-import { createCompactionSummaryMessage, createHeartbeatPromptMessage } from "../../core/messages.js";
+import {
+	createCompactionSummaryMessage,
+	createHeartbeatPromptMessage,
+	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+} from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
@@ -2823,6 +2827,12 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private clearStaleRecapForPromptTurn(): void {
+		this.sessionRecap = undefined;
+		this.renderRecap();
+		this.updatePendingMessagesDisplay();
+	}
+
 	private renderWidgetContainer(
 		container: Container,
 		widgets: Map<string, Component & { dispose?(): void }>,
@@ -4146,13 +4156,13 @@ export class InteractiveMode {
 			case "message_start":
 				if (event.message.role === "custom") {
 					this.addMessageToChat(event.message);
+					if (event.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
+						this.clearStaleRecapForPromptTurn();
+					}
 					this.ui.requestRender();
 				} else if (event.message.role === "user") {
 					this.addMessageToChat(event.message);
-					// A new turn makes the recap stale; clear it until the summarizer pushes a fresh one.
-					this.sessionRecap = undefined;
-					this.renderRecap();
-					this.updatePendingMessagesDisplay();
+					this.clearStaleRecapForPromptTurn();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
 					this.startAssistantStreamingMessage(event.message);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5042,17 +5042,7 @@ export class InteractiveMode {
 		if (directRunTimes.some((runAt) => Math.abs(timestamp - runAt) <= tolerance)) {
 			return true;
 		}
-
-		const intervalMs = job.schedule.intervalMs;
-		const nextRunAt = job.nextRunAt ? Date.parse(job.nextRunAt) : Number.NaN;
-		if (job.schedule.kind !== "interval" || !intervalMs || intervalMs <= 0 || !Number.isFinite(nextRunAt)) {
-			return false;
-		}
-
-		const distanceFromReference = Math.abs(timestamp - nextRunAt);
-		const remainder = distanceFromReference % intervalMs;
-		const nearestRunDistance = Math.min(remainder, intervalMs - remainder);
-		return nearestRunDistance <= Math.min(tolerance, intervalMs / 2);
+		return false;
 	}
 
 	private heartbeatLegacyPromptToleranceMs(job: AgentCronJob): number {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -76,12 +76,13 @@ import type {
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
-import { emptyGoalState, formatGoalUsage, type GoalState } from "../../core/goals.js";
+import { emptyGoalState, formatGoalUsage, GOAL_CONTEXT_PREVIEW_LABEL, type GoalState } from "../../core/goals.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import {
 	createCompactionSummaryMessage,
 	createHeartbeatPromptMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
@@ -220,6 +221,12 @@ interface PendingToolCallRenderInput {
 
 const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
 const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
+
+function isLabeledQueuedFollowUpPreview(message: string): boolean {
+	return (
+		message.startsWith(`${HEARTBEAT_PROMPT_PREVIEW_LABEL}: `) || message.startsWith(`${GOAL_CONTEXT_PREVIEW_LABEL}: `)
+	);
+}
 
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
@@ -5941,7 +5948,7 @@ export class InteractiveMode {
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			for (const message of followUpMessages) {
-				const text = theme.fg("dim", message.startsWith("Heartbeat: ") ? message : `Follow-up: ${message}`);
+				const text = theme.fg("dim", isLabeledQueuedFollowUpPreview(message) ? message : `Follow-up: ${message}`);
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -230,6 +230,7 @@ describe("AgentCronJobStore", () => {
 			status: "cancelled",
 		});
 		expect(store.getHeartbeat("active-1")).toBeUndefined();
+		expect(store.getLatestHeartbeat("active-1")).toMatchObject({ id: job.id, status: "cancelled" });
 	});
 
 	it("rejects one-shot heartbeat schedules", () => {

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -11,8 +11,10 @@ import {
 	createAgentSessionServices,
 } from "../src/core/agent-session-runtime.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
+import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import type { ExtensionAPI, ExtensionFactory } from "../src/index.js";
+import { createAgentConnectionState } from "../src/modes/agent-connection/snapshot.js";
 import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
 import { bindActiveSessionState } from "../src/modes/daemon/daemon-extension-binding.js";
 import type { DaemonOutbound } from "../src/modes/daemon/daemon-protocol.js";
@@ -171,6 +173,21 @@ describe("daemon extension binding", () => {
 		);
 
 		const outbound: DaemonOutbound[] = [];
+		const heartbeat: AgentCronJob = {
+			id: "heartbeat-1",
+			status: "active",
+			source: "heartbeat",
+			activeSessionId: "active-test",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			prompt: "check status",
+			schedule: { kind: "interval", expression: "every 10s", intervalMs: 10_000 },
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+			nextRunAt: "2026-01-01T00:00:10.000Z",
+			runCount: 0,
+		};
 		const state: ActiveSessionState = {
 			activeSessionId: "active-test",
 			runtime,
@@ -185,6 +202,10 @@ describe("daemon extension binding", () => {
 					phases.push("broadcast:session_replaced");
 				}
 			},
+			createConnectionState: (targetState) => ({
+				...createAgentConnectionState(targetState.runtime, targetState.activeSessionId),
+				heartbeat,
+			}),
 			shutdown: () => {
 				phases.push("shutdown");
 			},
@@ -203,6 +224,9 @@ describe("daemon extension binding", () => {
 			expect.objectContaining({
 				type: "session_replaced",
 				activeSessionId: "active-test",
+				state: expect.objectContaining({
+					heartbeat: expect.objectContaining({ id: "heartbeat-1" }),
+				}),
 			}),
 		);
 		expect(runtime.session.messages.map((message) => `${message.role}:${getText(message)}`)).toEqual([

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -194,6 +194,7 @@ describe("daemon extension binding", () => {
 			clients: new Set(),
 			extensionUiRequests: new Map(),
 			lastEventSequence: 0,
+			summaryState: { summary: "old recap", taskState: "completed", basedOnMessageCount: 2 },
 		};
 		await bindActiveSessionState(state, {
 			broadcast: (_state, message) => {
@@ -202,10 +203,18 @@ describe("daemon extension binding", () => {
 					phases.push("broadcast:session_replaced");
 				}
 			},
-			createConnectionState: (targetState) => ({
-				...createAgentConnectionState(targetState.runtime, targetState.activeSessionId),
-				heartbeat,
-			}),
+			createConnectionState: (targetState) => {
+				const connectionState = createAgentConnectionState(targetState.runtime, targetState.activeSessionId);
+				if (targetState.summaryState?.summary) {
+					connectionState.recap = targetState.summaryState.summary;
+				}
+				connectionState.heartbeat = heartbeat;
+				return connectionState;
+			},
+			sessionReplaced: (targetState) => {
+				phases.push("sessionReplaced");
+				targetState.summaryState = undefined;
+			},
 			shutdown: () => {
 				phases.push("shutdown");
 			},
@@ -217,6 +226,7 @@ describe("daemon extension binding", () => {
 		const withSessionIndex = phases.indexOf("withSession");
 		expect(replacementIndex).toBeGreaterThan(-1);
 		expect(withSessionIndex).toBeGreaterThan(-1);
+		expect(phases.indexOf("sessionReplaced")).toBeLessThan(replacementIndex);
 		expect(replacementIndex).toBeLessThan(withSessionIndex);
 		expect(replacementSessionFile).toBeDefined();
 		expect(replacementSessionFile).not.toBe(oldSessionFile);
@@ -229,6 +239,11 @@ describe("daemon extension binding", () => {
 				}),
 			}),
 		);
+		const replaced = outbound.find(
+			(message): message is Extract<DaemonOutbound, { type: "session_replaced" }> =>
+				message.type === "session_replaced",
+		);
+		expect(replaced?.state.recap).toBeUndefined();
 		expect(runtime.session.messages.map((message) => `${message.role}:${getText(message)}`)).toEqual([
 			"user:daemon replacement message",
 			"assistant:replacement reply",

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2761,6 +2761,7 @@ describe("daemon mode helpers", () => {
 			},
 		});
 		const prompt = vi.fn(async () => {});
+		const promptHeartbeat = vi.fn(async () => {});
 		const followUp = vi.fn(async () => true);
 		const state = makeState("active-1") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
@@ -2769,6 +2770,7 @@ describe("daemon mode helpers", () => {
 					isBashRunning: boolean;
 					pendingMessageCount: number;
 					prompt: typeof prompt;
+					promptHeartbeat: typeof promptHeartbeat;
 					followUp: typeof followUp;
 				};
 			};
@@ -2778,6 +2780,7 @@ describe("daemon mode helpers", () => {
 			isBashRunning: false,
 			pendingMessageCount: 0,
 			prompt,
+			promptHeartbeat,
 			followUp,
 		} as never;
 		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
@@ -2787,14 +2790,15 @@ describe("daemon mode helpers", () => {
 		);
 
 		// The preparing guard adds an internal preflightResult hook.
-		expect(prompt).toHaveBeenCalledWith(
-			"heartbeat prompt",
+		expect(promptHeartbeat).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "heartbeat-1", prompt: "heartbeat prompt" }),
 			expect.objectContaining({
 				streamingBehavior: "followUp",
 				followUpQueueKey: "heartbeat:heartbeat-1",
 				source: "rpc",
 			}),
 		);
+		expect(prompt).not.toHaveBeenCalled();
 		expect(followUp).not.toHaveBeenCalled();
 	});
 
@@ -2805,7 +2809,12 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
-		const prompt = vi.fn(async () => {});
+		const prompt = vi.fn(
+			async (
+				_message: string,
+				_options?: { streamingBehavior?: "steer" | "followUp"; followUpQueueKey?: string; source?: string },
+			) => {},
+		);
 		const followUp = vi.fn(async () => true);
 		const state = makeState("active-1") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
@@ -2836,10 +2845,10 @@ describe("daemon mode helpers", () => {
 			"heartbeat prompt",
 			expect.objectContaining({
 				streamingBehavior: "followUp",
-				followUpQueueKey: undefined,
 				source: "rpc",
 			}),
 		);
+		expect(prompt.mock.calls[0]?.[1]).not.toHaveProperty("followUpQueueKey");
 		expect(followUp).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -11,6 +11,7 @@ import {
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { formatNoModelsAvailableMessage } from "../src/core/auth-guidance.js";
 import type { AuthStatus } from "../src/core/auth-storage.js";
+import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.js";
 import { emptyGoalState, type GoalState } from "../src/core/goals.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
@@ -1266,12 +1267,31 @@ describe("InteractiveMode tray goal label", () => {
 	type TrayLabelHarness = {
 		connectionState: {
 			goal: GoalState;
+			heartbeat?: AgentCronJob | null;
 			contextUsage: TrayUsage | undefined;
 		};
 		uiServices: { getContextUsage(): TrayUsage | undefined };
 		getTrayContextLabel(): string | undefined;
 	};
 	const getTrayContextLabel = (InteractiveMode.prototype as unknown as TrayLabelHarness).getTrayContextLabel;
+
+	function createHeartbeat(status: AgentCronJob["status"]): AgentCronJob {
+		return {
+			id: "heartbeat-1",
+			status,
+			source: "heartbeat",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			prompt: "check whether there is follow-up work",
+			schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+			nextRunAt: "2026-01-01T00:05:00.000Z",
+			runCount: 0,
+		};
+	}
 
 	test("shows active goals in the lower tray without an objective", () => {
 		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
@@ -1307,6 +1327,25 @@ describe("InteractiveMode tray goal label", () => {
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
 		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 75k (75%)");
+	});
+
+	test("combines active goals, active heartbeats, and context usage in one lower-tray label", () => {
+		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLabelHarness;
+		fakeThis.connectionState = {
+			goal: {
+				active: true,
+				status: "active",
+				objective: "finish the task",
+				tokensUsed: 0,
+				timeUsedSeconds: 65,
+				continuationsUsed: 1,
+			} satisfies GoalState,
+			heartbeat: createHeartbeat("active"),
+			contextUsage: { contextWindow: 100_000, tokens: 75_000, percent: 75 },
+		};
+		fakeThis.uiServices = { getContextUsage: () => undefined };
+
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · Heartbeat active (5m) · 75k (75%)");
 	});
 
 	test("omits the usage segment when token count is unknown", () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -412,14 +412,14 @@ describe("InteractiveMode pending bash components", () => {
 		expect(pendingMessagesContainer.children).toContain(component);
 	});
 
-	test("does not double-prefix labeled injected follow-up previews", () => {
+	test("does not double-prefix labeled injected queue previews", () => {
 		const queuedMessagesContainer = new Container();
 		const fakeThis = {
 			pendingMessagesContainer: new Container(),
 			queuedMessagesContainer,
 			pendingBashComponents: [],
 			getAllQueuedMessages: () => ({
-				steering: [],
+				steering: ["Heartbeat prompt: check steering", "Goal context: steer goal", "plain steering"],
 				followUp: ["Heartbeat prompt: check status", "Goal context: continue goal", "plain follow-up"],
 			}),
 			getAppKeyDisplay: () => "Ctrl+Q",
@@ -430,6 +430,11 @@ describe("InteractiveMode pending bash components", () => {
 		).updatePendingMessagesDisplay.call(fakeThis);
 
 		const rendered = normalizeRenderedOutput(queuedMessagesContainer);
+		expect(rendered).toContain("Heartbeat prompt: check steering");
+		expect(rendered).not.toContain("Steering: Heartbeat prompt");
+		expect(rendered).toContain("Goal context: steer goal");
+		expect(rendered).not.toContain("Steering: Goal context");
+		expect(rendered).toContain("Steering: plain steering");
 		expect(rendered).toContain("Heartbeat prompt: check status");
 		expect(rendered).not.toContain("Follow-up: Heartbeat prompt");
 		expect(rendered).toContain("Goal context: continue goal");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -412,6 +412,31 @@ describe("InteractiveMode pending bash components", () => {
 		expect(pendingMessagesContainer.children).toContain(component);
 	});
 
+	test("does not double-prefix labeled injected follow-up previews", () => {
+		const queuedMessagesContainer = new Container();
+		const fakeThis = {
+			pendingMessagesContainer: new Container(),
+			queuedMessagesContainer,
+			pendingBashComponents: [],
+			getAllQueuedMessages: () => ({
+				steering: [],
+				followUp: ["Heartbeat prompt: check status", "Goal context: continue goal", "plain follow-up"],
+			}),
+			getAppKeyDisplay: () => "Ctrl+Q",
+		} as unknown as InteractiveMode;
+
+		(
+			InteractiveMode.prototype as unknown as { updatePendingMessagesDisplay(this: unknown): void }
+		).updatePendingMessagesDisplay.call(fakeThis);
+
+		const rendered = normalizeRenderedOutput(queuedMessagesContainer);
+		expect(rendered).toContain("Heartbeat prompt: check status");
+		expect(rendered).not.toContain("Follow-up: Heartbeat prompt");
+		expect(rendered).toContain("Goal context: continue goal");
+		expect(rendered).not.toContain("Follow-up: Goal context");
+		expect(rendered).toContain("Follow-up: plain follow-up");
+	});
+
 	test("flushes pending bash components from the pending area to chat", () => {
 		const pendingMessagesContainer = new Container();
 		const chatContainer = new Container();

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -30,6 +30,24 @@ type LegacyHeartbeatRenderMode = {
 	getMarkdownThemeWithSettings: () => MarkdownTheme;
 };
 
+type MessageStartHandleMode = {
+	isInitialized: boolean;
+	footer: { invalidate: () => void };
+	updateConnectionStateFromEvent: (event: unknown) => void;
+	contextUsageTokenBaseline: number;
+	activityTracker: { handleEvent: (event: unknown) => void };
+	updateWorkingLoaderMessage: () => void;
+	addMessageToChat: (message: AgentMessage) => void;
+	ui: { requestRender: () => void };
+	sessionRecap?: string;
+	renderRecap: () => void;
+	updatePendingMessagesDisplay: () => void;
+};
+
+type MessageStartHandleHost = {
+	handleEvent(this: MessageStartHandleMode, event: { type: "message_start"; message: AgentMessage }): Promise<void>;
+};
+
 function stripAnsi(text: string): string {
 	return text.replace(/\u001b\[[0-9;]*m/g, "");
 }
@@ -54,6 +72,29 @@ function createHeartbeat(): AgentCronJob {
 		nextRunAt: "2026-01-01T00:05:00.000Z",
 		runCount: 2,
 	};
+}
+
+function createMessageStartMode(sessionRecap = "previous recap"): MessageStartHandleMode {
+	return Object.assign(Object.create(InteractiveMode.prototype), {
+		isInitialized: true,
+		footer: { invalidate: vi.fn() },
+		updateConnectionStateFromEvent: vi.fn(),
+		contextUsageTokenBaseline: 12,
+		activityTracker: { handleEvent: vi.fn() },
+		updateWorkingLoaderMessage: vi.fn(),
+		addMessageToChat: vi.fn(),
+		ui: { requestRender: vi.fn() },
+		sessionRecap,
+		renderRecap: vi.fn(),
+		updatePendingMessagesDisplay: vi.fn(),
+	}) as MessageStartHandleMode;
+}
+
+async function handleMessageStart(mode: MessageStartHandleMode, message: AgentMessage): Promise<void> {
+	await (InteractiveMode.prototype as unknown as MessageStartHandleHost).handleEvent.call(mode, {
+		type: "message_start",
+		message,
+	});
 }
 
 describe("ENG-4482 heartbeat injected prompt UI", () => {
@@ -220,6 +261,36 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		const expanded = render(component);
 		expect(expanded).toContain("Heartbeat prompt");
 		expect(expanded).toContain("Check whether the long-running task needs another step.");
+	});
+
+	it("clears stale recaps when heartbeat prompt turns start", async () => {
+		const heartbeatMode = createMessageStartMode();
+		const heartbeatMessage = createHeartbeatPromptMessage(createHeartbeat());
+
+		await handleMessageStart(heartbeatMode, heartbeatMessage);
+
+		expect(heartbeatMode.addMessageToChat).toHaveBeenCalledWith(heartbeatMessage);
+		expect(heartbeatMode.sessionRecap).toBeUndefined();
+		expect(heartbeatMode.renderRecap).toHaveBeenCalled();
+		expect(heartbeatMode.updatePendingMessagesDisplay).toHaveBeenCalled();
+
+		const goalMode = createMessageStartMode();
+		const goal: GoalState = {
+			active: true,
+			status: "active",
+			goalId: "goal-1",
+			objective: "Finish the implementation plan",
+			tokensUsed: 10,
+			timeUsedSeconds: 20,
+			continuationsUsed: 1,
+		};
+		const goalMessage = createGoalContextMessage(goal, "continuation");
+
+		await handleMessageStart(goalMode, goalMessage);
+
+		expect(goalMode.sessionRecap).toBe("previous recap");
+		expect(goalMode.renderRecap).not.toHaveBeenCalled();
+		expect(goalMode.updatePendingMessagesDisplay).not.toHaveBeenCalled();
 	});
 
 	it("renders expanded injected prompt images as placeholders", () => {

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -1,6 +1,7 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, type Message } from "@earendil-works/pi-ai";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall, type Message } from "@earendil-works/pi-ai";
 import { Container, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AgentCronJob } from "../../../src/core/cron-jobs.js";
 import { createGoalContextMessage, type GoalState } from "../../../src/core/goals.js";
@@ -94,6 +95,104 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		expect(getMessageText(providerMessages.at(-1))).toBe("Check whether the long-running task needs another step.");
 	});
 
+	it("runs heartbeat prompts through before_agent_start handlers", async () => {
+		const harness = await createHarness({
+			systemPrompt: "base prompt",
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => ({
+						message: {
+							customType: "before-start",
+							content: "extension context",
+							display: true,
+							details: { source: "test" },
+						},
+						systemPrompt: `${event.systemPrompt}\n\nheartbeat instructions`,
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		let providerSystemPrompt = "";
+		let sawExtensionContext = false;
+		harness.setResponses([
+			(context) => {
+				providerSystemPrompt = context.systemPrompt ?? "";
+				sawExtensionContext = context.messages.some(
+					(message) => message.role === "user" && getMessageText(message) === "extension context",
+				);
+				return fauxAssistantMessage("heartbeat handled");
+			},
+		]);
+
+		await harness.session.promptHeartbeat(createHeartbeat());
+
+		expect(providerSystemPrompt).toContain("heartbeat instructions");
+		expect(sawExtensionContext).toBe(true);
+		expect(
+			harness.session.messages.some((message) => message.role === "custom" && message.customType === "before-start"),
+		).toBe(true);
+	});
+
+	it("folds pending nextTurn context into queued heartbeat prompts", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return {
+					content: [{ type: "text", text: "released" }],
+					details: {},
+				};
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		let queuedHeartbeatText = "";
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("original turn complete"),
+			(context) => {
+				const queuedUserMessage = context.messages.find(
+					(message) =>
+						message.role === "user" &&
+						getMessageText(message).includes("Check whether the long-running task needs another step."),
+				);
+				queuedHeartbeatText = getMessageText(queuedUserMessage);
+				return fauxAssistantMessage("heartbeat handled");
+			},
+		]);
+
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		const promptPromise = harness.session.prompt("start");
+		await sawToolStart;
+		await harness.session.sendCustomMessage(
+			{ customType: "pending-context", content: "pending heartbeat context", display: true, details: {} },
+			{ deliverAs: "nextTurn" },
+		);
+		await harness.session.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" });
+
+		releaseToolExecution?.();
+		await promptPromise;
+
+		expect(queuedHeartbeatText).toContain("pending heartbeat context");
+		expect(queuedHeartbeatText).toContain("Check whether the long-running task needs another step.");
+	});
+
 	it("renders heartbeat prompts as expandable injected prompt panels", () => {
 		const component = new InjectedPromptMessageComponent(createHeartbeatPromptMessage(createHeartbeat()));
 		const collapsed = render(component);
@@ -110,33 +209,53 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		expect(expanded).toContain("Check whether the long-running task needs another step.");
 	});
 
-	it("renders legacy daemon heartbeat user messages as injected prompt panels", () => {
-		const heartbeat = createHeartbeat();
-		const timestamp = Date.parse(heartbeat.nextRunAt ?? heartbeat.createdAt);
-		const chatContainer = new Container();
-		const addToHistory = vi.fn();
-		const mode = Object.create(InteractiveMode.prototype) as LegacyHeartbeatRenderMode;
-		mode.connectionState = { heartbeat };
-		mode.chatContainer = chatContainer;
-		mode.toolOutputExpanded = false;
-		mode.editor = { addToHistory };
-		mode.getMarkdownThemeWithSettings = () => getMarkdownTheme();
-		const message: AgentMessage = {
-			role: "user",
-			content: [{ type: "text", text: heartbeat.prompt }],
-			timestamp,
-		};
+	it("renders expanded injected prompt images as placeholders", () => {
+		const message = createHeartbeatPromptMessage(createHeartbeat());
+		message.content = [
+			{ type: "text", text: "Review this screenshot." },
+			{ type: "image", data: "base64-data", mimeType: "image/png" },
+		];
+		const component = new InjectedPromptMessageComponent(message);
 
-		(InteractiveMode.prototype as unknown as AddMessageToChatHost).addMessageToChat.call(mode, message, {
-			populateHistory: true,
-		});
+		component.setExpanded(true);
 
-		const rendered = stripAnsi(chatContainer.render(120).join("\n"));
-		expect(rendered).toContain("Heartbeat prompt");
-		expect(rendered).toContain("every 5m");
-		expect(rendered).not.toContain("Check whether the long-running task needs another step.");
-		expect(addToHistory).not.toHaveBeenCalled();
+		expect(render(component)).toContain("Review this screenshot.");
+		expect(render(component)).toContain("[image]");
 	});
+
+	it.each(["active", "cancelled"] as const)(
+		"renders %s legacy daemon heartbeat user messages as injected prompt panels",
+		(status) => {
+			const heartbeat =
+				status === "cancelled"
+					? { ...createHeartbeat(), status, nextRunAt: undefined, lastRunAt: "2026-01-01T00:05:00.000Z" }
+					: { ...createHeartbeat(), status };
+			const timestamp = Date.parse(heartbeat.nextRunAt ?? heartbeat.lastRunAt ?? heartbeat.createdAt);
+			const chatContainer = new Container();
+			const addToHistory = vi.fn();
+			const mode = Object.create(InteractiveMode.prototype) as LegacyHeartbeatRenderMode;
+			mode.connectionState = { heartbeat };
+			mode.chatContainer = chatContainer;
+			mode.toolOutputExpanded = false;
+			mode.editor = { addToHistory };
+			mode.getMarkdownThemeWithSettings = () => getMarkdownTheme();
+			const message: AgentMessage = {
+				role: "user",
+				content: [{ type: "text", text: heartbeat.prompt }],
+				timestamp,
+			};
+
+			(InteractiveMode.prototype as unknown as AddMessageToChatHost).addMessageToChat.call(mode, message, {
+				populateHistory: true,
+			});
+
+			const rendered = stripAnsi(chatContainer.render(120).join("\n"));
+			expect(rendered).toContain("Heartbeat prompt");
+			expect(rendered).toContain("every 5m");
+			expect(rendered).not.toContain("Check whether the long-running task needs another step.");
+			expect(addToHistory).not.toHaveBeenCalled();
+		},
+	);
 
 	it("renders goal continuation prompts as injected prompt panels", () => {
 		const goal: GoalState = {

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -134,6 +134,19 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		).toBe(true);
 	});
 
+	it("resets overflow recovery state when heartbeat prompt turns start", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as { _overflowRecoveryAttempted: boolean };
+		sessionInternals._overflowRecoveryAttempted = true;
+		harness.setResponses([fauxAssistantMessage("heartbeat handled")]);
+
+		await harness.session.promptHeartbeat(createHeartbeat());
+		await harness.session.agent.waitForIdle();
+
+		expect(sessionInternals._overflowRecoveryAttempted).toBe(false);
+	});
+
 	it("folds pending nextTurn context into queued heartbeat prompts", async () => {
 		let releaseToolExecution: (() => void) | undefined;
 		const toolRelease = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -209,6 +209,12 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		const harness = await createHarness({ tools: [waitTool] });
 		harnesses.push(harness);
 		let queuedHeartbeatText = "";
+		const queueEvents: Array<{ steering: readonly string[]; followUp: readonly string[] }> = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "queue_update") {
+				queueEvents.push({ steering: event.steering, followUp: event.followUp });
+			}
+		});
 		harness.setResponses([
 			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("original turn complete"),
@@ -245,6 +251,11 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 
 		expect(queuedHeartbeatText).toContain("pending heartbeat context");
 		expect(queuedHeartbeatText).toContain("Check whether the long-running task needs another step.");
+		expect(
+			queueEvents.some((event) =>
+				event.followUp.includes("Heartbeat prompt: Check whether the long-running task needs another step."),
+			),
+		).toBe(true);
 	});
 
 	it("renders heartbeat prompts as expandable injected prompt panels", () => {

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -270,6 +270,28 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		},
 	);
 
+	it("does not render matching user messages at interval phases as heartbeat panels", () => {
+		const heartbeat = createHeartbeat();
+		const chatContainer = new Container();
+		const mode = Object.create(InteractiveMode.prototype) as LegacyHeartbeatRenderMode;
+		mode.connectionState = { heartbeat };
+		mode.chatContainer = chatContainer;
+		mode.toolOutputExpanded = false;
+		mode.editor = {};
+		mode.getMarkdownThemeWithSettings = () => getMarkdownTheme();
+		const message: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: heartbeat.prompt }],
+			timestamp: Date.parse("2026-01-01T00:15:00.000Z"),
+		};
+
+		(InteractiveMode.prototype as unknown as AddMessageToChatHost).addMessageToChat.call(mode, message);
+
+		const rendered = stripAnsi(chatContainer.render(120).join("\n"));
+		expect(rendered).not.toContain("Heartbeat prompt");
+		expect(rendered).toContain("Check whether the long-running task needs another step.");
+	});
+
 	it("renders goal continuation prompts as injected prompt panels", () => {
 		const goal: GoalState = {
 			active: true,

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -1,0 +1,163 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, type Message } from "@earendil-works/pi-ai";
+import { Container, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { AgentCronJob } from "../../../src/core/cron-jobs.js";
+import { createGoalContextMessage, type GoalState } from "../../../src/core/goals.js";
+import { createHeartbeatPromptMessage, HEARTBEAT_PROMPT_CUSTOM_TYPE } from "../../../src/core/messages.js";
+import {
+	InjectedPromptMessageComponent,
+	isInjectedPromptMessage,
+} from "../../../src/modes/interactive/components/injected-prompt-message.js";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
+import { getMarkdownTheme, initTheme } from "../../../src/modes/interactive/theme/theme.js";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
+
+type AddMessageToChatHost = {
+	addMessageToChat(
+		this: LegacyHeartbeatRenderMode,
+		message: AgentMessage,
+		options?: { populateHistory?: boolean },
+	): void;
+};
+
+type LegacyHeartbeatRenderMode = {
+	connectionState: { heartbeat: AgentCronJob };
+	chatContainer: Container;
+	toolOutputExpanded: boolean;
+	editor: { addToHistory?: (text: string) => void };
+	getMarkdownThemeWithSettings: () => MarkdownTheme;
+};
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function render(component: InjectedPromptMessageComponent): string {
+	return stripAnsi(component.render(120).join("\n"));
+}
+
+function createHeartbeat(): AgentCronJob {
+	return {
+		id: "heartbeat-1",
+		status: "active",
+		source: "heartbeat",
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		prompt: "Check whether the long-running task needs another step.",
+		schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		nextRunAt: "2026-01-01T00:05:00.000Z",
+		runCount: 2,
+	};
+}
+
+describe("ENG-4482 heartbeat injected prompt UI", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("records heartbeat prompts as custom transcript messages while keeping provider input as user content", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let providerMessages: Message[] = [];
+		harness.setResponses([
+			(context) => {
+				providerMessages = [...context.messages];
+				return fauxAssistantMessage("heartbeat handled");
+			},
+		]);
+
+		await harness.session.promptHeartbeat(createHeartbeat());
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.session.messages[0]).toMatchObject({
+			role: "custom",
+			customType: HEARTBEAT_PROMPT_CUSTOM_TYPE,
+			display: true,
+		});
+		expect(getMessageText(harness.session.messages[0])).toBe(
+			"Check whether the long-running task needs another step.",
+		);
+		expect(providerMessages.at(-1)).toMatchObject({ role: "user" });
+		expect(getMessageText(providerMessages.at(-1))).toBe("Check whether the long-running task needs another step.");
+	});
+
+	it("renders heartbeat prompts as expandable injected prompt panels", () => {
+		const component = new InjectedPromptMessageComponent(createHeartbeatPromptMessage(createHeartbeat()));
+		const collapsed = render(component);
+
+		expect(collapsed).toContain("♥");
+		expect(collapsed).toContain("Heartbeat prompt");
+		expect(collapsed).toContain("5m");
+		expect(collapsed).not.toContain("every 5m");
+		expect(collapsed).toContain("to expand");
+		expect(collapsed).not.toContain("Check whether the long-running task needs another step.");
+
+		component.setExpanded(true);
+		const expanded = render(component);
+		expect(expanded).toContain("Heartbeat prompt");
+		expect(expanded).toContain("Check whether the long-running task needs another step.");
+	});
+
+	it("renders legacy daemon heartbeat user messages as injected prompt panels", () => {
+		const heartbeat = createHeartbeat();
+		const timestamp = Date.parse(heartbeat.nextRunAt ?? heartbeat.createdAt);
+		const chatContainer = new Container();
+		const addToHistory = vi.fn();
+		const mode = Object.create(InteractiveMode.prototype) as LegacyHeartbeatRenderMode;
+		mode.connectionState = { heartbeat };
+		mode.chatContainer = chatContainer;
+		mode.toolOutputExpanded = false;
+		mode.editor = { addToHistory };
+		mode.getMarkdownThemeWithSettings = () => getMarkdownTheme();
+		const message: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: heartbeat.prompt }],
+			timestamp,
+		};
+
+		(InteractiveMode.prototype as unknown as AddMessageToChatHost).addMessageToChat.call(mode, message, {
+			populateHistory: true,
+		});
+
+		const rendered = stripAnsi(chatContainer.render(120).join("\n"));
+		expect(rendered).toContain("Heartbeat prompt");
+		expect(rendered).toContain("5m");
+		expect(rendered).not.toContain("every 5m");
+		expect(rendered).not.toContain("Check whether the long-running task needs another step.");
+		expect(addToHistory).not.toHaveBeenCalled();
+	});
+
+	it("renders goal continuation prompts as injected prompt panels", () => {
+		const goal: GoalState = {
+			active: true,
+			status: "active",
+			goalId: "goal-1",
+			objective: "Finish the implementation plan",
+			tokensUsed: 10,
+			timeUsedSeconds: 20,
+			continuationsUsed: 1,
+		};
+		const message = createGoalContextMessage(goal, "continuation");
+		const component = new InjectedPromptMessageComponent(message);
+
+		expect(message.display).toBe(true);
+		expect(isInjectedPromptMessage(message)).toBe(true);
+		expect(render(component)).toContain("Goal continuation");
+
+		component.setExpanded(true);
+		expect(render(component)).toContain("<goal_context>");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -100,8 +100,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 
 		expect(collapsed).toContain("♥");
 		expect(collapsed).toContain("Heartbeat prompt");
-		expect(collapsed).toContain("5m");
-		expect(collapsed).not.toContain("every 5m");
+		expect(collapsed).toContain("every 5m");
 		expect(collapsed).toContain("to expand");
 		expect(collapsed).not.toContain("Check whether the long-running task needs another step.");
 
@@ -134,8 +133,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 
 		const rendered = stripAnsi(chatContainer.render(120).join("\n"));
 		expect(rendered).toContain("Heartbeat prompt");
-		expect(rendered).toContain("5m");
-		expect(rendered).not.toContain("every 5m");
+		expect(rendered).toContain("every 5m");
 		expect(rendered).not.toContain("Check whether the long-running task needs another step.");
 		expect(addToHistory).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -258,6 +258,53 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		).toBe(true);
 	});
 
+	it("returns labeled previews when clearing queued heartbeat prompts", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return {
+					content: [{ type: "text", text: "released" }],
+					details: {},
+				};
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		const heartbeatPreview = "Heartbeat prompt: Check whether the long-running task needs another step.";
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("original turn complete"),
+		]);
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		const promptPromise = harness.session.prompt("start");
+		await sawToolStart;
+		await harness.session.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" });
+
+		expect(harness.session.getFollowUpMessagePreviews()).toEqual([heartbeatPreview]);
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [heartbeatPreview] });
+
+		releaseToolExecution?.();
+		await promptPromise;
+
+		expect(harness.session.getFollowUpMessagePreviews()).toEqual([]);
+	});
+
 	it("renders heartbeat prompts as expandable injected prompt panels", () => {
 		const component = new InjectedPromptMessageComponent(createHeartbeatPromptMessage(createHeartbeat()));
 		const collapsed = render(component);


### PR DESCRIPTION
- heartbeat and goal continuation prompts now render as injected prompt entries instead of ordinary user messages.
- heartbeat entries collapse to a compact red heart line and expand with ctrl+o to show the prompt.
- added regression coverage for daemon heartbeat delivery, legacy rendering, and tray status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches prompt delivery, queue semantics, and transcript rendering across session, daemon, and TUI; behavior is well covered by regression tests but cron/heartbeat timing edge cases could still affect legacy reclassification.
> 
> **Overview**
> Fixes **ENG-4482** by treating scheduled heartbeat text and goal continuation context as **injected prompts** in the transcript and queue, not as plain user bubbles.
> 
> **Session / daemon:** New `heartbeat_prompt` custom messages (`createHeartbeatPromptMessage`, `AgentSession.promptHeartbeat`) keep the same prompt text for the model while recording a typed entry in history. Daemon cron delivery calls `promptHeartbeat` with follow-up coalescing on `heartbeat:<jobId>`. Shared `_promptInjectedMessage` handles busy-session queuing with **preview labels** (`Heartbeat prompt`, `Goal context`) on `queue_update` and RPC `get_queue`.
> 
> **UI:** `InjectedPromptMessageComponent` renders heartbeat (♥ + schedule) and goal context as collapsible headers; goal context is now `display: true`. Queued previews skip double `Steering:` / `Follow-up:` prefixes when already labeled. Legacy user messages that match the active heartbeat job within a time tolerance are shown as injected panels on replay. Tray context includes heartbeat status/schedule; connection state exposes `heartbeat` via `getLatestHeartbeat`.
> 
> **Session replace:** Daemon `sessionReplaced` refreshes recap, rebinds cron, and rebuilds connection state with heartbeat metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687039922f2de6162ea75b70af87a6e138a2cddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix heartbeat and goal context prompts rendering as injected prompt UI instead of plain user messages
> - Introduces `InjectedPromptMessageComponent` to render heartbeat and goal context prompts with dedicated headers, scheduling metadata, and expand/collapse behavior instead of the generic user/custom message renderers.
> - Adds `promptHeartbeat` to `AgentSession` and routes heartbeat cron jobs through it in the daemon, so heartbeat messages carry structured metadata and correct queue/preflight semantics.
> - Queued steering and follow-up previews now include labels (e.g. `Heartbeat prompt:`, `Goal context:`) and `updatePendingMessagesDisplay` skips adding a redundant `Steering:`/`Follow-up:` prefix when a label is already present.
> - Legacy daemon heartbeat messages delivered as plain user text are detected by content and timing proximity and re-rendered as injected prompt panels.
> - `createGoalContextMessage` now sets `display: true` so goal context messages are visible in conversation history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 369b62c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->