### PR TITLE
support mid-prompt slash command autocomplete

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed slash-command and skill autocomplete not appearing for references typed in the middle of prompts ([ENG-4628](https://linear.app/primeintellect/issue/ENG-4628/support-skill-and-command-autocomplete-mid-prompt)).
 - Fixed focused full-pane overlays becoming slow to navigate on wider terminals.
 
 ## [0.3.0] - 2026-07-13

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -3,6 +3,7 @@ import { readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
 import { fuzzyFilter } from "./fuzzy.js";
+import { getSlashCommandContext } from "./slash-command-context.js";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
@@ -239,6 +240,7 @@ export interface SlashCommand {
 export interface AutocompleteSuggestions {
 	items: AutocompleteItem[];
 	prefix: string; // What we're matching against (e.g., "/" or "src/")
+	kind?: "slash-command" | "file";
 }
 
 export interface AutocompleteProvider {
@@ -302,64 +304,60 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return {
 				items: suggestions,
 				prefix: atPrefix,
+				kind: "file",
 			};
 		}
 
-		if (!options.force && textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
+		const slashContext = options.force ? null : getSlashCommandContext(lines, cursorLine, cursorCol);
+		if (slashContext?.kind === "name") {
+			const prefix = slashContext.prefix.slice(1);
+			const commandItems = this.commands.map((cmd) => {
+				const name = "name" in cmd ? cmd.name : cmd.value;
+				const aliases = "aliases" in cmd && cmd.aliases ? cmd.aliases : [];
+				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+				const desc = cmd.description ?? "";
+				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+				const takesArgument = "takesArgument" in cmd ? cmd.takesArgument === true : false;
+				return {
+					name,
+					searchText: [name, ...aliases].join(" "),
+					label: name,
+					description: fullDesc || undefined,
+					takesArgument,
+				};
+			});
 
-			if (spaceIndex === -1) {
-				const prefix = textBeforeCursor.slice(1);
-				const commandItems = this.commands.map((cmd) => {
-					const name = "name" in cmd ? cmd.name : cmd.value;
-					const aliases = "aliases" in cmd && cmd.aliases ? cmd.aliases : [];
-					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-					const desc = cmd.description ?? "";
-					const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-					const takesArgument = "takesArgument" in cmd ? cmd.takesArgument === true : false;
-					return {
-						name,
-						searchText: [name, ...aliases].join(" "),
-						label: name,
-						description: fullDesc || undefined,
-						takesArgument,
-					};
-				});
+			const filtered = fuzzyFilter(commandItems, prefix, (item) => item.searchText).map((item) => ({
+				value: item.name,
+				label: item.label,
+				...(item.description && { description: item.description }),
+				...(item.takesArgument && { takesArgument: true }),
+			}));
 
-				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.searchText).map((item) => ({
-					value: item.name,
-					label: item.label,
-					...(item.description && { description: item.description }),
-					...(item.takesArgument && { takesArgument: true }),
-				}));
-
-				if (filtered.length === 0) return null;
-
+			if (filtered.length > 0) {
 				return {
 					items: filtered,
-					prefix: textBeforeCursor,
+					prefix: slashContext.prefix,
+					kind: "slash-command",
 				};
 			}
-
-			const commandName = textBeforeCursor.slice(1, spaceIndex);
-			const argumentText = textBeforeCursor.slice(spaceIndex + 1);
-
+		} else if (slashContext?.kind === "argument") {
 			const command = this.commands.find((cmd) => {
 				const name = "name" in cmd ? cmd.name : cmd.value;
-				return name === commandName;
+				return name === slashContext.commandName;
 			});
 			if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
 				return null;
 			}
 
-			const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+			const argumentSuggestions = await command.getArgumentCompletions(slashContext.prefix);
 			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
 				return null;
 			}
 
 			return {
 				items: argumentSuggestions,
-				prefix: argumentText,
+				prefix: slashContext.prefix,
 			};
 		}
 
@@ -374,6 +372,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return {
 			items: suggestions,
 			prefix: pathMatch,
+			kind: "file",
 		};
 	}
 
@@ -392,20 +391,23 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const hasTrailingQuoteInItem = item.value.endsWith('"');
 		const adjustedAfterCursor =
 			isQuotedPrefix && hasTrailingQuoteInItem && hasLeadingQuoteAfterCursor ? afterCursor.slice(1) : afterCursor;
+		const slashContext = getSlashCommandContext(lines, cursorLine, cursorCol);
 
-		// Check if we're completing a slash command (prefix starts with "/" but NOT a file path)
-		// Slash commands are at the start of the line and don't contain path separators after the first /
-		const isSlashCommand = prefix.startsWith("/") && beforePrefix.trim() === "" && !prefix.slice(1).includes("/");
+		const isSlashCommand =
+			slashContext?.kind === "name" &&
+			slashContext.prefix === prefix &&
+			this.commands.some((command) => ("name" in command ? command.name : command.value) === item.value);
 		if (isSlashCommand) {
-			// This is a command name completion
-			const newLine = `${beforePrefix}/${item.value} ${adjustedAfterCursor}`;
+			const hasSeparatorAfterCursor = /^[ \t]/.test(adjustedAfterCursor);
+			const separator = hasSeparatorAfterCursor ? "" : " ";
+			const newLine = `${beforePrefix}/${item.value}${separator}${adjustedAfterCursor}`;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
 
 			return {
 				lines: newLines,
 				cursorLine,
-				cursorCol: beforePrefix.length + item.value.length + 2, // +2 for "/" and space
+				cursorCol: beforePrefix.length + item.value.length + 2,
 			};
 		}
 
@@ -429,10 +431,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		// Check if we're in a slash command context (beforePrefix contains "/command ")
-		const textBeforeCursor = currentLine.slice(0, cursorCol);
-		if (textBeforeCursor.includes("/") && textBeforeCursor.includes(" ")) {
-			// This is likely a command argument completion
+		if (slashContext?.kind === "argument" && slashContext.prefix === prefix) {
 			const newLine = beforePrefix + item.value + adjustedAfterCursor;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
@@ -778,14 +777,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 	// Check if we should trigger file completion (called on Tab key)
 	shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
-		const currentLine = lines[cursorLine] || "";
-		const textBeforeCursor = currentLine.slice(0, cursorCol);
-
-		// Don't trigger if we're typing a slash command at the start of the line
-		if (textBeforeCursor.trim().startsWith("/") && !textBeforeCursor.trim().includes(" ")) {
-			return false;
-		}
-
-		return true;
+		return getSlashCommandContext(lines, cursorLine, cursorCol)?.kind !== "name";
 	}
 }

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -341,6 +341,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					kind: "slash-command",
 				};
 			}
