### PR TITLE
Steer agent messages by default

### DIFF
--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -24,11 +24,13 @@ receipt = await agent_message.send("worker", "Please inspect the latest result."
 - `await agent_message.send(target, message, mode="auto")` — sends one direct
   text message to an active session. `target` is resolved by the daemon like
   other live-session selectors. `mode` is `"auto"`, `"follow_up"`, or
-  `"steer"`. Returns a receipt with a `deliveryStatus` field: `"delivered"`
-  means the message reached an idle target's context; `"queued"` means it was
-  accepted and will deliver when the target's current work allows (`send`
-  does not block waiting for that). Delivered receipts carry `deliveredAt`,
-  queued receipts carry `queuedAt`.
+  `"steer"`. In `auto` mode, messages to busy sessions are queued as steering
+  messages so the target sees them during the active run; use `"follow_up"` for
+  intentionally delayed delivery. Returns a receipt with a `deliveryStatus`
+  field: `"delivered"` means the message reached an idle target's context;
+  `"queued"` means it was accepted and will deliver when the target's current
+  work allows (`send` does not block waiting for that). Delivered receipts
+  carry `deliveredAt`, queued receipts carry `queuedAt`.
 
 ## Safety
 

--- a/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
+++ b/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
@@ -24,7 +24,7 @@ async def send(target: str, message: str, mode: MessageMode = "auto") -> dict[st
     Args:
         target: Active session id, session id/name, or unambiguous suffix.
         message: Text payload to deliver.
-        mode: "auto" queues as follow-up only if the target is streaming;
+        mode: "auto" steers into a busy/streaming target so the message is visible promptly;
             "follow_up" always uses follow-up when the target is streaming;
             "steer" interrupts a streaming target.
 

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -138,7 +138,10 @@ export function resolveAgentSessionMessageStreamingBehavior(
 	if (mode === "steer") {
 		return "steer";
 	}
-	return "followUp";
+	if (mode === "follow_up") {
+		return "followUp";
+	}
+	return "steer";
 }
 
 export function parseAgentSessionMessagePromptId(text: string): string | undefined {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2014,7 +2014,7 @@ export class AgentDaemon {
 			session.pendingMessageCount > 0;
 		const streamingBehavior =
 			resolveAgentSessionMessageStreamingBehavior(shouldQueue, payload.deliveryMode) ??
-			(payload.deliveryMode === "steer" ? "steer" : "followUp");
+			(payload.deliveryMode === "follow_up" ? "followUp" : "steer");
 		const prompt = createAgentSessionMessagePrompt(payload);
 
 		if (shouldQueue) {

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -116,9 +116,9 @@ describe("agent session bus", () => {
 		expect(prompt).toContain("To: Worker active spoof, active worker, session session-worker");
 	});
 
-	it("uses follow-up delivery by default only when the target is streaming", () => {
+	it("uses steering delivery by default only when the target is streaming", () => {
 		expect(resolveAgentSessionMessageStreamingBehavior(false, "auto")).toBeUndefined();
-		expect(resolveAgentSessionMessageStreamingBehavior(true, "auto")).toBe("followUp");
+		expect(resolveAgentSessionMessageStreamingBehavior(true, "auto")).toBe("steer");
 		expect(resolveAgentSessionMessageStreamingBehavior(true, "follow_up")).toBe("followUp");
 		expect(resolveAgentSessionMessageStreamingBehavior(true, "steer")).toBe("steer");
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -181,6 +181,7 @@ describe("daemon mode helpers", () => {
 				targetSelector: string;
 				message: string;
 				fromState?: ActiveSessionState;
+				deliveryMode?: "auto" | "steer" | "follow_up";
 				origin: "agent" | "cli";
 			}): Promise<unknown>;
 		};
@@ -198,6 +199,22 @@ describe("daemon mode helpers", () => {
 			deliveryStatus: "queued",
 			target: { activeSessionId: targetState.activeSessionId },
 		});
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({ streamingBehavior: "steer" });
+
+		acceptAgentMessagePrompt.mockClear();
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "please continue later",
+				fromState,
+				deliveryMode: "follow_up",
+				origin: "agent",
+			}),
+		).resolves.toMatchObject({
+			deliveryStatus: "queued",
+			target: { activeSessionId: targetState.activeSessionId },
+		});
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({ streamingBehavior: "followUp" });
 	});
 
 	it("rate limits agent messages per sender and target pair", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -995,7 +995,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
 
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		expect(followUp).not.toHaveBeenCalled();
 		expect(prompt).not.toHaveBeenCalled();
 	});
@@ -1051,7 +1051,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
 
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		expect(followUp).not.toHaveBeenCalled();
 		expect(prompt).not.toHaveBeenCalled();
 	});
@@ -1106,7 +1106,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
 
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		expect(prompt).not.toHaveBeenCalled();
 	});
 
@@ -1160,7 +1160,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
 
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 	});
 
@@ -1294,7 +1294,7 @@ describe("daemon mode helpers", () => {
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		expect(followUp).not.toHaveBeenCalled();
 		await expect(second).resolves.toMatchObject({ message: "second" });
 	});
@@ -1462,7 +1462,7 @@ describe("daemon mode helpers", () => {
 		await send;
 		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		resolvePrompt();
 	});
 
@@ -1596,7 +1596,7 @@ describe("daemon mode helpers", () => {
 
 		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("followUp");
+		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
 		resolvePrompt();
 		await cronRun;
 	});


### PR DESCRIPTION
## Summary
- change `agent_message.send(..., mode="auto")` so busy target sessions receive messages as steering prompts by default
- preserve explicit `mode="follow_up"` for intentionally delayed delivery
- update skill docs and daemon/message tests for the new default

## Testing
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-mode.test.ts test/agent-session-bus.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default agent message delivery to 'steer' mode when target session is streaming
> - Changes `resolveAgentSessionMessageStreamingBehavior` in [agent-messages.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/341/files#diff-d56c5dcb3c4410339ae008806859f45d787d326d94c56b2e7c839dae397048b6) so that `auto` delivery mode now resolves to `steer` instead of `followUp` when the target is streaming.
> - Updates the fallback mapping in `AgentDaemon.sendAgentSessionMessage` in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/341/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) to match: only an explicit `follow_up` mode yields `followUp` behavior.
> - Updates docstrings in the `agent_message` skill to reflect that `auto` steers into a busy session promptly, while `follow_up` is for intentionally delayed delivery.
> - Behavioral Change: messages sent with `auto` mode to a streaming/busy session are now delivered as steering messages (visible during the active run) rather than queued as follow-ups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 407fba9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default inter-agent delivery semantics for busy sessions, which can alter multi-agent coordination and interrupt in-flight work unless callers opt into `follow_up`.
> 
> **Overview**
> **`agent_message.send(..., mode="auto")` now steers into busy targets by default** instead of queuing as follow-up, so inter-session messages surface during an active run rather than waiting for the turn to finish.
> 
> `resolveAgentSessionMessageStreamingBehavior` maps **`auto` → `steer`** when the target is streaming; **`follow_up`** still forces follow-up delivery, and **`steer`** is unchanged. The daemon’s queued-delivery fallback aligns the same way (`follow_up` → follow-up, otherwise steer). The **agent-message** skill docs and Python `send` docstring describe the new default; daemon and bus tests expect **`steer`** for default/auto queued paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407fba95fd5cc97a1034d4c9fbfc801f2af8216c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->