### PR TITLE
improve heartbeat command guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `/heartbeat` autocomplete guidance to show lifecycle actions, `stop`, and the `every <duration> <instruction>` interval syntax ([ENG-4484](https://linear.app/primeintellect/issue/ENG-4484/improve-heartbeat-command-syntax-guidance-in-ui)).
+
 ## [0.2.6] - 2026-07-06
 
 - Fixed the installer splash flickering during animation and resize by stabilizing full-screen redraws and removing misleading synthetic percentages ([ENG-4481](https://linear.app/primeintellect/issue/ENG-4481/installer-screen-is-unstable-and-flickery)).

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -77,8 +77,9 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	},
 	{
 		name: "heartbeat",
-		description: "Set or view a persistent heartbeat; supports pause, resume, and clear",
-		argumentHint: "[--every <interval>] <instruction>",
+		description: "Set or view a persistent heartbeat; supports pause, resume, stop, and clear",
+		argumentHint: "[status|pause|resume|stop|every <duration> <instruction>]",
+		takesArgument: true,
 	},
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -382,16 +382,11 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 };
 
 const HEARTBEAT_ARGUMENT_COMPLETIONS: AutocompleteItem[] = [
-	{ value: "status", label: "status", description: "Show the current heartbeat" },
-	{ value: "stop", label: "stop", description: "Stop and clear the heartbeat" },
-	{ value: "pause", label: "pause", description: "Pause the heartbeat" },
-	{ value: "resume", label: "resume", description: "Resume the heartbeat" },
 	{
 		value: "every ",
 		label: "every <duration> <instruction>",
 		description: "Set an interval, then add an instruction: /heartbeat every 10s Scan the logs",
 	},
-	{ value: "clear", label: "clear", description: "Clear the heartbeat" },
 ];
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -381,6 +381,19 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	max: "Maximum reasoning",
 };
 
+const HEARTBEAT_ARGUMENT_COMPLETIONS: AutocompleteItem[] = [
+	{ value: "status", label: "status", description: "Show the current heartbeat" },
+	{ value: "stop", label: "stop", description: "Stop and clear the heartbeat" },
+	{ value: "pause", label: "pause", description: "Pause the heartbeat" },
+	{ value: "resume", label: "resume", description: "Resume the heartbeat" },
+	{
+		value: "every ",
+		label: "every <duration> <instruction>",
+		description: "Set an interval, then add an instruction: /heartbeat every 10s Scan the logs",
+	},
+	{ value: "clear", label: "clear", description: "Clear the heartbeat" },
+];
+
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 
 // Cap on retained pasted-image bytes (base64). Images are resized below the
@@ -864,6 +877,12 @@ export class InteractiveMode {
 			if (levels.length > 0) {
 				effortCommand.argumentHint = `[${levels.join("/")}]`;
 			}
+		}
+
+		const heartbeatCommand = slashCommands.find((command) => command.name === "heartbeat");
+		if (heartbeatCommand) {
+			heartbeatCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
+				this.getHeartbeatArgumentCompletions(prefix);
 		}
 
 		const connectionCommands = this.connectionCommands;
@@ -6278,6 +6297,16 @@ export class InteractiveMode {
 			description:
 				level === current ? `${THINKING_LEVEL_DESCRIPTIONS[level]} (current)` : THINKING_LEVEL_DESCRIPTIONS[level],
 		}));
