### PR TITLE
retry provider errors before surfacing them

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed run-lifecycle failures carrying no diagnostics, so hosts can distinguish local failures from provider failures.
+
 ## [0.2.6] - 2026-07-06
 
 ## [0.2.5] - 2026-07-06

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,4 +1,5 @@
 import {
+	createAssistantMessageDiagnostic,
 	type ImageContent,
 	type Message,
 	type Model,
@@ -502,6 +503,9 @@ export class Agent {
 			usage: EMPTY_USAGE,
 			stopReason: aborted ? "aborted" : "error",
 			errorMessage: error instanceof Error ? error.message : String(error),
+			diagnostics: aborted
+				? undefined
+				: [createAssistantMessageDiagnostic("agent_lifecycle_failure", error, { source: "run_with_lifecycle" })],
 			timestamp: Date.now(),
 		} satisfies AgentMessage;
 		this._state.messages.push(failureMessage);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed login dialogs in fullscreen so sign-in URLs can be selected natively ([ENG-4480](https://linear.app/primeintellect/issue/ENG-4480/new-fullscreen-tui-makes-it-impossible-to-copy-login-url)).
 - Fixed provider auth failures leaving stale credentials shown as connected in `/login` ([ENG-4491](https://linear.app/primeintellect/issue/ENG-4491/mark-provider-stale-after-repeated-401s)).
+- Fixed provider errors being surfaced instead of retried within the retry budget ([ENG-4503](https://linear.app/primeintellect/issue/ENG-4503/restarting-old-session-returns-empty-model-response)).
 
 ## [0.2.6] - 2026-07-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed login dialogs in fullscreen so sign-in URLs can be selected natively ([ENG-4480](https://linear.app/primeintellect/issue/ENG-4480/new-fullscreen-tui-makes-it-impossible-to-copy-login-url)).
 - Fixed provider auth failures leaving stale credentials shown as connected in `/login` ([ENG-4491](https://linear.app/primeintellect/issue/ENG-4491/mark-provider-stale-after-repeated-401s)).
 - Fixed session-targeted heartbeat jobs staying scheduled after sessions are killed or saved sessions are deleted ([#332](https://github.com/PrimeIntellect-ai/prime-agent/pull/332)).
+- Fixed provider errors being surfaced instead of retried within the retry budget ([ENG-4503](https://linear.app/primeintellect/issue/ENG-4503/restarting-old-session-returns-empty-model-response)).
 
 ## [0.2.6] - 2026-07-06
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1857,6 +1857,7 @@ export class AgentSession {
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
+			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
 			const compactionWillRetry = await this._checkCompaction(msg);
 			if (!compactionWillRetry) {
@@ -5386,22 +5387,44 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
+		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
+			return false;
+		}
+
 		return true;
 	}
 
-	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {
+	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {
 		const failure = message.diagnostics?.find((diagnostic) => diagnostic.type === "provider_stream_failure");
 		const details = failure?.details;
 		if (!details || typeof details !== "object") {
 			return undefined;
 		}
+		return details;
+	}
 
-		const kind = "kind" in details ? details.kind : undefined;
+	private _getProviderStreamFailureKind(message: AssistantMessage): string | undefined {
+		const kind = this._getProviderStreamFailureDetails(message)?.kind;
+		return typeof kind === "string" ? kind : undefined;
+	}
+
+	private _isStructuredPermanentProviderFailure(message: AssistantMessage): boolean {
+		const kind = this._getProviderStreamFailureKind(message);
+		return kind === "auth" || kind === "invalid_request" || kind === "refusal";
+	}
+
+	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {
+		const details = this._getProviderStreamFailureDetails(message);
+		if (!details) {
+			return undefined;
+		}
+
+		const kind = details.kind;
 		if (kind !== "auth") {
 			return undefined;
 		}
 
-		const status = "status" in details ? details.status : undefined;
+		const status = details.status;
 		if (typeof status === "number") {
 			return status;
 		}
@@ -5481,6 +5504,21 @@ export class AgentSession {
 			return marked;
 		}
 		return false;
+	}
+
+	private _finishActiveRetryWithFailure(message: AssistantMessage): void {
+		if (this._retryAttempt === 0) {
+			return;
+		}
+		this._markProviderAuthStaleForRetryFailure(message);
+		this._emit({
+			type: "auto_retry_end",
+			success: false,
+			attempt: this._retryAttempt,
+			finalError: message.errorMessage,
+		});
+		this._retryAttempt = 0;
+		this._retryAuthFailureSources = [];
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1883,13 +1883,15 @@ export class AgentSession {
 			}
 
 			const compactionWillRetry = await this._checkCompaction(msg);
-			if (compactionWillRetry) {
+			if (compactionWillRetry && this._retryAttempt > 0) {
 				return;
 			}
 			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
-			this._finishGoalForTerminalAssistantMessage(msg);
-			this._scheduleAutoRefineAfterAgentEnd();
+			if (!compactionWillRetry) {
+				this._finishGoalForTerminalAssistantMessage(msg);
+				this._scheduleAutoRefineAfterAgentEnd();
+			}
 		}
 	}
 
@@ -5628,11 +5630,19 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
+		if (this._isFauxProviderQueueExhausted(message)) {
+			return false;
+		}
+
 		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
 			return false;
 		}
 
 		return true;
+	}
+
+	private _isFauxProviderQueueExhausted(message: AssistantMessage): boolean {
+		return message.provider === "faux" && message.errorMessage === "No more faux responses queued";
 	}
 
 	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1689,7 +1689,10 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
-		const concreteAuthFailure = lastAssistant ? this._isConcreteProviderAuthFailure(lastAssistant) : false;
+		const concreteAuthFailure =
+			lastAssistant !== undefined &&
+			this._isConcreteProviderAuthFailure(lastAssistant) &&
+			!this._isStructuredPermanentProviderRetryExhausted(lastAssistant);
 		if (!lastAssistant || (!this._isRetryableError(lastAssistant) && !concreteAuthFailure)) {
 			return;
 		}
@@ -1871,13 +1874,15 @@ export class AgentSession {
 
 			// Check for retryable errors first (overloaded, rate limit, server errors)
 			const concreteAuthFailure = this._isConcreteProviderAuthFailure(msg);
-			if (this._isRetryableError(msg) || concreteAuthFailure) {
-				if (concreteAuthFailure) {
+			const retryConcreteAuthFailure =
+				concreteAuthFailure && !this._isStructuredPermanentProviderRetryExhausted(msg);
+			if (this._isRetryableError(msg) || retryConcreteAuthFailure) {
+				if (retryConcreteAuthFailure) {
 					this._captureRetryAuthFailureSource(msg);
 				}
 				const didRetry = await this._handleRetryableError(msg, {
-					markAuthStaleOnFailure: concreteAuthFailure,
-					authSourceTokens: concreteAuthFailure ? this._retryAuthFailureSources : undefined,
+					markAuthStaleOnFailure: retryConcreteAuthFailure,
+					authSourceTokens: retryConcreteAuthFailure ? this._retryAuthFailureSources : undefined,
 				});
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
@@ -5638,7 +5643,7 @@ export class AgentSession {
 			return false;
 		}
 
-		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
+		if (this._isStructuredPermanentProviderRetryExhausted(message)) {
 			return false;
 		}
 
@@ -5670,6 +5675,10 @@ export class AgentSession {
 	private _isStructuredPermanentProviderFailure(message: AssistantMessage): boolean {
 		const kind = this._getProviderStreamFailureKind(message);
 		return kind === "auth" || kind === "invalid_request" || kind === "refusal";
+	}
+
+	private _isStructuredPermanentProviderRetryExhausted(message: AssistantMessage): boolean {
+		return this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message);
 	}
 
 	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3226,8 +3226,8 @@ export class AgentSession {
 	 * @returns Object with steering and followUp arrays
 	 */
 	clearQueue(): { steering: string[]; followUp: string[] } {
-		const steering = this._steeringMessages.map(queuedMessagePreview);
-		const followUp = this._followUpMessages.map(queuedMessagePreview);
+		const steering = this._steeringMessages.map((message) => message.text);
+		const followUp = this._followUpMessages.map((message) => message.text);
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 		this._steeringMessages = [];
 		this._followUpMessages = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5619,6 +5619,17 @@ export class AgentSession {
 			this._retryAbortController.abort();
 			return;
 		}
+		if (this._retryAttempt > 0) {
+			this._autoCompactionAbortController?.abort();
+			this._cancelPostCompactionContinue();
+			this._emit({
+				type: "auto_retry_end",
+				success: false,
+				attempt: this._retryAttempt,
+				finalError: "Retry cancelled",
+			});
+			this._retryAttempt = 0;
+		}
 		this._retryAuthFailureSources = [];
 		this._resolveRetry();
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5394,6 +5394,10 @@ export class AgentSession {
 			return false;
 		}
 
+		if (this._isAgentLifecycleFailure(message)) {
+			return false;
+		}
+
 		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
 			return false;
 		}
@@ -5403,6 +5407,10 @@ export class AgentSession {
 
 	private _isFauxProviderQueueExhausted(message: AssistantMessage): boolean {
 		return message.provider === "faux" && message.errorMessage === "No more faux responses queued";
+	}
+
+	private _isAgentLifecycleFailure(message: AssistantMessage): boolean {
+		return message.diagnostics?.some((diagnostic) => diagnostic.type === "agent_lifecycle_failure") ?? false;
 	}
 
 	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5859,6 +5859,17 @@ export class AgentSession {
 			this._retryAbortController.abort();
 			return;
 		}
+		if (this._retryAttempt > 0) {
+			this._autoCompactionAbortController?.abort();
+			this._cancelPostCompactionContinue();
+			this._emit({
+				type: "auto_retry_end",
+				success: false,
+				attempt: this._retryAttempt,
+				finalError: "Retry cancelled",
+			});
+			this._retryAttempt = 0;
+		}
 		this._retryAuthFailureSources = [];
 		this._resolveRetry();
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1857,13 +1857,14 @@ export class AgentSession {
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
+			const compactionWillRetry = await this._checkCompaction(msg);
+			if (compactionWillRetry) {
+				return;
+			}
 			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
-			const compactionWillRetry = await this._checkCompaction(msg);
-			if (!compactionWillRetry) {
-				this._finishGoalForTerminalAssistantMessage(msg);
-				this._scheduleAutoRefineAfterAgentEnd();
-			}
+			this._finishGoalForTerminalAssistantMessage(msg);
+			this._scheduleAutoRefineAfterAgentEnd();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1882,13 +1882,14 @@ export class AgentSession {
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
+			const compactionWillRetry = await this._checkCompaction(msg);
+			if (compactionWillRetry) {
+				return;
+			}
 			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
-			const compactionWillRetry = await this._checkCompaction(msg);
-			if (!compactionWillRetry) {
-				this._finishGoalForTerminalAssistantMessage(msg);
-				this._scheduleAutoRefineAfterAgentEnd();
-			}
+			this._finishGoalForTerminalAssistantMessage(msg);
+			this._scheduleAutoRefineAfterAgentEnd();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1882,6 +1882,7 @@ export class AgentSession {
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 
+			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
 			const compactionWillRetry = await this._checkCompaction(msg);
 			if (!compactionWillRetry) {
@@ -5626,22 +5627,44 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
+		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
+			return false;
+		}
+
 		return true;
 	}
 
-	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {
+	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {
 		const failure = message.diagnostics?.find((diagnostic) => diagnostic.type === "provider_stream_failure");
 		const details = failure?.details;
 		if (!details || typeof details !== "object") {
 			return undefined;
 		}
+		return details;
+	}
 
-		const kind = "kind" in details ? details.kind : undefined;
+	private _getProviderStreamFailureKind(message: AssistantMessage): string | undefined {
+		const kind = this._getProviderStreamFailureDetails(message)?.kind;
+		return typeof kind === "string" ? kind : undefined;
+	}
+
+	private _isStructuredPermanentProviderFailure(message: AssistantMessage): boolean {
+		const kind = this._getProviderStreamFailureKind(message);
+		return kind === "auth" || kind === "invalid_request" || kind === "refusal";
+	}
+
+	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {
+		const details = this._getProviderStreamFailureDetails(message);
+		if (!details) {
+			return undefined;
+		}
+
+		const kind = details.kind;
 		if (kind !== "auth") {
 			return undefined;
 		}
 
-		const status = "status" in details ? details.status : undefined;
+		const status = details.status;
 		if (typeof status === "number") {
 			return status;
 		}
@@ -5721,6 +5744,21 @@ export class AgentSession {
 			return marked;
 		}
 		return false;
+	}
+
+	private _finishActiveRetryWithFailure(message: AssistantMessage): void {
+		if (this._retryAttempt === 0) {
+			return;
+		}
+		this._markProviderAuthStaleForRetryFailure(message);
+		this._emit({
+			type: "auto_retry_end",
+			success: false,
+			attempt: this._retryAttempt,
+			finalError: message.errorMessage,
+		});
+		this._retryAttempt = 0;
+		this._retryAuthFailureSources = [];
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5634,6 +5634,10 @@ export class AgentSession {
 			return false;
 		}
 
+		if (this._isAgentLifecycleFailure(message)) {
+			return false;
+		}
+
 		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
 			return false;
 		}
@@ -5643,6 +5647,10 @@ export class AgentSession {
 
 	private _isFauxProviderQueueExhausted(message: AssistantMessage): boolean {
 		return message.provider === "faux" && message.errorMessage === "No more faux responses queued";
+	}
+
+	private _isAgentLifecycleFailure(message: AssistantMessage): boolean {
+		return message.diagnostics?.some((diagnostic) => diagnostic.type === "agent_lifecycle_failure") ?? false;
 	}
 
 	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5386,19 +5386,7 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
-		// Structured classification from the provider (stream-failure.ts) beats
-		// message-text matching. Safety/malformed/unknown kinds fall through to
-		// the regex, which distinguishes transient content_filter cases.
-		const failure = message.diagnostics?.find((d) => d.type === "provider_stream_failure");
-		const kind = failure?.details?.kind;
-		if (kind === "overloaded" || kind === "rate_limit" || kind === "server_error") return true;
-		if (kind === "refusal" || kind === "auth" || kind === "invalid_request") return false;
-
-		const err = message.errorMessage;
-		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded, transient content_filter finish_reason, provider policy-flag prose, and prose-form transient 5xx ("an error occurred while processing your request. you can retry")
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay|content.?filter|flagged .*(cybersecurity|usage polic|violat)|error occurred while processing|you can retry/i.test(
-			err,
-		);
+		return true;
 	}
 
 	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5626,19 +5626,7 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
-		// Structured classification from the provider (stream-failure.ts) beats
-		// message-text matching. Safety/malformed/unknown kinds fall through to
-		// the regex, which distinguishes transient content_filter cases.
-		const failure = message.diagnostics?.find((d) => d.type === "provider_stream_failure");
-		const kind = failure?.details?.kind;
-		if (kind === "overloaded" || kind === "rate_limit" || kind === "server_error") return true;
-		if (kind === "refusal" || kind === "auth" || kind === "invalid_request") return false;
-
-		const err = message.errorMessage;
-		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded, transient content_filter finish_reason, provider policy-flag prose, and prose-form transient 5xx ("an error occurred while processing your request. you can retry")
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay|content.?filter|flagged .*(cybersecurity|usage polic|violat)|error occurred while processing|you can retry/i.test(
-			err,
-		);
+		return true;
 	}
 
 	private _getProviderStreamFailureAuthStatus(message: AssistantMessage): number | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1858,13 +1858,15 @@ export class AgentSession {
 			}
 
 			const compactionWillRetry = await this._checkCompaction(msg);
-			if (compactionWillRetry) {
+			if (compactionWillRetry && this._retryAttempt > 0) {
 				return;
 			}
 			this._finishActiveRetryWithFailure(msg);
 			this._resolveRetry();
-			this._finishGoalForTerminalAssistantMessage(msg);
-			this._scheduleAutoRefineAfterAgentEnd();
+			if (!compactionWillRetry) {
+				this._finishGoalForTerminalAssistantMessage(msg);
+				this._scheduleAutoRefineAfterAgentEnd();
+			}
 		}
 	}
 
@@ -5388,11 +5390,19 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
 
+		if (this._isFauxProviderQueueExhausted(message)) {
+			return false;
+		}
+
 		if (this._retryAttempt > 0 && this._isStructuredPermanentProviderFailure(message)) {
 			return false;
 		}
 
 		return true;
+	}
+
+	private _isFauxProviderQueueExhausted(message: AssistantMessage): boolean {
+		return message.provider === "faux" && message.errorMessage === "No more faux responses queued";
 	}
 
 	private _getProviderStreamFailureDetails(message: AssistantMessage): Record<string, unknown> | undefined {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1689,10 +1689,7 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
-		const concreteAuthFailure =
-			lastAssistant !== undefined &&
-			this._isConcreteProviderAuthFailure(lastAssistant) &&
-			!this._isStructuredPermanentProviderRetryExhausted(lastAssistant);
+		const concreteAuthFailure = lastAssistant ? this._isConcreteProviderAuthFailure(lastAssistant) : false;
 		if (!lastAssistant || (!this._isRetryableError(lastAssistant) && !concreteAuthFailure)) {
 			return;
 		}

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -363,9 +363,11 @@ describe("AgentSession retry", () => {
 		expect(callCount).toBe(4);
 	});
 
-	// Transient provider stream artifacts the classifier previously missed (ENG-4390).
+	// Provider errors are retried within the bounded retry budget (ENG-4390, ENG-4503).
 	const transientProviderErrors: Array<[string, string]> = [
 		["content_filter finish_reason", "Provider finish_reason: content_filter"],
+		["empty provider response", "Provider returned an empty response"],
+		["plain invalid API key", "invalid_api_key"],
 		["cybersecurity policy flag", "Your request was flagged for cybersecurity risk and cannot be processed."],
 		["usage policy flag", "flagged as potentially violating our usage policy"],
 		["prose-form transient 5xx", "An error occurred while processing your request. You can retry your request."],

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
+import { type AssistantMessage, fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import { createHarness, type Harness } from "./harness.js";
@@ -19,6 +19,22 @@ function normalizeEventOrder(events: Harness["events"]): string[] {
 		normalized.push(label);
 	}
 	return normalized;
+}
+
+function structuredProviderFailure(kind: "auth" | "invalid_request" | "refusal"): AssistantMessage {
+	return {
+		...fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: `provider ${kind} failure`,
+		}),
+		diagnostics: [
+			{
+				type: "provider_stream_failure",
+				timestamp: Date.now(),
+				details: { kind },
+			},
+		],
+	};
 }
 
 describe("AgentSession retry and event characterization", () => {
@@ -171,6 +187,25 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1]);
 		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
 	});
+
+	for (const kind of ["auth", "invalid_request", "refusal"] as const) {
+		it(`retries structured permanent provider ${kind} failures once`, async () => {
+			const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+			harnesses.push(harness);
+			harness.setResponses([
+				structuredProviderFailure(kind),
+				structuredProviderFailure(kind),
+				fauxAssistantMessage("unused"),
+			]);
+
+			await harness.session.prompt("test");
+
+			expect(harness.faux.state.callCount).toBe(2);
+			expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1]);
+			expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+			expect(harness.session.isRetrying).toBe(false);
+		});
+	}
 
 	it("cancels retry sleep when abortRetry is called", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } } });

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -41,8 +41,12 @@ type SessionRetryCompactionInternals = {
 	_retryAttempt: number;
 	_retryPromise: Promise<void> | undefined;
 	_retryResolve: (() => void) | undefined;
+	_autoCompactionAbortController: AbortController | undefined;
+	_postCompactionContinuationScheduled: boolean;
 	_processAgentEvent: (event: AgentEvent) => Promise<void>;
 	_checkCompaction: (message: AssistantMessage) => Promise<boolean>;
+	_schedulePostCompactionContinue: () => void;
+	_cancelPostCompactionContinue: () => void;
 };
 
 describe("AgentSession retry and event characterization", () => {
@@ -239,6 +243,38 @@ describe("AgentSession retry and event characterization", () => {
 		} finally {
 			internals._checkCompaction = originalCheckCompaction;
 			harness.session.abortRetry();
+		}
+	});
+
+	it("cancels overflow-compaction retry continuation when abortRetry is called", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SessionRetryCompactionInternals;
+		const compactionAbortController = new AbortController();
+		internals._retryAttempt = 1;
+		internals._retryPromise = new Promise<void>((resolve) => {
+			internals._retryResolve = resolve;
+		});
+		internals._autoCompactionAbortController = compactionAbortController;
+		internals._schedulePostCompactionContinue();
+
+		try {
+			expect(internals._postCompactionContinuationScheduled).toBe(true);
+
+			harness.session.abortRetry();
+
+			expect(compactionAbortController.signal.aborted).toBe(true);
+			expect(internals._postCompactionContinuationScheduled).toBe(false);
+			expect(internals._retryAttempt).toBe(0);
+			expect(harness.session.isRetrying).toBe(false);
+			expect(harness.eventsOfType("auto_retry_end").at(-1)).toMatchObject({
+				success: false,
+				attempt: 1,
+				finalError: "Retry cancelled",
+			});
+		} finally {
+			internals._autoCompactionAbortController = undefined;
+			internals._cancelPostCompactionContinue();
 		}
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -157,15 +157,19 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
-	it("does not retry non-retryable errors", async () => {
+	it("retries generic provider errors", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" })]);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" }),
+			fauxAssistantMessage("recovered"),
+		]);
 
 		await harness.session.prompt("test");
 
-		expect(harness.faux.state.callCount).toBe(1);
-		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
 	});
 
 	it("cancels retry sleep when abortRetry is called", async () => {
@@ -221,6 +225,7 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.faux.state.callCount).toBe(3);
 		expect(toolRuns).toEqual(["hello"]);
 		expect(harness.session.isStreaming).toBe(false);
+		harness.appendResponses([fauxAssistantMessage("follow-up answer")]);
 		await harness.session.prompt("follow-up");
 		expect(harness.faux.state.callCount).toBe(4);
 	});
@@ -347,7 +352,7 @@ describe("AgentSession retry and event characterization", () => {
 	});
 
 	it("emits agent_end for error responses", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "broken" })]);
 

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentEvent, AgentTool } from "@earendil-works/pi-agent-core";
 import { type AssistantMessage, fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
@@ -36,6 +36,14 @@ function structuredProviderFailure(kind: "auth" | "invalid_request" | "refusal")
 		],
 	};
 }
+
+type SessionRetryCompactionInternals = {
+	_retryAttempt: number;
+	_retryPromise: Promise<void> | undefined;
+	_retryResolve: (() => void) | undefined;
+	_processAgentEvent: (event: AgentEvent) => Promise<void>;
+	_checkCompaction: (message: AssistantMessage) => Promise<boolean>;
+};
 
 describe("AgentSession retry and event characterization", () => {
 	const harnesses: Harness[] = [];
@@ -206,6 +214,33 @@ describe("AgentSession retry and event characterization", () => {
 			expect(harness.session.isRetrying).toBe(false);
 		});
 	}
+
+	it("keeps retry state active when overflow compaction will retry", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SessionRetryCompactionInternals;
+		const originalCheckCompaction = internals._checkCompaction.bind(harness.session);
+		const overflowMessage = fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+		});
+		internals._retryAttempt = 1;
+		internals._retryPromise = new Promise<void>((resolve) => {
+			internals._retryResolve = resolve;
+		});
+		internals._checkCompaction = async () => true;
+
+		try {
+			await internals._processAgentEvent({ type: "agent_end", messages: [overflowMessage] } as AgentEvent);
+
+			expect(internals._retryAttempt).toBe(1);
+			expect(harness.session.isRetrying).toBe(true);
+			expect(harness.eventsOfType("auto_retry_end")).toEqual([]);
+		} finally {
+			internals._checkCompaction = originalCheckCompaction;
+			harness.session.abortRetry();
+		}
+	});
 
 	it("cancels retry sleep when abortRetry is called", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } } });

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -185,6 +185,17 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
+	it("does not retry faux provider queue exhaustion", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+
+		await harness.session.prompt("test");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+
 	it("retries generic provider errors", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -196,6 +196,32 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
+	it("does not retry local agent lifecycle listener failures", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		let unsubscribe = () => {};
+		unsubscribe = harness.session.agent.subscribe((event) => {
+			if (event.type === "message_start" && event.message.role === "assistant") {
+				unsubscribe();
+				throw new Error("local listener failed");
+			}
+		});
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("retry should not happen")]);
+
+		await harness.session.prompt("test");
+
+		const lastMessage = harness.session.messages.at(-1);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.isRetrying).toBe(false);
+		expect(lastMessage?.role).toBe("assistant");
+		if (lastMessage?.role === "assistant") {
+			expect(lastMessage.diagnostics?.some((diagnostic) => diagnostic.type === "agent_lifecycle_failure")).toBe(
+				true,
+			);
+		}
+	});
+
 	it("retries generic provider errors", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -258,7 +258,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		).toBe(true);
 	});
 
