### PR TITLE
speed up focused overlay navigation

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed focused full-pane overlays becoming slow to navigate on wider terminals.
+
 ## [0.3.0] - 2026-07-13
 
 - Fixed fullscreen TUI handoffs temporarily releasing raw input and leaking keyboard-protocol timers, which caused flicker and echoed arrow escape sequences while opening sessions.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -17,7 +17,7 @@ import {
 	normalizeTerminalOutput,
 	sliceByColumn,
 	sliceWithWidth,
-	stripAnsi,
+	visibleContentSpan,
 	visibleWidth,
 } from "./utils.js";
 
@@ -1108,16 +1108,7 @@ export class TUI extends Container {
 	}
 
 	private selectableSpan(line: string, maxWidth: number): { from: number; to: number } | null {
-		const width = Math.min(maxWidth, visibleWidth(line));
-		let from = -1;
-		let to = -1;
-		for (let col = 0; col < width; col++) {
-			const cell = stripAnsi(sliceByColumn(line, col, 1));
-			if (cell.trim().length === 0) continue;
-			if (from === -1) from = col;
-			to = col + 1;
-		}
-		return from === -1 ? null : { from, to };
+		return visibleContentSpan(line, maxWidth);
 	}
 
 	private createDockSelectionRegions(

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -255,6 +255,53 @@ export function visibleWidth(str: string): number {
 	return width;
 }
 
+/** Find the terminal-column span containing visible, non-whitespace content. */
+export function visibleContentSpan(line: string, maxWidth: number): { from: number; to: number } | null {
+	const limit = Math.floor(maxWidth);
+	if (line.length === 0 || !Number.isFinite(limit) || limit <= 0) {
+		return null;
+	}
+
+	let from = -1;
+	let to = -1;
+	let currentCol = 0;
+	let i = 0;
+
+	while (i < line.length && currentCol < limit) {
+		const ansi = extractAnsiCode(line, i);
+		if (ansi) {
+			i += ansi.length;
+			continue;
+		}
+
+		if (line[i] === "\t") {
+			currentCol += 3;
+			i++;
+			continue;
+		}
+
+		let textEnd = i;
+		while (textEnd < line.length && line[textEnd] !== "\t" && !extractAnsiCode(line, textEnd)) {
+			textEnd++;
+		}
+
+		for (const { segment } of segmenter.segment(line.slice(i, textEnd))) {
+			const width = graphemeWidth(segment);
+			const segmentStart = currentCol;
+			const segmentEnd = currentCol + width;
+			if (width > 0 && segment.trim().length > 0 && segmentStart < limit) {
+				if (from === -1) from = segmentStart;
+				to = Math.min(segmentEnd, limit);
+			}
+			currentCol = segmentEnd;
+			if (currentCol >= limit) break;
+		}
+		i = textEnd;
+	}
+
+	return from === -1 ? null : { from, to };
+}
+
 /**
  * Normalize text for terminal output without changing logical editor content.
  * Some terminals render precomposed Thai/Lao AM vowels inconsistently during

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -19,6 +19,21 @@ class InputComponent extends TestComponent {
 	}
 }
 
+class SelectionOverlay extends TestComponent {
+	private selected = 0;
+
+	override render(width: number): string[] {
+		return ["first", "second"].map((label, index) => {
+			const line = label.padEnd(width);
+			return index === this.selected ? `\x1b[48;5;238m${line}\x1b[49m` : line;
+		});
+	}
+
+	handleInput(_data: string): void {
+		this.selected = (this.selected + 1) % 2;
+	}
+}
+
 class LoggingVirtualTerminal extends VirtualTerminal {
 	private writes: string[] = [];
 	lastStopOptions: TerminalStopOptions | undefined;
@@ -263,6 +278,26 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("repaints only changed rows when navigating a focused overlay", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20));
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		tui.showOverlay(new SelectionOverlay(), { anchor: "center", width: 20 });
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.sendInput("j");
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		const repaintedRows = writes.match(/\x1b\[\d+;1H\x1b\[2K/g) ?? [];
+		assert.ok(!writes.includes("\x1b[2J"), "overlay navigation should not clear the screen");
+		assert.strictEqual(repaintedRows.length, 2, "only the old and new selected rows should repaint");
+
+		tui.stop();
+	});
+
 	it("suspends fullscreen mouse tracking while a visible overlay requests native mouse", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
 		tui.enterFullscreen({ scroll: [chat], dock });
@@ -326,6 +361,27 @@ describe("TUI fullscreen mode", () => {
 		assert.deepStrictEqual(copies, [url]);
 		assert.deepStrictEqual(overlay.inputs, [], "mouse reports are consumed before overlay input handlers");
 
+		tui.stop();
+	});
+
+	it("drag-selects ANSI-styled wide text from a focused overlay", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 40, 10);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const overlay = new InputComponent();
+		overlay.lines = ["\x1b[48;5;236m  界🙂  \x1b[49m"];
+		tui.showOverlay(overlay, { anchor: "top-left", width: 20 });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;3;1M");
+		terminal.sendInput("\x1b[<32;7;1M");
+		terminal.sendInput("\x1b[<0;7;1m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["界🙂"]);
 		tui.stop();
 	});
 

--- a/packages/tui/test/overlay-navigation-bench.ts
+++ b/packages/tui/test/overlay-navigation-bench.ts
@@ -1,0 +1,131 @@
+/**
+ * Benchmark focused full-pane overlay navigation. Run with:
+ *
+ *   npx tsx test/overlay-navigation-bench.ts
+ */
+import { performance } from "node:perf_hooks";
+import type { Terminal, TerminalStopOptions } from "../src/terminal.js";
+import { type Component, type Focusable, TUI } from "../src/tui.js";
+
+const HEIGHT = 40;
+const ITERATIONS = 200;
+const WIDTHS = [80, 120, 200];
+
+class BenchmarkTerminal implements Terminal {
+	altScreenActive = false;
+	mouseTrackingActive = false;
+	readonly kittyProtocolActive = false;
+
+	constructor(
+		readonly columns: number,
+		readonly rows: number,
+	) {}
+
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
+	stop(_options?: TerminalStopOptions): void {}
+	async drainInput(): Promise<void> {}
+	write(_data: string): void {}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+	setProgress(_active: boolean): void {}
+
+	enterAltScreen(): void {
+		this.altScreenActive = true;
+	}
+
+	leaveAltScreen(): void {
+		this.altScreenActive = false;
+	}
+
+	setMouseTracking(enabled: boolean): void {
+		this.mouseTrackingActive = enabled;
+	}
+}
+
+class StaticComponent implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class FullPaneSelector implements Component, Focusable {
+	focused = false;
+	private selected = 0;
+
+	constructor(private readonly rows: number) {}
+
+	handleInput(_data: string): void {
+		this.selected = (this.selected + 1) % 10;
+	}
+
+	render(width: number): string[] {
+		const lines = Array.from({ length: this.rows }, () => `\x1b[48;5;235m${" ".repeat(width)}\x1b[49m`);
+		for (let index = 0; index < 10; index++) {
+			const label = `  model-${index}  provider`.padEnd(width);
+			const background = index === this.selected ? 238 : 235;
+			lines[index + 5] = `\x1b[48;5;${background}m${label}\x1b[49m`;
+		}
+		return lines;
+	}
+
+	invalidate(): void {}
+}
+
+interface ImmediateTuiRender {
+	doRender(): void;
+}
+
+function percentile(sorted: number[], percentileValue: number): number {
+	const index = Math.min(sorted.length - 1, Math.floor((percentileValue / 100) * sorted.length));
+	return sorted[index];
+}
+
+function run(width: number, fullscreen: boolean): { p50: number; p95: number } {
+	const terminal = new BenchmarkTerminal(width, HEIGHT);
+	const tui = new TUI(terminal);
+	const transcript = new StaticComponent(Array.from({ length: 100 }, (_, index) => `line-${index}`));
+	const dock = new StaticComponent(["> prompt", "footer"]);
+	const overlay = new FullPaneSelector(HEIGHT);
+
+	if (fullscreen) {
+		tui.enterFullscreen({ scroll: [transcript], dock, mouse: false });
+	} else {
+		tui.addChild(transcript);
+		tui.addChild(dock);
+	}
+	tui.showOverlay(overlay, { width: "100%", maxHeight: "100%", row: 0, col: 0 });
+
+	const render = (tui as unknown as ImmediateTuiRender).doRender.bind(tui);
+	render();
+	const durations: number[] = [];
+	for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+		overlay.handleInput("down");
+		const start = performance.now();
+		render();
+		durations.push(performance.now() - start);
+	}
+	tui.stop({ flushFullscreen: false });
+
+	durations.sort((a, b) => a - b);
+	return { p50: percentile(durations, 50), p95: percentile(durations, 95) };
+}
+
+console.log(`focused overlay navigation (${HEIGHT} rows, ${ITERATIONS} updates)`);
+for (const fullscreen of [false, true]) {
+	const mode = fullscreen ? "fullscreen" : "inline";
+	for (const width of WIDTHS) {
+		const result = run(width, fullscreen);
+		console.log(
+			`${mode.padEnd(10)} ${String(width).padStart(3)} cols  p50 ${result.p50.toFixed(3)} ms  p95 ${result.p95.toFixed(3)} ms`,
+		);
+	}
+}

