### PR TITLE
open services menu from /mcp

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed bare `/mcp` to open the Services menu while preserving explicit `list`, `login`, and `logout` subcommands ([ENG-4535](https://linear.app/primeintellect/issue/ENG-4535/open-services-mcp-menu-from-mcp)).
 - Added `/btw` and `/side` for one-turn inline side questions that use the current context without changing the main session ([ENG-4509](https://linear.app/primeintellect/issue/ENG-4509/add-btw-and-side-side-question-flows)).
 - Changed scheduled heartbeat prompts to steer (interrupt the current turn) by default, with a `steer`/`follow_up` delivery mode selectable via `/heartbeat --steer|--follow-up` and the `rlm_heartbeat` skill's `delivery_mode` argument.
 - Changed the new-chat splash to show only version, model, and cwd metadata and rotate among five example prompts.

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -73,7 +73,12 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "tree", description: "Navigate session tree (switch branches)" },
 	{ name: "login", description: "Configure provider authentication" },
 	{ name: "logout", description: "Remove provider authentication" },
-	{ name: "mcp", description: "Manage MCP integrations (list, login <name>, logout <name>)" },
+	{
+		name: "mcp",
+		description: "Open Services or manage MCP integrations",
+		argumentHint: "[list|login <name>|logout <name>]",
+		takesArgument: true,
+	},
 	{ name: "new", description: "Start a new session" },
 	{
 		name: "compact",

--- a/packages/coding-agent/src/modes/interactive/auth-flows.ts
+++ b/packages/coding-agent/src/modes/interactive/auth-flows.ts
@@ -32,6 +32,7 @@ import { showFullPaneOverlay } from "./components/centered-overlay.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
 import {
+	type AuthSelectorCategory,
 	type AuthSelectorProvider,
 	compareAuthSelectorProviders,
 	OAuthSelectorComponent,
@@ -114,6 +115,11 @@ export interface ProviderAuthFlowsHost {
 	onLoginCompleted?(): void;
 }
 
+export interface ProviderLoginOptions {
+	authType?: "oauth" | "api_key";
+	initialCategory?: AuthSelectorCategory;
+}
+
 export class ProviderAuthFlows {
 	constructor(private readonly host: ProviderAuthFlowsHost) {}
 
@@ -135,7 +141,8 @@ export class ProviderAuthFlows {
 		return this.showLoginDialog(providerId, label ?? provider.name, "service");
 	}
 
-	runLogin(authType?: "oauth" | "api_key"): Promise<AuthenticationResult> {
+	runLogin(options: ProviderLoginOptions = {}): Promise<AuthenticationResult> {
+		const { authType, initialCategory } = options;
 		const providerOptions = this.getLoginProviderOptions(authType);
 		if (providerOptions.length === 0) {
 			this.host.showStatus(
@@ -177,7 +184,7 @@ export class ProviderAuthFlows {
 					resolve({ status: "cancelled" });
 				},
 				(providerId) => this.host.modelRegistry.getProviderAuthStatus(providerId),
-				{ getRows: () => this.host.ui.terminal.rows },
+				{ getRows: () => this.host.ui.terminal.rows, initialCategory },
 			);
 			handle = showFullPaneOverlay(this.host.ui, selector, 78);
 		});

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -20,6 +20,10 @@ export type AuthSelectorProvider = {
 	category?: AuthSelectorCategory;
 };
 
+export interface OAuthSelectorOptions extends MenuViewportProvider {
+	initialCategory?: AuthSelectorCategory;
+}
+
 export function compareAuthSelectorProviders(a: AuthSelectorProvider, b: AuthSelectorProvider): number {
 	if (a.authType !== b.authType) {
 		return a.authType === "oauth" ? -1 : 1;
@@ -77,14 +81,14 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		onSelect: (provider: AuthSelectorProvider) => void,
 		onCancel: () => void,
 		getAuthStatus?: (providerId: string) => AuthStatus,
-		viewport: MenuViewportProvider = {},
+		options: OAuthSelectorOptions = {},
 	) {
 		super();
 
 		this.mode = mode;
 		this.authStorage = authStorage;
 		this.getAuthStatus = getAuthStatus ?? ((providerId) => this.authStorage.getAuthStatus(providerId));
-		this.viewport = viewport;
+		this.viewport = options;
 		this.allProviders = this.sortProviders(providers);
 		this.filteredProviders = this.allProviders;
 		this.onSelectCallback = onSelect;
@@ -92,7 +96,10 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 		const present = new Set(providers.map((p) => p.category ?? "provider"));
 		this.categories = (["provider", "service"] as const).filter((c) => present.has(c));
-		this.activeCategory = this.categories[0] ?? "provider";
+		this.activeCategory =
+			options.initialCategory && this.categories.includes(options.initialCategory)
+				? options.initialCategory
+				: (this.categories[0] ?? "provider");
 
 		const panel = new MenuPanel({
 			title: mode === "login" ? "Providers" : "Saved Credentials",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -139,7 +139,12 @@ import {
 	formatUpdateAvailableNotice,
 } from "../shared/startup-notices.js";
 import { AGENT_ACTIVITY_LABELS, AgentActivityTracker, formatTokenCount } from "./agent-activity.js";
-import { type AuthenticationResult, getAnthropicSubscriptionAuthWarning, ProviderAuthFlows } from "./auth-flows.js";
+import {
+	type AuthenticationResult,
+	getAnthropicSubscriptionAuthWarning,
+	ProviderAuthFlows,
+	type ProviderLoginOptions,
+} from "./auth-flows.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -7478,16 +7483,21 @@ export class InteractiveMode {
 		});
 	}
 
-	private showLoginProviderSelector(authType?: "oauth" | "api_key"): Promise<AuthenticationResult> {
-		return this.createAuthFlows().runLogin(authType);
+	private showLoginProviderSelector(options: ProviderLoginOptions = {}): Promise<AuthenticationResult> {
+		return this.createAuthFlows().runLogin(options);
 	}
 
 	private async handleMcpCommand(args: string | undefined): Promise<void> {
 		const [sub, server] = (args ?? "").trim().split(/\s+/);
+		if (!sub) {
+			await this.showOAuthSelector("login", { initialCategory: "service" });
+			return;
+		}
+
 		const authStorage = this.modelRegistry.authStorage;
 		const isAuthed = (name: string) => authStorage.get(`mcp:${name}`) !== undefined;
 
-		if (!sub || sub === "list") {
+		if (sub === "list") {
 			const labels = new Map(BUILTIN_MCP_CATALOG.map((e) => [e.server, e.label]));
 			const names = new Set([...labels.keys(), ...Object.keys(this.settingsManager.getMcpServers() ?? {})]);
 			const lines = [...names].map((name) => {
@@ -7541,9 +7551,9 @@ export class InteractiveMode {
 		this.showError(`Unknown /mcp subcommand: ${sub}. Use list, login, or logout.`);
 	}
 
-	private async showOAuthSelector(mode: "login" | "logout"): Promise<void> {
+	private async showOAuthSelector(mode: "login" | "logout", loginOptions: ProviderLoginOptions = {}): Promise<void> {
 		if (mode === "login") {
-			const authResult = await this.showLoginProviderSelector();
+			const authResult = await this.showLoginProviderSelector(loginOptions);
 			// Service credentials don't change the model, so skip the model picker.
 			if (authResult.status === "success" && authResult.kind !== "service") {
 				this.invalidateConnectionModels();

--- a/packages/coding-agent/test/auth-flows.test.ts
+++ b/packages/coding-agent/test/auth-flows.test.ts
@@ -55,6 +55,7 @@ function createHost(authStorage: AuthStorage): {
 		refresh: vi.fn(),
 		getAll: () => [],
 		getProviderDisplayName: (providerId: string) => providerId,
+		getProviderAuthStatus: (providerId: string) => authStorage.getAuthStatus(providerId),
 	} as unknown as ModelRegistry;
 
 	return {
@@ -204,5 +205,19 @@ describe("ProviderAuthFlows", () => {
 		expect(stripAnsi(overlays[0]?.render(80).join("\n") ?? "")).toContain("Prime Inference");
 		overlays[0]?.handleInput?.("\x1b");
 		await expect(logoutResult).resolves.toBeNull();
+	});
+
+	it("opens login on the requested Services category", async () => {
+		const authStorage = AuthStorage.create(authJsonPath, { usePrimeCliConfig: false });
+		const { host, overlays } = createHost(authStorage);
+
+		const loginResult = new ProviderAuthFlows(host).runLogin({ initialCategory: "service" });
+
+		expect(overlays).toHaveLength(1);
+		const output = stripAnsi(overlays[0]?.render(80).join("\n") ?? "");
+		expect(output).toContain("Serper (web search)");
+		expect(output).not.toContain("Anthropic");
+		overlays[0]?.handleInput?.("\x1b");
+		await expect(loginResult).resolves.toEqual({ status: "cancelled" });
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -416,6 +416,41 @@ describe("InteractiveMode submit handling", () => {
 	});
 });
 
+describe("InteractiveMode MCP command", () => {
+	type McpCommandHarness = {
+		modelRegistry: { authStorage: { get(providerId: string): unknown } };
+		settingsManager: { getMcpServers(): Record<string, unknown> };
+		showOAuthSelector(mode: "login" | "logout", options?: { initialCategory?: string }): Promise<void>;
+		showStatus(message: string): void;
+		handleMcpCommand(args: string | undefined): Promise<void>;
+	};
+	const handleMcpCommand = (InteractiveMode.prototype as unknown as McpCommandHarness).handleMcpCommand;
+
+	test("opens bare /mcp on the Services category", async () => {
+		const fakeThis = {
+			showOAuthSelector: vi.fn(async () => {}),
+		} as unknown as McpCommandHarness;
+
+		await handleMcpCommand.call(fakeThis, undefined);
+
+		expect(fakeThis.showOAuthSelector).toHaveBeenCalledWith("login", { initialCategory: "service" });
+	});
+
+	test("preserves the explicit /mcp list status output", async () => {
+		const fakeThis = {
+			modelRegistry: { authStorage: { get: vi.fn(() => undefined) } },
+			settingsManager: { getMcpServers: vi.fn(() => ({})) },
+			showOAuthSelector: vi.fn(async () => {}),
+			showStatus: vi.fn(),
+		} as unknown as McpCommandHarness;
+
+		await handleMcpCommand.call(fakeThis, "list");
+
+		expect(fakeThis.showOAuthSelector).not.toHaveBeenCalled();
+		expect(fakeThis.showStatus).toHaveBeenCalledWith(expect.stringContaining("MCP integrations:"));
+	});
+});
+
 describe("InteractiveMode pending bash components", () => {
 	beforeAll(() => {
 		initTheme("dark");

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -407,6 +407,39 @@ describe("OAuthSelectorComponent", () => {
 		expect(chosen).toBe("serper");
 	});
 
+	it("can open with the Services tab active", () => {
+		const selector = new OAuthSelectorComponent(
+			"login",
+			AuthStorage.inMemory(),
+			[
+				{ id: "anthropic", name: "Anthropic", authType: "oauth", category: "provider" },
+				{ id: "serper", name: "Serper (web search)", authType: "api_key", category: "service" },
+			],
+			() => {},
+			() => {},
+			undefined,
+			{ initialCategory: "service" },
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("Serper (web search)");
+		expect(output).not.toContain("Anthropic");
+	});
+
+	it("falls back when the requested initial category is unavailable", () => {
+		const selector = new OAuthSelectorComponent(
+			"login",
+			AuthStorage.inMemory(),
+			[{ id: "anthropic", name: "Anthropic", authType: "oauth", category: "provider" }],
+			() => {},
+			() => {},
+			undefined,
+			{ initialCategory: "service" },
+		);
+
+		expect(stripAnsi(selector.render(120).join("\n"))).toContain("Anthropic");
+	});
+
 	it("shows no tab bar when only one category is present", () => {
 		const selector = new OAuthSelectorComponent(
 			"login",

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -43,6 +43,14 @@ describe("built-in slash commands", () => {
 		expect(builtinSlashCommandTakesArgument("side")).toBe(true);
 	});
 
+	test("describes /mcp as the Services menu entry point", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "mcp")).toMatchObject({
+			description: "Open Services or manage MCP integrations",
+			argumentHint: "[list|login <name>|logout <name>]",
+			takesArgument: true,
+		});
+	});
+
 	test("marks argument commands as taking a free-form argument", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "goal")).toMatchObject({
 			takesArgument: true,
@@ -54,6 +62,7 @@ describe("built-in slash commands", () => {
 		expect(builtinSlashCommandTakesArgument("effort")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("heartbeat")).toBe(true);
+		expect(builtinSlashCommandTakesArgument("mcp")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("new")).toBe(false);
 		expect(builtinSlashCommandTakesArgument("clear")).toBe(false);
 	});


### PR DESCRIPTION
- bare `/mcp` now opens the shared services selector for direct integration setup.
- explicit `list`, `login`, and `logout` subcommands remain available for scripted workflows.
- added regression coverage for category selection, command routing, and help metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive slash-command and auth UI routing only; credentials and MCP login/logout flows are unchanged aside from the default bare `/mcp` entry point.
> 
> **Overview**
> Bare **`/mcp`** now opens the shared login selector on the **Services** tab (MCP integrations, Serper, etc.) instead of printing the integration list. **`/mcp list`**, **`/mcp login <name>`**, and **`/mcp logout <name>`** behave as before for scripted use.
> 
> **`ProviderAuthFlows.runLogin`** takes an options object (`authType`, **`initialCategory`**) instead of a lone auth-type argument, and **`OAuthSelectorComponent`** honors **`initialCategory`** when opening the Providers/Services tabs (with fallback if that tab has no entries). Built-in **`/mcp`** help text and **`takesArgument`** metadata were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd92781e22ba3df0053644e79cb5eba6262034ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open Services menu when `/mcp` is run with no subcommand
> - Bare `/mcp` now opens the OAuth selector pre-focused on the Services category; explicit `list`, `login <name>`, and `logout <name>` subcommands continue to work as before.
> - `OAuthSelectorComponent` accepts a new `initialCategory` option to preselect a tab (e.g. `service`) on open, falling back to the first available category.
> - `ProviderAuthFlows.runLogin` accepts a `ProviderLoginOptions` object with optional `authType` and `initialCategory`, and now passes `getProviderAuthStatus` from `modelRegistry` to the selector.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd92781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->