### PR TITLE
fix fullscreen transcript selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added confirmation when fullscreen text selection copies to the clipboard ([ENG-4644](https://linear.app/primeintellect/issue/ENG-4644/copy-issues)).
 - Added compact file change stats to collapsed tool calls and an agent-run edit total above the recap.
 - Changed tool expansion hints to appear only on the latest tool row instead of every tool call ([ENG-4583](https://linear.app/primeintellect/issue/ENG-4583/too-many-ctrlo-alerts)).
 - Changed IPython kernels to set `NO_COLOR=1`, preventing ANSI color escapes from inflating `%%bash` output.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -862,7 +862,7 @@ export class InteractiveMode {
 		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.ui.onCopy = (text) => {
-			void copyToClipboard(text).catch(() => undefined);
+			void this.copyFullscreenSelection(text);
 		};
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
@@ -5485,6 +5485,15 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private async copyFullscreenSelection(text: string): Promise<void> {
+		try {
+			await copyToClipboard(text);
+			this.showStatus("Copied selection to clipboard");
+		} catch (error) {
+			this.showError(`Failed to copy selection: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
 	// Local slash commands (/context, /system-prompt, …) print into the chat
 	// without round-tripping through the agent, so no user message event echoes
 	// the typed command. Render the turn ourselves, mirroring the "user" case
@@ -8512,6 +8521,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 | \`${viewportTop}\` | Scroll to top |
 | \`${viewportFollow}\` | Scroll to bottom and follow output |
 | mouse wheel | Scroll transcript |
+| mouse drag | Select and copy text |
 `;
 
 		const shortcuts = this.bindLocalSessionExtensions

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed fullscreen drag selection so holding at a transcript edge scrolls through offscreen text ([ENG-4644](https://linear.app/primeintellect/issue/ENG-4644/copy-issues)).
 - Fixed focused full-pane overlays becoming slow to navigate on wider terminals.
 
 ## [0.3.0] - 2026-07-13

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -24,6 +24,8 @@ export interface ScrollInfo {
 	linesAbove: number;
 }
 
+export type SelectionScrollDirection = -1 | 1;
+
 // Transcript-anchored selection endpoint (line index + visible column), so
 // streaming appends and scrolling never shift what is selected.
 interface SelectionPoint {
@@ -153,6 +155,34 @@ export class FullscreenViewport {
 		this.selectionHead = { line, col: Math.max(0, screenCol) };
 	}
 
+	selectionAutoScrollDirection(screenRow: number): SelectionScrollDirection | null {
+		if (!this.selectionAnchor || !this.selectionHead || this.selectionMode !== "transcript") return null;
+		const bounds = this.transcriptScreenBounds();
+		if (!bounds) return null;
+		if (this.selectionHead.line < this.selectionAnchor.line && screenRow <= bounds.firstRow && this.scrollTop > 0) {
+			return -1;
+		}
+		if (
+			this.selectionHead.line > this.selectionAnchor.line &&
+			screenRow >= bounds.lastRow &&
+			this.scrollTop < this.lastMaxScroll
+		) {
+			return 1;
+		}
+		return null;
+	}
+
+	scrollSelection(direction: SelectionScrollDirection, screenCol: number): boolean {
+		if (!this.selectionAnchor || this.selectionMode !== "transcript") return false;
+		const previousScrollTop = this.scrollTop;
+		this.scrollBy(direction);
+		if (this.scrollTop === previousScrollTop) return false;
+		const bounds = this.transcriptScreenBounds();
+		if (!bounds) return false;
+		this.extendSelection(direction === -1 ? bounds.firstRow : bounds.lastRow, screenCol);
+		return true;
+	}
+
 	/** Finish the selection and return its plain text (null when empty). */
 	endSelection(): string | null {
 		if (this.selectionMode !== "transcript") {
@@ -271,20 +301,40 @@ export class FullscreenViewport {
 		return { line, col: Math.max(0, screenCol) };
 	}
 
-	private transcriptLineForScreenRow(screenRow: number, clamp: boolean): number | null {
+	private transcriptScreenBounds(): {
+		firstRow: number;
+		lastRow: number;
+		visibleStart: number;
+		visibleHeight: number;
+		transcriptStart: number;
+		transcriptEnd: number;
+	} | null {
 		if (this.lastWindowHeight <= 0) return null;
 		const visibleHeight = this.lastFrameVisibleHeight > 0 ? this.lastFrameVisibleHeight : this.lastWindowHeight;
 		if (visibleHeight <= 0) return null;
-		if (!clamp && (screenRow < 0 || screenRow >= visibleHeight)) return null;
-		const row = clamp ? Math.max(0, Math.min(screenRow, visibleHeight - 1)) : screenRow;
 		const visibleStart = this.lastFrameVisibleHeight > 0 ? this.lastFrameVisibleStart : 0;
 		const visibleEnd = visibleStart + visibleHeight - 1;
 		const transcriptStart = Math.max(0, visibleStart);
 		const transcriptEnd = Math.min(this.lastWindowHeight - 1, visibleEnd);
 		if (transcriptStart > transcriptEnd) return null;
-		const frameLine = visibleStart + row;
-		if (!clamp && (frameLine < transcriptStart || frameLine > transcriptEnd)) return null;
-		return this.scrollTop + Math.max(transcriptStart, Math.min(frameLine, transcriptEnd));
+		return {
+			firstRow: transcriptStart - visibleStart,
+			lastRow: transcriptEnd - visibleStart,
+			visibleStart,
+			visibleHeight,
+			transcriptStart,
+			transcriptEnd,
+		};
+	}
+
+	private transcriptLineForScreenRow(screenRow: number, clamp: boolean): number | null {
+		const bounds = this.transcriptScreenBounds();
+		if (!bounds) return null;
+		if (!clamp && (screenRow < 0 || screenRow >= bounds.visibleHeight)) return null;
+		const row = clamp ? Math.max(0, Math.min(screenRow, bounds.visibleHeight - 1)) : screenRow;
+		const frameLine = bounds.visibleStart + row;
+		if (!clamp && (frameLine < bounds.transcriptStart || frameLine > bounds.transcriptEnd)) return null;
+		return this.scrollTop + Math.max(bounds.transcriptStart, Math.min(frameLine, bounds.transcriptEnd));
 	}
 
 	private isFrameSelectable(point: SelectionPoint): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
-import { FullscreenViewport, type ScrollInfo } from "./fullscreen.js";
+import { FullscreenViewport, type ScrollInfo, type SelectionScrollDirection } from "./fullscreen.js";
 import { getKeybindings } from "./keybindings.js";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import { isMouseSequence, isWheelDown, isWheelUp, MOUSE_BUTTON_LEFT, parseSgrMouseEvent } from "./mouse.js";
@@ -321,6 +321,12 @@ export class TUI extends Container {
 		};
 	} | null = null;
 	private static readonly WHEEL_SCROLL_LINES = 3;
+	private static readonly SELECTION_AUTO_SCROLL_DELAY_MS = 150;
+	private static readonly SELECTION_AUTO_SCROLL_INTERVAL_MS = 50;
+	private selectionAutoScrollTimer: NodeJS.Timeout | undefined;
+	private selectionAutoScrollDirection: SelectionScrollDirection | null = null;
+	private selectionAutoScrollRow = 0;
+	private selectionAutoScrollColumn = 0;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -508,8 +514,19 @@ export class TUI extends Container {
 		);
 	}
 
+	private isFullscreenOverlayFocused(): boolean {
+		return this.overlayStack.some((entry) => entry.component === this.focusedComponent);
+	}
+
 	private syncFullscreenMouseTracking(): void {
-		this.terminal.setMouseTracking(this.shouldEnableFullscreenMouseTracking());
+		const enabled = this.shouldEnableFullscreenMouseTracking();
+		if (!enabled) {
+			this.stopSelectionAutoScroll();
+			this.fullscreen?.viewport.clearSelection();
+		} else if (this.isFullscreenOverlayFocused()) {
+			this.stopSelectionAutoScroll();
+		}
+		this.terminal.setMouseTracking(enabled);
 	}
 
 	override invalidate(): void {
@@ -657,6 +674,7 @@ export class TUI extends Container {
 	 * so content produced while fullscreen flows into native scrollback.
 	 */
 	exitFullscreen(options: ExitFullscreenOptions = {}): void {
+		this.stopSelectionAutoScroll();
 		if (!this.fullscreen) return;
 		const { inlineState } = this.fullscreen;
 		this.fullscreen = null;
@@ -714,6 +732,46 @@ export class TUI extends Container {
 		// fallback: OSC 52 works locally, over SSH, and through tmux (set-clipboard)
 		const base64 = Buffer.from(text, "utf8").toString("base64");
 		this.terminal.write(`\x1b]52;c;${base64}\x07`);
+	}
+
+	private updateSelectionAutoScroll(viewport: FullscreenViewport, screenRow: number, screenColumn: number): void {
+		const direction = viewport.selectionAutoScrollDirection(screenRow);
+		this.selectionAutoScrollRow = screenRow;
+		this.selectionAutoScrollColumn = screenColumn;
+		if (direction === this.selectionAutoScrollDirection && this.selectionAutoScrollTimer) return;
+		this.stopSelectionAutoScroll();
+		if (direction === null) return;
+		this.selectionAutoScrollDirection = direction;
+		this.scheduleSelectionAutoScroll(TUI.SELECTION_AUTO_SCROLL_DELAY_MS);
+	}
+
+	private scheduleSelectionAutoScroll(delay: number): void {
+		this.selectionAutoScrollTimer = setTimeout(() => {
+			this.selectionAutoScrollTimer = undefined;
+			const fullscreen = this.fullscreen;
+			const direction = this.selectionAutoScrollDirection;
+			if (
+				!fullscreen ||
+				this.isFullscreenOverlayFocused() ||
+				direction === null ||
+				fullscreen.viewport.selectionAutoScrollDirection(this.selectionAutoScrollRow) !== direction ||
+				!fullscreen.viewport.scrollSelection(direction, this.selectionAutoScrollColumn)
+			) {
+				this.stopSelectionAutoScroll();
+				return;
+			}
+			this.requestRender();
+			this.scheduleSelectionAutoScroll(TUI.SELECTION_AUTO_SCROLL_INTERVAL_MS);
+		}, delay);
+		this.selectionAutoScrollTimer.unref();
+	}
+
+	private stopSelectionAutoScroll(): void {
+		if (this.selectionAutoScrollTimer) {
+			clearTimeout(this.selectionAutoScrollTimer);
+			this.selectionAutoScrollTimer = undefined;
+		}
+		this.selectionAutoScrollDirection = null;
 	}
 
 	private scheduleRender(): void {
@@ -802,7 +860,7 @@ export class TUI extends Container {
 		const fullscreen = this.fullscreen;
 		if (!fullscreen) return false;
 
-		const overlayFocused = this.overlayStack.some((o) => o.component === this.focusedComponent);
+		const overlayFocused = this.isFullscreenOverlayFocused();
 
 		if (isMouseSequence(data)) {
 			// consumed even when disabled — mouse reports are garbage downstream
@@ -810,25 +868,32 @@ export class TUI extends Container {
 			if (event && !overlayFocused) {
 				const viewport = fullscreen.viewport;
 				if (isWheelUp(event)) {
+					this.stopSelectionAutoScroll();
 					this.scrollBy(-TUI.WHEEL_SCROLL_LINES);
 				} else if (isWheelDown(event)) {
+					this.stopSelectionAutoScroll();
 					this.scrollBy(TUI.WHEEL_SCROLL_LINES);
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
+					this.stopSelectionAutoScroll();
 					if (!viewport.beginSelection(event.y - 1, event.x - 1)) {
 						viewport.beginFrameSelection(event.y - 1, event.x - 1);
 					}
 					this.requestRender();
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && event.motion) {
 					viewport.extendActiveSelection(event.y - 1, event.x - 1);
+					this.updateSelectionAutoScroll(viewport, event.y - 1, event.x - 1);
 					this.requestRender();
 				} else if (!event.press && viewport.hasSelection()) {
+					this.stopSelectionAutoScroll();
 					const text = viewport.endActiveSelection();
 					if (text) this.copySelection(text);
 					this.requestRender();
 				} else if (!event.press) {
+					this.stopSelectionAutoScroll();
 					viewport.clearSelection();
 				}
 			} else if (event && overlayFocused) {
+				this.stopSelectionAutoScroll();
 				const viewport = fullscreen.viewport;
 				if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
 					if (!viewport.beginFrameSelection(event.y - 1, event.x - 1)) {
@@ -848,6 +913,7 @@ export class TUI extends Container {
 			}
 			return true;
 		}
+		this.stopSelectionAutoScroll();
 
 		if (overlayFocused || !fullscreen.viewportControls) return false;
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -89,6 +89,14 @@ function lines(count: number, prefix = "Line"): string[] {
 	return Array.from({ length: count }, (_, i) => `${prefix} ${i}`);
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
 describe("TUI fullscreen mode", () => {
 	it("enters the alt screen and lays out transcript window above the dock", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(20));
@@ -630,6 +638,78 @@ describe("TUI fullscreen mode", () => {
 		terminal.sendInput("\x1b[<0;6;2m");
 		await terminal.waitForRender();
 		assert.deepStrictEqual(copies, ["Line 12\nLine"]);
+
+		tui.stop();
+	});
+
+	it("auto-scrolls upward while selecting at the transcript edge", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(30));
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<32;1;1M");
+		await waitFor(() => (tui.getScrollInfo()?.linesAbove ?? 22) < 22);
+		await terminal.waitForRender();
+
+		const scrollInfo = tui.getScrollInfo();
+		assert.ok(scrollInfo);
+		const { linesAbove } = scrollInfo;
+		terminal.sendInput("\x1b[<0;1;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(copies, [lines(26).slice(linesAbove).join("\n")]);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		assert.strictEqual(tui.getScrollInfo()?.linesAbove, linesAbove, "release stops auto-scrolling");
+
+		tui.stop();
+	});
+
+	it("auto-scrolls downward while selecting at the transcript edge", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(30));
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput(VIEWPORT_TOP);
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b[<0;1;4M");
+		terminal.sendInput("\x1b[<32;8;8M");
+		await waitFor(() => (tui.getScrollInfo()?.linesAbove ?? 0) > 0);
+		await terminal.waitForRender();
+
+		const scrollInfo = tui.getScrollInfo();
+		assert.ok(scrollInfo);
+		const { linesAbove } = scrollInfo;
+		terminal.sendInput("\x1b[<0;8;8m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(copies, [
+			lines(30)
+				.slice(3, linesAbove + 8)
+				.join("\n"),
+		]);
+
+		tui.stop();
+	});
+
+	it("does not auto-scroll a horizontal selection on the top row", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(30));
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;8;1M");
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		assert.strictEqual(tui.getScrollInfo()?.linesAbove, 22);
+
+		terminal.sendInput("\x1b[<0;8;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(copies, ["Line 22"]);
 
 		tui.stop();
 	});


### PR DESCRIPTION
- fullscreen drag selection now auto-scrolls through transcript content beyond the visible viewport.
- selection timers stop on release and view changes, with regression coverage for both directions.
- successful copies now show a transcript confirmation and clipboard failures remain visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input and clipboard UX changes with tests; no auth, data, or core agent logic touched.
> 
> **Overview**
> Fixes **fullscreen transcript text selection** so dragging past the visible viewport can include offscreen lines, and copy actions give clear feedback in the coding agent.
> 
> **TUI (`FullscreenViewport` + `TUI`)** adds edge auto-scroll while extending a drag selection: when the head is above/below the anchor and the pointer sits on the top/bottom transcript row, the viewport scrolls on a delayed/repeating timer and the selection head moves with it. Auto-scroll stops on mouse release, wheel scroll, keyboard input, overlay focus, disabled mouse tracking, and fullscreen exit. Horizontal-only selection on the top row does not trigger scroll. `transcriptScreenBounds()` refactors row/line mapping to support this.
> 
> **Coding agent** routes fullscreen copy through `copyFullscreenSelection`, showing a success status or a visible error instead of silently ignoring clipboard failures. Shortcut help documents mouse drag for select/copy.
> 
> Regression tests cover upward/downward auto-scroll and the no-scroll case for horizontal top-row selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db35f0a42ce8ca4c70d3a567bc9007a03614b351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fullscreen transcript drag selection with auto-scroll and copy confirmation
> - Dragging a selection to the top or bottom edge of the fullscreen transcript now auto-scrolls the viewport and extends the selection to offscreen text; auto-scroll stops on release, wheel events, overlay focus, or fullscreen exit.
> - Copy failures in fullscreen mode now surface an error message instead of being silently ignored; successful copies show a status confirmation.
> - Adds `selectionAutoScrollDirection()` and `scrollSelection()` to `FullscreenViewport`, and auto-scroll timer management (`scheduleSelectionAutoScroll`, `stopSelectionAutoScroll`) to the `TUI` class.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db35f0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->