### PR TITLE
fix ipython restore message rendering

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed steering and follow-up queues to preserve grouped messages as an atomic batch.
+
 ## [0.2.8] - 2026-07-09
 
 - Fixed abort settling for provider streams and tool executions that ignore cancellation ([ENG-4490](https://linear.app/primeintellect/issue/ENG-4490)).

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -116,48 +116,51 @@ export interface AgentOptions {
 }
 
 class PendingMessageQueue {
-	private messages: AgentMessage[] = [];
+	private batches: AgentMessage[][] = [];
 
 	constructor(public mode: QueueMode) {}
 
-	enqueue(message: AgentMessage): void {
-		this.messages.push(message);
+	enqueue(message: AgentMessage | AgentMessage[]): void {
+		const batch = Array.isArray(message) ? message.slice() : [message];
+		if (batch.length > 0) {
+			this.batches.push(batch);
+		}
 	}
 
 	hasItems(): boolean {
-		return this.messages.length > 0;
+		return this.batches.length > 0;
 	}
 
 	drain(): AgentMessage[] {
 		if (this.mode === "all") {
-			const drained = this.messages.slice();
-			this.messages = [];
+			const drained = this.batches.flat();
+			this.batches = [];
 			return drained;
 		}
 
-		const first = this.messages[0];
+		const first = this.batches[0];
 		if (!first) {
 			return [];
 		}
-		this.messages = this.messages.slice(1);
-		return [first];
+		this.batches = this.batches.slice(1);
+		return first;
 	}
 
 	clear(): void {
-		this.messages = [];
+		this.batches = [];
 	}
 
 	removeWhere(predicate: (message: AgentMessage) => boolean): AgentMessage[] {
 		const removed: AgentMessage[] = [];
-		const retained: AgentMessage[] = [];
-		for (const message of this.messages) {
-			if (predicate(message)) {
-				removed.push(message);
+		const retained: AgentMessage[][] = [];
+		for (const batch of this.batches) {
+			if (batch.some(predicate)) {
+				removed.push(...batch);
 			} else {
-				retained.push(message);
+				retained.push(batch);
 			}
 		}
-		this.messages = retained;
+		this.batches = retained;
 		return removed;
 	}
 }
@@ -274,13 +277,13 @@ export class Agent {
 		return this.followUpQueue.mode;
 	}
 
-	/** Queue a message to be injected after the current assistant turn finishes. */
-	steer(message: AgentMessage): void {
+	/** Queue a message batch to be injected after the current assistant turn finishes. */
+	steer(message: AgentMessage | AgentMessage[]): void {
 		this.steeringQueue.enqueue(message);
 	}
 
-	/** Queue a message to run only after the agent would otherwise stop. */
-	followUp(message: AgentMessage): void {
+	/** Queue a message batch to run only after the agent would otherwise stop. */
+	followUp(message: AgentMessage | AgentMessage[]): void {
 		this.followUpQueue.enqueue(message);
 	}
 
@@ -300,7 +303,7 @@ export class Agent {
 		this.clearFollowUpQueue();
 	}
 
-	/** Remove queued messages matching the predicate from both queues. */
+	/** Remove queued batches containing a message matching the predicate from both queues. */
 	removeQueuedMessages(predicate: (message: AgentMessage) => boolean): AgentMessage[] {
 		return [...this.steeringQueue.removeWhere(predicate), ...this.followUpQueue.removeWhere(predicate)];
 	}

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -615,6 +615,46 @@ describe("Agent", () => {
 		expect(responseCount).toBe(2);
 	});
 
+	it("keeps queued message batches atomic in one-at-a-time mode", async () => {
+		const agent = new Agent({
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("Processed") });
+				});
+				return stream;
+			},
+		});
+		const prefix = { role: "user" as const, content: "Prefix", timestamp: Date.now() };
+		const prompt = { role: "user" as const, content: "Prompt", timestamp: Date.now() + 1 };
+		const next = { role: "user" as const, content: "Next", timestamp: Date.now() + 2 };
+		agent.state.messages = [createAssistantMessage("Initial response")];
+		agent.followUp([prefix, prompt]);
+		agent.followUp(next);
+
+		await agent.continue();
+
+		expect(agent.state.messages.slice(1).map((message) => message.role)).toEqual([
+			"user",
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+		]);
+	});
+
+	it("removes a whole queued batch when one message matches", () => {
+		const agent = new Agent();
+		const prefix = { role: "user" as const, content: "Prefix", timestamp: Date.now() };
+		const prompt = { role: "user" as const, content: "Prompt", timestamp: Date.now() + 1 };
+		const next = { role: "user" as const, content: "Next", timestamp: Date.now() + 2 };
+		agent.followUp([prefix, prompt]);
+		agent.followUp(next);
+
+		expect(agent.removeQueuedMessages((message) => message === prompt)).toEqual([prefix, prompt]);
+		expect(agent.hasQueuedMessages()).toBe(true);
+	});
+
 	it("forwards sessionId to streamFn options", async () => {
 		let receivedSessionId: string | undefined;
 		const agent = new Agent({

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed IPython state restore notices rendering as full user messages when prompts were queued or restored ([ENG-4530](https://linear.app/primeintellect/issue/ENG-4530/collapse-ipython-state-restore-messages-in-chat-tui)).
 - Added `/btw` and `/side` for one-turn inline side questions that use the current context without changing the main session ([ENG-4509](https://linear.app/primeintellect/issue/ENG-4509/add-btw-and-side-side-question-flows)).
 - Changed scheduled heartbeat prompts to steer (interrupt the current turn) by default, with a `steer`/`follow_up` delivery mode selectable via `/heartbeat --steer|--follow-up` and the `rlm_heartbeat` skill's `delivery_mode` argument.
 - Changed the new-chat splash to show only version, model, and cwd metadata and rotate among five example prompts.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6345,16 +6345,21 @@ export class AgentSession {
 			await this.agent.prompt([...nextTurnMessages, ...queuedMessages]);
 			await this.waitForRetry();
 		} catch {
-			this._pendingNextTurnMessages.unshift(...nextTurnMessages.map((message) => ({ ...message })));
+			const deliveredMessages = new Set(this.agent.state.messages);
+			this._pendingNextTurnMessages.unshift(
+				...nextTurnMessages.filter((message) => !deliveredMessages.has(message)).map((message) => ({ ...message })),
+			);
 			const queuedSteering = new Set(this._steeringMessages.map((message) => message.message));
 			const queuedFollowUps = new Set(this._followUpMessages.map((message) => message.message));
 			for (const queued of drainedSteeringMessages) {
-				if (queuedSteering.has(queued.message)) {
+				queued.prefixMessages = queued.prefixMessages.filter((message) => !deliveredMessages.has(message));
+				if (queuedSteering.has(queued.message) && !deliveredMessages.has(queued.message)) {
 					this.agent.steer([...queued.prefixMessages, queued.message]);
 				}
 			}
 			for (const queued of drainedFollowUpMessages) {
-				if (queuedFollowUps.has(queued.message)) {
+				queued.prefixMessages = queued.prefixMessages.filter((message) => !deliveredMessages.has(message));
+				if (queuedFollowUps.has(queued.message) && !deliveredMessages.has(queued.message)) {
 					this.agent.followUp([...queued.prefixMessages, queued.message]);
 				}
 			}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -149,6 +149,7 @@ import {
 	createHeartbeatPromptMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
+	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -419,6 +420,7 @@ interface QueuedSteeringMessage {
 	previewLabel?: string;
 	queueKey?: string;
 	agentMessageId?: string;
+	prefixMessages: CustomMessage[];
 	message: QueuedAgentMessage;
 }
 
@@ -427,6 +429,7 @@ interface QueuedFollowUpMessage {
 	previewLabel?: string;
 	queueKey?: string;
 	agentMessageId?: string;
+	prefixMessages: CustomMessage[];
 	message: QueuedAgentMessage;
 }
 
@@ -437,6 +440,7 @@ export interface QueuedAgentInputSnapshot {
 	queueKey?: string;
 	agentMessageId?: string;
 	customMessage?: CustomMessage;
+	prefixMessages?: CustomMessage[];
 }
 
 export interface AcceptedAgentInputSnapshot extends QueuedAgentInputSnapshot {
@@ -472,6 +476,9 @@ function createQueuedAgentInputSnapshot(
 	const snapshot = createQueuedAgentInputSnapshotFromUserMessage(message.text, message.message);
 	return {
 		...snapshot,
+		...(message.prefixMessages.length > 0
+			? { prefixMessages: message.prefixMessages.map((prefix) => cloneCustomMessage(prefix)) }
+			: {}),
 		...(message.agentMessageId ? { agentMessageId: message.agentMessageId } : {}),
 		...("queueKey" in message && message.queueKey ? { queueKey: message.queueKey } : {}),
 	};
@@ -3095,6 +3102,7 @@ export class AgentSession {
 			agentMessageId?: string;
 			content?: (TextContent | ImageContent)[];
 			customMessage?: CustomMessage;
+			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<void> {
 		await this._queueSteer(text, images, {
@@ -3102,6 +3110,7 @@ export class AgentSession {
 			agentMessageId: options.agentMessageId,
 			content: options.content,
 			message: options.customMessage,
+			prefixMessages: options.prefixMessages,
 		});
 	}
 
@@ -3113,6 +3122,7 @@ export class AgentSession {
 			agentMessageId?: string;
 			content?: (TextContent | ImageContent)[];
 			customMessage?: CustomMessage;
+			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<boolean> {
 		return this._queueFollowUp(text, images, {
@@ -3120,22 +3130,12 @@ export class AgentSession {
 			agentMessageId: options.agentMessageId,
 			content: options.content,
 			message: options.customMessage,
+			prefixMessages: options.prefixMessages,
 		});
 	}
 
-	private _buildPromptContent(
-		text: string,
-		images?: ImageContent[],
-		prefixMessages: readonly CustomMessage[] = [],
-	): (TextContent | ImageContent)[] {
+	private _buildPromptContent(text: string, images?: ImageContent[]): (TextContent | ImageContent)[] {
 		const content: (TextContent | ImageContent)[] = [];
-		for (const message of prefixMessages) {
-			if (typeof message.content === "string") {
-				content.push({ type: "text", text: message.content });
-			} else {
-				content.push(...message.content);
-			}
-		}
 		content.push({ type: "text", text });
 		if (images) {
 			content.push(...images);
@@ -3151,19 +3151,21 @@ export class AgentSession {
 	): Promise<boolean> {
 		const pendingNextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
-		const content = this._buildPromptContent(text, images, pendingNextTurnMessages);
 		try {
 			if (streamingBehavior === "followUp") {
-				const queued = await this._queueFollowUp(text, undefined, { ...options, content });
+				const queued = await this._queueFollowUp(text, images, {
+					...options,
+					prefixMessages: pendingNextTurnMessages,
+				});
 				if (!queued) {
 					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 				}
 				return queued;
 			}
-			await this._queueSteer(text, undefined, {
+			await this._queueSteer(text, images, {
 				agentMessageId: options.agentMessageId,
 				queueKey: options.queueKey,
-				content,
+				prefixMessages: pendingNextTurnMessages,
 			});
 			return true;
 		} catch (error) {
@@ -3180,15 +3182,12 @@ export class AgentSession {
 	): Promise<boolean> {
 		const pendingNextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
-		const queuedMessage: CustomMessage = {
-			...message,
-			content: this._buildPromptContent(text, undefined, pendingNextTurnMessages),
-		};
 		try {
 			if (streamingBehavior === "followUp") {
 				const queued = await this._queueFollowUp(text, undefined, {
 					queueKey: options.queueKey,
-					message: queuedMessage,
+					message,
+					prefixMessages: pendingNextTurnMessages,
 					previewLabel: options.previewLabel,
 				});
 				if (!queued) {
@@ -3197,7 +3196,8 @@ export class AgentSession {
 				return queued;
 			}
 			await this._queueSteer(text, undefined, {
-				message: queuedMessage,
+				message,
+				prefixMessages: pendingNextTurnMessages,
 				previewLabel: options.previewLabel,
 				queueKey: options.queueKey,
 			});
@@ -3219,6 +3219,7 @@ export class AgentSession {
 			queueKey?: string;
 			content?: (TextContent | ImageContent)[];
 			message?: QueuedAgentMessage;
+			prefixMessages?: CustomMessage[];
 			previewLabel?: string;
 		} = {},
 	): Promise<void> {
@@ -3235,9 +3236,10 @@ export class AgentSession {
 			previewLabel: options.previewLabel,
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
+			prefixMessages: options.prefixMessages ?? [],
 			message,
 		});
-		this.agent.steer(message);
+		this.agent.steer(options.prefixMessages?.length ? [...options.prefixMessages, message] : message);
 		this._emitQueueUpdate();
 	}
 
@@ -3252,6 +3254,7 @@ export class AgentSession {
 			agentMessageId?: string;
 			content?: (TextContent | ImageContent)[];
 			message?: QueuedAgentMessage;
+			prefixMessages?: CustomMessage[];
 			previewLabel?: string;
 		} = {},
 	): Promise<boolean> {
@@ -3271,9 +3274,10 @@ export class AgentSession {
 			previewLabel: options.previewLabel,
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
+			prefixMessages: options.prefixMessages ?? [],
 			message,
 		});
-		this.agent.followUp(message);
+		this.agent.followUp(options.prefixMessages?.length ? [...options.prefixMessages, message] : message);
 		this._emitQueueUpdate();
 		return true;
 	}
@@ -3917,9 +3921,10 @@ export class AgentSession {
 		lines.push("</ipython_state_restored>");
 		void this.sendCustomMessage(
 			{
-				customType: "ipython_state_restored",
+				customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
 				content: lines.join("\n"),
-				display: false,
+				display: true,
+				details: { restored: result.restored.length > 0 },
 			},
 			{ deliverAs: "nextTurn" },
 		).catch(() => {});
@@ -6323,7 +6328,10 @@ export class AgentSession {
 		const followUpMessages = [...this._followUpMessages];
 		const drainedSteeringMessages = steeringMessages.length > 0 ? steeringMessages : [];
 		const drainedFollowUpMessages = steeringMessages.length > 0 ? [] : followUpMessages;
-		const queuedMessages = [...drainedSteeringMessages, ...drainedFollowUpMessages].map((message) => message.message);
+		const queuedMessages = [...drainedSteeringMessages, ...drainedFollowUpMessages].flatMap((message) => [
+			...message.prefixMessages,
+			message.message,
+		]);
 		if (queuedMessages.length === 0) {
 			return;
 		}
@@ -6342,12 +6350,12 @@ export class AgentSession {
 			const queuedFollowUps = new Set(this._followUpMessages.map((message) => message.message));
 			for (const queued of drainedSteeringMessages) {
 				if (queuedSteering.has(queued.message)) {
-					this.agent.steer(queued.message);
+					this.agent.steer([...queued.prefixMessages, queued.message]);
 				}
 			}
 			for (const queued of drainedFollowUpMessages) {
 				if (queuedFollowUps.has(queued.message)) {
-					this.agent.followUp(queued.message);
+					this.agent.followUp([...queued.prefixMessages, queued.message]);
 				}
 			}
 		}

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -26,6 +26,7 @@ export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
 
 export const HEARTBEAT_PROMPT_CUSTOM_TYPE = "heartbeat_prompt";
 export const HEARTBEAT_PROMPT_PREVIEW_LABEL = "Heartbeat prompt";
+export const IPYTHON_STATE_RESTORED_CUSTOM_TYPE = "ipython_state_restored";
 
 /**
  * Message type for bash executions via the ! command.
@@ -63,6 +64,10 @@ export interface HeartbeatPromptDetails {
 	runCount: number;
 	nextRunAt?: string;
 	lastRunAt?: string;
+}
+
+export interface IpythonStateRestoredDetails {
+	restored: boolean;
 }
 
 export interface BranchSummaryMessage {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1666,6 +1666,7 @@ export class AgentDaemon {
 						agentMessageId: command.agentMessageId,
 						content: command.content,
 						customMessage: command.customMessage,
+						prefixMessages: command.prefixMessages,
 					});
 				} else {
 					await state.runtime.session.steer(command.message, command.images, {
@@ -1685,6 +1686,7 @@ export class AgentDaemon {
 						agentMessageId: command.agentMessageId,
 						content: command.content,
 						customMessage: command.customMessage,
+						prefixMessages: command.prefixMessages,
 					});
 				} else {
 					queued = await state.runtime.session.followUp(command.message, command.images, {
@@ -2597,6 +2599,7 @@ export class AgentDaemon {
 				...(message.queueKey ? { queueKey: message.queueKey } : {}),
 				...(message.agentMessageId ? { agentMessageId: message.agentMessageId } : {}),
 				...(message.customMessage ? { customMessage: message.customMessage } : {}),
+				...(message.prefixMessages ? { prefixMessages: message.prefixMessages } : {}),
 			})),
 			followUp: [...session.getFollowUpQueueSnapshots()].map((message) => ({
 				message: message.text,
@@ -2605,6 +2608,7 @@ export class AgentDaemon {
 				...(message.queueKey ? { queueKey: message.queueKey } : {}),
 				...(message.agentMessageId ? { agentMessageId: message.agentMessageId } : {}),
 				...(message.customMessage ? { customMessage: message.customMessage } : {}),
+				...(message.prefixMessages ? { prefixMessages: message.prefixMessages } : {}),
 			})),
 			nextTurn: [...session.getPendingNextTurnMessageSnapshots()],
 		};

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -196,6 +196,7 @@ export interface DaemonUpdateRestartQueuedMessage {
 	queueKey?: string;
 	agentMessageId?: string;
 	customMessage?: CustomMessage;
+	prefixMessages?: CustomMessage[];
 }
 
 export interface DaemonUpdateRestartAcceptedPrompt extends DaemonUpdateRestartQueuedMessage {
@@ -289,6 +290,7 @@ export type DaemonCommand =
 			expandPromptTemplates?: boolean;
 			agentMessageId?: string;
 			customMessage?: CustomMessage;
+			prefixMessages?: CustomMessage[];
 	  }
 	| {
 			id?: string;
@@ -301,6 +303,7 @@ export type DaemonCommand =
 			expandPromptTemplates?: boolean;
 			agentMessageId?: string;
 			customMessage?: CustomMessage;
+			prefixMessages?: CustomMessage[];
 	  }
 	| { id?: string; type: "restore_next_turn"; activeSessionId: string; messages: CustomMessage[] }
 	| { id?: string; type: "resume_queue"; activeSessionId: string }

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -13,17 +13,21 @@ import {
 	type CustomMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	type HeartbeatPromptDetails,
+	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+	type IpythonStateRestoredDetails,
 } from "../../../core/messages.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 import { keyText } from "./keybinding-hints.js";
 
-type InjectedPromptDetails = GoalContextDetails | HeartbeatPromptDetails;
+type InjectedPromptDetails = GoalContextDetails | HeartbeatPromptDetails | IpythonStateRestoredDetails;
 type InjectedPromptMessage = CustomMessage<InjectedPromptDetails>;
 
 export function isInjectedPromptMessage(message: AgentMessage): message is InjectedPromptMessage {
 	return (
 		message.role === "custom" &&
-		(message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE || message.customType === GOAL_CONTEXT_CUSTOM_TYPE)
+		(message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE ||
+			message.customType === GOAL_CONTEXT_CUSTOM_TYPE ||
+			message.customType === IPYTHON_STATE_RESTORED_CUSTOM_TYPE)
 	);
 }
 
@@ -96,7 +100,7 @@ export class InjectedPromptMessageComponent extends Container {
 		this.content.clear();
 		this.header.setText(this.headerText());
 		this.content.addChild(this.header);
-		if (this.expanded) {
+		if (this.expanded && this.message.customType !== IPYTHON_STATE_RESTORED_CUSTOM_TYPE) {
 			this.content.addChild(
 				new Markdown(readCustomText(this.message), 1, 0, this.markdownTheme, {
 					color: (text: string) => theme.fg("customMessageText", text),
@@ -109,6 +113,13 @@ export class InjectedPromptMessageComponent extends Container {
 	private headerText(): string {
 		if (this.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
 			return this.heartbeatHeaderText();
+		}
+		if (this.message.customType === IPYTHON_STATE_RESTORED_CUSTOM_TYPE) {
+			const details = this.message.details as IpythonStateRestoredDetails | undefined;
+			return theme.fg(
+				"muted",
+				details?.restored === false ? "Started fresh IPython kernel" : "Restored IPython kernel state",
+			);
 		}
 
 		const details = this.message.details;

--- a/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/injected-prompt-message.ts
@@ -116,10 +116,8 @@ export class InjectedPromptMessageComponent extends Container {
 		}
 		if (this.message.customType === IPYTHON_STATE_RESTORED_CUSTOM_TYPE) {
 			const details = this.message.details as IpythonStateRestoredDetails | undefined;
-			return theme.fg(
-				"muted",
-				details?.restored === false ? "Started fresh IPython kernel" : "Restored IPython kernel state",
-			);
+			const label = details?.restored === false ? "Started fresh IPython kernel" : "Restored IPython kernel state";
+			return `${theme.fg("accent", "◆")} ${theme.fg("muted", label)}`;
 		}
 
 		const details = this.message.details;

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -505,6 +505,7 @@ function parseDaemonUpdateRestartQueuedMessage(value: unknown): DaemonUpdateRest
 	const content = readOptionalMessageContent(value.content, "queue.content");
 	const images = readOptionalImages(value.images, "queue.images");
 	const queueKey = readOptionalString(value.queueKey, "queue.queueKey");
+	const prefixMessages = readCustomMessages(value.prefixMessages, "queue.prefixMessages");
 	const customMessage =
 		value.customMessage === undefined
 			? undefined
@@ -523,6 +524,7 @@ function parseDaemonUpdateRestartQueuedMessage(value: unknown): DaemonUpdateRest
 		...(queueKey ? { queueKey } : {}),
 		...(agentMessageId ? { agentMessageId } : {}),
 		...(customMessage ? { customMessage } : {}),
+		...(prefixMessages.length > 0 ? { prefixMessages } : {}),
 	};
 }
 
@@ -838,6 +840,7 @@ async function restoreDaemonUpdateRestartSession(
 				expandPromptTemplates: false,
 				agentMessageId: queued.agentMessageId,
 				customMessage: queued.customMessage,
+				prefixMessages: queued.prefixMessages,
 			},
 			30000,
 		);
@@ -863,6 +866,7 @@ async function restoreDaemonUpdateRestartSession(
 				expandPromptTemplates: false,
 				agentMessageId: queued.agentMessageId,
 				customMessage: queued.customMessage,
+				prefixMessages: queued.prefixMessages,
 			},
 			30000,
 		);

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -37,6 +37,7 @@ interface MockQueuedMessage {
 	agentMessageId?: string;
 	queueKey?: string;
 	customMessage?: MockCustomMessage;
+	prefixMessages?: MockCustomMessage[];
 }
 
 interface MockUpdateRestartSession {
@@ -72,6 +73,7 @@ interface MockDaemonRequest {
 	message?: string;
 	agentMessageId?: string;
 	customMessage?: MockCustomMessage;
+	prefixMessages?: MockCustomMessage[];
 	content?: unknown;
 	messages?: MockCustomMessage[];
 	queueKey?: string;
@@ -552,11 +554,18 @@ describe("self-update daemon restart", () => {
 		}
 	});
 
-	it("preserves queued custom messages when restoring update restart queues", async () => {
+	it("preserves queued custom messages and prefixes when restoring update restart queues", async () => {
 		const customMessage: MockCustomMessage = {
 			role: "custom",
 			customType: "heartbeat_prompt",
 			content: "heartbeat body",
+			display: true,
+			timestamp: Date.now(),
+		};
+		const prefixMessage: MockCustomMessage = {
+			role: "custom",
+			customType: "ipython_state_restored",
+			content: "restore context",
 			display: true,
 			timestamp: Date.now(),
 		};
@@ -577,6 +586,7 @@ describe("self-update daemon restart", () => {
 								queueKey: "heartbeat:job-1",
 								agentMessageId: "agentmsg_followup",
 								customMessage,
+								prefixMessages: [prefixMessage],
 							},
 						],
 						nextTurn: [],
@@ -605,6 +615,7 @@ describe("self-update daemon restart", () => {
 					queueKey: "heartbeat:job-1",
 					agentMessageId: "agentmsg_followup",
 					customMessage,
+					prefixMessages: [prefixMessage],
 				}),
 			);
 		} finally {

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -360,7 +360,7 @@ stale extension instructions`,
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
-	it("folds pending nextTurn context into accepted agent messages queued while busy", async () => {
+	it("keeps pending nextTurn context separate from accepted agent messages queued while busy", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		const agentPrompt =
@@ -382,21 +382,27 @@ stale extension instructions`,
 		expect(harness.session.getFollowUpMessages()).toEqual([agentPrompt]);
 
 		sessionInternals._compactionAbortController = undefined;
-		let queuedTurnSawNextTurnContext = false;
+		let queuedTurnSawSeparateNextTurnContext = false;
 		harness.setResponses([
 			fauxAssistantMessage("first turn"),
 			(context) => {
+				const queuedContext = context.messages.find(
+					(message) => message.role === "user" && getMessageText(message) === "queued context",
+				);
 				const queuedUser = context.messages.find(
 					(message) => message.role === "user" && getMessageText(message).includes("agentmsg_next_turn_queued"),
 				);
-				queuedTurnSawNextTurnContext = queuedUser ? getMessageText(queuedUser).includes("queued context") : false;
+				queuedTurnSawSeparateNextTurnContext =
+					queuedContext !== undefined &&
+					queuedUser !== undefined &&
+					!getMessageText(queuedUser).includes("queued context");
 				return fauxAssistantMessage("queued turn");
 			},
 		]);
 
 		await harness.session.prompt("normal prompt");
 
-		expect(queuedTurnSawNextTurnContext).toBe(true);
+		expect(queuedTurnSawSeparateNextTurnContext).toBe(true);
 		expect(harness.session.pendingMessageCount).toBe(0);
 	});
 

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -26,12 +26,14 @@ type QueueInternals = {
 		text: string;
 		queueKey?: string;
 		agentMessageId?: string;
+		prefixMessages: CustomMessage[];
 		message: UserMessage | CustomMessage;
 	}>;
 	_followUpMessages: Array<{
 		text: string;
 		queueKey?: string;
 		agentMessageId?: string;
+		prefixMessages: CustomMessage[];
 		message: UserMessage | CustomMessage;
 	}>;
 	_pendingNextTurnMessages: CustomMessage[];
@@ -300,16 +302,11 @@ describe("issue #4257 update restart resume", () => {
 		harnesses.push(parentHarness, childHarness);
 
 		const image: ImageContent = { type: "image", data: "ZmFrZQ==", mimeType: "image/png" };
-		const content: (TextContent | ImageContent)[] = [
-			{ type: "text", text: "queued context" },
-			{ type: "text", text: "queued work" },
-			image,
-		];
+		const content: (TextContent | ImageContent)[] = [{ type: "text", text: "queued work" }, image];
+		const queuedContext = createCustomMessage("queued context");
 		const message: UserMessage = { role: "user", content, timestamp: Date.now() };
-		const followUpContent: TextContent[] = [
-			{ type: "text", text: "follow-up context" },
-			{ type: "text", text: "heartbeat" },
-		];
+		const followUpContent: TextContent[] = [{ type: "text", text: "heartbeat" }];
+		const followUpContext = createCustomMessage("follow-up context");
 		const followUpMessage: UserMessage = {
 			role: "user",
 			content: followUpContent,
@@ -318,19 +315,27 @@ describe("issue #4257 update restart resume", () => {
 		const customFollowUp = createCustomMessage("custom heartbeat");
 		const queueInternals = parentHarness.session as unknown as QueueInternals;
 		queueInternals._steeringMessages = [
-			{ text: "queued work", queueKey: "heartbeat:steer", agentMessageId: "agentmsg_steer", message },
+			{
+				text: "queued work",
+				queueKey: "heartbeat:steer",
+				agentMessageId: "agentmsg_steer",
+				prefixMessages: [queuedContext],
+				message,
+			},
 		];
 		queueInternals._followUpMessages = [
 			{
 				text: "heartbeat",
 				queueKey: "heartbeat:job-1",
 				agentMessageId: "agentmsg_followup",
+				prefixMessages: [followUpContext],
 				message: followUpMessage,
 			},
 			{
 				text: "custom heartbeat",
 				queueKey: "heartbeat:custom",
 				agentMessageId: "agentmsg_custom",
+				prefixMessages: [],
 				message: customFollowUp,
 			},
 		];
@@ -383,6 +388,7 @@ describe("issue #4257 update restart resume", () => {
 						message: "queued work",
 						content,
 						images: [image],
+						prefixMessages: [queuedContext],
 						queueKey: "heartbeat:steer",
 						agentMessageId: "agentmsg_steer",
 					},
@@ -391,6 +397,7 @@ describe("issue #4257 update restart resume", () => {
 					{
 						message: "heartbeat",
 						content: followUpContent,
+						prefixMessages: [followUpContext],
 						queueKey: "heartbeat:job-1",
 						agentMessageId: "agentmsg_followup",
 					},
@@ -496,6 +503,7 @@ describe("issue #4257 update restart resume", () => {
 				text: "queued follow-up",
 				queueKey: "heartbeat:job-1",
 				agentMessageId: "agentmsg_followup",
+				prefixMessages: [],
 				message: { role: "user", content: followUpContent, timestamp: Date.now() },
 			},
 		];
@@ -753,11 +761,13 @@ describe("issue #4257 update restart resume", () => {
 			{ type: "text", text: "restored follow-up context" },
 			{ type: "text", text: "restored follow-up" },
 		];
+		const restoredPrefix = createCustomMessage("restored custom prefix");
 		queueInternals._followUpMessages = [
 			{
 				text: "existing",
 				queueKey: "heartbeat:job-1",
 				agentMessageId: "agentmsg_existing",
+				prefixMessages: [],
 				message: { role: "user", content: [{ type: "text", text: "existing" }], timestamp: Date.now() },
 			},
 		];
@@ -788,6 +798,7 @@ describe("issue #4257 update restart resume", () => {
 				queueKey: "heartbeat:steer",
 				expandPromptTemplates: false,
 				agentMessageId: "agentmsg_restored_steer",
+				prefixMessages: [restoredPrefix],
 			}),
 		);
 		await internals.handleLine(
@@ -830,6 +841,7 @@ describe("issue #4257 update restart resume", () => {
 			expect.objectContaining({
 				text: "restored steer",
 				content: restoredSteerContent,
+				prefixMessages: [restoredPrefix],
 				queueKey: "heartbeat:steer",
 				agentMessageId: "agentmsg_restored_steer",
 			}),

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -188,7 +188,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		expect(sessionInternals._overflowRecoveryAttempted).toBe(false);
 	});
 
-	it("folds pending nextTurn context into queued heartbeat prompts", async () => {
+	it("keeps pending nextTurn context separate from queued heartbeat prompts", async () => {
 		let releaseToolExecution: (() => void) | undefined;
 		const toolRelease = new Promise<void>((resolve) => {
 			releaseToolExecution = resolve;
@@ -209,6 +209,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		const harness = await createHarness({ tools: [waitTool] });
 		harnesses.push(harness);
 		let queuedHeartbeatText = "";
+		let queuedPendingContextText = "";
 		const queueEvents: Array<{ steering: readonly string[]; followUp: readonly string[] }> = [];
 		harness.session.subscribe((event) => {
 			if (event.type === "queue_update") {
@@ -219,11 +220,15 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("original turn complete"),
 			(context) => {
+				const pendingContextMessage = context.messages.find(
+					(message) => message.role === "user" && getMessageText(message) === "pending heartbeat context",
+				);
 				const queuedUserMessage = context.messages.find(
 					(message) =>
 						message.role === "user" &&
 						getMessageText(message).includes("Check whether the long-running task needs another step."),
 				);
+				queuedPendingContextText = getMessageText(pendingContextMessage);
 				queuedHeartbeatText = getMessageText(queuedUserMessage);
 				return fauxAssistantMessage("heartbeat handled");
 			},
@@ -249,8 +254,8 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		releaseToolExecution?.();
 		await promptPromise;
 
-		expect(queuedHeartbeatText).toContain("pending heartbeat context");
-		expect(queuedHeartbeatText).toContain("Check whether the long-running task needs another step.");
+		expect(queuedPendingContextText).toBe("pending heartbeat context");
+		expect(queuedHeartbeatText).toBe("Check whether the long-running task needs another step.");
 		expect(
 			queueEvents.some((event) =>
 				event.followUp.includes("Heartbeat prompt: Check whether the long-running task needs another step."),

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -1,7 +1,7 @@
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { RestoreResult } from "../../../src/core/kernel/state-snapshot.js";
 import {
 	type CustomMessage,
@@ -17,6 +17,11 @@ import { createHarness, getMessageText, getUserTexts, type Harness } from "../ha
 
 type StateRestoreHost = {
 	_onIpythonStateRestored(result: RestoreResult): void;
+};
+
+type QueueDrainHost = {
+	_followUpMessages: Array<{ prefixMessages: CustomMessage[]; message: AgentMessage }>;
+	_drainQueuedMessagesAfterBash(): Promise<void>;
 };
 
 function stripAnsi(text: string): string {
@@ -132,5 +137,39 @@ describe("ENG-4530 IPython state restore message", () => {
 		expect(render(component)).toContain("Started fresh IPython kernel");
 		component.setExpanded(true);
 		expect(render(component)).not.toContain("restore details");
+	});
+
+	it("does not requeue prefixes already delivered before a drain failure", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await harness.session.sendCustomMessage(
+			{
+				customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+				content: "restore context",
+				display: true,
+				details: { restored: true },
+			},
+			{ deliverAs: "nextTurn" },
+		);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		await harness.session.prompt("queued prompt", { streamingBehavior: "followUp" });
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+
+		const queueHost = harness.session as unknown as QueueDrainHost;
+		const queued = queueHost._followUpMessages[0];
+		const deliveredPrefix = queued?.prefixMessages[0];
+		if (!queued || !deliveredPrefix) {
+			throw new Error("Expected queued restore context");
+		}
+		vi.spyOn(harness.session.agent, "prompt").mockImplementation(async () => {
+			harness.session.agent.state.messages.push(deliveredPrefix);
+			throw new Error("partial delivery failed");
+		});
+		const followUp = vi.spyOn(harness.session.agent, "followUp");
+
+		await queueHost._drainQueuedMessagesAfterBash();
+
+		expect(queued.prefixMessages).toEqual([]);
+		expect(followUp).toHaveBeenCalledWith([queued.message]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -1,0 +1,136 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { RestoreResult } from "../../../src/core/kernel/state-snapshot.js";
+import {
+	type CustomMessage,
+	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+	type IpythonStateRestoredDetails,
+} from "../../../src/core/messages.js";
+import {
+	InjectedPromptMessageComponent,
+	isInjectedPromptMessage,
+} from "../../../src/modes/interactive/components/injected-prompt-message.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
+
+type StateRestoreHost = {
+	_onIpythonStateRestored(result: RestoreResult): void;
+};
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function render(component: InjectedPromptMessageComponent): string {
+	return stripAnsi(component.render(120).join("\n"));
+}
+
+describe("ENG-4530 IPython state restore message", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("preserves restore context as a custom message when the next prompt is queued", async () => {
+		let releaseToolExecution = () => {};
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		let providerSawRestoreContext = false;
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("original turn complete"),
+			(context) => {
+				providerSawRestoreContext = context.messages.some((message) =>
+					getMessageText(message).includes("These names are available again: alpha, beta."),
+				);
+				return fauxAssistantMessage("queued turn complete");
+			},
+		]);
+		const toolStarted = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		const firstPrompt = harness.session.prompt("start");
+		await toolStarted;
+		(harness.session as unknown as StateRestoreHost)._onIpythonStateRestored({
+			restored: ["alpha", "beta"],
+			failed: [],
+			path: "/tmp/kernel-state.dill",
+		});
+		await harness.session.prompt("stop the heartbeat", { streamingBehavior: "followUp" });
+
+		const [queued] = harness.session.getFollowUpQueueSnapshots();
+		expect(queued?.content).toEqual([{ type: "text", text: "stop the heartbeat" }]);
+		expect(queued?.prefixMessages).toHaveLength(1);
+		expect(queued?.prefixMessages?.[0]).toMatchObject({
+			role: "custom",
+			customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+			display: true,
+			details: { restored: true },
+		});
+
+		releaseToolExecution();
+		await firstPrompt;
+
+		expect(providerSawRestoreContext).toBe(true);
+		expect(getUserTexts(harness)).toEqual(["start", "stop the heartbeat"]);
+		const restoreMessage = harness.session.messages.find(
+			(message): message is CustomMessage =>
+				message.role === "custom" && message.customType === IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+		);
+		if (!restoreMessage || !isInjectedPromptMessage(restoreMessage)) {
+			throw new Error("Expected an injected IPython restore message");
+		}
+
+		const component = new InjectedPromptMessageComponent(restoreMessage);
+		expect(render(component)).toContain("Restored IPython kernel state");
+		expect(render(component)).not.toContain("alpha");
+		component.setExpanded(true);
+		expect(render(component)).toContain("Restored IPython kernel state");
+		expect(render(component)).not.toContain("ipython_state_restored");
+		expect(render(component)).not.toContain("alpha");
+	});
+
+	it("shows an accurate fixed label when restoration starts a fresh kernel", () => {
+		const message: CustomMessage<IpythonStateRestoredDetails> = {
+			role: "custom",
+			customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+			content: "restore details",
+			display: true,
+			details: { restored: false },
+			timestamp: Date.now(),
+		};
+		const component = new InjectedPromptMessageComponent(message);
+
+		expect(render(component)).toContain("Started fresh IPython kernel");
+		component.setExpanded(true);
+		expect(render(component)).not.toContain("restore details");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -115,10 +115,10 @@ describe("ENG-4530 IPython state restore message", () => {
 		}
 
 		const component = new InjectedPromptMessageComponent(restoreMessage);
-		expect(render(component)).toContain("Restored IPython kernel state");
+		expect(render(component)).toContain("◆ Restored IPython kernel state");
 		expect(render(component)).not.toContain("alpha");
 		component.setExpanded(true);
-		expect(render(component)).toContain("Restored IPython kernel state");
+		expect(render(component)).toContain("◆ Restored IPython kernel state");
 		expect(render(component)).not.toContain("ipython_state_restored");
 		expect(render(component)).not.toContain("alpha");
 	});
@@ -134,7 +134,7 @@ describe("ENG-4530 IPython state restore message", () => {
 		};
 		const component = new InjectedPromptMessageComponent(message);
 
-		expect(render(component)).toContain("Started fresh IPython kernel");
+		expect(render(component)).toContain("◆ Started fresh IPython kernel");
 		component.setExpanded(true);
 		expect(render(component)).not.toContain("restore details");
 	});


### PR DESCRIPTION
- ipython restore context now stays separate from queued user prompts.
- restore notices render as a fixed non-expandable status line while retaining model context.
- queued message batches survive daemon restarts and are covered by focused regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent loop queue semantics and session prompt assembly paths used by heartbeats, agent-to-agent handoff, and update restart; regressions could reorder or duplicate context, but coverage is broad in tests.
> 
> **Overview**
> **IPython restore notices** are now typed custom messages (`ipython_state_restored`) that render as a fixed one-line status in the TUI (restored vs fresh kernel), not expandable user prompts, while still reaching the model as separate context.
> 
> **Queued steering/follow-up** no longer merges pending next-turn context into the prompt body. Prefix custom messages ride alongside the main queued message; the agent package’s `PendingMessageQueue` stores **atomic batches**, so one-at-a-time drain delivers prefix + prompt together and removal drops the whole batch if any member matches.
> 
> **Daemon self-update / restore** serializes and replays `prefixMessages` on steer and follow-up. Partial drain failures skip re-queuing prefixes already appended to the transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a73c57cdf9847bfc95e3e2c4f2a5e3c8d8d6190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix IPython state restore notices to render as header labels instead of user messages
> - IPython state restore events are now sent as a dedicated custom message type (`ipython_state_restored`) and rendered in the interactive UI as a fixed header label ('Restored IPython kernel state' or 'Started fresh IPython kernel') with no body text.
> - `PendingMessageQueue` in [agent.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/378/files#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143) is refactored to store messages as atomic batches; `drain` in 'one' mode returns a whole batch, and `removeWhere` removes entire batches when any message matches.
> - Pending next-turn context messages (e.g. IPython restore notices) are now queued as separate prefix messages alongside the main user prompt rather than being folded into its text content.
> - The daemon protocol and self-update restore path preserve and resubmit `prefixMessages` so prefix context survives session restarts.
> - Behavioral Change: queued steering/follow-up entries now deliver prefix custom messages atomically with the user message; partial drain failures no longer requeue already-delivered prefixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a73c57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->