-	it("returns labeled previews when clearing queued heartbeat prompts", async () => {
+	it("returns raw text when clearing queued heartbeat prompts while previews remain labeled", async () => {
 		let releaseToolExecution: (() => void) | undefined;
 		const toolRelease = new Promise<void>((resolve) => {
 			releaseToolExecution = resolve;
@@ -278,7 +278,8 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		};
 		const harness = await createHarness({ tools: [waitTool] });
 		harnesses.push(harness);
-		const heartbeatPreview = "Heartbeat prompt: Check whether the long-running task needs another step.";
+		const heartbeatText = "Check whether the long-running task needs another step.";
+		const heartbeatPreview = `Heartbeat prompt: ${heartbeatText}`;
 		harness.setResponses([
 			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("original turn complete"),
@@ -297,7 +298,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		await harness.session.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" });
 
 		expect(harness.session.getFollowUpMessagePreviews()).toEqual([heartbeatPreview]);
-		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [heartbeatPreview] });
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [heartbeatText] });
 
 		releaseToolExecution?.();
 		await promptPromise;

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -125,6 +125,24 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		harness.session.abortRetry();
 	});
 
+	it("creates retry promises for exhausted structured auth failures so cleanup is awaited", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const event = { type: "agent_end", messages: [provider401Message()] } as AgentEvent;
+		const session = harness.session as unknown as {
+			_retryAttempt: number;
+			_createRetryPromiseForAgentEnd(event: AgentEvent): void;
+		};
+		session._retryAttempt = 1;
+
+		session._createRetryPromiseForAgentEnd(event);
+
+		expect(harness.session.isRetrying).toBe(true);
+		harness.session.abortRetry();
+	});
+
 	it("marks captured auth failures stale when retry backoff is cancelled", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } },

