### PR TITLE
fix resume picker across all entry points

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed automatic harness refinement to be enabled by default while keeping `autoRefine.enabled: false` as the opt-out.
 - Fixed non-numeric `autoRefine.turnInterval` and `autoRefine.cooldownMs` settings falling back to defaults instead of silently enabling a noisy auto-refine loop.
+- Fixed all session-resume entry points to share a searchable full-screen picker, stream results while loading, and support renaming ([ENG-4513](https://linear.app/primeintellect/issue/ENG-4513/resume-in-agents-view-is-broken)).
 
 ## [0.2.7] - 2026-07-08
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -701,7 +701,7 @@ const { session: opened } = await createAgentSession({
 
 // List sessions
 const currentProjectSessions = await SessionManager.list(process.cwd());
-const allSessions = await SessionManager.listAll(process.cwd());
+const allSessions = await SessionManager.listAll();
 
 // Session replacement API for /new, /resume, /fork, /clone, and import flows.
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
@@ -743,7 +743,7 @@ const sm = SessionManager.open("/path/to/session.jsonl");
 
 // Session listing
 const currentProjectSessions = await SessionManager.list(process.cwd());
-const allSessions = await SessionManager.listAll(process.cwd());
+const allSessions = await SessionManager.listAll();
 
 // Tree traversal
 const entries = sm.getEntries();        // All entries (excludes header)

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -370,8 +370,10 @@ Key methods for working with sessions programmatically.
 - `SessionManager.forkFrom(sourcePath, targetCwd, sessionDir?)` - Fork session from another project
 
 ### Static Listing Methods
-- `SessionManager.list(cwd, sessionDir?, onProgress?)` - List sessions for a directory
-- `SessionManager.listAll(onProgress?)` - List all sessions across all projects
+- `SessionManager.list(cwd, sessionDir?, callbacks?)` - List sessions for a directory
+- `SessionManager.listAll(callbacks?, sessionDir?)` - List all sessions across all projects
+
+`callbacks` can provide `onProgress(loaded, total)` and `onSession(session)` handlers.
 
 ### Instance Methods - Session Management
 - `newSession(options?)` - Start a new session (options: `{ parentSession?: string }`)

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -2,48 +2,21 @@
  * TUI session selector for --resume flag
  */
 
-import { type Component, ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
+import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
 import { VERSION } from "../config.js";
 import { KeybindingsManager } from "../core/keybindings.js";
-import type { SessionInfo, SessionListProgress } from "../core/session-manager.js";
+import { type SessionInfo, type SessionListCallbacks, SessionManager } from "../core/session-manager.js";
+import { SessionPickerScreen } from "../modes/interactive/components/session-picker-screen.js";
 import { SessionSelectorComponent } from "../modes/interactive/components/session-selector.js";
 import { BrandSplashHeader } from "../modes/interactive/interactive-mode.js";
 
-type SessionsLoader = (onProgress?: SessionListProgress) => Promise<SessionInfo[]>;
-
-/** Full-screen layout matching the agents view: brand splash on top, selector below. */
-class SessionPickerScreen implements Component {
-	constructor(
-		private readonly ui: TUI,
-		private readonly splash: BrandSplashHeader,
-		private readonly selector: SessionSelectorComponent,
-	) {}
-
-	invalidate(): void {
-		this.splash.invalidate();
-		this.selector.invalidate();
-	}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(1, width);
-		const height = Math.max(1, this.ui.terminal.rows);
-		const splashLines = this.splash.render(safeWidth);
-		// Selector chrome (header, hints, search, spacers) takes ~8 rows; give the
-		// list the rest of the terminal instead of its compact default.
-		this.selector.setListMaxVisible(height - splashLines.length - 10);
-		const lines = [...splashLines, ...this.selector.render(safeWidth)];
-		while (lines.length < height) {
-			lines.push("");
-		}
-		return lines.slice(0, height);
-	}
-}
+type SessionsLoader = (callbacks?: SessionListCallbacks) => Promise<SessionInfo[]>;
 
 /** Show TUI session selector and return selected session path or null if cancelled */
 export async function selectSession(
 	currentSessionsLoader: SessionsLoader,
 	allSessionsLoader: SessionsLoader,
-	options?: { cwd?: string; modelId?: string },
+	options?: { cwd?: string; modelId?: string; sessionDir?: string },
 ): Promise<string | null> {
 	return new Promise((resolve) => {
 		const ui = new TUI(new ProcessTerminal());
@@ -52,8 +25,16 @@ export async function selectSession(
 		let resolved = false;
 
 		const selector = new SessionSelectorComponent(
-			currentSessionsLoader,
-			allSessionsLoader,
+			(callbacks) =>
+				currentSessionsLoader({
+					onProgress: callbacks?.onProgress,
+					onSession: callbacks?.onSession,
+				}),
+			(callbacks) =>
+				allSessionsLoader({
+					onProgress: callbacks?.onProgress,
+					onSession: callbacks?.onSession,
+				}),
 			(path: string) => {
 				if (!resolved) {
 					resolved = true;
@@ -73,7 +54,16 @@ export async function selectSession(
 				process.exit(0);
 			},
 			() => ui.requestRender(),
-			{ showRenameHint: false, keybindings, frameless: true },
+			{
+				renameSession: async (sessionPath, nextName) => {
+					const name = (nextName ?? "").trim();
+					if (!name) return;
+					SessionManager.open(sessionPath, options?.sessionDir).appendSessionInfo(name);
+				},
+				showRenameHint: true,
+				keybindings,
+				frameless: true,
+			},
 		);
 
 		const splash = new BrandSplashHeader(

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -11,11 +11,12 @@ import { SessionSelectorComponent } from "../modes/interactive/components/sessio
 import { BrandSplashHeader } from "../modes/interactive/interactive-mode.js";
 
 type SessionsLoader = (callbacks?: SessionListCallbacks) => Promise<SessionInfo[]>;
+type AllSessionsLoader = (callbacks?: SessionListCallbacks, sessionDir?: string) => Promise<SessionInfo[]>;
 
 /** Show TUI session selector and return selected session path or null if cancelled */
 export async function selectSession(
 	currentSessionsLoader: SessionsLoader,
-	allSessionsLoader: SessionsLoader,
+	allSessionsLoader: AllSessionsLoader,
 	options?: { cwd?: string; modelId?: string; sessionDir?: string },
 ): Promise<string | null> {
 	return new Promise((resolve) => {
@@ -31,10 +32,13 @@ export async function selectSession(
 					onSession: callbacks?.onSession,
 				}),
 			(callbacks) =>
-				allSessionsLoader({
-					onProgress: callbacks?.onProgress,
-					onSession: callbacks?.onSession,
-				}),
+				allSessionsLoader(
+					{
+						onProgress: callbacks?.onProgress,
+						onSession: callbacks?.onSession,
+					},
+					options?.sessionDir,
+				),
 			(path: string) => {
 				if (!resolved) {
 					resolved = true;

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -72,7 +72,7 @@ export async function selectSession(
 			() => options?.cwd ?? process.cwd(),
 		);
 		ui.addChild(new SessionPickerScreen(ui, splash, selector));
-		ui.setFocus(selector.getSessionList());
+		ui.setFocus(selector);
 		ui.start();
 	});
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -988,10 +988,16 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 }
 
 export type SessionListProgress = (loaded: number, total: number) => void;
+export type SessionListItem = (session: SessionInfo) => void;
+
+export interface SessionListCallbacks {
+	onProgress?: SessionListProgress;
+	onSession?: SessionListItem;
+}
 
 async function listSessionsFromDir(
 	dir: string,
-	onProgress?: SessionListProgress,
+	callbacks?: SessionListCallbacks,
 	progressOffset = 0,
 	progressTotal?: number,
 ): Promise<SessionInfo[]> {
@@ -1017,9 +1023,10 @@ async function listSessionsFromDir(
 		for (const file of files) {
 			const info = await buildSessionInfo(file);
 			loaded++;
-			onProgress?.(progressOffset + loaded, total);
+			callbacks?.onProgress?.(progressOffset + loaded, total);
 			if (info) {
 				sessions.push(info);
+				callbacks?.onSession?.(info);
 			}
 		}
 	} catch {
@@ -2016,25 +2023,35 @@ export class SessionManager {
 	 * List all sessions for a directory.
 	 * @param cwd Working directory (used to compute default session directory)
 	 * @param sessionDir Optional session directory. If omitted, uses the configured session root.
-	 * @param onProgress Optional callback for progress updates (loaded, total)
+	 * @param callbacks Optional callbacks for progress and discovered sessions
 	 */
-	static async list(cwd: string, sessionDir?: string, onProgress?: SessionListProgress): Promise<SessionInfo[]> {
+	static async list(cwd: string, sessionDir?: string, callbacks?: SessionListCallbacks): Promise<SessionInfo[]> {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		const sessions = (await listSessionsFromDir(dir, onProgress)).filter((session) =>
-			sessionInfoMatchesCwd(session, cwd),
-		);
+		const matchesCwd = (session: SessionInfo) => sessionInfoMatchesCwd(session, cwd);
+		const sessions = (
+			await listSessionsFromDir(dir, {
+				onProgress: callbacks?.onProgress,
+				onSession: callbacks?.onSession
+					? (session) => {
+							if (matchesCwd(session)) {
+								callbacks.onSession?.(session);
+							}
+						}
+					: undefined,
+			})
+		).filter(matchesCwd);
 		sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
 		return sessions;
 	}
 
 	/**
 	 * List all sessions across all project directories.
-	 * @param onProgress Optional callback for progress updates (loaded, total)
+	 * @param callbacks Optional callbacks for progress and discovered sessions
 	 * @param sessionDir Optional session root. If omitted, uses the configured session root.
 	 */
-	static async listAll(onProgress?: SessionListProgress, sessionDir?: string): Promise<SessionInfo[]> {
+	static async listAll(callbacks?: SessionListCallbacks, sessionDir?: string): Promise<SessionInfo[]> {
 		const sessionsDir = sessionDir ?? getSessionsDir();
-		const sessions = await listSessionsFromDir(sessionsDir, onProgress);
+		const sessions = await listSessionsFromDir(sessionsDir, callbacks);
 		sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
 		return sessions;
 	}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1266,7 +1266,7 @@ export class SessionManager {
 		if (!this.persist || !this.sessionFile) return;
 
 		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
-		const shouldPersistWithoutAssistant = entry.type === "session_state";
+		const shouldPersistWithoutAssistant = entry.type === "session_state" || entry.type === "session_info";
 		if (!hasAssistant && !shouldPersistWithoutAssistant) {
 			// Mark as not flushed so when assistant arrives, all entries get written
 			this.flushed = false;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -529,9 +529,9 @@ export async function createSessionManager(
 		initTheme(settingsManager.getTheme(), true);
 		try {
 			const selectedPath = await selectSession(
-				(onProgress) => SessionManager.list(cwd, sessionDir, onProgress),
+				(callbacks) => SessionManager.list(cwd, sessionDir, callbacks),
 				SessionManager.listAll,
-				{ cwd },
+				{ cwd, sessionDir },
 			);
 			if (!selectedPath) {
 				console.log(chalk.dim("No session selected"));

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -13,14 +13,17 @@ import {
 	collectDaemonClientEnv,
 	type DaemonAttachResult,
 	type DaemonCommand,
-	type DaemonDeleteSavedSessionResult,
 	type DaemonOutbound,
 	type DaemonReplayInfo,
-	type DaemonSavedSessionInfo,
 	type DaemonSessionSnapshot,
 	isUnknownDaemonCommandError,
 } from "../daemon/daemon-protocol.js";
 import type { SessionSummary } from "../daemon/daemon-session-list.js";
+import {
+	deleteDaemonSavedSession,
+	listDaemonSavedSessions,
+	renameDaemonSavedSession,
+} from "../daemon/saved-session-catalog.js";
 import type {
 	AgentConnection,
 	AgentConnectionBeforeSessionInvalidateListener,
@@ -42,7 +45,7 @@ import type {
 	AgentConnectionSavedSessionScope,
 	AgentConnectionScopedModel,
 	AgentConnectionSessionContext,
-	AgentConnectionSessionListProgress,
+	AgentConnectionSessionListCallbacks,
 	AgentConnectionSessionTreeNode,
 	AgentConnectionSessionWatcher,
 	AgentConnectionSlashCommand,
@@ -273,26 +276,9 @@ export class DaemonAgentConnection implements AgentConnection {
 
 	async listSavedSessions(
 		scope: AgentConnectionSavedSessionScope,
-		onProgress?: AgentConnectionSessionListProgress,
+		callbacks?: AgentConnectionSessionListCallbacks,
 	): Promise<AgentConnectionSavedSessionInfo[]> {
-		const response = await this.client.request(
-			{
-				type: "list_saved_sessions",
-				activeSessionId: this.activeSessionId,
-				scope,
-			},
-			30000,
-			{
-				onProgress: (progress) => {
-					onProgress?.(progress.loaded, progress.total);
-				},
-			},
-		);
-		if (!response.success) {
-			throw deserializeDaemonError(response);
-		}
-		const data = response.data as { sessions: DaemonSavedSessionInfo[] };
-		return data.sessions.map(deserializeSavedSessionInfo);
+		return listDaemonSavedSessions(this.client, { activeSessionId: this.activeSessionId }, scope, callbacks);
 	}
 
 	async getQueue(): Promise<AgentConnectionQueueState> {
@@ -672,20 +658,11 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async renameSavedSession(sessionPath: string, name: string): Promise<void> {
-		await this.requestOk({
-			type: "rename_saved_session",
-			activeSessionId: this.activeSessionId,
-			sessionPath,
-			name,
-		});
+		await renameDaemonSavedSession(this.client, { activeSessionId: this.activeSessionId }, sessionPath, name);
 	}
 
 	async deleteSavedSession(sessionPath: string): Promise<DeleteSessionFileResult> {
-		return this.requestData<DaemonDeleteSavedSessionResult>({
-			type: "delete_saved_session",
-			activeSessionId: this.activeSessionId,
-			sessionPath,
-		});
+		return deleteDaemonSavedSession(this.client, { activeSessionId: this.activeSessionId }, sessionPath);
 	}
 
 	async watchSession(activeSessionId: string): Promise<AgentConnectionSessionWatcher | undefined> {
@@ -898,20 +875,4 @@ function invalidatesCachedSnapshot(commandType: DaemonCommandBody["type"]): bool
 		default:
 			return true;
 	}
-}
-
-function deserializeSavedSessionInfo(session: DaemonSavedSessionInfo): AgentConnectionSavedSessionInfo {
-	return {
-		path: session.path,
-		id: session.id,
-		cwd: session.cwd,
-		name: session.name,
-		state: session.state,
-		parentSessionPath: session.parentSessionPath,
-		created: new Date(session.created),
-		modified: new Date(session.modified),
-		messageCount: session.messageCount,
-		firstMessage: session.firstMessage,
-		allMessagesText: session.allMessagesText,
-	};
 }

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -37,7 +37,7 @@ import type {
 	AgentConnectionSavedSessionScope,
 	AgentConnectionScopedModel,
 	AgentConnectionSessionContext,
-	AgentConnectionSessionListProgress,
+	AgentConnectionSessionListCallbacks,
 	AgentConnectionSessionTreeNode,
 	AgentConnectionSessionWatcher,
 	AgentConnectionSlashCommand,
@@ -130,16 +130,16 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async listSavedSessions(
 		scope: AgentConnectionSavedSessionScope,
-		onProgress?: AgentConnectionSessionListProgress,
+		callbacks?: AgentConnectionSessionListCallbacks,
 	): Promise<AgentConnectionSavedSessionInfo[]> {
 		if (scope === "current") {
 			return SessionManager.list(
 				this.session.sessionManager.getCwd(),
 				this.session.sessionManager.getSessionDir(),
-				onProgress,
+				callbacks,
 			);
 		}
-		return SessionManager.listAll(onProgress, this.session.sessionManager.getSessionDir());
+		return SessionManager.listAll(callbacks, this.session.sessionManager.getSessionDir());
 	}
 
 	async getQueue(): Promise<AgentConnectionQueueState> {

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -51,6 +51,7 @@ export type {
 	AgentConnectionSessionEntryBase,
 	AgentConnectionSessionEvent,
 	AgentConnectionSessionInfoEntry,
+	AgentConnectionSessionListCallbacks,
 	AgentConnectionSessionListProgress,
 	AgentConnectionSessionMessageEntry,
 	AgentConnectionSessionStateEntry,

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -3,6 +3,7 @@ export { InProcessAgentConnection } from "./in-process-agent-connection.js";
 export { createAgentConnectionCommands, createAgentConnectionState } from "./snapshot.js";
 export type {
 	AgentConnection,
+	AgentConnectionAgentStatus,
 	AgentConnectionArtifactReference,
 	AgentConnectionArtifactType,
 	AgentConnectionBeforeSessionInvalidateListener,

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -67,6 +67,12 @@ export interface AgentConnectionSavedSessionState {
 	status: AgentConnectionSavedSessionStateStatus;
 }
 
+export interface AgentConnectionAgentStatus {
+	summary: string;
+	taskState?: "needs_input" | "completed";
+	basedOnMessageCount: number;
+}
+
 /**
  * Saved-session registry row for the current local TUI migration.
  *
@@ -88,6 +94,7 @@ export interface AgentConnectionSavedSessionInfo {
 	messageCount: number;
 	firstMessage: string;
 	allMessagesText: string;
+	agentStatus?: AgentConnectionAgentStatus;
 }
 
 export type AgentConnectionSessionListProgress = (loaded: number, total: number) => void;
@@ -176,11 +183,7 @@ export interface AgentConnectionSessionStateEntry extends AgentConnectionSession
 
 export interface AgentConnectionAgentStatusEntry extends AgentConnectionSessionEntryBase {
 	type: "agent_status";
-	status: {
-		summary: string;
-		taskState?: "needs_input" | "completed";
-		basedOnMessageCount: number;
-	};
+	status: AgentConnectionAgentStatus;
 }
 
 export interface AgentConnectionGitStateEntry extends AgentConnectionSessionEntryBase {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -92,6 +92,11 @@ export interface AgentConnectionSavedSessionInfo {
 
 export type AgentConnectionSessionListProgress = (loaded: number, total: number) => void;
 
+export interface AgentConnectionSessionListCallbacks {
+	onProgress?: AgentConnectionSessionListProgress;
+	onSession?: (session: AgentConnectionSavedSessionInfo) => void;
+}
+
 export interface AgentConnectionSessionEntryBase {
 	type: string;
 	id: string;
@@ -515,7 +520,7 @@ export interface AgentConnection {
 	getSessionTree(): Promise<{ tree: AgentConnectionSessionTreeNode[]; leafId: string | null }>;
 	listSavedSessions(
 		scope: AgentConnectionSavedSessionScope,
-		onProgress?: AgentConnectionSessionListProgress,
+		callbacks?: AgentConnectionSessionListCallbacks,
 	): Promise<AgentConnectionSavedSessionInfo[]>;
 	getQueue(): Promise<AgentConnectionQueueState>;
 	clearQueue(): Promise<AgentConnectionQueueState>;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -19,9 +19,9 @@ import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSI
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { findExactModelReferenceMatch } from "../../core/model-resolver.js";
-import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
-import { type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import { SessionManager } from "../../core/session-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
+import type { AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
 import { DaemonClient } from "../daemon/daemon-client.js";
 import { type DaemonCommand, type DaemonResponse, isUnknownDaemonCommandError } from "../daemon/daemon-protocol.js";
 import {
@@ -29,12 +29,19 @@ import {
 	type SessionSummary,
 	summaryForInactiveSession,
 } from "../daemon/daemon-session-list.js";
+import {
+	type DaemonSavedSessionCatalogContext,
+	deleteDaemonSavedSession,
+	listDaemonSavedSessions,
+	renameDaemonSavedSession,
+} from "../daemon/saved-session-catalog.js";
 import { getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "../interactive/auth-flows.js";
 import { showFullPaneOverlay } from "../interactive/components/centered-overlay.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
 import { ModelSelectorComponent } from "../interactive/components/model-selector.js";
-import { SessionSelectorComponent } from "../interactive/components/session-selector.js";
+import { SessionPickerScreen } from "../interactive/components/session-picker-screen.js";
+import { type SessionListCallbacks, SessionSelectorComponent } from "../interactive/components/session-selector.js";
 import { BrandSplashHeader, InteractiveMode } from "../interactive/interactive-mode.js";
 import type { InteractiveModeUiServices } from "../interactive/interactive-mode-services.js";
 import {
@@ -126,7 +133,6 @@ type AgentsViewPersistentState = {
 };
 
 type PromptCommand = Extract<DaemonCommand, { type: "prompt" }>;
-type DeleteSavedSessionCommand = Extract<DaemonCommand, { type: "delete_saved_session" }>;
 type PendingDeleteAgent = {
 	identity: string;
 	activeSessionId?: string;
@@ -168,13 +174,9 @@ export function createAgentsViewListCommand(): Extract<DaemonCommand, { type: "l
 	return { type: "list" };
 }
 
-export function createAgentsViewDeleteSavedSessionCommand(sessionPath: string): DeleteSavedSessionCommand {
-	return { type: "delete_saved_session", sessionPath };
-}
-
 export function resolveAgentsViewResumeSummary(
 	sessionPath: string,
-	savedSessions: readonly SessionInfo[],
+	savedSessions: readonly AgentConnectionSavedSessionInfo[],
 	visibleSummaries: readonly SessionSummary[],
 ): SessionSummary | undefined {
 	const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, visibleSummaries);
@@ -1040,13 +1042,31 @@ class AgentsViewMode implements Component, Focusable {
 		return new Promise((done) => {
 			let handle: OverlayHandle | undefined;
 			let settled = false;
-			const savedSessionsByPath = new Map<string, SessionInfo>();
+			const savedSessionsByPath = new Map<string, AgentConnectionSavedSessionInfo>();
 
-			const rememberSessions = (sessions: SessionInfo[]): SessionInfo[] => {
+			const rememberSessions = <T extends AgentConnectionSavedSessionInfo[]>(sessions: T): T => {
 				for (const session of sessions) {
 					savedSessionsByPath.set(resolvePath(session.path), session);
 				}
 				return sessions;
+			};
+			const listSavedSessions = async (
+				scope: "current" | "all",
+				callbacks?: SessionListCallbacks,
+			): Promise<AgentConnectionSavedSessionInfo[]> => {
+				const sessions = await listDaemonSavedSessions(
+					this.requireClient(),
+					this.getSavedSessionCatalogContext(),
+					scope,
+					{
+						onProgress: callbacks?.onProgress,
+						onSession: (session) => {
+							rememberSessions([session]);
+							callbacks?.onSession?.(session);
+						},
+					},
+				);
+				return rememberSessions(sessions);
 			};
 
 			const close = () => {
@@ -1060,12 +1080,8 @@ class AgentsViewMode implements Component, Focusable {
 			};
 
 			const selector = new SessionSelectorComponent(
-				async (onProgress) =>
-					rememberSessions(
-						await SessionManager.list(this.getSavedSessionCwd(), this.options.config.sessionDir, onProgress),
-					),
-				async (onProgress) =>
-					rememberSessions(await SessionManager.listAll(onProgress, this.options.config.sessionDir)),
+				(callbacks) => listSavedSessions("current", callbacks),
+				(callbacks) => listSavedSessions("all", callbacks),
 				(sessionPath) => {
 					const summary = resolveAgentsViewResumeSummary(
 						sessionPath,
@@ -1096,9 +1112,17 @@ class AgentsViewMode implements Component, Focusable {
 					deleteSession: (sessionPath) => this.deleteSavedSessionFromSelector(sessionPath),
 					showRenameHint: true,
 					keybindings: this.keybindings,
+					frameless: true,
 				},
 			);
-			handle = showFullPaneOverlay(this.ui, selector, 96);
+			const splash = new BrandSplashHeader(
+				VERSION,
+				() => this.getSplashModelId(),
+				() => this.getSavedSessionCwd(),
+			);
+			handle = showFullPaneOverlay(this.ui, new SessionPickerScreen(this.ui, splash, selector), {
+				fullWidth: true,
+			});
 		});
 	}
 
@@ -1106,25 +1130,17 @@ class AgentsViewMode implements Component, Focusable {
 		return this.options.config.cwd ?? this.options.uiServices.getInitialCwd();
 	}
 
+	private getSavedSessionCatalogContext(): DaemonSavedSessionCatalogContext {
+		return { cwd: this.getSavedSessionCwd(), sessionDir: this.options.config.sessionDir };
+	}
+
 	private async renameSavedSessionFromSelector(sessionPath: string, name: string): Promise<void> {
-		const activeSummary = resolveAgentsViewActiveSummaryForPath(sessionPath, this.lastListedSummaries);
-		if (!activeSummary?.activeSessionId) {
-			SessionManager.open(sessionPath).appendSessionInfo(name);
-			return;
-		}
-		const response = await this.requireClient().request({
-			type: "rename_saved_session",
-			activeSessionId: activeSummary.activeSessionId,
-			sessionPath,
-			name,
-		});
-		requireDaemonData(response);
+		await renameDaemonSavedSession(this.requireClient(), this.getSavedSessionCatalogContext(), sessionPath, name);
 		await this.refreshSessions();
 	}
 
-	private async deleteSavedSessionFromSelector(sessionPath: string): Promise<DeleteSessionFileResult> {
-		const response = await this.requireClient().request(createAgentsViewDeleteSavedSessionCommand(sessionPath));
-		return expectDeleteSessionFileResult(requireDaemonData(response));
+	private async deleteSavedSessionFromSelector(sessionPath: string) {
+		return deleteDaemonSavedSession(this.requireClient(), this.getSavedSessionCatalogContext(), sessionPath);
 	}
 
 	private getDefaultModelForNewAgents(): Model<Api> | undefined {
@@ -2201,22 +2217,6 @@ function expectSessionSummary(value: unknown): SessionSummary {
 		throw new Error("Daemon returned an invalid session summary");
 	}
 	return value;
-}
-
-function expectDeleteSessionFileResult(value: unknown): DeleteSessionFileResult {
-	if (!isRecord(value) || typeof value.ok !== "boolean") {
-		throw new Error("Daemon returned an invalid delete session response");
-	}
-	if (value.ok) {
-		if (value.method !== "trash" && value.method !== "unlink") {
-			throw new Error("Daemon returned an invalid delete session response");
-		}
-		return { ok: true, method: value.method };
-	}
-	if (typeof value.error !== "string") {
-		throw new Error("Daemon returned an invalid delete session response");
-	}
-	return { ok: false, error: value.error };
 }
 
 function isSessionSummary(value: unknown): value is SessionSummary {

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -1,6 +1,12 @@
 import { createConnection, type Socket } from "node:net";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
-import type { DaemonCommand, DaemonOutbound, DaemonRequestProgress, DaemonResponse } from "./daemon-protocol.js";
+import type {
+	DaemonCommand,
+	DaemonOutbound,
+	DaemonRequestProgress,
+	DaemonResponse,
+	DaemonSavedSessionInfo,
+} from "./daemon-protocol.js";
 
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
@@ -250,13 +256,30 @@ function isDaemonRequestProgress(value: unknown): value is DaemonRequestProgress
 		activeSessionId?: unknown;
 		loaded?: unknown;
 		total?: unknown;
+		session?: unknown;
 	};
+	if (candidate.command !== "list_saved_sessions" || typeof candidate.id !== "string") {
+		return false;
+	}
+	if (candidate.type === "session_list_progress") {
+		return typeof candidate.loaded === "number" && typeof candidate.total === "number";
+	}
+	return candidate.type === "session_list_item" && isDaemonSavedSessionInfo(candidate.session);
+}
+
+function isDaemonSavedSessionInfo(value: unknown): value is DaemonSavedSessionInfo {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const candidate = value as Record<string, unknown>;
 	return (
-		candidate.type === "session_list_progress" &&
-		candidate.command === "list_saved_sessions" &&
+		typeof candidate.path === "string" &&
 		typeof candidate.id === "string" &&
-		typeof candidate.activeSessionId === "string" &&
-		typeof candidate.loaded === "number" &&
-		typeof candidate.total === "number"
+		typeof candidate.cwd === "string" &&
+		typeof candidate.created === "string" &&
+		typeof candidate.modified === "string" &&
+		typeof candidate.messageCount === "number" &&
+		typeof candidate.firstMessage === "string" &&
+		typeof candidate.allMessagesText === "string"
 	);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -280,6 +280,21 @@ function isDaemonSavedSessionInfo(value: unknown): value is DaemonSavedSessionIn
 		typeof candidate.modified === "string" &&
 		typeof candidate.messageCount === "number" &&
 		typeof candidate.firstMessage === "string" &&
-		typeof candidate.allMessagesText === "string"
+		typeof candidate.allMessagesText === "string" &&
+		(candidate.agentStatus === undefined || isDaemonSavedSessionAgentStatus(candidate.agentStatus))
+	);
+}
+
+function isDaemonSavedSessionAgentStatus(value: unknown): boolean {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.summary === "string" &&
+		typeof candidate.basedOnMessageCount === "number" &&
+		(candidate.taskState === undefined ||
+			candidate.taskState === "needs_input" ||
+			candidate.taskState === "completed")
 	);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2751,6 +2751,7 @@ function serializeSavedSessionInfo(session: SessionInfo): DaemonSavedSessionInfo
 		messageCount: session.messageCount,
 		firstMessage: session.firstMessage,
 		allMessagesText: session.allMessagesText,
+		agentStatus: session.agentStatus,
 	};
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1270,24 +1270,45 @@ export class AgentDaemon {
 			}
 
 			case "list_saved_sessions": {
-				const state = this.getSessionState(command.activeSessionId);
-				const sessionManager = state.runtime.session.sessionManager;
-				const onProgress = command.id
-					? (loaded: number, total: number) => {
-							this.write(client, {
-								id: command.id,
-								type: "session_list_progress",
-								command: "list_saved_sessions",
-								activeSessionId: command.activeSessionId,
-								loaded,
-								total,
-							});
+				let activeSessionId: string | undefined;
+				let cwd: string;
+				let sessionDir: string | undefined;
+				if ("activeSessionId" in command) {
+					activeSessionId = command.activeSessionId;
+					const sessionManager = this.getSessionState(activeSessionId).runtime.session.sessionManager;
+					cwd = sessionManager.getCwd();
+					sessionDir = sessionManager.getSessionDir();
+				} else {
+					cwd = resolve(command.cwd);
+					sessionDir = command.sessionDir;
+				}
+				const callbacks = command.id
+					? {
+							onProgress: (loaded: number, total: number) => {
+								this.write(client, {
+									id: command.id,
+									type: "session_list_progress",
+									command: "list_saved_sessions",
+									...(activeSessionId ? { activeSessionId } : {}),
+									loaded,
+									total,
+								});
+							},
+							onSession: (session: SessionInfo) => {
+								this.write(client, {
+									id: command.id,
+									type: "session_list_item",
+									command: "list_saved_sessions",
+									...(activeSessionId ? { activeSessionId } : {}),
+									session: serializeSavedSessionInfo(session),
+								});
+							},
 						}
 					: undefined;
 				const savedSessions =
 					command.scope === "current"
-						? await SessionManager.list(sessionManager.getCwd(), sessionManager.getSessionDir(), onProgress)
-						: await SessionManager.listAll(onProgress, sessionManager.getSessionDir());
+						? await SessionManager.list(cwd, sessionDir, callbacks)
+						: await SessionManager.listAll(callbacks, sessionDir);
 				return success(command.id, "list_saved_sessions", {
 					sessions: savedSessions.map(serializeSavedSessionInfo),
 				});
@@ -1353,7 +1374,9 @@ export class AgentDaemon {
 			}
 
 			case "rename_saved_session": {
-				this.getSessionState(command.activeSessionId);
+				if (command.activeSessionId) {
+					this.getSessionState(command.activeSessionId);
+				}
 				const state = this.findActiveSessionByFile(command.sessionPath);
 				const name = command.name.trim();
 				if (!name) {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -230,9 +230,19 @@ export interface DaemonUpdateRestartManifest {
 	sessions: DaemonUpdateRestartSession[];
 }
 
+export type DaemonSavedSessionListCommand =
+	| { id?: string; type: "list_saved_sessions"; activeSessionId: string; scope: AgentConnectionSavedSessionScope }
+	| {
+			id?: string;
+			type: "list_saved_sessions";
+			cwd: string;
+			sessionDir?: string;
+			scope: AgentConnectionSavedSessionScope;
+	  };
+
 export type DaemonCommand =
 	| { id?: string; type: "list"; all?: boolean; cwd?: string; sessionDir?: string }
-	| { id?: string; type: "list_saved_sessions"; activeSessionId: string; scope: AgentConnectionSavedSessionScope }
+	| DaemonSavedSessionListCommand
 	| ({
 			id?: string;
 			type: "create";
@@ -370,7 +380,7 @@ export type DaemonCommand =
 	| { id?: string; type: "export_html"; activeSessionId: string; outputPath?: string }
 	| { id?: string; type: "export_jsonl"; activeSessionId: string; outputPath?: string }
 	| { id?: string; type: "set_session_name"; activeSessionId: string; name: string }
-	| { id?: string; type: "rename_saved_session"; activeSessionId: string; sessionPath: string; name: string }
+	| { id?: string; type: "rename_saved_session"; activeSessionId?: string; sessionPath: string; name: string }
 	| { id?: string; type: "delete_saved_session"; activeSessionId?: string; sessionPath: string }
 	| { id?: string; type: "get_session_context"; activeSessionId: string }
 	| { id?: string; type: "get_session_tree"; activeSessionId: string }
@@ -422,14 +432,22 @@ export function isUnknownDaemonCommandError(error: unknown, command: DaemonComma
 	return error instanceof Error && error.message.includes(`Unknown daemon command: ${command}`);
 }
 
-export interface DaemonRequestProgress {
-	id?: string;
-	type: "session_list_progress";
-	command: "list_saved_sessions";
-	activeSessionId: string;
-	loaded: number;
-	total: number;
-}
+export type DaemonRequestProgress =
+	| {
+			id?: string;
+			type: "session_list_progress";
+			command: "list_saved_sessions";
+			activeSessionId?: string;
+			loaded: number;
+			total: number;
+	  }
+	| {
+			id?: string;
+			type: "session_list_item";
+			command: "list_saved_sessions";
+			activeSessionId?: string;
+			session: DaemonSavedSessionInfo;
+	  };
 
 export interface DaemonSavedSessionInfo {
 	path: string;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -12,6 +12,7 @@ import type { CustomMessage } from "../../core/messages.js";
 import type { SessionCwdIssue } from "../../core/session-cwd.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type {
+	AgentConnectionAgentStatus,
 	AgentConnectionQueueMode,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionRlmChildAgentSnapshot,
@@ -35,7 +36,7 @@ import type { SessionSummary } from "./daemon-session-list.js";
  */
 
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
-export const DAEMON_PROTOCOL_VERSION = 1;
+export const DAEMON_PROTOCOL_VERSION = 2;
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = typeof DAEMON_PROTOCOL_VERSION;
@@ -461,6 +462,7 @@ export interface DaemonSavedSessionInfo {
 	messageCount: number;
 	firstMessage: string;
 	allMessagesText: string;
+	agentStatus?: AgentConnectionAgentStatus;
 }
 
 export type DaemonDeleteSavedSessionResult = DeleteSessionFileResult;

--- a/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
@@ -86,5 +86,6 @@ export function deserializeSavedSessionInfo(session: DaemonSavedSessionInfo): Ag
 		messageCount: session.messageCount,
 		firstMessage: session.firstMessage,
 		allMessagesText: session.allMessagesText,
+		agentStatus: session.agentStatus,
 	};
 }

--- a/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
@@ -1,0 +1,90 @@
+import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
+import type {
+	AgentConnectionSavedSessionInfo,
+	AgentConnectionSavedSessionScope,
+	AgentConnectionSessionListCallbacks,
+} from "../agent-connection/types.js";
+import type { DaemonClient } from "./daemon-client.js";
+import { deserializeDaemonError } from "./daemon-errors.js";
+import type {
+	DaemonCommand,
+	DaemonDeleteSavedSessionResult,
+	DaemonSavedSessionInfo,
+	DaemonSavedSessionListCommand,
+} from "./daemon-protocol.js";
+
+export type DaemonSavedSessionCatalogContext = { activeSessionId: string } | { cwd: string; sessionDir?: string };
+
+export async function listDaemonSavedSessions(
+	client: DaemonClient,
+	context: DaemonSavedSessionCatalogContext,
+	scope: AgentConnectionSavedSessionScope,
+	callbacks?: AgentConnectionSessionListCallbacks,
+): Promise<AgentConnectionSavedSessionInfo[]> {
+	const command: DaemonSavedSessionListCommand =
+		"activeSessionId" in context
+			? { type: "list_saved_sessions", activeSessionId: context.activeSessionId, scope }
+			: { type: "list_saved_sessions", cwd: context.cwd, sessionDir: context.sessionDir, scope };
+	const response = await client.request(command, 30000, {
+		onProgress: (update) => {
+			if (update.type === "session_list_progress") {
+				callbacks?.onProgress?.(update.loaded, update.total);
+			} else {
+				callbacks?.onSession?.(deserializeSavedSessionInfo(update.session));
+			}
+		},
+	});
+	if (!response.success) {
+		throw deserializeDaemonError(response);
+	}
+	const data = response.data as { sessions: DaemonSavedSessionInfo[] };
+	return data.sessions.map(deserializeSavedSessionInfo);
+}
+
+export async function renameDaemonSavedSession(
+	client: DaemonClient,
+	context: DaemonSavedSessionCatalogContext,
+	sessionPath: string,
+	name: string,
+): Promise<void> {
+	const command: Extract<DaemonCommand, { type: "rename_saved_session" }> =
+		"activeSessionId" in context
+			? { type: "rename_saved_session", activeSessionId: context.activeSessionId, sessionPath, name }
+			: { type: "rename_saved_session", sessionPath, name };
+	const response = await client.request(command);
+	if (!response.success) {
+		throw deserializeDaemonError(response);
+	}
+}
+
+export async function deleteDaemonSavedSession(
+	client: DaemonClient,
+	context: DaemonSavedSessionCatalogContext,
+	sessionPath: string,
+): Promise<DeleteSessionFileResult> {
+	const command: Extract<DaemonCommand, { type: "delete_saved_session" }> =
+		"activeSessionId" in context
+			? { type: "delete_saved_session", activeSessionId: context.activeSessionId, sessionPath }
+			: { type: "delete_saved_session", sessionPath };
+	const response = await client.request(command);
+	if (!response.success) {
+		throw deserializeDaemonError(response);
+	}
+	return response.data as DaemonDeleteSavedSessionResult;
+}
+
+export function deserializeSavedSessionInfo(session: DaemonSavedSessionInfo): AgentConnectionSavedSessionInfo {
+	return {
+		path: session.path,
+		id: session.id,
+		cwd: session.cwd,
+		name: session.name,
+		state: session.state,
+		parentSessionPath: session.parentSessionPath,
+		created: new Date(session.created),
+		modified: new Date(session.modified),
+		messageCount: session.messageCount,
+		firstMessage: session.firstMessage,
+		allMessagesText: session.allMessagesText,
+	};
+}

--- a/packages/coding-agent/src/modes/interactive/components/centered-overlay.ts
+++ b/packages/coding-agent/src/modes/interactive/components/centered-overlay.ts
@@ -19,8 +19,9 @@ interface InputHandler {
 	handleInput(data: string): void;
 }
 
-interface FullPaneOverlayOptions {
+export interface FullPaneOverlayOptions {
 	maxContentWidth?: number;
+	fullWidth?: boolean;
 	suspendFullscreenMouse?: boolean;
 }
 
@@ -34,8 +35,13 @@ export function showFullPaneOverlay(
 	component: Component,
 	options: number | FullPaneOverlayOptions = 80,
 ): OverlayHandle {
-	const { maxContentWidth = 80, suspendFullscreenMouse } =
-		typeof options === "number" ? { maxContentWidth: options } : options;
+	const { maxContentWidth, suspendFullscreenMouse } =
+		typeof options === "number"
+			? { maxContentWidth: options, suspendFullscreenMouse: undefined }
+			: {
+					maxContentWidth: options.fullWidth ? undefined : (options.maxContentWidth ?? 80),
+					suspendFullscreenMouse: options.suspendFullscreenMouse,
+				};
 	const overlayOptions: OverlayOptions = {
 		width: "100%",
 		maxHeight: "100%",

--- a/packages/coding-agent/src/modes/interactive/components/session-picker-screen.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-picker-screen.ts
@@ -1,0 +1,51 @@
+import { type Component, type Focusable, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { SessionSelectorComponent } from "./session-selector.js";
+
+export function sessionPickerListMaxVisible(rows: number, headerLines: number): number {
+	return Math.max(3, rows - headerLines - 10);
+}
+
+export class SessionPickerScreen implements Component, Focusable {
+	private _focused = false;
+
+	constructor(
+		private readonly ui: TUI,
+		private readonly header: Component,
+		private readonly selector: SessionSelectorComponent,
+	) {}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.selector.focused = value;
+	}
+
+	handleInput(data: string): void {
+		this.selector.handleInput(data);
+	}
+
+	invalidate(): void {
+		this.header.invalidate?.();
+		this.selector.invalidate();
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const height = Math.max(1, this.ui.terminal.rows);
+		const headerLines = this.header.render(safeWidth);
+		this.selector.setListMaxVisible(sessionPickerListMaxVisible(height, headerLines.length));
+		const content = [...headerLines, ...this.selector.render(safeWidth)];
+
+		const lines = content.slice(0, height).map((line) => {
+			const truncated = truncateToWidth(line, safeWidth, "");
+			return truncated + " ".repeat(Math.max(0, safeWidth - visibleWidth(truncated)));
+		});
+		while (lines.length < height) {
+			lines.push(" ".repeat(safeWidth));
+		}
+		return lines;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -291,6 +291,7 @@ class SessionList implements Component, Focusable {
 	private nameFilter: NameFilter = "all";
 	private keybindings: KeybindingsManager;
 	private showPath = false;
+	private streaming = false;
 	private confirmingDeletePath: string | null = null;
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | null = null;
 	private currentSessionCanonicalPath?: string;
@@ -360,10 +361,18 @@ class SessionList implements Component, Focusable {
 		this.filterSessions(this.searchInput.getValue());
 	}
 
-	setSessions(sessions: AgentConnectionSavedSessionInfo[], showCwd: boolean): void {
+	setSessions(sessions: AgentConnectionSavedSessionInfo[], showCwd: boolean, streaming = false): void {
+		const selectedPath = this.getSelectedSessionPath();
 		this.allSessions = sessions;
 		this.showCwd = showCwd;
+		this.streaming = streaming;
 		this.filterSessions(this.searchInput.getValue());
+		if (selectedPath) {
+			const selectedIndex = this.filteredSessions.findIndex((session) => session.session.path === selectedPath);
+			if (selectedIndex >= 0) {
+				this.selectedIndex = selectedIndex;
+			}
+		}
 	}
 
 	private filterSessions(query: string): void {
@@ -371,7 +380,7 @@ class SessionList implements Component, Focusable {
 		const nameFiltered =
 			this.nameFilter === "all" ? this.allSessions : this.allSessions.filter((session) => hasSessionName(session));
 
-		if (this.sortMode === "threaded" && !trimmed) {
+		if (this.sortMode === "threaded" && !trimmed && !this.streaming) {
 			// Threaded mode without search: show tree structure
 			const roots = buildSessionTree(nameFiltered);
 			this.filteredSessions = flattenSessionTree(roots);
@@ -976,7 +985,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		const onSession = (session: AgentConnectionSavedSessionInfo) => {
 			if (reason === "refresh" || !isLatestLoad() || !isCurrentView()) return;
 			streamedSessions.set(session.path, session);
-			this.sessionList.setSessions([...streamedSessions.values()], showCwd);
+			this.sessionList.setSessions([...streamedSessions.values()], showCwd, true);
 			this.requestRender();
 		};
 

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -856,7 +856,8 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
 				const showCwd = this.scope === "all";
-				this.sessionList.setSessions(sessions, showCwd);
+				const streaming = this.scope === "all" ? this.allLoading : this.currentLoading;
+				this.sessionList.setSessions(sessions, showCwd, streaming);
 
 				const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
 				try {
@@ -985,7 +986,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		const onSession = (session: AgentConnectionSavedSessionInfo) => {
 			if (reason === "refresh" || !isLatestLoad() || !isCurrentView()) return;
 			streamedSessions.set(session.path, session);
-			this.sessionList.setSessions([...streamedSessions.values()], showCwd, true);
+			const sessions = [...streamedSessions.values()];
+			if (scope === "current") {
+				this.currentSessions = sessions;
+			} else {
+				this.allSessions = sessions;
+			}
+			this.sessionList.setSessions(sessions, showCwd, true);
 			this.requestRender();
 		};
 
@@ -1060,8 +1067,8 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			this.header.setScope(this.scope);
 
 			if (this.allSessions !== null) {
-				this.header.setLoading(false);
-				this.sessionList.setSessions(this.allSessions, true);
+				this.header.setLoading(this.allLoading);
+				this.sessionList.setSessions(this.allSessions, true, this.allLoading);
 				this.requestRender();
 				return;
 			}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -25,6 +25,11 @@ import { filterAndSortSessions, hasSessionName, type NameFilter, type SortMode }
 
 type SessionScope = "current" | "all";
 
+export interface SessionListCallbacks {
+	onProgress?: AgentConnectionSessionListProgress;
+	onSession?: (session: AgentConnectionSavedSessionInfo) => void;
+}
+
 // Mirrors the agents view delete flow: press the delete key once to arm, again
 // within this window to confirm; anything else (or the timeout) cancels.
 const DELETE_CONFIRM_DURATION_MS = 2000;
@@ -652,7 +657,7 @@ class SessionList implements Component, Focusable {
 	}
 }
 
-type SessionsLoader = (onProgress?: AgentConnectionSessionListProgress) => Promise<AgentConnectionSavedSessionInfo[]>;
+type SessionsLoader = (callbacks?: SessionListCallbacks) => Promise<AgentConnectionSavedSessionInfo[]>;
 type SessionDeleter = (sessionPath: string) => Promise<DeleteSessionFileResult>;
 
 /**
@@ -691,6 +696,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 	private deleteSession: SessionDeleter;
 	private currentLoading = false;
 	private allLoading = false;
+	private currentLoadSeq = 0;
 	private allLoadSeq = 0;
 
 	private mode: "list" | "rename" = "list";
@@ -954,22 +960,32 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			this.allLoading = true;
 		}
 
-		const seq = scope === "all" ? ++this.allLoadSeq : undefined;
+		const seq = scope === "current" ? ++this.currentLoadSeq : ++this.allLoadSeq;
 		this.header.setScope(scope);
 		this.header.setLoading(true);
 		this.requestRender();
+		const isLatestLoad = () => seq === (scope === "current" ? this.currentLoadSeq : this.allLoadSeq);
+		const isCurrentView = () => scope === this.scope;
+		const streamedSessions = new Map<string, AgentConnectionSavedSessionInfo>();
 
 		const onProgress = (loaded: number, total: number) => {
-			if (scope !== this.scope) return;
-			if (seq !== undefined && seq !== this.allLoadSeq) return;
+			if (!isLatestLoad() || !isCurrentView()) return;
 			this.header.setProgress(loaded, total);
+			this.requestRender();
+		};
+		const onSession = (session: AgentConnectionSavedSessionInfo) => {
+			if (reason === "refresh" || !isLatestLoad() || !isCurrentView()) return;
+			streamedSessions.set(session.path, session);
+			this.sessionList.setSessions([...streamedSessions.values()], showCwd);
 			this.requestRender();
 		};
 
 		try {
 			const sessions = await (scope === "current"
-				? this.currentSessionsLoader(onProgress)
-				: this.allSessionsLoader(onProgress));
+				? this.currentSessionsLoader({ onProgress, onSession })
+				: this.allSessionsLoader({ onProgress, onSession }));
+
+			if (!isLatestLoad()) return;
 
 			if (scope === "current") {
 				this.currentSessions = sessions;
@@ -979,8 +995,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				this.allLoading = false;
 			}
 
-			if (scope !== this.scope) return;
-			if (seq !== undefined && seq !== this.allLoadSeq) return;
+			if (!isCurrentView()) return;
 
 			this.header.setLoading(false);
 			this.sessionList.setSessions(sessions, showCwd);
@@ -990,14 +1005,15 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				this.onCancel();
 			}
 		} catch (err) {
+			if (!isLatestLoad()) return;
+
 			if (scope === "current") {
 				this.currentLoading = false;
 			} else {
 				this.allLoading = false;
 			}
 
-			if (scope !== this.scope) return;
-			if (seq !== undefined && seq !== this.allLoadSeq) return;
+			if (!isCurrentView()) return;
 
 			const message = err instanceof Error ? err.message : String(err);
 			this.header.setLoading(false);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -143,7 +143,7 @@ import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
 import { BorderedLoader } from "./components/bordered-loader.js";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.js";
-import { showFullPaneOverlay } from "./components/centered-overlay.js";
+import { type FullPaneOverlayOptions, showFullPaneOverlay } from "./components/centered-overlay.js";
 import {
 	ChildAgentDetailComponent,
 	type ChildAgentInspectorNode,
@@ -167,6 +167,7 @@ import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybin
 import { type ModelSelectorAction, ModelSelectorComponent } from "./components/model-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
+import { SessionPickerScreen } from "./components/session-picker-screen.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
@@ -6198,8 +6199,8 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private showFullPaneOverlay(component: Component, maxContentWidth = 80): OverlayHandle {
-		return showFullPaneOverlay(this.ui, component, maxContentWidth);
+	private showFullPaneOverlay(component: Component, options: number | FullPaneOverlayOptions = 80): OverlayHandle {
+		return showFullPaneOverlay(this.ui, component, options);
 	}
 
 	private async showSettingsSelector(): Promise<void> {
@@ -7044,19 +7045,30 @@ export class InteractiveMode {
 			this.showError(error instanceof Error ? error.message : String(error));
 			return;
 		}
-		this.showSelector((done) => {
+		await new Promise<void>((done) => {
+			let handle: OverlayHandle | undefined;
+			let settled = false;
+			const close = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				handle?.hide();
+				this.ui.requestRender();
+				done();
+			};
 			const selector = new SessionSelectorComponent(
-				(onProgress) => this.agentConnection.listSavedSessions("current", onProgress),
-				(onProgress) => this.agentConnection.listSavedSessions("all", onProgress),
+				(callbacks) => this.agentConnection.listSavedSessions("current", callbacks),
+				(callbacks) => this.agentConnection.listSavedSessions("all", callbacks),
 				async (sessionPath) => {
-					done();
+					close();
 					await this.handleResumeSession(sessionPath);
 				},
 				() => {
-					done();
-					this.ui.requestRender();
+					close();
 				},
 				() => {
+					close();
 					void this.shutdown();
 				},
 				() => this.ui.requestRender(),
@@ -7069,11 +7081,17 @@ export class InteractiveMode {
 					deleteSession: (sessionFilePath: string) => this.agentConnection.deleteSavedSession(sessionFilePath),
 					showRenameHint: true,
 					keybindings: this.keybindings,
+					frameless: true,
 				},
 
 				state.sessionFile,
 			);
-			return { component: selector, focus: selector };
+			const splash = new BrandSplashHeader(
+				this.version,
+				() => this.getCurrentModelId(),
+				() => this.getCurrentCwd(),
+			);
+			handle = this.showFullPaneOverlay(new SessionPickerScreen(this.ui, splash, selector), { fullWidth: true });
 		});
 	}
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -7,7 +7,11 @@ import {
 	DAEMON_REFINE_REQUEST_TIMEOUT_MS,
 	DaemonAgentConnection,
 } from "../src/modes/agent-connection/daemon-agent-connection.js";
-import type { AgentConnectionEvent, AgentConnectionState } from "../src/modes/agent-connection/types.js";
+import type {
+	AgentConnectionEvent,
+	AgentConnectionSavedSessionInfo,
+	AgentConnectionState,
+} from "../src/modes/agent-connection/types.js";
 import type {
 	DaemonClient,
 	DaemonClientCloseListener,
@@ -183,20 +187,38 @@ class FakeDaemonClient {
 					success: true,
 					data: { steering: ["aborted"], followUp: ["cleared"] },
 				};
-			case "list_saved_sessions":
+			case "list_saved_sessions": {
+				const activeSessionId = "activeSessionId" in command ? command.activeSessionId : undefined;
 				options.onProgress?.({
 					id: "daemon_test",
 					type: "session_list_progress",
 					command: "list_saved_sessions",
-					activeSessionId: command.activeSessionId,
+					...(activeSessionId ? { activeSessionId } : {}),
 					loaded: 1,
 					total: 2,
 				});
 				options.onProgress?.({
 					id: "daemon_test",
+					type: "session_list_item",
+					command: "list_saved_sessions",
+					...(activeSessionId ? { activeSessionId } : {}),
+					session: {
+						path: "/tmp/session-a.jsonl",
+						id: "session-a",
+						cwd: "/tmp",
+						name: "Saved session",
+						created: "2026-01-01T00:00:00.000Z",
+						modified: "2026-01-02T00:00:00.000Z",
+						messageCount: 2,
+						firstMessage: "hello",
+						allMessagesText: "hello world",
+					},
+				});
+				options.onProgress?.({
+					id: "daemon_test",
 					type: "session_list_progress",
 					command: "list_saved_sessions",
-					activeSessionId: command.activeSessionId,
+					...(activeSessionId ? { activeSessionId } : {}),
 					loaded: 2,
 					total: 2,
 				});
@@ -220,6 +242,7 @@ class FakeDaemonClient {
 						],
 					},
 				};
+			}
 			case "wait_for_idle":
 			case "set_scoped_models":
 			case "rename_saved_session":
@@ -1124,9 +1147,15 @@ describe("DaemonAgentConnection", () => {
 		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
 		await connection.attach();
 		const progress: Array<[number, number]> = [];
+		const discovered: AgentConnectionSavedSessionInfo[] = [];
 
-		const sessions = await connection.listSavedSessions("current", (loaded, total) => {
-			progress.push([loaded, total]);
+		const sessions = await connection.listSavedSessions("current", {
+			onProgress: (loaded, total) => {
+				progress.push([loaded, total]);
+			},
+			onSession: (session) => {
+				discovered.push(session);
+			},
 		});
 		await connection.renameSavedSession("/tmp/session-a.jsonl", "Next name");
 		await expect(connection.deleteSavedSession("/tmp/session-a.jsonl")).resolves.toEqual({
@@ -1151,6 +1180,7 @@ describe("DaemonAgentConnection", () => {
 			[1, 2],
 			[2, 2],
 		]);
+		expect(discovered).toEqual(sessions);
 		expect(fakeClient.requests[1]).toMatchObject({
 			type: "list_saved_sessions",
 			activeSessionId: "active-1",

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -519,6 +519,12 @@ describe("agents view state", () => {
 			id: "saved",
 			name: "Saved session",
 			cwd: "/tmp/project",
+			messageCount: 2,
+			agentStatus: {
+				summary: "Finished the task",
+				taskState: "completed",
+				basedOnMessageCount: 2,
+			},
 		});
 
 		const summary = resolveAgentsViewResumeSummary(savedSession.path, [savedSession], []);
@@ -530,6 +536,8 @@ describe("agents view state", () => {
 			sessionFile: savedSession.path,
 			sessionName: "Saved session",
 			cwd: "/tmp/project",
+			summary: "Finished the task",
+			taskState: "completed",
 		});
 		expect(summary?.activeSessionId).toBeUndefined();
 		expect(summary?.lifecycle).toBe("live");

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -7,7 +7,6 @@ import type { ModelRegistry } from "../src/core/model-registry.js";
 import type { SessionInfo } from "../src/core/session-manager.js";
 import type { SettingsManager } from "../src/core/settings-manager.js";
 import {
-	createAgentsViewDeleteSavedSessionCommand,
 	createAgentsViewListCommand,
 	createAgentsViewReplyHeadline,
 	createAgentsViewResumeConfig,
@@ -572,17 +571,6 @@ describe("agents view state", () => {
 			resolveAgentsViewActiveSummaryForPath("/tmp/sessions/active.jsonl", [inactiveSummary, activeSummary]),
 		).toBe(activeSummary);
 		expect(resolveAgentsViewActiveSummaryForPath("/tmp/sessions/inactive.jsonl", [inactiveSummary])).toBeUndefined();
-	});
-
-	test("routes saved session deletes through the daemon file guard", () => {
-		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/active.jsonl")).toEqual({
-			type: "delete_saved_session",
-			sessionPath: "/tmp/sessions/active.jsonl",
-		});
-		expect(createAgentsViewDeleteSavedSessionCommand("/tmp/sessions/inactive.jsonl")).toEqual({
-			type: "delete_saved_session",
-			sessionPath: "/tmp/sessions/inactive.jsonl",
-		});
 	});
 
 	test("derives the reply headline from the first line of the latest assistant text", () => {

--- a/packages/coding-agent/test/centered-overlay.test.ts
+++ b/packages/coding-agent/test/centered-overlay.test.ts
@@ -1,6 +1,6 @@
-import { type Component, type Focusable, visibleWidth } from "@earendil-works/pi-tui";
+import { type Component, type Focusable, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { CenteredOverlayComponent } from "../src/modes/interactive/components/centered-overlay.js";
+import { CenteredOverlayComponent, showFullPaneOverlay } from "../src/modes/interactive/components/centered-overlay.js";
 
 class TestComponent implements Component, Focusable {
 	focused = false;
@@ -51,5 +51,20 @@ describe("CenteredOverlayComponent", () => {
 
 		expect(inner.focused).toBe(true);
 		expect(inner.inputs).toEqual(["x"]);
+	});
+
+	it("uses the full terminal width when requested", () => {
+		let overlay: Component | undefined;
+		const ui = {
+			terminal: { rows: 1 },
+			showOverlay: (component: Component) => {
+				overlay = component;
+				return {};
+			},
+		} as unknown as TUI;
+
+		showFullPaneOverlay(ui, new TestComponent(), { fullWidth: true });
+
+		expect(overlay?.render(120)[0]).toContain("content 120");
 	});
 });

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -234,6 +234,7 @@ describe("DaemonClient", () => {
 		await connect;
 
 		const progress: Array<[number, number]> = [];
+		const discovered: string[] = [];
 		const listenerMessages: unknown[] = [];
 		const unsubscribe = client.onMessage((message) => {
 			listenerMessages.push(message);
@@ -243,7 +244,11 @@ describe("DaemonClient", () => {
 			30000,
 			{
 				onProgress: (message) => {
-					progress.push([message.loaded, message.total]);
+					if (message.type === "session_list_progress") {
+						progress.push([message.loaded, message.total]);
+					} else {
+						discovered.push(message.session.id);
+					}
 				},
 			},
 		);
@@ -270,6 +275,25 @@ describe("DaemonClient", () => {
 			"data",
 			`${JSON.stringify({
 				id: command.id,
+				type: "session_list_item",
+				command: "list_saved_sessions",
+				activeSessionId: "active-1",
+				session: {
+					path: "/tmp/session-a.jsonl",
+					id: "session-a",
+					cwd: "/tmp",
+					created: "2026-01-01T00:00:00.000Z",
+					modified: "2026-01-02T00:00:00.000Z",
+					messageCount: 1,
+					firstMessage: "hello",
+					allMessagesText: "hello",
+				},
+			})}\n`,
+		);
+		socket.emit(
+			"data",
+			`${JSON.stringify({
+				id: command.id,
 				type: "response",
 				command: "list_saved_sessions",
 				success: true,
@@ -279,6 +303,7 @@ describe("DaemonClient", () => {
 
 		await expect(response).resolves.toMatchObject({ id: command.id, success: true });
 		expect(progress).toEqual([[1, 2]]);
+		expect(discovered).toEqual(["session-a"]);
 		expect(listenerMessages).toEqual([]);
 
 		unsubscribe();

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -235,6 +235,7 @@ describe("DaemonClient", () => {
 
 		const progress: Array<[number, number]> = [];
 		const discovered: string[] = [];
+		let discoveredStatus: unknown;
 		const listenerMessages: unknown[] = [];
 		const unsubscribe = client.onMessage((message) => {
 			listenerMessages.push(message);
@@ -248,6 +249,7 @@ describe("DaemonClient", () => {
 						progress.push([message.loaded, message.total]);
 					} else {
 						discovered.push(message.session.id);
+						discoveredStatus = message.session.agentStatus;
 					}
 				},
 			},
@@ -287,6 +289,11 @@ describe("DaemonClient", () => {
 					messageCount: 1,
 					firstMessage: "hello",
 					allMessagesText: "hello",
+					agentStatus: {
+						summary: "Finished the task",
+						taskState: "completed",
+						basedOnMessageCount: 1,
+					},
 				},
 			})}\n`,
 		);
@@ -304,6 +311,11 @@ describe("DaemonClient", () => {
 		await expect(response).resolves.toMatchObject({ id: command.id, success: true });
 		expect(progress).toEqual([[1, 2]]);
 		expect(discovered).toEqual(["session-a"]);
+		expect(discoveredStatus).toEqual({
+			summary: "Finished the task",
+			taskState: "completed",
+			basedOnMessageCount: 1,
+		});
 		expect(listenerMessages).toEqual([]);
 
 		unsubscribe();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2650,6 +2650,12 @@ describe("daemon mode helpers", () => {
 			const sessionDir = join(tempDir, "sessions");
 			const session = SessionManager.create(tempDir, sessionDir);
 			session.appendSessionState({ status: "active" });
+			session.appendAgentStatus({
+				summary: "Finished the task",
+				taskState: "completed",
+				basedOnMessageCount: 0,
+			});
+			session.appendSessionState({ status: "active" });
 			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
 				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
 				createRuntime: async () => {
@@ -2677,10 +2683,26 @@ describe("daemon mode helpers", () => {
 				cwd: tempDir,
 				sessionDir,
 				scope: "current",
-			})) as { data: { sessions: Array<{ id: string }> } };
+			})) as {
+				data: {
+					sessions: Array<{
+						id: string;
+						agentStatus?: {
+							summary: string;
+							taskState?: "needs_input" | "completed";
+							basedOnMessageCount: number;
+						};
+					}>;
+				};
+			};
 			const updates = writes.map((line) => JSON.parse(line) as { type: string; activeSessionId?: string });
 
-			expect(response.data.sessions).toEqual([expect.objectContaining({ id: session.getSessionId() })]);
+			expect(response.data.sessions).toEqual([
+				expect.objectContaining({
+					id: session.getSessionId(),
+					agentStatus: { summary: "Finished the task", taskState: "completed", basedOnMessageCount: 0 },
+				}),
+			]);
 			expect(updates).toEqual(
 				expect.arrayContaining([
 					expect.objectContaining({
@@ -2694,7 +2716,10 @@ describe("daemon mode helpers", () => {
 						id: "list-1",
 						type: "session_list_item",
 						command: "list_saved_sessions",
-						session: expect.objectContaining({ id: session.getSessionId() }),
+						session: expect.objectContaining({
+							id: session.getSessionId(),
+							agentStatus: { summary: "Finished the task", taskState: "completed", basedOnMessageCount: 0 },
+						}),
 					}),
 				]),
 			);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -6,6 +6,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
+import { SessionManager } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import {
 	AgentDaemon,
@@ -2638,6 +2639,66 @@ describe("daemon mode helpers", () => {
 				status: "cancelled",
 			});
 			expect(internals.cronStore.list().find((job) => job.id === unrelated.id)).toMatchObject({ status: "active" });
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("streams detached saved-session catalog requests", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-saved-session-catalog-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(tempDir, sessionDir);
+			session.appendSessionState({ status: "active" });
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			const internals = daemon as unknown as {
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			const writes: string[] = [];
+			const client = {
+				...makeClient("client-1", "detached"),
+				socket: {
+					destroyed: false,
+					write: (line: string) => {
+						writes.push(line);
+						return true;
+					},
+				} as unknown as Socket,
+			};
+
+			const response = (await internals.handleCommand(client, {
+				id: "list-1",
+				type: "list_saved_sessions",
+				cwd: tempDir,
+				sessionDir,
+				scope: "current",
+			})) as { data: { sessions: Array<{ id: string }> } };
+			const updates = writes.map((line) => JSON.parse(line) as { type: string; activeSessionId?: string });
+
+			expect(response.data.sessions).toEqual([expect.objectContaining({ id: session.getSessionId() })]);
+			expect(updates).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						id: "list-1",
+						type: "session_list_progress",
+						command: "list_saved_sessions",
+						loaded: 1,
+						total: 1,
+					}),
+					expect.objectContaining({
+						id: "list-1",
+						type: "session_list_item",
+						command: "list_saved_sessions",
+						session: expect.objectContaining({ id: session.getSessionId() }),
+					}),
+				]),
+			);
+			expect(updates.every((update) => update.activeSessionId === undefined)).toBe(true);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/saved-session-catalog.test.ts
+++ b/packages/coding-agent/test/saved-session-catalog.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { DaemonClient, DaemonClientRequestOptions } from "../src/modes/daemon/daemon-client.js";
+import type { DaemonCommand, DaemonResponse } from "../src/modes/daemon/daemon-protocol.js";
+import {
+	deleteDaemonSavedSession,
+	listDaemonSavedSessions,
+	renameDaemonSavedSession,
+} from "../src/modes/daemon/saved-session-catalog.js";
+
+class FakeDaemonClient {
+	readonly commands: DaemonCommand[] = [];
+
+	async request(
+		command: DaemonCommand,
+		_timeoutMs = 30000,
+		options: DaemonClientRequestOptions = {},
+	): Promise<DaemonResponse> {
+		this.commands.push(command);
+		if (command.type === "list_saved_sessions") {
+			options.onProgress?.({
+				type: "session_list_progress",
+				command: "list_saved_sessions",
+				loaded: 1,
+				total: 1,
+			});
+			options.onProgress?.({
+				type: "session_list_item",
+				command: "list_saved_sessions",
+				session: {
+					path: "/tmp/sessions/one.jsonl",
+					id: "one",
+					cwd: "/tmp/project",
+					created: "2026-01-01T00:00:00.000Z",
+					modified: "2026-01-02T00:00:00.000Z",
+					messageCount: 1,
+					firstMessage: "hello",
+					allMessagesText: "hello",
+				},
+			});
+			return {
+				type: "response",
+				command: "list_saved_sessions",
+				success: true,
+				data: {
+					sessions: [
+						{
+							path: "/tmp/sessions/one.jsonl",
+							id: "one",
+							cwd: "/tmp/project",
+							created: "2026-01-01T00:00:00.000Z",
+							modified: "2026-01-02T00:00:00.000Z",
+							messageCount: 1,
+							firstMessage: "hello",
+							allMessagesText: "hello",
+						},
+					],
+				},
+			};
+		}
+		if (command.type === "delete_saved_session") {
+			return {
+				type: "response",
+				command: "delete_saved_session",
+				success: true,
+				data: { ok: true, method: "trash" },
+			};
+		}
+		return { type: "response", command: command.type, success: true };
+	}
+}
+
+function asDaemonClient(client: FakeDaemonClient): DaemonClient {
+	return client as unknown as DaemonClient;
+}
+
+describe("saved session catalog", () => {
+	it("streams detached saved sessions through the daemon catalog", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const progress: Array<[number, number]> = [];
+		const discovered: string[] = [];
+
+		const sessions = await listDaemonSavedSessions(
+			asDaemonClient(fakeClient),
+			{ cwd: "/tmp/project", sessionDir: "/tmp/sessions" },
+			"current",
+			{
+				onProgress: (loaded, total) => progress.push([loaded, total]),
+				onSession: (session) => discovered.push(session.id),
+			},
+		);
+
+		expect(fakeClient.commands[0]).toEqual({
+			type: "list_saved_sessions",
+			cwd: "/tmp/project",
+			sessionDir: "/tmp/sessions",
+			scope: "current",
+		});
+		expect(progress).toEqual([[1, 1]]);
+		expect(discovered).toEqual(["one"]);
+		expect(sessions).toEqual([
+			{
+				path: "/tmp/sessions/one.jsonl",
+				id: "one",
+				cwd: "/tmp/project",
+				created: new Date("2026-01-01T00:00:00.000Z"),
+				modified: new Date("2026-01-02T00:00:00.000Z"),
+				messageCount: 1,
+				firstMessage: "hello",
+				allMessagesText: "hello",
+			},
+		]);
+	});
+
+	it("mutates detached saved sessions without an active session id", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const context = { cwd: "/tmp/project", sessionDir: "/tmp/sessions" };
+
+		await renameDaemonSavedSession(asDaemonClient(fakeClient), context, "/tmp/sessions/one.jsonl", "One");
+		await expect(
+			deleteDaemonSavedSession(asDaemonClient(fakeClient), context, "/tmp/sessions/one.jsonl"),
+		).resolves.toEqual({
+			ok: true,
+			method: "trash",
+		});
+
+		expect(fakeClient.commands).toEqual([
+			{ type: "rename_saved_session", sessionPath: "/tmp/sessions/one.jsonl", name: "One" },
+			{ type: "delete_saved_session", sessionPath: "/tmp/sessions/one.jsonl" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/saved-session-catalog.test.ts
+++ b/packages/coding-agent/test/saved-session-catalog.test.ts
@@ -35,6 +35,11 @@ class FakeDaemonClient {
 					messageCount: 1,
 					firstMessage: "hello",
 					allMessagesText: "hello",
+					agentStatus: {
+						summary: "Finished the task",
+						taskState: "completed",
+						basedOnMessageCount: 1,
+					},
 				},
 			});
 			return {
@@ -52,6 +57,11 @@ class FakeDaemonClient {
 							messageCount: 1,
 							firstMessage: "hello",
 							allMessagesText: "hello",
+							agentStatus: {
+								summary: "Finished the task",
+								taskState: "completed",
+								basedOnMessageCount: 1,
+							},
 						},
 					],
 				},
@@ -107,6 +117,11 @@ describe("saved session catalog", () => {
 				messageCount: 1,
 				firstMessage: "hello",
 				allMessagesText: "hello",
+				agentStatus: {
+					summary: "Finished the task",
+					taskState: "completed",
+					basedOnMessageCount: 1,
+				},
 			},
 		]);
 	});

--- a/packages/coding-agent/test/session-manager/session-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-state.test.ts
@@ -67,6 +67,26 @@ describe("SessionManager session state", () => {
 		}
 	});
 
+	it("persists renamed sessions without assistant messages", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "session-state-rename-empty-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const session = SessionManager.create(cwd, sessionDir);
+			session.appendSessionState({ status: "active" });
+			const sessionFile = session.getSessionFile();
+			expect(sessionFile).toBeDefined();
+
+			SessionManager.open(sessionFile!, sessionDir).appendSessionInfo("Renamed draft");
+
+			await expect(SessionManager.list(cwd, sessionDir)).resolves.toEqual([
+				expect.objectContaining({ id: session.getSessionId(), name: "Renamed draft" }),
+			]);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("archives a deactivated session that has no prior state entry", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "session-state-deactivate-"));
 		try {

--- a/packages/coding-agent/test/session-picker-screen.test.ts
+++ b/packages/coding-agent/test/session-picker-screen.test.ts
@@ -1,0 +1,40 @@
+import { type Component, type TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import {
+	SessionPickerScreen,
+	sessionPickerListMaxVisible,
+} from "../src/modes/interactive/components/session-picker-screen.js";
+import type { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.js";
+
+describe("SessionPickerScreen", () => {
+	it("uses a centered full-terminal surface and sizes the session list to the viewport", () => {
+		const ui = { terminal: { rows: 24 } } as unknown as TUI;
+		const header = {
+			invalidate: vi.fn(),
+			render: vi.fn(() => ["Resume Session"]),
+		} as Component;
+		const selector = {
+			focused: false,
+			handleInput: vi.fn(),
+			invalidate: vi.fn(),
+			render: vi.fn(() => ["Saved session"]),
+			setListMaxVisible: vi.fn(),
+		} as unknown as SessionSelectorComponent;
+
+		const screen = new SessionPickerScreen(ui, header, selector);
+		screen.focused = true;
+		screen.handleInput("x");
+		const lines = screen.render(120);
+
+		expect(selector.focused).toBe(true);
+		expect(selector.handleInput).toHaveBeenCalledWith("x");
+		expect(sessionPickerListMaxVisible(24, 1)).toBe(13);
+		expect(header.render).toHaveBeenCalledWith(120);
+		expect(selector.setListMaxVisible).toHaveBeenCalledWith(13);
+		expect(selector.render).toHaveBeenCalledWith(120);
+		expect(lines).toHaveLength(24);
+		expect(lines[0]!.trim()).toBe("Resume Session");
+		expect(lines[1]!.trim()).toBe("Saved session");
+		expect(lines.every((line) => visibleWidth(line) === 120)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -271,6 +271,35 @@ describe("session selector path/delete interactions", () => {
 		expect(output).not.toContain("Failed to delete");
 	});
 
+	it("renders streamed sessions before the initial load completes", async () => {
+		const streamedSession = makeSession({ id: "streamed", name: "Streamed session" });
+		const sessionsDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
+
+		const selector = new SessionSelectorComponent(
+			async (callbacks) => {
+				callbacks?.onProgress?.(1, 2);
+				callbacks?.onSession?.(streamedSession);
+				return sessionsDeferred.promise;
+			},
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const loadingOutput = stripAnsi(selector.render(120).join("\n"));
+		expect(loadingOutput).toContain("loading 1/2");
+		expect(loadingOutput).toContain("Streamed session");
+
+		sessionsDeferred.resolve([streamedSession]);
+		await flushPromises();
+
+		expect(stripAnsi(selector.render(120).join("\n"))).toContain("current folder");
+	});
+
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
 		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -332,6 +332,48 @@ describe("session selector path/delete interactions", () => {
 		expect(onSelect).toHaveBeenCalledWith(child.path);
 	});
 
+	it("keeps other streamed rows visible when deleting before loading completes", async () => {
+		const first = makeSession({ id: "first", name: "First streamed session" });
+		const second = makeSession({ id: "second", name: "Second streamed session" });
+		const initialLoad = createDeferred<AgentConnectionSavedSessionInfo[]>();
+		const refreshLoad = createDeferred<AgentConnectionSavedSessionInfo[]>();
+		const deleteSession = vi.fn(async () => ({ ok: true as const, method: "unlink" as const }));
+		let loadCalls = 0;
+
+		const selector = new SessionSelectorComponent(
+			async (callbacks) => {
+				loadCalls++;
+				if (loadCalls === 1) {
+					callbacks?.onSession?.(first);
+					callbacks?.onSession?.(second);
+					return initialLoad.promise;
+				}
+				return refreshLoad.promise;
+			},
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings, deleteSession },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput(CTRL_X);
+		list.handleInput(CTRL_X);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(deleteSession).toHaveBeenCalledWith(first.path);
+		expect(output).not.toContain("First streamed session");
+		expect(output).toContain("Second streamed session");
+
+		refreshLoad.resolve([second]);
+		initialLoad.resolve([first, second]);
+		await flushPromises();
+	});
+
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
 		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -300,6 +300,38 @@ describe("session selector path/delete interactions", () => {
 		expect(stripAnsi(selector.render(120).join("\n"))).toContain("current folder");
 	});
 
+	it("keeps streamed threaded sessions flat until loading completes", async () => {
+		const parent = makeSession({ id: "parent", name: "Parent" });
+		const child = makeSession({ id: "child", name: "Child", parentSessionPath: parent.path });
+		const sessionsDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
+		const onSelect = vi.fn();
+
+		const selector = new SessionSelectorComponent(
+			async (callbacks) => {
+				callbacks?.onSession?.(child);
+				callbacks?.onSession?.(parent);
+				return sessionsDeferred.promise;
+			},
+			async () => [],
+			onSelect,
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		expect(stripAnsi(selector.render(120).join("\n"))).not.toContain("└─");
+
+		sessionsDeferred.resolve([parent, child]);
+		await flushPromises();
+
+		expect(stripAnsi(selector.render(120).join("\n"))).toContain("└─ ✓ Child");
+		list.handleInput("\r");
+		expect(onSelect).toHaveBeenCalledWith(child.path);
+	});
+
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
 		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -60,7 +60,7 @@ describe("session selector rename", () => {
 		expect(output).toContain("rename");
 	});
 
-	it("does not show rename hint in --resume picker configuration", async () => {
+	it("shows rename hint in --resume picker configuration", async () => {
 		const sessions = [makeSession({ id: "a" })];
 		const keybindings = new KeybindingsManager();
 		const selector = new SessionSelectorComponent(
@@ -70,13 +70,13 @@ describe("session selector rename", () => {
 			() => {},
 			() => {},
 			() => {},
-			{ showRenameHint: false, keybindings },
+			{ renameSession: async () => {}, showRenameHint: true, keybindings },
 		);
 		await flushPromises();
 
 		const output = selector.render(120).join("\n");
-		expect(output).not.toContain("Ctrl+R");
-		expect(output).not.toContain("rename");
+		expect(output).toContain("Ctrl+R");
+		expect(output).toContain("rename");
 	});
 
 	it("enters rename mode on Ctrl+R and submits with Enter", async () => {
@@ -95,7 +95,7 @@ describe("session selector rename", () => {
 		);
 		await flushPromises();
 
-		selector.getSessionList().handleInput(CTRL_R);
+		selector.handleInput(CTRL_R);
 		await flushPromises();
 
 		// Rename mode layout


### PR DESCRIPTION
- unifies cli, chat, and agents view session resume flows in one full-width picker.
- streams saved sessions while scanning and routes agents view catalog operations through the daemon.
- adds rename support and focused coverage for resume and daemon catalog behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Daemon protocol version 2 is required for streaming catalog and detached list/rename; mixed client/daemon versions are rejected at connect, and large TUI/daemon surface area touches resume and saved-session mutations.
> 
> **Overview**
> Unifies **session resume** across CLI `--resume`, interactive chat, and Agents View behind one **full-terminal `SessionPickerScreen`** (brand header + searchable selector) instead of divergent overlays.
> 
> **Streaming lists:** `SessionManager.list` / `listAll` and `AgentConnection.listSavedSessions` now take **`SessionListCallbacks`** (`onProgress`, **`onSession`**) so rows appear while disk scans run; the selector keeps selection, shows a flat list during load, and only uses threaded tree mode after load completes.
> 
> **Daemon (protocol v2):** Saved-session catalog goes through **`saved-session-catalog`** helpers; `list_saved_sessions` can run **without an active session** (`cwd` + `sessionDir`), streams **`session_list_item`** progress messages, and carries optional **`agentStatus`** on saved session DTOs. Rename/delete/rename_saved_session similarly allow optional `activeSessionId`.
> 
> **Other fixes:** **`session_info`** renames persist even when no assistant message exists yet; CLI `--resume` enables rename like the other pickers; Agents View resume uses the daemon catalog instead of direct `SessionManager` calls for listing/mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4647f9aad2a90f4442e7a883160c2b63832b71d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resume picker to use a full-screen streaming session selector across all entry points
> - All session-resume entry points (CLI `--resume`, interactive mode, agents view) now use a shared `SessionPickerScreen` with a brand header, rendered via `showFullPaneOverlay({ fullWidth: true })`.
> - `SessionManager.list` and `listAll` now accept a `SessionListCallbacks` object (`onProgress`, `onSession`) so sessions stream into the picker as they are discovered rather than waiting for full load.
> - The daemon protocol is bumped to version 2 to support two new `list_saved_sessions` progress message types (`session_list_progress`, `session_list_item`) and detached (cwd-based) session listing without an active session.
> - A new `saved-session-catalog` module centralizes list/rename/delete operations for daemon-backed sessions, replacing ad-hoc RPC calls in `AgentsViewMode` and `DaemonAgentConnection`.
> - Rename is now available in the `--resume` picker and persists via `SessionManager` even before any assistant messages exist.
> - Behavioral Change: daemon clients on protocol version 1 will be incompatible with a version 2 daemon (and vice versa).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4647f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->