### PR TITLE
show source before diffs in expanded ipython cells

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added compact file change stats to collapsed tool calls and an agent-run edit total above the recap.
 - Changed tool expansion hints to appear only on the latest tool row instead of every tool call ([ENG-4583](https://linear.app/primeintellect/issue/ENG-4583/too-many-ctrlo-alerts)).
 - Changed IPython kernels to set `NO_COLOR=1`, preventing ANSI color escapes from inflating `%%bash` output.
+- Fixed expanded IPython edit cells rendering diffs before their full source.
 - Fixed tool-only responses rendering directly against the preceding user prompt.
 
 ## [0.3.0] - 2026-07-13

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -359,19 +359,21 @@ export class IPythonCellComponent implements Component {
 		const lines = [truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "")];
 
 		const hasDiffs = (details.diffs?.length ?? 0) > 0;
-		if (hasDiffs && this.state.expanded) {
-			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
-		}
-		if ((details.sentAgentMessages?.length ?? 0) > 0) {
-			this.renderSentAgentMessages(lines, safeWidth, details.sentAgentMessages ?? []);
-		}
-
 		if (!this.state.expanded) {
+			if ((details.sentAgentMessages?.length ?? 0) > 0) {
+				this.renderSentAgentMessages(lines, safeWidth, details.sentAgentMessages ?? []);
+			}
 			return this.renderCache.set(safeWidth, cacheVersion, lines);
 		}
 
 		const hasCode = this.renderCode(lines, safeWidth);
+		if (hasDiffs) {
+			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
+		}
 		this.renderOutput(lines, safeWidth, details, hasCode);
+		if ((details.sentAgentMessages?.length ?? 0) > 0) {
+			this.renderSentAgentMessages(lines, safeWidth, details.sentAgentMessages ?? []);
+		}
 		return this.renderCache.set(safeWidth, cacheVersion, lines);
 	}
 

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -183,17 +183,26 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(addedRows.every((line) => /^\s*\+ /.test(line) || /\d+ \+ /.test(line))).toBe(true);
 	});
 
-	it("separates the diff from the summary line with a blank line", () => {
+	it("renders expanded source before diffs and output", () => {
 		const out = renderCell({
-			code: "await edit(...)",
-			details: { status: "ok", durationMs: 4, diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
+			code: 'side_effect = "visible"\nawait edit(path="a.ts", old_str="x", new_str="X")',
+			details: {
+				status: "ok",
+				durationMs: 4,
+				stdout: "side effect complete",
+				diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }],
+			},
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
 		}).split("\n");
-		expect(out[0]).toContain("to collapse");
 		expect(out[1].trim()).toBe("");
-		expect(out[2]).toContain("a.ts");
+		const sourceIndex = out.findIndex((line) => line.includes('side_effect = "visible"'));
+		const diffIndex = out.findIndex((line) => line.includes("a.ts") && line.includes("+1 -1"));
+		const outputIndex = out.findIndex((line) => line.includes("side effect complete"));
+		expect(sourceIndex).toBeGreaterThan(0);
+		expect(diffIndex).toBeGreaterThan(sourceIndex);
+		expect(outputIndex).toBeGreaterThan(diffIndex);
 	});
 
 	it("hides the full diff when collapsed", () => {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -586,9 +586,10 @@ describe("ToolExecutionComponent parity", () => {
 		component.setArgsComplete();
 		component.updateResult(
 			{
-				content: [],
+				content: [{ type: "text", text: "side effect complete" }],
 				details: {
 					status: "ok",
+					stdout: "side effect complete",
 					diffs: [{ path: "README.md", oldStr: "before", newStr: "after", startLine: 1 }],
 				},
 				isError: false,
@@ -602,9 +603,15 @@ describe("ToolExecutionComponent parity", () => {
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(120).join("\n"));
-		expect(expanded).toContain('hidden_side_effect = "only in full source"');
+		const sourceIndex = expanded.indexOf('hidden_side_effect = "only in full source"');
+		const diffIndex = expanded.indexOf("README.md  +1 -1");
+		const outputIndex = expanded.indexOf("side effect complete");
+		expect(sourceIndex).toBeGreaterThan(-1);
+		expect(diffIndex).toBeGreaterThan(sourceIndex);
+		expect(outputIndex).toBeGreaterThan(diffIndex);
 		expect(expanded).toContain("before");
 		expect(expanded).toContain("after");
+		expect(expanded).not.toContain("╰─ README.md +1 -1");
 	});
 
 	test("collapses built-in edit diffs to a one-line file stat", () => {


### PR DESCRIPTION
- expanded ipython edit cells now show their complete source before file diffs and output.
- collapsed edit summaries from #393 remain compact and unchanged.
- adds renderer and tool integration coverage for the complete expanded ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order change in the interactive TUI only; collapsed summaries and edit logic are unchanged.
> 
> **Overview**
> Fixes expanded IPython edit cells so the **full cell source** appears **before** file diffs and stdout/stderr, instead of showing diffs above the code.
> 
> **Collapsed** behavior is unchanged: one-line summary with compact `path +N -N` stats; sent agent messages still render under the summary when collapsed. **Expanded** order is now: summary line → blank → highlighted source → diffs → execution output → sent agent messages.
> 
> Tests in `ipython-cell-diff.test.ts` and `tool-execution-component.test.ts` assert source → diff → output ordering for edit cells integrated through `ToolExecutionComponent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0629d033b7aeed04288707831853affa2a50cc93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix expanded IPython cells to render source before diffs and output
> In `IPythonCellComponent.render`, reorders expanded cell rendering so full source code appears first, followed by diffs, then output, then sent agent messages. Previously, diffs were rendered before the source in expanded cells. Updates tests in [ipython-cell-diff.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/404/files#diff-f7b047ac57d725660308ea0d37b1f82fb9a142a5939128ff89ad4149c2cd766f) and [tool-execution-component.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/404/files#diff-2d950c334e0a0a37b3320e5b595fedfc1c7c89f40405defd3cc0b9dac21535eb) to assert the new ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0629d03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->