### PR TITLE
Fix compaction for very long sessions

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -995,13 +995,19 @@ async function generateTurnPrefixSummary(
 		},
 	];
 
-	const response = await completeSimple(
+	let response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers },
+		buildSummaryCompletionOptions(model, maxTokens, apiKey, headers, signal, thinkingLevel),
 	);
+
+	if (shouldRetrySummaryWithoutReasoning(response, thinkingLevel)) {
+		response = await completeSimple(
+			model,
+			{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
+			buildSummaryCompletionOptions(model, maxTokens, apiKey, headers, signal, "off"),
+		);
+	}
 
 	if (response.stopReason === "error") {
 		throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -547,6 +547,167 @@ export function buildSummarizationPrompt(customInstructions?: string, previousSu
 	return `${basePrompt}\n\n${KERNEL_PERSIST_SUMMARY_NOTE}`;
 }
 
+const SUMMARY_CHUNK_TARGET_TOKENS = 80_000;
+const SUMMARY_CHUNK_CONTEXT_SAFETY_TOKENS = 8_192;
+const SUMMARY_CHUNK_CHARS_PER_TOKEN = 3;
+const SUMMARY_CHUNK_MIN_CHARS = 48_000;
+
+function buildSummaryPromptText(
+	conversationText: string,
+	customInstructions?: string,
+	previousSummary?: string,
+): string {
+	let promptText = `<conversation>
+${conversationText}
+</conversation>
+
+`;
+	if (previousSummary) {
+		promptText += `<previous-summary>
+${previousSummary}
+</previous-summary>
+
+`;
+	}
+	promptText += buildSummarizationPrompt(customInstructions, previousSummary);
+	return promptText;
+}
+
+function getSummaryConversationCharBudget(model: Model<any>, maxTokens: number, previousSummary?: string): number {
+	const contextWindow = typeof model.contextWindow === "number" ? model.contextWindow : 0;
+	const targetTokens =
+		contextWindow > 0
+			? Math.min(
+					SUMMARY_CHUNK_TARGET_TOKENS,
+					Math.max(16_000, contextWindow - maxTokens - SUMMARY_CHUNK_CONTEXT_SAFETY_TOKENS),
+				)
+			: SUMMARY_CHUNK_TARGET_TOKENS;
+	const previousSummaryChars = previousSummary?.length ?? 0;
+	return Math.max(SUMMARY_CHUNK_MIN_CHARS, targetTokens * SUMMARY_CHUNK_CHARS_PER_TOKEN - previousSummaryChars);
+}
+
+function truncateConversationPiece(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	const marker = `
+
+[... ${text.length - maxChars} more characters truncated to keep the compaction request within provider context]`;
+	const keepChars = Math.max(0, maxChars - marker.length);
+	return `${text.slice(0, keepChars)}${marker}`;
+}
+
+function serializeConversationChunks(messages: AgentMessage[], maxChars: number): string[] {
+	if (messages.length === 0) return [""];
+
+	const chunks: string[] = [];
+	let currentParts: string[] = [];
+	let currentChars = 0;
+
+	for (const message of messages) {
+		const serialized = serializeConversation(convertToLlm([message]));
+		if (!serialized) continue;
+		const piece = truncateConversationPiece(serialized, maxChars);
+		const separatorChars = currentParts.length > 0 ? 2 : 0;
+		if (currentParts.length > 0 && currentChars + separatorChars + piece.length > maxChars) {
+			chunks.push(currentParts.join("\n\n"));
+			currentParts = [];
+			currentChars = 0;
+		}
+		currentParts.push(piece);
+		currentChars += (currentParts.length > 1 ? 2 : 0) + piece.length;
+	}
+
+	if (currentParts.length > 0) {
+		chunks.push(currentParts.join("\n\n"));
+	}
+	return chunks.length > 0 ? chunks : [""];
+}
+
+function buildSummaryCompletionOptions(
+	model: Model<any>,
+	maxTokens: number,
+	apiKey: string,
+	headers?: Record<string, string>,
+	signal?: AbortSignal,
+	thinkingLevel?: ThinkingLevel,
+): {
+	maxTokens: number;
+	signal?: AbortSignal;
+	apiKey: string;
+	headers?: Record<string, string>;
+	reasoning?: Exclude<ThinkingLevel, "off">;
+} {
+	return model.reasoning && thinkingLevel && thinkingLevel !== "off"
+		? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
+		: { maxTokens, signal, apiKey, headers };
+}
+
+function shouldRetrySummaryWithoutReasoning(response: AssistantMessage, thinkingLevel?: ThinkingLevel): boolean {
+	if (!thinkingLevel || thinkingLevel === "off") return false;
+	if (response.stopReason !== "error") return false;
+	return /400|invalid request|reasoning|effort/i.test(response.errorMessage ?? "");
+}
+
+async function requestSummaryForConversationText(
+	conversationText: string,
+	model: Model<any>,
+	maxTokens: number,
+	apiKey: string,
+	headers?: Record<string, string>,
+	signal?: AbortSignal,
+	customInstructions?: string,
+	previousSummary?: string,
+	thinkingLevel?: ThinkingLevel,
+): Promise<string> {
+	const summarizationMessages = [
+		{
+			role: "user" as const,
+			content: [
+				{
+					type: "text" as const,
+					text: buildSummaryPromptText(conversationText, customInstructions, previousSummary),
+				},
+			],
+			timestamp: Date.now(),
+		},
+	];
+
+	let response = await completeSimple(
+		model,
+		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
+		buildSummaryCompletionOptions(model, maxTokens, apiKey, headers, signal, thinkingLevel),
+	);
+
+	if (shouldRetrySummaryWithoutReasoning(response, thinkingLevel)) {
+		response = await completeSimple(
+			model,
+			{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
+			buildSummaryCompletionOptions(model, maxTokens, apiKey, headers, signal, "off"),
+		);
+	}
+
+	if (response.stopReason === "error") {
+		throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
+	}
+
+	return response.content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map((c) => c.text)
+		.join("\n");
+}
+
+function buildChunkedSummaryInstructions(
+	customInstructions: string | undefined,
+	chunkIndex: number,
+	chunkCount: number,
+): string {
+	const chunkInstruction = `Internal compaction note: the conversation was too large for one summarization request. This is chunk ${chunkIndex + 1} of ${chunkCount}. Produce one concise cumulative summary; do not grow the summary linearly with each chunk.`;
+	return customInstructions
+		? `${customInstructions}
+
+${chunkInstruction}`
+		: chunkInstruction;
+}
+
 /**
  * Generate a summary of the conversation using the LLM.
  * If previousSummary is provided, uses the update prompt to merge.
@@ -563,50 +724,38 @@ export async function generateSummary(
 	thinkingLevel?: ThinkingLevel,
 ): Promise<string> {
 	const maxTokens = Math.floor(0.8 * reserveTokens);
+	const maxConversationChars = getSummaryConversationCharBudget(model, maxTokens, previousSummary);
+	const conversationChunks = serializeConversationChunks(currentMessages, maxConversationChars);
 
-	const basePrompt = buildSummarizationPrompt(customInstructions, previousSummary);
-
-	// Serialize conversation to text so model doesn't try to continue it
-	// Convert to LLM messages first (handles custom types like bashExecution, custom, etc.)
-	const llmMessages = convertToLlm(currentMessages);
-	const conversationText = serializeConversation(llmMessages);
-
-	// Build the prompt with conversation wrapped in tags
-	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
-	if (previousSummary) {
-		promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
-	}
-	promptText += basePrompt;
-
-	const summarizationMessages = [
-		{
-			role: "user" as const,
-			content: [{ type: "text" as const, text: promptText }],
-			timestamp: Date.now(),
-		},
-	];
-
-	const completionOptions =
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers };
-
-	const response = await completeSimple(
-		model,
-		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		completionOptions,
-	);
-
-	if (response.stopReason === "error") {
-		throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
+	if (conversationChunks.length <= 1) {
+		return requestSummaryForConversationText(
+			conversationChunks[0] ?? "",
+			model,
+			maxTokens,
+			apiKey,
+			headers,
+			signal,
+			customInstructions,
+			previousSummary,
+			thinkingLevel,
+		);
 	}
 
-	const textContent = response.content
-		.filter((c): c is { type: "text"; text: string } => c.type === "text")
-		.map((c) => c.text)
-		.join("\n");
-
-	return textContent;
+	let rollingSummary = previousSummary;
+	for (let i = 0; i < conversationChunks.length; i++) {
+		rollingSummary = await requestSummaryForConversationText(
+			conversationChunks[i]!,
+			model,
+			maxTokens,
+			apiKey,
+			headers,
+			signal,
+			buildChunkedSummaryInstructions(customInstructions, i, conversationChunks.length),
+			rollingSummary,
+			thinkingLevel,
+		);
+	}
+	return rollingSummary ?? "";
 }
 
 // ============================================================================

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -115,4 +115,57 @@ describe("generateSummary reasoning options", () => {
 		});
 		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
 	});
+
+	it("chunks very large summarization inputs before calling the provider", async () => {
+		const largeMessages: AgentMessage[] = Array.from({ length: 4 }, (_, index) => ({
+			role: "user" as const,
+			content: `message ${index} ${"x".repeat(100_000)}`,
+			timestamp: Date.now() + index,
+		}));
+
+		await generateSummary(
+			largeMessages,
+			createModel(true),
+			2000,
+			"test-key",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"medium",
+		);
+
+		expect(completeSimpleMock.mock.calls.length).toBeGreaterThan(1);
+		for (const call of completeSimpleMock.mock.calls) {
+			const promptText = call[1].messages[0].content[0].text;
+			expect(promptText.length).toBeLessThan(260_000);
+		}
+	});
+
+	it("retries summarization without reasoning when the provider rejects reasoning options", async () => {
+		completeSimpleMock
+			.mockResolvedValueOnce({
+				...mockSummaryResponse,
+				content: [],
+				stopReason: "error",
+				errorMessage: "400 Invalid request.",
+			})
+			.mockResolvedValueOnce(mockSummaryResponse);
+
+		await generateSummary(
+			messages,
+			createModel(true),
+			2000,
+			"test-key",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"medium",
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(2);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({ reasoning: "medium" });
+		expect(completeSimpleMock.mock.calls[1][2]).not.toHaveProperty("reasoning");
+	});
 });


### PR DESCRIPTION
## Summary
- Add bounded/chunked rescue summarization for oversized compaction inputs.
- Retry compaction summarization without reasoning when the provider rejects reasoning/400s.
- Apply the retry path to split-turn prefix summaries too.

## Validation
- npm test -- test/compaction-summary-reasoning.test.ts test/compaction.test.ts
- npm run check

Stack note: this PR is based on #343 (`sethkarten/factorio-session-open-speed`) and keeps the compaction fix separate from the kitchen aggregate branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compaction/summarization behavior for long sessions; chunked rolling summaries could alter summary quality or cost (multiple LLM calls), but scope is isolated to compaction utilities with new tests.
> 
> **Overview**
> Fixes compaction failures on **very long sessions** by bounding what gets sent to the summarization model and hardening provider error handling.
> 
> **Chunked rescue summarization:** `generateSummary` no longer serializes the full conversation in one request. It computes a per-model character budget from `contextWindow`, splits messages into chunks (with per-message truncation when a single message exceeds the budget), and runs **sequential rolling summaries**—each chunk merges into the previous summary with internal instructions to stay cumulative and concise.
> 
> **Reasoning fallback:** Summarization calls share `buildSummaryCompletionOptions` and, on provider errors that look like rejected reasoning/400s, **automatically retry once without** the `reasoning` option. The same path is wired into **turn-prefix** summarization for split turns.
> 
> Tests cover multi-chunk inputs (prompt size caps) and the reasoning retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f94e68489fa5136dd671e3c53d9bcb97bb00fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compaction for very long sessions by chunking summarization input
> - Large conversations are now split into multiple chunks, each within a per-model character budget derived from the model's context window, reserved `maxTokens`, and a safety margin
> - Each chunk is summarized sequentially, with the rolling summary passed as context to subsequent chunks via a `<previous-summary>` section
> - Individual messages that exceed the budget are truncated with an explicit marker showing the number of removed characters
> - Summarization requests now automatically retry once without reasoning when a provider returns a 400 error rejecting reasoning options, in both `generateSummary` and `generateTurnPrefixSummary`
> - Behavioral Change: `generateSummary` may now issue multiple provider calls for long sessions instead of a single call
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5f94e68. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->