### PR TITLE
stop onboarding from gating normal tui use

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed daemon connection errors to report the failed operation, session identity, recovery steps, socket, and diagnostic log instead of raw protocol reasons.
 - Fixed Agents View retrying after an intentional daemon shutdown instead of stopping with restart guidance.
 - Fixed stale heartbeat jobs reopening archived, deleted, or concurrently terminated sessions ([ENG-4519](https://linear.app/primeintellect/issue/ENG-4519/heartbeats-rebirth-sessions-that-were-previously-killed)).
+- Fixed onboarding blocking normal TUI use by reopening login or model selection after startup ([ENG-4537](https://linear.app/primeintellect/issue/ENG-4537/stop-onboarding-from-gating-normal-tui-use)).
 
 ## [0.2.8] - 2026-07-09
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -120,6 +120,9 @@ export type McpServerConfig =
 	  };
 
 export interface Settings {
+	/** The first-run onboarding flow has been offered. */
+	onboardingShown?: boolean;
+	/** Legacy field read as onboardingShown so existing users are not re-onboarded. */
 	onboardingCompleted?: boolean;
 	defaultProvider?: string;
 	defaultModel?: string;
@@ -616,13 +619,13 @@ export class SettingsManager {
 		return drained;
 	}
 
-	getOnboardingCompleted(): boolean {
-		return this.settings.onboardingCompleted ?? false;
+	getOnboardingShown(): boolean {
+		return this.settings.onboardingShown ?? this.settings.onboardingCompleted ?? false;
 	}
 
-	setOnboardingCompleted(completed: boolean): void {
-		this.globalSettings.onboardingCompleted = completed;
-		this.markModified("onboardingCompleted");
+	setOnboardingShown(shown: boolean): void {
+		this.globalSettings.onboardingShown = shown;
+		this.markModified("onboardingShown");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -120,9 +120,7 @@ export type McpServerConfig =
 	  };
 
 export interface Settings {
-	/** The first-run onboarding flow has been offered. */
 	onboardingShown?: boolean;
-	/** Legacy field read as onboardingShown so existing users are not re-onboarded. */
 	onboardingCompleted?: boolean;
 	defaultProvider?: string;
 	defaultModel?: string;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1392,8 +1392,6 @@ export class InteractiveMode {
 		}
 
 		const showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash();
-		// Onboarding is a one-shot offer, never a runtime readiness gate. Persist
-		// before opening UI so any later process starts directly in the normal TUI.
 		this.markOnboardingShown();
 		await this.settingsManager.flush();
 		await this.runOnboardingFlow(showPrimeCliSplash);
@@ -7502,8 +7500,6 @@ export class InteractiveMode {
 	private async showOAuthSelector(mode: "login" | "logout", loginOptions: ProviderLoginOptions = {}): Promise<void> {
 		if (mode === "login") {
 			const authResult = await this.showLoginProviderSelector(loginOptions);
-			// Refresh the model catalog lazily when the user explicitly opens /model.
-			// /login must never redirect into a separate command's UI.
 			if (authResult.status === "success" && authResult.kind !== "service") {
 				this.invalidateConnectionModels();
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -185,12 +185,7 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
-import {
-	isOnboardingModelReady,
-	type OnboardingStartupState,
-	shouldRunOnboarding,
-	shouldRunPrimeCliOnboardingSplash,
-} from "./onboarding.js";
+import { type OnboardingStartupState, shouldRunOnboarding, shouldRunPrimeCliOnboardingSplash } from "./onboarding.js";
 import { formatResumeHint } from "./resume-hint.js";
 import {
 	getAvailableThemes,
@@ -403,7 +398,7 @@ type GoalAnnouncementSnapshot = {
 
 type ModelSelectionResult = { status: "selected" } | { status: "cancelled" } | { status: "action"; actionId: string };
 
-type ModelFallbackWarningAction = "show" | "suppress" | "wait";
+type ModelFallbackWarningAction = "show" | "suppress";
 
 const MODEL_SELECTOR_ACTIONS: readonly ModelSelectorAction[] = [
 	{ id: "add_provider", label: "Add provider...", description: "subscription or API key" },
@@ -1258,10 +1253,9 @@ export class InteractiveMode {
 			}
 		};
 
-		const needsOnboarding = this.shouldRunOnboarding();
 		let deferredStartupNotificationsShown = false;
 		const showDeferredStartupNotifications = () => {
-			if (deferredStartupNotificationsShown || this.shouldRunOnboarding()) {
+			if (deferredStartupNotificationsShown) {
 				return;
 			}
 			deferredStartupNotificationsShown = true;
@@ -1303,42 +1297,24 @@ export class InteractiveMode {
 			if (modelFallbackWarningShown) {
 				return;
 			}
-			const action = this.getModelFallbackWarningAction(modelFallbackMessage, needsOnboarding);
-			if (action === "wait") {
-				return;
-			}
+			const action = this.getModelFallbackWarningAction(modelFallbackMessage);
 			modelFallbackWarningShown = true;
 			if (action === "show" && modelFallbackMessage) {
 				this.showWarning(modelFallbackMessage);
 			}
 		};
 
-		if (!needsOnboarding) {
-			showModelFallbackWarning();
-		}
-
-		let promptReady = !needsOnboarding;
-		if (needsOnboarding) {
-			promptReady = await this.runOnboardingFlow();
-		}
-
-		if (promptReady) {
-			showDeferredStartupNotifications();
-			showModelFallbackWarning();
-			void this.maybeWarnAboutAnthropicSubscriptionAuth();
-			await sendInitialPrompts();
-		}
+		await this.runStartupOnboarding();
+		showDeferredStartupNotifications();
+		showModelFallbackWarning();
+		void this.maybeWarnAboutAnthropicSubscriptionAuth();
+		await sendInitialPrompts();
 
 		// Main interactive loop
 		while (true) {
 			const userInput = await this.getUserInput();
 			if (userInput === undefined || this.returnToAgentsViewRequested) {
 				return "agents_view";
-			}
-			if (!(await this.ensurePromptReady())) {
-				this.editor.setText(userInput);
-				this.showStatus("Complete onboarding to send the restored prompt.");
-				continue;
 			}
 			showDeferredStartupNotifications();
 			showModelFallbackWarning();
@@ -1356,10 +1332,7 @@ export class InteractiveMode {
 		}
 	}
 
-	private getModelFallbackWarningAction(
-		modelFallbackMessage: string | undefined,
-		startupNeededOnboarding: boolean,
-	): ModelFallbackWarningAction {
+	private getModelFallbackWarningAction(modelFallbackMessage: string | undefined): ModelFallbackWarningAction {
 		if (!modelFallbackMessage) {
 			return "suppress";
 		}
@@ -1368,12 +1341,6 @@ export class InteractiveMode {
 		// visible to the daemon, or added after the snapshot was taken).
 		if (isNoModelsAvailableMessage(modelFallbackMessage) && this.getCurrentModel()) {
 			return "suppress";
-		}
-		if (startupNeededOnboarding && isNoModelsAvailableMessage(modelFallbackMessage) && !this.shouldRunOnboarding()) {
-			return "suppress";
-		}
-		if (startupNeededOnboarding && isNoModelsAvailableMessage(modelFallbackMessage)) {
-			return "wait";
 		}
 		return "show";
 	}
@@ -1394,81 +1361,50 @@ export class InteractiveMode {
 		return shouldRunPrimeCliOnboardingSplash(this.getOnboardingState());
 	}
 
-	private isCurrentModelReady(): boolean {
-		return isOnboardingModelReady(this.getOnboardingState());
-	}
-
-	private completeOnboarding(): void {
-		if (!this.settingsManager.getOnboardingCompleted()) {
-			this.settingsManager.setOnboardingCompleted(true);
+	private markOnboardingShown(): void {
+		if (!this.settingsManager.getOnboardingShown()) {
+			this.settingsManager.setOnboardingShown(true);
 		}
 	}
 
-	private completeOnboardingIfCurrentModelReady(): void {
-		if (this.isCurrentModelReady()) {
-			this.completeOnboarding();
-		}
-	}
-
-	private isOnboardingResolvedAfterModelPrompt(selectedModel: boolean): boolean {
-		if (selectedModel) {
-			this.completeOnboarding();
-			return true;
-		}
-		return !this.shouldRunOnboarding();
-	}
-
-	private async ensurePromptReady(): Promise<boolean> {
+	private async runStartupOnboarding(): Promise<boolean> {
 		if (!this.shouldRunOnboarding()) {
-			return true;
+			return false;
 		}
-		return this.runOnboardingFlow();
+
+		const showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash();
+		// Onboarding is a one-shot offer, never a runtime readiness gate. Persist
+		// before opening UI so any later process starts directly in the normal TUI.
+		this.markOnboardingShown();
+		await this.settingsManager.flush();
+		await this.runOnboardingFlow(showPrimeCliSplash);
+		return true;
 	}
 
-	private async runOnboardingFlow(): Promise<boolean> {
+	private async runOnboardingFlow(showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash()): Promise<void> {
 		this.modelRegistry.refresh();
-		if (this.shouldRunPrimeCliOnboardingSplash()) {
+		if (showPrimeCliSplash) {
 			const shouldContinue = await this.showOnboardingModelSelectionSplash();
 			if (!shouldContinue) {
-				this.showStatus("Model selection required. Use /model to continue.");
-				return false;
+				return;
 			}
 
-			const selectedModel = await this.promptForModelSelection({ allowProviderSetup: true });
-			if (this.isOnboardingResolvedAfterModelPrompt(selectedModel)) {
-				return true;
-			}
-
-			this.showStatus("Model selection required. Use /model to continue.");
-			return false;
+			await this.promptForModelSelection({ allowProviderSetup: true });
+			return;
 		}
 
 		const availableModels = await this.getModelCandidates();
 		if (availableModels.length > 0) {
-			const selectedModel = await this.promptForModelSelection({ allowProviderSetup: true });
-			if (this.isOnboardingResolvedAfterModelPrompt(selectedModel)) {
-				return true;
-			}
-
-			this.showStatus("Model selection required. Use /model to continue.");
-			return false;
+			await this.promptForModelSelection({ allowProviderSetup: true });
+			return;
 		}
 
 		const authResult = await this.showOnboardingPrimeLogin();
 		if (authResult.status !== "success") {
-			this.showStatus(
-				"Prime Intellect login required for onboarding. Use /login to configure other providers later.",
-			);
-			return false;
+			return;
 		}
 
-		const selectedModel = await this.promptForModelSelection({ allowProviderSetup: true });
-		if (this.isOnboardingResolvedAfterModelPrompt(selectedModel)) {
-			return true;
-		}
-
-		this.showStatus("Model selection required. Use /model to continue.");
-		return false;
+		await this.promptForModelSelection({ allowProviderSetup: true });
 	}
 
 	private getMarkdownThemeWithSettings(): MarkdownTheme {
@@ -6642,7 +6578,6 @@ export class InteractiveMode {
 			try {
 				this.showStatus(`Switching model: ${model.id}`);
 				await this.applySelectedModel(model);
-				this.completeOnboardingIfCurrentModelReady();
 				this.showStatus(`Model: ${model.id}`);
 				void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 				this.checkDaxnutsEasterEgg(model);
@@ -6950,7 +6885,6 @@ export class InteractiveMode {
 					this.showStatus(`Switching model: ${model.id}`);
 					try {
 						await this.applySelectedModel(model);
-						this.completeOnboardingIfCurrentModelReady();
 						this.showStatus(`Model: ${model.id}`);
 						void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 						this.checkDaxnutsEasterEgg(model);
@@ -7544,10 +7478,10 @@ export class InteractiveMode {
 	private async showOAuthSelector(mode: "login" | "logout"): Promise<void> {
 		if (mode === "login") {
 			const authResult = await this.showLoginProviderSelector();
-			// Service credentials don't change the model, so skip the model picker.
+			// Refresh the model catalog lazily when the user explicitly opens /model.
+			// /login must never redirect into a separate command's UI.
 			if (authResult.status === "success" && authResult.kind !== "service") {
 				this.invalidateConnectionModels();
-				await this.promptForModelSelection();
 			}
 			// An MCP integration login enables its skill, so reload resources — but a
 			// reload is refused mid-turn, so tell the user to /reload (matching /mcp login).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1235,6 +1235,13 @@ export class InteractiveMode {
 			if (initialPromptsSent) {
 				return;
 			}
+			if (!initialMessage && !initialMessages?.length) {
+				initialPromptsSent = true;
+				return;
+			}
+			if (!this.getCurrentModel()) {
+				return;
+			}
 			initialPromptsSent = true;
 
 			if (initialMessage) {

--- a/packages/coding-agent/src/modes/interactive/onboarding.ts
+++ b/packages/coding-agent/src/modes/interactive/onboarding.ts
@@ -3,7 +3,7 @@ import type { AuthStatus } from "../../core/auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "../../core/prime-inference-auth.js";
 
 export interface OnboardingSettingsReader {
-	getOnboardingCompleted(): boolean;
+	getOnboardingShown(): boolean;
 }
 
 export interface OnboardingModelRegistryReader {
@@ -19,7 +19,7 @@ export interface OnboardingStartupState {
 }
 
 export function shouldRunPrimeCliOnboardingSplash(state: OnboardingStartupState): boolean {
-	if (state.settingsManager.getOnboardingCompleted()) {
+	if (state.settingsManager.getOnboardingShown()) {
 		return false;
 	}
 	if (!state.model || state.model.provider !== PRIME_INFERENCE_PROVIDER_ID) {
@@ -34,6 +34,9 @@ export function isOnboardingModelReady(state: OnboardingStartupState): boolean {
 }
 
 export function shouldRunOnboarding(state: OnboardingStartupState): boolean {
+	if (state.settingsManager.getOnboardingShown()) {
+		return false;
+	}
 	state.modelRegistry.refresh();
 	if (shouldRunPrimeCliOnboardingSplash(state)) {
 		return true;

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -824,65 +824,41 @@ describe("InteractiveMode transcript rebuild", () => {
 
 describe("InteractiveMode startup onboarding warnings", () => {
 	type StartupWarningHarness = {
-		shouldRunOnboarding(): boolean;
 		getCurrentModel(): AgentConnectionModel | undefined;
-		getModelFallbackWarningAction(
-			modelFallbackMessage: string | undefined,
-			startupNeededOnboarding: boolean,
-		): "show" | "suppress" | "wait";
+		getModelFallbackWarningAction(modelFallbackMessage: string | undefined): "show" | "suppress";
 	};
 
 	const getModelFallbackWarningAction = (InteractiveMode.prototype as unknown as StartupWarningHarness)
 		.getModelFallbackWarningAction;
 
-	const createHarness = (options: {
-		shouldRunOnboarding?: boolean;
-		currentModel?: AgentConnectionModel;
-	}): StartupWarningHarness => ({
-		shouldRunOnboarding: vi.fn(() => options.shouldRunOnboarding ?? false),
+	const createHarness = (options: { currentModel?: AgentConnectionModel }): StartupWarningHarness => ({
 		getCurrentModel: vi.fn(() => options.currentModel),
 		getModelFallbackWarningAction,
 	});
 
 	const liveModel = { id: "gpt-5.5", provider: "prime-inference" } as AgentConnectionModel;
 
-	test("suppresses the stale no-model warning after onboarding selects a model", () => {
-		const fakeThis = createHarness({ shouldRunOnboarding: false });
-
-		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe("suppress");
-		expect(fakeThis.shouldRunOnboarding).toHaveBeenCalledTimes(1);
-	});
-
-	test("waits to suppress the stale no-model warning while onboarding is still needed", () => {
-		const fakeThis = createHarness({ shouldRunOnboarding: true });
-
-		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), true)).toBe("wait");
-		expect(fakeThis.shouldRunOnboarding).toHaveBeenCalledTimes(1);
-	});
-
 	test("suppresses the no-model warning when the live session has a model", () => {
 		const fakeThis = createHarness({ currentModel: liveModel });
 
-		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), false)).toBe("suppress");
+		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage())).toBe("suppress");
 	});
 
 	test("shows the no-model warning when the live session has no model", () => {
 		const fakeThis = createHarness({});
 
-		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage(), false)).toBe("show");
+		expect(getModelFallbackWarningAction.call(fakeThis, formatNoModelsAvailableMessage())).toBe("show");
 	});
 
 	test("keeps real model restore fallback warnings after onboarding", () => {
-		const fakeThis = createHarness({ shouldRunOnboarding: false, currentModel: liveModel });
+		const fakeThis = createHarness({ currentModel: liveModel });
 
 		expect(
 			getModelFallbackWarningAction.call(
 				fakeThis,
 				"Could not restore model anthropic/claude-old. Using prime-inference/openai/gpt-5.5.",
-				true,
 			),
 		).toBe("show");
-		expect(fakeThis.shouldRunOnboarding).not.toHaveBeenCalled();
 	});
 });
 
@@ -973,7 +949,6 @@ describe("InteractiveMode model selection persistence", () => {
 		checkDaxnutsEasterEgg(model: AgentConnectionModel): void;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		handleModelCommand(searchTerm?: string): Promise<void>;
-		completeOnboardingIfCurrentModelReady(): void;
 		setupAutocompleteProvider(): void;
 	};
 	type ModelSelectorOverlayHarness = {
@@ -1010,7 +985,6 @@ describe("InteractiveMode model selection persistence", () => {
 			initialSearchInput?: string,
 			options?: { actions?: ReadonlyArray<unknown>; subtitle?: string },
 		): Promise<{ status: string; actionId?: string }>;
-		completeOnboardingIfCurrentModelReady(): void;
 		maybeWarnAboutAnthropicSubscriptionAuth(model: AgentConnectionModel): Promise<void>;
 		checkDaxnutsEasterEgg(model: AgentConnectionModel): void;
 		setupAutocompleteProvider(): void;
@@ -1085,7 +1059,6 @@ describe("InteractiveMode model selection persistence", () => {
 			return { hide };
 		});
 		fakeThis.showModelSelectorAsync = overlayPrototype.showModelSelectorAsync;
-		fakeThis.completeOnboardingIfCurrentModelReady = vi.fn();
 		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn(async () => {});
 		fakeThis.checkDaxnutsEasterEgg = vi.fn();
 		fakeThis.setupAutocompleteProvider = vi.fn();
@@ -1179,7 +1152,6 @@ describe("InteractiveMode model selection persistence", () => {
 		fakeThis.findExactModelMatch = vi.fn(async () => model);
 		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn(async () => {});
 		fakeThis.checkDaxnutsEasterEgg = vi.fn();
-		fakeThis.completeOnboardingIfCurrentModelReady = vi.fn();
 		fakeThis.setupAutocompleteProvider = vi.fn();
 
 		await fakeThis.handleModelCommand("gpt-5.5");
@@ -1189,7 +1161,6 @@ describe("InteractiveMode model selection persistence", () => {
 		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({ model, availableThinkingLevels: ["off"] });
 		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model: gpt-5.5");
 		expect(fakeThis.showError).not.toHaveBeenCalled();
-		expect(fakeThis.completeOnboardingIfCurrentModelReady).toHaveBeenCalledTimes(1);
 	});
 
 	test("opens the model selector before live model refresh resolves", async () => {
@@ -1526,9 +1497,9 @@ describe("InteractiveMode model selection persistence", () => {
 describe("InteractiveMode Prime CLI onboarding", () => {
 	type OnboardingHarness = {
 		shouldRunOnboarding(): boolean;
-		completeOnboarding(): void;
-		handleModelCommand(searchTerm?: string): Promise<void>;
-		runOnboardingFlow(): Promise<boolean>;
+		markOnboardingShown(): void;
+		runStartupOnboarding(): Promise<boolean>;
+		runOnboardingFlow(showPrimeCliSplash?: boolean): Promise<void>;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		setupAutocompleteProvider(): void;
 	};
@@ -1546,9 +1517,10 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 				getProviderAuthStatus: (provider: string) => AuthStatus;
 			};
 			settingsManager: {
-				getOnboardingCompleted: () => boolean;
-				setOnboardingCompleted: (completed: boolean) => void;
+				getOnboardingShown: () => boolean;
+				setOnboardingShown: (shown: boolean) => void;
 				setDefaultModelAndProvider: (provider: string, modelId: string) => void;
+				flush: () => Promise<void>;
 			};
 		};
 		footer?: { invalidate: () => void };
@@ -1562,14 +1534,12 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		showOnboardingModelSelectionSplash?: () => Promise<boolean>;
 		showOnboardingPrimeLogin?: () => Promise<{ status: string }>;
 		promptForModelSelection?: (options?: { allowProviderSetup?: boolean }) => Promise<boolean>;
-		completeOnboardingIfCurrentModelReady?: () => void;
 		getModelCandidates?: () => Promise<AgentConnectionModel[]>;
 	};
 	const shouldRunOnboarding = (InteractiveMode.prototype as unknown as OnboardingHarness).shouldRunOnboarding;
-	const completeOnboarding = (InteractiveMode.prototype as unknown as OnboardingHarness).completeOnboarding;
-	const handleModelCommand = (InteractiveMode.prototype as unknown as OnboardingHarness).handleModelCommand;
+	const markOnboardingShown = (InteractiveMode.prototype as unknown as OnboardingHarness).markOnboardingShown;
+	const runStartupOnboarding = (InteractiveMode.prototype as unknown as OnboardingHarness).runStartupOnboarding;
 	const runOnboardingFlow = (InteractiveMode.prototype as unknown as OnboardingHarness).runOnboardingFlow;
-	const applySelectedModel = (InteractiveMode.prototype as unknown as OnboardingHarness).applySelectedModel;
 
 	const primeModel: AgentConnectionModel = {
 		id: "openai/gpt-5.5",
@@ -1589,7 +1559,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		maxTokens: 128000,
 	} as AgentConnectionModel;
 
-	function createPrimeCliHarness(completed: boolean): OnboardingFake {
+	function createPrimeCliHarness(shown: boolean): OnboardingFake {
 		const fakeThis = Object.create(InteractiveMode.prototype) as OnboardingFake;
 		fakeThis.connectionState = createConnectionState({ model: primeModel });
 		fakeThis.connectionModels = [primeModel];
@@ -1608,9 +1578,10 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 				),
 			},
 			settingsManager: {
-				getOnboardingCompleted: vi.fn(() => completed),
-				setOnboardingCompleted: vi.fn(),
+				getOnboardingShown: vi.fn(() => shown),
+				setOnboardingShown: vi.fn(),
 				setDefaultModelAndProvider: vi.fn(),
+				flush: vi.fn(async () => {}),
 			},
 		};
 		fakeThis.getModelCandidates = vi.fn(async () => [primeModel]);
@@ -1624,62 +1595,55 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		expect(fakeThis.uiServices.modelRegistry.refresh).toHaveBeenCalledTimes(1);
 	});
 
-	test("skips Prime CLI onboarding after it has been completed", () => {
+	test("skips Prime CLI onboarding after it has been shown", () => {
 		const fakeThis = createPrimeCliHarness(true);
 
 		expect(shouldRunOnboarding.call(fakeThis)).toBe(false);
 	});
 
-	test("persists onboarding completion once", () => {
+	test("persists that onboarding was shown once", () => {
 		const fakeThis = createPrimeCliHarness(false);
 
-		completeOnboarding.call(fakeThis);
+		markOnboardingShown.call(fakeThis);
 
-		expect(fakeThis.uiServices.settingsManager.setOnboardingCompleted).toHaveBeenCalledWith(true);
+		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).toHaveBeenCalledWith(true);
 	});
 
-	test("manual exact model selection completes Prime CLI onboarding", async () => {
-		let completed = false;
+	test("persists onboarding before opening the one-shot flow", async () => {
+		let shown = false;
+		let flushed = false;
 		const fakeThis = createPrimeCliHarness(false);
-		fakeThis.connectionState = createConnectionState({ model: undefined });
-		fakeThis.uiServices.settingsManager.getOnboardingCompleted = vi.fn(() => completed);
-		fakeThis.uiServices.settingsManager.setOnboardingCompleted = vi.fn((nextCompleted: boolean) => {
-			completed = nextCompleted;
+		fakeThis.uiServices.settingsManager.getOnboardingShown = vi.fn(() => shown);
+		fakeThis.uiServices.settingsManager.setOnboardingShown = vi.fn((nextShown: boolean) => {
+			shown = nextShown;
 		});
-		fakeThis.agentConnection.setModel = vi.fn(async (_provider: string, _modelId: string) => {
-			fakeThis.connectionState = { ...fakeThis.connectionState, model: primeModel };
+		fakeThis.uiServices.settingsManager.flush = vi.fn(async () => {
+			flushed = true;
 		});
-		fakeThis.findExactModelMatch = vi.fn(async () => primeModel);
-		fakeThis.footer = { invalidate: vi.fn() };
-		fakeThis.updateEditorBorderColor = vi.fn();
-		fakeThis.patchConnectionState = vi.fn((patch: Partial<AgentConnectionState>) => {
-			fakeThis.connectionState = { ...fakeThis.connectionState, ...patch };
+		fakeThis.runOnboardingFlow = vi.fn(async (showPrimeCliSplash?: boolean) => {
+			expect(showPrimeCliSplash).toBe(true);
+			expect(shown).toBe(true);
+			expect(flushed).toBe(true);
 		});
-		fakeThis.showStatus = vi.fn();
-		fakeThis.showError = vi.fn();
-		fakeThis.maybeWarnAboutAnthropicSubscriptionAuth = vi.fn();
-		fakeThis.checkDaxnutsEasterEgg = vi.fn();
-		fakeThis.applySelectedModel = applySelectedModel;
-		fakeThis.setupAutocompleteProvider = vi.fn();
 
-		await handleModelCommand.call(fakeThis, "prime-inference/openai/gpt-5.5");
+		await expect(runStartupOnboarding.call(fakeThis)).resolves.toBe(true);
 
-		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith(PRIME_INFERENCE_PROVIDER_ID, "openai/gpt-5.5");
-		expect(fakeThis.uiServices.settingsManager.setOnboardingCompleted).toHaveBeenCalledWith(true);
-		expect(shouldRunOnboarding.call(fakeThis)).toBe(false);
+		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).toHaveBeenCalledWith(true);
+		expect(fakeThis.uiServices.settingsManager.flush).toHaveBeenCalledTimes(1);
+		expect(fakeThis.runOnboardingFlow).toHaveBeenCalledWith(true);
 	});
 
-	test("cancelled model picker does not complete Prime CLI onboarding", async () => {
+	test("cancelled model picker exits onboarding without a required-selection warning", async () => {
 		const fakeThis = createPrimeCliHarness(false);
 		fakeThis.showOnboardingModelSelectionSplash = vi.fn(async () => true);
 		fakeThis.promptForModelSelection = vi.fn(async () => false);
 		fakeThis.showStatus = vi.fn();
 
-		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBe(false);
+		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBeUndefined();
 
 		expect(fakeThis.promptForModelSelection).toHaveBeenCalledWith({ allowProviderSetup: true });
-		expect(fakeThis.uiServices.settingsManager.setOnboardingCompleted).not.toHaveBeenCalled();
-		expect(fakeThis.showStatus).toHaveBeenCalledWith("Model selection required. Use /model to continue.");
+		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).not.toHaveBeenCalled();
+		expect(fakeThis.showStatus).not.toHaveBeenCalled();
 	});
 
 	test("uses live connection models before falling back to Prime login during onboarding", async () => {
@@ -1689,7 +1653,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		fakeThis.promptForModelSelection = vi.fn(async () => true);
 		fakeThis.showOnboardingPrimeLogin = vi.fn(async () => ({ status: "success" }));
 
-		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBe(true);
+		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBeUndefined();
 
 		expect(fakeThis.getModelCandidates).toHaveBeenCalledTimes(1);
 		expect(fakeThis.promptForModelSelection).toHaveBeenCalledWith({ allowProviderSetup: true });
@@ -1707,11 +1671,46 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		fakeThis.promptForModelSelection = vi.fn(async () => false);
 		fakeThis.showStatus = vi.fn();
 
-		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBe(true);
+		await expect(runOnboardingFlow.call(fakeThis)).resolves.toBeUndefined();
 
 		expect(fakeThis.promptForModelSelection).toHaveBeenCalledWith({ allowProviderSetup: true });
-		expect(fakeThis.uiServices.settingsManager.setOnboardingCompleted).not.toHaveBeenCalled();
+		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).not.toHaveBeenCalled();
 		expect(fakeThis.showStatus).not.toHaveBeenCalled();
+	});
+});
+
+describe("InteractiveMode explicit login", () => {
+	type LoginHarness = {
+		showOAuthSelector(mode: "login" | "logout"): Promise<void>;
+		showLoginProviderSelector(): Promise<{
+			status: "success";
+			providerId: string;
+			providerName: string;
+			authType: "oauth";
+			kind: "provider";
+		}>;
+		invalidateConnectionModels(): void;
+		promptForModelSelection(): Promise<boolean>;
+	};
+
+	const showOAuthSelector = (InteractiveMode.prototype as unknown as LoginHarness).showOAuthSelector;
+
+	test("does not open model selection after provider login", async () => {
+		const fakeThis = Object.create(InteractiveMode.prototype) as LoginHarness;
+		fakeThis.showLoginProviderSelector = vi.fn(async () => ({
+			status: "success" as const,
+			providerId: "anthropic",
+			providerName: "Anthropic",
+			authType: "oauth" as const,
+			kind: "provider" as const,
+		}));
+		fakeThis.invalidateConnectionModels = vi.fn();
+		fakeThis.promptForModelSelection = vi.fn(async () => true);
+
+		await showOAuthSelector.call(fakeThis, "login");
+
+		expect(fakeThis.invalidateConnectionModels).toHaveBeenCalledTimes(1);
+		expect(fakeThis.promptForModelSelection).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1594,6 +1594,43 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		maxTokens: 128000,
 	} as AgentConnectionModel;
 
+	test("defers CLI initial prompts until a model is selected after onboarding dismissal", async () => {
+		let currentModel: AgentConnectionModel | undefined;
+		const prompt = vi.fn(async () => {});
+		const getUserInput = vi
+			.fn<() => Promise<string | undefined>>()
+			.mockImplementationOnce(async () => {
+				currentModel = primeModel;
+				return "interactive prompt";
+			})
+			.mockResolvedValueOnce(undefined);
+		const fakeThis = {
+			init: vi.fn(async () => {}),
+			options: {
+				agentsViewOwnsStartupNotices: true,
+				initialMessage: "initial prompt",
+			},
+			modelRegistry: { getError: vi.fn(() => undefined) },
+			runStartupOnboarding: vi.fn(async () => true),
+			getModelFallbackWarningAction: vi.fn(() => "suppress"),
+			getCurrentModel: vi.fn(() => currentModel),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
+			getUserInput,
+			collectImagesFor: vi.fn(() => []),
+			agentConnection: { prompt },
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+			returnToAgentsViewRequested: false,
+			sessionHasMessages: false,
+		};
+
+		await expect(InteractiveMode.prototype.run.call(fakeThis as never)).resolves.toBe("agents_view");
+
+		expect(prompt).toHaveBeenNthCalledWith(1, "initial prompt", { images: undefined });
+		expect(prompt).toHaveBeenNthCalledWith(2, "interactive prompt", { images: [] });
+		expect(prompt).toHaveBeenCalledTimes(2);
+	});
+
 	function createPrimeCliHarness(shown: boolean): OnboardingFake {
 		const fakeThis = Object.create(InteractiveMode.prototype) as OnboardingFake;
 		fakeThis.connectionState = createConnectionState({ model: primeModel });

--- a/packages/coding-agent/test/onboarding-startup.test.ts
+++ b/packages/coding-agent/test/onboarding-startup.test.ts
@@ -13,14 +13,14 @@ function makeModel(provider: string): Model<Api> {
 }
 
 function makeState(overrides: {
-	onboardingCompleted: boolean;
+	onboardingShown: boolean;
 	model: Model<Api> | undefined;
 	modelHasAuth?: boolean;
 	primeAuthSource?: AuthStatus["source"];
 }): OnboardingStartupState {
 	return {
 		settingsManager: {
-			getOnboardingCompleted: () => overrides.onboardingCompleted,
+			getOnboardingShown: () => overrides.onboardingShown,
 		},
 		modelRegistry: {
 			refresh: () => {},
@@ -37,7 +37,7 @@ function makeState(overrides: {
 describe("startup onboarding decision", () => {
 	test("runs onboarding on first launch with Prime CLI auth", () => {
 		const state = makeState({
-			onboardingCompleted: false,
+			onboardingShown: false,
 			model: makeModel(PRIME_INFERENCE_PROVIDER_ID),
 			modelHasAuth: true,
 			primeAuthSource: "prime_cli",
@@ -46,21 +46,23 @@ describe("startup onboarding decision", () => {
 		expect(shouldRunOnboarding(state)).toBe(true);
 	});
 
-	test("runs onboarding when no model is available", () => {
-		expect(shouldRunOnboarding(makeState({ onboardingCompleted: true, model: undefined }))).toBe(true);
+	test("runs onboarding on first launch when no model is available", () => {
+		expect(shouldRunOnboarding(makeState({ onboardingShown: false, model: undefined }))).toBe(true);
 	});
 
-	test("runs onboarding when the current model has no configured auth", () => {
+	test("does not reopen onboarding after dismissal when the current model has no local auth", () => {
 		expect(
-			shouldRunOnboarding(
-				makeState({ onboardingCompleted: true, model: makeModel("anthropic"), modelHasAuth: false }),
-			),
-		).toBe(true);
+			shouldRunOnboarding(makeState({ onboardingShown: true, model: makeModel("anthropic"), modelHasAuth: false })),
+		).toBe(false);
+	});
+
+	test("does not reopen onboarding after dismissal when no model is available", () => {
+		expect(shouldRunOnboarding(makeState({ onboardingShown: true, model: undefined }))).toBe(false);
 	});
 
 	test("skips onboarding once completed with a ready model", () => {
 		const state = makeState({
-			onboardingCompleted: true,
+			onboardingShown: true,
 			model: makeModel(PRIME_INFERENCE_PROVIDER_ID),
 			modelHasAuth: true,
 			primeAuthSource: "prime_cli",
@@ -71,7 +73,7 @@ describe("startup onboarding decision", () => {
 
 	test("skips the Prime CLI splash for non-Prime providers with ready auth", () => {
 		const state = makeState({
-			onboardingCompleted: false,
+			onboardingShown: false,
 			model: makeModel("anthropic"),
 			modelHasAuth: true,
 			primeAuthSource: "stored",

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -197,18 +197,24 @@ describe("SettingsManager", () => {
 		});
 	});
 
-	describe("onboardingCompleted", () => {
+	describe("onboardingShown", () => {
 		it("defaults to false and persists globally", async () => {
 			const manager = SettingsManager.create(projectDir, agentDir);
 
-			expect(manager.getOnboardingCompleted()).toBe(false);
+			expect(manager.getOnboardingShown()).toBe(false);
 
-			manager.setOnboardingCompleted(true);
+			manager.setOnboardingShown(true);
 			await manager.flush();
 
 			const savedSettings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
-			expect(savedSettings.onboardingCompleted).toBe(true);
-			expect(manager.getOnboardingCompleted()).toBe(true);
+			expect(savedSettings.onboardingShown).toBe(true);
+			expect(manager.getOnboardingShown()).toBe(true);
+		});
+
+		it("treats the legacy completion field as already shown", () => {
+			const manager = SettingsManager.inMemory({ onboardingCompleted: true });
+
+			expect(manager.getOnboardingShown()).toBe(true);
 		});
 	});
 

--- a/packages/coding-agent/test/suite/regressions/4537-nonblocking-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4537-nonblocking-onboarding.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { shouldRunOnboarding } from "../../../src/modes/interactive/onboarding.js";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("ENG-4537 non-blocking onboarding", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) {
+			harness.cleanup();
+		}
+	});
+
+	test("never reopens shown onboarding for a client-local auth mismatch", async () => {
+		const harness = await createHarness({
+			settings: { onboardingShown: true },
+			withConfiguredAuth: false,
+		});
+		harnesses.push(harness);
+
+		expect(
+			shouldRunOnboarding({
+				settingsManager: harness.settingsManager,
+				modelRegistry: harness.session.modelRegistry,
+				model: harness.session.model,
+			}),
+		).toBe(false);
+	});
+
+	test("never reopens shown onboarding when the daemon session has no model", async () => {
+		const harness = await createHarness({
+			settings: { onboardingShown: true },
+			withConfiguredAuth: false,
+		});
+		harnesses.push(harness);
+
+		expect(
+			shouldRunOnboarding({
+				settingsManager: harness.settingsManager,
+				modelRegistry: harness.session.modelRegistry,
+				model: undefined,
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
- onboarding is now a one-time offer and never blocks prompts or later tui launches.
- explicit login no longer opens model selection, keeping setup commands independent.
- added migration and regression coverage for existing users, auth mismatches, and missing models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run and auth/model startup paths for all interactive users; behavior change is intentional but wrong persistence or prompt timing could affect new sessions and CLI launches.
> 
> **Overview**
> Onboarding is now a **one-time offer** instead of a gate: settings track `onboardingShown` (with legacy `onboardingCompleted` treated as already shown), the flag is **persisted and flushed before** the splash/login/model UI runs, and **`shouldRunOnboarding` never runs again** after dismissal—even with missing models or auth mismatches.
> 
> The interactive loop **no longer blocks** on onboarding completion: `ensurePromptReady` and “complete onboarding when model is ready” paths are removed, cancelled pickers no longer show “model selection required,” and **CLI initial prompts wait until a model exists** before sending. Model fallback warnings drop the **`wait`** state and show or suppress immediately.
> 
> **`/login`** still refreshes the model catalog but **no longer auto-opens** the model selector; users pick a model via `/model` when they want.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a25fe196a9773b1ac9867bd807bfd96596a53dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop onboarding from blocking normal TUI use after first display
> - Introduces a new `onboardingShown` settings flag (alongside the legacy `onboardingCompleted`) to track whether onboarding has been presented, decoupling display state from completion state.
> - Replaces the blocking onboarding sequence in `InteractiveMode.run` with a non-blocking `runStartupOnboarding` helper that records onboarding as shown and then returns, allowing the prompt loop to proceed immediately.
> - Onboarding (login, model selection) no longer reopens after it has been shown once, even if no model is configured or auth is missing.
> - After a successful OAuth login, the model selector no longer opens automatically.
> - Behavioral Change: `ModelFallbackWarningAction` drops the `wait` state; the warning decision is now always immediate (`show` or `suppress`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a25fe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->