### PR TITLE
fill selector backgrounds through terminal edge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Escape repeats around autocomplete, queued draft restoration, whitespace-only drafts, and active background work ([ENG-4489](https://linear.app/primeintellect/issue/ENG-4489/rewire-prime-agent-shortcuts-to-match-claude-code-flow)).
 - Fixed the agents-view splash shifting when opening an agent session ([ENG-4517](https://linear.app/primeintellect/issue/ENG-4517)).
 - Changed `/model` to sort featured flagship models above a provider's long tail (with a numeric-aware alphabetical tiebreak), so the full Prime Inference catalog doesn't flood the picker.
+- Fixed selector prompts and choices filling their background through the terminal's right edge.
 - Changed automatic harness refinement to be enabled by default while keeping `autoRefine.enabled: false` as the opt-out.
 - Fixed non-numeric `autoRefine.turnInterval` and `autoRefine.cooldownMs` settings falling back to defaults instead of silently enabling a noisy auto-refine loop.
 - Fixed all session-resume entry points to share a searchable full-screen picker, stream results while loading, and support renaming ([ENG-4513](https://linear.app/primeintellect/issue/ENG-4513/resume-in-agents-view-is-broken)).

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -183,28 +183,30 @@ export function getMenuListLayout(options: MenuListLayoutOptions): MenuListLayou
 		: { compact: false, visibleItems: comfortableLayout.visibleItems };
 }
 
-function surfaceLine(text: string, width: number, paddingX = PANEL_PADDING_X): string {
+function paddedBackgroundLine(
+	text: string,
+	width: number,
+	paddingX: number,
+	background: ((text: string) => string) | undefined,
+): string {
 	const innerWidth = Math.max(1, width - paddingX * 2);
 	const content = truncateToWidth(text, innerWidth, "");
 	const rightPadding = " ".repeat(Math.max(0, innerWidth - visibleWidth(content)));
-	const line = " ".repeat(paddingX) + content + rightPadding + " ".repeat(paddingX);
-	return theme.getEditorBackgroundColor()?.(line) ?? line;
+	const contentSpan = " ".repeat(paddingX) + content;
+	const trailingSpan = rightPadding + " ".repeat(paddingX);
+	if (!background) {
+		return contentSpan + trailingSpan;
+	}
+	return background(contentSpan) + background(trailingSpan);
+}
+
+function surfaceLine(text: string, width: number, paddingX = PANEL_PADDING_X): string {
+	return paddedBackgroundLine(text, width, paddingX, theme.getEditorBackgroundColor());
 }
 
 function surfaceWrappedLines(text: string, width: number, paddingX = PANEL_PADDING_X): string[] {
 	const innerWidth = Math.max(1, width - paddingX * 2);
-	return wrapTextWithAnsi(text, innerWidth).map((content) => {
-		const rightPadding = " ".repeat(Math.max(0, innerWidth - visibleWidth(content)));
-		const line = " ".repeat(paddingX) + content + rightPadding + " ".repeat(paddingX);
-		return theme.getEditorBackgroundColor()?.(line) ?? line;
-	});
-}
-
-function padLine(text: string, width: number, paddingX: number): string {
-	const innerWidth = Math.max(1, width - paddingX * 2);
-	const content = truncateToWidth(text, innerWidth, "");
-	const rightPadding = " ".repeat(Math.max(0, innerWidth - visibleWidth(content)));
-	return " ".repeat(paddingX) + content + rightPadding + " ".repeat(paddingX);
+	return wrapTextWithAnsi(text, innerWidth).map((content) => surfaceLine(content, width, paddingX));
 }
 
 export class MenuPanel extends Container {
@@ -300,8 +302,7 @@ export class MenuSearchInput implements Component, Focusable, FullWidthMenuCompo
 			this.getValue() === "" && !this.focused
 				? theme.fg("dim", this.placeholder)
 				: this.stripInputPrompt(this.input.render(innerWidth + 2)[0] ?? "");
-		const field = padLine(content, safeWidth, FIELD_PADDING_X);
-		return [theme.getEditorBackgroundColor()?.(field) ?? field];
+		return [paddedBackgroundLine(content, safeWidth, FIELD_PADDING_X, theme.getEditorBackgroundColor())];
 	}
 
 	private stripInputPrompt(line: string): string {
@@ -369,11 +370,10 @@ export class MenuRow implements Component, FullWidthMenuComponent {
 	}
 
 	private rowLine(text: string, width: number, selected: boolean): string {
-		const line = padLine(text, width, ROW_PADDING_X);
-		if (selected) {
-			return theme.bg("selectedBg", line);
-		}
-		return theme.getEditorBackgroundColor()?.(line) ?? line;
+		const background = selected
+			? (content: string) => theme.bg("selectedBg", content)
+			: theme.getEditorBackgroundColor();
+		return paddedBackgroundLine(text, width, ROW_PADDING_X, background);
 	}
 }
 

--- a/packages/coding-agent/test/extension-selector.test.ts
+++ b/packages/coding-agent/test/extension-selector.test.ts
@@ -4,6 +4,15 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { ExtensionSelectorComponent } from "../src/modes/interactive/components/extension-selector.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
+const BACKGROUND_START = /\x1b\[(?:4[0-8]|48;5;\d+|48;2;\d+;\d+;\d+)m/;
+
+function expectTrailingBackground(line: string | undefined, text: string): void {
+	const renderedLine = line ?? "";
+	const textEnd = renderedLine.indexOf(text) + text.length;
+	expect(textEnd).toBeGreaterThanOrEqual(text.length);
+	expect(renderedLine.slice(textEnd)).toMatch(BACKGROUND_START);
+}
+
 describe("ExtensionSelectorComponent", () => {
 	beforeAll(() => {
 		initTheme("dark");
@@ -33,6 +42,12 @@ describe("ExtensionSelectorComponent", () => {
 		expect(output).toContain("Waiting preserves the current kernel state");
 		expect(waitIndex).toBeGreaterThan(-1);
 		expect(killIndex).toBe(waitIndex + 1);
+		expectTrailingBackground(
+			lines.find((line) => line.includes("Interrupted IPython cell is still running")),
+			"Interrupted IPython cell is still running",
+		);
+		expectTrailingBackground(lines[waitIndex], "Wait and preserve state");
+		expectTrailingBackground(lines[killIndex], "Kill kernel and restart");
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBe(88);
 		}


### PR DESCRIPTION
- selector prompts and options repaint trailing padding so background colors reach the terminal edge.
- the shared menu renderer covers selected rows, ordinary rows, and search fields.
- regression coverage verifies the ipython recovery prompt retains background styling after its text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only presentation change in menu rendering; no auth, data, or session logic touched.
> 
> **Overview**
> **Selector and menu panels** no longer leave uncolored gaps on the right: trailing padding and filler spaces are painted with the same background as the row content, including **selected** rows (`selectedBg`) and **search** fields.
> 
> The shared **`menu-panel`** helper now splits each full-width line into a content span and a trailing span and applies the background callback to **both**, instead of wrapping one unpainted padding string. **Wrapped** prompt lines and **extension selector** prompts/options inherit this behavior.
> 
> **Regression tests** on the IPython recovery selector assert that background ANSI sequences continue **after** the visible text while line width stays fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2a77807134605f04d17860ad107275a81baa01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fill selector prompt and choice backgrounds through the terminal's right edge
> - Introduces `paddedBackgroundLine` in [menu-panel.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/366/files#diff-22f82f8366fad943dc6e7f231f4645c864e17b89b5228a1453cc21e1a57a329c), a helper that applies a background color function separately to the content span and trailing padding span, ensuring background coverage extends to the right edge.
> - Refactors `surfaceLine`, `surfaceWrappedLines`, `MenuSearchInput.render`, and `MenuRow.rowLine` to use this helper, replacing the previous `padLine` utility which did not reliably control background styling.
> - Adds `expectTrailingBackground` in [extension-selector.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/366/files#diff-b3198a4a3d1c612d8d8bf28267ec25c71a3f48e3cb06cfdd4314b17e589a5d34) to assert that prompt and option lines carry a background ANSI sequence after their text content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db2a778.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->