+	}
+
+	private getHeartbeatArgumentCompletions(prefix: string): AutocompleteItem[] | null {
+		const term = prefix.trim().toLowerCase();
+		const filtered = term
+			? HEARTBEAT_ARGUMENT_COMPLETIONS.filter(
+					(item) => item.value.toLowerCase().startsWith(term) || item.label.toLowerCase().startsWith(term),
+				)
+			: HEARTBEAT_ARGUMENT_COMPLETIONS;
+		return filtered.length === 0 ? null : filtered;
 	}
 
 	private handleEffortCommand(arg: string): void {

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -63,6 +63,11 @@ describe("parseHeartbeatCommand", () => {
 			schedule: "every 30s",
 			instruction: "check on me",
 		});
+		expect(parseHeartbeatCommand("/heartbeat every 10m check status")).toEqual({
+			type: "set",
+			schedule: "every 10m",
+			instruction: "check status",
+		});
 		expect(parseHeartbeatCommand("/heartbeat every 10m -- check status")).toEqual({
 			type: "set",
 			schedule: "every 10m",

--- a/packages/coding-agent/test/interactive-mode-heartbeat-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-heartbeat-command.test.ts
@@ -10,17 +10,10 @@ const interactiveModePrototype = InteractiveMode.prototype as unknown as Interac
 
 describe("InteractiveMode /heartbeat", () => {
 	describe("argument autocomplete", () => {
-		it("lists lifecycle commands and the interval syntax starter for an empty prefix", () => {
+		it("lists the interval syntax starter for an empty prefix", () => {
 			const items = interactiveModePrototype.getHeartbeatArgumentCompletions("");
 
-			expect(items?.map((item) => item.label)).toEqual([
-				"status",
-				"stop",
-				"pause",
-				"resume",
-				"every <duration> <instruction>",
-				"clear",
-			]);
+			expect(items?.map((item) => item.label)).toEqual(["every <duration> <instruction>"]);
 			const everyItem = items?.find((item) => item.label === "every <duration> <instruction>");
 			expect(everyItem?.value).toBe("every ");
 			expect(everyItem?.description).toBe(
@@ -28,10 +21,10 @@ describe("InteractiveMode /heartbeat", () => {
 			);
 		});
 
-		it("filters lifecycle commands by prefix", () => {
+		it("does not autocomplete lifecycle commands over free-form instructions", () => {
 			const items = interactiveModePrototype.getHeartbeatArgumentCompletions("st");
 
-			expect(items?.map((item) => item.label)).toEqual(["status", "stop"]);
+			expect(items).toBeNull();
 		});
 
 		it("filters interval syntax by keyword", () => {

--- a/packages/coding-agent/test/interactive-mode-heartbeat-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-heartbeat-command.test.ts
@@ -1,0 +1,43 @@
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+type InteractiveModePrototype = {
+	getHeartbeatArgumentCompletions(prefix: string): AutocompleteItem[] | null;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+describe("InteractiveMode /heartbeat", () => {
+	describe("argument autocomplete", () => {
+		it("lists lifecycle commands and the interval syntax starter for an empty prefix", () => {
+			const items = interactiveModePrototype.getHeartbeatArgumentCompletions("");
+
+			expect(items?.map((item) => item.label)).toEqual([
+				"status",
+				"stop",
+				"pause",
+				"resume",
+				"every <duration> <instruction>",
+				"clear",
+			]);
+			const everyItem = items?.find((item) => item.label === "every <duration> <instruction>");
+			expect(everyItem?.value).toBe("every ");
+			expect(everyItem?.description).toBe(
+				"Set an interval, then add an instruction: /heartbeat every 10s Scan the logs",
+			);
+		});
+
+		it("filters lifecycle commands by prefix", () => {
+			const items = interactiveModePrototype.getHeartbeatArgumentCompletions("st");
+
+			expect(items?.map((item) => item.label)).toEqual(["status", "stop"]);
+		});
+
+		it("filters interval syntax by keyword", () => {
+			const items = interactiveModePrototype.getHeartbeatArgumentCompletions("every");
+
+			expect(items?.map((item) => item.label)).toEqual(["every <duration> <instruction>"]);
+		});
+	});
+});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -16,6 +16,14 @@ describe("built-in slash commands", () => {
 		expect(commandNames).not.toContain("cron");
 	});
 
+	test("exposes heartbeat syntax guidance", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "heartbeat")).toMatchObject({
+			description: "Set or view a persistent heartbeat; supports pause, resume, stop, and clear",
+			argumentHint: "[status|pause|resume|stop|every <duration> <instruction>]",
+			takesArgument: true,
+		});
+	});
+
 	test("exposes /effort for selecting the thinking level", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
 			description: "Set reasoning/thinking level",
@@ -34,6 +42,7 @@ describe("built-in slash commands", () => {
 		expect(builtinSlashCommandTakesArgument("goal")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("effort")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true);
+		expect(builtinSlashCommandTakesArgument("heartbeat")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("new")).toBe(false);
 		expect(builtinSlashCommandTakesArgument("clear")).toBe(false);
 	});


### PR DESCRIPTION
- heartbeat autocomplete now shows lifecycle actions and the open interval syntax without implying fixed duration choices.
- selecting the interval starter inserts the slash-command style form and shows a concrete example.
- added parser and autocomplete regressions for the documented heartbeat syntax.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve `/heartbeat` command guidance with `stop` support and argument autocompletion
> - Updates the `/heartbeat` command metadata in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/339/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051) to include `stop` in the description and change the argument hint to `[status|pause|resume|stop|every <duration> <instruction>]`.
> - Adds argument autocompletion for `/heartbeat` in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/339/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316), suggesting the `every <duration> <instruction>` syntax when typing arguments.
> - Completion filtering returns `null` (no suggestions) when the prefix matches a free-form instruction rather than a lifecycle subcommand.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e144df0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, autocomplete, and test-only coverage for `/heartbeat`; no changes to heartbeat scheduling or daemon behavior in the diff.
> 
> **Overview**
> Updates built-in **`/heartbeat`** help so users see **`stop`** in the description, a clearer **`argumentHint`** (`status|pause|resume|stop|every <duration> <instruction>`), and **`takesArgument: true`** so the prompt treats arguments like other free-form slash commands.
> 
> In interactive mode, **`/heartbeat`** argument autocomplete now suggests only the **`every <duration> <instruction>`** form (inserts `every ` with an example description). Prefixes like `st` do not get lifecycle-command completions, avoiding misleading suggestions over custom instructions.
> 
> Adds regression tests for the documented metadata, autocomplete behavior, and parser acceptance of **`/heartbeat every 10m …`** alongside existing `--every` forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e144df0eb0eb7e7dc072a5617e2137bad25797f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->