### PR TITLE
fix slow model selection in daemon sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed heartbeat and goal continuation prompts rendering like ordinary user messages ([ENG-4482](https://linear.app/primeintellect/issue/ENG-4482/heartbeat-message-should-have-a-different-ui-from-user-message)).
 - Fixed `/heartbeat` guidance to show `stop` and the `every <duration> <instruction>` interval syntax ([ENG-4484](https://linear.app/primeintellect/issue/ENG-4484/improve-heartbeat-command-syntax-guidance-in-ui)).
 - Fixed login dialogs in fullscreen so sign-in URLs can be selected natively ([ENG-4480](https://linear.app/primeintellect/issue/ENG-4480/new-fullscreen-tui-makes-it-impossible-to-copy-login-url)).
+- Fixed `/model` opening and selection staying blocked on live model refreshes ([ENG-4505](https://linear.app/primeintellect/issue/ENG-4505/model-ui-is-extremely-slow)).
 - Fixed provider auth failures leaving stale credentials shown as connected in `/login` ([ENG-4491](https://linear.app/primeintellect/issue/ENG-4491/mark-provider-stale-after-repeated-401s)).
 - Fixed session-targeted heartbeat jobs staying scheduled after sessions are killed or saved sessions are deleted ([#332](https://github.com/PrimeIntellect-ai/prime-agent/pull/332)).
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2455,6 +2455,8 @@ export class AgentSession {
 				await this._checkCompaction(lastAssistant, false);
 			}
 
+			await this._waitForPendingModelSelectEmit();
+
 			drainedNextTurnMessages = this._pendingNextTurnMessages;
 			this._pendingNextTurnMessages = [];
 			messages = [...drainedNextTurnMessages, message];
@@ -2651,6 +2653,8 @@ export class AgentSession {
 				}
 				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
 			}
+
+			await this._waitForPendingModelSelectEmit();
 			if (options?.skipPrePromptWork) {
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 				messages = [];
@@ -2694,10 +2698,6 @@ export class AgentSession {
 				const lastAssistant = this._findLastAssistantMessage();
 				if (lastAssistant) {
 					await this._checkCompaction(lastAssistant, false);
-				}
-
-				if (!this._modelSelectEmitContext.getStore()) {
-					await this._modelSelectEmitQueue;
 				}
 
 				// Build messages array (custom message if any, then user message)
@@ -3437,6 +3437,12 @@ export class AgentSession {
 
 	private _shouldWaitForModelSelectEmit(options: ModelSelectOptions): boolean {
 		return options.waitForExtensions !== false && !this._modelSelectEmitContext.getStore();
+	}
+
+	private async _waitForPendingModelSelectEmit(): Promise<void> {
+		if (!this._modelSelectEmitContext.getStore()) {
+			await this._modelSelectEmitQueue;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -466,6 +466,10 @@ export interface ModelCycleResult {
 	isScoped: boolean;
 }
 
+interface ModelSelectOptions {
+	waitForExtensions?: boolean;
+}
+
 interface ToolDefinitionEntry {
 	definition: ToolDefinition;
 	sourceInfo: SourceInfo;
@@ -3398,7 +3402,7 @@ export class AgentSession {
 	 * Validates that auth is configured, saves to session and settings.
 	 * @throws Error if no auth is configured for the model
 	 */
-	async setModel(model: Model<any>, options: { waitForExtensions?: boolean } = {}): Promise<void> {
+	async setModel(model: Model<any>, options: ModelSelectOptions = {}): Promise<void> {
 		if (!this._modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
@@ -3414,18 +3418,22 @@ export class AgentSession {
 
 		const emitPromise = this._queueModelSelectEmit(model, previousModel, "set");
 		if (options.waitForExtensions === false) {
-			void emitPromise.catch((error) => {
-				this._extensionRunner.emitError({
-					extensionPath: "<internal>",
-					event: "model_select",
-					error: error instanceof Error ? error.message : String(error),
-					stack: error instanceof Error ? error.stack : undefined,
-				});
-			});
+			this._trackModelSelectEmitError(emitPromise);
 			return;
 		}
 
 		await emitPromise;
+	}
+
+	private _trackModelSelectEmitError(emitPromise: Promise<void>): void {
+		void emitPromise.catch((error) => {
+			this._extensionRunner.emitError({
+				extensionPath: "<internal>",
+				event: "model_select",
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		});
 	}
 
 	/**
@@ -3434,14 +3442,20 @@ export class AgentSession {
 	 * @param direction - "forward" (default) or "backward"
 	 * @returns The new model info, or undefined if only one model available
 	 */
-	async cycleModel(direction: "forward" | "backward" = "forward"): Promise<ModelCycleResult | undefined> {
+	async cycleModel(
+		direction: "forward" | "backward" = "forward",
+		options: ModelSelectOptions = {},
+	): Promise<ModelCycleResult | undefined> {
 		if (this._scopedModels.length > 0) {
-			return this._cycleScopedModel(direction);
+			return this._cycleScopedModel(direction, options);
 		}
-		return this._cycleAvailableModel(direction);
+		return this._cycleAvailableModel(direction, options);
 	}
 
-	private async _cycleScopedModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
+	private async _cycleScopedModel(
+		direction: "forward" | "backward",
+		options: ModelSelectOptions,
+	): Promise<ModelCycleResult | undefined> {
 		const scopedModels = this._scopedModels.filter((scoped) => this._modelRegistry.hasConfiguredAuth(scoped.model));
 		if (scopedModels.length <= 1) return undefined;
 
@@ -3465,12 +3479,20 @@ export class AgentSession {
 		// setThinkingLevel clamps to model capabilities.
 		this.setThinkingLevel(thinkingLevel);
 
-		await this._queueModelSelectEmit(next.model, currentModel, "cycle");
+		const emitPromise = this._queueModelSelectEmit(next.model, currentModel, "cycle");
+		if (options.waitForExtensions === false) {
+			this._trackModelSelectEmitError(emitPromise);
+		} else {
+			await emitPromise;
+		}
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
 	}
 
-	private async _cycleAvailableModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
+	private async _cycleAvailableModel(
+		direction: "forward" | "backward",
+		options: ModelSelectOptions,
+	): Promise<ModelCycleResult | undefined> {
 		const availableModels = await this._modelRegistry.getAvailable();
 		if (availableModels.length <= 1) return undefined;
 
@@ -3490,7 +3512,12 @@ export class AgentSession {
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 
-		await this._queueModelSelectEmit(nextModel, currentModel, "cycle");
+		const emitPromise = this._queueModelSelectEmit(nextModel, currentModel, "cycle");
+		if (options.waitForExtensions === false) {
+			this._trackModelSelectEmitError(emitPromise);
+		} else {
+			await emitPromise;
+		}
 
 		return { model: nextModel, thinkingLevel: this.thinkingLevel, isScoped: false };
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -646,6 +646,7 @@ export class AgentSession {
 	private _execEnvProvider?: () => Record<string, string | undefined> | undefined;
 	private _turnIndex = 0;
 	private _modelSelectEmitQueue: Promise<void> = Promise.resolve();
+	private _modelSelectEmitQueueIdle = true;
 	private _modelSelectEmitContext = new AsyncLocalStorage<boolean>();
 
 	private _resourceLoader: ResourceLoader;
@@ -2455,7 +2456,10 @@ export class AgentSession {
 				await this._checkCompaction(lastAssistant, false);
 			}
 
-			await this._waitForPendingModelSelectEmit();
+			const pendingModelSelectEmit = this._pendingModelSelectEmit();
+			if (pendingModelSelectEmit) {
+				await pendingModelSelectEmit;
+			}
 
 			drainedNextTurnMessages = this._pendingNextTurnMessages;
 			this._pendingNextTurnMessages = [];
@@ -2654,7 +2658,10 @@ export class AgentSession {
 				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
 			}
 
-			await this._waitForPendingModelSelectEmit();
+			const pendingModelSelectEmit = this._pendingModelSelectEmit();
+			if (pendingModelSelectEmit) {
+				await pendingModelSelectEmit;
+			}
 			if (options?.skipPrePromptWork) {
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 				messages = [];
@@ -3392,8 +3399,15 @@ export class AgentSession {
 	): Promise<void> {
 		const emit = () =>
 			this._modelSelectEmitContext.run(true, () => this._emitModelSelect(nextModel, previousModel, source));
+		this._modelSelectEmitQueueIdle = false;
 		const promise = this._modelSelectEmitQueue.then(emit, emit);
-		this._modelSelectEmitQueue = promise.catch(() => {});
+		const queued = promise.catch(() => {});
+		this._modelSelectEmitQueue = queued;
+		void queued.finally(() => {
+			if (this._modelSelectEmitQueue === queued) {
+				this._modelSelectEmitQueueIdle = true;
+			}
+		});
 		return promise;
 	}
 
@@ -3439,10 +3453,11 @@ export class AgentSession {
 		return options.waitForExtensions !== false && !this._modelSelectEmitContext.getStore();
 	}
 
-	private async _waitForPendingModelSelectEmit(): Promise<void> {
-		if (!this._modelSelectEmitContext.getStore()) {
-			await this._modelSelectEmitQueue;
+	private _pendingModelSelectEmit(): Promise<void> | undefined {
+		if (!this._modelSelectEmitContext.getStore() && !this._modelSelectEmitQueueIdle) {
+			return this._modelSelectEmitQueue;
 		}
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3460,7 +3460,7 @@ export class AgentSession {
 		// setThinkingLevel clamps to model capabilities.
 		this.setThinkingLevel(thinkingLevel);
 
-		await this._emitModelSelect(next.model, currentModel, "cycle");
+		await this._queueModelSelectEmit(next.model, currentModel, "cycle");
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
 	}
@@ -3485,7 +3485,7 @@ export class AgentSession {
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 
-		await this._emitModelSelect(nextModel, currentModel, "cycle");
+		await this._queueModelSelectEmit(nextModel, currentModel, "cycle");
 
 		return { model: nextModel, thinkingLevel: this.thinkingLevel, isScoped: false };
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -640,6 +640,7 @@ export class AgentSession {
 	private _extensionRunner!: ExtensionRunner;
 	private _execEnvProvider?: () => Record<string, string | undefined> | undefined;
 	private _turnIndex = 0;
+	private _modelSelectEmitQueue: Promise<void> = Promise.resolve();
 
 	private _resourceLoader: ResourceLoader;
 	private _customTools: ToolDefinition[];
@@ -2711,6 +2712,8 @@ export class AgentSession {
 				};
 				messages.push(userMessage);
 
+				await this._modelSelectEmitQueue;
+
 				// Emit before_agent_start extension event
 				const result = await this._extensionRunner.emitBeforeAgentStart(
 					expandedText,
@@ -3374,6 +3377,17 @@ export class AgentSession {
 		});
 	}
 
+	private _queueModelSelectEmit(
+		nextModel: Model<any>,
+		previousModel: Model<any> | undefined,
+		source: "set" | "cycle" | "restore",
+	): Promise<void> {
+		const emit = () => this._emitModelSelect(nextModel, previousModel, source);
+		const promise = this._modelSelectEmitQueue.then(emit, emit);
+		this._modelSelectEmitQueue = promise.catch(() => {});
+		return promise;
+	}
+
 	/**
 	 * Set model directly.
 	 * Validates that auth is configured, saves to session and settings.
@@ -3393,7 +3407,7 @@ export class AgentSession {
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 
-		const emitPromise = this._emitModelSelect(model, previousModel, "set");
+		const emitPromise = this._queueModelSelectEmit(model, previousModel, "set");
 		if (options.waitForExtensions === false) {
 			void emitPromise.catch((error) => {
 				this._extensionRunner.emitError({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3417,12 +3417,11 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 
 		const emitPromise = this._queueModelSelectEmit(model, previousModel, "set");
-		if (options.waitForExtensions === false) {
+		if (this._shouldWaitForModelSelectEmit(options)) {
+			await emitPromise;
+		} else {
 			this._trackModelSelectEmitError(emitPromise);
-			return;
 		}
-
-		await emitPromise;
 	}
 
 	private _trackModelSelectEmitError(emitPromise: Promise<void>): void {
@@ -3434,6 +3433,10 @@ export class AgentSession {
 				stack: error instanceof Error ? error.stack : undefined,
 			});
 		});
+	}
+
+	private _shouldWaitForModelSelectEmit(options: ModelSelectOptions): boolean {
+		return options.waitForExtensions !== false && !this._modelSelectEmitContext.getStore();
 	}
 
 	/**
@@ -3480,10 +3483,10 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 
 		const emitPromise = this._queueModelSelectEmit(next.model, currentModel, "cycle");
-		if (options.waitForExtensions === false) {
-			this._trackModelSelectEmitError(emitPromise);
-		} else {
+		if (this._shouldWaitForModelSelectEmit(options)) {
 			await emitPromise;
+		} else {
+			this._trackModelSelectEmitError(emitPromise);
 		}
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
@@ -3513,10 +3516,10 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 
 		const emitPromise = this._queueModelSelectEmit(nextModel, currentModel, "cycle");
-		if (options.waitForExtensions === false) {
-			this._trackModelSelectEmitError(emitPromise);
-		} else {
+		if (this._shouldWaitForModelSelectEmit(options)) {
 			await emitPromise;
+		} else {
+			this._trackModelSelectEmitError(emitPromise);
 		}
 
 		return { model: nextModel, thinkingLevel: this.thinkingLevel, isScoped: false };

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3379,7 +3379,7 @@ export class AgentSession {
 	 * Validates that auth is configured, saves to session and settings.
 	 * @throws Error if no auth is configured for the model
 	 */
-	async setModel(model: Model<any>): Promise<void> {
+	async setModel(model: Model<any>, options: { waitForExtensions?: boolean } = {}): Promise<void> {
 		if (!this._modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
@@ -3393,7 +3393,20 @@ export class AgentSession {
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 
-		await this._emitModelSelect(model, previousModel, "set");
+		const emitPromise = this._emitModelSelect(model, previousModel, "set");
+		if (options.waitForExtensions === false) {
+			void emitPromise.catch((error) => {
+				this._extensionRunner.emitError({
+					extensionPath: "<internal>",
+					event: "model_select",
+					error: error instanceof Error ? error.message : String(error),
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			});
+			return;
+		}
+
+		await emitPromise;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -13,6 +13,7 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -641,6 +642,7 @@ export class AgentSession {
 	private _execEnvProvider?: () => Record<string, string | undefined> | undefined;
 	private _turnIndex = 0;
 	private _modelSelectEmitQueue: Promise<void> = Promise.resolve();
+	private _modelSelectEmitContext = new AsyncLocalStorage<boolean>();
 
 	private _resourceLoader: ResourceLoader;
 	private _customTools: ToolDefinition[];
@@ -2712,7 +2714,9 @@ export class AgentSession {
 				};
 				messages.push(userMessage);
 
-				await this._modelSelectEmitQueue;
+				if (!this._modelSelectEmitContext.getStore()) {
+					await this._modelSelectEmitQueue;
+				}
 
 				// Emit before_agent_start extension event
 				const result = await this._extensionRunner.emitBeforeAgentStart(
@@ -3382,7 +3386,8 @@ export class AgentSession {
 		previousModel: Model<any> | undefined,
 		source: "set" | "cycle" | "restore",
 	): Promise<void> {
-		const emit = () => this._emitModelSelect(nextModel, previousModel, source);
+		const emit = () =>
+			this._modelSelectEmitContext.run(true, () => this._emitModelSelect(nextModel, previousModel, source));
 		const promise = this._modelSelectEmitQueue.then(emit, emit);
 		this._modelSelectEmitQueue = promise.catch(() => {});
 		return promise;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2696,6 +2696,10 @@ export class AgentSession {
 					await this._checkCompaction(lastAssistant, false);
 				}
 
+				if (!this._modelSelectEmitContext.getStore()) {
+					await this._modelSelectEmitQueue;
+				}
+
 				// Build messages array (custom message if any, then user message)
 				messages = [];
 
@@ -2717,10 +2721,6 @@ export class AgentSession {
 					timestamp: Date.now(),
 				};
 				messages.push(userMessage);
-
-				if (!this._modelSelectEmitContext.getStore()) {
-					await this._modelSelectEmitQueue;
-				}
 
 				// Emit before_agent_start extension event
 				const result = await this._extensionRunner.emitBeforeAgentStart(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1601,7 +1601,10 @@ export class AgentDaemon {
 
 			case "cycle_model": {
 				const state = this.getSessionState(command.activeSessionId);
-				const result = await state.runtime.session.cycleModel(command.direction);
+				const session = state.runtime.session;
+				const result = await session.cycleModel(command.direction, {
+					waitForExtensions: !(session.isStreaming || session.isCompacting),
+				});
 				return success(command.id, "cycle_model", result ?? null);
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1595,7 +1595,7 @@ export class AgentDaemon {
 				if (!model) {
 					throw new Error(`Model not found: ${command.provider}/${command.modelId}`);
 				}
-				await session.setModel(model);
+				await session.setModel(model, { waitForExtensions: !(session.isStreaming || session.isCompacting) });
 				return success(command.id, "set_model", model);
 			}
 

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -167,24 +167,21 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.panel.addChild(this.listContainer);
 		this.updateResponsiveLayout();
 
-		// Load models and do initial render
-		this.loadModels().then(() => {
-			if (initialSearchInput) {
-				this.filterModels(initialSearchInput);
-			} else {
-				this.updateList();
-			}
-			// Request re-render after models are loaded
-			this.tui.requestRender();
-		});
+		this.loadModels();
+		if (initialSearchInput) {
+			this.filterModels(initialSearchInput);
+		} else {
+			this.updateList();
+		}
+		this.tui.requestRender();
 	}
 
-	async updateAvailableModels(availableModels: ReadonlyArray<Model<any>>): Promise<void> {
+	updateAvailableModels(availableModels: ReadonlyArray<Model<any>>): void {
 		this.availableModels = availableModels;
 		const query = this.searchInput.getValue();
 		const selectedKey = this.getSelectedModelKey();
 
-		await this.loadModels();
+		this.loadModels();
 		this.filterModels(query);
 
 		if (selectedKey) {
@@ -198,24 +195,23 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.tui.requestRender();
 	}
 
-	private async loadModels(): Promise<void> {
+	private loadModels(): void {
 		let models: ModelItem[];
 		this.errorMessage = undefined;
 
-		// Refresh to pick up any changes to models.json
-		this.modelRegistry.refresh();
-
-		// Check for models.json errors
-		const loadError = this.modelRegistry.getError();
-		if (loadError) {
-			this.errorMessage = loadError;
+		if (this.availableModels === undefined) {
+			this.modelRegistry.refresh();
+			const loadError = this.modelRegistry.getError();
+			if (loadError) {
+				this.errorMessage = loadError;
+			}
 		}
 
 		// Load available models (built-in models still work even if models.json failed)
 		let availableModels: ReadonlyArray<Model<any>>;
 		try {
 			availableModels =
-				this.availableModels !== undefined ? this.availableModels : await this.modelRegistry.getAvailable();
+				this.availableModels !== undefined ? this.availableModels : this.modelRegistry.getAvailable();
 			models = availableModels.map((model: Model<any>) => ({
 				provider: model.provider,
 				id: model.id,

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -179,8 +179,28 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		});
 	}
 
+	async updateAvailableModels(availableModels: ReadonlyArray<Model<any>>): Promise<void> {
+		this.availableModels = availableModels;
+		const query = this.searchInput.getValue();
+		const selectedKey = this.getSelectedModelKey();
+
+		await this.loadModels();
+		this.filterModels(query);
+
+		if (selectedKey) {
+			const selectedIndex = this.filteredModels.findIndex((item) => this.getModelKey(item) === selectedKey);
+			if (selectedIndex >= 0) {
+				this.selectedIndex = selectedIndex;
+				this.updateList();
+			}
+		}
+
+		this.tui.requestRender();
+	}
+
 	private async loadModels(): Promise<void> {
 		let models: ModelItem[];
+		this.errorMessage = undefined;
 
 		// Refresh to pick up any changes to models.json
 		this.modelRegistry.refresh();
@@ -233,6 +253,15 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		const currentIndex = this.filteredModels.findIndex((item) => modelsAreEqual(this.currentModel, item.model));
 		this.selectedIndex =
 			currentIndex >= 0 ? currentIndex : Math.min(this.selectedIndex, Math.max(0, this.getSelectableCount() - 1));
+	}
+
+	private getModelKey(item: ModelItem): string {
+		return `${item.provider}/${item.id}`;
+	}
+
+	private getSelectedModelKey(): string | undefined {
+		const selected = this.filteredModels[this.selectedIndex];
+		return selected ? this.getModelKey(selected) : undefined;
 	}
 
 	private recentRankOf(item: ModelItem): number {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -214,10 +214,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		// Load available models (built-in models still work even if models.json failed)
 		let availableModels: ReadonlyArray<Model<any>>;
 		try {
-			// An empty snapshot may predate login; prefer a live query.
-			availableModels = this.availableModels?.length
-				? this.availableModels
-				: await this.modelRegistry.getAvailable();
+			availableModels =
+				this.availableModels !== undefined ? this.availableModels : await this.modelRegistry.getAvailable();
 			models = availableModels.map((model: Model<any>) => ({
 				provider: model.provider,
 				id: model.id,
@@ -238,7 +236,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			const scopedModelId = `${scoped.model.provider}/${scoped.model.id}`;
 			const refreshed =
 				availableModelsById.get(scopedModelId) ??
-				(this.availableModels?.length
+				(this.availableModels !== undefined
 					? undefined
 					: this.modelRegistry.find(scoped.model.provider, scoped.model.id));
 			return refreshed ? { ...scoped, model: refreshed } : scoped;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -221,6 +221,7 @@ interface PendingToolCallRenderInput {
 
 const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
 const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
+const MODEL_CATALOG_REFRESH_TTL_MS = 60_000;
 
 function isLabeledQueuedPreview(message: string): boolean {
 	return (
@@ -625,6 +626,9 @@ export class InteractiveMode {
 	private skillCommands = new Map<string, string>();
 	private connectionCommands: AgentConnectionSlashCommand[] = [];
 	private connectionModels: AgentConnectionModel[] = [];
+	private connectionModelsFetchedAt = 0;
+	private connectionModelsRefreshVersion = 0;
+	private connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
 	private initialConnectionSnapshotConsumed = false;
@@ -1341,7 +1345,7 @@ export class InteractiveMode {
 			return false;
 		}
 
-		const availableModels = await this.getModelCandidates();
+		const availableModels = this.getCachedModelCandidates();
 		if (availableModels.length > 0) {
 			const selectedModel = await this.promptForModelSelection({ allowProviderSetup: true });
 			if (this.isOnboardingResolvedAfterModelPrompt(selectedModel)) {
@@ -2112,6 +2116,7 @@ export class InteractiveMode {
 		this.applyConnectionStateSnapshot(state);
 		this.connectionCommands = commands;
 		this.connectionModels = models;
+		this.connectionModelsFetchedAt = Date.now();
 		this.connectionResourceSnapshot = resources;
 	}
 
@@ -6311,6 +6316,7 @@ export class InteractiveMode {
 		const model = await this.findExactModelMatch(searchTerm);
 		if (model) {
 			try {
+				this.showStatus(`Switching model: ${model.id}`);
 				await this.applySelectedModel(model);
 				this.completeOnboardingIfCurrentModelReady();
 				this.showStatus(`Model: ${model.id}`);
@@ -6326,7 +6332,7 @@ export class InteractiveMode {
 	}
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined> {
-		const models = await this.getModelCandidates();
+		const models = this.getCachedModelCandidates();
 		return findExactModelReferenceMatch(searchTerm, models);
 	}
 
@@ -6344,9 +6350,64 @@ export class InteractiveMode {
 	}
 
 	private async getConnectionAvailableModels(): Promise<AgentConnectionModel[]> {
-		const models = await this.agentConnection.getAvailableModels();
-		this.connectionModels = [...models];
-		return [...models];
+		const inFlight = this.connectionModelsRefreshInFlight;
+		if (inFlight && inFlight.version === this.connectionModelsRefreshVersion) {
+			return [...(await inFlight.promise)];
+		}
+
+		const version = this.connectionModelsRefreshVersion;
+		const promise = this.agentConnection.getAvailableModels().then((models) => {
+			const nextModels = [...models];
+			if (version === this.connectionModelsRefreshVersion) {
+				this.connectionModels = nextModels;
+				this.connectionModelsFetchedAt = Date.now();
+			}
+			return nextModels;
+		});
+		this.connectionModelsRefreshInFlight = { version, promise };
+
+		try {
+			return [...(await promise)];
+		} finally {
+			if (this.connectionModelsRefreshInFlight?.promise === promise) {
+				this.connectionModelsRefreshInFlight = undefined;
+			}
+		}
+	}
+
+	private getCachedModelCandidates(): AgentConnectionModel[] {
+		const scopedModels = this.getScopedModelState();
+		if (scopedModels.length > 0) {
+			return scopedModels.map((scoped) => scoped.model);
+		}
+
+		if (this.connectionModels.length > 0) {
+			return [...this.connectionModels];
+		}
+
+		try {
+			this.modelRegistry.refresh();
+			return this.modelRegistry.getAvailable();
+		} catch {
+			return [];
+		}
+	}
+
+	private shouldRefreshConnectionModels(): boolean {
+		if (this.connectionModelsRefreshInFlight) {
+			return false;
+		}
+		if (this.connectionModelsFetchedAt === 0) {
+			return true;
+		}
+		return Date.now() - this.connectionModelsFetchedAt > MODEL_CATALOG_REFRESH_TTL_MS;
+	}
+
+	private invalidateConnectionModels(): void {
+		this.connectionModels = [];
+		this.connectionModelsFetchedAt = 0;
+		this.connectionModelsRefreshVersion++;
+		this.connectionModelsRefreshInFlight = undefined;
 	}
 
 	private async getModelCandidates(): Promise<AgentConnectionModel[]> {
@@ -6488,17 +6549,12 @@ export class InteractiveMode {
 				return;
 			}
 			await this.showLoginProviderSelector();
+			this.invalidateConnectionModels();
 			nextSearchInput = undefined;
 		}
 	}
 
 	private async promptForModelSelection(options: { allowProviderSetup?: boolean } = {}): Promise<boolean> {
-		const availableModels = await this.getModelCandidates();
-		if (availableModels.length === 0 && !options.allowProviderSetup) {
-			this.showStatus("No models available. Add credentials with /login.");
-			return false;
-		}
-
 		while (true) {
 			this.showStatus("Select a model to continue.");
 			const result = await this.showModelSelectorAsync(
@@ -6518,6 +6574,7 @@ export class InteractiveMode {
 			}
 
 			await this.showLoginProviderSelector();
+			this.invalidateConnectionModels();
 		}
 	}
 
@@ -6525,17 +6582,12 @@ export class InteractiveMode {
 		initialSearchInput?: string,
 		options?: { actions?: ReadonlyArray<ModelSelectorAction>; subtitle?: string },
 	): Promise<ModelSelectionResult> {
-		let availableModels: AgentConnectionModel[];
-		try {
-			availableModels = await this.getConnectionAvailableModels();
-		} catch (error) {
-			this.showError(error instanceof Error ? error.message : String(error));
-			return { status: "cancelled" };
-		}
+		const availableModels = this.getCachedModelCandidates();
 
 		return new Promise((resolve) => {
 			let handle: OverlayHandle | undefined;
 			let settled = false;
+			let selector: ModelSelectorComponent | undefined;
 			const settle = (result: ModelSelectionResult) => {
 				if (settled) {
 					return;
@@ -6548,15 +6600,16 @@ export class InteractiveMode {
 				this.ui.requestRender();
 			};
 
-			const selector = new ModelSelectorComponent(
+			selector = new ModelSelectorComponent(
 				this.ui,
 				this.getCurrentModel(),
 				this.modelRegistry,
 				this.getScopedModelState(),
 				async (model) => {
+					close();
+					this.showStatus(`Switching model: ${model.id}`);
 					try {
 						await this.applySelectedModel(model);
-						close();
 						this.completeOnboardingIfCurrentModelReady();
 						this.showStatus(`Model: ${model.id}`);
 						void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
@@ -6586,6 +6639,21 @@ export class InteractiveMode {
 				},
 			);
 			handle = this.showFullPaneOverlay(selector, 96);
+
+			if (this.shouldRefreshConnectionModels()) {
+				void this.getConnectionAvailableModels()
+					.then((models) => {
+						if (settled || !selector) {
+							return undefined;
+						}
+						return selector.updateAvailableModels(models);
+					})
+					.catch((error) => {
+						if (!settled) {
+							this.showError(error instanceof Error ? error.message : String(error));
+						}
+					});
+			}
 		});
 	}
 
@@ -7123,6 +7191,7 @@ export class InteractiveMode {
 			const authResult = await this.showLoginProviderSelector();
 			// Service credentials don't change the model, so skip the model picker.
 			if (authResult.status === "success" && authResult.kind !== "service") {
+				this.invalidateConnectionModels();
 				await this.promptForModelSelection();
 			}
 			// An MCP integration login enables its skill, so reload resources — but a

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6334,7 +6334,21 @@ export class InteractiveMode {
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined> {
 		const models = this.getCachedModelCandidates();
-		return findExactModelReferenceMatch(searchTerm, models);
+		const cachedMatch = findExactModelReferenceMatch(searchTerm, models);
+		if (cachedMatch) {
+			return cachedMatch;
+		}
+
+		const refreshPromise = this.getModelSelectorRefreshPromise();
+		if (!refreshPromise) {
+			return undefined;
+		}
+
+		try {
+			return findExactModelReferenceMatch(searchTerm, await refreshPromise);
+		} catch {
+			return undefined;
+		}
 	}
 
 	private async applySelectedModel(model: AgentConnectionModel): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6402,16 +6402,7 @@ export class InteractiveMode {
 		if (this.connectionModels.length > 0) {
 			return [...this.connectionModels];
 		}
-		if (this.connectionModelsFetchedAt > 0) {
-			return [];
-		}
-
-		try {
-			this.modelRegistry.refresh();
-			return this.modelRegistry.getAvailable();
-		} catch {
-			return [];
-		}
+		return [];
 	}
 
 	private getModelSelectorRefreshPromise(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6333,10 +6333,7 @@ export class InteractiveMode {
 	}
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined> {
-		const scopedModels = this.getScopedModelState();
-		const cachedModels =
-			scopedModels.length > 0 ? scopedModels.map((scoped) => scoped.model) : [...this.connectionModels];
-		const cachedMatch = findExactModelReferenceMatch(searchTerm, cachedModels);
+		const cachedMatch = findExactModelReferenceMatch(searchTerm, this.getCachedModelCandidates());
 		if (cachedMatch) {
 			return cachedMatch;
 		}
@@ -6394,15 +6391,14 @@ export class InteractiveMode {
 	}
 
 	private getCachedModelCandidates(): AgentConnectionModel[] {
-		const scopedModels = this.getScopedModelState();
-		if (scopedModels.length > 0) {
-			return scopedModels.map((scoped) => scoped.model);
+		const modelsById = new Map<string, AgentConnectionModel>();
+		for (const scoped of this.getScopedModelState()) {
+			modelsById.set(`${scoped.model.provider}/${scoped.model.id}`, scoped.model);
 		}
-
-		if (this.connectionModels.length > 0) {
-			return [...this.connectionModels];
+		for (const model of this.connectionModels) {
+			modelsById.set(`${model.provider}/${model.id}`, model);
 		}
-		return [];
+		return [...modelsById.values()];
 	}
 
 	private getModelSelectorRefreshPromise(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1345,7 +1345,7 @@ export class InteractiveMode {
 			return false;
 		}
 
-		const availableModels = this.getCachedModelCandidates();
+		const availableModels = await this.getModelCandidates();
 		if (availableModels.length > 0) {
 			const selectedModel = await this.promptForModelSelection({ allowProviderSetup: true });
 			if (this.isOnboardingResolvedAfterModelPrompt(selectedModel)) {
@@ -2107,6 +2107,7 @@ export class InteractiveMode {
 	}
 
 	private async refreshConnectionCatalog(): Promise<void> {
+		this.invalidateConnectionModels();
 		const [state, commands, models, resources] = await Promise.all([
 			this.agentConnection.getState(),
 			this.agentConnection.getCommands(),
@@ -6393,14 +6394,17 @@ export class InteractiveMode {
 		}
 	}
 
-	private shouldRefreshConnectionModels(): boolean {
+	private getModelSelectorRefreshPromise(): Promise<AgentConnectionModel[]> | undefined {
 		if (this.connectionModelsRefreshInFlight) {
-			return false;
+			return this.getConnectionAvailableModels();
 		}
 		if (this.connectionModelsFetchedAt === 0) {
-			return true;
+			return this.getConnectionAvailableModels();
 		}
-		return Date.now() - this.connectionModelsFetchedAt > MODEL_CATALOG_REFRESH_TTL_MS;
+		if (Date.now() - this.connectionModelsFetchedAt > MODEL_CATALOG_REFRESH_TTL_MS) {
+			return this.getConnectionAvailableModels();
+		}
+		return undefined;
 	}
 
 	private invalidateConnectionModels(): void {
@@ -6640,8 +6644,9 @@ export class InteractiveMode {
 			);
 			handle = this.showFullPaneOverlay(selector, 96);
 
-			if (this.shouldRefreshConnectionModels()) {
-				void this.getConnectionAvailableModels()
+			const refreshPromise = this.getModelSelectorRefreshPromise();
+			if (refreshPromise) {
+				void refreshPromise
 					.then((models) => {
 						if (settled || !selector) {
 							return undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6333,8 +6333,10 @@ export class InteractiveMode {
 	}
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined> {
-		const models = this.getCachedModelCandidates();
-		const cachedMatch = findExactModelReferenceMatch(searchTerm, models);
+		const scopedModels = this.getScopedModelState();
+		const cachedModels =
+			scopedModels.length > 0 ? scopedModels.map((scoped) => scoped.model) : [...this.connectionModels];
+		const cachedMatch = findExactModelReferenceMatch(searchTerm, cachedModels);
 		if (cachedMatch) {
 			return cachedMatch;
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2107,7 +2107,7 @@ export class InteractiveMode {
 	}
 
 	private async refreshConnectionCatalog(): Promise<void> {
-		this.invalidateConnectionModels();
+		this.invalidateConnectionModelRefresh();
 		const [state, commands, models, resources] = await Promise.all([
 			this.agentConnection.getState(),
 			this.agentConnection.getCommands(),
@@ -6339,7 +6339,7 @@ export class InteractiveMode {
 			return cachedMatch;
 		}
 
-		const refreshPromise = this.getModelSelectorRefreshPromise();
+		const refreshPromise = this.getModelSelectorRefreshPromise({ force: true });
 		if (!refreshPromise) {
 			return undefined;
 		}
@@ -6373,10 +6373,11 @@ export class InteractiveMode {
 		const version = this.connectionModelsRefreshVersion;
 		const promise = this.agentConnection.getAvailableModels().then((models) => {
 			const nextModels = [...models];
-			if (version === this.connectionModelsRefreshVersion) {
-				this.connectionModels = nextModels;
-				this.connectionModelsFetchedAt = Date.now();
+			if (version !== this.connectionModelsRefreshVersion) {
+				return [...this.connectionModels];
 			}
+			this.connectionModels = nextModels;
+			this.connectionModelsFetchedAt = Date.now();
 			return nextModels;
 		});
 		this.connectionModelsRefreshInFlight = { version, promise };
@@ -6408,11 +6409,13 @@ export class InteractiveMode {
 		}
 	}
 
-	private getModelSelectorRefreshPromise(): Promise<AgentConnectionModel[]> | undefined {
+	private getModelSelectorRefreshPromise(
+		options: { force?: boolean } = {},
+	): Promise<AgentConnectionModel[]> | undefined {
 		if (this.connectionModelsRefreshInFlight) {
 			return this.getConnectionAvailableModels();
 		}
-		if (this.connectionModelsFetchedAt === 0) {
+		if (options.force || this.connectionModelsFetchedAt === 0) {
 			return this.getConnectionAvailableModels();
 		}
 		if (Date.now() - this.connectionModelsFetchedAt > MODEL_CATALOG_REFRESH_TTL_MS) {
@@ -6421,11 +6424,15 @@ export class InteractiveMode {
 		return undefined;
 	}
 
+	private invalidateConnectionModelRefresh(): void {
+		this.connectionModelsRefreshVersion++;
+		this.connectionModelsRefreshInFlight = undefined;
+	}
+
 	private invalidateConnectionModels(): void {
 		this.connectionModels = [];
 		this.connectionModelsFetchedAt = 0;
-		this.connectionModelsRefreshVersion++;
-		this.connectionModelsRefreshInFlight = undefined;
+		this.invalidateConnectionModelRefresh();
 	}
 
 	private async getModelCandidates(): Promise<AgentConnectionModel[]> {
@@ -6658,7 +6665,7 @@ export class InteractiveMode {
 			);
 			handle = this.showFullPaneOverlay(selector, 96);
 
-			const refreshPromise = this.getModelSelectorRefreshPromise();
+			const refreshPromise = this.getModelSelectorRefreshPromise({ force: initialSearchInput !== undefined });
 			if (refreshPromise) {
 				void refreshPromise
 					.then((models) => {
@@ -6670,6 +6677,10 @@ export class InteractiveMode {
 					.catch((error) => {
 						if (!settled) {
 							this.showError(error instanceof Error ? error.message : String(error));
+							if (availableModels.length === 0) {
+								close();
+								settle({ status: "cancelled" });
+							}
 						}
 					});
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6402,6 +6402,9 @@ export class InteractiveMode {
 		if (this.connectionModels.length > 0) {
 			return [...this.connectionModels];
 		}
+		if (this.connectionModelsFetchedAt > 0) {
+			return [];
+		}
 
 		try {
 			this.modelRegistry.refresh();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import type { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
@@ -3108,6 +3109,124 @@ describe("daemon mode helpers", () => {
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	it("sets models without waiting for model_select extension handlers while running", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const model: Model<Api> = {
+			provider: "faux",
+			id: "faux-2",
+			name: "Two",
+			api: "openai-completions",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+		const setModel = vi.fn(async () => {});
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					modelRegistry: {
+						refresh(): void;
+						getAvailable(): unknown[];
+					};
+					isStreaming: boolean;
+					isCompacting: boolean;
+					setModel(model: unknown, options?: { waitForExtensions?: boolean }): Promise<void>;
+				};
+			};
+		};
+		state.runtime.session = {
+			modelRegistry: {
+				refresh: vi.fn(),
+				getAvailable: vi.fn(() => [model]),
+			},
+			isStreaming: true,
+			isCompacting: false,
+			setModel,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+			id: "command-1",
+			type: "set_model",
+			activeSessionId: state.activeSessionId,
+			provider: "faux",
+			modelId: "faux-2",
+		});
+
+		expect(setModel).toHaveBeenCalledWith(model, { waitForExtensions: false });
+	});
+
+	it("waits for model_select extension handlers when setting models while idle", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const model: Model<Api> = {
+			provider: "faux",
+			id: "faux-2",
+			name: "Two",
+			api: "openai-completions",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+		const setModel = vi.fn(async () => {});
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					modelRegistry: {
+						refresh(): void;
+						getAvailable(): unknown[];
+					};
+					isStreaming: boolean;
+					isCompacting: boolean;
+					setModel(model: unknown, options?: { waitForExtensions?: boolean }): Promise<void>;
+				};
+			};
+		};
+		state.runtime.session = {
+			modelRegistry: {
+				refresh: vi.fn(),
+				getAvailable: vi.fn(() => [model]),
+			},
+			isStreaming: false,
+			isCompacting: false,
+			setModel,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+			id: "command-1",
+			type: "set_model",
+			activeSessionId: state.activeSessionId,
+			provider: "faux",
+			modelId: "faux-2",
+		});
+
+		expect(setModel).toHaveBeenCalledWith(model, { waitForExtensions: true });
 	});
 
 	it("validates active sessions before reading a heartbeat", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -3229,6 +3229,113 @@ describe("daemon mode helpers", () => {
 		expect(setModel).toHaveBeenCalledWith(model, { waitForExtensions: true });
 	});
 
+	it("cycles models without waiting for model_select extension handlers while running", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const model: Model<Api> = {
+			provider: "faux",
+			id: "faux-2",
+			name: "Two",
+			api: "openai-completions",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+		const cycleResult = { model, thinkingLevel: "off" as const, isScoped: false };
+		const cycleModel = vi.fn(async () => cycleResult);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					isStreaming: boolean;
+					isCompacting: boolean;
+					cycleModel(
+						direction?: "forward" | "backward",
+						options?: { waitForExtensions?: boolean },
+					): Promise<typeof cycleResult | undefined>;
+				};
+			};
+		};
+		state.runtime.session = {
+			isStreaming: true,
+			isCompacting: false,
+			cycleModel,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+			id: "command-1",
+			type: "cycle_model",
+			activeSessionId: state.activeSessionId,
+			direction: "backward",
+		});
+
+		expect(cycleModel).toHaveBeenCalledWith("backward", { waitForExtensions: false });
+	});
+
+	it("waits for model_select extension handlers when cycling models while idle", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const model: Model<Api> = {
+			provider: "faux",
+			id: "faux-2",
+			name: "Two",
+			api: "openai-completions",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+		const cycleResult = { model, thinkingLevel: "off" as const, isScoped: false };
+		const cycleModel = vi.fn(async () => cycleResult);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: {
+					isStreaming: boolean;
+					isCompacting: boolean;
+					cycleModel(
+						direction?: "forward" | "backward",
+						options?: { waitForExtensions?: boolean },
+					): Promise<typeof cycleResult | undefined>;
+				};
+			};
+		};
+		state.runtime.session = {
+			isStreaming: false,
+			isCompacting: false,
+			cycleModel,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+			id: "command-1",
+			type: "cycle_model",
+			activeSessionId: state.activeSessionId,
+		});
+
+		expect(cycleModel).toHaveBeenCalledWith(undefined, { waitForExtensions: true });
+	});
+
 	it("validates active sessions before reading a heartbeat", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3,9 +3,11 @@ import * as path from "node:path";
 import {
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,
+	type Component,
 	Container,
 	resetCapabilitiesCache,
 	setCapabilities,
+	type TUI,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
@@ -14,6 +16,7 @@ import type { AuthStatus } from "../src/core/auth-storage.js";
 import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.js";
 import { emptyGoalState, type GoalState } from "../src/core/goals.js";
+import type { ModelRegistry } from "../src/core/model-registry.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
 import type {
 	AgentConnectionExtensionUiRequest,
@@ -27,6 +30,7 @@ import type {
 } from "../src/modes/agent-connection/types.js";
 import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
+import type { ModelSelectorComponent } from "../src/modes/interactive/components/model-selector.js";
 import type { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
 import { formatSplashCwd, InteractiveMode, truncatePathMiddle } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -49,6 +53,24 @@ function normalizeRenderedOutput(container: Container, width = 220): string {
 		.map((line) => line.replace(/\s+$/g, ""))
 		.join("\n")
 		.trim();
+}
+
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve(value: T): void;
+	reject(error: unknown): void;
+} {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((nextResolve, nextReject) => {
+		resolve = nextResolve;
+		reject = nextReject;
+	});
+	return { promise, resolve, reject };
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function createConnectionState(overrides: Partial<AgentConnectionState> = {}): AgentConnectionState {
@@ -950,6 +972,43 @@ describe("InteractiveMode model selection persistence", () => {
 		completeOnboardingIfCurrentModelReady(): void;
 		setupAutocompleteProvider(): void;
 	};
+	type ModelSelectorOverlayHarness = {
+		agentConnection: {
+			getAvailableModels(): Promise<AgentConnectionModel[]>;
+			setModel(provider: string, modelId: string): Promise<void>;
+		};
+		connectionModels: AgentConnectionModel[];
+		connectionModelsFetchedAt: number;
+		connectionModelsRefreshVersion: number;
+		connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
+		ui: TUI;
+		uiServices: {
+			modelRegistry: ModelRegistry;
+			settingsManager: {
+				getRecentModels(): string[];
+				setDefaultModelAndProvider(provider: string, modelId: string): void;
+			};
+		};
+		footer: { invalidate(): void };
+		patchConnectionState(patch: Partial<AgentConnectionState>): void;
+		updateEditorBorderColor(): void;
+		showStatus(message: string): void;
+		showError(message: string): void;
+		getScopedModelState(): AgentConnectionState["scopedModels"];
+		getCurrentModel(): AgentConnectionModel | undefined;
+		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
+		getCachedModelCandidates(): AgentConnectionModel[];
+		applySelectedModel(model: AgentConnectionModel): Promise<void>;
+		showFullPaneOverlay(component: Component, maxContentWidth?: number): { hide(): void };
+		showModelSelectorAsync(
+			initialSearchInput?: string,
+			options?: { actions?: ReadonlyArray<unknown>; subtitle?: string },
+		): Promise<{ status: string; actionId?: string }>;
+		completeOnboardingIfCurrentModelReady(): void;
+		maybeWarnAboutAnthropicSubscriptionAuth(model: AgentConnectionModel): Promise<void>;
+		checkDaxnutsEasterEgg(model: AgentConnectionModel): void;
+		setupAutocompleteProvider(): void;
+	};
 
 	const createModel = (provider: string, id: string): AgentConnectionModel =>
 		({
@@ -957,6 +1016,81 @@ describe("InteractiveMode model selection persistence", () => {
 			id,
 			name: id,
 		}) as AgentConnectionModel;
+	const overlayPrototype = InteractiveMode.prototype as unknown as ModelSelectorOverlayHarness;
+
+	function createSelectorOverlayHarness(options: {
+		connectionModels: AgentConnectionModel[];
+		getAvailableModels?: () => Promise<AgentConnectionModel[]>;
+		applySelectedModel?: (model: AgentConnectionModel) => Promise<void>;
+		currentModel?: AgentConnectionModel;
+		connectionModelsFetchedAt?: number;
+	}) {
+		let overlayComponent: Component | undefined;
+		const hide = vi.fn();
+		const registryModels = [...options.connectionModels];
+		const modelRegistry = {
+			refresh: vi.fn(),
+			getError: vi.fn(() => undefined),
+			getAvailable: vi.fn(() => registryModels),
+			find: vi.fn((provider: string, modelId: string) =>
+				registryModels.find((model) => model.provider === provider && model.id === modelId),
+			),
+		} as unknown as ModelRegistry;
+		const fakeThis = Object.create(InteractiveMode.prototype) as ModelSelectorOverlayHarness;
+		fakeThis.agentConnection = {
+			getAvailableModels: options.getAvailableModels ?? vi.fn(async () => options.connectionModels),
+			setModel: vi.fn(async () => {}),
+		};
+		fakeThis.connectionModels = [...options.connectionModels];
+		fakeThis.connectionModelsFetchedAt = options.connectionModelsFetchedAt ?? 0;
+		fakeThis.connectionModelsRefreshVersion = 0;
+		fakeThis.connectionModelsRefreshInFlight = undefined;
+		fakeThis.ui = {
+			requestRender: vi.fn(),
+			terminal: { rows: 24 },
+		} as unknown as TUI;
+		fakeThis.uiServices = {
+			modelRegistry,
+			settingsManager: {
+				getRecentModels: vi.fn(() => []),
+				setDefaultModelAndProvider: vi.fn(),
+			},
+		};
+		fakeThis.footer = { invalidate: vi.fn() };
+		fakeThis.patchConnectionState = vi.fn();
+		fakeThis.updateEditorBorderColor = vi.fn();
+		fakeThis.showStatus = vi.fn();
+		fakeThis.showError = vi.fn();
+		fakeThis.getScopedModelState = vi.fn(() => []);
+		fakeThis.getCurrentModel = vi.fn(() => options.currentModel);
+		fakeThis.getConnectionAvailableModels = overlayPrototype.getConnectionAvailableModels;
+		fakeThis.getCachedModelCandidates = overlayPrototype.getCachedModelCandidates;
+		fakeThis.applySelectedModel = options.applySelectedModel ?? vi.fn(async () => {});
+		fakeThis.showFullPaneOverlay = vi.fn((component: Component) => {
+			overlayComponent = component;
+			return { hide };
+		});
+		fakeThis.showModelSelectorAsync = overlayPrototype.showModelSelectorAsync;
+		fakeThis.completeOnboardingIfCurrentModelReady = vi.fn();
+		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn(async () => {});
+		fakeThis.checkDaxnutsEasterEgg = vi.fn();
+		fakeThis.setupAutocompleteProvider = vi.fn();
+
+		return {
+			fakeThis,
+			hide,
+			getSelector: () => {
+				if (!overlayComponent) {
+					throw new Error("Expected model selector overlay to be shown");
+				}
+				return overlayComponent as ModelSelectorComponent;
+			},
+		};
+	}
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
 
 	test("persists local default only after the connection accepts the model", async () => {
 		const order: string[] = [];
@@ -1042,6 +1176,99 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model: gpt-5.5");
 		expect(fakeThis.showError).not.toHaveBeenCalled();
 		expect(fakeThis.completeOnboardingIfCurrentModelReady).toHaveBeenCalledTimes(1);
+	});
+
+	test("opens the model selector before live model refresh resolves", async () => {
+		const cachedModel = createModel("openai", "gpt-5.5");
+		const liveModels = createDeferred<AgentConnectionModel[]>();
+		const getAvailableModels = vi.fn(() => liveModels.promise);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [cachedModel],
+			getAvailableModels,
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+
+		expect(fakeThis.showFullPaneOverlay).toHaveBeenCalledTimes(1);
+		expect(getAvailableModels).toHaveBeenCalledTimes(1);
+
+		getSelector().handleInput("\x1b");
+		liveModels.resolve([cachedModel]);
+
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
+	test("uses a fresh cached model catalog without starting another refresh", async () => {
+		const cachedModel = createModel("openai", "gpt-5.5");
+		const getAvailableModels = vi.fn(async () => [cachedModel]);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [cachedModel],
+			connectionModelsFetchedAt: Date.now(),
+			getAvailableModels,
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+
+		expect(fakeThis.showFullPaneOverlay).toHaveBeenCalledTimes(1);
+		expect(getAvailableModels).not.toHaveBeenCalled();
+
+		getSelector().handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
+	test("closes the model selector before the selected model finishes applying", async () => {
+		const model = createModel("openai", "gpt-5.5");
+		const apply = createDeferred<void>();
+		const { fakeThis, getSelector, hide } = createSelectorOverlayHarness({
+			connectionModels: [model],
+			applySelectedModel: vi.fn(() => apply.promise),
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+		await flushAsyncWork();
+
+		let resolved: { status: string } | undefined;
+		void result.then((nextResult) => {
+			resolved = nextResult;
+		});
+
+		getSelector().handleInput("\r");
+		await flushAsyncWork();
+
+		expect(hide).toHaveBeenCalledTimes(1);
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Switching model: gpt-5.5");
+		expect(resolved).toBeUndefined();
+
+		apply.resolve();
+
+		await expect(result).resolves.toEqual({ status: "selected" });
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model: gpt-5.5");
+	});
+
+	test("refreshes model selector results in the background without clearing search", async () => {
+		const alpha = createModel("openai", "alpha");
+		const beta = { ...createModel("openai", "beta"), name: "Beta Model" };
+		const liveModels = createDeferred<AgentConnectionModel[]>();
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [alpha],
+			getAvailableModels: vi.fn(() => liveModels.promise),
+		});
+
+		const result = fakeThis.showModelSelectorAsync("beta");
+		await flushAsyncWork();
+
+		const selector = getSelector();
+		expect(selector.getSearchInput().getValue()).toBe("beta");
+		expect(selector.render(120).join("\n")).not.toContain("Beta");
+
+		liveModels.resolve([beta]);
+		await flushAsyncWork();
+
+		expect(selector.getSearchInput().getValue()).toBe("beta");
+		expect(selector.render(120).join("\n")).toContain("Beta");
+
+		selector.handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1022,6 +1022,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 	function createSelectorOverlayHarness(options: {
 		connectionModels: AgentConnectionModel[];
+		registryModels?: AgentConnectionModel[];
 		getAvailableModels?: () => Promise<AgentConnectionModel[]>;
 		applySelectedModel?: (model: AgentConnectionModel) => Promise<void>;
 		currentModel?: AgentConnectionModel;
@@ -1029,7 +1030,7 @@ describe("InteractiveMode model selection persistence", () => {
 	}) {
 		let overlayComponent: Component | undefined;
 		const hide = vi.fn();
-		const registryModels = [...options.connectionModels];
+		const registryModels = [...(options.registryModels ?? options.connectionModels)];
 		const modelRegistry = {
 			refresh: vi.fn(),
 			getError: vi.fn(() => undefined),
@@ -1244,6 +1245,20 @@ describe("InteractiveMode model selection persistence", () => {
 		});
 
 		await expect(fakeThis.findExactModelMatch("beta")).resolves.toEqual(beta);
+
+		expect(getAvailableModels).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not exact-match local fallback before daemon catalog loads", async () => {
+		const localOnly = createModel("openai", "local-only");
+		const getAvailableModels = vi.fn(async () => []);
+		const { fakeThis } = createSelectorOverlayHarness({
+			connectionModels: [],
+			registryModels: [localOnly],
+			getAvailableModels,
+		});
+
+		await expect(fakeThis.findExactModelMatch("local-only")).resolves.toBeUndefined();
 
 		expect(getAvailableModels).toHaveBeenCalledTimes(1);
 	});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1263,6 +1263,17 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(getAvailableModels).toHaveBeenCalledTimes(1);
 	});
 
+	test("keeps a fetched empty daemon catalog empty", () => {
+		const localOnly = createModel("openai", "local-only");
+		const { fakeThis } = createSelectorOverlayHarness({
+			connectionModels: [],
+			connectionModelsFetchedAt: Date.now(),
+			registryModels: [localOnly],
+		});
+
+		expect(fakeThis.getCachedModelCandidates()).toEqual([]);
+	});
+
 	test("uses a fresh cached model catalog without starting another refresh", async () => {
 		const cachedModel = createModel("openai", "gpt-5.5");
 		const getAvailableModels = vi.fn(async () => [cachedModel]);

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -996,6 +996,7 @@ describe("InteractiveMode model selection persistence", () => {
 		showError(message: string): void;
 		getScopedModelState(): AgentConnectionState["scopedModels"];
 		getCurrentModel(): AgentConnectionModel | undefined;
+		findExactModelMatch(searchTerm: string): Promise<AgentConnectionModel | undefined>;
 		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 		getCachedModelCandidates(): AgentConnectionModel[];
 		getModelSelectorRefreshPromise(): Promise<AgentConnectionModel[]> | undefined;
@@ -1064,6 +1065,11 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.showError = vi.fn();
 		fakeThis.getScopedModelState = vi.fn(() => []);
 		fakeThis.getCurrentModel = vi.fn(() => options.currentModel);
+		fakeThis.findExactModelMatch = (
+			InteractiveMode.prototype as unknown as {
+				findExactModelMatch(searchTerm: string): Promise<AgentConnectionModel | undefined>;
+			}
+		).findExactModelMatch;
 		fakeThis.getConnectionAvailableModels = overlayPrototype.getConnectionAvailableModels;
 		fakeThis.getCachedModelCandidates = overlayPrototype.getCachedModelCandidates;
 		fakeThis.getModelSelectorRefreshPromise = overlayPrototype.getModelSelectorRefreshPromise;
@@ -1225,6 +1231,21 @@ describe("InteractiveMode model selection persistence", () => {
 
 		getSelector().handleInput("\x1b");
 		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
+	test("refreshes stale cached candidates for exact model matches", async () => {
+		const alpha = createModel("openai", "alpha");
+		const beta = createModel("openai", "beta");
+		const getAvailableModels = vi.fn(async () => [beta]);
+		const { fakeThis } = createSelectorOverlayHarness({
+			connectionModels: [alpha],
+			connectionModelsFetchedAt: Date.now() - 120_000,
+			getAvailableModels,
+		});
+
+		await expect(fakeThis.findExactModelMatch("beta")).resolves.toEqual(beta);
+
+		expect(getAvailableModels).toHaveBeenCalledTimes(1);
 	});
 
 	test("uses a fresh cached model catalog without starting another refresh", async () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1274,6 +1274,28 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(fakeThis.getCachedModelCandidates()).toEqual([]);
 	});
 
+	test("does not show local fallback before daemon catalog loads", async () => {
+		const localOnly = createModel("openai", "local-only");
+		const liveModels = createDeferred<AgentConnectionModel[]>();
+		const getAvailableModels = vi.fn(() => liveModels.promise);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [],
+			registryModels: [localOnly],
+			getAvailableModels,
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+		await flushAsyncWork();
+
+		expect(getAvailableModels).toHaveBeenCalledTimes(1);
+		expect(getSelector().render(120).join("\n")).not.toContain("local-only");
+
+		liveModels.resolve([]);
+		await flushAsyncWork();
+		getSelector().handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
 	test("uses a fresh cached model catalog without starting another refresh", async () => {
 		const cachedModel = createModel("openai", "gpt-5.5");
 		const getAvailableModels = vi.fn(async () => [cachedModel]);

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1027,6 +1027,7 @@ describe("InteractiveMode model selection persistence", () => {
 		applySelectedModel?: (model: AgentConnectionModel) => Promise<void>;
 		currentModel?: AgentConnectionModel;
 		connectionModelsFetchedAt?: number;
+		scopedModels?: AgentConnectionState["scopedModels"];
 	}) {
 		let overlayComponent: Component | undefined;
 		const hide = vi.fn();
@@ -1064,7 +1065,7 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.updateEditorBorderColor = vi.fn();
 		fakeThis.showStatus = vi.fn();
 		fakeThis.showError = vi.fn();
-		fakeThis.getScopedModelState = vi.fn(() => []);
+		fakeThis.getScopedModelState = vi.fn(() => options.scopedModels ?? []);
 		fakeThis.getCurrentModel = vi.fn(() => options.currentModel);
 		fakeThis.findExactModelMatch = (
 			InteractiveMode.prototype as unknown as {
@@ -1292,6 +1293,32 @@ describe("InteractiveMode model selection persistence", () => {
 
 		liveModels.resolve([]);
 		await flushAsyncWork();
+		getSelector().handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
+	test("keeps cached daemon models visible when scoped models are active", async () => {
+		const scopedModel = createModel("openai", "scoped");
+		const catalogModel = createModel("anthropic", "catalog");
+		const getAvailableModels = vi.fn(async () => [catalogModel]);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [catalogModel],
+			connectionModelsFetchedAt: Date.now(),
+			getAvailableModels,
+			scopedModels: [{ model: scopedModel }],
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+
+		expect(getAvailableModels).not.toHaveBeenCalled();
+		expect(getSelector().render(120).join("\n")).toContain("scoped");
+		expect(fakeThis.getCachedModelCandidates()).toEqual([scopedModel, catalogModel]);
+		await expect(fakeThis.findExactModelMatch("catalog")).resolves.toEqual(catalogModel);
+
+		getSelector().handleInput("\t");
+		expect(getSelector().render(120).join("\n")).toContain("catalog");
+		expect(getAvailableModels).not.toHaveBeenCalled();
+
 		getSelector().handleInput("\x1b");
 		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -999,7 +999,7 @@ describe("InteractiveMode model selection persistence", () => {
 		findExactModelMatch(searchTerm: string): Promise<AgentConnectionModel | undefined>;
 		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 		getCachedModelCandidates(): AgentConnectionModel[];
-		getModelSelectorRefreshPromise(): Promise<AgentConnectionModel[]> | undefined;
+		getModelSelectorRefreshPromise(options?: { force?: boolean }): Promise<AgentConnectionModel[]> | undefined;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		showFullPaneOverlay(component: Component, maxContentWidth?: number): { hide(): void };
 		showModelSelectorAsync(
@@ -1233,13 +1233,13 @@ describe("InteractiveMode model selection persistence", () => {
 		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});
 
-	test("refreshes stale cached candidates for exact model matches", async () => {
+	test("refreshes cached candidates for exact model misses", async () => {
 		const alpha = createModel("openai", "alpha");
 		const beta = createModel("openai", "beta");
 		const getAvailableModels = vi.fn(async () => [beta]);
 		const { fakeThis } = createSelectorOverlayHarness({
 			connectionModels: [alpha],
-			connectionModelsFetchedAt: Date.now() - 120_000,
+			connectionModelsFetchedAt: Date.now(),
 			getAvailableModels,
 		});
 
@@ -1321,6 +1321,26 @@ describe("InteractiveMode model selection persistence", () => {
 		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});
 
+	test("refreshes fresh cached selector results when opened with a search", async () => {
+		const alpha = createModel("openai", "alpha");
+		const beta = { ...createModel("openai", "beta"), name: "Beta Model" };
+		const getAvailableModels = vi.fn(async () => [beta]);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [alpha],
+			connectionModelsFetchedAt: Date.now(),
+			getAvailableModels,
+		});
+
+		const result = fakeThis.showModelSelectorAsync("beta");
+		await flushAsyncWork();
+
+		expect(getAvailableModels).toHaveBeenCalledTimes(1);
+		expect(getSelector().render(120).join("\n")).toContain("Beta");
+
+		getSelector().handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
 	test("does not let a stale model refresh overwrite a newer catalog refresh", async () => {
 		const oldModel = createModel("openai", "old");
 		const freshModel = createModel("openai", "fresh");
@@ -1335,6 +1355,7 @@ describe("InteractiveMode model selection persistence", () => {
 			refreshConnectionCatalog(): Promise<void>;
 			applyConnectionStateSnapshot(state: AgentConnectionState): void;
 			invalidateConnectionModels(): void;
+			invalidateConnectionModelRefresh(): void;
 		};
 		fakeThis.agentConnection = {
 			getAvailableModels,
@@ -1355,14 +1376,71 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.invalidateConnectionModels = (
 			InteractiveMode.prototype as unknown as { invalidateConnectionModels(): void }
 		).invalidateConnectionModels;
+		fakeThis.invalidateConnectionModelRefresh = (
+			InteractiveMode.prototype as unknown as { invalidateConnectionModelRefresh(): void }
+		).invalidateConnectionModelRefresh;
 		fakeThis.applyConnectionStateSnapshot = vi.fn();
 
 		const staleRefresh = fakeThis.getConnectionAvailableModels();
 		await fakeThis.refreshConnectionCatalog();
 		oldModels.resolve([oldModel]);
-		await staleRefresh;
+
+		await expect(staleRefresh).resolves.toEqual([freshModel]);
 
 		expect(fakeThis.connectionModels).toEqual([freshModel]);
+	});
+
+	test("keeps the cached model catalog when a catalog refresh fails", async () => {
+		const cachedModel = createModel("openai", "cached");
+		const fakeThis = Object.create(InteractiveMode.prototype) as ModelSelectorOverlayHarness & {
+			connectionCommands: unknown[];
+			connectionResourceSnapshot: unknown;
+			refreshConnectionCatalog(): Promise<void>;
+			applyConnectionStateSnapshot(state: AgentConnectionState): void;
+			invalidateConnectionModelRefresh(): void;
+		};
+		fakeThis.agentConnection = {
+			getAvailableModels: vi.fn(async () => [createModel("openai", "fresh")]),
+			getState: vi.fn(async () => createConnectionState()),
+			getCommands: vi.fn(async () => {
+				throw new Error("commands unavailable");
+			}),
+			getResourceSnapshot: vi.fn(async () => ({})),
+			setModel: vi.fn(async () => {}),
+		} as never;
+		fakeThis.connectionModels = [cachedModel];
+		fakeThis.connectionModelsFetchedAt = Date.now();
+		fakeThis.connectionModelsRefreshVersion = 0;
+		fakeThis.connectionModelsRefreshInFlight = undefined;
+		fakeThis.refreshConnectionCatalog = (
+			InteractiveMode.prototype as unknown as { refreshConnectionCatalog(): Promise<void> }
+		).refreshConnectionCatalog;
+		fakeThis.invalidateConnectionModelRefresh = (
+			InteractiveMode.prototype as unknown as { invalidateConnectionModelRefresh(): void }
+		).invalidateConnectionModelRefresh;
+		fakeThis.applyConnectionStateSnapshot = vi.fn();
+
+		await expect(fakeThis.refreshConnectionCatalog()).rejects.toThrow("commands unavailable");
+
+		expect(fakeThis.connectionModels).toEqual([cachedModel]);
+		expect(fakeThis.connectionModelsFetchedAt).toBeGreaterThan(0);
+	});
+
+	test("closes an empty model selector when the background refresh fails", async () => {
+		const getAvailableModels = vi.fn(async () => {
+			throw new Error("models unavailable");
+		});
+		const { fakeThis, hide } = createSelectorOverlayHarness({
+			connectionModels: [],
+			getAvailableModels,
+		});
+
+		const result = fakeThis.showModelSelectorAsync();
+		await flushAsyncWork();
+
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+		expect(fakeThis.showError).toHaveBeenCalledWith("models unavailable");
+		expect(hide).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -998,6 +998,7 @@ describe("InteractiveMode model selection persistence", () => {
 		getCurrentModel(): AgentConnectionModel | undefined;
 		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 		getCachedModelCandidates(): AgentConnectionModel[];
+		getModelSelectorRefreshPromise(): Promise<AgentConnectionModel[]> | undefined;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		showFullPaneOverlay(component: Component, maxContentWidth?: number): { hide(): void };
 		showModelSelectorAsync(
@@ -1065,6 +1066,7 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.getCurrentModel = vi.fn(() => options.currentModel);
 		fakeThis.getConnectionAvailableModels = overlayPrototype.getConnectionAvailableModels;
 		fakeThis.getCachedModelCandidates = overlayPrototype.getCachedModelCandidates;
+		fakeThis.getModelSelectorRefreshPromise = overlayPrototype.getModelSelectorRefreshPromise;
 		fakeThis.applySelectedModel = options.applySelectedModel ?? vi.fn(async () => {});
 		fakeThis.showFullPaneOverlay = vi.fn((component: Component) => {
 			overlayComponent = component;
@@ -1198,6 +1200,33 @@ describe("InteractiveMode model selection persistence", () => {
 		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});
 
+	test("updates the model selector from an already in-flight refresh", async () => {
+		const alpha = createModel("openai", "alpha");
+		const beta = { ...createModel("openai", "beta"), name: "Beta Model" };
+		const liveModels = createDeferred<AgentConnectionModel[]>();
+		const getAvailableModels = vi.fn(async () => [alpha]);
+		const { fakeThis, getSelector } = createSelectorOverlayHarness({
+			connectionModels: [alpha],
+			connectionModelsFetchedAt: Date.now(),
+			getAvailableModels,
+		});
+		fakeThis.connectionModelsRefreshInFlight = { version: 0, promise: liveModels.promise };
+
+		const result = fakeThis.showModelSelectorAsync("beta");
+		await flushAsyncWork();
+
+		expect(getAvailableModels).not.toHaveBeenCalled();
+		expect(getSelector().render(120).join("\n")).not.toContain("Beta");
+
+		liveModels.resolve([beta]);
+		await flushAsyncWork();
+
+		expect(getSelector().render(120).join("\n")).toContain("Beta");
+
+		getSelector().handleInput("\x1b");
+		await expect(result).resolves.toEqual({ status: "cancelled" });
+	});
+
 	test("uses a fresh cached model catalog without starting another refresh", async () => {
 		const cachedModel = createModel("openai", "gpt-5.5");
 		const getAvailableModels = vi.fn(async () => [cachedModel]);
@@ -1270,6 +1299,50 @@ describe("InteractiveMode model selection persistence", () => {
 		selector.handleInput("\x1b");
 		await expect(result).resolves.toEqual({ status: "cancelled" });
 	});
+
+	test("does not let a stale model refresh overwrite a newer catalog refresh", async () => {
+		const oldModel = createModel("openai", "old");
+		const freshModel = createModel("openai", "fresh");
+		const oldModels = createDeferred<AgentConnectionModel[]>();
+		const getAvailableModels = vi
+			.fn<() => Promise<AgentConnectionModel[]>>()
+			.mockImplementationOnce(() => oldModels.promise)
+			.mockImplementationOnce(async () => [freshModel]);
+		const fakeThis = Object.create(InteractiveMode.prototype) as ModelSelectorOverlayHarness & {
+			connectionCommands: unknown[];
+			connectionResourceSnapshot: unknown;
+			refreshConnectionCatalog(): Promise<void>;
+			applyConnectionStateSnapshot(state: AgentConnectionState): void;
+			invalidateConnectionModels(): void;
+		};
+		fakeThis.agentConnection = {
+			getAvailableModels,
+			getState: vi.fn(async () => createConnectionState()),
+			getCommands: vi.fn(async () => []),
+			getResourceSnapshot: vi.fn(async () => ({})),
+			setModel: vi.fn(async () => {}),
+		} as never;
+		fakeThis.connectionModels = [];
+		fakeThis.connectionModelsFetchedAt = 0;
+		fakeThis.connectionModelsRefreshVersion = 0;
+		fakeThis.connectionModelsRefreshInFlight = undefined;
+		fakeThis.getScopedModelState = vi.fn(() => []);
+		fakeThis.getConnectionAvailableModels = overlayPrototype.getConnectionAvailableModels;
+		fakeThis.refreshConnectionCatalog = (
+			InteractiveMode.prototype as unknown as { refreshConnectionCatalog(): Promise<void> }
+		).refreshConnectionCatalog;
+		fakeThis.invalidateConnectionModels = (
+			InteractiveMode.prototype as unknown as { invalidateConnectionModels(): void }
+		).invalidateConnectionModels;
+		fakeThis.applyConnectionStateSnapshot = vi.fn();
+
+		const staleRefresh = fakeThis.getConnectionAvailableModels();
+		await fakeThis.refreshConnectionCatalog();
+		oldModels.resolve([oldModel]);
+		await staleRefresh;
+
+		expect(fakeThis.connectionModels).toEqual([freshModel]);
+	});
 });
 
 describe("InteractiveMode Prime CLI onboarding", () => {
@@ -1309,6 +1382,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		checkDaxnutsEasterEgg?: (model: { provider: string; id: string }) => void;
 		findExactModelMatch?: (searchTerm: string) => Promise<AgentConnectionModel | undefined>;
 		showOnboardingModelSelectionSplash?: () => Promise<boolean>;
+		showOnboardingPrimeLogin?: () => Promise<{ status: string }>;
 		promptForModelSelection?: (options?: { allowProviderSetup?: boolean }) => Promise<boolean>;
 		completeOnboardingIfCurrentModelReady?: () => void;
 		getModelCandidates?: () => Promise<AgentConnectionModel[]>;
@@ -1428,6 +1502,20 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		expect(fakeThis.promptForModelSelection).toHaveBeenCalledWith({ allowProviderSetup: true });
 		expect(fakeThis.uiServices.settingsManager.setOnboardingCompleted).not.toHaveBeenCalled();
 		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model selection required. Use /model to continue.");
+	});
+
+	test("uses live connection models before falling back to Prime login during onboarding", async () => {
+		const fakeThis = createPrimeCliHarness(false);
+		fakeThis.connectionState = createConnectionState({ model: undefined });
+		fakeThis.getModelCandidates = vi.fn(async () => [primeModel]);
+		fakeThis.promptForModelSelection = vi.fn(async () => true);
+		fakeThis.showOnboardingPrimeLogin = vi.fn(async () => ({ status: "success" }));
+
+		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBe(true);
+
+		expect(fakeThis.getModelCandidates).toHaveBeenCalledTimes(1);
+		expect(fakeThis.promptForModelSelection).toHaveBeenCalledWith({ allowProviderSetup: true });
+		expect(fakeThis.showOnboardingPrimeLogin).not.toHaveBeenCalled();
 	});
 
 	test("cancelled model picker continues when current model is ready outside Prime CLI onboarding", async () => {

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -1,6 +1,6 @@
 import { type KeyId, setKeybindings, type TUI } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import { ModelSelectorComponent } from "../src/modes/interactive/components/model-selector.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -77,7 +77,7 @@ describe("ModelSelectorComponent provider actions", () => {
 		expect(selectedAction).toBe("add_provider");
 	});
 
-	it("uses injected available models when refreshing scoped models", async () => {
+	it("renders injected daemon models without refreshing the local registry", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", name: "Local One", reasoning: true }],
 		});
@@ -85,6 +85,7 @@ describe("ModelSelectorComponent provider actions", () => {
 
 		const localModel = harness.getModel("faux-1")!;
 		const connectionModel = { ...localModel, name: "Connection One" };
+		const refresh = vi.spyOn(harness.session.modelRegistry, "refresh");
 		const selector = new ModelSelectorComponent(
 			createFakeTui(),
 			localModel,
@@ -98,11 +99,14 @@ describe("ModelSelectorComponent provider actions", () => {
 			},
 		);
 
-		await waitForAsyncRender();
-
 		const output = stripAnsi(selector.render(120).join("\n"));
 		expect(output).toContain("Connection One");
 		expect(output).not.toContain("Local One");
+		expect(refresh).not.toHaveBeenCalled();
+
+		selector.updateAvailableModels([connectionModel]);
+
+		expect(refresh).not.toHaveBeenCalled();
 	});
 
 	it("updates injected models without clearing the current search", async () => {

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -140,6 +140,36 @@ describe("ModelSelectorComponent provider actions", () => {
 		expect(output).toContain("Beta");
 	});
 
+	it("keeps an empty injected model snapshot empty instead of falling back to local models", async () => {
+		const harness = await createHarness({
+			models: [{ id: "alpha", name: "Alpha", reasoning: true }],
+		});
+		harnesses.push(harness);
+
+		const alpha = harness.getModel("alpha")!;
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			undefined,
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{
+				availableModels: [alpha],
+			},
+		);
+
+		await waitForAsyncRender();
+		expect(stripAnsi(selector.render(120).join("\n"))).toContain("Alpha");
+
+		await selector.updateAvailableModels([]);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).not.toContain("Alpha");
+		expect(output).toContain("No matching models");
+	});
+
 	it("keeps the model menu within a short terminal viewport", async () => {
 		const harness = await createHarness({
 			models: Array.from({ length: 12 }, (_, index) => ({

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -105,6 +105,41 @@ describe("ModelSelectorComponent provider actions", () => {
 		expect(output).not.toContain("Local One");
 	});
 
+	it("updates injected models without clearing the current search", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "alpha", name: "Alpha", reasoning: true },
+				{ id: "beta", name: "Beta", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+
+		const alpha = harness.getModel("alpha")!;
+		const beta = harness.getModel("beta")!;
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			undefined,
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			"beta",
+			{
+				availableModels: [alpha],
+			},
+		);
+
+		await waitForAsyncRender();
+		expect(stripAnsi(selector.render(120).join("\n"))).not.toContain("Beta");
+
+		await selector.updateAvailableModels([beta]);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(selector.getSearchInput().getValue()).toBe("beta");
+		expect(output).toContain("beta");
+		expect(output).toContain("Beta");
+	});
+
 	it("keeps the model menu within a short terminal viewport", async () => {
 		const harness = await createHarness({
 			models: Array.from({ length: 12 }, (_, index) => ({

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -93,6 +93,80 @@ describe("AgentSession model and extension characterization", () => {
 		expect(handlerCompleted).toBe(true);
 	});
 
+	it("serializes nonblocking model_select handlers across quick switches", async () => {
+		const firstHandlerStarted = createDeferred();
+		const finishFirstHandler = createDeferred();
+		const events: string[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+				{ id: "faux-3", name: "Three", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async (event) => {
+						events.push(`start:${event.model.id}`);
+						if (event.model.id === "faux-2") {
+							firstHandlerStarted.resolve();
+							await finishFirstHandler.promise;
+						}
+						events.push(`end:${event.model.id}`);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await firstHandlerStarted.promise;
+		await harness.session.setModel(harness.getModel("faux-3")!, { waitForExtensions: false });
+		await flushAsyncWork();
+
+		expect(harness.session.model?.id).toBe("faux-3");
+		expect(events).toEqual(["start:faux-2"]);
+
+		finishFirstHandler.resolve();
+		await flushAsyncWork();
+		await flushAsyncWork();
+
+		expect(events).toEqual(["start:faux-2", "end:faux-2", "start:faux-3", "end:faux-3"]);
+	});
+
+	it("waits for pending model_select handlers before starting the next prompt", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("after model select")]);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		const prompt = harness.session.prompt("hi");
+		await flushAsyncWork();
+
+		expect(getAssistantTexts(harness)).not.toContain("after model select");
+
+		finishHandler.resolve();
+		await prompt;
+
+		expect(getAssistantTexts(harness)).toContain("after model select");
+	});
+
 	it("cycles through scoped models and preserves the scoped thinking preference", async () => {
 		const harness = await createHarness({
 			models: [

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -178,6 +178,40 @@ describe("AgentSession model and extension characterization", () => {
 		expect(events).toEqual(["start:faux-2", "end:faux-2", "start:faux-3", "end:faux-3"]);
 	});
 
+	it("can cycle models before slow model_select handlers finish", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		let handlerCompleted = false;
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+						handlerCompleted = true;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const result = await harness.session.cycleModel("forward", { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		expect(result?.model.id).toBe("faux-2");
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(handlerCompleted).toBe(false);
+
+		finishHandler.resolve();
+		await flushAsyncWork();
+
+		expect(handlerCompleted).toBe(true);
+	});
+
 	it("waits for pending model_select handlers before starting the next prompt", async () => {
 		const handlerStarted = createDeferred();
 		const finishHandler = createDeferred();

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -133,6 +133,51 @@ describe("AgentSession model and extension characterization", () => {
 		expect(events).toEqual(["start:faux-2", "end:faux-2", "start:faux-3", "end:faux-3"]);
 	});
 
+	it("queues cycle model_select handlers behind pending nonblocking switches", async () => {
+		const firstHandlerStarted = createDeferred();
+		const finishFirstHandler = createDeferred();
+		const events: string[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+				{ id: "faux-3", name: "Three", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async (event) => {
+						events.push(`start:${event.model.id}`);
+						if (event.model.id === "faux-2") {
+							firstHandlerStarted.resolve();
+							await finishFirstHandler.promise;
+						}
+						events.push(`end:${event.model.id}`);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await firstHandlerStarted.promise;
+
+		let cycleResolved = false;
+		const cycle = harness.session.cycleModel().then((result) => {
+			cycleResolved = true;
+			return result;
+		});
+		await flushAsyncWork();
+
+		expect(cycleResolved).toBe(false);
+		expect(events).toEqual(["start:faux-2"]);
+
+		finishFirstHandler.resolve();
+		const result = await cycle;
+
+		expect(result?.model.id).toBe("faux-3");
+		expect(events).toEqual(["start:faux-2", "end:faux-2", "start:faux-3", "end:faux-3"]);
+	});
+
 	it("waits for pending model_select handlers before starting the next prompt", async () => {
 		const handlerStarted = createDeferred();
 		const finishHandler = createDeferred();

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -2,6 +2,7 @@ import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
+import type { AgentCronJob } from "../../src/core/cron-jobs.js";
 import type { ExtensionAPI } from "../../src/index.js";
 import { createHarness, getAssistantTexts, getMessageText, type Harness } from "./harness.js";
 
@@ -18,6 +19,24 @@ function createDeferred<T = void>(): {
 
 async function flushAsyncWork(): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createHeartbeat(): AgentCronJob {
+	return {
+		id: "heartbeat-1",
+		status: "active",
+		source: "heartbeat",
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		prompt: "Check whether the long-running task needs another step.",
+		schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		nextRunAt: "2026-01-01T00:05:00.000Z",
+		runCount: 2,
+	};
 }
 
 describe("AgentSession model and extension characterization", () => {
@@ -295,6 +314,106 @@ describe("AgentSession model and extension characterization", () => {
 			{ role: "user", text: "hi" },
 		]);
 		expect(getAssistantTexts(harness)).toContain("after model context");
+	});
+
+	it("includes nextTurn messages queued by pending model_select handlers in accepted prompts", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+						await pi.sendMessage(
+							{
+								customType: "model-context",
+								content: "accepted model context",
+								display: false,
+							},
+							{ deliverAs: "nextTurn" },
+						);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("accepted")]);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		const accepted = harness.session.acceptAgentMessagePrompt("agent-to-agent payload", {
+			expandPromptTemplates: false,
+		});
+		await flushAsyncWork();
+
+		expect(harness.session.messages).toHaveLength(0);
+
+		finishHandler.resolve();
+		await accepted;
+		await harness.session.agent.waitForIdle();
+
+		expect(
+			harness.session.messages.slice(0, 2).map((message) => ({ role: message.role, text: getMessageText(message) })),
+		).toEqual([
+			{ role: "custom", text: "accepted model context" },
+			{ role: "user", text: "agent-to-agent payload" },
+		]);
+		expect(getAssistantTexts(harness)).toContain("accepted");
+	});
+
+	it("includes nextTurn messages queued by pending model_select handlers in injected prompts", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+						await pi.sendMessage(
+							{
+								customType: "model-context",
+								content: "heartbeat model context",
+								display: false,
+							},
+							{ deliverAs: "nextTurn" },
+						);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("heartbeat")]);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		const heartbeat = harness.session.promptHeartbeat(createHeartbeat());
+		await flushAsyncWork();
+
+		expect(harness.session.messages).toHaveLength(0);
+
+		finishHandler.resolve();
+		await heartbeat;
+		await harness.session.agent.waitForIdle();
+
+		expect(
+			harness.session.messages.slice(0, 2).map((message) => ({ role: message.role, text: getMessageText(message) })),
+		).toEqual([
+			{ role: "custom", text: "heartbeat model context" },
+			{ role: "custom", text: "Check whether the long-running task needs another step." },
+		]);
+		expect(getAssistantTexts(harness)).toContain("heartbeat");
 	});
 
 	it("allows model_select handlers to enqueue user messages without waiting on themselves", async () => {

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -5,6 +5,21 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { ExtensionAPI } from "../../src/index.js";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.js";
 
+function createDeferred<T = void>(): {
+	promise: Promise<T>;
+	resolve(value: T): void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("AgentSession model and extension characterization", () => {
 	const harnesses: Harness[] = [];
 
@@ -42,6 +57,40 @@ describe("AgentSession model and extension characterization", () => {
 				.filter((entry) => entry.type === "model_change")
 				.map((entry) => `${entry.provider}/${entry.modelId}`),
 		).toEqual([`${nextModel.provider}/${nextModel.id}`]);
+	});
+
+	it("can save the model before slow model_select handlers finish", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		let handlerCompleted = false;
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+						handlerCompleted = true;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const nextModel = harness.getModel("faux-2")!;
+
+		await harness.session.setModel(nextModel, { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(handlerCompleted).toBe(false);
+
+		finishHandler.resolve();
+		await flushAsyncWork();
+
+		expect(handlerCompleted).toBe(true);
 	});
 
 	it("cycles through scoped models and preserves the scoped thinking preference", async () => {

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -3,7 +3,7 @@ import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ExtensionAPI } from "../../src/index.js";
-import { createHarness, getAssistantTexts, type Harness } from "./harness.js";
+import { createHarness, getAssistantTexts, getMessageText, type Harness } from "./harness.js";
 
 function createDeferred<T = void>(): {
 	promise: Promise<T>;
@@ -244,6 +244,57 @@ describe("AgentSession model and extension characterization", () => {
 		await prompt;
 
 		expect(getAssistantTexts(harness)).toContain("after model select");
+	});
+
+	it("includes nextTurn messages queued by pending model_select handlers in the next prompt", async () => {
+		const handlerStarted = createDeferred();
+		const finishHandler = createDeferred();
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async () => {
+						handlerStarted.resolve();
+						await finishHandler.promise;
+						await pi.sendMessage(
+							{
+								customType: "model-context",
+								content: "model context",
+								display: false,
+							},
+							{ deliverAs: "nextTurn" },
+						);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("after model context")]);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		await handlerStarted.promise;
+
+		const prompt = harness.session.prompt("hi");
+		await flushAsyncWork();
+
+		expect(harness.session.messages).toHaveLength(0);
+
+		finishHandler.resolve();
+		await prompt;
+		for (let i = 0; i < 5 && !getAssistantTexts(harness).includes("after model context"); i++) {
+			await flushAsyncWork();
+		}
+
+		expect(
+			harness.session.messages.slice(0, 2).map((message) => ({ role: message.role, text: getMessageText(message) })),
+		).toEqual([
+			{ role: "custom", text: "model context" },
+			{ role: "user", text: "hi" },
+		]);
+		expect(getAssistantTexts(harness)).toContain("after model context");
 	});
 
 	it("allows model_select handlers to enqueue user messages without waiting on themselves", async () => {

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -322,6 +322,39 @@ describe("AgentSession model and extension characterization", () => {
 		expect(getAssistantTexts(harness)).toContain("queued from hook");
 	});
 
+	it("allows model_select handlers to switch models without waiting on themselves", async () => {
+		const events: string[] = [];
+		let harness: Harness;
+		harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+				{ id: "faux-3", name: "Three", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", async (event) => {
+						events.push(`start:${event.model.id}`);
+						if (event.model.id === "faux-2") {
+							await harness.session.setModel(harness.getModel("faux-3")!);
+							events.push("nested-returned");
+						}
+						events.push(`end:${event.model.id}`);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!);
+		for (let i = 0; i < 5 && !events.includes("end:faux-3"); i++) {
+			await flushAsyncWork();
+		}
+
+		expect(harness.session.model?.id).toBe("faux-3");
+		expect(events).toEqual(["start:faux-2", "nested-returned", "end:faux-2", "start:faux-3", "end:faux-3"]);
+	});
+
 	it("cycles through scoped models and preserves the scoped thinking preference", async () => {
 		const harness = await createHarness({
 			models: [

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -212,6 +212,31 @@ describe("AgentSession model and extension characterization", () => {
 		expect(getAssistantTexts(harness)).toContain("after model select");
 	});
 
+	it("allows model_select handlers to enqueue user messages without waiting on themselves", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", () => {
+						pi.sendUserMessage("from model_select");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("queued from hook")]);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { waitForExtensions: false });
+		for (let i = 0; i < 5 && !getAssistantTexts(harness).includes("queued from hook"); i++) {
+			await flushAsyncWork();
+		}
+
+		expect(getAssistantTexts(harness)).toContain("queued from hook");
+	});
+
 	it("cycles through scoped models and preserves the scoped thinking preference", async () => {
 		const harness = await createHarness({
 			models: [


### PR DESCRIPTION
- model selection now opens from cached choices and refreshes the catalog in the background.
- daemon model switches no longer wait on extension handlers while a session is running.
- added regressions for selector refreshes, popup selection, and daemon running and idle behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-switch timing, extension `model_select` ordering, and when prompts start relative to pending handlers—behavior-critical paths with broad test coverage but real concurrency edge cases.
> 
> **Overview**
> Fixes **`/model` feeling stuck** when the daemon or connection was still fetching the live model catalog ([ENG-4505](https://linear.app/primeintellect/issue/ENG-4505/model-ui-is-extremely-slow)).
> 
> **Interactive `/model` flow** now opens the selector **immediately** from cached daemon/scoped candidates, then **refreshes the catalog in the background** (60s TTL, coalesced in-flight fetches, version invalidation after login). The overlay **closes as soon as you pick a model** (with a “Switching model…” status) instead of waiting on the connection. `ModelSelectorComponent` can **`updateAvailableModels`** without wiping search/selection and treats an **empty injected snapshot** as empty rather than falling back to local registry models.
> 
> **`AgentSession`** queues **`model_select`** extension emissions, adds **`waitForExtensions`** on `setModel` / `cycleModel`, and **awaits pending emissions before starting prompts** so next-turn messages from slow handlers still land in order. The **daemon** passes `waitForExtensions: false` while a session is **streaming or compacting** so remote model changes return quickly; idle sessions still wait on extensions.
> 
> Regression tests cover selector refresh races, popup selection, daemon idle vs running behavior, and extension queue semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5617d49ea1f0ed5dcfed8e12dada52c19945a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slow model selection in daemon sessions by opening selector instantly with cached models
> - The `/model` selector now opens immediately using cached model candidates instead of blocking on a live registry refresh, which could be slow in daemon sessions.
> - A background refresh runs after the selector opens and updates it in place via the new `updateAvailableModels` method on `ModelSelectorComponent`.
> - `AgentSession.setModel` and `cycleModel` now serialize `model_select` extension handler emissions using a queue, and prompt start waits for any pending handler to finish before proceeding.
> - In [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/352/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450), `waitForExtensions` is set to `false` while the session is streaming or compacting, and `true` when idle, preventing handler waits from blocking active sessions.
> - Behavioral Change: model selection no longer triggers a synchronous live refresh on open; stale cached models may briefly appear before the background refresh completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5617d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->