### PR TITLE
Tighten tool call spacing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed consecutive tool calls to stack without a blank row between each call.
 - Fixed IPython state restore notices rendering as full user messages when prompts were queued or restored ([ENG-4530](https://linear.app/primeintellect/issue/ENG-4530/collapse-ipython-state-restore-messages-in-chat-tui)).
 - Changed bare `/mcp` to open the Services menu while preserving explicit `list`, `login`, and `logout` subcommands ([ENG-4535](https://linear.app/primeintellect/issue/ENG-4535/open-services-mcp-menu-from-mcp)).
 - Added `/btw` and `/side` for one-turn inline side questions that use the current context without changing the main session ([ENG-4509](https://linear.app/primeintellect/issue/ENG-4509/add-btw-and-side-side-question-flows)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Changed consecutive tool calls to stack without a blank row between each call.
+- Changed tool call groups to use one blank row above and below without blank rows between consecutive calls.
 - Fixed IPython state restore notices rendering as full user messages when prompts were queued or restored ([ENG-4530](https://linear.app/primeintellect/issue/ENG-4530/collapse-ipython-state-restore-messages-in-chat-tui)).
 - Changed bare `/mcp` to open the Services menu while preserving explicit `list`, `login`, and `logout` subcommands ([ENG-4535](https://linear.app/primeintellect/issue/ENG-4535/open-services-mcp-menu-from-mcp)).
 - Added `/btw` and `/side` for one-turn inline side questions that use the current context without changing the main session ([ENG-4509](https://linear.app/primeintellect/issue/ENG-4509/add-btw-and-side-side-question-flows)).

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -264,6 +264,10 @@ export class AssistantMessageComponent extends Container {
 			this.contentContainer.addChild(new Spacer(1));
 			this.contentContainer.addChild(this.createErrorComponent(errorMsg, "Error"));
 		}
+
+		if (hasToolCalls && (hasVisibleContent || message.stopReason === "aborted")) {
+			this.contentContainer.addChild(new Spacer(1));
+		}
 	}
 
 	private createErrorComponent(message: string, prefix?: string): Component {

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -123,8 +123,6 @@ export class ToolExecutionComponent extends Container {
 		this.ui = ui;
 		this.cwd = cwd;
 
-		this.addChild(new Spacer(1));
-
 		// Always create both shell variants. contentPanel is the tool panel used
 		// for default renderer-based composition (and the generic fallback when no
 		// tool definition exists). selfRenderContainer is used when the tool

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -56,6 +56,35 @@ describe("AssistantMessageComponent", () => {
 		expect(rendered.includes(OSC133_ZONE_FINAL)).toBe(false);
 	});
 
+	test("adds one trailing spacer between visible assistant content and its tool batch", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([
+				{ type: "text", text: "calling tools" },
+				{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "pwd" } },
+				{ type: "toolCall", id: "tool-2", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+		const lines = component.render(60);
+
+		expect(stripAnsi(lines.at(-2) ?? "")).toContain("calling tools");
+		expect(lines.at(-1)).toBe("");
+	});
+
+	test("does not add spacing for a tool-only assistant message", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([
+				{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "pwd" } },
+				{ type: "toolCall", id: "tool-2", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+
+		expect(component.render(60)).toEqual([]);
+	});
+
 	test("renders an abort status for messages with tool calls", () => {
 		initTheme("dark");
 

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -482,7 +482,9 @@ describe("ToolExecutionComponent parity", () => {
 			createFakeTui(),
 			process.cwd(),
 		);
-		expect(stripAnsi(component.render(100).join("\n"))).toContain("bash · queued");
+		const queuedLines = component.render(100);
+		expect(stripAnsi(queuedLines.join("\n"))).toContain("bash · queued");
+		expect(stripAnsi(queuedLines[0])).toContain("bash · queued");
 
 		component.markExecutionStarted();
 		// Running status leads with the animated working glyph for the current frame.


### PR DESCRIPTION
## Summary

- remove the blank row prepended to every tool execution
- let consecutive collapsed tool calls stack as a compact activity log
- preserve expanded content, status rendering, panels, images, and controls

## Why

Each tool execution owned an unconditional leading spacer, so batches of short collapsed calls consumed twice the necessary vertical space. Removing that spacer makes dense tool activity easier to scan and matches the compact layout in the reference.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/tool-execution-component.test.ts` (21 tests)
- `npm run check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten tool call spacing in the interactive assistant message view
> - Removes the leading blank line from `ToolExecutionComponent` so tool calls no longer start with an empty row.
> - Adds a single trailing blank line after visible assistant content (or on abort) in `AssistantMessageComponent` when tool calls follow, giving one blank row above and below each tool call group.
> - New tests in `assistant-message.test.ts` and `tool-execution-component.test.ts` cover the updated spacing behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b37298c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI spacing changes with targeted tests; no runtime, auth, or data-path impact.
> 
> **Overview**
> **Tightens vertical spacing** around batches of tool calls in the interactive chat TUI so dense tool activity reads more like a compact activity log.
> 
> `ToolExecutionComponent` no longer prepends a blank row on every tool row, so consecutive collapsed calls stack without gaps between them. `AssistantMessageComponent` adds a single trailing blank line after visible assistant text/thinking (or after an abort notice) when tool calls follow, which pairs with the existing leading spacer on visible content to give **one blank row above and below the whole tool group** instead of double spacing per call.
> 
> Changelog and unit tests cover the new spacing rules, including tool-only assistant turns (no extra assistant spacing) and bash panel rendering starting on the first line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37298ccf843a5d6dfafb48541139bac837c839b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->