### PR TITLE
Speed up opening long live sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed long live session opens to render a bounded recent transcript tail while preserving full prompt history ([#343](https://github.com/PrimeIntellect-ai/prime-agent/pull/343) by [@sethkarten](https://github.com/sethkarten)).
+
 ## [0.3.2] - 2026-07-20
 
 - Fixed invalid `--resume` session IDs being submitted as prompts, with nearest-session guidance instead ([ENG-4722](https://linear.app/primeintellect/issue/ENG-4722/prime-agent-resume-accepts-incorrect-session-ids)).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -521,6 +521,37 @@ const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 // inline limit before storing, so this holds many recent pastes; the oldest are
 // evicted past the cap to keep a long session bounded.
 const MAX_PASTED_IMAGE_BYTES = 64 * 1024 * 1024;
+const INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT = 400;
+
+function initialRenderMessages(messages: AgentMessage[]): AgentMessage[] {
+	if (messages.length <= INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT) {
+		return messages;
+	}
+	const visibleMessages = messages.slice(-INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT);
+	return omitOrphanToolResults(visibleMessages);
+}
+
+function omitOrphanToolResults(messages: AgentMessage[]): AgentMessage[] {
+	const renderedToolCallIds = new Set<string>();
+	const renderableMessages: AgentMessage[] = [];
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			for (const content of message.content) {
+				if (content.type === "toolCall") {
+					renderedToolCallIds.add(content.id);
+				}
+			}
+			renderableMessages.push(message);
+		} else if (message.role === "toolResult") {
+			if (renderedToolCallIds.has(message.toolCallId)) {
+				renderableMessages.push(message);
+			}
+		} else {
+			renderableMessages.push(message);
+		}
+	}
+	return renderableMessages;
+}
 
 function isDeadTerminalError(error: unknown): boolean {
 	if (!error || typeof error !== "object" || !("code" in error)) {
@@ -5824,6 +5855,16 @@ export class InteractiveMode {
 		this.chatContainer.addChild(new UserMessageComponent(text, this.getMarkdownThemeWithSettings()));
 	}
 
+	private addMessageToEditorHistory(message: AgentMessage): void {
+		if (message.role !== "user") {
+			return;
+		}
+		const textContent = this.getUserMessageText(message);
+		if (textContent && !this.createLegacyHeartbeatPromptMessage(message, textContent)) {
+			this.editor.addToHistory?.(textContent);
+		}
+	}
+
 	private addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void {
 		switch (message.role) {
 			case "bashExecution": {
@@ -5952,11 +5993,12 @@ export class InteractiveMode {
 		options: { updateFooter?: boolean; populateHistory?: boolean; clearChat?: boolean } = {},
 	): Promise<void> {
 		this.resetPendingToolState();
+		const messagesToRender = initialRenderMessages(sessionContext.messages);
 		this.ipythonToolComponents.clear();
 		this.lateIpythonSentAgentMessages.clear();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();
 		const toolNames: string[] = [];
-		for (const message of sessionContext.messages) {
+		for (const message of messagesToRender) {
 			if (message.role !== "assistant") {
 				continue;
 			}
@@ -5977,7 +6019,29 @@ export class InteractiveMode {
 			this.updateEditorBorderColor();
 		}
 
-		for (const message of sessionContext.messages) {
+		if (options.populateHistory) {
+			for (const message of sessionContext.messages) {
+				this.addMessageToEditorHistory(message);
+			}
+		}
+
+		const renderOptions = { ...options, populateHistory: false };
+
+		if (messagesToRender.length < sessionContext.messages.length) {
+			this.chatContainer.addChild(
+				new Text(
+					theme.fg(
+						"dim",
+						`Showing latest ${messagesToRender.length} of ${sessionContext.messages.length} messages for faster open.`,
+					),
+					1,
+					0,
+				),
+			);
+			this.chatContainer.addChild(new Spacer(1));
+		}
+
+		for (const message of messagesToRender) {
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
 				this.addMessageToChat(message);
@@ -6029,7 +6093,7 @@ export class InteractiveMode {
 				}
 			} else {
 				// All other messages use standard rendering
-				this.addMessageToChat(message, options);
+				this.addMessageToChat(message, renderOptions);
 			}
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5987,13 +5987,21 @@ export class InteractiveMode {
 	 * @param options.updateFooter Update footer state
 	 * @param options.populateHistory Add user messages to editor history
 	 * @param options.clearChat Clear the current transcript immediately before rendering
+	 * @param options.limitTranscript Limit transcript replay to the recent tail
 	 */
 	private async renderSessionContext(
 		sessionContext: AgentConnectionSessionContext,
-		options: { updateFooter?: boolean; populateHistory?: boolean; clearChat?: boolean } = {},
+		options: {
+			updateFooter?: boolean;
+			populateHistory?: boolean;
+			clearChat?: boolean;
+			limitTranscript?: boolean;
+		} = {},
 	): Promise<void> {
 		this.resetPendingToolState();
-		const messagesToRender = initialRenderMessages(sessionContext.messages);
+		const messagesToRender = options.limitTranscript
+			? initialRenderMessages(sessionContext.messages)
+			: sessionContext.messages;
 		this.ipythonToolComponents.clear();
 		this.lateIpythonSentAgentMessages.clear();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();
@@ -6115,6 +6123,7 @@ export class InteractiveMode {
 		await this.renderSessionContext(context, {
 			updateFooter: true,
 			populateHistory: true,
+			limitTranscript: true,
 		});
 		await this.restoreStreamingMessageFromSnapshot(streamingMessage);
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -527,8 +527,67 @@ function initialRenderMessages(messages: AgentMessage[]): AgentMessage[] {
 	if (messages.length <= INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT) {
 		return messages;
 	}
-	const visibleMessages = messages.slice(-INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT);
-	return omitOrphanToolResults(visibleMessages);
+	const toolCallMessages = new Map<string, { index: number; message: Extract<AgentMessage, { role: "assistant" }> }>();
+	for (const [index, message] of messages.entries()) {
+		if (message.role !== "assistant") {
+			continue;
+		}
+		for (const content of message.content) {
+			if (content.type === "toolCall") {
+				toolCallMessages.set(content.id, { index, message });
+			}
+		}
+	}
+
+	const initialStartIndex = messages.length - INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT;
+	for (let startIndex = initialStartIndex; startIndex < messages.length; startIndex++) {
+		const visibleMessages = messages.slice(startIndex);
+		const visibleToolCallIds = new Set<string>();
+		for (const message of visibleMessages) {
+			if (message.role !== "assistant") {
+				continue;
+			}
+			for (const content of message.content) {
+				if (content.type === "toolCall") {
+					visibleToolCallIds.add(content.id);
+				}
+			}
+		}
+
+		const requiredToolCallIdsByMessage = new Map<
+			number,
+			{ message: Extract<AgentMessage, { role: "assistant" }>; toolCallIds: Set<string> }
+		>();
+		for (const message of visibleMessages) {
+			if (message.role !== "toolResult" || visibleToolCallIds.has(message.toolCallId)) {
+				continue;
+			}
+			const toolCallMessage = toolCallMessages.get(message.toolCallId);
+			if (!toolCallMessage || toolCallMessage.index >= startIndex) {
+				continue;
+			}
+			const requiredMessage = requiredToolCallIdsByMessage.get(toolCallMessage.index) ?? {
+				message: toolCallMessage.message,
+				toolCallIds: new Set<string>(),
+			};
+			requiredMessage.toolCallIds.add(message.toolCallId);
+			requiredToolCallIdsByMessage.set(toolCallMessage.index, requiredMessage);
+		}
+
+		if (visibleMessages.length + requiredToolCallIdsByMessage.size > INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT) {
+			continue;
+		}
+
+		const requiredToolCallMessages = [...requiredToolCallIdsByMessage.entries()]
+			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+			.map(([, { message, toolCallIds }]) => ({
+				...message,
+				content: message.content.filter((content) => content.type !== "toolCall" || toolCallIds.has(content.id)),
+			}));
+		return omitOrphanToolResults([...requiredToolCallMessages, ...visibleMessages]);
+	}
+
+	return [];
 }
 
 function omitOrphanToolResults(messages: AgentMessage[]): AgentMessage[] {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import * as path from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,
@@ -21,6 +22,7 @@ import { emptyGoalState, type GoalState } from "../src/core/goals.js";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { ModelRegistry } from "../src/core/model-registry.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
+import { emptyUsage } from "../src/core/usage.js";
 import type {
 	AgentConnectionExtensionUiRequest,
 	AgentConnectionExtensionUiResponse,
@@ -30,6 +32,7 @@ import type {
 	AgentConnectionResourceDiagnostic,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionRlmChildAgentSnapshot,
+	AgentConnectionSessionContext,
 	AgentConnectionSessionEvent,
 	AgentConnectionSnapshot,
 	AgentConnectionSourceInfo,
@@ -261,6 +264,109 @@ describe("InteractiveMode.showStatus", () => {
 	});
 });
 
+type RenderSessionContextHarness = {
+	pendingTools: Map<string, ToolExecutionComponent>;
+	ipythonToolComponents: Map<string, unknown>;
+	lateIpythonSentAgentMessages: Map<string, unknown[]>;
+	toolOutputExpanded: boolean;
+	chatContainer: Container;
+	editor: { addToHistory?: (text: string) => void };
+	footer: { invalidate: () => void };
+	updateEditorBorderColor: () => void;
+	resetPendingToolState: () => void;
+	preloadToolDefinitions: (toolNames: string[]) => Promise<void>;
+	settingsManager: { getShowImages: () => boolean };
+	getCachedToolDefinition: () => undefined;
+	getCurrentCwd: () => string;
+	getRetryAttempt: () => number;
+	ui: { requestRender: () => void };
+	addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) => void;
+	connectionState?: AgentConnectionState;
+};
+
+type RenderSessionContextOptions = { updateFooter?: boolean; populateHistory?: boolean; clearChat?: boolean };
+
+const renderSessionContext = (
+	InteractiveMode.prototype as unknown as {
+		renderSessionContext(
+			this: RenderSessionContextHarness,
+			sessionContext: AgentConnectionSessionContext,
+			options?: RenderSessionContextOptions,
+		): Promise<void>;
+	}
+).renderSessionContext;
+
+function createRenderSessionContextHarness(overrides: Partial<RenderSessionContextHarness> = {}): {
+	harness: RenderSessionContextHarness;
+	chatContainer: Container;
+	addMessageToChat: ReturnType<typeof vi.fn>;
+	addToHistory: ReturnType<typeof vi.fn>;
+} {
+	const chatContainer = overrides.chatContainer ?? new Container();
+	const addMessageToChat = vi.fn(() => {
+		chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
+	});
+	const addToHistory = vi.fn();
+	const harness: RenderSessionContextHarness = {
+		pendingTools: new Map<string, ToolExecutionComponent>(),
+		ipythonToolComponents: new Map<string, unknown>(),
+		lateIpythonSentAgentMessages: new Map<string, unknown[]>(),
+		toolOutputExpanded: false,
+		chatContainer,
+		editor: { addToHistory },
+		footer: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		resetPendingToolState: vi.fn(),
+		preloadToolDefinitions: vi.fn(async () => {}),
+		settingsManager: { getShowImages: () => true },
+		getCachedToolDefinition: () => undefined,
+		getCurrentCwd: () => process.cwd(),
+		getRetryAttempt: () => 0,
+		ui: { requestRender: vi.fn() },
+		addMessageToChat,
+		...overrides,
+	};
+	Object.setPrototypeOf(harness, InteractiveMode.prototype);
+	return { harness, chatContainer, addMessageToChat, addToHistory };
+}
+
+function userMessage(content: string, timestamp: number): Extract<AgentMessage, { role: "user" }> {
+	return { role: "user", content, timestamp };
+}
+
+function toolCallMessage(id: string, name: string): Extract<AgentMessage, { role: "assistant" }> {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", name, id, arguments: {} }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "test-model",
+		usage: emptyUsage(),
+		stopReason: "toolUse",
+		timestamp: 0,
+	};
+}
+
+function toolResultMessage(
+	id: string,
+	name: string,
+	content: Extract<AgentMessage, { role: "toolResult" }>["content"],
+): Extract<AgentMessage, { role: "toolResult" }> {
+	return { role: "toolResult", toolCallId: id, toolName: name, content, isError: false, timestamp: 0 };
+}
+
+async function renderMessages(
+	harness: RenderSessionContextHarness,
+	messages: AgentMessage[],
+	options?: RenderSessionContextOptions,
+): Promise<void> {
+	await renderSessionContext.call(
+		harness,
+		{ messages, thinkingLevel: "medium", serviceTier: "default", model: null },
+		options,
+	);
+}
+
 describe("InteractiveMode.renderSessionContext", () => {
 	beforeAll(() => {
 		initTheme("dark");
@@ -370,6 +476,109 @@ describe("InteractiveMode.renderSessionContext", () => {
 		} finally {
 			resetCapabilitiesCache();
 		}
+	});
+
+	test("renders only the recent tail for very long initial transcripts", async () => {
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
+		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
+
+		await renderMessages(harness, messages);
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(400);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 5" });
+		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
+	});
+
+	test("applies the recent-tail cap when rebuilding a cleared transcript", async () => {
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
+		chatContainer.addChild({ render: () => ["old transcript"], invalidate: () => {} });
+		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
+
+		await renderMessages(harness, messages, { clearChat: true });
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(400);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 5" });
+		expect(renderAll(chatContainer)).not.toContain("old transcript");
+		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
+	});
+
+	test("populates editor history from the full transcript when initial rendering is capped", async () => {
+		const { harness, addMessageToChat, addToHistory } = createRenderSessionContextHarness();
+		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
+
+		await renderMessages(harness, messages, { populateHistory: true });
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(400);
+		expect(addToHistory).toHaveBeenCalledTimes(405);
+		expect(addToHistory.mock.calls[0]?.[0]).toBe("message 0");
+		expect(addToHistory.mock.calls.at(-1)?.[0]).toBe("message 404");
+	});
+
+	test("excludes legacy heartbeat prompts from editor history", async () => {
+		const timestamp = Date.parse("2026-01-01T00:05:00.000Z");
+		const heartbeat = {
+			id: "heartbeat-1",
+			status: "active",
+			source: "heartbeat",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			prompt: "check whether there is follow-up work",
+			schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+			lastRunAt: "2026-01-01T00:05:00.000Z",
+			runCount: 1,
+		} satisfies AgentCronJob;
+		const { harness, addToHistory } = createRenderSessionContextHarness({
+			connectionState: createConnectionState({ heartbeat }),
+		});
+
+		await renderMessages(
+			harness,
+			[
+				userMessage(heartbeat.prompt, timestamp),
+				userMessage(heartbeat.prompt, timestamp + 86_400_000),
+				userMessage("ordinary prompt", timestamp + 86_400_001),
+			],
+			{ populateHistory: true },
+		);
+
+		expect(addToHistory).toHaveBeenCalledTimes(2);
+		expect(addToHistory).toHaveBeenNthCalledWith(1, heartbeat.prompt);
+		expect(addToHistory).toHaveBeenCalledWith("ordinary prompt");
+	});
+
+	test("trims capped initial renders past orphaned tool results", async () => {
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
+		const messages = [
+			toolCallMessage("tool-old", "old_tool"),
+			toolResultMessage("tool-old", "old_tool", [{ type: "text", text: "old result" }]),
+			...Array.from({ length: 399 }, (_, index) => userMessage(`message ${index}`, index)),
+		];
+
+		await renderMessages(harness, messages);
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(399);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
+		expect(renderAll(chatContainer)).toContain("Showing latest 399 of 401 messages for faster open.");
+	});
+
+	test("omits a trailing orphaned tool result without dropping the recent tail", async () => {
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
+		const messages = [
+			toolCallMessage("tool-old", "old_tool"),
+			...Array.from({ length: 399 }, (_, index) => userMessage(`message ${index}`, index)),
+			toolResultMessage("tool-old", "old_tool", [{ type: "text", text: "old result" }]),
+		];
+
+		await renderMessages(harness, messages);
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(399);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
+		expect(addMessageToChat.mock.calls.at(-1)?.[0]).toMatchObject({ content: "message 398" });
+		expect(renderAll(chatContainer)).toContain("Showing latest 399 of 401 messages for faster open.");
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -284,7 +284,12 @@ type RenderSessionContextHarness = {
 	connectionState?: AgentConnectionState;
 };
 
-type RenderSessionContextOptions = { updateFooter?: boolean; populateHistory?: boolean; clearChat?: boolean };
+type RenderSessionContextOptions = {
+	updateFooter?: boolean;
+	populateHistory?: boolean;
+	clearChat?: boolean;
+	limitTranscript?: boolean;
+};
 
 const renderSessionContext = (
 	InteractiveMode.prototype as unknown as {
@@ -482,31 +487,31 @@ describe("InteractiveMode.renderSessionContext", () => {
 		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
 		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
 
-		await renderMessages(harness, messages);
+		await renderMessages(harness, messages, { limitTranscript: true });
 
 		expect(addMessageToChat).toHaveBeenCalledTimes(400);
 		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 5" });
 		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
 	});
 
-	test("applies the recent-tail cap when rebuilding a cleared transcript", async () => {
+	test("preserves the full transcript when rebuilding a cleared transcript", async () => {
 		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
 		chatContainer.addChild({ render: () => ["old transcript"], invalidate: () => {} });
 		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
 
 		await renderMessages(harness, messages, { clearChat: true });
 
-		expect(addMessageToChat).toHaveBeenCalledTimes(400);
-		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 5" });
+		expect(addMessageToChat).toHaveBeenCalledTimes(405);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
 		expect(renderAll(chatContainer)).not.toContain("old transcript");
-		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
+		expect(renderAll(chatContainer)).not.toContain("for faster open");
 	});
 
 	test("populates editor history from the full transcript when initial rendering is capped", async () => {
 		const { harness, addMessageToChat, addToHistory } = createRenderSessionContextHarness();
 		const messages = Array.from({ length: 405 }, (_, index) => userMessage(`message ${index}`, index));
 
-		await renderMessages(harness, messages, { populateHistory: true });
+		await renderMessages(harness, messages, { populateHistory: true, limitTranscript: true });
 
 		expect(addMessageToChat).toHaveBeenCalledTimes(400);
 		expect(addToHistory).toHaveBeenCalledTimes(405);
@@ -558,7 +563,7 @@ describe("InteractiveMode.renderSessionContext", () => {
 			...Array.from({ length: 399 }, (_, index) => userMessage(`message ${index}`, index)),
 		];
 
-		await renderMessages(harness, messages);
+		await renderMessages(harness, messages, { limitTranscript: true });
 
 		expect(addMessageToChat).toHaveBeenCalledTimes(399);
 		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
@@ -573,7 +578,7 @@ describe("InteractiveMode.renderSessionContext", () => {
 			toolResultMessage("tool-old", "old_tool", [{ type: "text", text: "old result" }]),
 		];
 
-		await renderMessages(harness, messages);
+		await renderMessages(harness, messages, { limitTranscript: true });
 
 		expect(addMessageToChat).toHaveBeenCalledTimes(399);
 		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
@@ -950,6 +955,7 @@ describe("InteractiveMode connection events", () => {
 			{ state: createConnectionState(), messages: [] },
 			{ state: createConnectionState({ isStreaming: true }), messages: [], streamingMessage },
 		];
+		const renderSessionContextMock = vi.fn(async () => {});
 		const restoreStreamingMessageFromSnapshot = vi.fn(async () => {});
 		const fakeThis = {
 			agentConnection: { getInitialSnapshot: vi.fn(async () => snapshots.shift()!) },
@@ -961,7 +967,7 @@ describe("InteractiveMode connection events", () => {
 			seedChildAgentInspector: vi.fn(),
 			setSessionHasMessages: vi.fn(),
 			applyConnectionStateSnapshot: vi.fn(),
-			renderSessionContext: vi.fn(async () => {}),
+			renderSessionContext: renderSessionContextMock,
 			restoreStreamingMessageFromSnapshot,
 			showStatus: vi.fn(),
 		} as unknown as InteractiveMode;
@@ -976,6 +982,17 @@ describe("InteractiveMode connection events", () => {
 			(fakeThis as unknown as { agentConnection: { getInitialSnapshot: ReturnType<typeof vi.fn> } }).agentConnection
 				.getInitialSnapshot,
 		).toHaveBeenCalledTimes(2);
+		expect(renderSessionContextMock).toHaveBeenCalledTimes(2);
+		expect(renderSessionContextMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+			updateFooter: true,
+			populateHistory: true,
+			limitTranscript: true,
+		});
+		expect(renderSessionContextMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+			updateFooter: true,
+			populateHistory: true,
+			limitTranscript: true,
+		});
 		expect(restoreStreamingMessageFromSnapshot).toHaveBeenNthCalledWith(1, undefined);
 		expect(restoreStreamingMessageFromSnapshot).toHaveBeenNthCalledWith(2, streamingMessage);
 	});
@@ -1126,6 +1143,9 @@ describe("InteractiveMode connection events", () => {
 			(fakeThis as unknown as { activeConnectionExtensionUiRequests: unknown }).activeConnectionExtensionUiRequests,
 		).toBe(extensionRequests);
 		expect((fakeThis as unknown as { activeBashComponent: unknown }).activeBashComponent).toBe(activeBashComponent);
+		expect(
+			(fakeThis as unknown as { renderSessionContext: ReturnType<typeof vi.fn> }).renderSessionContext,
+		).toHaveBeenCalledWith(expect.anything(), { clearChat: true, updateFooter: true });
 		expect(startAssistantStreamingMessage).toHaveBeenCalledWith(streamingMessage);
 	});
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -581,9 +581,30 @@ describe("InteractiveMode.renderSessionContext", () => {
 		await renderMessages(harness, messages, { limitTranscript: true });
 
 		expect(addMessageToChat).toHaveBeenCalledTimes(399);
-		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ content: "message 0" });
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ role: "assistant" });
+		expect(addMessageToChat.mock.calls[1]?.[0]).toMatchObject({ content: "message 1" });
 		expect(addMessageToChat.mock.calls.at(-1)?.[0]).toMatchObject({ content: "message 398" });
-		expect(renderAll(chatContainer)).toContain("Showing latest 399 of 401 messages for faster open.");
+		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 401 messages for faster open.");
+	});
+
+	test("keeps a bounded tool-call context when the recent tail contains only tool results", async () => {
+		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
+		const toolCallIds = Array.from({ length: 400 }, (_, index) => `tool-${index}`);
+		const assistantMessage: Extract<AgentMessage, { role: "assistant" }> = {
+			...toolCallMessage(toolCallIds[0]!, "custom_tool"),
+			content: toolCallIds.map((id) => ({ type: "toolCall" as const, name: "custom_tool", id, arguments: {} })),
+		};
+		const messages = [
+			assistantMessage,
+			...toolCallIds.map((id) => toolResultMessage(id, "custom_tool", [{ type: "text", text: `result ${id}` }])),
+		];
+
+		await renderMessages(harness, messages, { limitTranscript: true });
+
+		expect(addMessageToChat).toHaveBeenCalledOnce();
+		expect(addMessageToChat.mock.calls[0]?.[0]).toMatchObject({ role: "assistant" });
+		expect(harness.preloadToolDefinitions).toHaveBeenCalledWith(Array(399).fill("custom_tool"));
+		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 401 messages for faster open.");
 	});
 });
 


### PR DESCRIPTION
## Summary

- cap initial TUI hydration for very long live sessions to the latest 400 messages
- keep the full daemon/session context intact; only the rendered transcript is bounded
- keep visible tool results paired with their tool calls while staying within the 400-message bound
- preserve current historical image rendering behavior from `main`
- populate editor history from the full transcript while excluding automated legacy heartbeat prompts
- show a visible marker when the transcript is tail-rendered for faster open

## Testing

- `npm run check`
- `node ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-status.test.ts` from `packages/coding-agent` (118 tests)
- real tmux TUI checks for 400/401/405/10,000-message sessions, orphaned tool results, images, and editor history

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up opening long live sessions by limiting initial transcript render to 400 messages
> - Introduces `INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT` (400) in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/343/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to cap how many messages are rendered on session open, reducing startup time for long sessions.
> - Adds `initialRenderMessages` and `omitOrphanToolResults` helpers to trim the transcript to its recent tail and drop tool result messages whose corresponding tool call is outside the visible window.
> - Editor history is still populated from the full transcript (not the capped tail), and a dim notice is shown when only a partial transcript is rendered.
> - Behavioral Change: Initial renders now show only the last 400 messages; users opening very long sessions will see a truncated transcript with a notice rather than the full history.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #343 opened
>
> - Replaced the simple message slicing logic in `interactive-mode.initialRenderMessages` with a bounded tool-call context algorithm [aa765be]
> - Updated tests in `interactive-mode-status.test` to verify the new bounded tool-call context rendering behavior [aa765be]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc89e16.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only initial render optimization with explicit tests; daemon/session context is unchanged and full transcript rebuild paths are preserved.
> 
> **Overview**
> **Speeds up opening long live sessions** by capping the initial TUI transcript hydration to the latest 400 messages (`INITIAL_TRANSCRIPT_RENDER_MESSAGE_LIMIT`), enabled via `limitTranscript: true` on `renderInitialMessages` only—not on compaction/resync rebuilds (`clearChat` still replays the full transcript).
> 
> Adds `initialRenderMessages` to pick a recent tail while pulling in assistant tool-call messages needed for visible tool results, trimming orphaned tool results with `omitOrphanToolResults`, and showing a dim notice when the rendered count is below the full session message count.
> 
> **Editor prompt history** is populated from the **full** message list through a new `addMessageToEditorHistory` path (still excluding legacy automated heartbeat prompts), so up-arrow recall is unchanged even when the visible chat is truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa765be7ff1e295ed7272011ad66584f65f496a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->