### PR TITLE
fix marquee expansion hint assertion

### DIFF
--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -617,15 +617,18 @@ describe("marquee TUI components", () => {
 		const collapsed = stripAnsi(collapsedLines.join("\n"));
 		expect(collapsed).toContain("python");
 		expect(collapsed).toContain("12ms");
+		expect(collapsed).toContain("Ctrl+O to expand");
 		expect(collapsed).not.toContain("ipython");
 		expect(collapsed).not.toContain('"code"');
 
-		// Expanded keeps the identical top line — no restructuring — and just
-		// attaches the code and output below it, backgroundless like the top line.
+		// Expanded keeps the same status content while updating the toggle hint,
+		// then attaches the code and output below it, backgroundless like the top line.
 		component.setExpanded(true);
 		const expandedLines = component.render(100);
-		expect(stripAnsi(expandedLines[0])).toBe(stripAnsi(collapsedLines[0]));
 		const expanded = stripAnsi(expandedLines.join("\n"));
+		const expandedStatus = expandedLines.map(stripAnsi).find((line) => line.includes("python · print(55)"));
+		expect(expandedStatus).toContain("↑ 1 ↓ 1 lines · 12ms");
+		expect(expanded).toContain("Ctrl+O to collapse");
 		expect(expanded).toContain("print(55)");
 		expect(expanded).toContain("55");
 		expect(expanded).not.toContain('"code"');


### PR DESCRIPTION
- the ipython renderer test assumed the status row always occupied the first rendered line.
- locate the status row by content and verify the expand and collapse hints for each state.
- keeps the test valid when tool execution spacing changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test assertions and comments change; no production rendering or behavior is modified.
> 
> **Overview**
> Updates the **built-in ipython tool row** test in `marquee-components.test.ts` so it no longer assumes the status row is always `expandedLines[0]`.
> 
> **Collapsed** rendering now also asserts **`Ctrl+O to expand`**. **Expanded** rendering finds the status line by content (`python · print(55)`), checks **`↑ 1 ↓ 1 lines · 12ms`** and **`Ctrl+O to collapse`**, and drops the strict equality check between the first collapsed and expanded lines—so the test stays valid when tool execution spacing or line layout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8414e8d04f6a907d45c15672e57e59ac821ea71c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix marquee expansion hint assertions in collapsed/expanded rendering test
> Updates the `python cell collapsed/expanded rendering` test in [marquee-components.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/382/files#diff-e64bda7bdf957b0f1d5ffd73064d138feea73841c600f8a8aebe0ff287ce3738) to match actual component behavior. The test now asserts that `Ctrl+O to expand` appears in the collapsed state, `Ctrl+O to collapse` appears in the expanded state, and the expanded status line shows a line-count indicator. The strict equality check between collapsed and expanded first-line content is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8414e8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->