### PR TITLE
disable color in ipython subprocesses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed IPython kernels to set `NO_COLOR=1`, preventing ANSI color escapes from inflating `%%bash` output.
+
 ## [0.3.0] - 2026-07-13
 
 - Changed daemon and headless execution to isolate each root session tree in a recoverable worker process, with protocol-v2 chunked snapshots, compact streaming, attachment-local backpressure, session leases, and unchanged print, JSON, and RPC interfaces.

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -23,6 +23,9 @@ import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const RLM_BOOTSTRAP_BASE_CODE = `
 import asyncio
+import os as _prime_agent_os
+
+_prime_agent_os.environ["NO_COLOR"] = "1"
 
 try:
     import nest_asyncio as _prime_agent_nest_asyncio

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -11,6 +11,10 @@ describe("IPython RLM bootstrap", () => {
 		expect(buildRlmBootstrapCode()).toMatch(/^import asyncio$/m);
 	});
 
+	it("disables colored output for subprocesses launched by the kernel", () => {
+		expect(buildRlmBootstrapCode()).toContain('_prime_agent_os.environ["NO_COLOR"] = "1"');
+	});
+
 	it("guards Python skill imports so a broken skill does not abort bootstrap", () => {
 		const code = buildRlmBootstrapCode([
 			{
@@ -62,6 +66,10 @@ describeIfKernel("IPython RLM bootstrap (real kernel)", () => {
 			const result = await manager.execute("_t = asyncio.create_task(asyncio.sleep(0))\nprint(type(_t).__name__)");
 			expect(result.status).toBe("ok");
 			expect(result.stdout).toContain("Task");
+
+			const bashResult = await manager.execute('%%bash\nprintf %s "$NO_COLOR"');
+			expect(bashResult.status).toBe("ok");
+			expect(bashResult.stdout).toBe("1");
 		} finally {
 			await manager.dispose();
 		}


### PR DESCRIPTION
- ipython kernels now set no_color before agent code runs so later bash cells inherit it.
- prevents ansi escape sequences from inflating pytest and other cli output.
- adds regression coverage for bootstrap code and real bash environment inheritance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bootstrap env tweak with tests; no auth, persistence, or protocol changes.
> 
> **Overview**
> IPython kernels now set **`NO_COLOR=1`** in the RLM bootstrap (`buildRlmBootstrapCode`) before agent code runs, so **`%%bash`** cells inherit it and CLIs such as pytest emit plain text instead of ANSI escapes that bloat tool output.
> 
> Regression tests assert the bootstrap snippet includes the assignment, and a real-kernel test confirms **`$NO_COLOR`** is **`1`** in a **`%%bash`** cell after bootstrap. The unreleased changelog notes the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9afdd5734e42ec8a5ff7ba90bd6b7500916313c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable ANSI color output in IPython kernel subprocesses by setting `NO_COLOR=1`
> Sets `NO_COLOR=1` in the IPython kernel's environment via the bootstrap code in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/395/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d), so subprocesses like `%%bash` cells inherit the flag and omit ANSI escape codes from their output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9afdd57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->