### PR TITLE
restore concise splash hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed the new-chat splash to show only version, model, and cwd metadata and rotate among five example prompts.
+
 ## [0.2.8] - 2026-07-09
 
 - Added built-in Herdr integration that reports agent lifecycle state to Herdr panes automatically, without requiring `herdr integration install pi`.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -228,6 +228,18 @@ const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
 const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
 const MODEL_CATALOG_REFRESH_TTL_MS = 60_000;
 
+export const START_HINTS = [
+	'Try "refactor @<filepath>"',
+	'Try "fix bugs in @<filepath>"',
+	'Try "add tests for @<filepath>"',
+	'Try "explain how @<filepath> works"',
+	'Try "improve performance in @<filepath>"',
+] as const;
+
+export function getRandomStartHint(random = Math.random): (typeof START_HINTS)[number] {
+	return START_HINTS[Math.floor(random() * START_HINTS.length)] ?? START_HINTS[0];
+}
+
 function isLabeledQueuedPreview(message: string): boolean {
 	return (
 		message.startsWith(`${HEARTBEAT_PROMPT_PREVIEW_LABEL}: `) || message.startsWith(`${GOAL_CONTEXT_PREVIEW_LABEL}: `)
@@ -606,6 +618,7 @@ export class InteractiveMode {
 	// Stored so the same manager can be injected into custom editors, selectors, and extension UI.
 	private keybindings: KeybindingsManager;
 	private version: string;
+	private readonly startHint = getRandomStartHint();
 	private isInitialized = false;
 	private onInputCallback?: (text: string | undefined) => void;
 	private returnToAgentsViewRequested = false;
@@ -812,7 +825,7 @@ export class InteractiveMode {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
 			isArgumentCommand: builtinSlashCommandTakesArgument,
-			placeholder: 'Try "refactor @<filepath>"',
+			placeholder: this.startHint,
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
 		this.editor = this.defaultEditor;
@@ -1064,9 +1077,8 @@ export class InteractiveMode {
 				() => this.getCurrentCwd(),
 				verboseInstructions,
 				{
-					getExtraMetadata: () => this.getStartupMetadata(),
 					getHideStartHint: () => this.childAgentPanelMode !== undefined || !this.isNewChat(),
-					getStartHint: () => 'Try "refactor @<filepath>"',
+					getStartHint: () => this.startHint,
 				},
 			);
 			this.headerContainer.addChild(this.builtInHeader);
@@ -4839,27 +4851,11 @@ export class InteractiveMode {
 		return [agentsHint, modelLabel, shortcutsHint].filter((label): label is string => label !== undefined).join("  ");
 	}
 
-	private getStartupMetadata(): BrandSplashMetadataLine[] {
-		if (this.childAgentPanelMode || !this.isNewChat()) {
-			return [];
-		}
-		return [
-			{ label: "input", value: "! shell · / commands" },
-			{ label: "files", value: "@ file paths" },
-			{ label: "help", value: this.getShortcutHelpHint() },
-		];
-	}
-
 	private getShortcutsTrayHint(): string | undefined {
 		if (!this.isNewChat()) {
 			return undefined;
 		}
 		return keyText("app.shortcuts") ? keyHint("app.shortcuts", "for shortcuts") : "/hotkeys for shortcuts";
-	}
-
-	private getShortcutHelpHint(): string {
-		const shortcuts = keyText("app.shortcuts");
-		return shortcuts ? `${shortcuts} for shortcuts` : "/hotkeys for shortcuts";
 	}
 
 	private isNewChat(): boolean {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -2,7 +2,12 @@ import { Container, setKeybindings } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
-import { BrandSplashHeader, InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import {
+	BrandSplashHeader,
+	getRandomStartHint,
+	InteractiveMode,
+	START_HINTS,
+} from "../src/modes/interactive/interactive-mode.js";
 import { getMarkdownTheme, initTheme } from "../src/modes/interactive/theme/theme.js";
 
 describe("InteractiveMode startup hints", () => {
@@ -29,26 +34,36 @@ describe("InteractiveMode startup hints", () => {
 		return mode;
 	}
 
-	it("renders compact new-chat guidance and the configured shortcut hint", () => {
-		const mode = createMode();
-		const metadata = Reflect.get(InteractiveMode.prototype, "getStartupMetadata").call(mode);
+	it("keeps the splash metadata to version, model, and cwd", () => {
 		const header = new BrandSplashHeader(
 			"0.0.0",
 			() => "test-model",
 			() => "/tmp/project",
 			undefined,
 			{
-				getExtraMetadata: () => metadata,
 				getStartHint: () => 'Try "refactor @<filepath>"',
 			},
 		);
 
 		const output = stripAnsi(header.render(120).join("\n"));
 
-		expect(output).toContain("! shell · / commands");
-		expect(output).toContain("@ file paths");
-		expect(output).toContain("? for shortcuts");
+		expect(output).toContain("version  v0.0.0");
+		expect(output).toContain("model    test-model");
+		expect(output).toContain("cwd      /tmp/project");
 		expect(output).toContain('Try "refactor @<filepath>"');
+		expect(output).not.toContain("input");
+		expect(output).not.toContain("files");
+		expect(output).not.toContain("help");
+	});
+
+	it("randomly selects from five concise filepath prompts", () => {
+		expect(START_HINTS).toHaveLength(5);
+		expect(new Set(START_HINTS).size).toBe(5);
+
+		for (const [index, hint] of START_HINTS.entries()) {
+			expect(getRandomStartHint(() => index / START_HINTS.length)).toBe(hint);
+			expect(hint).toMatch(/^Try ".*@<filepath>.*"$/);
+		}
 	});
 
 	it("places the fresh-chat shortcut hint after the model and effort", () => {
@@ -65,12 +80,10 @@ describe("InteractiveMode startup hints", () => {
 		expect(stripAnsi(label)).toBe("← agents view  test-model • high  ? for shortcuts");
 	});
 
-	it("hides startup shortcut guidance for chats with history", () => {
+	it("hides the tray shortcut guidance for chats with history", () => {
 		const mode = createMode(true);
-		const metadata = Reflect.get(InteractiveMode.prototype, "getStartupMetadata").call(mode);
 		const label = Reflect.get(InteractiveMode.prototype, "getTrayLocationLabel").call(mode);
 
-		expect(metadata).toEqual([]);
 		expect(stripAnsi(label)).toBe("test-model • high");
 	});
 


### PR DESCRIPTION
- restores the new-chat splash to version, model, and cwd while retaining the shortcut flow.
- rotates five concise filepath prompt examples across new interactive sessions.
- adds startup coverage for the reduced metadata and randomized prompt selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and placeholder copy only; no auth, session, or tool behavior changes.
> 
> **Overview**
> The **new-chat splash** is trimmed back: it no longer shows the extra `input` / `files` / `help` metadata lines (shell, `@` paths, shortcut copy). **Version, model, and cwd** stay on the splash, and the footer tray still surfaces Agents View, model/effort, and `?` / `/hotkeys` for shortcuts on a fresh chat.
> 
> Each new interactive session picks **one of five** `@<filepath>` example strings via exported `START_HINTS` and `getRandomStartHint()`; that same hint drives the **prompt placeholder** and the splash start hint (replacing the fixed refactor example). `getStartupMetadata` / `getShortcutHelpHint` are removed from `InteractiveMode` because splash help no longer duplicates tray guidance.
> 
> Tests now assert the reduced splash output and deterministic random hint selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae30b19a85315c868e4fa7892ed0c0f682bbd210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore concise splash hints with randomized example prompts in new-chat view
> - Replaces the prior three guidance metadata lines (input/files/help) in the new-chat splash with only version, model, and cwd metadata, plus a single randomized example prompt.
> - Adds a `START_HINTS` array of five filepath-oriented example prompts and a `getRandomStartHint` helper that selects one per session using an injectable RNG.
> - Syncs the prompt bar placeholder text in `CustomEditor` to the same randomized hint, replacing the hardcoded `'Try "refactor @<filepath>"'` string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae30b19.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->