### PR TITLE
speed up ci test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  build-check-test:
+  build-check:
+    name: Build and check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -38,10 +43,84 @@ jobs:
       - name: Check
         run: npm run check
 
+  test:
+    name: Test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: agent-core
+            package: packages/agent
+            command: npm test
+            install_uv: false
+          - name: ai
+            package: packages/ai
+            command: npm test
+            install_uv: false
+          - name: tui
+            package: packages/tui
+            command: npm test
+            install_uv: false
+          - name: coding-agent 1/3
+            package: packages/coding-agent
+            command: npm run test:ci -- --shard=1/3
+            install_uv: true
+          - name: coding-agent 2/3
+            package: packages/coding-agent
+            command: npm run test:ci -- --shard=2/3
+            install_uv: true
+          - name: coding-agent 3/3
+            package: packages/coding-agent
+            command: npm run test:ci -- --shard=3/3
+            install_uv: true
+          - name: coding-agent process smoke
+            package: packages/coding-agent
+            command: npm run test:process
+            install_uv: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+          sudo ln -s $(which fdfind) /usr/local/bin/fd
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
       - name: Install uv
+        if: matrix.install_uv
         run: |
           python3 -m pip install --user uv
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Test
-        run: npm test
+        working-directory: ${{ matrix.package }}
+        run: ${{ matrix.command }}
+
+  build-check-test:
+    name: build-check-test
+    if: always()
+    needs: [build-check, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CI results
+        env:
+          BUILD_CHECK_RESULT: ${{ needs.build-check.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          test "$BUILD_CHECK_RESULT" = success
+          test "$TEST_RESULT" = success

--- a/.github/workflows/nightly-process-stress.yml
+++ b/.github/workflows/nightly-process-stress.yml
@@ -1,0 +1,51 @@
+name: Nightly Process Stress
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-process-stress
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  process-stress:
+    name: Process stress
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+          sudo ln -s $(which fdfind) /usr/local/bin/fd
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Install uv
+        run: |
+          python3 -m pip install --user uv
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run process stress tests
+        working-directory: packages/coding-agent
+        env:
+          PRIME_AGENT_STRESS_WORKERS: "10"
+        run: npm run test:process-stress

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -38,6 +38,9 @@
 		"copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/ && shx rm -rf dist/prime-agent-runtime && shx cp -r ../../prime-agent-runtime dist/prime-agent-runtime && shx rm -rf dist/skills && shx cp -r skills dist/skills",
 		"copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor && shx cp src/core/export-html/template.html dist/export-html/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/ && shx rm -rf dist/skills && shx cp -r skills dist/skills",
 		"test": "vitest --run",
+		"test:ci": "vitest --run --exclude test/daemon-supervisor-process.test.ts",
+		"test:process": "vitest --run test/daemon-supervisor-process.test.ts",
+		"test:process-stress": "vitest --run --tagsFilter process-stress test/daemon-supervisor-process.test.ts",
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs"

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -20,6 +20,7 @@ import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-p
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
+const blockingProcessPath = resolve(__dirname, "fixtures/blocking-process.mjs");
 const tempDirs: string[] = [];
 const children = new Set<ChildProcess>();
 const workerPids = new Set<number>();
@@ -178,8 +179,10 @@ async function connectEventually(socketPath: string, child?: ChildProcess): Prom
 	let lastError: unknown;
 	while (Date.now() < deadline) {
 		if (child && (child.exitCode !== null || child.signalCode !== null)) {
+			const diagnostics = childDiagnostics.get(child);
 			throw new Error(
-				`Supervisor exited before becoming ready (code ${child.exitCode}, signal ${child.signalCode})`,
+				`Supervisor exited before becoming ready (code ${child.exitCode}, signal ${child.signalCode})\n` +
+					`stdout:\n${diagnostics?.stdout ?? ""}\nstderr:\n${diagnostics?.stderr ?? ""}`,
 			);
 		}
 		const client = new DaemonClient(socketPath);
@@ -269,8 +272,21 @@ async function waitForCondition(predicate: () => boolean, failureMessage: string
 	throw new Error(failureMessage);
 }
 
+function quoteShellArgument(argument: string): string {
+	return `'${argument.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function startBlockingBash(client: DaemonClient, activeSessionId: string, readyPath: string): Promise<void> {
+	const command = [process.execPath, blockingProcessPath, readyPath].map(quoteShellArgument).join(" ");
+	const response = await client.request({ type: "execute_bash", activeSessionId, command });
+	if (!response.success) {
+		throw new Error(response.error);
+	}
+	await waitForCondition(() => existsSync(readyPath), `Blocking bash process did not become ready: ${readyPath}`);
+}
+
 describe("daemon supervisor resident workers", () => {
-	it("cancels an archived session heartbeat without spawning a worker", async () => {
+	it("cancels an archived session heartbeat without spawning a worker", { tags: ["process-stress"] }, async () => {
 		const root = tempDir();
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
@@ -321,55 +337,62 @@ describe("daemon supervisor resident workers", () => {
 		await client.request({ type: "shutdown" });
 		client.close();
 		await waitForSocketGone(socketPath);
-	}, 30_000);
+	});
 
-	it("cancels an orphan heartbeat instead of recreating a descriptorless active session", async () => {
-		const root = tempDir();
-		const agentDir = join(root, "agent");
-		const projectDir = join(root, "project");
-		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-orphan-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
-		mkdirSync(projectDir, { recursive: true });
-		const sessionManager = SessionManager.create(projectDir, sessionDir);
-		sessionManager.appendMessage({ role: "user", content: "old scheduled work", timestamp: 1 });
-		sessionManager.appendSessionState({ status: "active" });
-		const sessionFile = sessionManager.getSessionFile();
-		if (!sessionFile) {
-			throw new Error("Fixture session did not persist");
-		}
-		const cronStore = new AgentCronJobStore(getCronJobsPath(agentDir));
-		const heartbeat = cronStore.createHeartbeat({
-			activeSessionId: "deleted-worker",
-			sessionId: sessionManager.getSessionId(),
-			sessionFile,
-			cwd: projectDir,
-			scheduleText: "every 10s",
-			prompt: "continue old work",
-			now: new Date(Date.now() - 20_000),
-		});
+	it(
+		"cancels an orphan heartbeat instead of recreating a descriptorless active session",
+		{ tags: ["process-stress"] },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(
+				tmpdir(),
+				`prime-supervisor-orphan-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+			);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionManager = SessionManager.create(projectDir, sessionDir);
+			sessionManager.appendMessage({ role: "user", content: "old scheduled work", timestamp: 1 });
+			sessionManager.appendSessionState({ status: "active" });
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Fixture session did not persist");
+			}
+			const cronStore = new AgentCronJobStore(getCronJobsPath(agentDir));
+			const heartbeat = cronStore.createHeartbeat({
+				activeSessionId: "deleted-worker",
+				sessionId: sessionManager.getSessionId(),
+				sessionFile,
+				cwd: projectDir,
+				scheduleText: "every 10s",
+				prompt: "continue old work",
+				now: new Date(Date.now() - 20_000),
+			});
 
-		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
-		const client = await connectEventually(socketPath, supervisor);
-		const migratedStore = AgentCronJobStore.forSessionArtifacts();
-		migratedStore.registerSessionArtifact(sessionManager.getSessionId(), sessionManager.getSessionArtifactDir()!);
-		await waitForCondition(
-			() => migratedStore.list().find((job) => job.id === heartbeat.id)?.status === "cancelled",
-			"Orphan heartbeat was not cancelled",
-		);
+			const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, supervisor);
+			const migratedStore = AgentCronJobStore.forSessionArtifacts();
+			migratedStore.registerSessionArtifact(sessionManager.getSessionId(), sessionManager.getSessionArtifactDir()!);
+			await waitForCondition(
+				() => migratedStore.list().find((job) => job.id === heartbeat.id)?.status === "cancelled",
+				"Orphan heartbeat was not cancelled",
+			);
 
-		expect(countWorkerDescriptors(agentDir)).toBe(0);
-		const listed = await client.request({ type: "list" });
-		expect(listed.success).toBe(true);
-		expect(
-			requireSessionList(listed.success ? listed.data : undefined).filter(
-				(session) => session.activeSessionId || session.workerPid,
-			),
-		).toEqual([]);
+			expect(countWorkerDescriptors(agentDir)).toBe(0);
+			const listed = await client.request({ type: "list" });
+			expect(listed.success).toBe(true);
+			expect(
+				requireSessionList(listed.success ? listed.data : undefined).filter(
+					(session) => session.activeSessionId || session.workerPid,
+				),
+			).toEqual([]);
 
-		await client.request({ type: "shutdown" });
-		client.close();
-		await waitForSocketGone(socketPath);
-	}, 30_000);
+			await client.request({ type: "shutdown" });
+			client.close();
+			await waitForSocketGone(socketPath);
+		},
+	);
 
 	it("restarts an empty supervisor without requiring a resident worker", async () => {
 		const root = tempDir();
@@ -398,7 +421,7 @@ describe("daemon supervisor resident workers", () => {
 		await waitForSocketGone(socketPath);
 	});
 
-	it("survives a worker process spawn error", async () => {
+	it("survives a worker process spawn error", { tags: ["process-stress"] }, async () => {
 		const root = tempDir();
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
@@ -490,96 +513,105 @@ describe("daemon supervisor resident workers", () => {
 		await waitForSocketGone(socketPath);
 	}, 30_000);
 
-	it("does not resurrect an intentionally stopped root when the supervisor dies during kill", async () => {
+	it(
+		"does not resurrect an intentionally stopped root when the supervisor dies during kill",
+		{ tags: ["process-stress"], timeout: 30_000 },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(
+				tmpdir(),
+				`prime-supervisor-stop-race-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+			);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionManager = SessionManager.create(projectDir, sessionDir);
+			sessionManager.appendMessage({ role: "user", content: "stop me", timestamp: 1 });
+			sessionManager.appendSessionState({ status: "active" });
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Fixture session did not persist");
+			}
+
+			const firstSupervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, firstSupervisor);
+			const firstSupervisorPid = client.hello?.supervisorPid;
+			if (!firstSupervisorPid) {
+				throw new Error("Daemon hello did not expose its supervisor pid");
+			}
+			const created = await client.request({
+				type: "create",
+				sessionPath: sessionFile,
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			if (!created.success) {
+				throw new Error(created.error);
+			}
+			const summary = requireSummary(created.data);
+			if (!summary.workerPid) {
+				throw new Error("Resident worker did not expose its pid");
+			}
+			workerPids.add(summary.workerPid);
+			const activeSessionId = summary.activeSessionId ?? summary.id;
+			const heartbeatResponse = await client.request({
+				type: "heartbeat_set",
+				activeSessionId,
+				schedule: "every 1h",
+				prompt: "continue old work",
+			});
+			if (!heartbeatResponse.success || !heartbeatResponse.data || typeof heartbeatResponse.data !== "object") {
+				throw new Error(
+					heartbeatResponse.success ? "Heartbeat response was missing data" : heartbeatResponse.error,
+				);
+			}
+			const heartbeat = (heartbeatResponse.data as { heartbeat: { id: string } }).heartbeat;
+			const cronStore = AgentCronJobStore.forSessionArtifacts();
+			cronStore.registerSessionArtifact(summary.sessionId, sessionManager.getSessionArtifactDir()!);
+			process.kill(summary.workerPid, "SIGSTOP");
+			const killResult = client.request({ type: "kill", activeSessionId }).catch((error: unknown) => error);
+			const tombstone = await waitForWorkerStopTombstone(agentDir);
+			expect(tombstone.stopRequestedAt).toEqual(expect.any(String));
+			expect(tombstone.archiveOnStop).toBe(true);
+
+			process.kill(firstSupervisorPid, "SIGKILL");
+			await waitForExit(firstSupervisor);
+			children.delete(firstSupervisor);
+			client.close();
+			await expect(killResult).resolves.toBeInstanceOf(Error);
+
+			const replacementSupervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const replacementClient = await connectEventually(socketPath, replacementSupervisor);
+			const listed = await replacementClient.request({ type: "list" });
+			expect(listed.success).toBe(true);
+			const sessions = requireSessionList(listed.success ? listed.data : undefined);
+			expect(sessions.filter((session) => session.activeSessionId || session.workerPid)).toEqual([]);
+			await waitForProcessGone(summary.workerPid);
+			workerPids.delete(summary.workerPid);
+			await waitForCondition(
+				() => countWorkerDescriptors(agentDir) === 0,
+				"Intentional worker stop descriptor was not removed",
+			);
+			expect(countWorkerDescriptors(agentDir)).toBe(0);
+			expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
+			expect(cronStore.list().find((job) => job.id === heartbeat.id)).toMatchObject({ status: "cancelled" });
+
+			await replacementClient.request({ type: "shutdown" });
+			replacementClient.close();
+			await waitForSocketGone(socketPath);
+		},
+	);
+
+	it("hosts and adopts isolated worker processes", async () => {
 		const root = tempDir();
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-stop-race-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = join(tmpdir(), `prime-supervisor-smoke-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
 		mkdirSync(projectDir, { recursive: true });
-		const sessionManager = SessionManager.create(projectDir, sessionDir);
-		sessionManager.appendMessage({ role: "user", content: "stop me", timestamp: 1 });
-		sessionManager.appendSessionState({ status: "active" });
-		const sessionFile = sessionManager.getSessionFile();
-		if (!sessionFile) {
-			throw new Error("Fixture session did not persist");
-		}
-
-		const firstSupervisor = spawnSupervisor(agentDir, socketPath, projectDir);
-		const client = await connectEventually(socketPath, firstSupervisor);
-		const firstSupervisorPid = client.hello?.supervisorPid;
-		if (!firstSupervisorPid) {
-			throw new Error("Daemon hello did not expose its supervisor pid");
-		}
-		const created = await client.request({
-			type: "create",
-			sessionPath: sessionFile,
-			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
-		});
-		if (!created.success) {
-			throw new Error(created.error);
-		}
-		const summary = requireSummary(created.data);
-		if (!summary.workerPid) {
-			throw new Error("Resident worker did not expose its pid");
-		}
-		workerPids.add(summary.workerPid);
-		const activeSessionId = summary.activeSessionId ?? summary.id;
-		const heartbeatResponse = await client.request({
-			type: "heartbeat_set",
-			activeSessionId,
-			schedule: "every 1h",
-			prompt: "continue old work",
-		});
-		if (!heartbeatResponse.success || !heartbeatResponse.data || typeof heartbeatResponse.data !== "object") {
-			throw new Error(heartbeatResponse.success ? "Heartbeat response was missing data" : heartbeatResponse.error);
-		}
-		const heartbeat = (heartbeatResponse.data as { heartbeat: { id: string } }).heartbeat;
-		const cronStore = AgentCronJobStore.forSessionArtifacts();
-		cronStore.registerSessionArtifact(summary.sessionId, sessionManager.getSessionArtifactDir()!);
-		process.kill(summary.workerPid, "SIGSTOP");
-		const killResult = client.request({ type: "kill", activeSessionId }).catch((error: unknown) => error);
-		const tombstone = await waitForWorkerStopTombstone(agentDir);
-		expect(tombstone.stopRequestedAt).toEqual(expect.any(String));
-		expect(tombstone.archiveOnStop).toBe(true);
-
-		process.kill(firstSupervisorPid, "SIGKILL");
-		await waitForExit(firstSupervisor);
-		children.delete(firstSupervisor);
-		client.close();
-		await expect(killResult).resolves.toBeInstanceOf(Error);
-
-		const replacementSupervisor = spawnSupervisor(agentDir, socketPath, projectDir);
-		const replacementClient = await connectEventually(socketPath, replacementSupervisor);
-		const listed = await replacementClient.request({ type: "list" });
-		expect(listed.success).toBe(true);
-		const sessions = requireSessionList(listed.success ? listed.data : undefined);
-		expect(sessions.filter((session) => session.activeSessionId || session.workerPid)).toEqual([]);
-		await waitForProcessGone(summary.workerPid);
-		workerPids.delete(summary.workerPid);
-		await waitForCondition(
-			() => countWorkerDescriptors(agentDir) === 0,
-			"Intentional worker stop descriptor was not removed",
-		);
-		expect(countWorkerDescriptors(agentDir)).toBe(0);
-		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
-		expect(cronStore.list().find((job) => job.id === heartbeat.id)).toMatchObject({ status: "cancelled" });
-
-		await replacementClient.request({ type: "shutdown" });
-		replacementClient.close();
-		await waitForSocketGone(socketPath);
-	}, 30_000);
-
-	it("hosts resident roots in isolated worker processes without a session cap", async () => {
-		const root = tempDir();
-		const agentDir = join(root, "agent");
-		const projectDir = join(root, "project");
-		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-many-roots-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
-		mkdirSync(projectDir, { recursive: true });
-		const sessionFiles = Array.from({ length: PROCESS_STRESS_WORKERS }, (_, index) => {
+		const sessionFiles = Array.from({ length: 2 }, (_, index) => {
 			const manager = SessionManager.create(projectDir, sessionDir);
-			manager.appendMessage({ role: "user", content: `root ${index}`, timestamp: index + 1 });
+			manager.appendMessage({ role: "user", content: `smoke root ${index}`, timestamp: index + 1 });
 			const sessionFile = manager.getSessionFile();
 			if (!sessionFile) {
 				throw new Error("Fixture session did not persist");
@@ -589,22 +621,6 @@ describe("daemon supervisor resident workers", () => {
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
 		const client = await connectEventually(socketPath, supervisor);
-		const externalLease = acquireSessionLease(sessionFiles[0], agentDir, {
-			[SESSION_LEASES_ENABLED_ENV]: "1",
-			[SESSION_LEASE_OWNER_ID_ENV]: "external-owner",
-		});
-		const conflict = await client.request({
-			type: "create",
-			sessionPath: sessionFiles[0],
-			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
-		});
-		expect(conflict).toMatchObject({
-			success: false,
-			errorInfo: { code: "session_already_active", activeSessionId: "external-owner" },
-		});
-		const emptyAfterConflict = await client.request({ type: "list" });
-		expect(requireSessionList(emptyAfterConflict.success ? emptyAfterConflict.data : undefined)).toHaveLength(0);
-		externalLease?.release();
 		const created = await Promise.all(
 			sessionFiles.map((sessionPath) =>
 				client.request({
@@ -621,7 +637,7 @@ describe("daemon supervisor resident workers", () => {
 			return requireSummary(response.data);
 		});
 		const pids = summaries.map((summary) => summary.workerPid);
-		expect(new Set(pids).size).toBe(PROCESS_STRESS_WORKERS);
+		expect(new Set(pids).size).toBe(2);
 		expect(pids).not.toContain(supervisor.pid);
 		for (const pid of pids) {
 			if (!pid) {
@@ -629,62 +645,15 @@ describe("daemon supervisor resident workers", () => {
 			}
 			workerPids.add(pid);
 		}
-		const firstActiveSessionId = summaries[0]!.activeSessionId ?? summaries[0]!.id;
-		const addedCron = await client.request({
-			type: "cron_add",
-			activeSessionId: firstActiveSessionId,
-			schedule: "every 1h",
-			prompt: "check status",
-		});
-		expect(addedCron.success).toBe(true);
-		const cronJob = (addedCron.success ? addedCron.data : undefined) as { job?: { id?: string } } | undefined;
-		if (!cronJob?.job?.id) {
-			throw new Error("Supervisor did not persist the cron job");
-		}
-		const listedCron = await client.request({ type: "cron_list", activeSessionId: firstActiveSessionId });
-		expect(listedCron).toMatchObject({ success: true, data: { jobs: [{ id: cronJob.job.id }] } });
-		const cancelledCron = await client.request({ type: "cron_cancel", jobId: cronJob.job.id });
-		expect(cancelledCron.success).toBe(true);
-		const activeSessionIds = summaries.map((summary) => summary.activeSessionId ?? summary.id);
-		await Promise.all(
-			activeSessionIds.map((activeSessionId) =>
-				client.request({ type: "execute_bash", activeSessionId, command: "sleep 30" }),
-			),
-		);
-		const heartbeats = await Promise.all(
-			activeSessionIds.map((activeSessionId, index) =>
-				client.request({
-					type: "heartbeat_set",
-					activeSessionId,
-					schedule: "every 10s",
-					prompt: `heartbeat ${index}`,
-				}),
-			),
-		);
-		expect(heartbeats.every((response) => response.success)).toBe(true);
-		await waitForCondition(
-			() => {
-				const stores = summaries.map((summary, index) => {
-					const store = AgentCronJobStore.forSessionArtifacts();
-					store.registerSessionArtifact(
-						summary.sessionId,
-						join(dirname(dirname(sessionFiles[index]!)), "session-artifacts", summary.sessionId),
-					);
-					return store;
-				});
-				return stores.every((store) => store.list().some((job) => job.lastSkippedAt !== undefined));
-			},
-			"Session workers did not advance their heartbeats independently",
-			15_000,
-		);
 
 		const listed = await client.request({ type: "list" });
 		expect(listed.success).toBe(true);
-		expect(requireSessionList(listed.success ? listed.data : undefined)).toHaveLength(PROCESS_STRESS_WORKERS);
+		expect(requireSessionList(listed.success ? listed.data : undefined)).toHaveLength(2);
 		supervisor.kill("SIGTERM");
 		await waitForExit(supervisor);
 		children.delete(supervisor);
 		client.close();
+
 		const replacementClient = await connectEventually(socketPath);
 		const adopted = await replacementClient.request({ type: "list" });
 		expect(adopted.success).toBe(true);
@@ -702,7 +671,148 @@ describe("daemon supervisor resident workers", () => {
 				}
 			}),
 		);
-	}, 180_000);
+	}, 60_000);
+
+	it(
+		"hosts resident roots in isolated worker processes without a session cap",
+		{ tags: ["process-stress"], timeout: 180_000 },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(
+				tmpdir(),
+				`prime-supervisor-many-roots-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+			);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionFiles = Array.from({ length: PROCESS_STRESS_WORKERS }, (_, index) => {
+				const manager = SessionManager.create(projectDir, sessionDir);
+				manager.appendMessage({ role: "user", content: `root ${index}`, timestamp: index + 1 });
+				const sessionFile = manager.getSessionFile();
+				if (!sessionFile) {
+					throw new Error("Fixture session did not persist");
+				}
+				return sessionFile;
+			});
+
+			const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, supervisor);
+			const externalLease = acquireSessionLease(sessionFiles[0], agentDir, {
+				[SESSION_LEASES_ENABLED_ENV]: "1",
+				[SESSION_LEASE_OWNER_ID_ENV]: "external-owner",
+			});
+			const conflict = await client.request({
+				type: "create",
+				sessionPath: sessionFiles[0],
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			expect(conflict).toMatchObject({
+				success: false,
+				errorInfo: { code: "session_already_active", activeSessionId: "external-owner" },
+			});
+			const emptyAfterConflict = await client.request({ type: "list" });
+			expect(requireSessionList(emptyAfterConflict.success ? emptyAfterConflict.data : undefined)).toHaveLength(0);
+			externalLease?.release();
+			const created = await Promise.all(
+				sessionFiles.map((sessionPath) =>
+					client.request({
+						type: "create",
+						sessionPath,
+						config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+					}),
+				),
+			);
+			const summaries = created.map((response) => {
+				if (!response.success) {
+					throw new Error(response.error);
+				}
+				return requireSummary(response.data);
+			});
+			const pids = summaries.map((summary) => summary.workerPid);
+			expect(new Set(pids).size).toBe(PROCESS_STRESS_WORKERS);
+			expect(pids).not.toContain(supervisor.pid);
+			for (const pid of pids) {
+				if (!pid) {
+					throw new Error("Resident root did not expose a worker pid");
+				}
+				workerPids.add(pid);
+			}
+			const firstActiveSessionId = summaries[0]!.activeSessionId ?? summaries[0]!.id;
+			const addedCron = await client.request({
+				type: "cron_add",
+				activeSessionId: firstActiveSessionId,
+				schedule: "every 1h",
+				prompt: "check status",
+			});
+			expect(addedCron.success).toBe(true);
+			const cronJob = (addedCron.success ? addedCron.data : undefined) as { job?: { id?: string } } | undefined;
+			if (!cronJob?.job?.id) {
+				throw new Error("Supervisor did not persist the cron job");
+			}
+			const listedCron = await client.request({ type: "cron_list", activeSessionId: firstActiveSessionId });
+			expect(listedCron).toMatchObject({ success: true, data: { jobs: [{ id: cronJob.job.id }] } });
+			const cancelledCron = await client.request({ type: "cron_cancel", jobId: cronJob.job.id });
+			expect(cancelledCron.success).toBe(true);
+			const activeSessionIds = summaries.map((summary) => summary.activeSessionId ?? summary.id);
+			await Promise.all(
+				activeSessionIds.map((activeSessionId, index) =>
+					startBlockingBash(client, activeSessionId, join(root, `stress-blocker-${index}.ready`)),
+				),
+			);
+			const heartbeats = await Promise.all(
+				activeSessionIds.map((activeSessionId, index) =>
+					client.request({
+						type: "heartbeat_set",
+						activeSessionId,
+						schedule: "every 10s",
+						prompt: `heartbeat ${index}`,
+					}),
+				),
+			);
+			expect(heartbeats.every((response) => response.success)).toBe(true);
+			await waitForCondition(
+				() => {
+					const stores = summaries.map((summary, index) => {
+						const store = AgentCronJobStore.forSessionArtifacts();
+						store.registerSessionArtifact(
+							summary.sessionId,
+							join(dirname(dirname(sessionFiles[index]!)), "session-artifacts", summary.sessionId),
+						);
+						return store;
+					});
+					return stores.every((store) => store.list().some((job) => job.lastSkippedAt !== undefined));
+				},
+				"Session workers did not advance their heartbeats independently",
+				15_000,
+			);
+
+			const listed = await client.request({ type: "list" });
+			expect(listed.success).toBe(true);
+			expect(requireSessionList(listed.success ? listed.data : undefined)).toHaveLength(PROCESS_STRESS_WORKERS);
+			supervisor.kill("SIGTERM");
+			await waitForExit(supervisor);
+			children.delete(supervisor);
+			client.close();
+			const replacementClient = await connectEventually(socketPath);
+			const adopted = await replacementClient.request({ type: "list" });
+			expect(adopted.success).toBe(true);
+			expect(
+				new Set(requireSessionList(adopted.success ? adopted.data : undefined).map((summary) => summary.workerPid)),
+			).toEqual(new Set(pids));
+			await replacementClient.request({ type: "shutdown" });
+			replacementClient.close();
+			await waitForSocketGone(socketPath);
+			await Promise.all(
+				pids.map(async (pid) => {
+					if (pid) {
+						await waitForProcessGone(pid);
+						workerPids.delete(pid);
+					}
+				}),
+			);
+		},
+	);
 
 	it("isolates a root, streams a chunked snapshot, and adopts the same worker after restart", async () => {
 		const root = tempDir();
@@ -827,12 +937,7 @@ describe("daemon supervisor resident workers", () => {
 		});
 
 		const descriptor = readWorkerDescriptor(agentDir);
-		const bashStarted = await client.request({
-			type: "execute_bash",
-			activeSessionId,
-			command: "sleep 60",
-		});
-		expect(bashStarted.success).toBe(true);
+		await startBlockingBash(client, activeSessionId, join(root, "orphan-blocker.ready"));
 		if (!descriptor.orphanProcessJournalPath) {
 			throw new Error("Resident worker did not persist its orphan-process journal path");
 		}
@@ -889,73 +994,72 @@ describe("daemon supervisor resident workers", () => {
 		workerPids.delete(recovered.workerPid);
 	});
 
-	it("runs a session-artifact cron job while the supervisor is being replaced", async () => {
-		const root = tempDir();
-		const agentDir = join(root, "agent");
-		const projectDir = join(root, "project");
-		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-worker-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
-		mkdirSync(projectDir, { recursive: true });
-		const sessionManager = SessionManager.create(projectDir, sessionDir);
-		sessionManager.appendMessage({ role: "user", content: "scheduled work", timestamp: 1 });
-		sessionManager.appendSessionState({ status: "active" });
-		const sessionFile = sessionManager.getSessionFile();
-		const artifactDir = sessionManager.getSessionArtifactDir();
-		if (!sessionFile || !artifactDir) {
-			throw new Error("Fixture session did not persist");
-		}
+	it(
+		"runs a session-artifact cron job while the supervisor is being replaced",
+		{ tags: ["process-stress"], timeout: 30_000 },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(tmpdir(), `prime-worker-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionManager = SessionManager.create(projectDir, sessionDir);
+			sessionManager.appendMessage({ role: "user", content: "scheduled work", timestamp: 1 });
+			sessionManager.appendSessionState({ status: "active" });
+			const sessionFile = sessionManager.getSessionFile();
+			const artifactDir = sessionManager.getSessionArtifactDir();
+			if (!sessionFile || !artifactDir) {
+				throw new Error("Fixture session did not persist");
+			}
 
-		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
-		const client = await connectEventually(socketPath, supervisor);
-		const created = await client.request({
-			type: "create",
-			sessionPath: sessionFile,
-			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
-		});
-		if (!created.success) {
-			throw new Error(created.error);
-		}
-		const summary = requireSummary(created.data);
-		if (!summary.workerPid) {
-			throw new Error("Resident worker did not expose its pid");
-		}
-		workerPids.add(summary.workerPid);
-		const bashStarted = await client.request({
-			type: "execute_bash",
-			activeSessionId: summary.activeSessionId ?? summary.id,
-			command: "sleep 30",
-		});
-		expect(bashStarted.success).toBe(true);
-		const scheduled = await client.request({
-			type: "heartbeat_set",
-			activeSessionId: summary.activeSessionId ?? summary.id,
-			schedule: "every 10s",
-			prompt: "continue without the supervisor",
-		});
-		if (!scheduled.success || !scheduled.data || typeof scheduled.data !== "object") {
-			throw new Error(scheduled.success ? "Heartbeat response was missing its job" : scheduled.error);
-		}
-		const job = (scheduled.data as { heartbeat: { id: string } }).heartbeat;
+			const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, supervisor);
+			const created = await client.request({
+				type: "create",
+				sessionPath: sessionFile,
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			if (!created.success) {
+				throw new Error(created.error);
+			}
+			const summary = requireSummary(created.data);
+			if (!summary.workerPid) {
+				throw new Error("Resident worker did not expose its pid");
+			}
+			workerPids.add(summary.workerPid);
+			await startBlockingBash(client, summary.activeSessionId ?? summary.id, join(root, "heartbeat-blocker.ready"));
+			const scheduled = await client.request({
+				type: "heartbeat_set",
+				activeSessionId: summary.activeSessionId ?? summary.id,
+				schedule: "every 10s",
+				prompt: "continue without the supervisor",
+			});
+			if (!scheduled.success || !scheduled.data || typeof scheduled.data !== "object") {
+				throw new Error(scheduled.success ? "Heartbeat response was missing its job" : scheduled.error);
+			}
+			const job = (scheduled.data as { heartbeat: { id: string } }).heartbeat;
 
-		client.close();
-		supervisor.kill("SIGKILL");
-		await waitForExit(supervisor);
-		children.delete(supervisor);
+			client.close();
+			supervisor.kill("SIGKILL");
+			await waitForExit(supervisor);
+			children.delete(supervisor);
 
-		const store = AgentCronJobStore.forSessionArtifacts();
-		store.registerSessionArtifact(sessionManager.getSessionId(), artifactDir);
-		await waitForCondition(
-			() => store.list().find((candidate) => candidate.id === job.id)?.lastSkippedAt !== undefined,
-			"Resident worker did not advance its heartbeat without the supervisor",
-			15_000,
-		);
-		expect(store.list().find((candidate) => candidate.id === job.id)).toBeDefined();
+			const store = AgentCronJobStore.forSessionArtifacts();
+			store.registerSessionArtifact(sessionManager.getSessionId(), artifactDir);
+			await waitForCondition(
+				() => store.list().find((candidate) => candidate.id === job.id)?.lastSkippedAt !== undefined,
+				"Resident worker did not advance its heartbeat without the supervisor",
+				15_000,
+			);
+			expect(store.list().find((candidate) => candidate.id === job.id)).toBeDefined();
 
-		const replacement = await connectEventually(socketPath);
-		await replacement.request({ type: "shutdown" });
-		replacement.close();
-		await waitForSocketGone(socketPath);
-		await waitForProcessGone(summary.workerPid);
-		workerPids.delete(summary.workerPid);
-	}, 30_000);
+			const replacement = await connectEventually(socketPath);
+			await replacement.request({ type: "shutdown" });
+			replacement.close();
+			await waitForSocketGone(socketPath);
+			await waitForProcessGone(summary.workerPid);
+			workerPids.delete(summary.workerPid);
+		},
+	);
 });

--- a/packages/coding-agent/test/fixtures/blocking-process.mjs
+++ b/packages/coding-agent/test/fixtures/blocking-process.mjs
@@ -1,0 +1,17 @@
+import { writeFileSync } from "node:fs";
+
+const readyPath = process.argv[2];
+if (!readyPath) {
+	throw new Error("A readiness marker path is required");
+}
+
+writeFileSync(readyPath, `${process.pid}\n`);
+
+const keepAlive = setInterval(() => {}, 2_147_483_647);
+const stop = () => {
+	clearInterval(keepAlive);
+	process.exit(0);
+};
+
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		testTimeout: 30000,
+		tags: [
+			{
+				name: "process-stress",
+				description: "Slow real-process stress and wall-clock scheduling coverage",
+			},
+		],
+		tagsFilter: ["!process-stress"],
 		server: {
 			deps: {
 				external: [/@silvia-odwyer\/photon-node/],


### PR DESCRIPTION
- addresses eng-4647 by running workspace tests and coding-agent shards in parallel behind the existing ci gate.
- keeps focused worker-process smoke coverage on pull requests and moves scale and heartbeat timing coverage to nightly runs.
- replaces fixed shell sleeps with readiness-signaling blocker fixtures to reduce latency and flakiness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, Vitest config, and test harness scripts; no production runtime behavior is modified.
> 
> **Overview**
> **CI is restructured** so build/check runs in one job and tests fan out in parallel across `agent`, `ai`, `tui`, three **coding-agent Vitest shards** (`test:ci`), and a **daemon process smoke** job (`test:process`). A small **gate job** still fails the workflow if either build-check or the matrix tests fail.
> 
> **coding-agent** gains `test:ci` (excludes the heavy supervisor process file), `test:process`, and `test:process-stress`. Default Vitest runs skip tests tagged **`process-stress`**; nightly workflow runs only those with `PRIME_AGENT_STRESS_WORKERS=10`.
> 
> Supervisor integration tests use a **readiness-signaling blocker fixture** instead of `sleep` in `execute_bash`, and PR smoke keeps a **lighter** multi-worker adoption test while scale/cron timing cases move behind the stress tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8488ab47ba8ecf292f1c7e83c1f720977c60e39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up CI by parallelizing tests across jobs and excluding slow process-stress tests by default
> - Splits the single CI job into a `build-check` job and a parallel `test` matrix job across `agent-core`, `ai`, `tui`, and sharded `coding-agent` tests, plus a smoke run; a final aggregator job gates overall success
> - Adds a `process-stress` vitest tag and excludes it from default runs via [vitest.config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/424/files#diff-bde9d899eecf81df61ac3e23b7661d244fa4c650c879157d49d0577ad9063862); tagged tests must be opted into explicitly
> - Adds new npm scripts (`test:ci`, `test:process`, `test:process-stress`) to [packages/coding-agent/package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/424/files#diff-8539bf3a7fb8b77848c0018f167f04fac756a980228bd467182af459cd8c5674) to support the split execution
> - Adds a nightly workflow ([nightly-process-stress.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/424/files#diff-d1175db99e1e2f68d172311e664dcf0f1f68a4d1746b80dd6b467fcb54e00faf)) that runs process-stress tests on a schedule with `PRIME_AGENT_STRESS_WORKERS=10`
> - Replaces `sleep`-based long-lived processes in tests with a deterministic [blocking-process.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/424/files#diff-6830e6741862a42ffea8ca18a0f7ab3989affa883d79e8406362ad8d03d99fc0) fixture that signals readiness via a file, reducing flakiness
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8488ab4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->