### PR TITLE
show latest sessions first in resume picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed Prime Inference login leaving new sessions without a persisted model selection ([ENG-4573](https://linear.app/primeintellect/issue/ENG-4573/prompt-for-model-selection-after-prime-inference-login)).
 - Fixed empty prompt placeholders hiding the input caret.
 - Fixed missing ripgrep blocking subagents and added actionable installation guidance for the optional search helper ([ENG-4572](https://linear.app/primeintellect/issue/ENG-4572/ripgrep-not-installed)).
+- Fixed the resume picker opening on an older session instead of the newest session ([ENG-4630](https://linear.app/primeintellect/issue/ENG-4630/show-latest-sessions-first-in-resume-list)).
 - Fixed tool-only responses rendering directly against the preceding user prompt.
 
 ## [0.3.0] - 2026-07-13

--- a/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
@@ -36,6 +36,14 @@ function matchesNameFilter(session: AgentConnectionSavedSessionInfo, filter: Nam
 	return hasSessionName(session);
 }
 
+function compareSessionsByModifiedDesc(a: AgentConnectionSavedSessionInfo, b: AgentConnectionSavedSessionInfo): number {
+	const modifiedDiff = b.modified.getTime() - a.modified.getTime();
+	if (modifiedDiff !== 0) return modifiedDiff;
+	const createdDiff = b.created.getTime() - a.created.getTime();
+	if (createdDiff !== 0) return createdDiff;
+	return a.path.localeCompare(b.path);
+}
+
 export function parseSearchQuery(query: string): ParsedSearchQuery {
 	const trimmed = query.trim();
 	if (!trimmed) {
@@ -162,19 +170,21 @@ export function filterAndSortSessions(
 	const nameFiltered =
 		nameFilter === "all" ? sessions : sessions.filter((session) => matchesNameFilter(session, nameFilter));
 	const trimmed = query.trim();
-	if (!trimmed) return nameFiltered;
+	if (!trimmed) {
+		return sortMode === "recent" ? [...nameFiltered].sort(compareSessionsByModifiedDesc) : nameFiltered;
+	}
 
 	const parsed = parseSearchQuery(query);
 	if (parsed.error) return [];
 
-	// Recent mode: filter only, keep incoming order.
+	// Recent mode: filter, then order by the latest user or assistant message.
 	if (sortMode === "recent") {
 		const filtered: AgentConnectionSavedSessionInfo[] = [];
 		for (const s of nameFiltered) {
 			const res = matchSession(s, parsed);
 			if (res.matches) filtered.push(s);
 		}
-		return filtered;
+		return filtered.sort(compareSessionsByModifiedDesc);
 	}
 
 	// Relevance mode: sort by score, tie-break by modified desc.
@@ -187,7 +197,7 @@ export function filterAndSortSessions(
 
 	scored.sort((a, b) => {
 		if (a.score !== b.score) return a.score - b.score;
-		return b.session.modified.getTime() - a.session.modified.getTime();
+		return compareSessionsByModifiedDesc(a.session, b.session);
 	});
 
 	return scored.map((r) => r.session);

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -283,6 +283,10 @@ function flattenSessionTree(roots: SessionTreeNode[]): FlatSessionNode[] {
  * Custom session list component with multi-line items and search
  */
 class SessionList implements Component, Focusable {
+	private getSelectedSessionPath(): string | undefined {
+		return this.filteredSessions[this.selectedIndex]?.session.path;
+	}
+
 	private allSessions: AgentConnectionSavedSessionInfo[] = [];
 	private filteredSessions: FlatSessionNode[] = [];
 	private selectedIndex: number = 0;
@@ -362,9 +366,16 @@ class SessionList implements Component, Focusable {
 	}
 
 	setSessions(sessions: AgentConnectionSavedSessionInfo[], showCwd: boolean): void {
+		const selectedPath = this.getSelectedSessionPath();
 		this.allSessions = sessions;
 		this.showCwd = showCwd;
 		this.filterSessions(this.searchInput.getValue());
+		if (selectedPath) {
+			const selectedIndex = this.filteredSessions.findIndex((session) => session.session.path === selectedPath);
+			if (selectedIndex >= 0) {
+				this.selectedIndex = selectedIndex;
+			}
+		}
 	}
 
 	private filterSessions(query: string): void {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -296,6 +296,7 @@ class SessionList implements Component, Focusable {
 	private nameFilter: NameFilter = "all";
 	private keybindings: KeybindingsManager;
 	private showPath = false;
+	private loading = false;
 	private confirmingDeletePath: string | null = null;
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | null = null;
 	private currentSessionCanonicalPath?: string;
@@ -353,6 +354,10 @@ class SessionList implements Component, Focusable {
 
 	setMaxVisible(maxVisible: number): void {
 		this.maxVisible = Math.max(3, maxVisible);
+	}
+
+	setLoading(loading: boolean): void {
+		this.loading = loading;
 	}
 
 	setSortMode(sortMode: SortMode): void {
@@ -455,6 +460,7 @@ class SessionList implements Component, Focusable {
 		// Render search input
 		lines.push(...this.searchInput.render(width));
 		lines.push(""); // Blank line after search
+		if (this.loading && this.filteredSessions.length === 0) return lines;
 
 		if (this.filteredSessions.length === 0) {
 			let emptyMessage: string;
@@ -975,6 +981,10 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		const seq = scope === "current" ? ++this.currentLoadSeq : ++this.allLoadSeq;
 		this.header.setScope(scope);
 		this.header.setLoading(true);
+		this.sessionList.setLoading(true);
+		if (reason !== "refresh") {
+			this.sessionList.setSessions([], showCwd);
+		}
 		this.requestRender();
 		const isLatestLoad = () => seq === (scope === "current" ? this.currentLoadSeq : this.allLoadSeq);
 		const isCurrentView = () => scope === this.scope;
@@ -1002,6 +1012,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			if (!isCurrentView()) return;
 
 			this.header.setLoading(false);
+			this.sessionList.setLoading(false);
 			this.sessionList.setSessions(sessions, showCwd);
 			this.requestRender();
 
@@ -1021,6 +1032,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 			const message = err instanceof Error ? err.message : String(err);
 			this.header.setLoading(false);
+			this.sessionList.setLoading(false);
 			this.header.setStatusMessage({ type: "error", message: `Failed to load sessions: ${message}` }, 4000);
 
 			if (reason === "initial") {
@@ -1053,9 +1065,10 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		if (this.scope === "current") {
 			this.scope = "all";
 			this.header.setScope(this.scope);
+			this.header.setLoading(this.allLoading);
+			this.sessionList.setLoading(this.allLoading);
 
 			if (this.allSessions !== null) {
-				this.header.setLoading(this.allLoading);
 				this.sessionList.setSessions(this.allSessions, true);
 				this.requestRender();
 				return;
@@ -1063,6 +1076,9 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 			if (!this.allLoading) {
 				void this.loadScope("all", "toggle");
+			} else {
+				this.sessionList.setSessions([], true);
+				this.requestRender();
 			}
 			return;
 		}
@@ -1070,6 +1086,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.scope = "current";
 		this.header.setScope(this.scope);
 		this.header.setLoading(this.currentLoading);
+		this.sessionList.setLoading(this.currentLoading);
 		this.sessionList.setSessions(this.currentSessions ?? [], false);
 		this.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -68,6 +68,11 @@ function formatMutationError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+// truncateToWidth brackets its marker with a full SGR reset, which would clear a selected row's background.
+function truncateRowContent(text: string, width: number, ellipsis = "..."): string {
+	return truncateToWidth(text, width, ellipsis).replaceAll("\x1b[0m", "");
+}
+
 class SessionSelectorHeader implements Component {
 	private scope: SessionScope;
 	private sortMode: SortMode;
@@ -278,20 +283,15 @@ function flattenSessionTree(roots: SessionTreeNode[]): FlatSessionNode[] {
  * Custom session list component with multi-line items and search
  */
 class SessionList implements Component, Focusable {
-	public getSelectedSessionPath(): string | undefined {
-		const selected = this.filteredSessions[this.selectedIndex];
-		return selected?.session.path;
-	}
 	private allSessions: AgentConnectionSavedSessionInfo[] = [];
 	private filteredSessions: FlatSessionNode[] = [];
 	private selectedIndex: number = 0;
 	private searchInput: Input;
 	private showCwd = false;
-	private sortMode: SortMode = "threaded";
+	private sortMode: SortMode = "recent";
 	private nameFilter: NameFilter = "all";
 	private keybindings: KeybindingsManager;
 	private showPath = false;
-	private streaming = false;
 	private confirmingDeletePath: string | null = null;
 	private deleteConfirmTimer: ReturnType<typeof setTimeout> | null = null;
 	private currentSessionCanonicalPath?: string;
@@ -361,18 +361,10 @@ class SessionList implements Component, Focusable {
 		this.filterSessions(this.searchInput.getValue());
 	}
 
-	setSessions(sessions: AgentConnectionSavedSessionInfo[], showCwd: boolean, streaming = false): void {
-		const selectedPath = this.getSelectedSessionPath();
+	setSessions(sessions: AgentConnectionSavedSessionInfo[], showCwd: boolean): void {
 		this.allSessions = sessions;
 		this.showCwd = showCwd;
-		this.streaming = streaming;
 		this.filterSessions(this.searchInput.getValue());
-		if (selectedPath) {
-			const selectedIndex = this.filteredSessions.findIndex((session) => session.session.path === selectedPath);
-			if (selectedIndex >= 0) {
-				this.selectedIndex = selectedIndex;
-			}
-		}
 	}
 
 	private filterSessions(query: string): void {
@@ -380,7 +372,7 @@ class SessionList implements Component, Focusable {
 		const nameFiltered =
 			this.nameFilter === "all" ? this.allSessions : this.allSessions.filter((session) => hasSessionName(session));
 
-		if (this.sortMode === "threaded" && !trimmed && !this.streaming) {
+		if (this.sortMode === "threaded" && !trimmed) {
 			// Threaded mode without search: show tree structure
 			const roots = buildSessionTree(nameFiltered);
 			this.filteredSessions = flattenSessionTree(roots);
@@ -520,7 +512,7 @@ class SessionList implements Component, Focusable {
 			const rightWidth = visibleWidth(rightPart) + 2; // +2 for spacing
 			const availableForMsg = width - 2 - prefixWidth - rightWidth - 2; // icon + gap
 
-			const truncatedMsg = truncateToWidth(normalizedMessage, Math.max(10, availableForMsg), "…");
+			const truncatedMsg = truncateRowContent(normalizedMessage, Math.max(10, availableForMsg), "…");
 
 			const styledMsg = isConfirmingDelete ? theme.fg("error", truncatedMsg) : truncatedMsg;
 
@@ -532,7 +524,7 @@ class SessionList implements Component, Focusable {
 
 			let line = leftPart + " ".repeat(spacing) + styledRight;
 			if (isSelected) {
-				const padded = truncateToWidth(line, width);
+				const padded = truncateRowContent(line, width);
 				line = theme.bg("selectedBg", padded + " ".repeat(Math.max(0, width - visibleWidth(padded))));
 			}
 			lines.push(truncateToWidth(line, width));
@@ -693,7 +685,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 	private header: SessionSelectorHeader;
 	private keybindings: KeybindingsManager;
 	private scope: SessionScope = "current";
-	private sortMode: SortMode = "threaded";
+	private sortMode: SortMode = "recent";
 	private nameFilter: NameFilter = "all";
 	private currentSessions: AgentConnectionSavedSessionInfo[] | null = null;
 	private allSessions: AgentConnectionSavedSessionInfo[] | null = null;
@@ -856,8 +848,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
 				const showCwd = this.scope === "all";
-				const streaming = this.scope === "all" ? this.allLoading : this.currentLoading;
-				this.sessionList.setSessions(sessions, showCwd, streaming);
+				this.sessionList.setSessions(sessions, showCwd);
 
 				const msg = result.method === "trash" ? "Session moved to trash" : "Session deleted";
 				try {
@@ -976,30 +967,16 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.requestRender();
 		const isLatestLoad = () => seq === (scope === "current" ? this.currentLoadSeq : this.allLoadSeq);
 		const isCurrentView = () => scope === this.scope;
-		const streamedSessions = new Map<string, AgentConnectionSavedSessionInfo>();
-
 		const onProgress = (loaded: number, total: number) => {
 			if (!isLatestLoad() || !isCurrentView()) return;
 			this.header.setProgress(loaded, total);
 			this.requestRender();
 		};
-		const onSession = (session: AgentConnectionSavedSessionInfo) => {
-			if (reason === "refresh" || !isLatestLoad() || !isCurrentView()) return;
-			streamedSessions.set(session.path, session);
-			const sessions = [...streamedSessions.values()];
-			if (scope === "current") {
-				this.currentSessions = sessions;
-			} else {
-				this.allSessions = sessions;
-			}
-			this.sessionList.setSessions(sessions, showCwd, true);
-			this.requestRender();
-		};
 
 		try {
 			const sessions = await (scope === "current"
-				? this.currentSessionsLoader({ onProgress, onSession })
-				: this.allSessionsLoader({ onProgress, onSession }));
+				? this.currentSessionsLoader({ onProgress })
+				: this.allSessionsLoader({ onProgress }));
 
 			if (!isLatestLoad()) return;
 
@@ -1043,7 +1020,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 	}
 
 	private toggleSortMode(): void {
-		// Cycle: threaded -> recent -> relevance -> threaded
+		// Cycle: recent -> relevance -> threaded -> recent
 		this.sortMode = this.sortMode === "threaded" ? "recent" : this.sortMode === "recent" ? "relevance" : "threaded";
 		this.header.setSortMode(this.sortMode);
 		this.sessionList.setSortMode(this.sortMode);
@@ -1068,7 +1045,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 			if (this.allSessions !== null) {
 				this.header.setLoading(this.allLoading);
-				this.sessionList.setSessions(this.allSessions, true, this.allLoading);
+				this.sessionList.setSessions(this.allSessions, true);
 				this.requestRender();
 				return;
 			}

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -1,12 +1,12 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { setKeybindings } from "@earendil-works/pi-tui";
+import { setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { AgentConnectionSavedSessionInfo } from "../src/modes/agent-connection/index.js";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.js";
-import { initTheme, preloadCodeHighlighter } from "../src/modes/interactive/theme/theme.js";
+import { initTheme, preloadCodeHighlighter, theme } from "../src/modes/interactive/theme/theme.js";
 
 type Deferred<T> = {
 	promise: Promise<T>;
@@ -86,6 +86,7 @@ function createSymlinkedSessionPaths(): {
 }
 
 const CTRL_X = "\x18";
+const CTRL_S = "\x13";
 const CTRL_BACKSPACE = "\x1b[127;5u";
 
 describe("session selector path/delete interactions", () => {
@@ -271,14 +272,15 @@ describe("session selector path/delete interactions", () => {
 		expect(output).not.toContain("Failed to delete");
 	});
 
-	it("renders streamed sessions before the initial load completes", async () => {
-		const streamedSession = makeSession({ id: "streamed", name: "Streamed session" });
+	it("waits for the complete session list while reporting load progress", async () => {
+		const session = makeSession({ id: "complete", name: "Complete session" });
 		const sessionsDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
+		let receivedItemCallback = false;
 
 		const selector = new SessionSelectorComponent(
 			async (callbacks) => {
 				callbacks?.onProgress?.(1, 2);
-				callbacks?.onSession?.(streamedSession);
+				receivedItemCallback = callbacks?.onSession !== undefined;
 				return sessionsDeferred.promise;
 			},
 			async () => [],
@@ -292,26 +294,33 @@ describe("session selector path/delete interactions", () => {
 
 		const loadingOutput = stripAnsi(selector.render(120).join("\n"));
 		expect(loadingOutput).toContain("loading 1/2");
-		expect(loadingOutput).toContain("Streamed session");
+		expect(loadingOutput).not.toContain("Complete session");
+		expect(receivedItemCallback).toBe(false);
 
-		sessionsDeferred.resolve([streamedSession]);
+		sessionsDeferred.resolve([session]);
 		await flushPromises();
 
-		expect(stripAnsi(selector.render(120).join("\n"))).toContain("current folder");
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("current folder");
+		expect(output).toContain("Complete session");
 	});
 
-	it("keeps streamed threaded sessions flat until loading completes", async () => {
-		const parent = makeSession({ id: "parent", name: "Parent" });
-		const child = makeSession({ id: "child", name: "Child", parentSessionPath: parent.path });
+	it("selects the newest session from an unsorted completed list", async () => {
+		const older = makeSession({
+			id: "older",
+			name: "Older session",
+			modified: new Date("2026-01-01T00:00:00.000Z"),
+		});
+		const newer = makeSession({
+			id: "newer",
+			name: "Newer session",
+			modified: new Date("2026-01-03T00:00:00.000Z"),
+		});
 		const sessionsDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
 		const onSelect = vi.fn();
 
 		const selector = new SessionSelectorComponent(
-			async (callbacks) => {
-				callbacks?.onSession?.(child);
-				callbacks?.onSession?.(parent);
-				return sessionsDeferred.promise;
-			},
+			async () => sessionsDeferred.promise,
 			async () => [],
 			onSelect,
 			() => {},
@@ -321,57 +330,41 @@ describe("session selector path/delete interactions", () => {
 		);
 		await flushPromises();
 
-		const list = selector.getSessionList();
-		expect(stripAnsi(selector.render(120).join("\n"))).not.toContain("└─");
-
-		sessionsDeferred.resolve([parent, child]);
+		sessionsDeferred.resolve([older, newer]);
 		await flushPromises();
 
-		expect(stripAnsi(selector.render(120).join("\n"))).toContain("└─ ✓ Child");
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("sort: recent");
+		expect(output.indexOf("Newer session")).toBeLessThan(output.indexOf("Older session"));
+
+		const list = selector.getSessionList();
 		list.handleInput("\r");
-		expect(onSelect).toHaveBeenCalledWith(child.path);
+		expect(onSelect).toHaveBeenCalledWith(newer.path);
 	});
 
-	it("keeps other streamed rows visible when deleting before loading completes", async () => {
-		const first = makeSession({ id: "first", name: "First streamed session" });
-		const second = makeSession({ id: "second", name: "Second streamed session" });
-		const initialLoad = createDeferred<AgentConnectionSavedSessionInfo[]>();
-		const refreshLoad = createDeferred<AgentConnectionSavedSessionInfo[]>();
-		const deleteSession = vi.fn(async () => ({ ok: true as const, method: "unlink" as const }));
-		let loadCalls = 0;
-
+	it("keeps the selected background across a truncated session row", async () => {
+		const session = makeSession({
+			id: "long",
+			name: "A session prompt that is much too long to fit within the available row width",
+		});
 		const selector = new SessionSelectorComponent(
-			async (callbacks) => {
-				loadCalls++;
-				if (loadCalls === 1) {
-					callbacks?.onSession?.(first);
-					callbacks?.onSession?.(second);
-					return initialLoad.promise;
-				}
-				return refreshLoad.promise;
-			},
+			async () => [session],
 			async () => [],
 			() => {},
 			() => {},
 			() => {},
 			() => {},
-			{ keybindings, deleteSession },
+			{ keybindings },
 		);
 		await flushPromises();
 
-		const list = selector.getSessionList();
-		list.handleInput(CTRL_X);
-		list.handleInput(CTRL_X);
-		await flushPromises();
-
-		const output = stripAnsi(selector.render(120).join("\n"));
-		expect(deleteSession).toHaveBeenCalledWith(first.path);
-		expect(output).not.toContain("First streamed session");
-		expect(output).toContain("Second streamed session");
-
-		refreshLoad.resolve([second]);
-		initialLoad.resolve([first, second]);
-		await flushPromises();
+		const line = selector.render(60).find((candidate) => stripAnsi(candidate).includes("A session prompt"));
+		const backgroundStart = theme.bg("selectedBg", "").replace("\x1b[49m", "");
+		expect(stripAnsi(line ?? "")).toContain("…");
+		expect(line?.startsWith(backgroundStart)).toBe(true);
+		expect(line?.endsWith("\x1b[49m")).toBe(true);
+		expect(line).not.toContain("\x1b[0m");
+		expect(visibleWidth(line ?? "")).toBe(60);
 	});
 
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
@@ -466,6 +459,10 @@ describe("session selector path/delete interactions", () => {
 			{ keybindings },
 		);
 		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput(CTRL_S);
+		list.handleInput(CTRL_S);
 
 		const output = stripAnsi(selector.render(120).join("\n"));
 		expect(output).toContain("Parent");

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -435,8 +435,38 @@ describe("session selector path/delete interactions", () => {
 		expect(output).not.toContain("all projects");
 	});
 
+	it("hides current-folder rows while all projects are loading", async () => {
+		const currentSession = makeSession({ id: "current", name: "Current folder session" });
+		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
+		const onSelect = vi.fn();
+		const selector = new SessionSelectorComponent(
+			async () => [currentSession],
+			async () => allDeferred.promise,
+			onSelect,
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput("\t");
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("loading");
+		expect(output).not.toContain("Current folder session");
+		expect(output).not.toContain("No sessions found");
+
+		list.handleInput("\r");
+		expect(onSelect).not.toHaveBeenCalled();
+
+		allDeferred.resolve([makeSession({ id: "all", name: "All projects session" })]);
+		await flushPromises();
+	});
+
 	it("does not start redundant All loads when toggling scopes while All is already loading", async () => {
-		const currentSessions = [makeSession({ id: "current" })];
+		const currentSessions = [makeSession({ id: "current", name: "Current folder session" })];
 		const allDeferred = createDeferred<AgentConnectionSavedSessionInfo[]>();
 		let allLoadCalls = 0;
 
@@ -460,6 +490,9 @@ describe("session selector path/delete interactions", () => {
 		list.handleInput("\t"); // current -> all again while load pending
 
 		expect(allLoadCalls).toBe(1);
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("loading");
+		expect(output).not.toContain("Current folder session");
 
 		allDeferred.resolve([makeSession({ id: "all" })]);
 		await flushPromises();

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -342,6 +342,42 @@ describe("session selector path/delete interactions", () => {
 		expect(onSelect).toHaveBeenCalledWith(newer.path);
 	});
 
+	it("keeps the selected session when a completed reload reorders the list", async () => {
+		const selected = makeSession({
+			id: "selected",
+			name: "Selected session",
+			modified: new Date("2026-01-02T00:00:00.000Z"),
+		});
+		const previousNewest = makeSession({
+			id: "previous-newest",
+			name: "Previous newest session",
+			modified: new Date("2026-01-03T00:00:00.000Z"),
+		});
+		const newNewest = makeSession({
+			id: "new-newest",
+			name: "New newest session",
+			modified: new Date("2026-01-04T00:00:00.000Z"),
+		});
+		const onSelect = vi.fn();
+		const selector = new SessionSelectorComponent(
+			async () => [selected, previousNewest],
+			async () => [],
+			onSelect,
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const list = selector.getSessionList();
+		list.handleInput("\x1b[B");
+		list.setSessions([selected, previousNewest, newNewest], false);
+		list.handleInput("\r");
+
+		expect(onSelect).toHaveBeenCalledWith(selected.path);
+	});
+
 	it("keeps the selected background across a truncated session row", async () => {
 		const session = makeSession({
 			id: "long",

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -55,16 +55,16 @@ describe("session selector search", () => {
 		expect(result.map((s) => s.id)).toEqual(["a"]);
 	});
 
-	it("recent sort preserves input order", () => {
+	it("recent sort orders matches by modified date descending", () => {
 		const sessions: AgentConnectionSavedSessionInfo[] = [
-			makeSession({
-				id: "newer",
-				modified: new Date("2026-01-03T00:00:00.000Z"),
-				allMessagesText: "brave",
-			}),
 			makeSession({
 				id: "older",
 				modified: new Date("2026-01-01T00:00:00.000Z"),
+				allMessagesText: "brave",
+			}),
+			makeSession({
+				id: "newer",
+				modified: new Date("2026-01-03T00:00:00.000Z"),
 				allMessagesText: "brave",
 			}),
 			makeSession({
@@ -76,6 +76,25 @@ describe("session selector search", () => {
 
 		const result = filterAndSortSessions(sessions, '"brave"', "recent");
 		expect(result.map((s) => s.id)).toEqual(["newer", "older"]);
+	});
+
+	it("searches session names", () => {
+		const sessions: AgentConnectionSavedSessionInfo[] = [
+			makeSession({
+				id: "named",
+				name: "Release Planning",
+				modified: new Date("2026-01-01T00:00:00.000Z"),
+				allMessagesText: "unrelated messages",
+			}),
+			makeSession({
+				id: "other",
+				modified: new Date("2026-01-02T00:00:00.000Z"),
+				allMessagesText: "another topic",
+			}),
+		];
+
+		const result = filterAndSortSessions(sessions, '"release planning"', "recent");
+		expect(result.map((session) => session.id)).toEqual(["named"]);
 	});
 
 	it("relevance sort orders by score and tie-breaks by modified desc", () => {
@@ -153,7 +172,7 @@ describe("session selector search", () => {
 
 		it("returns all sessions when nameFilter is 'all'", () => {
 			const result = filterAndSortSessions(sessions, "", "recent", "all");
-			expect(result.map((session) => session.id)).toEqual(["named1", "named2", "other1", "other2"]);
+			expect(result.map((session) => session.id)).toEqual(["other1", "named1", "named2", "other2"]);
 		});
 
 		it("returns only named sessions when nameFilter is 'named'", () => {


### PR DESCRIPTION
- the resume picker now loads the complete session list and sorts it by latest activity.
- the newest session is selected by default while threaded and relevance views remain available.
- truncated selected rows now keep their background color across the full width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive resume-picker UX and sort/load behavior only; no auth, persistence, or daemon protocol changes.
> 
> **Overview**
> The **resume picker** now defaults to **recent** sort (not threaded), so the list is ordered by latest activity and **index 0 is the newest session**—fixing the picker opening on an older row.
> 
> **`filterAndSortSessions`** applies a shared **`modified` → `created` → `path`** comparator for empty queries and **recent** search results; relevance ties use the same rule.
> 
> Loading no longer **streams partial rows** via `onSession`: the list stays empty (with header progress) until the full load finishes, including when switching to **all projects**.
> 
> **Selected-row** highlighting on truncated titles strips `\x1b[0m` from truncation so the background spans the full width. Sort cycling is **recent → relevance → threaded**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55feb39047edd5a1cda54cb5e606b61ab7ffc04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show newest sessions first in the resume picker session list
> - Changes the default sort mode from `'threaded'` to `'recent'` in [`session-selector.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/415/files#diff-5b419b444ad7ddfb6a7133b0813c8a636a74db2a346811f5eb8028100e3139bd), so the resume picker opens with the most recently modified session at the top.
> - Adds a `compareSessionsByModifiedDesc` comparator in [`session-selector-search.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/415/files#diff-27ed2afcf70bc6280d26b892aa932413ca923ae02b6a009a1140327245e07166) that sorts by modified descending, then created descending, then path ascending; `filterAndSortSessions` uses this in `'recent'` mode for both empty and non-empty queries.
> - The selector now waits for the full session list before rendering (no streaming partial updates), shows a blank loading state when switching scopes, and cycles sort modes in the order recent → relevance → threaded.
> - Fixes selected-row background being cleared on truncated rows by stripping SGR reset sequences before applying the highlight.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d55feb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->