--- a/packages/tui/test/visible-content-span.test.ts
+++ b/packages/tui/test/visible-content-span.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { visibleContentSpan } from "../src/utils.js";
+
+describe("visibleContentSpan", () => {
+	it("finds content between surrounding and interior whitespace", () => {
+		assert.deepStrictEqual(visibleContentSpan("  alpha beta  ", 80), { from: 2, to: 12 });
+	});
+
+	it("ignores ANSI styling and styled padding", () => {
+		const line = "\x1b[48;5;236m  \x1b[1malpha\x1b[22m  \x1b[49m";
+		assert.deepStrictEqual(visibleContentSpan(line, 80), { from: 2, to: 7 });
+		assert.strictEqual(visibleContentSpan("\x1b[48;5;236m      \x1b[49m", 80), null);
+	});
+
+	it("measures tabs, wide graphemes, and combining marks in terminal columns", () => {
+		assert.deepStrictEqual(visibleContentSpan("\talpha\t", 80), { from: 3, to: 8 });
+		assert.deepStrictEqual(visibleContentSpan(" 界🙂 ", 80), { from: 1, to: 5 });
+		assert.deepStrictEqual(visibleContentSpan(" e\u0301 ", 80), { from: 1, to: 2 });
+	});
+
+	it("clips the content span to the requested width", () => {
+		assert.deepStrictEqual(visibleContentSpan("  alpha", 4), { from: 2, to: 4 });
+		assert.deepStrictEqual(visibleContentSpan("   界", 4), { from: 3, to: 4 });
+		assert.strictEqual(visibleContentSpan("alpha", 0), null);
+	});
+});


