### PR TITLE
prepare v0.2.8 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.2.7",
+			"version": "0.2.8",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.2.7",
+				"@earendil-works/pi-coding-agent": "^0.2.8",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5847,10 +5847,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.2.7",
+			"version": "0.2.8",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.2.7",
+				"@earendil-works/pi-ai": "^0.2.8",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5877,7 +5877,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.2.7",
+			"version": "0.2.8",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5919,13 +5919,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.2.7",
+			"version": "0.2.8",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.2.7",
-				"@earendil-works/pi-ai": "^0.2.7",
-				"@earendil-works/pi-tui": "^0.2.7",
+				"@earendil-works/pi-agent-core": "^0.2.8",
+				"@earendil-works/pi-ai": "^0.2.8",
+				"@earendil-works/pi-tui": "^0.2.8",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -6068,7 +6068,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.2.7",
+			"version": "0.2.8",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.2.7",
+		"@earendil-works/pi-coding-agent": "^0.2.8",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-09
+
 - Fixed abort settling for provider streams and tool executions that ignore cancellation ([ENG-4490](https://linear.app/primeintellect/issue/ENG-4490)).
 
 ## [0.2.7] - 2026-07-08

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.2.7",
+		"@earendil-works/pi-ai": "^0.2.8",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-09
+
 - Registered the full Prime Inference catalog (97 models, up from 32) instead of a curated whitelist; context/output limits, vision, and reasoning now come from OpenRouter metadata with a small override table for limits the gateway enforces differently (verified against the live API), and raw/duplicate variants (BF16, HF-cased, `zai-org/`, fine-tune outputs) are skipped.
 - Fixed Prime Inference context windows that disagreed with the live gateway: `anthropic/claude-sonnet-4.5` capped at 200k (route rejects longer prompts), `z-ai/glm-5.2` and `internal/glm-5.2-fast` raised to 1M, `minimax/minimax-m3` corrected to 512k, `nvidia/nemotron-3-*` corrected to their enforced 262k/131k windows.
 - Removed `prime-intellect/intellect-3`, which no longer serves (404 from the gateway).

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-09
+
 - Changed `/model` to sort featured flagship models above a provider's long tail (with a numeric-aware alphabetical tiebreak), so the full Prime Inference catalog doesn't flood the picker.
 - Changed automatic harness refinement to be enabled by default while keeping `autoRefine.enabled: false` as the opt-out.
 - Fixed non-numeric `autoRefine.turnInterval` and `autoRefine.cooldownMs` settings falling back to defaults instead of silently enabling a noisy auto-refine loop.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Coding agent CLI with IPython-backed tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.2.7",
-		"@earendil-works/pi-ai": "^0.2.7",
-		"@earendil-works/pi-tui": "^0.2.7",
+		"@earendil-works/pi-agent-core": "^0.2.8",
+		"@earendil-works/pi-ai": "^0.2.8",
+		"@earendil-works/pi-tui": "^0.2.8",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-09
+
 ## [0.2.7] - 2026-07-08
 
 - Fixed full TUI redraws to preserve terminal scrollback on resize and shrink redraws ([#331](https://github.com/PrimeIntellect-ai/prime-agent/pull/331) by [@sethkarten](https://github.com/sethkarten)).

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the published packages and internal ranges to v0.2.8.
- finalizes the v0.2.8 changelogs, including the latest prime inference catalog updates.
- regenerates the lockfile and passes the repository checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release packaging only (versions, changelogs, lockfile); no application logic changes in this diff.
> 
> **Overview**
> Prepares **v0.2.8** across the monorepo: bumps `prime-agent` and all `@earendil-works/pi-*` packages from **0.2.7 → 0.2.8**, aligns internal dependency ranges, and adds dated **0.2.8** changelog sections (implementation landed in earlier commits).
> 
> Documented release highlights include **pi-agent-core** abort settling when streams/tools ignore cancellation; **pi-ai** full Prime Inference catalog (~97 models), gateway-aligned context limits, `featured` on `Model`, GPT-5.6 catalog entries, and removal of dead `intellect-3`; **pi-coding-agent** built-in Herdr reporting, Claude Code–style **Escape** / **`?`** shortcuts, featured-first `/model` sorting, auto-refine defaults, and assorted TUI/session fixes; **pi-tui** is version-only for this tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf51edb21a9c114fc2d29b6a27456c93c525a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v0.2.8 across all packages
> Bumps all package versions from 0.2.7 to 0.2.8 and updates inter-package dependencies accordingly. Key changes documented in the changelogs include: abort-settling fixes for provider streams and tool executions, AI model catalog updates (new GPT-5.6 models, context window corrections, featured flag, model removal), built-in Herdr integration in the coding agent, UI and shortcut fixes, auto-refine defaults, and session-resume improvements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecf51ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->