### PR TITLE
prefer prime inference for automatic model selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Changed the shared configuration menu to show prominent, responsive tabs with configurable navigation shortcuts ([ENG-4534](https://linear.app/primeintellect/issue/ENG-4534/make-login-tabs-more-obvious)).
 - Fixed Prime Inference login leaving new sessions without a persisted model selection ([ENG-4573](https://linear.app/primeintellect/issue/ENG-4573/prompt-for-model-selection-after-prime-inference-login)).
 - Fixed empty prompt placeholders hiding the input caret.
-- Fixed ambiguous GLM 5.2 model patterns selecting Hugging Face instead of Prime Inference.
+- Fixed automatic model selection preferring other configured providers over Prime Inference's GLM 5.2 default.
 - Fixed missing ripgrep blocking subagents and added actionable installation guidance for the optional search helper ([ENG-4572](https://linear.app/primeintellect/issue/ENG-4572/ripgrep-not-installed)).
 - Fixed tool-only responses rendering directly against the preceding user prompt.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed the shared configuration menu to show prominent, responsive tabs with configurable navigation shortcuts ([ENG-4534](https://linear.app/primeintellect/issue/ENG-4534/make-login-tabs-more-obvious)).
 - Fixed Prime Inference login leaving new sessions without a persisted model selection ([ENG-4573](https://linear.app/primeintellect/issue/ENG-4573/prompt-for-model-selection-after-prime-inference-login)).
 - Fixed empty prompt placeholders hiding the input caret.
+- Fixed ambiguous GLM 5.2 model patterns selecting Hugging Face instead of Prime Inference.
 - Fixed missing ripgrep blocking subagents and added actionable installation guidance for the optional search helper ([ENG-4572](https://linear.app/primeintellect/issue/ENG-4572/ripgrep-not-installed)).
 - Fixed tool-only responses rendering directly against the preceding user prompt.
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -139,6 +139,23 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 		return undefined;
 	}
 
+	const normalizedPattern = modelPattern.toLowerCase();
+	const primeInferenceDefault = matches.find((model) => {
+		if (model.provider !== "prime-inference" || model.id !== PRIME_INFERENCE_DEFAULT_MODEL_ID) {
+			return false;
+		}
+
+		const unqualifiedId = model.id.slice(model.id.lastIndexOf("/") + 1).toLowerCase();
+		return (
+			normalizedPattern === model.id.toLowerCase() ||
+			normalizedPattern === unqualifiedId ||
+			normalizedPattern === model.name?.toLowerCase()
+		);
+	});
+	if (primeInferenceDefault) {
+		return primeInferenceDefault;
+	}
+
 	// Separate into aliases and dated versions
 	const aliases = matches.filter((m) => isAlias(m.id));
 	const datedVersions = matches.filter((m) => !isAlias(m.id));

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -139,23 +139,6 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 		return undefined;
 	}
 
-	const normalizedPattern = modelPattern.toLowerCase();
-	const primeInferenceDefault = matches.find((model) => {
-		if (model.provider !== "prime-inference" || model.id !== PRIME_INFERENCE_DEFAULT_MODEL_ID) {
-			return false;
-		}
-
-		const unqualifiedId = model.id.slice(model.id.lastIndexOf("/") + 1).toLowerCase();
-		return (
-			normalizedPattern === model.id.toLowerCase() ||
-			normalizedPattern === unqualifiedId ||
-			normalizedPattern === model.name?.toLowerCase()
-		);
-	});
-	if (primeInferenceDefault) {
-		return primeInferenceDefault;
-	}
-
 	// Separate into aliases and dated versions
 	const aliases = matches.filter((m) => isAlias(m.id));
 	const datedVersions = matches.filter((m) => !isAlias(m.id));
@@ -192,6 +175,25 @@ function buildFallbackModel(provider: string, modelId: string, availableModels: 
 		id: modelId,
 		name: modelId,
 	};
+}
+
+function findPreferredDefaultModel(availableModels: Model<Api>[]): Model<Api> | undefined {
+	const primeInferenceDefault = availableModels.find(
+		(model) => model.provider === "prime-inference" && model.id === PRIME_INFERENCE_DEFAULT_MODEL_ID,
+	);
+	if (primeInferenceDefault) {
+		return primeInferenceDefault;
+	}
+
+	for (const provider of Object.keys(defaultModelPerProvider) as KnownProvider[]) {
+		const defaultId = defaultModelPerProvider[provider];
+		const match = availableModels.find((model) => model.provider === provider && model.id === defaultId);
+		if (match) {
+			return match;
+		}
+	}
+
+	return undefined;
 }
 
 /**
@@ -578,13 +580,9 @@ export async function findInitialModel(options: {
 	const availableModels = await modelRegistry.getAvailable();
 
 	if (availableModels.length > 0) {
-		// Try to find a default model from known providers
-		for (const provider of Object.keys(defaultModelPerProvider) as KnownProvider[]) {
-			const defaultId = defaultModelPerProvider[provider];
-			const match = availableModels.find((m) => m.provider === provider && m.id === defaultId);
-			if (match) {
-				return { model: match, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
-			}
+		const defaultModel = findPreferredDefaultModel(availableModels);
+		if (defaultModel) {
+			return { model: defaultModel, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
 		}
 
 		// If no default found, use first available
@@ -640,21 +638,7 @@ export async function restoreModelFromSession(
 	const availableModels = await modelRegistry.getAvailable();
 
 	if (availableModels.length > 0) {
-		// Try to find a default model from known providers
-		let fallbackModel: Model<Api> | undefined;
-		for (const provider of Object.keys(defaultModelPerProvider) as KnownProvider[]) {
-			const defaultId = defaultModelPerProvider[provider];
-			const match = availableModels.find((m) => m.provider === provider && m.id === defaultId);
-			if (match) {
-				fallbackModel = match;
-				break;
-			}
-		}
-
-		// If no default found, use first available
-		if (!fallbackModel) {
-			fallbackModel = availableModels[0];
-		}
+		const fallbackModel = findPreferredDefaultModel(availableModels) ?? availableModels[0];
 
 		if (shouldPrintMessages) {
 			console.log(chalk.dim(`Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -110,6 +110,29 @@ describe("parseModelPattern", () => {
 			expect(result.warning).toBeUndefined();
 		});
 
+		test("prefers the Prime Inference default when a fuzzy pattern matches multiple routes", () => {
+			const primeInferenceModel: Model<"anthropic-messages"> = {
+				...mockModels[0],
+				id: "z-ai/glm-5.2",
+				name: "GLM 5.2",
+				provider: "prime-inference",
+				baseUrl: "https://api.pinference.ai/api/v1",
+			};
+			const huggingFaceModel: Model<"anthropic-messages"> = {
+				...primeInferenceModel,
+				id: "zai-org/GLM-5.2",
+				provider: "huggingface",
+				baseUrl: "https://router.huggingface.co/v1",
+			};
+
+			const result = parseModelPattern("glm-5.2", [huggingFaceModel, primeInferenceModel]);
+
+			expect(result.model).toBe(primeInferenceModel);
+			expect(parseModelPattern("huggingface/zai-org/GLM-5.2", [primeInferenceModel, huggingFaceModel]).model).toBe(
+				huggingFaceModel,
+			);
+		});
+
 		test("no match returns undefined model and thinking level", () => {
 			const result = parseModelPattern("nonexistent", allModels);
 			expect(result.model).toBeUndefined();

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -110,7 +110,7 @@ describe("parseModelPattern", () => {
 			expect(result.warning).toBeUndefined();
 		});
 
-		test("prefers the Prime Inference default when a fuzzy pattern matches multiple routes", () => {
+		test("preserves provider-qualified selections when model names overlap", () => {
 			const primeInferenceModel: Model<"anthropic-messages"> = {
 				...mockModels[0],
 				id: "z-ai/glm-5.2",
@@ -125,12 +125,9 @@ describe("parseModelPattern", () => {
 				baseUrl: "https://router.huggingface.co/v1",
 			};
 
-			const result = parseModelPattern("glm-5.2", [huggingFaceModel, primeInferenceModel]);
+			const result = parseModelPattern("huggingface/zai-org/GLM-5.2", [primeInferenceModel, huggingFaceModel]);
 
-			expect(result.model).toBe(primeInferenceModel);
-			expect(parseModelPattern("huggingface/zai-org/GLM-5.2", [primeInferenceModel, huggingFaceModel]).model).toBe(
-				huggingFaceModel,
-			);
+			expect(result.model).toBe(huggingFaceModel);
 		});
 
 		test("no match returns undefined model and thinking level", () => {
@@ -475,7 +472,12 @@ describe("default model selection", () => {
 		expect(result.thinkingLevel).toBe("medium");
 	});
 
-	test("findInitialModel selects GLM 5.2 as the Prime Inference default", async () => {
+	test("findInitialModel prefers GLM 5.2 when Prime Inference is configured", async () => {
+		const anthropicModel: Model<"anthropic-messages"> = {
+			...mockModels[0],
+			id: "claude-opus-4-7",
+			name: "Claude Opus 4.7",
+		};
 		const primeModel: Model<"anthropic-messages"> = {
 			id: "z-ai/glm-5.2",
 			name: "GLM 5.2",
@@ -489,7 +491,7 @@ describe("default model selection", () => {
 			maxTokens: 101376,
 		};
 		const registry = {
-			getAvailable: async () => [primeModel],
+			getAvailable: async () => [anthropicModel, primeModel],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
 
 		const result = await findInitialModel({
@@ -499,6 +501,25 @@ describe("default model selection", () => {
 		});
 
 		expect(result.model).toBe(primeModel);
+	});
+
+	test("findInitialModel uses another provider default when Prime Inference is not configured", async () => {
+		const anthropicModel: Model<"anthropic-messages"> = {
+			...mockModels[0],
+			id: "claude-opus-4-7",
+			name: "Claude Opus 4.7",
+		};
+		const registry = {
+			getAvailable: async () => [anthropicModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: registry,
+		});
+
+		expect(result.model).toBe(anthropicModel);
 	});
 
 	test("findInitialModel selects ai-gateway default when available", async () => {


### PR DESCRIPTION
- prime inference is preferred only during automatic default and fallback selection when its authentication is configured.
- saved, scoped, restored, and provider-qualified model choices continue to take precedence.
- users without prime inference authentication continue using their available provider defaults.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer Prime Inference GLM 5.2 as default model in automatic model selection
> - Introduces `findPreferredDefaultModel` in [model-resolver.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/422/files#diff-22e2eb9b044dcbda43aec220ab0d91127a4f6ed0cc7e2757843bd6bc6aeaa144) to centralize default model selection logic, prioritizing the Prime Inference default (`PRIME_INFERENCE_DEFAULT_MODEL_ID`) over other configured providers.
> - Updates initial model selection and the post-restore fallback path to use this helper, so GLM 5.2 is chosen when Prime Inference is configured, regardless of provider ordering.
> - Behavioral Change: users with both Prime Inference and another provider configured will now start with the Prime Inference default instead of whichever provider's default appeared first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f5e897.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to default/fallback resolution only; explicit user and session model choices are untouched.
> 
> **Overview**
> Automatic default and session-restore fallback selection now go through **`findPreferredDefaultModel`**, which picks Prime Inference **`z-ai/glm-5.2`** when that model is in the available (authed) set, then falls back to each provider’s entry in **`defaultModelPerProvider`** as before.
> 
> **Behavioral change:** users with Prime Inference plus another provider no longer get whichever provider default happened to match first in the loop (e.g. Anthropic Opus); they get GLM 5.2 when Prime Inference is configured. Saved defaults, scoped models, CLI flags, and explicit **`provider/model`** choices are unchanged.
> 
> Tests cover multi-provider initial selection, Prime-absent fallback, and provider-qualified patterns when GLM-style IDs overlap across providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5e8971b7e8a315a95793ecee4ea0a50b4adddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->