### PR DESCRIPTION
- focused full-pane overlays now compute selectable text bounds in one terminal-aware pass.
- preserved ansi, unicode, mouse selection, and row-diff behavior with focused regression coverage.
- adds a repeatable navigation benchmark for eng-4574 across inline and fullscreen modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI rendering/selection helper change with focused tests and no auth or data-path impact; main risk is subtle unicode/ANSI selection bounds regressions.
> 
> **Overview**
> Fixes sluggish keyboard navigation in **focused full-pane overlays** (e.g. model selectors) when the terminal is wide, by replacing per-column selectable-boundary work with a single pass.
> 
> **`visibleContentSpan`** in `utils.ts` walks each line once, skipping ANSI, honoring tabs and grapheme width (wide emoji, combining marks), and returns the terminal-column span of visible non-whitespace. **`TUI.selectableSpan`** now calls that helper instead of scanning every column with `sliceByColumn` + `stripAnsi`.
> 
> Regression coverage adds unit tests for `visibleContentSpan`, a fullscreen test that overlay moves repaint only two rows (no full clear), and drag-select for ANSI-styled wide text. A small **`overlay-navigation-bench.ts`** script measures render time across column widths in inline vs fullscreen modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee63a4c3226ee63d5957a6319646c1dff800544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up focused overlay navigation by replacing column-scan logic in `selectableSpan`
> - Replaces the per-column iteration in `TUI.selectableSpan` (which called `stripAnsi`/`sliceByColumn` for every column) with a single-pass scan via the new `visibleContentSpan` utility in [utils.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/398/files#diff-4c3f9017cf74053e3b6aca505c66afe64a6bb0e33edf0348d2f7dc436e594a93).
> - `visibleContentSpan` handles ANSI escapes, tab expansion, multi-column characters, and combining marks in one pass, returning the `[from, to)` column span of visible non-whitespace content clipped to `maxWidth`.
> - Adds a benchmark script at [overlay-navigation-bench.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/398/files#diff-298e7c367ce5104f2048391873aed84edfdd1318345c4ace371c4f1b3552c121) that measures p50/p95 render durations across widths and modes to validate the fix.
> - Adds tests for the new utility and for repaint behavior during overlay navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aee63a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->