### PR TITLE
Enable auto refine by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed automatic harness refinement to be enabled by default while keeping `autoRefine.enabled: false` as the opt-out.
+- Fixed non-numeric `autoRefine.turnInterval` and `autoRefine.cooldownMs` settings falling back to defaults instead of silently enabling a noisy auto-refine loop.
 - Changed subagent and refinement guidance to favor non-blocking subagent tasks by default, use disk-backed tracking for long-running fan-out, inspect or message live subagents when agent observation/messaging skills are available, and capture reusable delegation roles, procedures, facts, preferences, and prompt addendums with `/refine`.
 - Changed `attach_image` to resize and compress large inline image attachments before storing them for rendering and replay ([#340](https://github.com/PrimeIntellect-ai/prime-agent/pull/340) by [@sethkarten](https://github.com/sethkarten)).
 - Fixed heartbeat and goal continuation prompts rendering like ordinary user messages ([ENG-4482](https://linear.app/primeintellect/issue/ENG-4482/heartbeat-message-should-have-a-different-ui-from-user-message)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed automatic harness refinement to be enabled by default while keeping `autoRefine.enabled: false` as the opt-out.
 - Changed subagent and refinement guidance to favor non-blocking subagent tasks by default, use disk-backed tracking for long-running fan-out, inspect or message live subagents when agent observation/messaging skills are available, and capture reusable delegation roles, procedures, facts, preferences, and prompt addendums with `/refine`.
 - Changed `attach_image` to resize and compress large inline image attachments before storing them for rendering and replay ([#340](https://github.com/PrimeIntellect-ai/prime-agent/pull/340) by [@sethkarten](https://github.com/sethkarten)).
 - Fixed heartbeat and goal continuation prompts rendering like ordinary user messages ([ENG-4482](https://linear.app/primeintellect/issue/ENG-4482/heartbeat-message-should-have-a-different-ui-from-user-message)).

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -20,7 +20,7 @@ export interface BranchSummarySettings {
 }
 
 export interface AutoRefineSettings {
-	enabled?: boolean; // default: false
+	enabled?: boolean; // default: true
 	turnInterval?: number; // default: 25 assistant turns
 	compact?: boolean; // default: true
 	cooldownMs?: number; // default: 20 minutes
@@ -778,7 +778,7 @@ export class SettingsManager {
 
 	getAutoRefineSettings(): { enabled: boolean; turnInterval: number; compact: boolean; cooldownMs: number } {
 		return {
-			enabled: this.settings.autoRefine?.enabled ?? false,
+			enabled: this.settings.autoRefine?.enabled ?? true,
 			turnInterval: Math.max(1, this.settings.autoRefine?.turnInterval ?? 25),
 			compact: this.settings.autoRefine?.compact ?? true,
 			cooldownMs: Math.max(0, this.settings.autoRefine?.cooldownMs ?? 20 * 60_000),

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -777,11 +777,19 @@ export class SettingsManager {
 	}
 
 	getAutoRefineSettings(): { enabled: boolean; turnInterval: number; compact: boolean; cooldownMs: number } {
+		const turnInterval = this.settings.autoRefine?.turnInterval;
+		const cooldownMs = this.settings.autoRefine?.cooldownMs;
 		return {
 			enabled: this.settings.autoRefine?.enabled ?? true,
-			turnInterval: Math.max(1, this.settings.autoRefine?.turnInterval ?? 25),
+			turnInterval: Math.max(
+				1,
+				typeof turnInterval === "number" && Number.isFinite(turnInterval) ? turnInterval : 25,
+			),
 			compact: this.settings.autoRefine?.compact ?? true,
-			cooldownMs: Math.max(0, this.settings.autoRefine?.cooldownMs ?? 20 * 60_000),
+			cooldownMs: Math.max(
+				0,
+				typeof cooldownMs === "number" && Number.isFinite(cooldownMs) ? cooldownMs : 20 * 60_000,
+			),
 		};
 	}
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -212,6 +212,24 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("autoRefine", () => {
+		it("defaults to enabled while preserving explicit opt-out", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getAutoRefineSettings()).toEqual({
+				enabled: true,
+				turnInterval: 25,
+				compact: true,
+				cooldownMs: 20 * 60_000,
+			});
+
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ autoRefine: { enabled: false } }));
+			const optedOut = SettingsManager.create(projectDir, agentDir);
+
+			expect(optedOut.getAutoRefineSettings().enabled).toBe(false);
+		});
+	});
+
 	describe("recentModels", () => {
 		it("records most-recently-used first, dedupes, and persists", async () => {
 			const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -228,6 +228,45 @@ describe("SettingsManager", () => {
 
 			expect(optedOut.getAutoRefineSettings().enabled).toBe(false);
 		});
+
+		it("falls back to defaults for non-numeric turnInterval and cooldownMs", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ autoRefine: { turnInterval: "oops", cooldownMs: "nope" } }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			const settings = manager.getAutoRefineSettings();
+			expect(settings.turnInterval).toBe(25);
+			expect(settings.cooldownMs).toBe(20 * 60_000);
+			expect(Number.isFinite(settings.turnInterval)).toBe(true);
+			expect(Number.isFinite(settings.cooldownMs)).toBe(true);
+		});
+
+		it("ignores non-finite numeric values that parse to Infinity", () => {
+			// 1e999 is valid JSON that JSON.parse turns into Infinity.
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				`{ "autoRefine": { "turnInterval": 1e999, "cooldownMs": 1e999 } }`,
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			const settings = manager.getAutoRefineSettings();
+			expect(settings.turnInterval).toBe(25);
+			expect(settings.cooldownMs).toBe(20 * 60_000);
+		});
+
+		it("preserves valid numeric overrides", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ autoRefine: { turnInterval: 5, cooldownMs: 1000 } }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			const settings = manager.getAutoRefineSettings();
+			expect(settings.turnInterval).toBe(5);
+			expect(settings.cooldownMs).toBe(1000);
+		});
 	});
 
 	describe("recentModels", () => {


### PR DESCRIPTION
## Summary
- enabled automatic harness refinement by default
- preserved `autoRefine.enabled: false` as the opt-out
- added SettingsManager coverage for the new default and explicit opt-out

## Validation
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/settings-manager.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on auto-refine changes runtime behavior for all users without explicit settings; the validation fix reduces misconfiguration risk but the default flip is the main behavioral change.
> 
> **Overview**
> **Automatic harness refinement is on by default** for sessions that never set `autoRefine`. Opt out with `autoRefine.enabled: false` in settings.
> 
> `SettingsManager.getAutoRefineSettings()` now treats only **finite numeric** `turnInterval` and `cooldownMs` as valid; strings, `Infinity`, and other bad values fall back to **25 turns** and **20 minutes** instead of producing invalid intervals that could spam refine prompts.
> 
> Changelog and `settings-manager` tests cover the new default, opt-out, validation, and valid overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2efd0fb53d73289259753f412fb9370eb4b7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable auto refine by default in coding agent settings
> - Changes the default for `autoRefine.enabled` from `false` to `true` in [`SettingsManager.getAutoRefineSettings`](https://github.com/PrimeIntellect-ai/prime-agent/pull/349/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab); users can opt out via config.
> - Adds validation for `turnInterval` and `cooldownMs`: non-numeric or non-finite values (e.g. `NaN`, `Infinity`) now fall back to defaults (25 turns, 20 minutes) instead of propagating bad values.
> - Behavioral Change: auto refine now runs by default for all users who have not explicitly set `enabled: false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be2efd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->