### PR TITLE
fix(ai): pin Nemotron Ultra output limit

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -144,7 +144,7 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"minimax/minimax-m3": { contextWindow: 524288 },
 	"moonshotai/kimi-k2-0905": { contextWindow: 98304 },
 	"nvidia/nemotron-3-super-120b-a12b": { contextWindow: 262144, maxTokens: 4096 },
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072 },
+	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072, maxTokens: 16384 },
 	// Enforced window is LARGER than OpenRouter's listing.
 	"qwen/qwen3-30b-a3b-instruct-2507": { contextWindow: 262144 },
 	// OpenRouter has no max_completion_tokens for the rest of these.


### PR DESCRIPTION
## Summary

- pin Nemotron 3 Ultra's verified 16k output limit in Prime Inference metadata generation
- avoid falling back to 8k when OpenRouter temporarily omits `max_completion_tokens`

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/prime-inference-models.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `maxTokens` to 16384 for Nemotron Ultra in model metadata
> Sets `maxTokens: 16384` for `nvidia/nvidia-nemotron-3-ultra-550b-a55b` in `PRIME_INFERENCE_MODEL_METADATA` in [generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/412/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c), while keeping `contextWindow: 131072` unchanged. This caps the model's output token limit wherever this metadata is consumed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ea5365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata override in the model generator; no auth or request-path logic changes.
> 
> **Overview**
> Adds **`maxTokens: 16384`** to the Prime Inference metadata override for **`nvidia/nvidia-nemotron-3-ultra-550b-a55b`** in `generate-models.ts` (context window stays **131072**).
> 
> Prime model generation merges catalog, OpenRouter, and these overrides; when OpenRouter temporarily omits `max_completion_tokens`, **`createPrimeInferenceModel`** would otherwise fall back to the **8k** default. Pinning **16k** matches the verified gateway output cap so generated `models.generated.ts` and runtime completion limits stay correct for this route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea536591fa1f7a7a4043d1d51ccf62ed9cbb1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->