### PR TITLE
preserve nemotron ultra output limit

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -144,7 +144,8 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"minimax/minimax-m3": { contextWindow: 524288 },
 	"moonshotai/kimi-k2-0905": { contextWindow: 98304 },
 	"nvidia/nemotron-3-super-120b-a12b": { contextWindow: 262144, maxTokens: 4096 },
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072 },
+	// Preserve the existing output cap when OpenRouter leaves it unspecified.
+	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072, maxTokens: 16384 },
 	// Enforced window is LARGER than OpenRouter's listing.
 	"qwen/qwen3-30b-a3b-instruct-2507": { contextWindow: 262144 },
 	// OpenRouter has no max_completion_tokens for the rest of these.


### PR DESCRIPTION
- openrouter stopped reporting the model's output cap, causing generated metadata to fall back to 8192 tokens.
- preserves the existing 16384-token cap with a model-specific override so the catalog regression test remains stable.
- leaves the broader ci workflow and live catalog refresh behavior unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static metadata override in the model generator; no runtime API or auth changes.
> 
> **Overview**
> Adds a **`maxTokens: 16384`** override for Prime Inference route `nvidia/nvidia-nemotron-3-ultra-550b-a55b` in `generate-models.ts`, with a short comment that OpenRouter no longer publishes the model’s completion limit.
> 
> Without this, regenerated catalog metadata falls back to the Prime default **8192** output tokens instead of the prior **16384** cap, which can shrink allowed completions and trip catalog regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132b49894df6c0a84ae9b642b6104d9f720d2ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `maxTokens` to 16384 for nvidia-nemotron-3-ultra-550b-a55b model metadata
> Adds `maxTokens: 16384` to the `PRIME_INFERENCE_MODEL_METADATA` entry for `nvidia/nvidia-nemotron-3-ultra-550b-a55b` in [generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/420/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c), preserving the model's output limit alongside the existing `contextWindow: 131072`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 132b498.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->