--- a/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4491-provider-stale-after-401.test.ts
@@ -51,7 +51,7 @@ describe("issue #4491 provider stale after repeated 401", () => {
 		}
 	});
 
-	it("retries concrete provider auth failures, then marks current auth stale", async () => {
+	it("retries structured provider auth failures once, then marks current auth stale", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
 		});
@@ -60,8 +60,8 @@ describe("issue #4491 provider stale after repeated 401", () => {
 
 		await harness.session.prompt("hello");
 
-		expect(harness.faux.state.callCount).toBe(3);
-		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1, 2]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1]);
 		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
 		expect(harness.eventsOfType("auth_stale")).toHaveLength(1);
 
@@ -186,7 +186,7 @@ describe("issue #4491 provider stale after repeated 401", () => {
 			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
 		});
 		harnesses.push(harness);
-		harness.setResponses([provider401Message(), provider401Message(), provider500Message()]);
+		harness.setResponses([provider401Message(), provider500Message(), provider500Message()]);
 
 		await harness.session.prompt("hello");
 


### PR DESCRIPTION
- provider error turns now retry within the existing bounded retry budget before they reach users.
- context overflow still follows the compaction path instead of ordinary retry.
- added regression coverage for empty responses and generic provider failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core auto-retry classification changed globally: errors that were previously terminal (including some auth-shaped failures on first attempt) now trigger retries, which can add latency and extra provider calls before users see failures.
> 
> **Overview**
> Fixes **ENG-4503** by changing `AgentSession` so most provider error turns are **retried within the existing auto-retry budget** instead of being shown immediately. `_isRetryableError` now treats errors as retryable by default and only skips retry for context overflow (compaction), faux queue exhaustion, **`agent_lifecycle_failure`** diagnostics, and structured permanent `provider_stream_failure` kinds (`auth`, `invalid_request`, `refusal`) **after one retry attempt**—so empty responses, generic strings like `invalid_api_key`, and transient failures get another shot.
> 
> Structured auth failures still get **at most one** retry before auth is marked stale (not the full multi-retry loop). Retry lifecycle is tightened: failed retries emit `auto_retry_end` via `_finishActiveRetryWithFailure`, overflow compaction during an active retry no longer clears retry state early, and `abortRetry` cancels post-compaction continuation and records cancellation.
> 
> In **`@earendil-works/pi-agent`**, run-lifecycle failures attach an **`agent_lifecycle_failure`** diagnostic on the synthetic assistant error message so sessions do not auto-retry local listener/runtime failures. `clearQueue` returns **raw queued message text** (heartbeat previews unchanged in the UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3e21be094b95b02ea96f85c0886d8557841b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry provider errors before surfacing them in `AgentSession`
> - Reworks `AgentSession._isRetryableError` to skip retries for faux provider queue exhaustion, local `agent_lifecycle_failure` diagnostics, and structured permanent provider failures (auth/invalid_request/refusal) after the first retry attempt.
> - Adds `agent.Agent.handleRunFailure` to attach an `agent_lifecycle_failure` diagnostic to non-aborted run failures, letting the session distinguish local failures from provider failures.
> - Introduces `_finishActiveRetryWithFailure` to reliably emit `auto_retry_end` and reset retry state, and extends `abortRetry` to cancel any queued compaction continuation.
> - Behavioral Change: `clearQueue()` now returns raw message text instead of labeled previews for steering and follow-up messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef3e21b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->