### PR TITLE
represent agent message in tui

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed agent-to-agent messages to render as directional rows, with received messages expandable in chat and sent messages shown below their Python cell ([ENG-4531](https://linear.app/primeintellect/issue/ENG-4531/collapse-and-simplify-agent2agent-messages-in-chat-tui)).
 - Changed bare `/mcp` to open the Services menu while preserving explicit `list`, `login`, and `logout` subcommands ([ENG-4535](https://linear.app/primeintellect/issue/ENG-4535/open-services-mcp-menu-from-mcp)).
 - Added `/btw` and `/side` for one-turn inline side questions that use the current context without changing the main session ([ENG-4509](https://linear.app/primeintellect/issue/ENG-4509/add-btw-and-side-side-question-flows)).
 - Changed scheduled heartbeat prompts to steer (interrupt the current turn) by default, with a `steer`/`follow_up` delivery mode selectable via `/heartbeat --steer|--follow-up` and the `rlm_heartbeat` skill's `delivery_mode` argument.

--- a/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
+++ b/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from IPython.display import display
 from rlm import host_request
 
 MessageMode = Literal["auto", "follow_up", "steer"]
+_MESSAGE_DISPLAY_MIME = "application/vnd.prime-agent.agent-message+json"
 
 
 async def list_agents() -> dict[str, Any]:
@@ -38,7 +40,7 @@ async def send(target: str, message: str, mode: MessageMode = "auto") -> dict[st
         raise TypeError(f"message must be str, got {type(message).__name__}")
     if mode not in ("auto", "follow_up", "steer"):
         raise ValueError('mode must be "auto", "follow_up", or "steer"')
-    return await host_request(
+    receipt = await host_request(
         "agent_message.send",
         {
             "target": target,
@@ -46,3 +48,23 @@ async def send(target: str, message: str, mode: MessageMode = "auto") -> dict[st
             "mode": mode,
         },
     )
+    _emit_sent_message(receipt)
+    return receipt
+
+
+def _emit_sent_message(receipt: dict[str, Any]) -> None:
+    try:
+        label = (
+            "Agent message queued"
+            if receipt.get("deliveryStatus") == "queued"
+            else "Agent message sent"
+        )
+        display(
+            {
+                _MESSAGE_DISPLAY_MIME: receipt,
+                "text/plain": label,
+            },
+            raw=True,
+        )
+    except Exception:
+        pass

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -7,6 +7,7 @@ export const AGENT_MESSAGE_CUSTOM_TYPE = "agent_message";
 export const AGENT_MESSAGE_SKILL_NAME = "agent-message";
 export const AGENT_MESSAGE_IMPORT_NAME = "agent_message";
 export const AGENT_MESSAGE_SOURCE = "agent_message";
+export const AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL = "Agent message received";
 export const DEFAULT_AGENT_MESSAGE_MAX_CHARS = 16_384;
 export const DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION = 20;
 export const DEFAULT_AGENT_MESSAGE_RATE_LIMIT_CAPACITY = 3;

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { HostRequestHandler } from "./kernel/index.js";
+import type { CustomMessage } from "./messages.js";
 
+export const AGENT_MESSAGE_CUSTOM_TYPE = "agent_message";
 export const AGENT_MESSAGE_SKILL_NAME = "agent-message";
 export const AGENT_MESSAGE_IMPORT_NAME = "agent_message";
 export const AGENT_MESSAGE_SOURCE = "agent_message";
@@ -44,6 +47,19 @@ export interface AgentSessionMessagePayload {
 	from?: AgentSessionMessageSender;
 	target: AgentSessionMessageEndpoint;
 	deliveryMode: AgentSessionMessageDeliveryMode;
+}
+
+export interface AgentSessionMessageDetails {
+	id: string;
+	message: string;
+	from?: AgentSessionMessageSender;
+	target?: AgentSessionMessageEndpoint;
+}
+
+export interface AgentSessionMessage extends CustomMessage<AgentSessionMessageDetails> {
+	customType: typeof AGENT_MESSAGE_CUSTOM_TYPE;
+	content: string;
+	details: AgentSessionMessageDetails;
 }
 
 export interface AgentSessionMessageReceipt {
@@ -171,6 +187,38 @@ export function createAgentSessionMessagePrompt(payload: AgentSessionMessagePayl
 	lines.push("");
 	lines.push(payload.message);
 	return lines.join("\n");
+}
+
+export function createAgentSessionMessage(
+	payload: AgentSessionMessagePayload,
+	timestamp = Date.now(),
+): AgentSessionMessage {
+	return {
+		role: "custom",
+		customType: AGENT_MESSAGE_CUSTOM_TYPE,
+		content: createAgentSessionMessagePrompt(payload),
+		display: true,
+		details: {
+			id: payload.id,
+			message: payload.message,
+			from: payload.from,
+			target: payload.target,
+		},
+		timestamp,
+	};
+}
+
+export function isAgentSessionMessage(message: AgentMessage): message is AgentSessionMessage {
+	if (message.role !== "custom" || message.customType !== AGENT_MESSAGE_CUSTOM_TYPE) {
+		return false;
+	}
+	const details = message.details;
+	return (
+		typeof details === "object" &&
+		details !== null &&
+		typeof (details as { id?: unknown }).id === "string" &&
+		typeof (details as { message?: unknown }).message === "string"
+	);
 }
 
 export function createAgentSessionMessageReceipt(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1034,17 +1034,17 @@ export class AgentSession {
 
 	private _rememberLateIpythonSentAgentMessage(toolCallId: string, message: KernelSentAgentMessage): boolean {
 		const messages = this._lateIpythonSentAgentMessages.get(toolCallId) ?? [];
-		if (messages.some((entry) => entry.id === message.id)) {
-			return false;
+		const isNew = !messages.some((entry) => entry.id === message.id);
+		if (isNew) {
+			messages.push(message);
+			this._lateIpythonSentAgentMessages.set(toolCallId, messages);
 		}
-		messages.push(message);
-		this._lateIpythonSentAgentMessages.set(toolCallId, messages);
 		for (let index = this.agent.state.messages.length - 1; index >= 0; index -= 1) {
 			if (appendSentAgentMessageToToolResult(this.agent.state.messages[index], toolCallId, message)) {
 				break;
 			}
 		}
-		return true;
+		return isNew;
 	}
 
 	private _applyLateIpythonSentAgentMessages(message: AgentMessage): void {
@@ -4234,6 +4234,7 @@ export class AgentSession {
 		);
 		const newEntries = this.sessionManager.getEntries();
 		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		this._restoreLateIpythonSentAgentMessages();
 
 		// Get the saved compaction entry for the extension event
 		const savedCompactionEntry = newEntries.find((e) => e.type === "compaction" && e.summary === summary) as
@@ -6834,6 +6835,7 @@ export class AgentSession {
 			// Update agent state
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._restoreLateIpythonSentAgentMessages();
 			this._reloadGoalStateFromBranch();
 
 			// Emit session_tree event

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -186,7 +186,7 @@ import {
 	type RlmUsage,
 	type SubagentRuntimeHost,
 } from "./rlm-runtime.js";
-import type { BranchSummaryEntry, CompactionEntry, SessionMessageEntry } from "./session-manager.js";
+import type { BranchSummaryEntry, CompactionEntry, SessionContext, SessionMessageEntry } from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
 	getLatestCompactionEntry,
@@ -2448,6 +2448,14 @@ export class AgentSession {
 	/** All messages including custom types like BashExecutionMessage */
 	get messages(): AgentMessage[] {
 		return this.agent.state.messages;
+	}
+
+	buildSessionContext(): SessionContext {
+		const context = this.sessionManager.buildSessionContext();
+		for (const message of context.messages) {
+			this._applyLateIpythonSentAgentMessages(message);
+		}
+		return context;
 	}
 
 	/** Current steering mode */

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1028,6 +1028,7 @@ export class AgentSession {
 	}
 
 	private _restoreLateIpythonSentAgentMessages(): void {
+		this._lateIpythonSentAgentMessages.clear();
 		for (const entry of this.sessionManager.getBranch()) {
 			if (entry.type !== "custom" || entry.customType !== IPYTHON_SENT_AGENT_MESSAGE_CUSTOM_ENTRY) {
 				continue;
@@ -2942,19 +2943,21 @@ export class AgentSession {
 				}
 				this._pendingNextTurnMessages = [];
 
-				// Add user message
-				const userContent: (TextContent | ImageContent)[] = options?.content
-					? options.content.map((block) => ({ ...block }))
-					: [{ type: "text", text: expandedText }];
-				if (!options?.content && currentImages) {
-					userContent.push(...currentImages);
+				if (options?.customMessage) {
+					messages.push(cloneCustomMessage(options.customMessage));
+				} else {
+					const userContent: (TextContent | ImageContent)[] = options?.content
+						? options.content.map((block) => ({ ...block }))
+						: [{ type: "text", text: expandedText }];
+					if (!options?.content && currentImages) {
+						userContent.push(...currentImages);
+					}
+					messages.push({
+						role: "user",
+						content: userContent,
+						timestamp: Date.now(),
+					});
 				}
-				const userMessage: AgentMessage = {
-					role: "user",
-					content: userContent,
-					timestamp: Date.now(),
-				};
-				messages.push(userMessage);
 
 				// Emit before_agent_start extension event
 				const result = await this._extensionRunner.emitBeforeAgentStart(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -44,11 +44,13 @@ import { sleep } from "../utils/sleep.js";
 import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../utils/tools-manager.js";
 import {
 	AGENT_MESSAGE_SKILL_NAME,
+	type AgentSessionMessage,
 	type AgentSessionMessageController,
 	type AgentSessionMessageListResult,
 	type AgentSessionMessageReceipt,
 	assertDirectAgentMessageTarget,
 	createAgentMessageHostHandlers,
+	isAgentSessionMessage,
 	normalizeAgentSessionMessage,
 	normalizeAgentSessionMessageDeliveryMode,
 	parseAgentSessionMessagePromptId,
@@ -404,6 +406,7 @@ export interface PromptOptions {
 	skipInputHandlers?: boolean;
 	agentMessageId?: string;
 	content?: (TextContent | ImageContent)[];
+	customMessage?: CustomMessage;
 }
 
 interface InternalPromptOptions extends PromptOptions {
@@ -481,6 +484,13 @@ function queuedMessagePreview(message: { text: string; previewLabel?: string }):
 	return message.previewLabel ? `${message.previewLabel}: ${message.text}` : message.text;
 }
 
+function queuedAgentMessagePreview(message: QueuedSteeringMessage | QueuedFollowUpMessage): string {
+	if (isAgentSessionMessage(message.message)) {
+		return `Agent message received: ${message.message.details.message}`;
+	}
+	return queuedMessagePreview(message);
+}
+
 function injectedMessagePreviewLabel(message: CustomMessage): string | undefined {
 	switch (message.customType) {
 		case HEARTBEAT_PROMPT_CUSTOM_TYPE:
@@ -495,7 +505,7 @@ function injectedMessagePreviewLabel(message: CustomMessage): string | undefined
 interface AcceptedAgentMessagePrompt {
 	text: string;
 	agentMessageId: string;
-	message: UserMessage;
+	message: QueuedAgentMessage;
 	messages: Set<AgentMessage>;
 	/** Pending nextTurn messages drained into this prompt; restored to the queue if the prompt is cleared. */
 	pendingNextTurnMessages: CustomMessage[];
@@ -943,8 +953,8 @@ export class AgentSession {
 	private _emitQueueUpdate(): void {
 		this._emit({
 			type: "queue_update",
-			steering: this._steeringMessages.map(queuedMessagePreview),
-			followUp: this._followUpMessages.map(queuedMessagePreview),
+			steering: this._steeringMessages.map(queuedAgentMessagePreview),
+			followUp: this._followUpMessages.map(queuedAgentMessagePreview),
 		});
 	}
 
@@ -1981,7 +1991,9 @@ export class AgentSession {
 
 	private _isPromptTurnStartMessage(message: AgentMessage): boolean {
 		return (
-			message.role === "user" || (message.role === "custom" && message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE)
+			message.role === "user" ||
+			isAgentSessionMessage(message) ||
+			(message.role === "custom" && message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE)
 		);
 	}
 
@@ -2442,23 +2454,30 @@ export class AgentSession {
 	}
 
 	async acceptAgentMessagePrompt(text: string, options?: PromptOptions): Promise<void> {
+		const customMessage =
+			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
 		return this._prompt(text, {
 			...options,
 			expandPromptTemplates: false,
 			skipInputHandlers: true,
 			skipPrePromptWork: true,
 			returnAfterAccepted: true,
-			agentMessageId: options?.agentMessageId ?? parseAgentSessionMessagePromptId(text),
+			agentMessageId: options?.agentMessageId ?? customMessage?.details.id ?? parseAgentSessionMessagePromptId(text),
+			customMessage,
 		});
 	}
 
-	async queueAgentMessagePrompt(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		const agentMessageId = parseAgentSessionMessagePromptId(text);
+	async queueAgentMessagePrompt(
+		text: string,
+		streamingBehavior: "steer" | "followUp",
+		customMessage?: AgentSessionMessage,
+	): Promise<boolean> {
+		const agentMessageId = customMessage?.details.id ?? parseAgentSessionMessagePromptId(text);
 		if (streamingBehavior === "steer") {
-			await this._queueSteer(text, undefined, { agentMessageId });
+			await this._queueSteer(text, undefined, { agentMessageId, message: customMessage });
 			return true;
 		}
-		return this._queueFollowUp(text, undefined, { agentMessageId });
+		return this._queueFollowUp(text, undefined, { agentMessageId, message: customMessage });
 	}
 
 	async promptHeartbeat(job: AgentCronJob, options?: PromptOptions): Promise<void> {
@@ -2708,6 +2727,7 @@ export class AgentSession {
 					{
 						queueKey: options.followUpQueueKey,
 						agentMessageId: options.agentMessageId,
+						customMessage: options.customMessage,
 					},
 				);
 				if (!queued) {
@@ -2756,12 +2776,14 @@ export class AgentSession {
 				if (!options?.content && currentImages) {
 					userContent.push(...currentImages);
 				}
-				const userMessage: AgentMessage = {
-					role: "user",
-					content: userContent,
-					timestamp: Date.now(),
-				};
-				messages.push(userMessage);
+				const promptMessage: QueuedAgentMessage = options.customMessage
+					? cloneCustomMessage(options.customMessage)
+					: {
+							role: "user",
+							content: userContent,
+							timestamp: Date.now(),
+						};
+				messages.push(promptMessage);
 				if (options.agentMessageId !== undefined && options.returnAfterAccepted) {
 					let resolveAccepted = () => {};
 					let rejectAccepted = (_error: Error) => {};
@@ -2772,8 +2794,8 @@ export class AgentSession {
 					acceptedAgentMessagePrompt = {
 						text: expandedText,
 						agentMessageId: options.agentMessageId,
-						message: userMessage,
-						messages: new Set<AgentMessage>([...drainedNextTurnMessages, userMessage]),
+						message: promptMessage,
+						messages: new Set<AgentMessage>([...drainedNextTurnMessages, promptMessage]),
 						pendingNextTurnMessages: drainedNextTurnMessages,
 						deliveredPendingNextTurnMessages: new Set(),
 						accepted,
@@ -2895,6 +2917,7 @@ export class AgentSession {
 				{
 					queueKey: options.followUpQueueKey,
 					agentMessageId: options.agentMessageId,
+					customMessage: options.customMessage,
 				},
 			);
 			if (!queued) {
@@ -3147,14 +3170,20 @@ export class AgentSession {
 		text: string,
 		images: ImageContent[] | undefined,
 		streamingBehavior: "steer" | "followUp",
-		options: { queueKey?: string; agentMessageId?: string } = {},
+		options: { queueKey?: string; agentMessageId?: string; customMessage?: CustomMessage } = {},
 	): Promise<boolean> {
 		const pendingNextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
 		const content = this._buildPromptContent(text, images, pendingNextTurnMessages);
+		const message = options.customMessage ? { ...cloneCustomMessage(options.customMessage), content } : undefined;
 		try {
 			if (streamingBehavior === "followUp") {
-				const queued = await this._queueFollowUp(text, undefined, { ...options, content });
+				const queued = await this._queueFollowUp(text, undefined, {
+					queueKey: options.queueKey,
+					agentMessageId: options.agentMessageId,
+					content,
+					message,
+				});
 				if (!queued) {
 					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 				}
@@ -3164,6 +3193,7 @@ export class AgentSession {
 				agentMessageId: options.agentMessageId,
 				queueKey: options.queueKey,
 				content,
+				message,
 			});
 			return true;
 		} catch (error) {
@@ -3410,12 +3440,10 @@ export class AgentSession {
 		if (steering.length === 0 && followUp.length === 0 && !acceptedMatches) {
 			return { steering: [], followUp: [] };
 		}
-		const steeringToRemove = new Set(steering.map((message) => message.message));
-		const followUpToRemove = new Set(followUp.map((message) => message.message));
+		const steeringToRemove = new Set<AgentMessage>(steering.map((message) => message.message));
+		const followUpToRemove = new Set<AgentMessage>(followUp.map((message) => message.message));
 		const removedQueuedMessages = new Set(
-			this.agent.removeQueuedMessages(
-				(message) => message.role === "user" && (steeringToRemove.has(message) || followUpToRemove.has(message)),
-			),
+			this.agent.removeQueuedMessages((message) => steeringToRemove.has(message) || followUpToRemove.has(message)),
 		);
 		const removedSteeringMessages = steering.filter((message) => removedQueuedMessages.has(message.message));
 		const removedFollowUpMessages = followUp.filter((message) => removedQueuedMessages.has(message.message));
@@ -3469,7 +3497,7 @@ export class AgentSession {
 	}
 
 	getSteeringMessagePreviews(): readonly string[] {
-		return this._steeringMessages.map(queuedMessagePreview);
+		return this._steeringMessages.map(queuedAgentMessagePreview);
 	}
 
 	/** Get pending follow-up messages (read-only) */
@@ -3478,7 +3506,7 @@ export class AgentSession {
 	}
 
 	getFollowUpMessagePreviews(): readonly string[] {
-		return this._followUpMessages.map(queuedMessagePreview);
+		return this._followUpMessages.map(queuedAgentMessagePreview);
 	}
 
 	getSteeringQueueSnapshots(): readonly QueuedAgentInputSnapshot[] {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -43,6 +43,7 @@ import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
 import { ensureTool, MISSING_RIPGREP_MESSAGE } from "../utils/tools-manager.js";
 import {
+	AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL,
 	AGENT_MESSAGE_SKILL_NAME,
 	type AgentSessionMessage,
 	type AgentSessionMessageController,
@@ -142,7 +143,7 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import type { HostRequestHandlers } from "./kernel/index.js";
+import type { HostRequestHandlers, KernelSentAgentMessage } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
@@ -240,6 +241,7 @@ export type CompactionReason = "manual" | "threshold" | "overflow" | "requested"
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| AgentEvent
+	| { type: "ipython_sent_agent_message"; toolCallId: string; message: KernelSentAgentMessage }
 	| {
 			type: "queue_update";
 			steering: readonly string[];
@@ -486,9 +488,67 @@ function queuedMessagePreview(message: { text: string; previewLabel?: string }):
 
 function queuedAgentMessagePreview(message: QueuedSteeringMessage | QueuedFollowUpMessage): string {
 	if (isAgentSessionMessage(message.message)) {
-		return `Agent message received: ${message.message.details.message}`;
+		return `${AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL}: ${message.message.details.message}`;
 	}
 	return queuedMessagePreview(message);
+}
+
+const IPYTHON_SENT_AGENT_MESSAGE_CUSTOM_ENTRY = "ipython_sent_agent_message";
+
+interface PersistedIpythonSentAgentMessage {
+	toolCallId: string;
+	message: KernelSentAgentMessage;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsePersistedIpythonSentAgentMessage(value: unknown): PersistedIpythonSentAgentMessage | undefined {
+	if (!isObjectRecord(value) || typeof value.toolCallId !== "string" || !isObjectRecord(value.message)) {
+		return undefined;
+	}
+	const { id, message, deliveryStatus, target } = value.message;
+	if (
+		typeof id !== "string" ||
+		typeof message !== "string" ||
+		(deliveryStatus !== "delivered" && deliveryStatus !== "queued") ||
+		!isObjectRecord(target) ||
+		typeof target.activeSessionId !== "string" ||
+		typeof target.sessionId !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		toolCallId: value.toolCallId,
+		message: {
+			id,
+			message,
+			deliveryStatus,
+			target: {
+				activeSessionId: target.activeSessionId,
+				sessionId: target.sessionId,
+				...(typeof target.sessionName === "string" ? { sessionName: target.sessionName } : {}),
+			},
+		},
+	};
+}
+
+function appendSentAgentMessageToToolResult(
+	message: AgentMessage,
+	toolCallId: string,
+	sentMessage: KernelSentAgentMessage,
+): boolean {
+	if (message.role !== "toolResult" || message.toolName !== "ipython" || message.toolCallId !== toolCallId) {
+		return false;
+	}
+	const details = isObjectRecord(message.details) ? message.details : {};
+	const current = Array.isArray(details.sentAgentMessages) ? details.sentAgentMessages : [];
+	if (current.some((entry) => isObjectRecord(entry) && entry.id === sentMessage.id)) {
+		return true;
+	}
+	message.details = { ...details, sentAgentMessages: [...current, sentMessage] };
+	return true;
 }
 
 function injectedMessagePreviewLabel(message: CustomMessage): string | undefined {
@@ -705,6 +765,7 @@ export class AgentSession {
 	private _agentMessageDeliveryWaiters = new Map<string, AgentMessageDeliveryWaiter>();
 	private _deliveredAgentMessageIds = new Set<string>();
 	private _failedAgentMessageDeliveries = new Map<string, Error>();
+	private _lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -823,6 +884,7 @@ export class AgentSession {
 		this._rlmParentNodeId = config.rlmParentNodeId;
 		this._subagentRuntimeHost = config.subagentRuntimeHost;
 		this._goalState = this._loadPersistedGoalState();
+		this._restoreLateIpythonSentAgentMessages();
 		if (this._goalState.status === "active") {
 			this._goalAccountingStartedAt = Date.now();
 		}
@@ -956,6 +1018,54 @@ export class AgentSession {
 			steering: this._steeringMessages.map(queuedAgentMessagePreview),
 			followUp: this._followUpMessages.map(queuedAgentMessagePreview),
 		});
+	}
+
+	private _restoreLateIpythonSentAgentMessages(): void {
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type !== "custom" || entry.customType !== IPYTHON_SENT_AGENT_MESSAGE_CUSTOM_ENTRY) {
+				continue;
+			}
+			const persisted = parsePersistedIpythonSentAgentMessage(entry.data);
+			if (persisted) {
+				this._rememberLateIpythonSentAgentMessage(persisted.toolCallId, persisted.message);
+			}
+		}
+	}
+
+	private _rememberLateIpythonSentAgentMessage(toolCallId: string, message: KernelSentAgentMessage): boolean {
+		const messages = this._lateIpythonSentAgentMessages.get(toolCallId) ?? [];
+		if (messages.some((entry) => entry.id === message.id)) {
+			return false;
+		}
+		messages.push(message);
+		this._lateIpythonSentAgentMessages.set(toolCallId, messages);
+		for (let index = this.agent.state.messages.length - 1; index >= 0; index -= 1) {
+			if (appendSentAgentMessageToToolResult(this.agent.state.messages[index], toolCallId, message)) {
+				break;
+			}
+		}
+		return true;
+	}
+
+	private _applyLateIpythonSentAgentMessages(message: AgentMessage): void {
+		if (message.role !== "toolResult" || message.toolName !== "ipython") {
+			return;
+		}
+		for (const sentMessage of this._lateIpythonSentAgentMessages.get(message.toolCallId) ?? []) {
+			appendSentAgentMessageToToolResult(message, message.toolCallId, sentMessage);
+		}
+	}
+
+	private _recordLateIpythonSentAgentMessage(toolCallId: string, message: KernelSentAgentMessage): void {
+		const record = () => {
+			if (this._disposed || !this._rememberLateIpythonSentAgentMessage(toolCallId, message)) {
+				return;
+			}
+			this.sessionManager.appendCustomEntry(IPYTHON_SENT_AGENT_MESSAGE_CUSTOM_ENTRY, { toolCallId, message });
+			this._emit({ type: "ipython_sent_agent_message", toolCallId, message });
+		};
+		this._agentEventQueue = this._agentEventQueue.then(record, record);
+		this._agentEventQueue.catch(() => {});
 	}
 
 	private _emitGoalUpdate(): void {
@@ -1814,6 +1924,9 @@ export class AgentSession {
 	}
 
 	private async _processAgentEvent(event: AgentEvent): Promise<void> {
+		if ((event.type === "message_start" || event.type === "message_end") && event.message.role === "toolResult") {
+			this._applyLateIpythonSentAgentMessages(event.message);
+		}
 		const acceptedPrompt = this._acceptedAgentMessagePrompt;
 		if (acceptedPrompt && (event.type === "message_start" || event.type === "message_end")) {
 			if (event.message === acceptedPrompt.message) {
@@ -5200,6 +5313,8 @@ export class AgentSession {
 					provisioner: this._ipythonKernelProvisioner,
 					commandPrefix: this.settingsManager.getShellCommandPrefix(),
 					shellPath: this.settingsManager.getShellPath(),
+					onLateSentAgentMessage: (toolCallId, message) =>
+						this._recordLateIpythonSentAgentMessage(toolCallId, message),
 				},
 			});
 		}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -41,6 +41,7 @@ const SNAPSHOT_DISPOSE_TIMEOUT_MS = 5000;
 const KERNEL_ABORT_GRACE_MS = 1000;
 const KERNEL_BUSY_REUSE_WAIT_MS = 5000;
 const KERNEL_BUSY_INTERRUPT_INTERVAL_MS = 500;
+const MAX_LATE_SENT_AGENT_MESSAGE_HANDLERS = 256;
 const KERNEL_BUSY_AFTER_INTERRUPT_MESSAGE =
 	"IPython kernel is still running the previously interrupted cell. Wait and try again, or kill the IPython kernel to start fresh.";
 
@@ -979,7 +980,12 @@ export class KernelManager {
 				const content = incoming.content as { data?: Record<string, unknown> };
 				const sentAgentMessage = parseSentAgentMessage(content.data?.[AGENT_MESSAGE_DISPLAY_MIME]);
 				if (sentAgentMessage && parentMessageId) {
-					this.lateSentAgentMessageHandlers.get(parentMessageId)?.(sentAgentMessage);
+					const handler = this.lateSentAgentMessageHandlers.get(parentMessageId);
+					if (handler) {
+						this.lateSentAgentMessageHandlers.delete(parentMessageId);
+						this.lateSentAgentMessageHandlers.set(parentMessageId, handler);
+						handler(sentAgentMessage);
+					}
 				}
 			}
 			return;
@@ -1047,7 +1053,7 @@ export class KernelManager {
 			this.activeExecution = undefined;
 		}
 		if (didClearActive && execution.opts.onLateSentAgentMessage) {
-			this.lateSentAgentMessageHandlers.set(execution.requestMsgId, execution.opts.onLateSentAgentMessage);
+			this.registerLateSentAgentMessageHandler(execution.requestMsgId, execution.opts.onLateSentAgentMessage);
 		}
 
 		let stdout = execution.stdout;
@@ -1075,6 +1081,20 @@ export class KernelManager {
 		});
 		if (didClearActive) {
 			this.notifyActiveExecutionIdle();
+		}
+	}
+
+	private registerLateSentAgentMessageHandler(
+		requestMessageId: string,
+		handler: (message: KernelSentAgentMessage) => void,
+	): void {
+		this.lateSentAgentMessageHandlers.set(requestMessageId, handler);
+		while (this.lateSentAgentMessageHandlers.size > MAX_LATE_SENT_AGENT_MESSAGE_HANDLERS) {
+			const oldestRequestMessageId = this.lateSentAgentMessageHandlers.keys().next().value;
+			if (oldestRequestMessageId === undefined) {
+				break;
+			}
+			this.lateSentAgentMessageHandlers.delete(oldestRequestMessageId);
 		}
 	}
 

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -110,6 +110,9 @@ export const DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json";
 /** MIME tag the `attach-image` skill emits media payloads under, via `display_data`. */
 export const ATTACHMENT_DISPLAY_MIME = "application/vnd.prime-agent.attachment+json";
 
+/** MIME tag the `agent-message` skill emits after sending a message. */
+export const AGENT_MESSAGE_DISPLAY_MIME = "application/vnd.prime-agent.agent-message+json";
+
 /**
  * Hard ceiling on a single attachment's base64 payload, a defensive guard
  * against a runaway direct `display_data` emit. The `attach-image` skill caps
@@ -136,6 +139,17 @@ export interface KernelAttachment {
 	path?: string;
 }
 
+export interface KernelSentAgentMessage {
+	id: string;
+	message: string;
+	deliveryStatus: "delivered" | "queued";
+	target: {
+		activeSessionId: string;
+		sessionId: string;
+		sessionName?: string;
+	};
+}
+
 export interface ExecuteResult {
 	stdout: string;
 	stderr: string;
@@ -145,6 +159,8 @@ export interface ExecuteResult {
 	diffs?: KernelDiffDisplay[];
 	/** Media attachments emitted via display_data, in order. */
 	attachments?: KernelAttachment[];
+	/** Agent messages sent from this cell, in order. */
+	sentAgentMessages?: KernelSentAgentMessage[];
 	status: "ok" | "error" | "aborted";
 	error?: { ename: string; evalue: string; traceback: string[] };
 	durationMs: number;
@@ -180,6 +196,33 @@ function parseAttachmentDisplay(payload: unknown): KernelAttachment | "oversized
 		return "oversized";
 	}
 	return { mimeType, data, path: typeof path === "string" ? path : undefined };
+}
+
+function parseSentAgentMessage(payload: unknown): KernelSentAgentMessage | undefined {
+	if (!isRecord(payload) || !isRecord(payload.target)) {
+		return undefined;
+	}
+	const { id, message, deliveryStatus, target } = payload;
+	const { activeSessionId, sessionId, sessionName } = target;
+	if (
+		typeof id !== "string" ||
+		typeof message !== "string" ||
+		(deliveryStatus !== "delivered" && deliveryStatus !== "queued") ||
+		typeof activeSessionId !== "string" ||
+		typeof sessionId !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		id,
+		message,
+		deliveryStatus,
+		target: {
+			activeSessionId,
+			sessionId,
+			...(typeof sessionName === "string" ? { sessionName } : {}),
+		},
+	};
 }
 
 function createKernelStartupAbortError(): Error {
@@ -267,6 +310,7 @@ interface ActiveExecution {
 	result?: string;
 	diffs: KernelDiffDisplay[];
 	attachments: KernelAttachment[];
+	sentAgentMessages: KernelSentAgentMessage[];
 	error?: ExecuteResult["error"];
 	status: ExecuteResult["status"];
 	resolve: (result: ExecuteResult) => void;
@@ -832,6 +876,7 @@ export class KernelManager {
 			stderrTruncated: false,
 			diffs: [],
 			attachments: [],
+			sentAgentMessages: [],
 			status: "ok",
 			resolve: result.resolve,
 			reject: result.reject,
@@ -968,6 +1013,8 @@ export class KernelManager {
 			} else if (attachment) {
 				execution.attachments.push(attachment);
 			}
+			const sentAgentMessage = parseSentAgentMessage(c.data?.[AGENT_MESSAGE_DISPLAY_MIME]);
+			if (sentAgentMessage) execution.sentAgentMessages.push(sentAgentMessage);
 		} else if (t === "error") {
 			const c = incoming.content as { ename: string; evalue: string; traceback: string[] };
 			execution.error = c;
@@ -1011,6 +1058,7 @@ export class KernelManager {
 			result,
 			diffs: execution.diffs.length > 0 ? execution.diffs : undefined,
 			attachments: execution.attachments.length > 0 ? execution.attachments : undefined,
+			sentAgentMessages: execution.sentAgentMessages.length > 0 ? execution.sentAgentMessages : undefined,
 			error: execution.error,
 			status,
 			durationMs: Date.now() - execution.started,

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -98,6 +98,7 @@ export interface ExecuteOptions {
 	/** Aborting interrupts the kernel via the control channel. */
 	signal?: AbortSignal;
 	onStream?: (chunk: string, name: "stdout" | "stderr") => void;
+	onLateSentAgentMessage?: (message: KernelSentAgentMessage) => void;
 	/** Cap stdout / stderr / result at this many characters. Default 65536. */
 	maxOutputChars?: number;
 	/** Synthetic host cell (snapshot/restore/list); excluded from lastCellCode attribution. */
@@ -529,6 +530,7 @@ export class KernelManager {
 	private executionQueue: Promise<unknown> = Promise.resolve();
 	private activeExecution?: ActiveExecution;
 	private readonly activeExecutionIdleWaiters = new Set<() => void>();
+	private readonly lateSentAgentMessageHandlers = new Map<string, (message: KernelSentAgentMessage) => void>();
 	// Source of the most recently started cell, retained after it finishes so
 	// rlm.run spawns from detached asyncio tasks (cell already idle) can still
 	// attribute their spawning program.
@@ -971,10 +973,15 @@ export class KernelManager {
 
 	private handleExecutionMessage(incoming: JupyterMessage): void {
 		const execution = this.activeExecution;
-		if (!execution) {
-			return;
-		}
-		if ((incoming.parent_header as { msg_id?: string }).msg_id !== execution.requestMsgId) {
+		const parentMessageId = (incoming.parent_header as { msg_id?: string }).msg_id;
+		if (!execution || parentMessageId !== execution.requestMsgId) {
+			if (incoming.header.msg_type === "display_data" || incoming.header.msg_type === "update_display_data") {
+				const content = incoming.content as { data?: Record<string, unknown> };
+				const sentAgentMessage = parseSentAgentMessage(content.data?.[AGENT_MESSAGE_DISPLAY_MIME]);
+				if (sentAgentMessage && parentMessageId) {
+					this.lateSentAgentMessageHandlers.get(parentMessageId)?.(sentAgentMessage);
+				}
+			}
 			return;
 		}
 
@@ -1038,6 +1045,9 @@ export class KernelManager {
 		const didClearActive = options.clearActive && this.activeExecution === execution;
 		if (options.clearActive && this.activeExecution === execution) {
 			this.activeExecution = undefined;
+		}
+		if (didClearActive && execution.opts.onLateSentAgentMessage) {
+			this.lateSentAgentMessageHandlers.set(execution.requestMsgId, execution.opts.onLateSentAgentMessage);
 		}
 
 		let stdout = execution.stdout;
@@ -1237,6 +1247,7 @@ export class KernelManager {
 
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
 		this.clearSnapshotTimer();
+		this.lateSentAgentMessageHandlers.clear();
 		if (this.forkedLivenessTimer) {
 			globalThis.clearInterval(this.forkedLivenessTimer);
 			this.forkedLivenessTimer = undefined;

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -315,6 +315,7 @@ interface ActiveExecution {
 	sentAgentMessages: KernelSentAgentMessage[];
 	error?: ExecuteResult["error"];
 	status: ExecuteResult["status"];
+	settled: boolean;
 	resolve: (result: ExecuteResult) => void;
 	reject: (error: Error) => void;
 }
@@ -881,6 +882,7 @@ export class KernelManager {
 			attachments: [],
 			sentAgentMessages: [],
 			status: "ok",
+			settled: false,
 			resolve: result.resolve,
 			reject: result.reject,
 		};
@@ -978,20 +980,18 @@ export class KernelManager {
 		if (!execution || parentMessageId !== execution.requestMsgId) {
 			if (incoming.header.msg_type === "display_data" || incoming.header.msg_type === "update_display_data") {
 				const content = incoming.content as { data?: Record<string, unknown> };
-				const sentAgentMessage = parseSentAgentMessage(content.data?.[AGENT_MESSAGE_DISPLAY_MIME]);
-				if (sentAgentMessage && parentMessageId) {
-					const handler = this.lateSentAgentMessageHandlers.get(parentMessageId);
-					if (handler) {
-						this.lateSentAgentMessageHandlers.delete(parentMessageId);
-						this.lateSentAgentMessageHandlers.set(parentMessageId, handler);
-						handler(sentAgentMessage);
-					}
-				}
+				this.dispatchLateSentAgentMessage(parentMessageId, content.data?.[AGENT_MESSAGE_DISPLAY_MIME]);
 			}
 			return;
 		}
 
 		const t = incoming.header.msg_type;
+		if (execution.settled && (t === "display_data" || t === "update_display_data")) {
+			const content = incoming.content as { data?: Record<string, unknown> };
+			if (this.dispatchLateSentAgentMessage(parentMessageId, content.data?.[AGENT_MESSAGE_DISPLAY_MIME])) {
+				return;
+			}
+		}
 		if (t === "stream") {
 			const c = incoming.content as { name: "stdout" | "stderr"; text: string };
 			if (c.name === "stdout") {
@@ -1052,36 +1052,54 @@ export class KernelManager {
 		if (options.clearActive && this.activeExecution === execution) {
 			this.activeExecution = undefined;
 		}
-		if (didClearActive && execution.opts.onLateSentAgentMessage) {
-			this.registerLateSentAgentMessageHandler(execution.requestMsgId, execution.opts.onLateSentAgentMessage);
+		if (!execution.settled) {
+			execution.settled = true;
+			if (execution.opts.onLateSentAgentMessage) {
+				this.registerLateSentAgentMessageHandler(execution.requestMsgId, execution.opts.onLateSentAgentMessage);
+			}
+
+			let stdout = execution.stdout;
+			let stderr = execution.stderr;
+			let result = execution.result;
+			let status = execution.status;
+			if (execution.stdoutTruncated) stdout += `\n[... output truncated at ${execution.maxChars} chars ...]`;
+			if (execution.stderrTruncated) stderr += `\n[... output truncated at ${execution.maxChars} chars ...]`;
+			if (result !== undefined && result.length > execution.maxChars) {
+				result = `${result.slice(0, execution.maxChars)}\n[... output truncated at ${execution.maxChars} chars ...]`;
+			}
+
+			if (execution.opts.signal?.aborted) status = "aborted";
+
+			execution.resolve({
+				stdout,
+				stderr,
+				result,
+				diffs: execution.diffs.length > 0 ? execution.diffs : undefined,
+				attachments: execution.attachments.length > 0 ? execution.attachments : undefined,
+				sentAgentMessages: execution.sentAgentMessages.length > 0 ? execution.sentAgentMessages : undefined,
+				error: execution.error,
+				status,
+				durationMs: Date.now() - execution.started,
+			});
 		}
-
-		let stdout = execution.stdout;
-		let stderr = execution.stderr;
-		let result = execution.result;
-		let status = execution.status;
-		if (execution.stdoutTruncated) stdout += `\n[... output truncated at ${execution.maxChars} chars ...]`;
-		if (execution.stderrTruncated) stderr += `\n[... output truncated at ${execution.maxChars} chars ...]`;
-		if (result !== undefined && result.length > execution.maxChars) {
-			result = `${result.slice(0, execution.maxChars)}\n[... output truncated at ${execution.maxChars} chars ...]`;
-		}
-
-		if (execution.opts.signal?.aborted) status = "aborted";
-
-		execution.resolve({
-			stdout,
-			stderr,
-			result,
-			diffs: execution.diffs.length > 0 ? execution.diffs : undefined,
-			attachments: execution.attachments.length > 0 ? execution.attachments : undefined,
-			sentAgentMessages: execution.sentAgentMessages.length > 0 ? execution.sentAgentMessages : undefined,
-			error: execution.error,
-			status,
-			durationMs: Date.now() - execution.started,
-		});
 		if (didClearActive) {
 			this.notifyActiveExecutionIdle();
 		}
+	}
+
+	private dispatchLateSentAgentMessage(parentMessageId: string | undefined, value: unknown): boolean {
+		const sentAgentMessage = parseSentAgentMessage(value);
+		if (!sentAgentMessage || !parentMessageId) {
+			return false;
+		}
+		const handler = this.lateSentAgentMessageHandlers.get(parentMessageId);
+		if (!handler) {
+			return false;
+		}
+		this.lateSentAgentMessageHandlers.delete(parentMessageId);
+		this.lateSentAgentMessageHandlers.set(parentMessageId, handler);
+		handler(sentAgentMessage);
+		return true;
 	}
 
 	private registerLateSentAgentMessageHandler(

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -275,6 +275,7 @@ export interface IpythonToolOptions {
 	 * (some names restored or some failed), so the session can tell the model.
 	 */
 	onRestore?: (result: RestoreResult) => void;
+	onLateSentAgentMessage?: (toolCallId: string, message: KernelSentAgentMessage) => void;
 	/** Shared provisioner owning the kernel lifecycle. When provided, the remaining options are ignored. */
 	provisioner?: IpythonKernelProvisioner;
 }
@@ -549,17 +550,26 @@ async function chooseBusyKernelAction(
 async function executeWithBusyKernelChoice(
 	provisioner: IpythonKernelProvisioner,
 	reportStartupProgress: KernelBootstrapProgressHandler,
+	toolCallId: string,
 	code: string,
 	signal: AbortSignal | undefined,
 	onStream: (chunk: string, name: "stdout" | "stderr") => void,
 	onWorkingMessage: (message?: string) => void,
+	onLateSentAgentMessage: ((toolCallId: string, message: KernelSentAgentMessage) => void) | undefined,
 	ctx: ExtensionContext | undefined,
 ): Promise<{ result: ExecuteResult; kernelRestarted: boolean }> {
 	let kernelRestarted = false;
 	while (true) {
 		const m = await provisioner.ensure(reportStartupProgress, signal);
 		try {
-			return { result: await m.execute(code, { signal, onStream }), kernelRestarted };
+			return {
+				result: await m.execute(code, {
+					signal,
+					onStream,
+					onLateSentAgentMessage: (message) => onLateSentAgentMessage?.(toolCallId, message),
+				}),
+				kernelRestarted,
+			};
 		} catch (error) {
 			if (!(error instanceof KernelBusyAfterInterruptError) || signal?.aborted) {
 				throw error;
@@ -603,7 +613,7 @@ export function createIpythonToolDefinition(
 		// The kernel is single-threaded — pi must not run two ipython calls in parallel within a batch.
 		executionMode: "sequential",
 		parameters: ipythonSchema,
-		execute: async (_toolCallId, params, signal, onUpdate, ctx) => {
+		execute: async (toolCallId, params, signal, onUpdate, ctx) => {
 			let hasWorkingMessage = false;
 			const setToolWorkingMessage = (message?: string) => {
 				setWorkingMessage(ctx, message);
@@ -622,6 +632,7 @@ export function createIpythonToolDefinition(
 				const { result: r, kernelRestarted } = await executeWithBusyKernelChoice(
 					provisioner,
 					reportStartupProgress,
+					toolCallId,
 					code,
 					signal,
 					(chunk) => {
@@ -631,6 +642,7 @@ export function createIpythonToolDefinition(
 						});
 					},
 					setToolWorkingMessage,
+					options?.onLateSentAgentMessage,
 					ctx,
 				);
 

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -14,6 +14,7 @@ import {
 	KernelBusyAfterInterruptError,
 	type KernelDiffDisplay,
 	KernelManager,
+	type KernelSentAgentMessage,
 } from "../kernel/index.js";
 import { manifestPathIn, type RestoreResult, snapshotPathIn } from "../kernel/state-snapshot.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
@@ -239,6 +240,8 @@ export interface IpythonToolDetails {
 	diffs?: KernelDiffDisplay[];
 	/** Media attachments loaded into context (e.g. by the attach-image skill). */
 	attachments?: KernelAttachment[];
+	/** Agent messages sent from this cell. */
+	sentAgentMessages?: KernelSentAgentMessage[];
 	/** True when this result came after killing and restarting a busy kernel. */
 	kernelRestarted?: boolean;
 	error?: {
@@ -655,6 +658,7 @@ export function createIpythonToolDefinition(
 						result: r.result,
 						diffs: r.diffs,
 						attachments: r.attachments,
+						sentAgentMessages: r.sentAgentMessages,
 						kernelRestarted,
 						error: r.error,
 					},

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -566,7 +566,9 @@ async function executeWithBusyKernelChoice(
 				result: await m.execute(code, {
 					signal,
 					onStream,
-					onLateSentAgentMessage: (message) => onLateSentAgentMessage?.(toolCallId, message),
+					onLateSentAgentMessage: onLateSentAgentMessage
+						? (message) => onLateSentAgentMessage(toolCallId, message)
+						: undefined,
 				}),
 				kernelRestarted,
 			};

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -334,6 +334,7 @@ export {
 } from "./modes/index.js";
 // UI components for extensions
 export {
+	AgentMessageComponent,
 	ArminComponent,
 	AssistantMessageComponent,
 	BashExecutionComponent,

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -121,7 +121,7 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async getSessionContext(): Promise<AgentConnectionSessionContext> {
-		return this.session.sessionManager.buildSessionContext();
+		return this.session.buildSessionContext();
 	}
 
 	async getSessionTree(): Promise<{ tree: AgentConnectionSessionTreeNode[]; leafId: string | null }> {

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -67,7 +67,7 @@ export function createAgentConnectionSnapshot(
 	return {
 		state: createAgentConnectionState(runtime, activeSessionId),
 		messages: [...session.messages],
-		sessionContext: sessionManager.buildSessionContext(),
+		sessionContext: session.buildSessionContext(),
 		sessionTree: {
 			tree: sessionManager.getTree(),
 			leafId: sessionManager.getLeafId(),

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -6,6 +6,7 @@ import type { ContextTreeNode } from "../../core/context-tree.js";
 import type { AgentCronJob, AgentHeartbeatDeliveryMode, AgentHeartbeatUpdateAction } from "../../core/cron-jobs.js";
 import type { ReplayBuiltInToolName } from "../../core/extensions/index.js";
 import type { GoalState } from "../../core/goals.js";
+import type { KernelSentAgentMessage } from "../../core/kernel/index.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import type { SessionStats } from "../../core/session-stats.js";
@@ -464,6 +465,7 @@ export interface AgentConnectionRlmChildAgentSnapshot {
 
 export type AgentConnectionSessionEvent =
 	| AgentEvent
+	| { type: "ipython_sent_agent_message"; toolCallId: string; message: KernelSentAgentMessage }
 	| {
 			type: "queue_update";
 			steering: readonly string[];

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -29,8 +29,8 @@ import {
 	type AgentSessionMessageSender,
 	assertAgentMessageQueueCapacity,
 	assertDirectAgentMessageTarget,
+	createAgentSessionMessage,
 	createAgentSessionMessageId,
-	createAgentSessionMessagePrompt,
 	createAgentSessionMessageReceipt,
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION,
@@ -1637,6 +1637,7 @@ export class AgentDaemon {
 					streamingBehavior: command.streamingBehavior,
 					expandPromptTemplates: command.expandPromptTemplates,
 					agentMessageId: command.agentMessageId,
+					customMessage: command.customMessage,
 					skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
 					source: "rpc",
 					preflightResult: (didSucceed) => {
@@ -2500,10 +2501,11 @@ export class AgentDaemon {
 		const streamingBehavior =
 			resolveAgentSessionMessageStreamingBehavior(shouldQueue, payload.deliveryMode) ??
 			(payload.deliveryMode === "follow_up" ? "followUp" : "steer");
-		const prompt = createAgentSessionMessagePrompt(payload);
+		const message = createAgentSessionMessage(payload);
+		const prompt = message.content;
 
 		if (shouldQueue) {
-			const didQueue = await session.queueAgentMessagePrompt(prompt, streamingBehavior);
+			const didQueue = await session.queueAgentMessagePrompt(prompt, streamingBehavior, message);
 			if (!didQueue) {
 				throw new Error("Agent message was not queued");
 			}
@@ -2519,11 +2521,7 @@ export class AgentDaemon {
 		let preflightFailed = false;
 		let preflightQueued = false;
 		try {
-			const acceptPrompt =
-				typeof session.acceptAgentMessagePrompt === "function"
-					? session.acceptAgentMessagePrompt.bind(session)
-					: session.prompt.bind(session);
-			await acceptPrompt(prompt, {
+			const promptOptions: PromptOptions = {
 				expandPromptTemplates: false,
 				streamingBehavior,
 				queueIfBusy: true,
@@ -2531,7 +2529,12 @@ export class AgentDaemon {
 					preflightFailed = !didSucceed;
 					preflightQueued = didSucceed && didQueue === true;
 				},
-			});
+			};
+			if (typeof session.acceptAgentMessagePrompt === "function") {
+				await session.acceptAgentMessagePrompt(prompt, { ...promptOptions, customMessage: message });
+			} else {
+				await session.prompt(prompt, promptOptions);
+			}
 			if (preflightFailed) {
 				throw new Error("Agent message was not accepted");
 			}
@@ -2617,6 +2620,7 @@ export class AgentDaemon {
 							message: acceptedPrompt.text,
 							...(acceptedPrompt.content ? { content: acceptedPrompt.content } : {}),
 							...(acceptedPrompt.images ? { images: acceptedPrompt.images } : {}),
+							...(acceptedPrompt.customMessage ? { customMessage: acceptedPrompt.customMessage } : {}),
 							agentMessageId: acceptedPrompt.agentMessageId,
 							nextTurn: acceptedPrompt.nextTurn,
 						},

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2154,7 +2154,7 @@ export class AgentDaemon {
 			case "get_session_context": {
 				const state = this.getSessionState(command.activeSessionId);
 				return success(command.id, "get_session_context", {
-					context: state.runtime.session.sessionManager.buildSessionContext(),
+					context: state.runtime.session.buildSessionContext(),
 				});
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -277,6 +277,7 @@ export type DaemonCommand =
 			streamingBehavior?: "steer" | "followUp";
 			expandPromptTemplates?: boolean;
 			agentMessageId?: string;
+			customMessage?: CustomMessage;
 	  }
 	| {
 			id?: string;

--- a/packages/coding-agent/src/modes/interactive/agent-activity.ts
+++ b/packages/coding-agent/src/modes/interactive/agent-activity.ts
@@ -1,3 +1,4 @@
+import { isAgentSessionMessage } from "../../core/agent-messages.js";
 import type { AgentConnectionSessionEvent } from "../agent-connection/index.js";
 
 export type AgentActivity = "waiting" | "thinking" | "writing" | "writing-code" | "executing";
@@ -45,7 +46,7 @@ export class AgentActivityTracker {
 				break;
 
 			case "message_start":
-				if (event.message.role === "user") {
+				if (event.message.role === "user" || isAgentSessionMessage(event.message)) {
 					this.reset();
 				} else if (event.message.role === "assistant") {
 					this.activity = "waiting";

--- a/packages/coding-agent/src/modes/interactive/components/agent-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/agent-message.ts
@@ -1,0 +1,82 @@
+import {
+	Container,
+	Markdown,
+	type MarkdownTheme,
+	Spacer,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import type { AgentSessionMessage, AgentSessionMessageDetails } from "../../../core/agent-messages.js";
+import { getMarkdownTheme, theme } from "../theme/theme.js";
+import { keyText } from "./keybinding-hints.js";
+
+function senderLabel(details: AgentSessionMessageDetails): string {
+	return (
+		details.from?.sessionName?.trim() ||
+		details.from?.activeSessionId?.trim() ||
+		details.from?.clientId?.trim() ||
+		"Unknown agent"
+	);
+}
+
+function collapseText(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+export class AgentMessageComponent extends Container {
+	private readonly content = new Container();
+	private readonly header = new Text("", 1, 0);
+	private expanded = false;
+
+	constructor(
+		private readonly message: AgentSessionMessage,
+		private readonly markdownTheme: MarkdownTheme = getMarkdownTheme(),
+	) {
+		super();
+		this.addChild(new Spacer(1));
+		this.addChild(this.content);
+		this.updateDisplay();
+	}
+
+	setExpanded(expanded: boolean): void {
+		if (this.expanded === expanded) {
+			return;
+		}
+		this.expanded = expanded;
+		this.updateDisplay();
+	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.updateDisplay();
+	}
+
+	private updateDisplay(): void {
+		this.content.clear();
+		this.header.setText(this.headerText());
+		this.content.addChild(this.header);
+		if (this.expanded) {
+			this.content.addChild(
+				new Markdown(this.message.details.message, 1, 0, this.markdownTheme, {
+					color: (text: string) => theme.fg("customMessageText", text),
+				}),
+			);
+		}
+	}
+
+	private headerText(): string {
+		const icon = theme.fg("accent", "◆");
+		const title = theme.fg("muted", "Agent message received");
+		const sender = theme.fg("muted", senderLabel(this.message.details));
+		const separator = theme.fg("dim", " · ");
+		if (this.expanded) {
+			return `${icon} ${title}${separator}${sender}`;
+		}
+
+		const prefixWidth = visibleWidth(`◆ Agent message received · ${senderLabel(this.message.details)} · `);
+		const preview = truncateToWidth(collapseText(this.message.details.message), Math.max(20, 100 - prefixWidth));
+		const hint = theme.fg("dim", ` (${keyText("app.tools.expand")} to expand)`);
+		return `${icon} ${title}${separator}${sender}${separator}${theme.fg("muted", preview)}${hint}`;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -1,5 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Component, MarkdownTheme, TUI } from "@earendil-works/pi-tui";
+import { isAgentSessionMessage } from "../../../core/agent-messages.js";
+import { AgentMessageComponent } from "./agent-message.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
 import { ToolExecutionComponent, type ToolExecutionDefinition, type ToolExecutionOptions } from "./tool-execution.js";
@@ -78,6 +80,10 @@ export function buildConversationComponents(
 		} else if (message.role === "toolResult") {
 			pendingTools.get(message.toolCallId)?.updateResult(message);
 			pendingTools.delete(message.toolCallId);
+		} else if (isAgentSessionMessage(message) && message.display) {
+			const component = new AgentMessageComponent(message, options.markdownTheme);
+			component.setExpanded(expanded);
+			components.push(component);
 		} else if (isInjectedPromptMessage(message) && message.display) {
 			const component = new InjectedPromptMessageComponent(message, options.markdownTheme);
 			component.setExpanded(expanded);

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -1,4 +1,6 @@
 // UI Components for extensions
+
+export { AgentMessageComponent } from "./agent-message.js";
 export { ArminComponent } from "./armin.js";
 export { AssistantMessageComponent } from "./assistant-message.js";
 export { BashExecutionComponent } from "./bash-execution.js";

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -44,6 +44,17 @@ interface DiffDisplay {
 	startLine?: number;
 }
 
+interface SentAgentMessageDisplay {
+	id: string;
+	message: string;
+	deliveryStatus: "delivered" | "queued";
+	target: {
+		activeSessionId: string;
+		sessionId: string;
+		sessionName?: string;
+	};
+}
+
 interface IpythonDetails {
 	durationMs?: number;
 	status?: string;
@@ -52,6 +63,7 @@ interface IpythonDetails {
 	stderr?: string;
 	result?: string;
 	diffs?: DiffDisplay[];
+	sentAgentMessages?: SentAgentMessageDisplay[];
 	error?: IpythonErrorDetails;
 }
 
@@ -131,8 +143,48 @@ function readDetails(details: unknown): IpythonDetails {
 		stderr: typeof record.stderr === "string" ? record.stderr : undefined,
 		result: typeof record.result === "string" ? record.result : undefined,
 		diffs: readDiffDisplays(record.diffs),
+		sentAgentMessages: readSentAgentMessages(record.sentAgentMessages),
 		error,
 	};
+}
+
+function readSentAgentMessages(value: unknown): SentAgentMessageDisplay[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const messages = value.flatMap((entry): SentAgentMessageDisplay[] => {
+		if (!entry || typeof entry !== "object") {
+			return [];
+		}
+		const record = entry as Record<string, unknown>;
+		const target = record.target;
+		if (!target || typeof target !== "object") {
+			return [];
+		}
+		const targetRecord = target as Record<string, unknown>;
+		if (
+			typeof record.id !== "string" ||
+			typeof record.message !== "string" ||
+			(record.deliveryStatus !== "delivered" && record.deliveryStatus !== "queued") ||
+			typeof targetRecord.activeSessionId !== "string" ||
+			typeof targetRecord.sessionId !== "string"
+		) {
+			return [];
+		}
+		return [
+			{
+				id: record.id,
+				message: record.message,
+				deliveryStatus: record.deliveryStatus,
+				target: {
+					activeSessionId: targetRecord.activeSessionId,
+					sessionId: targetRecord.sessionId,
+					...(typeof targetRecord.sessionName === "string" ? { sessionName: targetRecord.sessionName } : {}),
+				},
+			},
+		];
+	});
+	return messages.length > 0 ? messages : undefined;
 }
 
 function readDiffDisplays(value: unknown): DiffDisplay[] | undefined {
@@ -310,6 +362,9 @@ export class IPythonCellComponent implements Component {
 		if (hasDiffs) {
 			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
 		}
+		if ((details.sentAgentMessages?.length ?? 0) > 0) {
+			this.renderSentAgentMessages(lines, safeWidth, details.sentAgentMessages ?? []);
+		}
 
 		if (!this.state.expanded) {
 			return this.renderCache.set(safeWidth, cacheVersion, lines);
@@ -418,6 +473,7 @@ export class IPythonCellComponent implements Component {
 			details.result !== undefined ||
 			details.error !== undefined ||
 			(details.diffs?.length ?? 0) > 0 ||
+			(details.sentAgentMessages?.length ?? 0) > 0 ||
 			(this.state.content?.length ?? 0) > 0
 		);
 	}
@@ -523,6 +579,7 @@ export class IPythonCellComponent implements Component {
 			!traceback &&
 			!details.error &&
 			diffs.length === 0 &&
+			(details.sentAgentMessages?.length ?? 0) === 0 &&
 			this.state.executionStarted &&
 			imageCount === 0
 		) {
@@ -548,6 +605,26 @@ export class IPythonCellComponent implements Component {
 				? `${imageCount} image${imageCount === 1 ? "" : "s"} rendered below`
 				: `${imageCount} image${imageCount === 1 ? "" : "s"} hidden`;
 			this.addWrapped(lines, OUTPUT_INDENT, theme.fg("muted", text), width);
+		}
+	}
+
+	private renderSentAgentMessages(lines: string[], width: number, messages: readonly SentAgentMessageDisplay[]): void {
+		for (const message of messages) {
+			this.addPlain(lines, "");
+			const target =
+				message.target.sessionName?.trim() ||
+				message.target.activeSessionId.trim() ||
+				message.target.sessionId.trim() ||
+				"Unknown agent";
+			const label = message.deliveryStatus === "delivered" ? "Agent message sent" : "Agent message queued";
+			const text = message.message.replace(/\s+/g, " ").trim();
+			const line =
+				theme.fg("accent", "◆") +
+				` ${theme.fg("muted", label)}${theme.fg("dim", " · ")}` +
+				theme.fg("muted", target) +
+				theme.fg("dim", " · ") +
+				theme.fg("muted", text);
+			this.addPlain(lines, truncateToWidth(line, Math.max(1, width - 1), "…"));
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { type Component, Container, getCapabilities, Image, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDefinition, ToolRenderContext, ToolRenderResultOptions } from "../../../core/extensions/types.js";
+import type { KernelSentAgentMessage } from "../../../core/kernel/index.js";
 import { createBashToolDefinition } from "../../../core/tools/bash.js";
 import { createEditToolDefinition } from "../../../core/tools/edit.js";
 import { createAllToolDefinitions } from "../../../core/tools/index.js";
@@ -94,6 +95,7 @@ export class ToolExecutionComponent extends Container {
 	private cwd: string;
 	private executionStarted = false;
 	private argsComplete = false;
+	private pendingSentAgentMessages: KernelSentAgentMessage[] = [];
 	private result?: {
 		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
 		isError: boolean;
@@ -245,10 +247,34 @@ export class ToolExecutionComponent extends Container {
 		},
 		isPartial = false,
 	): void {
-		this.result = result;
+		const details =
+			typeof result.details === "object" && result.details !== null
+				? (result.details as Record<string, unknown>)
+				: {};
+		const sentAgentMessages = Array.isArray(details.sentAgentMessages) ? [...details.sentAgentMessages] : [];
+		for (const message of this.pendingSentAgentMessages) {
+			if (
+				!sentAgentMessages.some(
+					(entry) => typeof entry === "object" && entry !== null && "id" in entry && entry.id === message.id,
+				)
+			) {
+				sentAgentMessages.push(message);
+			}
+		}
+		this.result = sentAgentMessages.length > 0 ? { ...result, details: { ...details, sentAgentMessages } } : result;
 		this.isPartial = isPartial;
 		this.updateDisplay();
 		this.maybeConvertImagesForKitty();
+	}
+
+	appendSentAgentMessage(message: KernelSentAgentMessage): void {
+		if (this.pendingSentAgentMessages.some((entry) => entry.id === message.id)) {
+			return;
+		}
+		this.pendingSentAgentMessages.push(message);
+		if (this.result) {
+			this.updateResult(this.result, this.isPartial);
+		}
 	}
 
 	private maybeConvertImagesForKitty(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5511,6 +5511,8 @@ export class InteractiveMode {
 		options: { updateFooter?: boolean; populateHistory?: boolean; clearChat?: boolean } = {},
 	): Promise<void> {
 		this.resetPendingToolState();
+		this.ipythonToolComponents.clear();
+		this.lateIpythonSentAgentMessages.clear();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();
 		const toolNames: string[] = [];
 		for (const message of sessionContext.messages) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -61,7 +61,7 @@ import {
 	SELF_UPDATE_NOT_ATTEMPTED_EXIT_CODE,
 	VERSION,
 } from "../../config.js";
-import { isAgentSessionMessage } from "../../core/agent-messages.js";
+import { AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL, isAgentSessionMessage } from "../../core/agent-messages.js";
 import {
 	type AgentTraceUploadResult,
 	getPrimeAgentTraceCredential,
@@ -82,6 +82,7 @@ import type {
 } from "../../core/extensions/index.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { emptyGoalState, formatGoalUsage, GOAL_CONTEXT_PREVIEW_LABEL, type GoalState } from "../../core/goals.js";
+import type { KernelSentAgentMessage } from "../../core/kernel/index.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import {
 	createCompactionSummaryMessage,
@@ -246,8 +247,14 @@ export function getRandomStartHint(random = Math.random): (typeof START_HINTS)[n
 
 function isLabeledQueuedPreview(message: string): boolean {
 	return (
-		message.startsWith(`${HEARTBEAT_PROMPT_PREVIEW_LABEL}: `) || message.startsWith(`${GOAL_CONTEXT_PREVIEW_LABEL}: `)
+		message.startsWith(`${HEARTBEAT_PROMPT_PREVIEW_LABEL}: `) ||
+		message.startsWith(`${GOAL_CONTEXT_PREVIEW_LABEL}: `) ||
+		message.startsWith(`${AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL}: `)
 	);
+}
+
+export function formatQueuedMessagePreview(message: string, label: "Steering" | "Follow-up"): string {
+	return isLabeledQueuedPreview(message) ? message : `${label}: ${message}`;
 }
 
 function isExpandable(obj: unknown): obj is Expandable {
@@ -688,6 +695,8 @@ export class InteractiveMode {
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private ipythonToolComponents = new Map<string, ToolExecutionComponent>();
+	private lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
 	private pendingToolCreations = new Set<string>();
 	private startedToolCalls = new Set<string>();
 	private pendingToolGeneration = 0;
@@ -2420,6 +2429,8 @@ export class InteractiveMode {
 		this.activityTracker.reset();
 		this.contextUsageTokenBaseline = 0;
 		this.resetPendingToolState();
+		this.ipythonToolComponents.clear();
+		this.lateIpythonSentAgentMessages.clear();
 		this.resetChildAgentInspector();
 		this.setGoalAnnouncementBaseline(this.getGoalState());
 		this.syncGoalTray(this.getGoalState());
@@ -2459,6 +2470,16 @@ export class InteractiveMode {
 		return this.streamingMessage?.content.find(
 			(content): content is ToolCall => content.type === "toolCall" && content.id === toolCallId,
 		);
+	}
+
+	private registerIpythonToolComponent(toolName: string, toolCallId: string, component: ToolExecutionComponent): void {
+		if (toolName !== "ipython") {
+			return;
+		}
+		this.ipythonToolComponents.set(toolCallId, component);
+		for (const lateMessage of this.lateIpythonSentAgentMessages.get(toolCallId) ?? []) {
+			component.appendSentAgentMessage(lateMessage);
+		}
 	}
 
 	private async getOrCreatePendingToolComponent(
@@ -2506,6 +2527,7 @@ export class InteractiveMode {
 			}
 			this.chatContainer.addChild(component);
 			this.pendingTools.set(latestToolCall.id, component);
+			this.registerIpythonToolComponent(latestToolCall.name, latestToolCall.id, component);
 			return component;
 		} finally {
 			this.pendingToolCreations.delete(toolCall.id);
@@ -4468,6 +4490,17 @@ export class InteractiveMode {
 				break;
 			}
 
+			case "ipython_sent_agent_message": {
+				const messages = this.lateIpythonSentAgentMessages.get(event.toolCallId) ?? [];
+				if (!messages.some((message) => message.id === event.message.id)) {
+					messages.push(event.message);
+					this.lateIpythonSentAgentMessages.set(event.toolCallId, messages);
+				}
+				this.ipythonToolComponents.get(event.toolCallId)?.appendSentAgentMessage(event.message);
+				this.ui.requestRender();
+				break;
+			}
+
 			case "agent_end":
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(false);
@@ -5524,6 +5557,7 @@ export class InteractiveMode {
 						);
 						component.setExpanded(this.toolOutputExpanded);
 						this.chatContainer.addChild(component);
+						this.registerIpythonToolComponent(content.name, content.id, component);
 
 						if (message.stopReason === "aborted" || message.stopReason === "error") {
 							let errorMessage: string;
@@ -6229,11 +6263,11 @@ export class InteractiveMode {
 		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
 			this.queuedMessagesContainer.addChild(new Spacer(1));
 			for (const message of steeringMessages) {
-				const text = theme.fg("dim", isLabeledQueuedPreview(message) ? message : `Steering: ${message}`);
+				const text = theme.fg("dim", formatQueuedMessagePreview(message, "Steering"));
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			for (const message of followUpMessages) {
-				const text = theme.fg("dim", isLabeledQueuedPreview(message) ? message : `Follow-up: ${message}`);
+				const text = theme.fg("dim", formatQueuedMessagePreview(message, "Follow-up"));
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -61,6 +61,7 @@ import {
 	SELF_UPDATE_NOT_ATTEMPTED_EXIT_CODE,
 	VERSION,
 } from "../../config.js";
+import { isAgentSessionMessage } from "../../core/agent-messages.js";
 import {
 	type AgentTraceUploadResult,
 	getPrimeAgentTraceCredential,
@@ -145,6 +146,7 @@ import {
 	ProviderAuthFlows,
 	type ProviderLoginOptions,
 } from "./auth-flows.js";
+import { AgentMessageComponent } from "./components/agent-message.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -4339,7 +4341,7 @@ export class InteractiveMode {
 		this.updateConnectionStateFromEvent(event);
 		// A new user message resets the activity tracker to 0, so the in-flight baseline must
 		// reset with it. (agent_start on auto-retry does not reset the tracker.)
-		if (event.type === "message_start" && event.message.role === "user") {
+		if (event.type === "message_start" && (event.message.role === "user" || isAgentSessionMessage(event.message))) {
 			this.contextUsageTokenBaseline = 0;
 			this.setSessionHasMessages(true);
 			this.clearShortcutGuide();
@@ -4430,7 +4432,7 @@ export class InteractiveMode {
 			case "message_start":
 				if (event.message.role === "custom") {
 					this.addMessageToChat(event.message);
-					if (event.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE) {
+					if (event.message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE || isAgentSessionMessage(event.message)) {
 						this.clearStaleRecapForPromptTurn();
 					}
 					this.ui.requestRender();
@@ -5441,15 +5443,17 @@ export class InteractiveMode {
 			}
 			case "custom": {
 				if (message.display) {
-					const component = isInjectedPromptMessage(message)
-						? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
-						: new CustomMessageComponent(
-								message,
-								this.bindLocalSessionExtensions
-									? this.getLocalSessionHost().getExtensionRunner().getMessageRenderer(message.customType)
-									: undefined,
-								this.getMarkdownThemeWithSettings(),
-							);
+					const component = isAgentSessionMessage(message)
+						? new AgentMessageComponent(message, this.getMarkdownThemeWithSettings())
+						: isInjectedPromptMessage(message)
+							? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
+							: new CustomMessageComponent(
+									message,
+									this.bindLocalSessionExtensions
+										? this.getLocalSessionHost().getExtensionRunner().getMessageRenderer(message.customType)
+										: undefined,
+									this.getMarkdownThemeWithSettings(),
+								);
 					component.setExpanded(this.toolOutputExpanded);
 					this.chatContainer.addChild(component);
 				}

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -886,6 +886,7 @@ async function restoreDaemonUpdateRestartSession(
 				images: acceptedPrompt.images,
 				expandPromptTemplates: false,
 				agentMessageId: acceptedPrompt.agentMessageId,
+				customMessage: acceptedPrompt.customMessage,
 			},
 			120000,
 		);

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -69,6 +69,11 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 	const listeners = new Set<AgentSessionEventListener>();
 	let unsubscriptions = 0;
 	const thinkingLevel: AgentConnectionState["thinkingLevel"] = "medium";
+	const buildSessionContext = () => ({
+		messages,
+		thinkingLevel,
+		model: null,
+	});
 	const session = {
 		sessionManager: {
 			getCwd: () => `/tmp/${id}`,
@@ -76,12 +81,9 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 			getLeafId: () => `${id}-leaf`,
 			getEntries: () => [],
 			getTree: () => [],
-			buildSessionContext: () => ({
-				messages,
-				thinkingLevel,
-				model: null,
-			}),
+			buildSessionContext,
 		},
+		buildSessionContext,
 		model: undefined,
 		thinkingLevel,
 		getAvailableThinkingLevels: () => ["minimal", "low", "medium", "high", "xhigh"],

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -55,6 +55,8 @@ type ResetHarness = PromptStashLiveMarkerHarness & {
 	pendingBashComponents: unknown[];
 	activityTracker: { reset: Mock };
 	contextUsageTokenBaseline: number;
+	ipythonToolComponents: Map<string, unknown>;
+	lateIpythonSentAgentMessages: Map<string, unknown>;
 	resetPendingToolState: Mock;
 	resetChildAgentInspector: Mock;
 	setGoalAnnouncementBaseline: Mock;
@@ -348,6 +350,8 @@ describe("InteractiveMode prompt stash", () => {
 			pendingBashComponents: [],
 			activityTracker: { reset: vi.fn() },
 			contextUsageTokenBaseline: 1,
+			ipythonToolComponents: new Map(),
+			lateIpythonSentAgentMessages: new Map(),
 			resetPendingToolState: vi.fn(),
 			resetChildAgentInspector: vi.fn(),
 			setGoalAnnouncementBaseline: vi.fn(),
@@ -379,6 +383,8 @@ describe("InteractiveMode prompt stash", () => {
 			pendingBashComponents: [],
 			activityTracker: { reset: vi.fn() },
 			contextUsageTokenBaseline: 1,
+			ipythonToolComponents: new Map(),
+			lateIpythonSentAgentMessages: new Map(),
 			resetPendingToolState: vi.fn(),
 			resetChildAgentInspector: vi.fn(),
 			setGoalAnnouncementBaseline: vi.fn(),

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -225,6 +225,7 @@ describe("InteractiveMode.renderSessionContext", () => {
 					chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
 				}),
 			};
+			Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
 
 			await (InteractiveMode as any).prototype.renderSessionContext.call(fakeThis, {
 				messages: [
@@ -276,6 +277,7 @@ describe("InteractiveMode.renderSessionContext", () => {
 					chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
 				}),
 			};
+			Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
 
 			await (InteractiveMode as any).prototype.renderSessionContext.call(fakeThis, {
 				messages: [
@@ -583,6 +585,8 @@ describe("InteractiveMode pending bash components", () => {
 			activeBashComponent: component,
 			pendingBashComponents: [component],
 			activityTracker: { reset: vi.fn() },
+			ipythonToolComponents: new Map(),
+			lateIpythonSentAgentMessages: new Map(),
 			resetPendingToolState: vi.fn(),
 			resetChildAgentInspector: vi.fn(),
 			setGoalAnnouncementBaseline: vi.fn(),
@@ -767,6 +771,8 @@ describe("InteractiveMode tool event rendering", () => {
 			pendingTools: new Map<string, ToolExecutionComponent>(),
 			pendingToolCreations: new Set<string>(),
 			startedToolCalls: new Set<string>(),
+			ipythonToolComponents: new Map(),
+			lateIpythonSentAgentMessages: new Map(),
 			loadToolDefinition: vi.fn(() => definitionPromise),
 			uiServices: {
 				settingsManager: {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -205,8 +205,12 @@ describe("InteractiveMode.renderSessionContext", () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		try {
 			const chatContainer = new Container();
+			const ipythonToolComponents = new Map([["stale-tool", {}]]);
+			const lateIpythonSentAgentMessages = new Map([["stale-tool", []]]);
 			const fakeThis: any = {
 				pendingTools: new Map(),
+				ipythonToolComponents,
+				lateIpythonSentAgentMessages,
 				toolOutputExpanded: false,
 				chatContainer,
 				footer: { invalidate: vi.fn() },
@@ -247,6 +251,8 @@ describe("InteractiveMode.renderSessionContext", () => {
 			const rendered = renderAll(chatContainer);
 			expect(rendered).not.toContain("\x1b_G");
 			expect(normalizeRenderedOutput(chatContainer)).toContain("[Image: [image/png]]");
+			expect(ipythonToolComponents.size).toBe(0);
+			expect(lateIpythonSentAgentMessages.size).toBe(0);
 		} finally {
 			resetCapabilitiesCache();
 		}
@@ -259,6 +265,8 @@ describe("InteractiveMode.renderSessionContext", () => {
 			const pendingTools = new Map<string, ToolExecutionComponent>();
 			const fakeThis: any = {
 				pendingTools,
+				ipythonToolComponents: new Map(),
+				lateIpythonSentAgentMessages: new Map(),
 				toolOutputExpanded: false,
 				chatContainer,
 				footer: { invalidate: vi.fn() },

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { KernelManager } from "../src/core/kernel/index.js";
+import { AGENT_MESSAGE_DISPLAY_MIME, KernelManager, type KernelSentAgentMessage } from "../src/core/kernel/index.js";
 
 async function waitForCalls(mock: { mock: { calls: unknown[][] } }, count: number): Promise<void> {
 	for (let i = 0; i < 20; i++) {
@@ -113,8 +113,12 @@ describe("KernelManager abort handling", () => {
 			},
 		);
 		const controller = new AbortController();
+		const lateSentAgentMessages: KernelSentAgentMessage[] = [];
 
-		const executePromise = manager.execute("while True: pass", { signal: controller.signal });
+		const executePromise = manager.execute("while True: pass", {
+			signal: controller.signal,
+			onLateSentAgentMessage: (message) => lateSentAgentMessages.push(message),
+		});
 		await waitForCalls(shellSend, 1);
 		expect(shellSend).toHaveBeenCalledTimes(1);
 
@@ -139,6 +143,29 @@ describe("KernelManager abort handling", () => {
 		if (!activeExecution) {
 			throw new Error("Expected active execution to remain until kernel idle");
 		}
+		internals.handleExecutionMessage({
+			header: { msg_type: "display_data" },
+			parent_header: { msg_id: activeExecution.requestMsgId },
+			metadata: {},
+			content: {
+				data: {
+					[AGENT_MESSAGE_DISPLAY_MIME]: {
+						id: "agentmsg-after-abort",
+						message: "still sent",
+						deliveryStatus: "delivered",
+						target: { activeSessionId: "beta", sessionId: "session-beta" },
+					},
+				},
+			},
+		});
+		expect(lateSentAgentMessages).toEqual([
+			{
+				id: "agentmsg-after-abort",
+				message: "still sent",
+				deliveryStatus: "delivered",
+				target: { activeSessionId: "beta", sessionId: "session-beta" },
+			},
+		]);
 		const secondExecutePromise = manager.execute("x = 1");
 		await Promise.resolve();
 		expect(shellSend).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBundledSkillsDir } from "../src/config.js";
+import type { KernelSentAgentMessage } from "../src/core/kernel/index.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
@@ -133,5 +134,45 @@ except ValueError as error:
 `);
 		expect(result.status).toBe("ok");
 		expect(result.stdout.trim()).toBe('ValueError: mode must be "auto", "follow_up", or "steer"');
+	});
+
+	it("captures sent messages from detached tasks after the cell is idle", async () => {
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			pythonSkills: [bundledAgentMessageSkill()],
+			hostHandlers: {
+				"agent_message.send": async (payload) => ({
+					id: "agentmsg-background",
+					source: "agent_message",
+					target: { activeSessionId: payload.target, sessionId: "session-beta", sessionName: "Beta" },
+					message: payload.message,
+					deliveryStatus: "delivered",
+					deliveredAt: "2026-07-10T00:00:00.000Z",
+					deliveryMode: payload.mode,
+				}),
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		let resolveLateMessage!: (message: KernelSentAgentMessage) => void;
+		const lateMessage = new Promise<KernelSentAgentMessage>((resolve) => {
+			resolveLateMessage = resolve;
+		});
+		const result = await manager.execute(
+			`async def send_later():
+    await asyncio.sleep(0.05)
+    await agent_message.send("beta", "background hello")
+
+background_send = asyncio.create_task(send_later())`,
+			{ onLateSentAgentMessage: (message) => resolveLateMessage(message) },
+		);
+
+		expect(result.status).toBe("ok");
+		expect(result.sentAgentMessages).toBeUndefined();
+		await expect(lateMessage).resolves.toEqual({
+			id: "agentmsg-background",
+			message: "background hello",
+			deliveryStatus: "delivered",
+			target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "Beta" },
+		});
 	});
 });

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -64,7 +64,7 @@ describe("agent-message skill over the kernel host bridge", () => {
 					return {
 						id: "agentmsg-test",
 						source: "agent_message",
-						target: { activeSessionId: payload.target, sessionId: "session-beta" },
+						target: { activeSessionId: payload.target, sessionId: "session-beta", sessionName: "Beta" },
 						from: { activeSessionId: "alpha", sessionId: "session-alpha" },
 						message: payload.message,
 						deliveryStatus: "queued",
@@ -93,6 +93,14 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 			deliveryStatus: "queued",
 			deliveryMode: "follow_up",
 		});
+		expect(result.sentAgentMessages).toEqual([
+			{
+				id: "agentmsg-test",
+				message: "hello beta",
+				deliveryStatus: "queued",
+				target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "Beta" },
+			},
+		]);
 		expect(requests[0]).toMatchObject({ type: "agent_message.list", payload: { type: "agent_message.list" } });
 		expect(requests[1]).toMatchObject({
 			type: "agent_message.send",

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBundledSkillsDir } from "../src/config.js";
-import type { KernelSentAgentMessage } from "../src/core/kernel/index.js";
+import { KernelManager, type KernelSentAgentMessage } from "../src/core/kernel/index.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
@@ -16,6 +16,14 @@ function bundledAgentMessageSkill(): PythonSkillRuntimeInfo {
 		pyprojectPath: join(packagePath, "pyproject.toml"),
 	};
 }
+
+type LateHandlerRetentionHost = {
+	lateSentAgentMessageHandlers: Map<string, (message: KernelSentAgentMessage) => void>;
+	registerLateSentAgentMessageHandler: (
+		requestMessageId: string,
+		handler: (message: KernelSentAgentMessage) => void,
+	) => void;
+};
 
 describe("agent-message skill over the kernel host bridge", () => {
 	let tempDir: string;
@@ -174,5 +182,20 @@ background_send = asyncio.create_task(send_later())`,
 			deliveryStatus: "delivered",
 			target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "Beta" },
 		});
+	});
+
+	it("bounds retained handlers for late sent messages", async () => {
+		const manager = new KernelManager({ cwd: tempDir });
+		const host = manager as unknown as LateHandlerRetentionHost;
+		const handler = () => {};
+
+		for (let index = 0; index < 300; index += 1) {
+			host.registerLateSentAgentMessageHandler(`request-${index}`, handler);
+		}
+
+		expect(host.lateSentAgentMessageHandlers.size).toBe(256);
+		expect(host.lateSentAgentMessageHandlers.has("request-0")).toBe(false);
+		expect(host.lateSentAgentMessageHandlers.has("request-299")).toBe(true);
+		await manager.dispose();
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -32,6 +32,8 @@ const EMPTY_USAGE: Usage = {
 
 type RenderSessionContextThis = {
 	pendingTools: Map<string, ToolExecutionComponent>;
+	ipythonToolComponents: Map<string, ToolExecutionComponent>;
+	lateIpythonSentAgentMessages: Map<string, unknown[]>;
 	pendingToolCreations: Set<string>;
 	startedToolCalls: Set<string>;
 	resetPendingToolState(): void;
@@ -70,6 +72,8 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 	const startedToolCalls = new Set<string>();
 	const fakeThis: RenderSessionContextThis = {
 		pendingTools,
+		ipythonToolComponents: new Map(),
+		lateIpythonSentAgentMessages: new Map(),
 		pendingToolCreations,
 		startedToolCalls,
 		resetPendingToolState() {

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -68,7 +68,7 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 	const pendingTools = new Map<string, ToolExecutionComponent>();
 	const pendingToolCreations = new Set<string>();
 	const startedToolCalls = new Set<string>();
-	return {
+	const fakeThis: RenderSessionContextThis = {
 		pendingTools,
 		pendingToolCreations,
 		startedToolCalls,
@@ -98,6 +98,8 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 			chatContainer.addChild(new Text(message.role, 0, 0));
 		},
 	};
+	Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+	return fakeThis;
 }
 
 function createAssistantToolCallMessage(): AssistantMessage {

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -177,6 +177,10 @@ describe("ENG-4531 agent message UI", () => {
 		expect(events).toContain("ipython_sent_agent_message");
 
 		toolResult.details = { status: "ok" };
+		host._restoreLateIpythonSentAgentMessages();
+		expect(toolResult.details).toMatchObject({ sentAgentMessages: [lateMessage] });
+
+		toolResult.details = { status: "ok" };
 		host._lateIpythonSentAgentMessages = new Map();
 		host._restoreLateIpythonSentAgentMessages();
 		expect(toolResult.details).toMatchObject({ sentAgentMessages: [lateMessage] });

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -1,0 +1,232 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall, type Message } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+	AGENT_MESSAGE_SOURCE,
+	type AgentSessionMessagePayload,
+	createAgentSessionMessage,
+	createAgentSessionMessagePrompt,
+	isAgentSessionMessagePrompt,
+} from "../../../src/core/agent-messages.js";
+import { AgentMessageComponent } from "../../../src/modes/interactive/components/agent-message.js";
+import { IPythonCellComponent } from "../../../src/modes/interactive/components/ipython-cell.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
+
+function createPayload(message: string): AgentSessionMessagePayload {
+	return {
+		id: "agentmsg_4531",
+		source: AGENT_MESSAGE_SOURCE,
+		message,
+		deliveryMode: "auto",
+		from: {
+			activeSessionId: "planner-active",
+			sessionId: "planner-session",
+			sessionName: "Planner",
+		},
+		target: {
+			activeSessionId: "worker-active",
+			sessionId: "worker-session",
+			sessionName: "Worker",
+		},
+	};
+}
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function render(component: AgentMessageComponent): string {
+	return stripAnsi(component.render(120).join("\n"));
+}
+
+describe("ENG-4531 agent message UI", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("records delivered agent messages as custom transcript entries while preserving provider input", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const payload = createPayload("Review the benchmark notes.");
+		const prompt = createAgentSessionMessagePrompt(payload);
+		const message = createAgentSessionMessage(payload);
+		let providerMessages: Message[] = [];
+		harness.setResponses([
+			(context) => {
+				providerMessages = [...context.messages];
+				return fauxAssistantMessage("Reviewed.");
+			},
+		]);
+
+		await harness.session.acceptAgentMessagePrompt(prompt, { customMessage: message });
+		await harness.session.agent.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.session.messages[0]).toMatchObject({
+			role: "custom",
+			customType: "agent_message",
+			display: true,
+		});
+		expect(getMessageText(providerMessages.at(-1))).toBe(prompt);
+		expect(providerMessages.at(-1)?.role).toBe("user");
+		expect(
+			harness.session.sessionManager
+				.getEntries()
+				.some((entry) => entry.type === "custom_message" && entry.customType === "agent_message"),
+		).toBe(true);
+	});
+
+	it("leaves text-only agent envelopes as user messages", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const prompt = createAgentSessionMessagePrompt(createPayload("Previously persisted message."));
+		harness.setResponses([fauxAssistantMessage("Handled.")]);
+
+		await harness.session.acceptAgentMessagePrompt(prompt);
+		await harness.session.agent.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual([prompt]);
+		expect(harness.session.messages[0]?.role).toBe("user");
+	});
+
+	it("keeps queued agent messages structured and removable by message identity", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const payload = createPayload("Use shard seven.");
+		const prompt = createAgentSessionMessagePrompt(payload);
+		const message = createAgentSessionMessage(payload);
+
+		await harness.session.queueAgentMessagePrompt(prompt, "followUp", message);
+
+		expect(harness.session.getFollowUpMessagePreviews()).toEqual(["Agent message received: Use shard seven."]);
+		expect(harness.session.getFollowUpQueueSnapshots()[0]?.customMessage).toMatchObject({
+			customType: "agent_message",
+			details: { id: "agentmsg_4531", message: "Use shard seven." },
+		});
+		expect(harness.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt)).toEqual({
+			steering: [],
+			followUp: [prompt],
+		});
+	});
+
+	it("preserves the custom message when direct delivery races with active work", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Original turn complete."),
+			fauxAssistantMessage("Agent message handled."),
+		]);
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("Start work.");
+		await sawToolStart;
+		const payload = createPayload("Queue behind the active turn.");
+		const prompt = createAgentSessionMessagePrompt(payload);
+
+		await harness.session.acceptAgentMessagePrompt(prompt, {
+			customMessage: createAgentSessionMessage(payload),
+			streamingBehavior: "followUp",
+			queueIfBusy: true,
+		});
+
+		expect(harness.session.getFollowUpQueueSnapshots()[0]?.customMessage).toMatchObject({
+			customType: "agent_message",
+			details: { message: "Queue behind the active turn." },
+		});
+		releaseToolExecution?.();
+		await promptPromise;
+		await harness.session.agent.waitForIdle();
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "agent_message",
+			),
+		).toBe(true);
+	});
+
+	it("renders a compact subagent-style row and expands only the message body", () => {
+		const body = `${"Inspect the benchmark results and compare every shard. ".repeat(4)}Final instruction.`;
+		const component = new AgentMessageComponent(createAgentSessionMessage(createPayload(body)));
+		const collapsed = render(component);
+
+		expect(collapsed).toContain("◆ Agent message received · Planner");
+		expect(collapsed).toContain("to expand");
+		expect(collapsed).not.toContain("Final instruction.");
+		expect(collapsed).not.toContain("Source: agent_message");
+		expect(collapsed).not.toContain("Message id:");
+
+		component.setExpanded(true);
+		const expanded = render(component);
+		expect(expanded.replace(/\s+/g, " ")).toContain("Final instruction.");
+		expect(expanded).not.toContain("Source: agent_message");
+		expect(expanded).not.toContain("To: Worker");
+		expect(expanded).not.toContain("Message id:");
+	});
+
+	it("renders sent messages beneath collapsed Python cells", () => {
+		const component = new IPythonCellComponent({
+			code: 'await agent_message.send("worker-active", "Review shard seven.")',
+			executionStarted: true,
+			details: {
+				status: "ok",
+				sentAgentMessages: [
+					{
+						id: "agentmsg_4531",
+						message: "Review shard seven.",
+						deliveryStatus: "queued",
+						target: {
+							activeSessionId: "worker-active",
+							sessionId: "worker-session",
+							sessionName: "Worker",
+						},
+					},
+					{
+						id: "agentmsg_4531_delivered",
+						message: "Continue with shard eight.",
+						deliveryStatus: "delivered",
+						target: {
+							activeSessionId: "worker-active",
+							sessionId: "worker-session",
+							sessionName: "Worker",
+						},
+					},
+				],
+			},
+		});
+
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("◆ Agent message queued · Worker · Review shard seven.");
+		expect(rendered).toContain("◆ Agent message sent · Worker · Continue with shard eight.");
+		expect(rendered).not.toContain("Agent message received");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, fauxToolCall, type Message } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall, type Message, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -9,8 +9,10 @@ import {
 	createAgentSessionMessagePrompt,
 	isAgentSessionMessagePrompt,
 } from "../../../src/core/agent-messages.js";
+import type { KernelSentAgentMessage } from "../../../src/core/kernel/index.js";
 import { AgentMessageComponent } from "../../../src/modes/interactive/components/agent-message.js";
 import { IPythonCellComponent } from "../../../src/modes/interactive/components/ipython-cell.js";
+import { formatQueuedMessagePreview } from "../../../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
 import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
 
@@ -40,6 +42,13 @@ function stripAnsi(text: string): string {
 function render(component: AgentMessageComponent): string {
 	return stripAnsi(component.render(120).join("\n"));
 }
+
+type LateSentAgentMessageHost = {
+	_recordLateIpythonSentAgentMessage: (toolCallId: string, message: KernelSentAgentMessage) => void;
+	_agentEventQueue: Promise<void>;
+	_lateIpythonSentAgentMessages: Map<string, KernelSentAgentMessage[]>;
+	_restoreLateIpythonSentAgentMessages: () => void;
+};
 
 describe("ENG-4531 agent message UI", () => {
 	const harnesses: Harness[] = [];
@@ -117,6 +126,60 @@ describe("ENG-4531 agent message UI", () => {
 			steering: [],
 			followUp: [prompt],
 		});
+	});
+
+	it("does not add a second queue label to agent message previews", () => {
+		expect(formatQueuedMessagePreview("Agent message received: Use shard seven.", "Follow-up")).toBe(
+			"Agent message received: Use shard seven.",
+		);
+		expect(formatQueuedMessagePreview("Run the remaining checks.", "Steering")).toBe(
+			"Steering: Run the remaining checks.",
+		);
+	});
+
+	it("persists sent messages that arrive after their Python cell completes", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "ipython_4531",
+			toolName: "ipython",
+			content: [{ type: "text", text: "" }],
+			details: { status: "ok" },
+			isError: false,
+			timestamp: Date.now(),
+		};
+		harness.session.agent.state.messages.push(toolResult);
+		const lateMessage = {
+			id: "agentmsg_late_4531",
+			message: "Background review finished.",
+			deliveryStatus: "delivered" as const,
+			target: {
+				activeSessionId: "worker-active",
+				sessionId: "worker-session",
+				sessionName: "Worker",
+			},
+		};
+		const events: string[] = [];
+		const unsubscribe = harness.session.subscribe((event) => events.push(event.type));
+		const host = harness.session as unknown as LateSentAgentMessageHost;
+
+		host._recordLateIpythonSentAgentMessage(toolResult.toolCallId, lateMessage);
+		await host._agentEventQueue;
+		unsubscribe();
+
+		expect(toolResult.details).toMatchObject({ sentAgentMessages: [lateMessage] });
+		expect(
+			harness.session.sessionManager
+				.getEntries()
+				.some((entry) => entry.type === "custom" && entry.customType === "ipython_sent_agent_message"),
+		).toBe(true);
+		expect(events).toContain("ipython_sent_agent_message");
+
+		toolResult.details = { status: "ok" };
+		host._lateIpythonSentAgentMessages = new Map();
+		host._restoreLateIpythonSentAgentMessages();
+		expect(toolResult.details).toMatchObject({ sentAgentMessages: [lateMessage] });
 	});
 
 	it("preserves the custom message when direct delivery races with active work", async () => {

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -108,6 +108,27 @@ describe("ENG-4531 agent message UI", () => {
 		expect(harness.session.messages[0]?.role).toBe("user");
 	});
 
+	it("preserves structured messages passed through the normal prompt path", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const payload = createPayload("Run the idle-session review.");
+		const prompt = createAgentSessionMessagePrompt(payload);
+		harness.setResponses([fauxAssistantMessage("Handled.")]);
+
+		await harness.session.prompt(prompt, {
+			expandPromptTemplates: false,
+			customMessage: createAgentSessionMessage(payload),
+		});
+		await harness.session.agent.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.session.messages[0]).toMatchObject({
+			role: "custom",
+			customType: "agent_message",
+			details: { id: "agentmsg_4531", message: "Run the idle-session review." },
+		});
+	});
+
 	it("keeps queued agent messages structured and removable by message identity", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -184,6 +205,17 @@ describe("ENG-4531 agent message UI", () => {
 		host._lateIpythonSentAgentMessages = new Map();
 		host._restoreLateIpythonSentAgentMessages();
 		expect(toolResult.details).toMatchObject({ sentAgentMessages: [lateMessage] });
+
+		host._lateIpythonSentAgentMessages.set("ipython_other_branch", [
+			{
+				id: "agentmsg_other_branch",
+				message: "Stale branch receipt.",
+				deliveryStatus: "delivered",
+				target: { activeSessionId: "other", sessionId: "other-session" },
+			},
+		]);
+		host._restoreLateIpythonSentAgentMessages();
+		expect(host._lateIpythonSentAgentMessages.has("ipython_other_branch")).toBe(false);
 	});
 
 	it("preserves the custom message when direct delivery races with active work", async () => {

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -170,6 +170,10 @@ describe("ENG-4531 agent message UI", () => {
 			isError: false,
 			timestamp: Date.now(),
 		};
+		harness.session.sessionManager.appendMessage(
+			fauxAssistantMessage(fauxToolCall("ipython", { code: "background_send" }), { stopReason: "toolUse" }),
+		);
+		harness.session.sessionManager.appendMessage(toolResult);
 		harness.session.agent.state.messages.push(toolResult);
 		const lateMessage = {
 			id: "agentmsg_late_4531",
@@ -196,6 +200,14 @@ describe("ENG-4531 agent message UI", () => {
 				.some((entry) => entry.type === "custom" && entry.customType === "ipython_sent_agent_message"),
 		).toBe(true);
 		expect(events).toContain("ipython_sent_agent_message");
+		expect(
+			harness.session
+				.buildSessionContext()
+				.messages.find(
+					(message): message is ToolResultMessage =>
+						message.role === "toolResult" && message.toolCallId === toolResult.toolCallId,
+				)?.details,
+		).toMatchObject({ sentAgentMessages: [lateMessage] });
 
 		toolResult.details = { status: "ok" };
 		host._restoreLateIpythonSentAgentMessages();


### PR DESCRIPTION
- received agent messages now render as compact expandable rows instead of user prompts.
- sent messages appear beneath their python cell with queued or sent labels.
- preserves delivery, queue, restart, and session behavior while keeping legacy messages unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span session delivery, queuing, daemon restart snapshots, and IPython/kernel timing for late receipts; behavior is covered by new regression tests but cross-session messaging is inherently sensitive.
> 
> **Overview**
> **Received** inter-session messages no longer show up as full user prompts in chat. They are delivered as `agent_message` custom transcript entries (the model still gets the existing text envelope) and the TUI draws a compact **Agent message received** row with sender and preview, expandable to the full body.
> 
> **Sent** messages from `agent_message.send()` emit a `display_data` receipt from Python; the kernel collects those into `sentAgentMessages` on the IPython tool result and the cell UI shows **queued** / **sent** lines with target and a one-line preview. Receipts that arrive after the cell finishes are handled via `onLateSentAgentMessage`, persisted on the tool result, and replayed through `buildSessionContext()` and compaction/branch restores.
> 
> Daemon prompt, queue, and restart paths now thread an optional `customMessage` so structured agent messages survive busy delivery and session resume. Queued previews use **Agent message received:** without a duplicate Steering/Follow-up prefix. Text-only legacy envelopes without `customMessage` still land as ordinary user messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 969340576145dded770a14ca436c35e43f53babc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render agent-to-agent messages in the TUI with collapsible display and IPython cell attribution
> - Adds `AgentMessageComponent` for displaying received agent messages as collapsible rows with a Markdown body, sender label, and preview text.
> - Extends `IPythonCellComponent` to render sent agent messages inline beneath the cell summary, showing target session and delivery status.
> - Adds `KernelManager` support for capturing agent messages emitted via `display_data` during and after cell execution, surfacing them via `sentAgentMessages` on `ExecuteResult` and an `onLateSentAgentMessage` callback for late arrivals.
> - Introduces `AgentSessionMessage` as a first-class custom message type in `AgentSession`, allowing agent messages to be queued, accepted, and tracked through the prompt lifecycle.
> - The Python `agent_message.send()` function now emits an IPython display output with the receipt payload under a new MIME type (`application/vnd.prime-agent.agent-message+json`) so the kernel can capture and surface it.
> - Late-sent agent messages are persisted to the session branch and restored after compaction or session tree updates.
> - Risk: `AgentSession.removeQueuedAgentMessageByPredicate` now matches by object identity rather than `role === "user"`, which changes removal semantics for custom queued messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9693405.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->