### PR TITLE
prepare v0.2.9 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.2.8",
+			"version": "0.2.9",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.2.8",
+				"@earendil-works/pi-coding-agent": "^0.2.9",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5738,10 +5738,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.2.8",
+			"version": "0.2.9",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.2.8",
+				"@earendil-works/pi-ai": "^0.2.9",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5768,7 +5768,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.2.8",
+			"version": "0.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5810,13 +5810,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.2.8",
+			"version": "0.2.9",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.2.8",
-				"@earendil-works/pi-ai": "^0.2.8",
-				"@earendil-works/pi-tui": "^0.2.8",
+				"@earendil-works/pi-agent-core": "^0.2.9",
+				"@earendil-works/pi-ai": "^0.2.9",
+				"@earendil-works/pi-tui": "^0.2.9",
 				"@mariozechner/clipboard": "0.3.9",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
@@ -5960,7 +5960,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.2.8",
+			"version": "0.2.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.2.8",
+		"@earendil-works/pi-coding-agent": "^0.2.9",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-13
+
 - Changed steering and follow-up queues to preserve grouped messages as an atomic batch.
 
 ## [0.2.8] - 2026-07-09

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.2.8",
+		"@earendil-works/pi-ai": "^0.2.9",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-13
+
 ## [0.2.8] - 2026-07-09
 
 - Registered the full Prime Inference catalog (97 models, up from 32) instead of a curated whitelist; context/output limits, vision, and reasoning now come from OpenRouter metadata with a small override table for limits the gateway enforces differently (verified against the live API), and raw/duplicate variants (BF16, HF-cased, `zai-org/`, fine-tune outputs) are skipped.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-13
+
 - Changed tool call groups to use one blank row above and below without blank rows between consecutive calls.
 - Changed the session tree to show only user messages by default.
 - Changed agent-to-agent messages to render as directional rows, with received messages expandable in chat and sent messages shown below their Python cell ([ENG-4531](https://linear.app/primeintellect/issue/ENG-4531/collapse-and-simplify-agent2agent-messages-in-chat-tui)).

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Coding agent CLI with IPython-backed tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -43,9 +43,9 @@
 		"bundle": "node scripts/bundle.mjs"
 	},
 	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.2.8",
-		"@earendil-works/pi-ai": "^0.2.8",
-		"@earendil-works/pi-tui": "^0.2.8",
+		"@earendil-works/pi-agent-core": "^0.2.9",
+		"@earendil-works/pi-ai": "^0.2.9",
+		"@earendil-works/pi-tui": "^0.2.9",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-13
+
 - Fixed fullscreen dock selection so prompt text can be copied ([#342](https://github.com/PrimeIntellect-ai/prime-agent/pull/342)).
 
 ## [0.2.8] - 2026-07-09

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- bumps the published packages and internal dependency ranges to v0.2.9.
- finalizes the v0.2.9 changelogs for side questions, heartbeat steering, session reliability, and tui refinements.
- regenerates the lockfile and passes the repository checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code in the diff; risk is limited to incorrect version or release-note mismatches at publish time.
> 
> **Overview**
> **Release prep for v0.2.9** across the monorepo: root and workspace packages (`@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`) are bumped from **0.2.8 → 0.2.9**, with matching internal `^0.2.9` dependency ranges and an updated **`package-lock.json`**.
> 
> Changelogs are finalized under **`[0.2.9] - 2026-07-13`**: **agent** documents atomic batching for steering/follow-up queues; **coding-agent** lists TUI/UX flows (`/btw`, `/side`, heartbeat steering, `/mcp` menu, session tree, agent-to-agent rendering, daemon/heartbeat/onboarding fixes, and more); **tui** notes fullscreen dock text selection for copy. **`pi-ai`** gets a dated **0.2.9** section with no new bullets in this diff (prior **0.2.8** notes remain the last substantive ai changelog in the diff).
> 
> No application source changes appear in the diff—only version metadata, changelogs, and lockfile alignment for publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffedc261f72534ae1a4b4d61c471a2a6525de4ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v0.2.9 across all packages
> - Bumps all package versions from 0.2.8 to 0.2.9 and updates inter-package dependencies accordingly.
> - Key changes in `packages/coding-agent`: tool call group formatting, `/mcp` behavior change, new `/btw` and `/side` commands, heartbeat prompts now default to steering mode, self-update session retention fixes, and onboarding no longer blocks the TUI.
> - `packages/agent`: steering and follow-up queues now preserve grouped messages as an atomic batch.
> - `packages/tui`: fixes fullscreen dock selection to allow copying prompt text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffedc26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->