+
+			return null;
 		} else if (slashContext?.kind === "argument") {
 			const command = this.commands.find((cmd) => {
 				const name = "name" in cmd ? cmd.name : cmd.value;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,6 +3,7 @@ import type { EditorPasteSnapshot } from "../editor-component.js";
 import { getKeybindings } from "../keybindings.js";
 import { decodePrintableKey, matchesKey } from "../keys.js";
 import { KillRing } from "../kill-ring.js";
+import { getSlashCommandContext, type SlashCommandContext } from "../slash-command-context.js";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.js";
 import { UndoStack } from "../undo-stack.js";
 import { getSegmenter, isPunctuationChar, isWhitespaceChar, truncateToWidth, visibleWidth } from "../utils.js";
@@ -278,6 +279,7 @@ export class Editor implements Component, Focusable {
 	private autocompleteList?: SelectList;
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
+	private autocompleteKind?: AutocompleteSuggestions["kind"];
 	private autocompleteMaxVisible: number = 5;
 	private autocompleteAbort?: AbortController;
 	private autocompleteDebounceTimer?: ReturnType<typeof setTimeout>;
@@ -761,6 +763,14 @@ export class Editor implements Component, Focusable {
 			if (kb.matches(data, "tui.select.confirm")) {
 				const selected = this.autocompleteList.getSelectedItem();
 				if (selected && this.autocompleteProvider) {
+					const slashContext = this.getCurrentSlashCommandContext();
+					const isSlashCommandCompletion =
+						this.autocompleteKind === "slash-command" ||
+						(this.autocompleteKind === undefined &&
+							this.autocompleteState === "regular" &&
+							this.autocompletePrefix.startsWith("/"));
+					const shouldSubmitSlashCommand =
+						isSlashCommandCompletion && slashContext?.kind === "name" && slashContext.isAtPromptStart;
 					this.pushUndoSnapshot();
 					this.lastAction = null;
 					const result = this.autocompleteProvider.applyCompletion(
@@ -774,9 +784,9 @@ export class Editor implements Component, Focusable {
 					this.state.cursorLine = result.cursorLine;
 					this.setCursorCol(result.cursorCol);
 
-					if (this.autocompletePrefix.startsWith("/")) {
+					if (isSlashCommandCompletion) {
 						this.cancelAutocomplete();
-						if (selected.takesArgument) {
+						if (!shouldSubmitSlashCommand || selected.takesArgument) {
 							if (this.onChange) this.onChange(this.getText());
 							return;
 						}
@@ -1210,8 +1220,8 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.autocompleteState) {
-			// Auto-trigger for "/" at the start of a line (slash commands)
-			if (char === "/" && this.isAtStartOfMessage()) {
+			const slashContext = this.getCurrentSlashCommandContext();
+			if (char === "/" && slashContext?.kind === "name") {
 				this.tryTriggerAutocomplete();
 			}
 			// Auto-trigger for symbol-based completion like @ or # at token boundaries
@@ -1227,8 +1237,7 @@ export class Editor implements Component, Focusable {
 			else if (/[a-zA-Z0-9.\-_]/.test(char)) {
 				const currentLine = this.state.lines[this.state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
-				// Check if we're in a slash command (with or without space for arguments)
-				if (this.isInSlashCommandContext(textBeforeCursor)) {
+				if (slashContext) {
 					this.tryTriggerAutocomplete();
 				}
 				// Check if we're in a symbol-based completion context like @ or #
@@ -1414,8 +1423,7 @@ export class Editor implements Component, Focusable {
 			// If autocomplete was cancelled (no matches), re-trigger if we're in a completable context
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
-			// Slash command context
-			if (this.isInSlashCommandContext(textBeforeCursor)) {
+			if (this.getCurrentSlashCommandContext()) {
 				this.tryTriggerAutocomplete();
 			}
 			// Symbol-based completion context like @ or #
@@ -1781,8 +1789,7 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
-			// Slash command context
-			if (this.isInSlashCommandContext(textBeforeCursor)) {
+			if (this.getCurrentSlashCommandContext()) {
 				this.tryTriggerAutocomplete();
 			}
 			// Symbol-based completion context like @ or #
@@ -2226,21 +2233,8 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(newCol);
 	}
 
-	// Slash menu only allowed on the first line of the editor
-	private isSlashMenuAllowed(): boolean {
-		return this.state.cursorLine === 0;
-	}
-
-	// Helper method to check if cursor is at start of message (for slash command detection)
-	private isAtStartOfMessage(): boolean {
-		if (!this.isSlashMenuAllowed()) return false;
-		const currentLine = this.state.lines[this.state.cursorLine] || "";
-		const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-		return beforeCursor.trim() === "" || beforeCursor.trim() === "/";
-	}
-
-	private isInSlashCommandContext(textBeforeCursor: string): boolean {
-		return this.isSlashMenuAllowed() && textBeforeCursor.trimStart().startsWith("/");
+	private getCurrentSlashCommandContext(): SlashCommandContext | null {
+		return getSlashCommandContext(this.state.lines, this.state.cursorLine, this.state.cursorCol);
 	}
 
 	// Autocomplete methods
@@ -2273,12 +2267,12 @@ export class Editor implements Component, Focusable {
 		return firstPrefixIndex;
 	}
 
-	private createAutocompleteList(
-		prefix: string,
-		items: Array<{ value: string; label: string; description?: string }>,
-	): SelectList {
-		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
-		return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
+	private createAutocompleteList(suggestions: AutocompleteSuggestions): SelectList {
+		const layout =
+			suggestions.kind === "slash-command" || (suggestions.kind === undefined && suggestions.prefix.startsWith("/"))
+				? SLASH_COMMAND_SELECT_LIST_LAYOUT
+				: undefined;
+		return new SelectList(suggestions.items, this.autocompleteMaxVisible, this.theme.selectList, layout);
 	}
 
 	private tryTriggerAutocomplete(explicitTab: boolean = false): void {
@@ -2288,10 +2282,7 @@ export class Editor implements Component, Focusable {
 	private handleTabCompletion(): void {
 		if (!this.autocompleteProvider) return;
 
-		const currentLine = this.state.lines[this.state.cursorLine] || "";
-		const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-
-		if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
+		if (this.getCurrentSlashCommandContext()?.kind === "name") {
 			this.handleSlashCommandCompletion();
 		} else {
 			this.forceFileAutocomplete(true);
@@ -2441,9 +2432,11 @@ export class Editor implements Component, Focusable {
 
 	private applyAutocompleteSuggestions(suggestions: AutocompleteSuggestions, state: "regular" | "force"): void {
 		this.autocompletePrefix = suggestions.prefix;
-		this.autocompleteList = this.createAutocompleteList(suggestions.prefix, suggestions.items);
+		this.autocompleteKind = suggestions.kind;
+		this.autocompleteList = this.createAutocompleteList(suggestions);
 
-		const bestMatchIndex = this.getBestAutocompleteMatchIndex(suggestions.items, suggestions.prefix);
+		const matchingPrefix = suggestions.kind === "slash-command" ? suggestions.prefix.slice(1) : suggestions.prefix;
+		const bestMatchIndex = this.getBestAutocompleteMatchIndex(suggestions.items, matchingPrefix);
 		if (bestMatchIndex >= 0) {
 			this.autocompleteList.setSelectedIndex(bestMatchIndex);
 		}
@@ -2465,6 +2458,7 @@ export class Editor implements Component, Focusable {
 		this.autocompleteState = null;
 		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
+		this.autocompleteKind = undefined;
 	}
 
 	protected cancelAutocomplete(): void {

--- a/packages/tui/src/slash-command-context.ts
+++ b/packages/tui/src/slash-command-context.ts
@@ -1,0 +1,46 @@
+export type SlashCommandContext =
+	| { kind: "name"; prefix: string; isAtPromptStart: boolean }
+	| { kind: "argument"; commandName: string; prefix: string; isAtPromptStart: true };
+
+export function getSlashCommandContext(
+	lines: string[],
+	cursorLine: number,
+	cursorCol: number,
+): SlashCommandContext | null {
+	const currentLine = lines[cursorLine] ?? "";
+	const textBeforeCursor = currentLine.slice(0, cursorCol);
+	const trimmedStart = textBeforeCursor.trimStart();
+
+	if (cursorLine === 0 && trimmedStart.startsWith("/")) {
+		const separatorIndex = trimmedStart.search(/[ \t]/);
+		const commandToken = separatorIndex === -1 ? trimmedStart : trimmedStart.slice(0, separatorIndex);
+
+		if (commandToken.slice(1).includes("/")) {
+			return null;
+		}
+
+		if (separatorIndex === -1) {
+			return { kind: "name", prefix: commandToken, isAtPromptStart: true };
+		}
+
+		const commandName = commandToken.slice(1);
+		if (!commandName) {
+			return null;
+		}
+
+		return {
+			kind: "argument",
+			commandName,
+			prefix: trimmedStart.slice(separatorIndex + 1),
+			isAtPromptStart: true,
+		};
+	}
+
+	const tokenStart = Math.max(textBeforeCursor.lastIndexOf(" "), textBeforeCursor.lastIndexOf("\t")) + 1;
+	const prefix = textBeforeCursor.slice(tokenStart);
+	if (!prefix.startsWith("/") || prefix.slice(1).includes("/")) {
+		return null;
+	}
+
+	return { kind: "name", prefix, isAtPromptStart: false };
+}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, it, test } from "node:test";
 import { CombinedAutocompleteProvider } from "../src/autocomplete.js";
+import { getSlashCommandContext } from "../src/slash-command-context.js";
 
 const resolveFdPath = (): string | null => {
 	const command = process.platform === "win32" ? "where" : "which";
@@ -54,6 +55,35 @@ const getSuggestions = (
 	force: boolean = false,
 ) => provider.getSuggestions(lines, cursorLine, cursorCol, { signal: new AbortController().signal, force });
 
+describe("slash command context", () => {
+	it("finds inline command tokens on any line", () => {
+		assert.deepStrictEqual(getSlashCommandContext(["Please use /skill:brain"], 0, 23), {
+			kind: "name",
+			prefix: "/skill:brain",
+			isAtPromptStart: false,
+		});
+		assert.deepStrictEqual(getSlashCommandContext(["First line", "Then /he"], 1, 8), {
+			kind: "name",
+			prefix: "/he",
+			isAtPromptStart: false,
+		});
+	});
+
+	it("keeps standalone command arguments distinct from inline references", () => {
+		assert.deepStrictEqual(getSlashCommandContext(["/model gpt"], 0, 10), {
+			kind: "argument",
+			commandName: "model",
+			prefix: "gpt",
+			isAtPromptStart: true,
+		});
+	});
+
+	it("ignores URLs and path fragments", () => {
+		assert.strictEqual(getSlashCommandContext(["Visit https://example.com"], 0, 25), null);
+		assert.strictEqual(getSlashCommandContext(["Open src/components"], 0, 19), null);
+	});
+});
+
 describe("CombinedAutocompleteProvider", () => {
 	describe("slash commands", () => {
 		it("matches command aliases while previewing and completing the canonical command", async () => {
@@ -71,6 +101,7 @@ describe("CombinedAutocompleteProvider", () => {
 
 			assert.deepStrictEqual(result, {
 				prefix: "/clear",
+				kind: "slash-command",
 				items: [{ value: "new", label: "new", description: "Start a new session" }],
 			});
 		});
@@ -92,6 +123,49 @@ describe("CombinedAutocompleteProvider", () => {
 			const fresh = await getSuggestions(provider, ["/new"], 0, 4);
 			assert.deepStrictEqual(fresh?.items, [{ value: "new", label: "new", description: "Start a new session" }]);
 		});
+
+		it("suggests skill commands for inline references", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[{ name: "skill:brainstorm", description: "Brainstorm approaches" }],
+				"/tmp",
+			);
+			const line = "Please use /skill:brain";
+			const result = await getSuggestions(provider, [line], 0, line.length);
+
+			assert.deepStrictEqual(result, {
+				prefix: "/skill:brain",
+				kind: "slash-command",
+				items: [{ value: "skill:brainstorm", label: "skill:brainstorm", description: "Brainstorm approaches" }],
+			});
+		});
+
+		it("suggests commands on later prompt lines", async () => {
+			const provider = new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], "/tmp");
+			const lines = ["First line", "Then /he"];
+			const result = await getSuggestions(provider, lines, 1, lines[1]!.length);
+
+			assert.deepStrictEqual(result, {
+				prefix: "/he",
+				kind: "slash-command",
+				items: [{ value: "help", label: "help", description: "Show help" }],
+			});
+		});
+
+		it("replaces only the inline command token without duplicating whitespace", async () => {
+			const provider = new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], "/tmp");
+			const line = "Please use /he later";
+			const cursorCol = line.indexOf(" later");
+			const result = await getSuggestions(provider, [line], 0, cursorCol);
+			const item = result?.items[0];
+			assert.ok(result && item);
+
+			const applied = provider.applyCompletion([line], 0, cursorCol, item, result.prefix);
+			assert.deepStrictEqual(applied, {
+				lines: ["Please use /help later"],
+				cursorLine: 0,
+				cursorCol: "Please use /help ".length,
+			});
+		});
 	});
 
 	describe("extractPathPrefix", () => {
@@ -106,6 +180,7 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.notEqual(result, null, "Should return suggestions for root directory");
 			if (result) {
 				assert.strictEqual(result.prefix, "/", "Prefix should be '/'");
+				assert.strictEqual(result.kind, "file");
 			}
 		});
 

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -151,6 +151,13 @@ describe("CombinedAutocompleteProvider", () => {
 			});
 		});
 
+		it("does not fall back to file suggestions for unmatched command tokens", async () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = await getSuggestions(provider, ["/tm"], 0, 3);
+
+			assert.strictEqual(result, null);
+		});
+
 		it("replaces only the inline command token without duplicating whitespace", async () => {
 			const provider = new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], "/tmp");
 			const line = "Please use /he later";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2296,6 +2296,80 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.isShowingAutocomplete(), false);
 		});
 
+		it("accepts an inline slash command with Enter without submitting the prompt", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const submitted: string[] = [];
+			editor.onSubmit = (text) => submitted.push(text);
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], process.cwd()),
+			);
+			editor.setText("Please use ");
+
+			editor.handleInput("/");
+			editor.handleInput("h");
+			editor.handleInput("e");
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+
+			editor.handleInput("\r");
+			assert.strictEqual(editor.getText(), "Please use /help ");
+			assert.deepStrictEqual(submitted, []);
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+		});
+
+		it("accepts inline slash commands with Tab on later prompt lines", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], process.cwd()),
+			);
+			editor.setText("First line\nThen ");
+
+			editor.handleInput("/");
+			editor.handleInput("h");
+			editor.handleInput("e");
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+
+			editor.handleInput("\t");
+			assert.strictEqual(editor.getText(), "First line\nThen /help ");
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+		});
+
+		it("preserves standalone slash command submission", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const submitted: string[] = [];
+			editor.onSubmit = (text) => submitted.push(text);
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], process.cwd()),
+			);
+
+			editor.handleInput("/");
+			editor.handleInput("h");
+			editor.handleInput("e");
+			await flushAutocomplete();
+			editor.handleInput("\r");
+
+			assert.deepStrictEqual(submitted, ["/help"]);
+			assert.strictEqual(editor.getText(), "");
+		});
+
+		it("does not trigger slash command autocomplete inside URLs or paths", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider([{ name: "help", description: "Show help" }], process.cwd()),
+			);
+
+			editor.setText("Visit https:/");
+			editor.handleInput("/");
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+
+			editor.setText("Open src");
+			editor.handleInput("/");
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+		});
+
 		it("applies exact typed slash-argument value on Enter even when first item is highlighted", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
- slash commands and skills now autocomplete at token boundaries anywhere in multiline prompts.
- inline selections replace only the active token without submitting the surrounding prompt.
- standalone commands, arguments, urls, and file paths retain their existing behavior with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI editor/autocomplete behavior with broad regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Slash commands and skills now autocomplete when typed in the middle of a prompt**, not only as a standalone command at the start of line 0.
> 
> A new **`getSlashCommandContext`** helper decides whether the cursor is completing a command **name** or **argument**, including **inline** `/tokens` after whitespace on any line, while skipping URL/path-like fragments. **`CombinedAutocompleteProvider`** routes suggestions through that context, tags them with **`kind: "slash-command"`**, and stops unmatched command prefixes from falling through to file completion.
> 
> The **editor** auto-triggers and accepts inline completions without **submitting** the full prompt on Enter; **prompt-start** slash commands still submit as before. **`applyCompletion`** replaces only the active token and avoids duplicating a trailing space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820e8db31222080afb498e4f1785e95308b385e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support slash command autocomplete when typed mid-prompt
> - Introduces [`getSlashCommandContext`](https://github.com/PrimeIntellect-ai/prime-agent/pull/416/files#diff-739a8590ac48538bb3fb0cf9a8de5d7fc59bd649d66a84f690babdc66178e076) to parse the buffer and cursor position, returning a `name` or `argument` context for slash commands anywhere in the prompt (not just at line start).
> - `CombinedAutocompleteProvider` now uses this context to suggest slash commands and route argument completions inline, and suppresses file suggestions when the cursor is in a slash-command name token.
> - The editor distinguishes inline slash-command acceptance (inserts without submitting) from prompt-start slash commands (still submits on Enter).
> - `applyCompletion` replaces only the inline token and avoids inserting a duplicate space when one already follows the command.
> - Behavioral Change: slash commands typed mid-prompt now trigger autocomplete and are accepted without form submission; only a slash at the very start of the prompt auto-submits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 820e8db.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->