### PR TITLE
restore prime api key precedence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed `PRIME_API_KEY` being ignored when the Prime CLI config contained an API key.
+- Fixed Prime Inference credential precedence to prefer `PRIME_API_KEY`, then the Prime CLI config, then `auth.json`.
 
 ## [0.2.9] - 2026-07-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed Prime Inference credential precedence to prefer `PRIME_API_KEY`, then the Prime CLI config, then `auth.json`.
+- Fixed Prime Inference credential and team-header precedence to prefer `PRIME_API_KEY`, then the Prime CLI config, then `auth.json`.
 
 ## [0.2.9] - 2026-07-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed IPython Bash cells with leading blank lines being labeled and previewed as Python ([ENG-4529](https://linear.app/primeintellect/issue/ENG-4529/leading-newline-before-percentpercentbash-names-tool-call-as-python)).
 - Fixed recap layout shifts by keeping the previous recap visible until its replacement arrives ([ENG-4533](https://linear.app/primeintellect/issue/ENG-4533/reserve-space-for-recap-to-prevent-layout-shift)).
 - Changed the new-chat tray to hide shortcut guidance while typing and keep the `agents` link visible.
+- Fixed `PRIME_API_KEY` being ignored when the Prime CLI config contained an API key.
 
 ## [0.2.8] - 2026-07-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `PRIME_API_KEY` being ignored when the Prime CLI config contained an API key.
+
 ## [0.2.9] - 2026-07-13
 
 - Changed tool call groups to use one blank row above and below without blank rows between consecutive calls.
@@ -21,7 +23,6 @@
 - Fixed IPython Bash cells with leading blank lines being labeled and previewed as Python ([ENG-4529](https://linear.app/primeintellect/issue/ENG-4529/leading-newline-before-percentpercentbash-names-tool-call-as-python)).
 - Fixed recap layout shifts by keeping the previous recap visible until its replacement arrives ([ENG-4533](https://linear.app/primeintellect/issue/ENG-4533/reserve-space-for-recap-to-prevent-layout-shift)).
 - Changed the new-chat tray to hide shortcut guidance while typing and keep the `agents` link visible.
-- Fixed `PRIME_API_KEY` being ignored when the Prime CLI config contained an API key.
 
 ## [0.2.8] - 2026-07-09
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -481,13 +481,23 @@ export class AuthStorage {
 	}
 
 	private getAuthSourceCandidates(provider: string, options?: { includeFallback?: boolean }): AuthSourceCandidate[] {
-		const candidates = [
-			this.getRuntimeAuthCandidate(provider),
-			this.getStoredAuthCandidate(provider),
-			this.getEnvironmentAuthCandidate(provider),
-			provider === PRIME_INFERENCE_PROVIDER_ID ? this.getPrimeCliAuthCandidate(provider) : undefined,
-			options?.includeFallback === false ? undefined : this.getFallbackAuthCandidate(provider),
-		];
+		const fallbackCandidate =
+			options?.includeFallback === false ? undefined : this.getFallbackAuthCandidate(provider);
+		const candidates =
+			provider === PRIME_INFERENCE_PROVIDER_ID
+				? [
+						this.getRuntimeAuthCandidate(provider),
+						this.getEnvironmentAuthCandidate(provider),
+						this.getPrimeCliAuthCandidate(provider),
+						this.getStoredAuthCandidate(provider),
+						fallbackCandidate,
+					]
+				: [
+						this.getRuntimeAuthCandidate(provider),
+						this.getStoredAuthCandidate(provider),
+						this.getEnvironmentAuthCandidate(provider),
+						fallbackCandidate,
+					];
 		return candidates.filter((candidate): candidate is AuthSourceCandidate => candidate !== undefined);
 	}
 
@@ -801,11 +811,9 @@ export class AuthStorage {
 	 * Get API key for a provider.
 	 * Priority:
 	 * 1. Runtime override (CLI --api-key)
-	 * 2. API key from auth.json
-	 * 3. OAuth token from auth.json (auto-refreshed with locking)
-	 * 4. Environment variable
-	 * 5. Prime CLI config (Prime Inference only)
-	 * 6. Fallback resolver (models.json custom providers)
+	 * 2. Prime Inference: environment variable, Prime CLI config, auth.json
+	 * 3. Other providers: auth.json, environment variable
+	 * 4. Fallback resolver (models.json custom providers)
 	 */
 	async getApiKeyWithSourceToken(
 		providerId: string,
@@ -819,6 +827,31 @@ export class AuthStorage {
 				apiKey: runtimeKey,
 				sourceToken: this.getAuthSourceTokenForCandidate(providerId, runtimeCandidate),
 			};
+		}
+
+		const envCandidate = this.getEnvironmentAuthCandidate(providerId);
+		const envKey = getEnvApiKey(providerId);
+		if (
+			providerId === PRIME_INFERENCE_PROVIDER_ID &&
+			envKey &&
+			envCandidate &&
+			!this.isAuthSourceStale(providerId, envCandidate)
+		) {
+			return {
+				apiKey: envKey,
+				sourceToken: this.getAuthSourceTokenForCandidate(providerId, envCandidate),
+			};
+		}
+
+		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
+			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
+			const primeCliKey = this.getPrimeCliApiKey(providerId);
+			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
+				return {
+					apiKey: primeCliKey,
+					sourceToken: this.getAuthSourceTokenForCandidate(providerId, primeCliCandidate),
+				};
+			}
 		}
 
 		const cred = this.data[providerId];
@@ -901,25 +934,17 @@ export class AuthStorage {
 			}
 		}
 
-		// Fall back to environment variable
-		const envCandidate = this.getEnvironmentAuthCandidate(providerId);
-		const envKey = getEnvApiKey(providerId);
-		if (envKey && envCandidate && !this.isAuthSourceStale(providerId, envCandidate)) {
+		// Other providers preserve auth.json priority over environment variables.
+		if (
+			providerId !== PRIME_INFERENCE_PROVIDER_ID &&
+			envKey &&
+			envCandidate &&
+			!this.isAuthSourceStale(providerId, envCandidate)
+		) {
 			return {
 				apiKey: envKey,
 				sourceToken: this.getAuthSourceTokenForCandidate(providerId, envCandidate),
 			};
-		}
-
-		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
-			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
-			const primeCliKey = this.getPrimeCliApiKey(providerId);
-			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
-				return {
-					apiKey: primeCliKey,
-					sourceToken: this.getAuthSourceTokenForCandidate(providerId, primeCliCandidate),
-				};
-			}
 		}
 
 		// Fall back to custom resolver (e.g., models.json custom providers)

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -1033,30 +1033,33 @@ export class AuthStorage {
 			if (config?.teamIdFromEnv) {
 				return undefined;
 			}
-			const credential = this.data[PRIME_INFERENCE_PROVIDER_ID];
-			if (config?.apiKey) {
-				if (credential?.type === "api_key" && credential.primeTeam === null) {
-					return null;
-				}
-				if (config.teamId) {
-					return this.toPrimeTeamCredential({
-						teamId: config.teamId,
-						name: config.teamName ?? "Prime CLI team",
-						...(config.teamRole ? { role: config.teamRole } : {}),
-					});
-				}
-				if (credential?.type === "api_key" && credential.primeTeam) {
-					return credential.primeTeam;
-				}
-				return null;
-			}
 		}
 
 		const credential = this.data[PRIME_INFERENCE_PROVIDER_ID];
+		const authSource = this.getAuthStatus(PRIME_INFERENCE_PROVIDER_ID).source;
+		if (authSource === "runtime" || authSource === "environment") {
+			return undefined;
+		}
+		if (authSource === "prime_cli") {
+			if (credential?.type === "api_key" && credential.primeTeam === null) {
+				return null;
+			}
+			if (config?.teamId) {
+				return this.toPrimeTeamCredential({
+					teamId: config.teamId,
+					name: config.teamName ?? "Prime CLI team",
+					...(config.teamRole ? { role: config.teamRole } : {}),
+				});
+			}
+			if (credential?.type === "api_key" && credential.primeTeam) {
+				return credential.primeTeam;
+			}
+			return null;
+		}
 		if (credential?.type === "api_key" && credential.primeTeam !== undefined) {
 			return credential.primeTeam;
 		}
-		if (config?.teamId) {
+		if (!config?.apiKey && config?.teamId) {
 			return this.toPrimeTeamCredential({
 				teamId: config.teamId,
 				name: config.teamName ?? "Prime CLI team",
@@ -1076,30 +1079,7 @@ export class AuthStorage {
 			return primeCliConfig.teamId ? { "X-Prime-Team-ID": primeCliConfig.teamId } : undefined;
 		}
 
-		const credential = this.data[providerId];
-		if (primeCliConfig?.apiKey) {
-			if (credential?.type === "api_key" && credential.primeTeam === null) {
-				return undefined;
-			}
-			if (primeCliConfig.teamId) {
-				return { "X-Prime-Team-ID": primeCliConfig.teamId };
-			}
-			return credential?.type === "api_key" && credential.primeTeam?.teamId
-				? { "X-Prime-Team-ID": credential.primeTeam.teamId }
-				: undefined;
-		}
-
-		if (credential?.type === "api_key") {
-			if (credential.primeTeam === null) {
-				return undefined;
-			}
-			const selectedTeamId = credential.primeTeam?.teamId;
-			if (selectedTeamId) {
-				return { "X-Prime-Team-ID": selectedTeamId };
-			}
-		}
-
-		const teamId = primeCliConfig?.teamId;
+		const teamId = this.getPrimeInferenceTeamSelection()?.teamId;
 		return teamId ? { "X-Prime-Team-ID": teamId } : undefined;
 	}
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -483,9 +483,9 @@ export class AuthStorage {
 	private getAuthSourceCandidates(provider: string, options?: { includeFallback?: boolean }): AuthSourceCandidate[] {
 		const candidates = [
 			this.getRuntimeAuthCandidate(provider),
-			provider === PRIME_INFERENCE_PROVIDER_ID ? this.getPrimeCliAuthCandidate(provider) : undefined,
 			this.getStoredAuthCandidate(provider),
 			this.getEnvironmentAuthCandidate(provider),
+			provider === PRIME_INFERENCE_PROVIDER_ID ? this.getPrimeCliAuthCandidate(provider) : undefined,
 			options?.includeFallback === false ? undefined : this.getFallbackAuthCandidate(provider),
 		];
 		return candidates.filter((candidate): candidate is AuthSourceCandidate => candidate !== undefined);
@@ -804,7 +804,8 @@ export class AuthStorage {
 	 * 2. API key from auth.json
 	 * 3. OAuth token from auth.json (auto-refreshed with locking)
 	 * 4. Environment variable
-	 * 5. Fallback resolver (models.json custom providers)
+	 * 5. Prime CLI config (Prime Inference only)
+	 * 6. Fallback resolver (models.json custom providers)
 	 */
 	async getApiKeyWithSourceToken(
 		providerId: string,
@@ -818,17 +819,6 @@ export class AuthStorage {
 				apiKey: runtimeKey,
 				sourceToken: this.getAuthSourceTokenForCandidate(providerId, runtimeCandidate),
 			};
-		}
-
-		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
-			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
-			const primeCliKey = this.getPrimeCliApiKey(providerId);
-			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
-				return {
-					apiKey: primeCliKey,
-					sourceToken: this.getAuthSourceTokenForCandidate(providerId, primeCliCandidate),
-				};
-			}
 		}
 
 		const cred = this.data[providerId];
@@ -919,6 +909,17 @@ export class AuthStorage {
 				apiKey: envKey,
 				sourceToken: this.getAuthSourceTokenForCandidate(providerId, envCandidate),
 			};
+		}
+
+		if (providerId === PRIME_INFERENCE_PROVIDER_ID) {
+			const primeCliCandidate = this.getPrimeCliAuthCandidate(providerId);
+			const primeCliKey = this.getPrimeCliApiKey(providerId);
+			if (primeCliKey && primeCliCandidate && !this.isAuthSourceStale(providerId, primeCliCandidate)) {
+				return {
+					apiKey: primeCliKey,
+					sourceToken: this.getAuthSourceTokenForCandidate(providerId, primeCliCandidate),
+				};
+			}
 		}
 
 		// Fall back to custom resolver (e.g., models.json custom providers)

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -359,14 +359,20 @@ describe("AuthStorage", () => {
 
 		test("prime inference uses environment auth over Prime CLI and stored auth", async () => {
 			const originalPrimeApiKey = process.env.PRIME_API_KEY;
+			const originalPrimeTeamId = process.env.PRIME_TEAM_ID;
 			process.env.PRIME_API_KEY = "env-prime-key";
+			delete process.env.PRIME_TEAM_ID;
 			try {
 				const primeConfigPath = join(tempDir, "prime-config.json");
-				writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
+				writeFileSync(
+					primeConfigPath,
+					JSON.stringify({ api_key: "prime-cli-key", team_id: "cli-team", team_name: "CLI Research" }),
+				);
 				writeAuthJson({
 					"prime-inference": {
 						type: "api_key",
 						key: "agent-key",
+						primeTeam: { teamId: "stored-team", name: "Stored Research" },
 					},
 				});
 
@@ -381,11 +387,18 @@ describe("AuthStorage", () => {
 					source: "environment",
 					label: "PRIME_API_KEY",
 				});
+				expect(authStorage.getProviderHeaders("prime-inference")).toBeUndefined();
+				expect(authStorage.getPrimeInferenceTeamSelection()).toBeUndefined();
 			} finally {
 				if (originalPrimeApiKey === undefined) {
 					delete process.env.PRIME_API_KEY;
 				} else {
 					process.env.PRIME_API_KEY = originalPrimeApiKey;
+				}
+				if (originalPrimeTeamId === undefined) {
+					delete process.env.PRIME_TEAM_ID;
+				} else {
+					process.env.PRIME_TEAM_ID = originalPrimeTeamId;
 				}
 			}
 		});

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -334,7 +334,7 @@ describe("AuthStorage", () => {
 			expect(authStorage.getAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
 		});
 
-		test("prime inference uses Prime CLI auth over legacy Prime Agent auth", async () => {
+		test("prime inference uses stored auth over Prime CLI auth", async () => {
 			const primeConfigPath = join(tempDir, "prime-config.json");
 			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
 			writeAuthJson({
@@ -349,15 +349,14 @@ describe("AuthStorage", () => {
 				usePrimeCliConfig: true,
 			});
 
-			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("agent-key");
 			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
-				configured: false,
-				source: "prime_cli",
-				label: "Prime CLI",
+				configured: true,
+				source: "stored",
 			});
 		});
 
-		test("prime inference uses Prime CLI auth over environment auth", async () => {
+		test("prime inference uses environment auth over Prime CLI auth", async () => {
 			const originalPrimeApiKey = process.env.PRIME_API_KEY;
 			process.env.PRIME_API_KEY = "env-prime-key";
 			try {
@@ -370,11 +369,11 @@ describe("AuthStorage", () => {
 					usePrimeCliConfig: true,
 				});
 
-				await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
+				await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("env-prime-key");
 				expect(authStorage.getAuthStatus("prime-inference")).toEqual({
 					configured: false,
-					source: "prime_cli",
-					label: "Prime CLI",
+					source: "environment",
+					label: "PRIME_API_KEY",
 				});
 			} finally {
 				if (originalPrimeApiKey === undefined) {

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -334,7 +334,7 @@ describe("AuthStorage", () => {
 			expect(authStorage.getAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
 		});
 
-		test("prime inference uses stored auth over Prime CLI auth", async () => {
+		test("prime inference uses Prime CLI auth over stored auth", async () => {
 			const primeConfigPath = join(tempDir, "prime-config.json");
 			writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
 			writeAuthJson({
@@ -349,20 +349,26 @@ describe("AuthStorage", () => {
 				usePrimeCliConfig: true,
 			});
 
-			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("agent-key");
+			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("prime-cli-key");
 			expect(authStorage.getAuthStatus("prime-inference")).toEqual({
-				configured: true,
-				source: "stored",
+				configured: false,
+				source: "prime_cli",
+				label: "Prime CLI",
 			});
 		});
 
-		test("prime inference uses environment auth over Prime CLI auth", async () => {
+		test("prime inference uses environment auth over Prime CLI and stored auth", async () => {
 			const originalPrimeApiKey = process.env.PRIME_API_KEY;
 			process.env.PRIME_API_KEY = "env-prime-key";
 			try {
 				const primeConfigPath = join(tempDir, "prime-config.json");
 				writeFileSync(primeConfigPath, JSON.stringify({ api_key: "prime-cli-key" }));
-				writeAuthJson({});
+				writeAuthJson({
+					"prime-inference": {
+						type: "api_key",
+						key: "agent-key",
+					},
+				});
 
 				authStorage = AuthStorage.create(authJsonPath, {
 					primeCliConfigPath: primeConfigPath,


### PR DESCRIPTION
- prime inference now resolves normal credential sources as environment, prime cli, then auth.json.
- the explicit `--api-key` flag remains an in-memory one-process override above those sources.
- added regression coverage for environment and prime cli precedence.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `PRIME_API_KEY` precedence over Prime CLI config and stored auth for prime-inference
> - Reorders credential resolution in [`auth-storage.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/385/files#diff-c1bbb0577045e4d9c03e250fa121993eb80a6129ee047c6097583a07d24df74b) so that for the `prime-inference` provider, `PRIME_API_KEY` env var is preferred over Prime CLI config, which is preferred over stored auth.
> - For other providers, stored credentials remain preferred over environment variables (unchanged behavior).
> - Team selection (`getPrimeInferenceTeamSelection`) now returns `undefined` when auth source is runtime or environment, so `X-Prime-Team-ID` is omitted in those cases.
> - Behavioral Change: Auth source tokens and `getAuthStatus` will reflect the new ordering, and the team header is no longer sent when `PRIME_API_KEY` is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 448176f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication precedence and request headers for Prime Inference; behavior is localized and covered by tests, but wrong resolution could send requests with the wrong key or team context.
> 
> **Overview**
> Restores **Prime Inference** credential resolution so **`PRIME_API_KEY`** wins over Prime CLI config and **`auth.json`**, after runtime **`--api-key`**. Non–Prime Inference providers still prefer stored credentials over environment variables.
> 
> **Team context** (`X-Prime-Team-ID` and team selection) now follows the active auth source: runtime and environment keys do not inherit Prime CLI or stored team IDs unless **`PRIME_TEAM_ID`** applies via env. **`getProviderHeaders`** delegates to the shared team-selection logic instead of duplicating CLI vs stored rules.
> 
> Regression tests cover env beating CLI and stored auth, with no team header when only the env key is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448176f85bca53135fd6138f7deedca90735ae1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->