### PR TITLE
Fix Ghostty inline image placement

### DIFF
--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -72,11 +72,13 @@ describe("Prime Inference models", () => {
 		expect(gemini.reasoning).toBe(true);
 
 		// The HF-style ultra id maps onto OpenRouter's short id via alias for
-		// pricing/modality, but the gateway enforces a 131k window (measured
-		// 2026-07-08), so the curated override wins for contextWindow.
+		// modality/reasoning, but the gateway enforces a 131k window (measured
+		// 2026-07-08), so the curated override wins for contextWindow. OpenRouter
+		// may omit its live output cap, in which case the conservative fallback wins.
 		const ultra = getModel("prime-inference", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B");
 		expect(ultra.contextWindow).toBe(131072);
-		expect(ultra.maxTokens).toBe(16384);
+		expect(ultra.maxTokens).toBeGreaterThan(0);
+		expect(ultra.maxTokens).toBeLessThanOrEqual(ultra.contextWindow);
 
 		const maverick = getModel("prime-inference", "meta-llama/llama-4-maverick");
 		expect(maverick.contextWindow).toBe(1048576);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added parent-scoped subagent lifecycle APIs: create children with readable default or orchestrator-chosen names, recover running or completed children through `rlm.list_subagents()`, continue them through agent messaging, and close/remove them with `rlm.delete_subagent()`.
+
 ## [0.3.0] - 2026-07-13
 
 - Changed daemon and headless execution to isolate each root session tree in a recoverable worker process, with protocol-v2 chunked snapshots, compact streaming, attachment-local backpressure, session leases, and unchanged print, JSON, and RPC interfaces.

--- a/packages/coding-agent/docs/kernel-and-rlm-recursion.md
+++ b/packages/coding-agent/docs/kernel-and-rlm-recursion.md
@@ -69,13 +69,13 @@ packages/coding-agent/src/core/agent-session.ts
   Parent session owns recursion settings and implements runRlmChild().
 
 packages/coding-agent/src/core/rlm-runtime.ts
-  TypeScript request/result types for rlm.run and the adapter that registers
-  it as a typed host request handler.
+  TypeScript request/result types for rlm.run, rlm.list_subagents, and
+  rlm.delete_subagent plus their typed host request handlers.
 
 prime-agent-runtime/src/rlm/__init__.py
   Python shim installed into ~/.prime/agent/kernel-venv. Exposes rlm, rlm.run(),
-  host_request(), RLMResult, TokenUsage, and the session-backed harness state
-  helper.
+  rlm.list_subagents(), rlm.delete_subagent(), host_request(), RLMResult,
+  RLMSubagent, TokenUsage, and the session-backed harness state helper.
 
 prime-agent-runtime/src/rlm/harness.py
   Session-backed JSON store for reset-free harness refinement notes: prompt
@@ -382,8 +382,10 @@ It exports:
 ```python
 rlm
 run(prompt: str, **kwargs)
+list_subagents()
 host_request(request_type: str, payload: dict | None = None)
 RLMResult
+RLMSubagent
 TokenUsage
 ```
 
@@ -440,7 +442,7 @@ awaits the Future
 
 The callback strips the reply's `status` field and converts the payload into `RLMResult`, or raises `RuntimeError` when the host reports an error. The comm-open/await machinery is the public `host_request()`; `run()` is a typed wrapper around it, and other kernel-side skills reuse `host_request()` for their own request types.
 
-The shim accepts `**kwargs` for API compatibility with `rlm-harness` and includes them in the comm payload. V1 does not apply any kwargs on the TypeScript side. Unsupported kwargs are rejected with a clear error instead of being ignored.
+The shim accepts `**kwargs` and includes them in the comm payload. The TypeScript host supports `name="..."` for an orchestrator-chosen child session name; all other kwargs are rejected with a clear error instead of being ignored.
 
 ### Why Control-Channel Comm Replies Exist
 
@@ -507,6 +509,9 @@ options.hostHandlers[data.type](data)
   v
 sendCommMessage(comm_id, { status: "ok", ...result })
 ```
+
+The RLM handlers include `rlm.run` for child creation and
+`rlm.list_subagents` for the current parent session's automatic child registry.
 
 Unknown types fail with `host request type "<type>" is not available in this session`.
 
@@ -600,6 +605,79 @@ completion_tokens = output
 Turns are counted as assistant messages in the child transcript.
 
 The answer is the child's final assistant text. This matches the RLM-1 training surface: the model stops calling tools and the final assistant text is the answer.
+
+### Parent-Scoped Subagent Registry
+
+The host exposes the current parent session's direct children without relying on
+Python task handles or a model-maintained file:
+
+```python
+children = await rlm.list_subagents()
+for child in children:
+    print(
+        child.rlm_child_id,
+        child.active_session_id,
+        child.session_id,
+        child.session_name,
+        child.session_dir,
+        child.status,
+    )
+```
+
+Entries have status `running` while the initial `rlm()` call is active and
+`completed` after a successful call returns. Every child also gets a readable,
+collision-resistant default `session_name` derived from its task and child ID,
+for example `subagent-check-the-http-api-a1b2c3d4`. The orchestrator can choose
+an exact name at spawn time with `await rlm("Check the API", name="api-reviewer")`;
+empty, overlong, or already-addressable names are rejected. Users and
+orchestrators can rename it later without changing the child ID. Failed or
+cancelled children are
+removed. Because the registry is owned by the TypeScript parent session, it
+remains available after kernel restart, state restore, or compaction even if the
+original Python `asyncio.Task` handle was lost.
+
+In daemon mode `active_session_id` identifies the retained child session. The
+same parent/orchestrator can continue it directly:
+
+```python
+children = await rlm.list_subagents()
+child = next((item for item in children if item.active_session_id), None)
+if child is not None:
+    await agent_message.send(child.session_name, "Check the latest change.")
+```
+
+That message starts an ordinary follow-up turn in the existing child context; it
+does not reopen or alter the completed `rlm()` result. Inline and in-process
+children have `active_session_id=None`, so they remain inspectable but are not
+addressable through daemon agent messaging.
+
+Delete a direct child by passing its registry entry or any exact registry
+identifier (`session_name`, `rlm_child_id`, `session_id`, or
+`active_session_id`):
+
+```python
+child = (await rlm.list_subagents())[0]
+deleted = await rlm.delete_subagent(child)
+# Equivalent when the child has a chosen name:
+# deleted = await rlm.delete_subagent("api-reviewer")
+```
+
+Deletion cancels a running child and waits for its runtime to close. A completed
+retained child closes immediately. In both cases it is removed from
+`rlm.list_subagents()` and, in daemon mode, from agent messaging and observation.
+Deletion does not erase the child's session transcript or artifacts on disk.
+Only direct children in the current parent registry can be selected; unknown or
+ambiguous selectors raise an error. The returned `RLMSubagent` is the deleted
+entry's final registry snapshot.
+
+Together these APIs provide the parent-scoped lifecycle operations: create with
+`rlm(...)`, read with `rlm.list_subagents()` and `agent_observe`, continue/update
+with `agent_message.send(...)`, and delete with `rlm.delete_subagent(...)`.
+
+The registry is scoped to the current parent session. Closing or replacing the
+parent cascades cleanup to its retained children and clears the registry. A new
+parent session does not inherit them. There is no persistent identifier,
+sidecar, or cross-session reopen protocol.
 
 ### Cost Accounting
 

--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-message
-description: Message other active Prime Agent sessions through the daemon. Use to discover active agents and send a direct text message without spoofing sender identity.
+description: Message other active Prime Agent sessions, including completed retained subagents, through the daemon. Use to discover active agents and send a direct text message without spoofing sender identity.
 ---
 
 # Agent Message
@@ -12,8 +12,15 @@ not try to include a `from` field.
 Call directly from the kernel:
 
 ```python
-agents = await agent_message.list_agents()
-receipt = await agent_message.send("worker", "Please inspect the latest result.", mode="auto")
+children = await rlm.list_subagents()
+child = next((item for item in children if item.active_session_id), None)
+if child is not None:
+    receipt = await agent_message.send(
+        child.session_name,
+        "Please inspect the latest result.",
+        mode="auto",
+    )
+    # Keep the child until this follow-up finishes so its result remains observable.
 ```
 
 ## API
@@ -21,12 +28,17 @@ receipt = await agent_message.send("worker", "Please inspect the latest result."
 - `await agent_message.list_agents()` — returns `current` and `agents`, where
   each agent includes active session id, session id, optional name, runtime
   kind, cwd, streaming state, and pending message count. This includes live
-  subagents; filter by `runtimeKind == "subagent"`, `parentActiveSessionId`,
-  or `rlmChildId` before messaging a specific subagent.
+  subagents and successful completed subagents retained by an open parent.
+  For the current parent session's direct children, prefer
+  `await rlm.list_subagents()` over filtering this global list. Every RLM child
+  gets a readable unique `session_name`, or the orchestrator can choose one with
+  `rlm("task", name="api-reviewer")`; use that name directly as a target.
 - `await agent_message.send(target, message, mode="auto")` — sends one direct
-  text message to an active session. `target` is resolved by the daemon like
-  other live-session selectors. `mode` is `"auto"`, `"follow_up"`, or
-  `"steer"`. In `auto` mode, messages to busy sessions are queued as steering
+  text message to an active session. Sending to an idle completed subagent
+  starts an ordinary follow-up turn in that same child session and context.
+  The child remains available only until its parent session closes. `target`
+  is resolved by the daemon like other live-session selectors. `mode` is
+  `"auto"`, `"follow_up"`, or `"steer"`. In `auto` mode, messages to busy sessions are queued as steering
   messages so the target sees them during the active run; use `"follow_up"` for
   intentionally delayed delivery. Returns a receipt with a `deliveryStatus`
   field: `"delivered"` means the message reached an idle target's context;
@@ -36,6 +48,10 @@ receipt = await agent_message.send("worker", "Please inspect the latest result."
 
 ## Safety
 
+- Do not delete a child immediately after `send`: delivered follow-ups may still
+  be running and queued receipts have not run yet. Wait until observation shows
+  the child is idle and its context is no longer needed before calling
+  `await rlm.delete_subagent(child)`.
 - Broadcast sends are not supported.
 - Sender identity is daemon-derived and cannot be spoofed from Python.
 - The daemon enforces message size, rate, and pending-queue limits before

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -13,9 +13,13 @@ mutate another session.
 Call directly from the kernel:
 
 ```python
-agents = await agent_observe.list_agents()
-worker = await agent_observe.get_agent("worker")
-recent = await agent_observe.recent_messages("worker", limit=6)
+children = await rlm.list_subagents()
+child = next((item for item in children if item.active_session_id), None)
+if child is not None:
+    worker = await agent_observe.get_agent(child.session_name)
+    recent = await agent_observe.recent_messages(child.session_name, limit=6)
+    # Deletion is a parent-owned RLM operation, not an observe mutation:
+    await rlm.delete_subagent(child)
 ```
 
 ## API
@@ -23,9 +27,12 @@ recent = await agent_observe.recent_messages("worker", limit=6)
 - `await agent_observe.list_agents()` returns `current` and `agents`. Each
   agent includes active session id, session id, optional name, runtime kind,
   cwd, status, streaming state, message count, pending count, and a latest
-  message preview. This includes subagents shown in the agents view; filter
-  by `runtimeKind == "subagent"` and `parentSessionId` or
-  `parentActiveSessionId` to inspect subagents that belong to your session.
+  message preview. This includes live subagents and successful completed
+  subagents retained by an open parent. For the current parent session's direct
+  children, prefer `await rlm.list_subagents()` over filtering this global
+  list. Every RLM child gets a readable unique `session_name`, or the
+  orchestrator can choose one with `rlm("task", name="api-reviewer")`; use that
+  name directly as an observation target.
 - `await agent_observe.get_agent(target)` returns `agent`, where `agent`
   contains one agent summary. `target` is resolved like other live-session
   selectors: active id, session id/name, or unambiguous suffix.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -391,6 +391,23 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return runtime;
 	}
 
+	async deleteRlmSubagentRuntime(childId: string, session: AgentSession): Promise<void> {
+		const runtime = this.subagentRuntimes.get(childId);
+		if (!runtime) {
+			await session.disposeAsync();
+			return;
+		}
+		this.subagentRuntimes.delete(childId);
+		const shouldDisposeStaleSession = runtime.session !== session;
+		try {
+			await runtime.dispose();
+		} finally {
+			if (shouldDisposeStaleSession) {
+				await session.disposeAsync();
+			}
+		}
+	}
+
 	async releaseRlmSubagentRuntime(
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6167,7 +6167,12 @@ export class AgentSession {
 			sessionStartEvent: { type: "session_start", reason: "startup" },
 		});
 		if (child.sessionName !== options.sessionName) {
-			child.setSessionName(options.sessionName);
+			try {
+				child.setSessionName(options.sessionName);
+			} catch (error) {
+				child.dispose();
+				throw error;
+			}
 		}
 
 		return { session: child };
@@ -6564,7 +6569,7 @@ export class AgentSession {
 				child: {
 					id: childNodeId,
 					parentId: this._rlmParentNodeId,
-					sessionName,
+					sessionName: childSession?.sessionName ?? sessionName,
 					label,
 					status: run.status,
 					durationMs,
@@ -6616,6 +6621,7 @@ export class AgentSession {
 						return;
 					}
 					switch (event.type) {
+						case "session_info_changed":
 						case "recap_update":
 							emitChildUpdate();
 							break;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -670,6 +670,8 @@ interface RlmChildRun {
 	unsubscribe?: () => void;
 	/** Rejects the public rlm.run promise when deletion detaches stuck underlying work. */
 	rejectTask?: (error: Error) => void;
+	/** Snapshot retained until an in-flight runtime creation is released after early deletion. */
+	detachedDeletion?: RlmSubagentRegistryEntry;
 }
 
 // ============================================================================
@@ -6367,8 +6369,9 @@ export class AgentSession {
 			}
 
 			// Runtime creation has not published a session. Detach immediately rather
-			// than blocking on tool/runtime startup; its cancellation checks and final
-			// release path clean up anything that is published later.
+			// than blocking on tool/runtime startup; keep the selector snapshot until
+			// the eventual release succeeds or becomes hidden/retryable on failure.
+			run.detachedDeletion = subagent;
 			run.rejectTask?.(new Error("Deleted by parent orchestrator"));
 			this._deletedRlmChildIds.add(childId);
 			this._removeRlmSubagentTracking(childId, run);
@@ -6704,6 +6707,22 @@ export class AgentSession {
 					// delete attempt; drop its hidden retry entry and selector reservation.
 					if (!run.releaseError && releaseStatus !== "done" && this._retryableRlmSubagentDeletions.has(run.id)) {
 						this._removeRlmSubagentTracking(run.id, run);
+					}
+					if (run.releaseError && releaseStatus !== "done" && childSession && run.detachedDeletion) {
+						try {
+							// Early deletion returned before runtime creation completed. If normal
+							// release fails, use the host's delete path as a second cleanup attempt.
+							await this._deleteRlmSubagentSession(run.id, childSession);
+						} catch {
+							// Keep a hidden selector-addressable cleanup entry rather than orphaning
+							// a host runtime after delete already returned successfully.
+							if (!this._disposed && !this._disposing) {
+								this._retainedRlmChildSessions.set(run.id, childSession);
+								this._retryableRlmSubagentDeletions.set(run.id, run.detachedDeletion);
+							}
+						} finally {
+							run.detachedDeletion = undefined;
+						}
 					}
 					// A host release failure after successful work leaves a retryable parent
 					// entry. Failed/cancelled runs remain omitted from the public registry.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6344,8 +6344,14 @@ export class AgentSession {
 					await this._deleteRlmSubagentSession(childId, liveSession);
 				} catch (error) {
 					// The initial run was cancelled even though host closure failed. Reject its
-					// public promise now, then keep a retryable parent entry for runtime cleanup.
+					// public promise now. Parent teardown owns cleanup once it starts, so do not
+					// repopulate maps that dispose() has already cleared.
 					run.rejectTask?.(new Error("Deleted by parent orchestrator"));
+					if (this._disposed || this._disposing) {
+						this._removeRlmSubagentTracking(childId, run);
+						void liveSession.disposeAsync().catch(() => undefined);
+						throw error;
+					}
 					this._retainedRlmChildSessions.set(childId, liveSession);
 					this._retryableRlmSubagentDeletions.set(childId, subagent);
 					if (run.unsubscribe) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -46,6 +46,7 @@ import {
 	AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL,
 	AGENT_MESSAGE_SKILL_NAME,
 	type AgentSessionMessage,
+	type AgentSessionMessageAgentSummary,
 	type AgentSessionMessageController,
 	type AgentSessionMessageListResult,
 	type AgentSessionMessageReceipt,
@@ -190,9 +191,16 @@ import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
+	createDefaultRlmSubagentSessionName,
+	createRlmDeleteSubagentHostHandler,
+	createRlmListSubagentsHostHandler,
 	createRlmRunHostHandler,
+	normalizeRequestedRlmSubagentSessionName,
+	type RlmDeleteSubagentResult,
 	type RlmInternalRunResult,
+	type RlmListSubagentsResult,
 	type RlmRunResult,
+	type RlmSubagentRegistryEntry,
 	type RlmSubagentReleaseStatus,
 	type RlmSubagentRuntime,
 	type RlmUsage,
@@ -646,16 +654,22 @@ type AutonomousRuntimeSnapshot = Pick<
 interface RlmChildRun {
 	id: string;
 	prompt: string;
+	sessionName: string;
 	sessionDir: string;
 	status: RlmChildAgentStatus;
 	result?: RlmRunResult;
 	error?: string;
+	releaseError?: unknown;
 	task?: Promise<RlmInternalRunResult>;
 	abort: () => void;
 	/** Child session, once its runtime exists. Used to cancel nested child runs. */
 	session?: AgentSession;
 	/** Re-emits the run's rlm_child_update snapshot with its current status. */
 	emitUpdate?: () => void;
+	/** Idempotent child-event forwarder cleanup, once the child runtime exists. */
+	unsubscribe?: () => void;
+	/** Rejects the public rlm.run promise when deletion detaches stuck underlying work. */
+	rejectTask?: (error: Error) => void;
 }
 
 // ============================================================================
@@ -858,6 +872,12 @@ export class AgentSession {
 	// Inline mode keeps finished child sessions so the inspector can still read them;
 	// the daemon does the same by leaving the child session resident in its registry.
 	private _retainedRlmChildSessions = new Map<string, AgentSession>();
+	private _deletedRlmChildIds = new Set<string>();
+	private _retryableRlmSubagentDeletions = new Map<string, RlmSubagentRegistryEntry>();
+	private _deletingRlmChildren = new Map<
+		string,
+		{ subagent: RlmSubagentRegistryEntry; promise: Promise<RlmDeleteSubagentResult> }
+	>();
 	// Kept alive for retained children so nested updates (e.g. a grandchild cancel)
 	// still forward to root; torn down when the retained child is disposed.
 	private _retainedRlmChildUnsubscribes = new Map<string, () => void>();
@@ -2527,6 +2547,8 @@ export class AgentSession {
 			await session.disposeAsync().catch(() => undefined);
 		}
 		this._retainedRlmChildSessions.clear();
+		this._deletedRlmChildIds.clear();
+		this._retryableRlmSubagentDeletions.clear();
 		try {
 			await this._ipythonKernelProvisioner?.dispose();
 		} catch {
@@ -2556,6 +2578,8 @@ export class AgentSession {
 				session.dispose();
 			}
 			this._retainedRlmChildSessions.clear();
+			this._deletedRlmChildIds.clear();
+			this._retryableRlmSubagentDeletions.clear();
 			this._pendingNextTurnMessages = [];
 			this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 			this._steeringMessages = [];
@@ -5787,6 +5811,8 @@ export class AgentSession {
 			"rlm.run": createRlmRunHostHandler(({ prompt, kwargs, cellSourceCode }) =>
 				this.runRlmChild(prompt, kwargs, cellSourceCode),
 			),
+			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
+			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
 			"model.info": async () => ({
 				id: this.model?.id ?? null,
 				provider: this.model?.provider ?? null,
@@ -6030,6 +6056,7 @@ export class AgentSession {
 	private _createRlmSubagentRuntimeOptions(options: {
 		id: string;
 		prompt: string;
+		sessionName: string;
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
@@ -6038,6 +6065,7 @@ export class AgentSession {
 			parentSession: this,
 			id: options.id,
 			prompt: options.prompt,
+			sessionName: options.sessionName,
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
 			model: options.model,
@@ -6135,6 +6163,9 @@ export class AgentSession {
 			rlmParentNodeId: options.rlmParentNodeId,
 			sessionStartEvent: { type: "session_start", reason: "startup" },
 		});
+		if (child.sessionName !== options.sessionName) {
+			child.setSessionName(options.sessionName);
+		}
 
 		return { session: child };
 	}
@@ -6164,16 +6195,209 @@ export class AgentSession {
 		return this._activeRlmChildRuns.get(childId)?.status;
 	}
 
+	/** Current direct-child registry for the model-facing rlm.list_subagents API. */
+	listRlmSubagents(): RlmListSubagentsResult {
+		const daemonChildren = new Map<string, AgentSessionMessageAgentSummary>();
+		const listedAgents = this._agentMessageController?.listAgents();
+		const parentActiveSessionId = listedAgents?.current?.activeSessionId;
+		if (parentActiveSessionId) {
+			for (const agent of listedAgents.agents) {
+				if (
+					agent.runtimeKind === "subagent" &&
+					agent.parentActiveSessionId === parentActiveSessionId &&
+					agent.rlmChildId
+				) {
+					daemonChildren.set(agent.rlmChildId, agent);
+				}
+			}
+		}
+
+		const subagents: RlmListSubagentsResult["subagents"] = [];
+		const recorded = new Set<string>();
+		for (const run of this._activeRlmChildRuns.values()) {
+			if (this._deletingRlmChildren.has(run.id) || run.status === "error" || run.status === "cancelled") {
+				continue;
+			}
+			const daemonChild = daemonChildren.get(run.id);
+			subagents.push({
+				rlm_child_id: run.id,
+				active_session_id: daemonChild?.activeSessionId ?? null,
+				session_id: daemonChild?.sessionId ?? run.session?.sessionId ?? null,
+				session_name: daemonChild?.sessionName ?? run.session?.sessionName ?? run.sessionName,
+				session_dir: run.sessionDir,
+				status: run.status === "done" ? "completed" : "running",
+			});
+			recorded.add(run.id);
+		}
+		for (const [childId, childSession] of this._retainedRlmChildSessions) {
+			if (
+				this._deletingRlmChildren.has(childId) ||
+				recorded.has(childId) ||
+				this._retryableRlmSubagentDeletions.has(childId)
+			) {
+				continue;
+			}
+			const daemonChild = daemonChildren.get(childId);
+			const sessionDir = childSession._rlmSessionDir;
+			if (!sessionDir) {
+				continue;
+			}
+			subagents.push({
+				rlm_child_id: childId,
+				active_session_id: daemonChild?.activeSessionId ?? null,
+				session_id: daemonChild?.sessionId ?? childSession.sessionId,
+				session_name:
+					daemonChild?.sessionName ?? childSession.sessionName ?? createDefaultRlmSubagentSessionName("", childId),
+				session_dir: sessionDir,
+				status: "completed",
+			});
+		}
+		return { subagents };
+	}
+
+	private _rlmSubagentMatchesTarget(entry: RlmSubagentRegistryEntry, target: string): boolean {
+		return (
+			entry.rlm_child_id === target ||
+			entry.active_session_id === target ||
+			entry.session_id === target ||
+			entry.session_name === target
+		);
+	}
+
+	private _resolveDirectRlmSubagent(target: string): RlmSubagentRegistryEntry {
+		const candidates = [...this.listRlmSubagents().subagents, ...this._retryableRlmSubagentDeletions.values()];
+		const matches = candidates.filter((entry) => this._rlmSubagentMatchesTarget(entry, target));
+		if (matches.length === 0) {
+			throw new Error(`No direct RLM subagent matches "${target}" in the current parent session`);
+		}
+		if (matches.length > 1) {
+			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
+		}
+		return matches[0]!;
+	}
+
+	/** Delete a running or retained direct child selected from this parent session's registry. */
+	async deleteRlmSubagent(target: string): Promise<RlmDeleteSubagentResult> {
+		const inFlight = [...this._deletingRlmChildren.values()].filter(({ subagent }) =>
+			this._rlmSubagentMatchesTarget(subagent, target),
+		);
+		const directMatches = [
+			...this.listRlmSubagents().subagents,
+			...this._retryableRlmSubagentDeletions.values(),
+		].filter((entry) => this._rlmSubagentMatchesTarget(entry, target));
+		const matchingChildIds = new Set([
+			...inFlight.map(({ subagent }) => subagent.rlm_child_id),
+			...directMatches.map((subagent) => subagent.rlm_child_id),
+		]);
+		if (matchingChildIds.size > 1) {
+			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
+		}
+		if (inFlight[0]) {
+			return inFlight[0].promise;
+		}
+
+		const subagent = directMatches[0] ?? this._resolveDirectRlmSubagent(target);
+		const deletion = this._deleteResolvedRlmSubagent(subagent);
+		this._deletingRlmChildren.set(subagent.rlm_child_id, { subagent, promise: deletion });
+		try {
+			return await deletion;
+		} finally {
+			if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.promise === deletion) {
+				this._deletingRlmChildren.delete(subagent.rlm_child_id);
+			}
+		}
+	}
+
+	private _deleteRlmSubagentSession(childId: string, session: AgentSession): Promise<void> {
+		if (this._subagentRuntimeHost) {
+			return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+		}
+		return session.disposeAsync();
+	}
+
+	private _removeRlmSubagentTracking(childId: string, run?: RlmChildRun): void {
+		run?.unsubscribe?.();
+		this._retainedRlmChildUnsubscribes.get(childId)?.();
+		this._retainedRlmChildUnsubscribes.delete(childId);
+		this._retainedRlmChildSessions.delete(childId);
+		this._retryableRlmSubagentDeletions.delete(childId);
+		if (!run || this._activeRlmChildRuns.get(childId) === run) {
+			this._activeRlmChildRuns.delete(childId);
+		}
+		if (run) {
+			run.abort = noopRlmChildAbort;
+			run.unsubscribe = undefined;
+			run.rejectTask = undefined;
+			run.session = undefined;
+		}
+	}
+
+	private async _deleteResolvedRlmSubagent(subagent: RlmSubagentRegistryEntry): Promise<RlmDeleteSubagentResult> {
+		const childId = subagent.rlm_child_id;
+		const run = this._activeRlmChildRuns.get(childId);
+		if (run) {
+			this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+			const liveSession = run.session;
+			if (liveSession) {
+				try {
+					await this._deleteRlmSubagentSession(childId, liveSession);
+				} catch (error) {
+					// The initial run was cancelled even though host closure failed. Reject its
+					// public promise now, then keep a retryable parent entry for runtime cleanup.
+					run.rejectTask?.(new Error("Deleted by parent orchestrator"));
+					this._retainedRlmChildSessions.set(childId, liveSession);
+					this._retryableRlmSubagentDeletions.set(childId, subagent);
+					if (run.unsubscribe) {
+						this._retainedRlmChildUnsubscribes.set(childId, run.unsubscribe);
+					}
+					this._activeRlmChildRuns.delete(childId);
+					run.abort = noopRlmChildAbort;
+					run.unsubscribe = undefined;
+					run.rejectTask = undefined;
+					run.session = undefined;
+					throw error;
+				}
+				// Runtime closure is the deletion boundary. Reject the public call and do
+				// not wait for provider/tool work that ignored abort; the tombstone blocks
+				// any late retention by the detached work task.
+				run.rejectTask?.(new Error("Deleted by parent orchestrator"));
+				this._deletedRlmChildIds.add(childId);
+				this._removeRlmSubagentTracking(childId, run);
+				return { subagent };
+			}
+
+			// Runtime creation has not published a session. Detach immediately rather
+			// than blocking on tool/runtime startup; its cancellation checks and final
+			// release path clean up anything that is published later.
+			run.rejectTask?.(new Error("Deleted by parent orchestrator"));
+			this._deletedRlmChildIds.add(childId);
+			this._removeRlmSubagentTracking(childId, run);
+			return { subagent };
+		}
+
+		const retained = this._retainedRlmChildSessions.get(childId);
+		if (retained) {
+			await this._deleteRlmSubagentSession(childId, retained);
+		}
+		this._deletedRlmChildIds.add(childId);
+		this._removeRlmSubagentTracking(childId);
+		return { subagent };
+	}
+
 	/**
-	 * Retain a finished child session so the inspector can still read it; disposed with
-	 * the parent. Returns false (and disposes the child) when the parent is already
-	 * tearing down, so the caller can drop the matching event forwarder too.
+	 * Retain a finished child session for the parent lifetime so inspectors and
+	 * daemon-hosted agent messaging can keep addressing it. Returns false (and disposes
+	 * the child) when the parent is already tearing down, so the caller can drop the
+	 * matching event forwarder too.
 	 */
 	retainFinishedRlmChildSession(childId: string, session: AgentSession): boolean {
 		// A child can finish concurrently while the parent is (or has) torn down; don't
 		// resurrect the map (it would never be disposed), just drop the child now.
 		if (this._disposed || this._disposing) {
 			void session.disposeAsync().catch(() => undefined);
+			return false;
+		}
+		if (this._deletingRlmChildren.has(childId) || this._deletedRlmChildIds.has(childId)) {
 			return false;
 		}
 		this._retainedRlmChildSessions.set(childId, session);
@@ -6245,10 +6469,47 @@ export class AgentSession {
 		return false;
 	}
 
+	private _assertRlmSubagentSessionNameAvailable(name: string): void {
+		const conflictsWithSelector = (endpoint: {
+			activeSessionId: string;
+			sessionId: string;
+			sessionName?: string;
+			rlmChildId?: string;
+		}) =>
+			endpoint.activeSessionId === name ||
+			endpoint.sessionId === name ||
+			endpoint.sessionName === name ||
+			endpoint.rlmChildId === name;
+		for (const [childId, run] of this._activeRlmChildRuns) {
+			if (childId === name || run.sessionName === name) {
+				throw new Error(`RLM subagent session name "${name}" is already in use`);
+			}
+		}
+		for (const [childId, session] of this._retainedRlmChildSessions) {
+			if (childId === name || session.sessionName === name) {
+				throw new Error(`RLM subagent session name "${name}" is already in use`);
+			}
+		}
+		const listedAgents = this._agentMessageController?.listAgents();
+		if (
+			listedAgents &&
+			((listedAgents.current ? conflictsWithSelector(listedAgents.current) : false) ||
+				listedAgents.agents.some(conflictsWithSelector))
+		) {
+			throw new Error(`RLM subagent session name "${name}" is already in use`);
+		}
+	}
+
 	private _startRlmChildRun(prompt: string, kwargs: Record<string, unknown> = {}, spawnCode?: string): RlmChildRun {
-		const unsupportedKwargs = Object.keys(kwargs);
+		const { name: rawName, ...unsupported } = kwargs;
+		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
+		}
+		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
+		if (requestedSessionName) {
+			assertDirectAgentMessageTarget(requestedSessionName);
+			this._assertRlmSubagentSessionNameAvailable(requestedSessionName);
 		}
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -6262,6 +6523,10 @@ export class AgentSession {
 
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
+		const sessionName = requestedSessionName ?? createDefaultRlmSubagentSessionName(prompt, childNodeId);
+		if (!requestedSessionName) {
+			this._assertRlmSubagentSessionNameAvailable(sessionName);
+		}
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
@@ -6276,6 +6541,7 @@ export class AgentSession {
 		const run: RlmChildRun = {
 			id: childNodeId,
 			prompt,
+			sessionName,
 			sessionDir: childSessionDir,
 			status: "running",
 			abort: noopRlmChildAbort,
@@ -6307,14 +6573,18 @@ export class AgentSession {
 		const subagentOptions = this._createRlmSubagentRuntimeOptions({
 			id: childNodeId,
 			prompt,
+			sessionName,
 			spawnCode,
 			sessionDir: childSessionDir,
 			model,
 		});
 		let childRuntime: RlmSubagentRuntime | undefined;
 		let unsubscribeChild: (() => void) | undefined;
+		const deletedTask = new Promise<never>((_resolve, reject) => {
+			run.rejectTask = reject;
+		});
 
-		const task = (async (): Promise<RlmInternalRunResult> => {
+		const workTask = (async (): Promise<RlmInternalRunResult> => {
 			try {
 				if (!(await ensureTool("rg", true))) {
 					throw new Error(MISSING_RIPGREP_MESSAGE);
@@ -6324,12 +6594,15 @@ export class AgentSession {
 				}
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
+				if (child.sessionName !== subagentOptions.sessionName) {
+					child.setSessionName(subagentOptions.sessionName);
+				}
 				childSession = child;
 				run.session = child;
 				run.abort = () => {
 					void child.abort();
 				};
-				unsubscribeChild = child.subscribe((event) => {
+				const unsubscribeChildEvents = child.subscribe((event) => {
 					if (event.type === "rlm_child_update") {
 						this._emit(event);
 						return;
@@ -6369,6 +6642,15 @@ export class AgentSession {
 						}
 					}
 				});
+				let childEventsSubscribed = true;
+				unsubscribeChild = () => {
+					if (!childEventsSubscribed) {
+						return;
+					}
+					childEventsSubscribed = false;
+					unsubscribeChildEvents();
+				};
+				run.unsubscribe = unsubscribeChild;
 				if (isRlmChildRunCancelled(run)) {
 					await child.abort();
 					throw new Error(run.error ?? "RLM child cancelled");
@@ -6410,24 +6692,53 @@ export class AgentSession {
 			} finally {
 				const releaseStatus: RlmSubagentReleaseStatus =
 					run.status === "cancelled" || run.status === "error" ? run.status : "done";
-				if (childRuntime) {
-					await this._releaseRlmSubagentRuntime(childRuntime, subagentOptions, releaseStatus);
-				}
-				// Keep the forwarder only if the child was actually retained (retention can
-				// decline when the parent is disposing); otherwise drop it.
-				if (unsubscribeChild) {
-					if (this._retainedRlmChildSessions.has(run.id)) {
-						this._retainedRlmChildUnsubscribes.set(run.id, unsubscribeChild);
-					} else {
-						unsubscribeChild();
+				try {
+					if (childRuntime) {
+						await this._releaseRlmSubagentRuntime(childRuntime, subagentOptions, releaseStatus).catch((error) => {
+							run.releaseError = error;
+							return Promise.reject(error);
+						});
 					}
+				} finally {
+					// A later successful cancelled/error release supersedes an earlier failed
+					// delete attempt; drop its hidden retry entry and selector reservation.
+					if (!run.releaseError && releaseStatus !== "done" && this._retryableRlmSubagentDeletions.has(run.id)) {
+						this._removeRlmSubagentTracking(run.id, run);
+					}
+					// A host release failure after successful work leaves a retryable parent
+					// entry. Failed/cancelled runs remain omitted from the public registry.
+					if (
+						run.releaseError &&
+						releaseStatus === "done" &&
+						childSession &&
+						!this._disposed &&
+						!this._disposing &&
+						!this._deletedRlmChildIds.has(run.id)
+					) {
+						this._retainedRlmChildSessions.set(run.id, childSession);
+					} else if (run.releaseError && releaseStatus !== "done" && childSession) {
+						// Failed/cancelled runs are not registry entries, so make a best-effort
+						// local cleanup if the host failed before releasing its runtime.
+						await childSession.disposeAsync().catch(() => undefined);
+					}
+					// Keep the forwarder only if the child was actually retained (retention can
+					// decline when the parent is disposing or deleting it); otherwise drop it.
+					if (unsubscribeChild) {
+						if (this._retainedRlmChildSessions.has(run.id)) {
+							this._retainedRlmChildUnsubscribes.set(run.id, unsubscribeChild);
+						} else {
+							unsubscribeChild();
+						}
+					}
+					run.abort = noopRlmChildAbort;
+					run.unsubscribe = undefined;
+					run.rejectTask = undefined;
+					run.session = undefined;
+					this._activeRlmChildRuns.delete(run.id);
 				}
-				run.abort = noopRlmChildAbort;
-				run.session = undefined;
-				this._activeRlmChildRuns.delete(run.id);
 			}
 		})();
-		run.task = task;
+		run.task = Promise.race([workTask, deletedTask]);
 		return run;
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -240,6 +240,8 @@ export interface RlmChildAgentSnapshot {
 	id: string;
 	parentId?: string;
 	activeSessionId?: string;
+	/** Stable daemon-visible session name for addressing/displaying the child. */
+	sessionName?: string;
 	label: string;
 	status: RlmChildAgentStatus;
 	durationMs?: number;
@@ -6562,6 +6564,7 @@ export class AgentSession {
 				child: {
 					id: childNodeId,
 					parentId: this._rlmParentNodeId,
+					sessionName,
 					label,
 					status: run.status,
 					durationMs,

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -40,7 +40,6 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	const activeTools = options.activeTools ?? [];
 	const hasIpython = options.activeTools === undefined ? true : activeTools.includes("ipython");
 	const canRunShellSkills = hasIpython || activeTools.includes("bash");
-	const hasAgentObserveSkill = installedSkills.includes("agent_observe");
 	const parts = [
 		"You are a general purpose agent that uses code to solve tasks.",
 		"You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
@@ -85,10 +84,10 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"A callable `rlm` is already in your global namespace. It returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`. A direct `await rlm('sub-task')` is valid only when the result is immediately required.",
+			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be non-empty and unique among addressable sessions. If omitted, the host generates a readable unique name.",
 			"Sub-agents should not block Prime Agent by default: start them with `task = asyncio.create_task(rlm('sub-task'))`, keep the task handle, continue any independent work, and await the task only when you need its result.",
-			hasAgentObserveSkill
-				? "For long-running fan-out, do not rely only on in-memory `asyncio.Task` handles: they can be lost if the kernel restarts or state is restored. Write a small disk registry under `os.environ.get('RLM_SESSION_DIR')` when set, or another explicit project path otherwise, with each subtask prompt/label and observed active session or child ids; recover status later with `agent_observe`."
-				: "For long-running fan-out, do not rely only on in-memory `asyncio.Task` handles: they can be lost if the kernel restarts or state is restored. Write a small disk registry under `os.environ.get('RLM_SESSION_DIR')` when set, or another explicit project path otherwise, with each subtask prompt/label and observed active session or child ids so work can be reconciled after restore.",
+			"For long-running fan-out, do not rely only on in-memory `asyncio.Task` handles: they can be lost if the kernel restarts or state is restored. Recover the current parent session's automatic child registry with `children = await rlm.list_subagents()`; each entry exposes `rlm_child_id`, `active_session_id`, `session_id`, `session_name`, `session_dir`, and `status`.",
+			"Delete a running or retained direct child with `await rlm.delete_subagent(child)` (or pass its name/ID); deletion cancels running work, closes the child runtime, and removes it from the registry and daemon addressability.",
 			"For parallel sub-agents, launch them together and collect them with normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`; `asyncio` is already imported.",
 			"For sub-agent work that can run in the background, keep the task handle from `asyncio.create_task(rlm('sub-task'))` so you do not block the main execution path; use normal task callbacks, `task.done()`, or `await task` later to observe completion and read the returned `RLMResult.answer`.",
 		);
@@ -116,9 +115,11 @@ export function buildSubagentGuidance(): string {
 		"You already have `rlm` in scope. This is about *when* to spawn one — which matters as much as how.",
 		"",
 		"Default to non-blocking subagents: create an `asyncio` task, keep the handle, continue independent work, and await only at the collection point where the result is needed.",
-		"For subagent work that must survive kernel restarts, state restore, or compaction, persist a disk-backed registry before or immediately after spawning: after importing `os` and `Path`, store the subtask label, prompt, start time, and any observed `activeSessionId`, `rlmChildId`, or `session_dir` under `Path(os.environ['RLM_SESSION_DIR'])` when that variable is set, or another explicit project path otherwise. Treat in-memory `asyncio.Task` objects as convenience handles only; after restore, reload the registry and recover status from live subagent sessions instead of assuming those task objects still exist.",
-		'If the `agent_observe` skill is installed, use it like the agents view to inspect live subagents without awaiting them: list agents with `await agent_observe.list_agents()`, filter `runtimeKind == "subagent"` and `parentSessionId` or `parentActiveSessionId`, and read bounded previews with `await agent_observe.recent_messages(target, limit=...)`.',
-		"If the `agent_message` skill is installed, live subagents are addressable like other active agents: list targets with `await agent_message.list_agents()` and send concise coordination or steering messages with `await agent_message.send(target, message, mode='auto')`; use `mode='steer'` only when you intend to interrupt current work.",
+		"The host automatically keeps a parent-scoped subagent registry across kernel restarts, state restore, and compaction. Recover it with `children = await rlm.list_subagents()` instead of maintaining a separate registry file or relying on lost `asyncio.Task` handles.",
+		"Successful subagent sessions remain in that registry after their initial `rlm()` call finishes, but only while the current parent session remains open. Failed or cancelled children are removed, and retained children close when their parent session closes.",
+		"Choose a child name at spawn time with `rlm('task', name='api-reviewer')`, or let the host generate a readable, unique default `session_name`. If the `agent_observe` skill is installed and a registry entry has `active_session_id`, inspect it by name with `await agent_observe.get_agent(child.session_name)` or read bounded previews with `await agent_observe.recent_messages(child.session_name, limit=...)`.",
+		"If the `agent_message` skill is installed and a registry entry has `active_session_id`, continue that same child by name with `await agent_message.send(child.session_name, message, mode='auto')`; use `mode='steer'` only when you intend to interrupt current work.",
+		"Delete a direct child by registry entry or selector with `await rlm.delete_subagent(child)` or `await rlm.delete_subagent('api-reviewer')`. Deleting a running child cancels it first; deleting any child closes its runtime, removes it from the parent registry, and makes it unavailable to messaging and observation.",
 		"",
 		"Reach for sub-agents when:",
 		"- you have independent sub-tasks that can run in parallel — fan them out with `asyncio.create_task(rlm('task'))` or collect a batch with `await asyncio.gather(rlm('task1'), rlm('task2'))` rather than working them one after another;",
@@ -129,9 +130,6 @@ export function buildSubagentGuidance(): string {
 		"",
 		"For example:",
 		"```python",
-		"from pathlib import Path",
-		"import os",
-		"",
 		"# Independent sub-tasks in parallel — each returns just its conclusion, not the files it read",
 		"auth, api = await asyncio.gather(",
 		"    rlm('Summarize how authentication works in this repo: entrypoints, token flow, and key files.'),",
@@ -143,12 +141,10 @@ export function buildSubagentGuidance(): string {
 		"print(res.answer)",
 		"",
 		"# Background — kick off a slow sub-task, keep working, collect it later",
-		"task = asyncio.create_task(rlm('Run the full test suite and report any failures with root causes.'))",
-		"# For long-running fan-out, also persist a label/prompt/id registry.",
-		"# Use RLM_SESSION_DIR when set; otherwise choose an explicit project path.",
-		"# Example: registry_root = Path(os.environ['RLM_SESSION_DIR']) if os.environ.get('RLM_SESSION_DIR') else Path('subagent-registry')",
-		"# registry_root.joinpath('subagents.jsonl').write_text(...)",
-		"# ... continue with other work while it runs ...",
+		"task = asyncio.create_task(rlm('Run the full test suite and report any failures with root causes.', name='test-runner'))",
+		"# The host registry remains available even if the Python task handle is later lost",
+		"children = await rlm.list_subagents()",
+		"# ... continue independent work ...",
 		"failures = (await task).answer",
 		"```",
 		"",

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -27,7 +27,68 @@ export interface RlmInternalRunResult extends RlmRunResult {
 	assistantUsage: Usage;
 }
 
+export type RlmSubagentRegistryStatus = "running" | "completed";
+
+export interface RlmSubagentRegistryEntry {
+	rlm_child_id: string;
+	active_session_id: string | null;
+	session_id: string | null;
+	session_name: string;
+	session_dir: string;
+	status: RlmSubagentRegistryStatus;
+}
+
+export interface RlmListSubagentsResult {
+	subagents: RlmSubagentRegistryEntry[];
+}
+
+export interface RlmDeleteSubagentResult {
+	subagent: RlmSubagentRegistryEntry;
+}
+
 export type RlmRunHandler = (request: RlmRunRequest) => Promise<RlmRunResult>;
+export type RlmListSubagentsHandler = () => RlmListSubagentsResult;
+export type RlmDeleteSubagentHandler = (target: string) => Promise<RlmDeleteSubagentResult>;
+
+const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
+
+/** Validate and normalize an orchestrator-supplied subagent session name. */
+export function normalizeRequestedRlmSubagentSessionName(value: unknown): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run name must be a string");
+	}
+	const name = value.trim();
+	if (!name) {
+		throw new Error("rlm.run name must not be empty");
+	}
+	if (name.length > RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH) {
+		throw new Error(`rlm.run name must be at most ${RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH} characters`);
+	}
+	return name;
+}
+
+/** Create a readable, collision-resistant default name usable as an agent-message selector. */
+export function createDefaultRlmSubagentSessionName(prompt: string, childId: string): string {
+	const promptSlug = prompt
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	const idSuffix =
+		childId
+			.replace(/^sub-/, "")
+			.replace(/[^A-Za-z0-9]+/g, "")
+			.slice(-8) || "child";
+	const fixedLength = "subagent--".length + idSuffix.length;
+	const promptPart = (promptSlug || "worker")
+		.slice(0, Math.max(1, RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH - fixedLength))
+		.replace(/-+$/g, "");
+	return `subagent-${promptPart || "worker"}-${idSuffix}`;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -46,6 +107,25 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 	};
 }
 
+/** Expose the current parent session's RLM child registry to its kernel. */
+export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandler): HostRequestHandler {
+	return async () => {
+		const { subagents } = handler();
+		return { subagents };
+	};
+}
+
+/** Delete one direct child selected from the current parent session's registry. */
+export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHandler): HostRequestHandler {
+	return async (payload) => {
+		if (typeof payload.target !== "string" || !payload.target.trim()) {
+			throw new Error("rlm.delete_subagent target must be a non-empty string");
+		}
+		const { subagent } = await handler(payload.target.trim());
+		return { subagent };
+	};
+}
+
 export interface RlmSubagentRuntime {
 	session: AgentSession;
 }
@@ -54,6 +134,7 @@ export interface CreateRlmSubagentRuntimeOptions {
 	parentSession: AgentSession;
 	id: string;
 	prompt: string;
+	sessionName: string;
 	sessionDir: string;
 	model: Model<any>;
 	thinkingLevel: ThinkingLevel;
@@ -75,6 +156,8 @@ export type RlmSubagentReleaseStatus = "done" | "error" | "cancelled";
 
 export interface SubagentRuntimeHost {
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
+	/** Close the host-owned child identified by childId; session may predate an in-child session replacement. */
+	deleteRlmSubagentRuntime(childId: string, session: AgentSession): Promise<void>;
 	releaseRlmSubagentRuntime?(
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -37,13 +37,22 @@ except Exception as _prime_agent_rlm_error:
     _PRIME_AGENT_RLM_IMPORT_ERROR = str(_prime_agent_rlm_error)
 
     class _PrimeAgentMissingRlm:
-        async def run(self, prompt, **kwargs):
+        def _raise_missing(self):
             raise RuntimeError(
                 "prime-agent-runtime is not installed in this IPython kernel. "
                 "Remove ~/.prime/agent/kernel-venv so prime-agent can rebuild it, or set "
                 "PRIME_AGENT_KERNEL_PYTHON to a kernel environment with prime-agent-runtime installed. "
                 f"Import error: {_PRIME_AGENT_RLM_IMPORT_ERROR}"
             )
+
+        async def run(self, prompt, **kwargs):
+            self._raise_missing()
+
+        async def list_subagents(self):
+            self._raise_missing()
+
+        async def delete_subagent(self, target):
+            self._raise_missing()
 
         async def __call__(self, prompt, **kwargs):
             return await self.run(prompt, **kwargs)

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -457,6 +457,8 @@ export interface AgentConnectionRlmChildAgentSnapshot {
 	parentId?: string;
 	/** The child's own daemon active-session id, for attaching to it directly. */
 	activeSessionId?: string;
+	/** Stable daemon-visible session name for addressing/displaying the child. */
+	sessionName?: string;
 	label: string;
 	status: AgentConnectionRlmChildAgentStatus;
 	durationMs?: number;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -23,6 +23,7 @@ import {
 import {
 	AGENT_MESSAGE_SOURCE,
 	type AgentSessionMessageAgentSummary,
+	type AgentSessionMessageController,
 	type AgentSessionMessageDeliveryStatus,
 	type AgentSessionMessageEndpoint,
 	type AgentSessionMessageListResult,
@@ -297,6 +298,7 @@ function delay(ms: number): Promise<void> {
 type RuntimeOpenGuard = () => boolean | Promise<boolean>;
 
 class RuntimeOpenCancelledError extends Error {}
+class BoundSessionUnavailableError extends Error {}
 
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
@@ -837,26 +839,7 @@ export class AgentDaemon {
 								return this.deleteRlmHeartbeatForState(stateRef, id);
 							},
 						},
-						agentMessageController: {
-							listAgents: () => {
-								if (!stateRef) {
-									throw new Error("Agent message state is not ready for this session yet");
-								}
-								return this.createAgentMessageListResult(stateRef);
-							},
-							sendAgentMessage: (input) => {
-								if (!stateRef) {
-									throw new Error("Agent message state is not ready for this session yet");
-								}
-								return this.sendAgentSessionMessage({
-									targetSelector: input.target,
-									message: input.message,
-									fromState: stateRef,
-									deliveryMode: input.deliveryMode,
-									origin: "agent",
-								});
-							},
-						},
+						agentMessageController: this.createAgentMessageController(() => stateRef),
 						agentObserveController: this.createAgentObserveController(() => stateRef),
 					},
 				}),
@@ -1087,6 +1070,9 @@ export class AgentDaemon {
 		};
 		try {
 			await this.agentMessageTargetLocks.get(activeSessionId)?.catch(() => undefined);
+			if (this.sessions.get(activeSessionId) !== state || this.closingSessions.has(activeSessionId)) {
+				throw new Error("Target session is closing before prompt delivery");
+			}
 			if (canRun && !canRun()) {
 				return false;
 			}
@@ -1419,7 +1405,10 @@ export class AgentDaemon {
 	private getBoundSessionState(id: string): ActiveSessionState {
 		const state = this.getSessionState(id);
 		if (this.bindingSessions.has(state.activeSessionId)) {
-			throw new Error(`Active session ${state.activeSessionId} is still initializing`);
+			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
+		}
+		if (this.closingSessions.has(state.activeSessionId)) {
+			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
 		}
 		return state;
 	}
@@ -1439,6 +1428,26 @@ export class AgentDaemon {
 	private createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost {
 		return {
 			createRlmSubagentRuntime: async (options) => this.createRlmSubagentRuntime(parentState, options),
+			deleteRlmSubagentRuntime: async (childId, session) => {
+				const state = [...this.sessions.values()].find(
+					(candidate) =>
+						candidate.runtime.metadata.kind === "subagent" &&
+						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+						candidate.runtime.metadata.rlmChildId === childId,
+				);
+				if (!state) {
+					await session.disposeAsync();
+					return;
+				}
+				const shouldDisposeStaleSession = state.runtime.session !== session;
+				try {
+					await this.closeSession(state, "killed", false);
+				} finally {
+					if (shouldDisposeStaleSession) {
+						await session.disposeAsync();
+					}
+				}
+			},
 			disposeRlmSubagentRuntimes: async () => {
 				const cascadeError = await this.closeChildSessions(parentState, "replaced");
 				if (cascadeError) {
@@ -1447,8 +1456,9 @@ export class AgentDaemon {
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
 				const state = this.findRuntimeState(runtime);
-				// A successful subagent stays resident so it's still viewable (torn down with the
-				// parent via closeChildSessions); errored/cancelled would re-seed as "done", so close them.
+				// A successful subagent stays resident so it's still viewable and messageable;
+				// closeChildSessions tears it down with the parent. Errored or cancelled children
+				// would re-seed as "done", so close them immediately.
 				if (state && status === "done") {
 					// Run shutdown side effects without disposing the still-readable session.
 					this.cancelSubagentRlmHeartbeats(state);
@@ -1498,6 +1508,8 @@ export class AgentDaemon {
 					customTools: options.customTools,
 					includeGoals: options.includeGoals,
 					includeCompactSkill: options.includeCompactSkill,
+					agentMessageController: this.createAgentMessageController(() => stateRef),
+					agentObserveController: this.createAgentObserveController(() => stateRef),
 					rlmHeartbeatController: {
 						listRlmHeartbeats: (listOptions) => {
 							if (!stateRef) {
@@ -1546,7 +1558,57 @@ export class AgentDaemon {
 		await this.addRuntime(runtime, undefined, parentState.clientEnv, (state) => {
 			stateRef = state;
 		});
+		if (runtime.session.sessionName !== options.sessionName) {
+			try {
+				runtime.session.setSessionName(options.sessionName);
+			} catch (error) {
+				const state = this.findRuntimeState(runtime);
+				if (state) {
+					try {
+						await this.closeSession(state, "completed");
+					} catch {
+						// Creation cannot return this runtime to the caller, so force the
+						// registration down even if normal close side effects failed early.
+						if (this.sessions.get(state.activeSessionId) === state) {
+							this.sessions.delete(state.activeSessionId);
+							try {
+								state.unsubscribe?.();
+							} catch {
+								// Best-effort cleanup after the original naming failure.
+							}
+							await runtime.dispose().catch(() => undefined);
+						}
+					}
+				} else {
+					await runtime.dispose().catch(() => undefined);
+				}
+				throw error;
+			}
+		}
 		return runtime;
+	}
+
+	private createAgentMessageController(
+		getCurrentState: () => ActiveSessionState | undefined,
+	): AgentSessionMessageController {
+		const requireCurrentState = () => {
+			const current = getCurrentState();
+			if (!current) {
+				throw new Error("Agent message state is not ready for this session yet");
+			}
+			return current;
+		};
+		return {
+			listAgents: () => this.createAgentMessageListResult(requireCurrentState()),
+			sendAgentMessage: (input) =>
+				this.sendAgentSessionMessage({
+					targetSelector: input.target,
+					message: input.message,
+					fromState: requireCurrentState(),
+					deliveryMode: input.deliveryMode,
+					origin: "agent",
+				}),
+		};
 	}
 
 	private createAgentObserveController(getCurrentState: () => ActiveSessionState | undefined): AgentObserveController {
@@ -2114,7 +2176,7 @@ export class AgentDaemon {
 			}
 
 			case "prompt": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				let responseSent = false;
 				const sendSuccessResponse = () => {
 					if (responseSent) {
@@ -2153,7 +2215,7 @@ export class AgentDaemon {
 			}
 
 			case "steer": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (command.expandPromptTemplates === false) {
 					await state.runtime.session.restoreSteeringMessage(command.message, command.images, {
 						queueKey: command.queueKey,
@@ -2173,7 +2235,7 @@ export class AgentDaemon {
 			}
 
 			case "follow_up": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				let queued: boolean;
 				if (command.expandPromptTemplates === false) {
 					queued = await state.runtime.session.restoreFollowUpMessage(command.message, command.images, {
@@ -2969,7 +3031,9 @@ export class AgentDaemon {
 			current: this.createAgentSessionMessageEndpoint(current),
 			agents: [
 				...localAgents,
-				...[...this.remoteAgentPeers.values()].filter((peer) => !localIds.has(peer.activeSessionId)),
+				...[...this.remoteAgentPeers.values()].filter(
+					(peer) => !localIds.has(peer.activeSessionId) && !this.closingSessions.has(peer.activeSessionId),
+				),
 			],
 		};
 	}
@@ -2979,7 +3043,8 @@ export class AgentDaemon {
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
 		return [...this.sessions.values()].filter(
 			(state) =>
-				state.activeSessionId === current.activeSessionId || !this.bindingSessions.has(state.activeSessionId),
+				state.activeSessionId === current.activeSessionId ||
+				(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId)),
 		);
 	}
 
@@ -3071,6 +3136,9 @@ export class AgentDaemon {
 		try {
 			targetState = this.getBoundSessionState(targetSelector);
 		} catch (error) {
+			if (error instanceof BoundSessionUnavailableError) {
+				throw error;
+			}
 			if (this.options.worker && options.fromState) {
 				return this.sendRemoteAgentSessionMessage(
 					options.fromState,
@@ -3528,7 +3596,11 @@ export class AgentDaemon {
 		return undefined;
 	}
 
-	private async closeSession(state: ActiveSessionState, reason: DaemonSessionClosedReason): Promise<void> {
+	private async closeSession(
+		state: ActiveSessionState,
+		reason: DaemonSessionClosedReason,
+		waitForAbort = true,
+	): Promise<void> {
 		for (const client of state.clients) {
 			this.abortSideQuestionsFor(client, state.activeSessionId);
 		}
@@ -3537,7 +3609,7 @@ export class AgentDaemon {
 			await existingClose;
 			return;
 		}
-		const closePromise = Promise.resolve().then(() => this.closeSessionOnce(state, reason));
+		const closePromise = Promise.resolve().then(() => this.closeSessionOnce(state, reason, waitForAbort));
 		this.closingSessions.set(state.activeSessionId, closePromise);
 		try {
 			await closePromise;
@@ -3557,7 +3629,11 @@ export class AgentDaemon {
 		}
 	}
 
-	private async closeSessionOnce(state: ActiveSessionState, reason: DaemonSessionClosedReason): Promise<void> {
+	private async closeSessionOnce(
+		state: ActiveSessionState,
+		reason: DaemonSessionClosedReason,
+		waitForAbort: boolean,
+	): Promise<void> {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
@@ -3569,7 +3645,7 @@ export class AgentDaemon {
 		// Abort in-flight status work before any await/dispose so it can't write
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
-		const cascadeError = await this.closeChildSessions(state, reason);
+		const cascadeError = await this.closeChildSessions(state, reason, waitForAbort);
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
 		// empty session file. Mirrors the detach-time discard so a config-bearing
 		// draft closed via kill/completed is never wiped.
@@ -3591,12 +3667,22 @@ export class AgentDaemon {
 		if (reason === "update") {
 			state.runtime.session.abortForUpdateRestart();
 		}
-		if (reason === "killed" || reason === "shutdown" || reason === "replaced") {
+		if (reason === "killed") {
+			const abort = state.runtime.session.abort().catch(() => undefined);
+			if (waitForAbort) {
+				await abort;
+			}
+		} else if (reason === "shutdown" || reason === "replaced") {
 			await state.runtime.session.abort().catch(() => undefined);
 		}
 		this.recordWorkerRecoveryState(state, `closed:${reason}`, false);
 		state.unsubscribe?.();
-		await state.runtime.dispose();
+		let disposeError: unknown;
+		try {
+			await state.runtime.dispose();
+		} catch (error) {
+			disposeError = error;
+		}
 		this.broadcastToSession(state, { type: "session_closed", activeSessionId: state.activeSessionId, reason });
 		for (const client of state.clients) {
 			client.attachedActiveSessionIds.delete(state.activeSessionId);
@@ -3610,6 +3696,9 @@ export class AgentDaemon {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
 		}
+		if (disposeError) {
+			throw disposeError;
+		}
 		if (persistError && !keepsResumeEntry && reason !== "completed") {
 			throw persistError;
 		}
@@ -3621,11 +3710,12 @@ export class AgentDaemon {
 	private async closeChildSessions(
 		parentState: ActiveSessionState,
 		reason: DaemonSessionClosedReason,
+		waitForAbort = true,
 	): Promise<unknown> {
 		let cascadeError: unknown;
 		for (const childState of getChildActiveSessionStates(this.sessions, parentState)) {
 			try {
-				await this.closeSession(childState, reason);
+				await this.closeSession(childState, reason, waitForAbort);
 			} catch (error) {
 				cascadeError ??= error;
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -8,7 +8,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { getLogger } from "@earendil-works/pi-ai";
@@ -296,6 +296,24 @@ function delay(ms: number): Promise<void> {
 }
 
 type RuntimeOpenGuard = () => boolean | Promise<boolean>;
+
+const RLM_SUBAGENT_REGISTRY_FILE = "rlm-subagents.jsonl";
+
+interface PersistedRlmSubagentRegistryEntry {
+	type: "rlm_subagent";
+	childId: string;
+	sessionName: string;
+	sessionDir: string;
+	sessionFile: string;
+	parentSessionId: string;
+	parentSessionFile?: string;
+	rlmParentNodeId?: string;
+	prompt?: string;
+	spawnCode?: string;
+	status: "running" | "completed";
+	createdAt: number;
+	updatedAt: string;
+}
 
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
@@ -639,6 +657,95 @@ export class AgentDaemon {
 		}
 	}
 
+	private rlmSubagentRegistryPath(parentSession: AgentSession): string | undefined {
+		const artifactDir = parentSession.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) {
+			return undefined;
+		}
+		return join(artifactDir, RLM_SUBAGENT_REGISTRY_FILE);
+	}
+
+	private appendRlmSubagentRegistryEntry(
+		parentState: ActiveSessionState,
+		entry: PersistedRlmSubagentRegistryEntry,
+	): void {
+		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
+		if (!path) {
+			return;
+		}
+		try {
+			mkdirSync(dirname(path), { recursive: true });
+			appendFileSync(path, `${JSON.stringify(entry)}\n`);
+		} catch (error) {
+			this.log(
+				`failed to persist RLM subagent registry entry: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	private recordRlmSubagentRegistryEntry(
+		parentState: ActiveSessionState,
+		input: {
+			childId: string;
+			sessionName: string;
+			sessionDir: string;
+			sessionFile: string;
+			rlmParentNodeId?: string;
+			prompt?: string;
+			spawnCode?: string;
+			status: PersistedRlmSubagentRegistryEntry["status"];
+			createdAt?: number;
+		},
+	): void {
+		const parentSession = parentState.runtime.session;
+		this.appendRlmSubagentRegistryEntry(parentState, {
+			type: "rlm_subagent",
+			childId: input.childId,
+			sessionName: input.sessionName,
+			sessionDir: input.sessionDir,
+			sessionFile: input.sessionFile,
+			parentSessionId: parentSession.sessionId,
+			...(parentSession.sessionFile ? { parentSessionFile: parentSession.sessionFile } : {}),
+			...(input.rlmParentNodeId ? { rlmParentNodeId: input.rlmParentNodeId } : {}),
+			...(input.prompt ? { prompt: input.prompt } : {}),
+			...(input.spawnCode ? { spawnCode: input.spawnCode } : {}),
+			status: input.status,
+			createdAt: input.createdAt ?? Date.now(),
+			updatedAt: new Date().toISOString(),
+		});
+	}
+
+	private readLatestRlmSubagentRegistry(parentState: ActiveSessionState): PersistedRlmSubagentRegistryEntry[] {
+		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
+		if (!path || !existsSync(path)) {
+			return [];
+		}
+		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		try {
+			for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+				const trimmed = line.trim();
+				if (!trimmed) {
+					continue;
+				}
+				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				if (
+					entry.type !== "rlm_subagent" ||
+					typeof entry.childId !== "string" ||
+					typeof entry.sessionName !== "string" ||
+					typeof entry.sessionDir !== "string" ||
+					typeof entry.sessionFile !== "string" ||
+					(entry.status !== "running" && entry.status !== "completed")
+				) {
+					continue;
+				}
+				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+			}
+		} catch (error) {
+			this.log(`failed to read RLM subagent registry: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		return [...latest.values()];
+	}
+
 	private async addRuntime(
 		runtime: AgentSessionRuntime,
 		name?: string,
@@ -848,7 +955,7 @@ export class AgentDaemon {
 				await runtime.dispose().catch(() => undefined);
 				throw new RuntimeOpenCancelledError();
 			}
-			return this.addRuntime(
+			const state = await this.addRuntime(
 				runtime,
 				command.name,
 				clientEnv,
@@ -857,6 +964,10 @@ export class AgentDaemon {
 				},
 				runtimeOpenGuard,
 			);
+			if (state.runtime.metadata.kind === "top-level") {
+				await this.rehydrateCompletedRlmSubagents(state);
+			}
+			return state;
 		};
 
 		const sessionFile = sessionManager.getSessionFile();
@@ -1463,6 +1574,19 @@ export class AgentDaemon {
 					// Run shutdown side effects without disposing the still-readable session.
 					this.cancelSubagentRlmHeartbeats(state);
 					await flushAgentTraceUpload(state.runtime.session.sessionManager).catch(() => undefined);
+					if (runtime.session.sessionFile) {
+						this.recordRlmSubagentRegistryEntry(parentState, {
+							childId: options.id,
+							sessionName: options.sessionName,
+							sessionDir: options.sessionDir,
+							sessionFile: runtime.session.sessionFile,
+							rlmParentNodeId: options.rlmParentNodeId,
+							prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
+							spawnCode: options.spawnCode,
+							status: "completed",
+							createdAt: state.runtime.metadata.createdAt,
+						});
+					}
 					// Retention can decline if the parent is already tearing down; if so, close
 					// the session here so it doesn't linger in the registry.
 					if (options.parentSession.retainFinishedRlmChildSession(options.id, runtime.session)) {
@@ -1585,7 +1709,120 @@ export class AgentDaemon {
 				throw error;
 			}
 		}
+		if (runtime.session.sessionFile) {
+			this.recordRlmSubagentRegistryEntry(parentState, {
+				childId: options.id,
+				sessionName: options.sessionName,
+				sessionDir: options.sessionDir,
+				sessionFile: runtime.session.sessionFile,
+				rlmParentNodeId: options.rlmParentNodeId,
+				prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
+				spawnCode: options.spawnCode,
+				status: "running",
+				createdAt: runtime.metadata.createdAt,
+			});
+		}
 		return runtime;
+	}
+
+	private hasRlmSubagentState(parentState: ActiveSessionState, childId: string, sessionFile?: string): boolean {
+		const targetSessionFile = sessionFile ? resolve(sessionFile) : undefined;
+		return [...this.sessions.values()].some((state) => {
+			const metadata = state.runtime.metadata;
+			if (metadata.kind !== "subagent") {
+				return false;
+			}
+			if (metadata.parentActiveSessionId === parentState.activeSessionId && metadata.rlmChildId === childId) {
+				return true;
+			}
+			const existingFile = state.runtime.session.sessionFile;
+			return !!targetSessionFile && !!existingFile && resolve(existingFile) === targetSessionFile;
+		});
+	}
+
+	private async rehydrateCompletedRlmSubagents(parentState: ActiveSessionState): Promise<void> {
+		for (const entry of this.readLatestRlmSubagentRegistry(parentState)) {
+			if (entry.status !== "completed") {
+				continue;
+			}
+			if (
+				!existsSync(entry.sessionFile) ||
+				this.hasRlmSubagentState(parentState, entry.childId, entry.sessionFile)
+			) {
+				continue;
+			}
+			let stateRef: ActiveSessionState | undefined;
+			try {
+				const sessionManager = await SessionManager.openAsync(entry.sessionFile, entry.sessionDir);
+				const runtime = await withClientEnv(parentState.clientEnv, () =>
+					createAgentSessionRuntime(this.options.createRuntime, {
+						cwd: sessionManager.getCwd(),
+						agentDir: parentState.runtime.services.agentDir,
+						sessionManager,
+						sessionStartEvent: { type: "session_start", reason: "startup" },
+						sessionConfig: parentState.runtime.runtimeConfig,
+						sessionOptions: {
+							agentMessageController: this.createAgentMessageController(() => stateRef),
+							agentObserveController: this.createAgentObserveController(() => stateRef),
+							rlmHeartbeatController: {
+								listRlmHeartbeats: (listOptions) => {
+									if (!stateRef) {
+										throw new Error("RLM heartbeat state is not ready for this session yet");
+									}
+									return this.cronStore.listRlmHeartbeats(stateRef.activeSessionId, listOptions);
+								},
+								createRlmHeartbeat: (input) => {
+									if (!stateRef) {
+										throw new Error("RLM heartbeat state is not ready for this session yet");
+									}
+									return this.createRlmHeartbeatForState(stateRef, input);
+								},
+								updateRlmHeartbeat: (input) => {
+									if (!stateRef) {
+										throw new Error("RLM heartbeat state is not ready for this session yet");
+									}
+									return this.updateRlmHeartbeatForState(stateRef, input);
+								},
+								deleteRlmHeartbeat: (id) => {
+									if (!stateRef) {
+										throw new Error("RLM heartbeat state is not ready for this session yet");
+									}
+									return this.deleteRlmHeartbeatForState(stateRef, id);
+								},
+							},
+							rlmSessionDir: entry.sessionDir,
+							rlmParentNodeId: entry.rlmParentNodeId ?? entry.childId,
+						},
+						runtimeMetadata: {
+							kind: "subagent",
+							createdAt: entry.createdAt,
+							parentActiveSessionId: parentState.activeSessionId,
+							parentSessionId: parentState.runtime.session.sessionId,
+							...(parentState.runtime.session.sessionFile
+								? { parentSessionFile: parentState.runtime.session.sessionFile }
+								: {}),
+							rlmChildId: entry.childId,
+							rlmParentNodeId: entry.rlmParentNodeId ?? entry.childId,
+							...(entry.prompt ? { prompt: entry.prompt } : {}),
+							...(entry.spawnCode ? { spawnCode: entry.spawnCode } : {}),
+							sessionDir: entry.sessionDir,
+						},
+					}),
+				);
+				await this.addRuntime(runtime, undefined, parentState.clientEnv, (state) => {
+					stateRef = state;
+				});
+				if (runtime.session.sessionName !== entry.sessionName) {
+					runtime.session.setSessionName(entry.sessionName);
+				}
+			} catch (error) {
+				this.log(
+					`failed to rehydrate completed RLM subagent ${entry.sessionName}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+		}
 	}
 
 	private createAgentMessageController(
@@ -3038,6 +3275,15 @@ export class AgentDaemon {
 		};
 	}
 
+	private findRemoteAgentPeer(selector: string): AgentSessionMessageAgentSummary | undefined {
+		for (const peer of this.remoteAgentPeers.values()) {
+			if (peer.activeSessionId === selector || peer.sessionId === selector || peer.sessionName === selector) {
+				return peer;
+			}
+		}
+		return undefined;
+	}
+
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
@@ -3139,7 +3385,7 @@ export class AgentDaemon {
 			if (error instanceof BoundSessionUnavailableError) {
 				throw error;
 			}
-			if (this.options.worker && options.fromState) {
+			if (this.options.worker && options.fromState && this.findRemoteAgentPeer(targetSelector)) {
 				return this.sendRemoteAgentSessionMessage(
 					options.fromState,
 					targetSelector,
@@ -3234,6 +3480,9 @@ export class AgentDaemon {
 				return response.data as AgentSessionMessageReceipt;
 			} catch (error) {
 				lastError = error;
+				if (error instanceof Error && error.message.startsWith("Unknown active session:")) {
+					throw error;
+				}
 			} finally {
 				client.close();
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -288,6 +288,7 @@ function rlmChildSnapshotForActiveSession(
 		id: metadata.rlmChildId ?? activeSession.activeSessionId,
 		parentId: parentNodeId,
 		activeSessionId: activeSession.activeSessionId,
+		sessionName: session.sessionName,
 		label: rlmChildLabel(metadata.prompt ?? ""),
 		status,
 		answerPreview,

--- a/packages/coding-agent/src/modes/daemon/snapshot-transcript-cache.ts
+++ b/packages/coding-agent/src/modes/daemon/snapshot-transcript-cache.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -22,6 +23,7 @@ export interface SnapshotTranscriptCacheOptions {
 export class SnapshotTranscriptCache {
 	private readonly chunks: SnapshotTranscriptChunk[] = [];
 	private cacheDirectory?: string;
+	private readonly cacheDirectoryName: string;
 	private totalBytes = 0;
 	private completed = false;
 	private readers = 0;
@@ -40,6 +42,7 @@ export class SnapshotTranscriptCache {
 		this.targetChunkBytes = options.targetChunkBytes ?? SNAPSHOT_TARGET_CHUNK_BYTES;
 		this.snapshotId = options.snapshotId;
 		this.activeSessionId = options.activeSessionId;
+		this.cacheDirectoryName = `${options.snapshotId.replaceAll(/[^a-zA-Z0-9_-]/g, "_")}-${randomUUID()}`;
 		if (options.messages) {
 			this.encodeMessages(options.messages);
 			this.completed = true;
@@ -186,7 +189,7 @@ export class SnapshotTranscriptCache {
 		this.totalBytes += buffer.length;
 		const memoryLimit = this.options.memoryCacheBytes ?? SNAPSHOT_MEMORY_CACHE_BYTES;
 		if (!this.cacheDirectory && this.totalBytes > memoryLimit) {
-			this.cacheDirectory = join(this.options.cacheRoot, this.options.snapshotId.replaceAll(/[^a-zA-Z0-9_-]/g, "_"));
+			this.cacheDirectory = join(this.options.cacheRoot, this.cacheDirectoryName);
 			mkdirSync(this.cacheDirectory, { recursive: true, mode: 0o700 });
 			for (let index = 0; index < this.chunks.length; index++) {
 				const existing = this.chunks[index]!;

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -24,6 +24,8 @@ export interface ChildAgentInspectorNode {
 	id: string;
 	/** The child's own daemon active-session id, for attaching directly to its stream. */
 	activeSessionId?: string;
+	/** Stable daemon-visible session name for addressing/displaying the child. */
+	sessionName?: string;
 	label: string;
 	status: ChildAgentStatus;
 	durationMs?: number;
@@ -389,7 +391,7 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		if (flat.length < 2) {
 			return "";
 		}
-		const labels = flat.map((entry) => entry.node.label);
+		const labels = flat.map((entry) => this.entryLabel(entry));
 		let prefix = labels[0] ?? "";
 		for (const label of labels) {
 			let i = 0;
@@ -411,7 +413,7 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		if (flat.length < 2 || !prefix) {
 			return "";
 		}
-		const labels = flat.map((entry) => entry.node.label);
+		const labels = flat.map((entry) => this.entryLabel(entry));
 		let suffix = labels[0] ?? "";
 		for (const label of labels) {
 			let i = 0;
@@ -447,7 +449,7 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const icon = formatChildAgentStatusIcon(entry.node.status, rawIcon);
 		const agentLabel = `S${number}`;
 		const agentCell = theme.fg("muted", padTableCell(agentLabel, agentWidth));
-		const promptCell = this.elidePrompt(entry.node.label, sharedPrefix, sharedSuffix, promptWidth);
+		const promptCell = this.elidePrompt(this.entryLabel(entry), sharedPrefix, sharedSuffix, promptWidth);
 		const recapCell = theme.fg("muted", padTableCell(childAgentRecap(entry.node), recapWidth, "…"));
 		const tools =
 			entry.node.toolUseCount === undefined
@@ -461,6 +463,10 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const metrics = `${toolsCell} ${tokensCell}${" ".repeat(SUMMARY_TOKEN_TIME_GAP)}${durationCell}`;
 		const gap = " ".repeat(SUMMARY_COLUMN_GAP);
 		return `${indent}${icon} ${agentCell}${gap}${promptCell}${gap}${recapCell}${gap}${theme.fg("muted", metrics)}`;
+	}
+
+	private entryLabel(entry: FlatChildAgentNode): string {
+		return entry.node.sessionName?.trim() || entry.node.label;
 	}
 
 	private elidePrompt(label: string, sharedPrefix: string, sharedSuffix: string, width: number): string {

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -35,6 +35,19 @@ function readUserText(content: string | Array<{ type: string; text?: string }>):
 		.join("");
 }
 
+function findLatestImageToolCallId(messages: readonly AgentMessage[]): string | undefined {
+	let latest: string | undefined;
+	for (const message of messages) {
+		if (
+			message.role === "toolResult" &&
+			message.content.some((block) => block.type === "image" && typeof block.data === "string" && block.data.length > 0)
+		) {
+			latest = message.toolCallId;
+		}
+	}
+	return latest;
+}
+
 /** Build conversation components from a message list, matching tool results to their calls. */
 export function buildConversationComponents(
 	messages: readonly AgentMessage[],
@@ -43,6 +56,7 @@ export function buildConversationComponents(
 	const components: Component[] = [];
 	const pendingTools = new Map<string, ToolExecutionComponent>();
 	const expanded = options.toolsExpanded ?? false;
+	const latestImageToolCallId = findLatestImageToolCallId(messages);
 
 	for (const message of messages) {
 		if (message.role === "assistant") {
@@ -63,8 +77,10 @@ export function buildConversationComponents(
 					content.name,
 					content.id,
 					content.arguments,
-					// Replayed history rebuilds on every event; don't re-emit inline images.
-					{ ...options.toolOptions, allowInlineImages: false },
+					// Replayed history rebuilds on every event. Keep old inline image
+					// payloads suppressed, but allow the latest image result to render
+					// so resumed image workflows don't come back as invisible output.
+					{ ...options.toolOptions, allowInlineImages: content.id === latestImageToolCallId },
 					options.getToolDefinition(content.name),
 					options.ui,
 					options.cwd,

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -292,13 +292,17 @@ export class ToolExecutionComponent extends Container {
 			if (this.convertedImages.has(i)) continue;
 
 			const index = i;
-			convertToPng(img.data, img.mimeType).then((converted) => {
-				if (converted) {
-					this.convertedImages.set(index, converted);
-					this.updateDisplay();
-					this.ui.requestRender();
-				}
-			});
+			convertToPng(img.data, img.mimeType)
+				.then((converted) => {
+					if (converted) {
+						this.convertedImages.set(index, converted);
+						this.updateDisplay();
+						this.ui.requestRender();
+					}
+				})
+				.catch(() => {
+					// Conversion is best-effort UI work. Leave the text fallback in place.
+				});
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5661,6 +5661,18 @@ export class InteractiveMode {
 			this.updateEditorBorderColor();
 		}
 
+		let latestImageToolCallId: string | undefined;
+		for (const message of sessionContext.messages) {
+			if (
+				message.role === "toolResult" &&
+				message.content.some(
+					(block) => block.type === "image" && typeof block.data === "string" && block.data.length > 0,
+				)
+			) {
+				latestImageToolCallId = message.toolCallId;
+			}
+		}
+
 		for (const message of sessionContext.messages) {
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
@@ -5675,8 +5687,10 @@ export class InteractiveMode {
 							{
 								showImages: this.settingsManager.getShowImages(),
 								imageWidthCells: this.settingsManager.getImageWidthCells(),
-								// Do not replay historical inline image payloads on session load/rebuild.
-								allowInlineImages: false,
+								// Do not replay every historical inline image payload on
+								// session load/rebuild. Keep only the newest image visible
+								// so resume opens with useful visual context.
+								allowInlineImages: content.id === latestImageToolCallId,
 							},
 							this.getCachedToolDefinition(content.name),
 							this.ui,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -301,6 +301,7 @@ export function mergeChildAgentSnapshots(
 		...incoming,
 		parentId: incoming.parentId ?? previous.parentId,
 		activeSessionId: incoming.activeSessionId ?? previous.activeSessionId,
+		sessionName: incoming.sessionName ?? previous.sessionName,
 		durationMs: incoming.durationMs ?? previous.durationMs,
 		answerPreview: incoming.answerPreview ?? previous.answerPreview,
 		toolUseCount:
@@ -322,6 +323,7 @@ function childAgentSummaryChanged(
 	const nextTokens = next.tokenCount === undefined ? undefined : formatTokenCount(next.tokenCount);
 	return (
 		previous.parentId !== next.parentId ||
+		previous.sessionName !== next.sessionName ||
 		previous.label !== next.label ||
 		previous.status !== next.status ||
 		previous.durationMs !== next.durationMs ||
@@ -5367,6 +5369,7 @@ export class InteractiveMode {
 		const build = (child: AgentConnectionRlmChildAgentSnapshot): ChildAgentInspectorNode => ({
 			id: child.id,
 			activeSessionId: child.activeSessionId,
+			sessionName: child.sessionName,
 			label: child.label,
 			status: child.status,
 			durationMs: child.durationMs,

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -111,6 +111,8 @@ interface InspectableRlmSession {
 		{ subagent: ReturnType<AgentSession["listRlmSubagents"]>["subagents"][number]; promise: Promise<unknown> }
 	>;
 	_retryableRlmSubagentDeletions: Map<string, ReturnType<AgentSession["listRlmSubagents"]>["subagents"][number]>;
+	_retainedRlmChildSessions: Map<string, AgentSession>;
+	_retainedRlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
 }
 
@@ -823,6 +825,48 @@ describe("AgentSession rlm recursion", () => {
 		releaseChild();
 		await Promise.resolve();
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("does not restore failed delete retry state after parent teardown", async () => {
+		let rejectDelete: (error: Error) => void = () => {};
+		const deleteGate = new Promise<void>((_resolve, reject) => {
+			rejectDelete = reject;
+		});
+		let childStarted = false;
+		const hostedChild = createSession({
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				return stream;
+			},
+		});
+		const deleteRuntime = vi.fn(async () => {
+			await deleteGate;
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+
+		const runPromise = root.runRlmChild("delete during parent teardown", { name: "teardown-worker" });
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		await waitFor(() => childStarted);
+		const deletion = root.deleteRlmSubagent("teardown-worker");
+		const deletionFailure = expect(deletion).rejects.toThrow("close failed during teardown");
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+
+		await root.disposeAsync();
+		rejectDelete(new Error("close failed during teardown"));
+		await deletionFailure;
+		await runFailure;
+
+		const internals = root as unknown as InspectableRlmSession;
+		expect(internals._activeRlmChildRuns.size).toBe(0);
+		expect(internals._retainedRlmChildSessions.size).toBe(0);
+		expect(internals._retainedRlmChildUnsubscribes.size).toBe(0);
+		expect(internals._retryableRlmSubagentDeletions.size).toBe(0);
 	});
 
 	it("drops a hidden delete retry after detached runtime release succeeds", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -12,12 +12,17 @@ import {
 	type Usage,
 } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionMessageController } from "../src/core/agent-messages.js";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { KernelManager } from "../src/core/kernel/index.js";
+import { type HostRequestHandlers, KernelManager } from "../src/core/kernel/index.js";
 import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
-import { createRlmRunHostHandler } from "../src/core/rlm-runtime.js";
+import {
+	createDefaultRlmSubagentSessionName,
+	createRlmRunHostHandler,
+	type SubagentRuntimeHost,
+} from "../src/core/rlm-runtime.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import type { Skill } from "../src/core/skills.js";
@@ -104,6 +109,8 @@ interface CapturedCommReply {
 }
 
 interface InspectableRlmRun {
+	id: string;
+	sessionDir: string;
 	abort: () => void;
 	status: string;
 	error?: string;
@@ -112,6 +119,12 @@ interface InspectableRlmRun {
 
 interface InspectableRlmSession {
 	_activeRlmChildRuns: Map<string, InspectableRlmRun>;
+	_deletingRlmChildren: Map<
+		string,
+		{ subagent: ReturnType<AgentSession["listRlmSubagents"]>["subagents"][number]; promise: Promise<unknown> }
+	>;
+	_retryableRlmSubagentDeletions: Map<string, ReturnType<AgentSession["listRlmSubagents"]>["subagents"][number]>;
+	_createKernelHostHandlers(): HostRequestHandlers;
 }
 
 interface KernelPumpTestApi {
@@ -216,7 +229,16 @@ describe("AgentSession rlm recursion", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	function createSession(options: { depth?: number; maxDepth?: number; streamFn?: StreamFn } = {}): AgentSession {
+	function createSession(
+		options: {
+			depth?: number;
+			maxDepth?: number;
+			streamFn?: StreamFn;
+			agentMessageController?: AgentSessionMessageController;
+			subagentRuntimeHost?: SubagentRuntimeHost;
+			rlmSessionDir?: string;
+		} = {},
+	): AgentSession {
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const sessionManager = SessionManager.create(tempDir, join(tempDir, "sessions"));
@@ -241,11 +263,64 @@ describe("AgentSession rlm recursion", () => {
 			cwd: tempDir,
 			modelRegistry: ModelRegistry.create(authStorage, join(tempDir, "models.json")),
 			resourceLoader: createTestResourceLoader(),
+			agentMessageController: options.agentMessageController,
+			subagentRuntimeHost: options.subagentRuntimeHost,
 			rlmDepth: options.depth,
 			rlmMaxDepth: options.maxDepth,
+			rlmSessionDir: options.rlmSessionDir,
 		});
 		return session;
 	}
+
+	it("creates readable collision-resistant default subagent session names", () => {
+		expect(createDefaultRlmSubagentSessionName("Summarize the HTTP API!", "sub-a1b2c3d4")).toBe(
+			"subagent-summarize-the-http-api-a1b2c3d4",
+		);
+		expect(createDefaultRlmSubagentSessionName("Summarize the HTTP API!", "sub-eeeeffff")).not.toBe(
+			createDefaultRlmSubagentSessionName("Summarize the HTTP API!", "sub-a1b2c3d4"),
+		);
+		expect(createDefaultRlmSubagentSessionName("same task", "sub-aBcDeFgH")).not.toBe(
+			createDefaultRlmSubagentSessionName("same task", "sub-AbCdEfGh"),
+		);
+		expect(createDefaultRlmSubagentSessionName("x".repeat(200), "sub-a1b2c3d4")).toHaveLength(64);
+	});
+
+	it("lets the orchestrator choose a unique subagent session name", async () => {
+		const root = createSession();
+		const result = await root.runRlmChild("inspect the API", { name: "  api-reviewer  " });
+		if (!result.session_dir) {
+			throw new Error("Missing child session directory");
+		}
+		const childId = basename(result.session_dir);
+		expect(root.getRlmChildSession(childId)?.sessionName).toBe("api-reviewer");
+		expect(root.listRlmSubagents().subagents[0]?.session_name).toBe("api-reviewer");
+
+		await expect(root.runRlmChild("collide with child id", { name: childId })).rejects.toThrow(
+			`RLM subagent session name "${childId}" is already in use`,
+		);
+		await expect(root.runRlmChild("inspect another API", { name: "api-reviewer" })).rejects.toThrow(
+			'RLM subagent session name "api-reviewer" is already in use',
+		);
+		await expect(root.runRlmChild("invalid name", { name: "   " })).rejects.toThrow("rlm.run name must not be empty");
+		await expect(root.runRlmChild("reserved name", { name: "all" })).rejects.toThrow(
+			"Broadcast agent messaging is not supported",
+		);
+	});
+
+	it("makes an orchestrator-chosen name override a custom runtime's preexisting name", async () => {
+		const hostedChild = createSession();
+		hostedChild.setSessionName("factory-assigned-name");
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		await root.runRlmChild("inspect custom runtime", { name: "orchestrator-name" });
+
+		expect(hostedChild.sessionName).toBe("orchestrator-name");
+	});
 
 	it("runs a child session under a sub directory and returns an RLM-shaped result", async () => {
 		const root = createSession();
@@ -281,6 +356,96 @@ describe("AgentSession rlm recursion", () => {
 		expect(doneUpdate?.toolUseCount).toBeUndefined();
 	});
 
+	it("lists a completed child with its parent-scoped messaging identity until disposal", async () => {
+		let daemonChildId = "";
+		const root = createSession({
+			agentMessageController: {
+				listAgents: () => ({
+					current: { activeSessionId: "parent-active", sessionId: "parent-session" },
+					agents: [
+						{
+							activeSessionId: "other-child-active",
+							sessionId: "other-child-session",
+							runtimeKind: "subagent",
+							cwd: tempDir,
+							isStreaming: false,
+							pendingMessageCount: 0,
+							parentActiveSessionId: "other-parent",
+							rlmChildId: daemonChildId,
+						},
+						{
+							activeSessionId: "child-active",
+							sessionId: "child-session",
+							runtimeKind: "subagent",
+							cwd: tempDir,
+							isStreaming: false,
+							pendingMessageCount: 0,
+							parentActiveSessionId: "parent-active",
+							rlmChildId: daemonChildId,
+						},
+					],
+				}),
+				sendAgentMessage: async () => {
+					throw new Error("unexpected send");
+				},
+			},
+		});
+
+		const result = await root.runRlmChild("retained worker");
+		if (!result.session_dir) {
+			throw new Error("Missing child session directory");
+		}
+		daemonChildId = basename(result.session_dir);
+
+		expect(root.getRlmChildSession(daemonChildId)?.getLastAssistantText()).toBe("child answer: retained worker");
+		const expectedSessionName = createDefaultRlmSubagentSessionName("retained worker", daemonChildId);
+		expect(root.getRlmChildSession(daemonChildId)?.sessionName).toBe(expectedSessionName);
+		const expectedRegistry = {
+			subagents: [
+				{
+					rlm_child_id: daemonChildId,
+					active_session_id: "child-active",
+					session_id: "child-session",
+					session_name: expectedSessionName,
+					session_dir: result.session_dir,
+					status: "completed",
+				},
+			],
+		};
+		expect(root.listRlmSubagents()).toEqual(expectedRegistry);
+		const inspectable = root as unknown as InspectableRlmSession;
+		const conflictingDeletion = {
+			...expectedRegistry.subagents[0],
+			rlm_child_id: "deleting-child",
+			session_name: daemonChildId,
+			status: "completed" as const,
+		};
+		inspectable._deletingRlmChildren.set("deleting-child", {
+			subagent: conflictingDeletion,
+			promise: Promise.resolve({ subagent: conflictingDeletion }),
+		});
+		await expect(root.deleteRlmSubagent(daemonChildId)).rejects.toThrow("is ambiguous");
+		inspectable._deletingRlmChildren.delete("deleting-child");
+
+		const handlers = inspectable._createKernelHostHandlers();
+		const listHandler = handlers["rlm.list_subagents"];
+		const deleteHandler = handlers["rlm.delete_subagent"];
+		if (!listHandler || !deleteHandler) {
+			throw new Error("Missing RLM subagent registry host handlers");
+		}
+		await expect(listHandler({})).resolves.toEqual(expectedRegistry);
+		await expect(deleteHandler({ target: expectedSessionName })).resolves.toEqual({
+			subagent: expectedRegistry.subagents[0],
+		});
+		expect(root.getRlmChildSession(daemonChildId)).toBeUndefined();
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		await expect(deleteHandler({ target: expectedSessionName })).rejects.toThrow("No direct RLM subagent matches");
+
+		root.dispose();
+
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
 	it("surfaces a child's recap on its snapshot once the summarizer sets it", async () => {
 		let releaseChild: () => void = () => {};
 		const release = new Promise<void>((resolve) => {
@@ -312,6 +477,18 @@ describe("AgentSession rlm recursion", () => {
 		if (!rootRun?.session) {
 			throw new Error("Missing child session on root run");
 		}
+		expect(root.listRlmSubagents()).toEqual({
+			subagents: [
+				{
+					rlm_child_id: rootRun.id,
+					active_session_id: null,
+					session_id: rootRun.session.sessionId,
+					session_name: createDefaultRlmSubagentSessionName("slow shard", rootRun.id),
+					session_dir: rootRun.sessionDir,
+					status: "running",
+				},
+			],
+		});
 
 		// What the daemon summarizer does for subagents: stash the recap on the session,
 		// which emits recap_update and re-emits the parent's enriched child snapshot.
@@ -335,6 +512,7 @@ describe("AgentSession rlm recursion", () => {
 
 		await expect(root.runRlmChild("summarize shard 1")).rejects.toThrow(MISSING_RIPGREP_MESSAGE);
 
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(toolsManagerMock.ensureTool).toHaveBeenCalledWith("rg", true);
 		expect(streamFn).not.toHaveBeenCalled();
 		const errorUpdate = [...childUpdates].reverse().find((update) => update.status === "error");
@@ -564,9 +742,258 @@ describe("AgentSession rlm recursion", () => {
 		releaseChild();
 		await expect(runPromise).rejects.toThrow("Cancelled by user");
 		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 
 		// The run has finished; a second cancel finds nothing to stop.
 		expect(root.cancelRlmChildRun(childId)).toBe(false);
+	});
+
+	it("does not let completion retention resurrect a child being deleted", async () => {
+		let releaseRetention: () => void = () => {};
+		const retentionGate = new Promise<void>((resolve) => {
+			releaseRetention = resolve;
+		});
+		let releaseStarted = false;
+		const hostedChild = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: async (_childId, child) => {
+					await child.disposeAsync();
+				},
+				releaseRlmSubagentRuntime: async (runtime, options, status) => {
+					if (status !== "done") {
+						await runtime.session.disposeAsync();
+						return;
+					}
+					releaseStarted = true;
+					await retentionGate;
+					if (!options.parentSession.retainFinishedRlmChildSession(options.id, runtime.session)) {
+						await runtime.session.disposeAsync();
+					}
+				},
+			},
+		});
+
+		const runPromise = root.runRlmChild("fast child", { name: "fast-worker" });
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		await waitFor(() => releaseStarted);
+		const completed = root.listRlmSubagents().subagents[0];
+		if (!completed) {
+			throw new Error("Missing completed child during release");
+		}
+		const deletion = root.deleteRlmSubagent("fast-worker");
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		await expect(deletion).resolves.toEqual({ subagent: completed });
+		await runFailure;
+		releaseRetention();
+		await Promise.resolve();
+
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("keeps failed closure retryable without hanging or late resurrection", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const childDir = join(tempDir, "release-failure-child");
+		const hostedChild = createSession({
+			rlmSessionDir: childDir,
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+				});
+				return stream;
+			},
+		});
+		let deleteAttempts = 0;
+		const deleteRuntime = vi.fn(async (_childId: string, child: AgentSession) => {
+			deleteAttempts++;
+			if (deleteAttempts === 1) {
+				throw new Error("close failed");
+			}
+			await child.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: deleteRuntime,
+				releaseRlmSubagentRuntime: async () => {
+					throw new Error("release failed");
+				},
+			},
+		});
+
+		const runPromise = root.runRlmChild("slow release", { name: "release-worker" });
+		await waitFor(() => childStarted);
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		const deletion = root.deleteRlmSubagent("release-worker");
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		await expect(deletion).rejects.toThrow("close failed");
+		await runFailure;
+		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns.size).toBe(0);
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+
+		// The failed close remains directly retryable by the original selector even
+		// though the cancelled child is hidden from the public registry.
+		await expect(root.deleteRlmSubagent("release-worker")).resolves.toMatchObject({
+			subagent: { session_name: "release-worker" },
+		});
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		releaseChild();
+		await Promise.resolve();
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("drops a hidden delete retry after detached runtime release succeeds", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const hostedChild = createSession({
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(userText(context)) });
+				});
+				return stream;
+			},
+		});
+		const releaseRuntime = vi.fn(async () => {
+			await hostedChild.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: async () => {
+					throw new Error("close failed");
+				},
+				releaseRlmSubagentRuntime: releaseRuntime,
+			},
+		});
+
+		const runPromise = root.runRlmChild("release after failed close", { name: "eventual-release-worker" });
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		await waitFor(() => childStarted);
+		await expect(root.deleteRlmSubagent("eventual-release-worker")).rejects.toThrow("close failed");
+		await runFailure;
+		const internals = root as unknown as InspectableRlmSession;
+		expect(internals._retryableRlmSubagentDeletions.size).toBe(1);
+
+		releaseChild();
+		await waitFor(() => releaseRuntime.mock.calls.length === 1);
+		await waitFor(() => internals._retryableRlmSubagentDeletions.size === 0);
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		await expect(root.deleteRlmSubagent("eventual-release-worker")).rejects.toThrow("No direct RLM subagent matches");
+	});
+
+	it("does not expose a cancelled child when release cleanup fails", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const hostedChild = createSession({
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(userText(context)) });
+				});
+				return stream;
+			},
+		});
+		const disposeHostedChild = vi.spyOn(hostedChild, "disposeAsync");
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: async () => {},
+				releaseRlmSubagentRuntime: async () => {
+					throw new Error("release failed");
+				},
+			},
+		});
+
+		const runPromise = root.runRlmChild("cancel before failed release", { name: "cancelled-worker" });
+		await waitFor(() => childStarted);
+		const childId = root.listRlmSubagents().subagents[0]?.rlm_child_id;
+		expect(childId).toBeTruthy();
+		expect(root.cancelRlmChildRun(childId as string)).toBe(true);
+		releaseChild();
+
+		await expect(runPromise).rejects.toThrow();
+		expect(disposeHostedChild).toHaveBeenCalledOnce();
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("deletes a queued child without waiting for blocked startup", async () => {
+		let releaseEnsureTool: () => void = () => {};
+		const ensureToolGate = new Promise<void>((resolve) => {
+			releaseEnsureTool = resolve;
+		});
+		let ensureToolStarted = false;
+		toolsManagerMock.ensureTool.mockImplementationOnce(async () => {
+			ensureToolStarted = true;
+			await ensureToolGate;
+			return "rg";
+		});
+		const root = createSession();
+		const runPromise = root.runRlmChild("blocked before runtime creation", { name: "queued-worker" });
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		await waitFor(() => ensureToolStarted);
+		const queued = root.listRlmSubagents().subagents[0];
+		expect(queued).toBeDefined();
+
+		await expect(root.deleteRlmSubagent("queued-worker")).resolves.toEqual({ subagent: queued });
+		await runFailure;
+		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns.size).toBe(0);
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+
+		releaseEnsureTool();
+		await Promise.resolve();
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("deletes a running direct child by name and waits for runtime cleanup", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const root = createSession({
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${text}`) });
+				});
+				return stream;
+			},
+		});
+
+		const runPromise = root.runRlmChild("slow named shard", { name: "slow-worker" });
+		await waitFor(() => childStarted);
+		const running = root.listRlmSubagents().subagents[0];
+		if (!running) {
+			throw new Error("Missing running child registry entry");
+		}
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		const deletion = root.deleteRlmSubagent("slow-worker");
+		const duplicateDeletion = root.deleteRlmSubagent(running.rlm_child_id);
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		await expect(deletion).resolves.toEqual({ subagent: running });
+		await expect(duplicateDeletion).resolves.toEqual({ subagent: running });
+		await runFailure;
+		releaseChild();
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("cancels nested rlm child runs through the root session", async () => {
@@ -618,6 +1045,7 @@ describe("AgentSession rlm recursion", () => {
 			throw new Error("Missing nested run id");
 		}
 
+		await expect(root.deleteRlmSubagent(nestedId)).rejects.toThrow("No direct RLM subagent matches");
 		expect(root.cancelRlmChildRun(nestedId)).toBe(true);
 		releaseNested();
 		await expect(nestedPromise).rejects.toThrow("Cancelled by user");

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -433,6 +433,47 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
+	it("disposes an inline child when setting its session name fails", async () => {
+		const root = createSession();
+		const appendSessionInfo = vi.spyOn(SessionManager.prototype, "appendSessionInfo").mockImplementation(() => {
+			throw new Error("session info failed");
+		});
+		const dispose = vi.spyOn(AgentSession.prototype, "dispose");
+		try {
+			await expect(root.runRlmChild("inline naming failure", { name: "bad-name" })).rejects.toThrow(
+				"session info failed",
+			);
+			expect(dispose).toHaveBeenCalled();
+		} finally {
+			appendSessionInfo.mockRestore();
+			dispose.mockRestore();
+		}
+	});
+
+	it("emits updated child session names after a retained child is renamed", async () => {
+		const root = createSession();
+		const events: unknown[] = [];
+		root.subscribe((event) => events.push(event));
+
+		const result = await root.runRlmChild("rename after completion", { name: "original-worker" });
+		if (!result.session_dir) {
+			throw new Error("Missing child session directory");
+		}
+		const childId = basename(result.session_dir);
+		const child = root.getRlmChildSession(childId);
+		if (!child) {
+			throw new Error("Missing retained child session");
+		}
+
+		child.setSessionName("renamed-worker");
+
+		const childUpdates = events.filter(
+			(event): event is { type: "rlm_child_update"; child: { sessionName?: string } } =>
+				typeof event === "object" && event !== null && (event as { type?: string }).type === "rlm_child_update",
+		);
+		expect(childUpdates.at(-1)?.child.sessionName).toBe("renamed-worker");
+	});
+
 	it("surfaces a child's recap on its snapshot once the summarizer sets it", async () => {
 		let releaseChild: () => void = () => {};
 		const release = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -961,6 +961,58 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
+	it("keeps late startup cleanup retryable when release and fallback delete fail", async () => {
+		let releaseRuntimeCreation: () => void = () => {};
+		const runtimeCreationGate = new Promise<void>((resolve) => {
+			releaseRuntimeCreation = resolve;
+		});
+		let runtimeCreationStarted = false;
+		const hostedChild = createSession();
+		let deleteAttempts = 0;
+		const deleteRuntime = vi.fn(async () => {
+			deleteAttempts++;
+			if (deleteAttempts === 1) {
+				throw new Error("fallback delete failed");
+			}
+			await hostedChild.disposeAsync();
+		});
+		const releaseRuntime = vi.fn(async () => {
+			throw new Error("cancelled release failed");
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					runtimeCreationStarted = true;
+					await runtimeCreationGate;
+					return { session: hostedChild };
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+				releaseRlmSubagentRuntime: releaseRuntime,
+			},
+		});
+
+		const runPromise = root.runRlmChild("delete during runtime creation", { name: "starting-worker" });
+		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
+		await waitFor(() => runtimeCreationStarted);
+		const starting = root.listRlmSubagents().subagents[0];
+		expect(starting).toBeDefined();
+
+		await expect(root.deleteRlmSubagent("starting-worker")).resolves.toEqual({ subagent: starting });
+		await runFailure;
+		expect(deleteRuntime).not.toHaveBeenCalled();
+		releaseRuntimeCreation();
+
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => releaseRuntime.mock.calls.length === 1);
+		await waitFor(() => internals._retryableRlmSubagentDeletions.size === 1);
+		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(deleteRuntime).toHaveBeenCalledTimes(1);
+
+		await expect(root.deleteRlmSubagent("starting-worker")).resolves.toEqual({ subagent: starting });
+		expect(deleteRuntime).toHaveBeenCalledTimes(2);
+		expect(internals._retryableRlmSubagentDeletions.size).toBe(0);
+	});
+
 	it("deletes a running direct child by name and waits for runtime cleanup", async () => {
 		let releaseChild: () => void = () => {};
 		const release = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/child-agent-summary-list.test.ts
+++ b/packages/coding-agent/test/child-agent-summary-list.test.ts
@@ -139,6 +139,22 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		expect(out[ellipsisIndex - 1]).not.toBe(" ");
 	});
 
+	it("prefers stable session names over spawn prompts in the summary row", () => {
+		const summary = new ChildAgentSummaryComponent();
+		summary.setNodes([
+			{
+				...node("a"),
+				sessionName: "anticheat-review",
+				label: "You are doing a manual trajectory review for anti-cheat evidence",
+				recap: "Extracting and analyzing test results",
+			},
+		]);
+		const out = stripAnsi(summary.render(120).join("\n"));
+		expect(out).toContain("anticheat-review");
+		expect(out).not.toContain("manual trajectory");
+		expect(out).toContain("Extracting and analyzing test results");
+	});
+
 	it("keeps the selected background active across the entire row", () => {
 		const summary = new ChildAgentSummaryComponent();
 		summary.focused = true;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -494,6 +494,50 @@ describe("daemon mode helpers", () => {
 		);
 	});
 
+	it("fails unknown local agent-message targets without worker remote retries", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+			worker: { authenticationToken: "worker-token" },
+		});
+		const source = makeState("source");
+		source.runtime = {
+			...source.runtime,
+			cwd: "/tmp",
+			session: {
+				sessionId: "session-source",
+				sessionName: "Source",
+				isStreaming: false,
+				pendingMessageCount: 0,
+			},
+		} as never;
+		const sendRemoteAgentSessionMessage = vi.fn();
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			sendRemoteAgentSessionMessage: typeof sendRemoteAgentSessionMessage;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState: ActiveSessionState;
+				origin: "agent";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(source.activeSessionId, source);
+		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: "deleted-child",
+				message: "continue",
+				fromState: source,
+				origin: "agent",
+			}),
+		).rejects.toThrow("Unknown active session: deleted-child");
+		expect(sendRemoteAgentSessionMessage).not.toHaveBeenCalled();
+	});
+
 	it("reports queued status when a direct accept races into the queue", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -2766,6 +2810,86 @@ describe("daemon mode helpers", () => {
 			await create({ type: "create", sessionPath: join(tempDir, "session.jsonl") });
 
 			expect(listedAgentsDuringBind).toBe(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rehydrates completed RLM subagents from the parent registry", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-rlm-rehydrate-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const parentManager = SessionManager.create(tempDir, sessionDir);
+			parentManager.newSession();
+			parentManager.appendSessionInfo("Parent");
+			const parentSessionFile = parentManager.getSessionFile();
+			const parentArtifactDir = parentManager.getSessionArtifactDir();
+			if (!parentSessionFile || !parentArtifactDir) {
+				throw new Error("Missing parent session paths");
+			}
+
+			const childId = "child-1";
+			const childSessionDir = join(parentArtifactDir, childId);
+			const childManager = SessionManager.create(tempDir, childSessionDir);
+			childManager.newSession({ parentSession: parentSessionFile });
+			childManager.appendSessionInfo("completed-worker");
+			const childSessionFile = childManager.getSessionFile();
+			if (!childSessionFile) {
+				throw new Error("Missing child session file");
+			}
+			writeFileSync(
+				join(parentArtifactDir, "rlm-subagents.jsonl"),
+				`${JSON.stringify({
+					type: "rlm_subagent",
+					childId,
+					sessionName: "completed-worker",
+					sessionDir: childSessionDir,
+					sessionFile: childSessionFile,
+					parentSessionId: parentManager.getSessionId(),
+					parentSessionFile,
+					rlmParentNodeId: childId,
+					status: "completed",
+					createdAt: 1,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				})}\n`,
+			);
+
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				return {
+					session: makeRuntimeSession(options.sessionManager),
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			};
+
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: parentSessionFile });
+			const childState = [...internals.sessions.values()].find(
+				(state) => state.runtime.metadata.rlmChildId === childId,
+			);
+
+			expect(createRuntime).toHaveBeenCalledTimes(2);
+			expect(childState?.runtime.session.sessionName).toBe("completed-worker");
+			expect(childState?.runtime.metadata).toMatchObject({
+				kind: "subagent",
+				parentActiveSessionId: parentState.activeSessionId,
+				parentSessionId: parentState.runtime.session.sessionId,
+				rlmChildId: childId,
+				rlmParentNodeId: childId,
+				sessionDir: childSessionDir,
+			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import type { AgentSessionMessageController } from "../src/core/agent-messages.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
+import { type CreateRlmSubagentRuntimeOptions, createDefaultRlmSubagentSessionName } from "../src/core/rlm-runtime.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import {
@@ -150,7 +152,7 @@ describe("daemon mode helpers", () => {
 		});
 	});
 
-	it("lists and sends agent messages to live subagents", async () => {
+	it("lists and sends agent messages to completed retained subagents", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -169,6 +171,7 @@ describe("daemon mode helpers", () => {
 				pendingMessageCount: 0,
 			},
 		} as never;
+		const defaultSubagentName = createDefaultRlmSubagentSessionName("retained worker", "child-1");
 		const subagentState = makeState("child", "parent") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
@@ -195,7 +198,7 @@ describe("daemon mode helpers", () => {
 			},
 			session: {
 				sessionId: "session-child",
-				sessionName: "Subagent",
+				sessionName: defaultSubagentName,
 				isStreaming: false,
 				pendingMessageCount: 0,
 				acceptAgentMessagePrompt,
@@ -203,47 +206,219 @@ describe("daemon mode helpers", () => {
 		} as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
-			createAgentMessageListResult(current: ActiveSessionState): {
-				agents: Array<{
-					activeSessionId: string;
-					runtimeKind?: string;
-					parentActiveSessionId?: string;
-					rlmChildId?: string;
-				}>;
-			};
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
+			createAgentMessageController(
+				getCurrentState: () => ActiveSessionState | undefined,
+			): AgentSessionMessageController;
 		};
 		internals.sessions.set(parentState.activeSessionId, parentState);
+		// A successfully completed RLM child remains idle in this daemon registry.
 		internals.sessions.set(subagentState.activeSessionId, subagentState);
 
-		const subagentSummary = internals
-			.createAgentMessageListResult(parentState)
+		const controller = internals.createAgentMessageController(() => parentState);
+		const subagentSummary = controller
+			.listAgents()
 			.agents.find((agent) => agent.activeSessionId === subagentState.activeSessionId);
 		expect(subagentSummary).toMatchObject({
+			sessionName: defaultSubagentName,
 			runtimeKind: "subagent",
 			parentActiveSessionId: parentState.activeSessionId,
 			rlmChildId: "child-1",
 		});
+		if (!subagentSummary?.sessionName) {
+			throw new Error("Missing default subagent session name");
+		}
 
 		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: subagentState.activeSessionId,
+			controller.sendAgentMessage({
+				target: subagentSummary.sessionName,
 				message: "report current progress",
-				fromState: parentState,
-				origin: "agent",
 			}),
 		).resolves.toMatchObject({
 			deliveryStatus: "delivered",
 			target: { activeSessionId: subagentState.activeSessionId, runtimeKind: "subagent" },
 		});
 		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(acceptAgentMessagePrompt.mock.calls[0]?.[0]).toContain("To: Subagent, active child");
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[0]).toContain(`To: ${defaultSubagentName}, active child`);
 		expect(acceptAgentMessagePrompt.mock.calls[0]?.[0]).toContain("report current progress");
+	});
+
+	it("closes the exact parent-scoped daemon runtime when a retained subagent is deleted", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const parentState = makeState("parent");
+		const childState = makeState("child", parentState.activeSessionId);
+		const foreignChildState = makeState("foreign-child", "other-parent");
+		const childSession = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		const foreignSession = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		childState.runtime = {
+			...childState.runtime,
+			metadata: { ...childState.runtime.metadata, rlmChildId: "child-1" },
+			session: childSession,
+		} as ActiveSessionState["runtime"];
+		foreignChildState.runtime = {
+			...foreignChildState.runtime,
+			metadata: { ...foreignChildState.runtime.metadata, rlmChildId: "child-1" },
+			session: foreignSession,
+		} as ActiveSessionState["runtime"];
+		const closeSession = vi.fn(async () => {});
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: typeof closeSession;
+			createSubagentRuntimeHost(parent: ActiveSessionState): {
+				deleteRlmSubagentRuntime(childId: string, session: ActiveSessionState["runtime"]["session"]): Promise<void>;
+			};
+		};
+		internals.sessions.set(childState.activeSessionId, childState);
+		internals.sessions.set(foreignChildState.activeSessionId, foreignChildState);
+		internals.closeSession = closeSession;
+
+		const staleParentReference = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		const host = internals.createSubagentRuntimeHost(parentState);
+		await host.deleteRlmSubagentRuntime("child-1", staleParentReference);
+
+		expect(closeSession).toHaveBeenCalledOnce();
+		expect(closeSession).toHaveBeenCalledWith(childState, "killed", false);
+		expect(closeSession).not.toHaveBeenCalledWith(foreignChildState, expect.anything());
+		expect(childSession.disposeAsync).not.toHaveBeenCalled();
+		expect(staleParentReference.disposeAsync).toHaveBeenCalledOnce();
+
+		const missingSession = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		await host.deleteRlmSubagentRuntime("missing-child", missingSession);
+		expect(missingSession.disposeAsync).toHaveBeenCalledOnce();
+	});
+
+	it("hides daemon sessions from messaging and observation while they are closing", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+			worker: { authenticationToken: "worker-token" },
+		});
+		const parentState = makeState("parent");
+		const childState = makeState("child", parentState.activeSessionId);
+		const sessionPrompt = vi.fn(async () => {});
+		for (const [state, sessionId] of [
+			[parentState, "session-parent"],
+			[childState, "session-child"],
+		] as const) {
+			state.runtime = {
+				...state.runtime,
+				cwd: "/tmp",
+				session: {
+					sessionId,
+					sessionName: sessionId,
+					prompt: sessionPrompt,
+					isStreaming: false,
+					pendingMessageCount: 0,
+				},
+			} as unknown as ActiveSessionState["runtime"];
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, Promise<void>>;
+			createAgentMessageController(
+				getCurrentState: () => ActiveSessionState | undefined,
+			): AgentSessionMessageController;
+			getBoundSessionState(id: string): ActiveSessionState;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			agentMessageTargetLocks: Map<string, Promise<void>>;
+			promptWithAgentMessagePreparingGuard(state: ActiveSessionState, message: string): Promise<boolean>;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		internals.sessions.set(childState.activeSessionId, childState);
+		internals.closingSessions.set(childState.activeSessionId, Promise.resolve());
+
+		const controller = internals.createAgentMessageController(() => parentState);
+		const listed = controller.listAgents();
+		expect(listed.agents).not.toContainEqual(
+			expect.objectContaining({ activeSessionId: childState.activeSessionId }),
+		);
+		expect(() => internals.getBoundSessionState(childState.activeSessionId)).toThrow("is closing");
+		await expect(
+			controller.sendAgentMessage({ target: childState.activeSessionId, message: "continue" }),
+		).rejects.toThrow("is closing");
+		const client = makeClient("client-1", childState.activeSessionId);
+		for (const command of [
+			{ id: "prompt", type: "prompt", activeSessionId: childState.activeSessionId, message: "continue" },
+			{ id: "steer", type: "steer", activeSessionId: childState.activeSessionId, message: "continue" },
+			{ id: "follow-up", type: "follow_up", activeSessionId: childState.activeSessionId, message: "continue" },
+		] as const) {
+			await expect(internals.handleCommand(client, command)).rejects.toThrow("is closing");
+		}
+
+		internals.closingSessions.delete(childState.activeSessionId);
+		let releaseTargetLock: () => void = () => {};
+		const targetLock = new Promise<void>((resolve) => {
+			releaseTargetLock = resolve;
+		});
+		internals.agentMessageTargetLocks.set(childState.activeSessionId, targetLock);
+		const guardedPrompt = internals.promptWithAgentMessagePreparingGuard(childState, "continue");
+		await Promise.resolve();
+		internals.closingSessions.set(childState.activeSessionId, Promise.resolve());
+		releaseTargetLock();
+		await expect(guardedPrompt).rejects.toThrow("closing before prompt delivery");
+		expect(sessionPrompt).not.toHaveBeenCalled();
+	});
+
+	it("removes a closing daemon session even when runtime disposal fails", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const state = makeState("child");
+		const dispose = vi.fn(async () => {
+			throw new Error("dispose failed");
+		});
+		state.runtime = {
+			...state.runtime,
+			dispose,
+			session: {
+				sessionId: "session-child",
+				sessionFile: undefined,
+				abort: vi.fn(() => new Promise<void>(() => {})),
+			},
+		} as unknown as ActiveSessionState["runtime"];
+		state.extensionUiRequests = new Map();
+		state.unsubscribe = vi.fn();
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, Promise<void>>;
+			closeSession(state: ActiveSessionState, reason: "killed", waitForAbort?: boolean): Promise<void>;
+			closeChildSessions: ReturnType<typeof vi.fn>;
+			isEmptyDraftContent: ReturnType<typeof vi.fn>;
+			abortBashForClose: ReturnType<typeof vi.fn>;
+			recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
+			broadcastToSession: ReturnType<typeof vi.fn>;
+			cancelScheduledJobsForSession: ReturnType<typeof vi.fn>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+		internals.closeChildSessions = vi.fn(async () => undefined);
+		internals.isEmptyDraftContent = vi.fn(() => true);
+		internals.abortBashForClose = vi.fn(async () => {});
+		internals.recordWorkerRecoveryState = vi.fn();
+		internals.broadcastToSession = vi.fn();
+		internals.cancelScheduledJobsForSession = vi.fn();
+
+		await expect(internals.closeSession(state, "killed", false)).rejects.toThrow("dispose failed");
+
+		expect(dispose).toHaveBeenCalledOnce();
+		expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
 	it("lists and routes agent messages to peers hosted by another worker", async () => {
@@ -265,10 +440,11 @@ describe("daemon mode helpers", () => {
 				pendingMessageCount: 0,
 			},
 		} as never;
+		const remoteSelector = "remote is closing";
 		const receipt = {
 			id: "agentmsg-remote",
 			source: "agent_message",
-			target: { activeSessionId: "remote", sessionId: "session-remote" },
+			target: { activeSessionId: remoteSelector, sessionId: "session-remote" },
 			message: "continue remotely",
 			deliveryStatus: "delivered",
 			deliveredAt: "2026-01-01T00:00:00.000Z",
@@ -288,8 +464,8 @@ describe("daemon mode helpers", () => {
 			}): Promise<unknown>;
 		};
 		internals.sessions.set(source.activeSessionId, source);
-		internals.remoteAgentPeers.set("remote", {
-			activeSessionId: "remote",
+		internals.remoteAgentPeers.set(remoteSelector, {
+			activeSessionId: remoteSelector,
 			sessionId: "session-remote",
 			sessionName: "Remote",
 			runtimeKind: "top-level",
@@ -300,17 +476,22 @@ describe("daemon mode helpers", () => {
 		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
 
 		expect(internals.createAgentMessageListResult(source).agents).toContainEqual(
-			expect.objectContaining({ activeSessionId: "remote" }),
+			expect.objectContaining({ activeSessionId: remoteSelector }),
 		);
 		await expect(
 			internals.sendAgentSessionMessage({
-				targetSelector: "remote",
+				targetSelector: remoteSelector,
 				message: "continue remotely",
 				fromState: source,
 				origin: "agent",
 			}),
 		).resolves.toEqual(receipt);
-		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "remote", "continue remotely", undefined);
+		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(
+			source,
+			remoteSelector,
+			"continue remotely",
+			undefined,
+		);
 	});
 
 	it("reports queued status when a direct accept races into the queue", async () => {
@@ -2590,6 +2771,172 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("gives RLM subagents messaging controllers for their own nested children", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-nested-controller-"));
+		try {
+			const sessionNamesDuringBind: Array<string | undefined> = [];
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				session.bindExtensions = vi.fn(async () => {
+					sessionNamesDuringBind.push(options.sessionManager.getSessionName());
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createRlmSubagentRuntime(
+					parentState: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<unknown>;
+			};
+			const parentState = await internals.createRuntime({
+				type: "create",
+				sessionPath: join(tempDir, "parent.jsonl"),
+			});
+			const childSessionName = createDefaultRlmSubagentSessionName("spawn a nested worker", "child-1");
+			await internals.createRlmSubagentRuntime(parentState, {
+				parentSession: parentState.runtime.session,
+				id: "child-1",
+				prompt: "spawn a nested worker",
+				sessionName: childSessionName,
+				sessionDir: join(tempDir, "child"),
+				model: {} as Model<Api>,
+				thinkingLevel: "off",
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 2,
+				rlmParentNodeId: "child-1",
+			});
+
+			const childOptions = createRuntime.mock.calls[1]?.[0];
+			const childController = childOptions?.sessionOptions?.agentMessageController;
+			expect(childController).toBeDefined();
+			const currentChild = childController?.listAgents().current;
+			const childActiveSessionId = currentChild?.activeSessionId;
+			expect(childActiveSessionId).toBeTruthy();
+			expect(currentChild?.sessionName).toBe(childSessionName);
+			expect(sessionNamesDuringBind[1]).toBeUndefined();
+
+			const grandchildState = makeState("grandchild", childActiveSessionId);
+			grandchildState.runtime = {
+				...grandchildState.runtime,
+				cwd: tempDir,
+				metadata: { ...grandchildState.runtime.metadata, rlmChildId: "grandchild-1" },
+				session: {
+					sessionId: "session-grandchild",
+					sessionName: "Grandchild",
+					isStreaming: false,
+					pendingMessageCount: 0,
+				},
+			} as never;
+			internals.sessions.set(grandchildState.activeSessionId, grandchildState);
+			expect(childController?.listAgents().agents).toContainEqual(
+				expect.objectContaining({
+					activeSessionId: grandchildState.activeSessionId,
+					parentActiveSessionId: childActiveSessionId,
+					rlmChildId: "grandchild-1",
+				}),
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("closes a registered RLM runtime when its requested session name cannot be persisted", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-child-name-failure-"));
+		try {
+			let failingChildSession: ReturnType<typeof makeRuntimeSession> | undefined;
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				if (createRuntime.mock.calls.length > 1) {
+					failingChildSession = session;
+					session.setSessionName = vi.fn(() => {
+						throw new Error("name persistence failed");
+					});
+				}
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createRlmSubagentRuntime(
+					parentState: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<unknown>;
+				closeSession: ReturnType<typeof vi.fn>;
+			};
+			const parentState = await internals.createRuntime({
+				type: "create",
+				sessionPath: join(tempDir, "parent.jsonl"),
+			});
+			let disposeRegisteredRuntime = vi.fn(async () => {});
+			const closeSession = vi.fn(async (state: ActiveSessionState) => {
+				disposeRegisteredRuntime = vi.fn(state.runtime.dispose.bind(state.runtime));
+				state.runtime.dispose = disposeRegisteredRuntime;
+				throw new Error("normal close failed early");
+			});
+			internals.closeSession = closeSession;
+
+			await expect(
+				internals.createRlmSubagentRuntime(parentState, {
+					parentSession: parentState.runtime.session,
+					id: "child-name-failure",
+					prompt: "fail while naming",
+					sessionName: "requested-name",
+					sessionDir: join(tempDir, "child"),
+					model: {} as Model<Api>,
+					thinkingLevel: "off",
+					scopedModels: [],
+					activeToolNames: [],
+					customTools: [],
+					includeGoals: false,
+					includeCompactSkill: false,
+					rlmDepth: 1,
+					rlmMaxDepth: 2,
+					rlmParentNodeId: "child-name-failure",
+				}),
+			).rejects.toThrow("name persistence failed");
+
+			expect(failingChildSession).toBeDefined();
+			expect(closeSession).toHaveBeenCalledOnce();
+			expect(disposeRegisteredRuntime).toHaveBeenCalledOnce();
+			expect(internals.sessions.size).toBe(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("excludes half-bound sessions from targeting until extension binding completes", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-binding-gate-"));
 		try {
@@ -4160,11 +4507,14 @@ function makeRuntimeSession(
 		sessionManager,
 		sessionFile: sessionManager.getSessionFile(),
 		sessionId: sessionManager.getSessionId(),
+		get sessionName() {
+			return sessionManager.getSessionName();
+		},
 		setSubagentRuntimeHost: vi.fn(),
 		subscribe: vi.fn(() => vi.fn()),
 		bindExtensions: vi.fn(async () => {}),
 		setExecEnvProvider: vi.fn(),
-		setSessionName: vi.fn(),
+		setSessionName: vi.fn((name: string) => sessionManager.appendSessionInfo(name)),
 		dispose: vi.fn(),
 		abort: vi.fn(async () => {}),
 	} as unknown as Awaited<ReturnType<CreateAgentSessionRuntimeFactory>>["session"];

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -257,7 +257,7 @@ describe("InteractiveMode.renderSessionContext", () => {
 		initTheme("dark");
 	});
 
-	test("renders historical tool result images as fallbacks instead of replaying inline payloads", async () => {
+	test("renders non-latest historical tool result images as fallbacks instead of replaying inline payloads", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		try {
 			const chatContainer = new Container();
@@ -299,13 +299,23 @@ describe("InteractiveMode.renderSessionContext", () => {
 						content: [{ type: "image", data: "AAAA", mimeType: "image/png" }],
 						isError: false,
 					},
+					{
+						role: "assistant",
+						content: [{ type: "toolCall", name: "custom_tool", id: "tool-2", arguments: {} }],
+					},
+					{
+						role: "toolResult",
+						toolCallId: "tool-2",
+						content: [{ type: "image", data: "BBBB", mimeType: "image/png" }],
+						isError: false,
+					},
 				],
 				thinkingLevel: "medium",
 				model: null,
 			});
 
 			const rendered = renderAll(chatContainer);
-			expect(rendered).not.toContain("\x1b_G");
+			expect((rendered.match(/\x1b_G/g) ?? []).length).toBe(1);
 			expect(normalizeRenderedOutput(chatContainer)).toContain("[Image: [image/png]]");
 			expect(ipythonToolComponents.size).toBe(0);
 			expect(lateIpythonSentAgentMessages.size).toBe(0);

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -11,6 +11,13 @@ describe("IPython RLM bootstrap", () => {
 		expect(buildRlmBootstrapCode()).toMatch(/^import asyncio$/m);
 	});
 
+	it("gives subagent registry operations the actionable missing-runtime fallback", () => {
+		const code = buildRlmBootstrapCode();
+		expect(code).toContain("async def list_subagents(self)");
+		expect(code).toContain("async def delete_subagent(self, target)");
+		expect(code).toContain("self._raise_missing()");
+	});
+
 	it("guards Python skill imports so a broken skill does not abort bootstrap", () => {
 		const code = buildRlmBootstrapCode([
 			{

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -1,5 +1,12 @@
 import type { AssistantMessage, Usage, UserMessage } from "@earendil-works/pi-ai";
-import { type Component, setKeybindings, TUI, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	resetCapabilitiesCache,
+	setCapabilities,
+	setKeybindings,
+	TUI,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test } from "vitest";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.js";
@@ -513,6 +520,50 @@ describe("marquee TUI components", () => {
 
 		const expanded = stripAnsi(detailComponent.render(100).join("\n"));
 		expect(expanded).toContain("/tmp/internal.py");
+	});
+
+	test("renders only the latest historical image tool result inline", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		try {
+			const image =
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+			const messages = [
+				{
+					...createAssistantMessage("old image"),
+					content: [{ type: "toolCall" as const, id: "old-image", name: "ipython", arguments: { code: "old" } }],
+					stopReason: "toolUse" as const,
+				},
+				{
+					role: "toolResult" as const,
+					toolCallId: "old-image",
+					toolName: "ipython",
+					content: [{ type: "image" as const, data: image, mimeType: "image/png" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{
+					...createAssistantMessage("new image"),
+					content: [{ type: "toolCall" as const, id: "new-image", name: "ipython", arguments: { code: "new" } }],
+					stopReason: "toolUse" as const,
+				},
+				{
+					role: "toolResult" as const,
+					toolCallId: "new-image",
+					toolName: "ipython",
+					content: [{ type: "image" as const, data: image, mimeType: "image/png" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			];
+
+			const rendered = buildConversationComponents(messages, bodyOptions())
+				.flatMap((component) => component.render(120))
+				.join("\n");
+			const inlineImageCount = (rendered.match(/\x1b_G/g) ?? []).length;
+			expect(inlineImageCount).toBe(1);
+		} finally {
+			resetCapabilitiesCache();
+		}
 	});
 
 	test("routes child agent detail tool expansion through app keybindings", () => {

--- a/packages/coding-agent/test/snapshot-transcript-cache.test.ts
+++ b/packages/coding-agent/test/snapshot-transcript-cache.test.ts
@@ -61,6 +61,35 @@ describe("snapshot transcript cache", () => {
 		cache.dispose();
 	});
 
+	it("keeps concurrent file-backed caches for the same snapshot id isolated", () => {
+		const cacheRoot = tempDir();
+		const first = new SnapshotTranscriptCache({
+			activeSessionId: "active-shared",
+			snapshotId: "snapshot-shared",
+			messages: messages(6, 100),
+			cacheRoot,
+			targetChunkBytes: 180,
+			memoryCacheBytes: 300,
+		});
+		const second = new SnapshotTranscriptCache({
+			activeSessionId: "active-shared",
+			snapshotId: "snapshot-shared",
+			messages: messages(6, 100),
+			cacheRoot,
+			targetChunkBytes: 180,
+			memoryCacheBytes: 300,
+		});
+
+		expect(first.fileBacked).toBe(true);
+		expect(second.fileBacked).toBe(true);
+		const secondChunk = second.readChunk(0);
+
+		first.dispose();
+
+		expect(second.readChunk(0)).toEqual(secondChunk);
+		second.dispose();
+	});
+
 	it("streams opaque worker chunks to waiting attachments", async () => {
 		const cache = new SnapshotTranscriptCache({
 			activeSessionId: "active-c",

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -233,12 +233,48 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(secondDispose).toHaveBeenCalledTimes(1);
 	});
 
+	it("deletes exact and replaced in-process RLM child runtimes and retained sessions", async () => {
+		const { runtime } = await createRuntimeForTest(() => {});
+		const childSession = {} as AgentSession;
+		const disposeRuntime = vi.fn(async () => {});
+		const childRuntime = { session: childSession, dispose: disposeRuntime } as unknown as AgentSessionRuntime;
+		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
+		runtimeWithSubagents.subagentRuntimes.set("child-1", childRuntime);
+
+		await runtime.deleteRlmSubagentRuntime("child-1", childSession);
+
+		expect(disposeRuntime).toHaveBeenCalledOnce();
+		expect(runtimeWithSubagents.subagentRuntimes.has("child-1")).toBe(false);
+
+		const currentSession = {} as AgentSession;
+		const disposeReplacedRuntime = vi.fn(async () => {});
+		const replacedRuntime = {
+			session: currentSession,
+			dispose: disposeReplacedRuntime,
+		} as unknown as AgentSessionRuntime;
+		const disposeStaleSession = vi.fn(async () => {});
+		const staleSession = { disposeAsync: disposeStaleSession } as unknown as AgentSession;
+		runtimeWithSubagents.subagentRuntimes.set("replaced-child", replacedRuntime);
+
+		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession);
+
+		expect(disposeReplacedRuntime).toHaveBeenCalledOnce();
+		expect(disposeStaleSession).toHaveBeenCalledOnce();
+		expect(runtimeWithSubagents.subagentRuntimes.has("replaced-child")).toBe(false);
+
+		const disposeRetained = vi.fn(async () => {});
+		const retainedSession = { disposeAsync: disposeRetained } as unknown as AgentSession;
+		await runtime.deleteRlmSubagentRuntime("retained-child", retainedSession);
+		expect(disposeRetained).toHaveBeenCalledOnce();
+	});
+
 	it("disposes hosted RLM children during session replacement", async () => {
 		const disposeRlmSubagentRuntimes = vi.fn(async () => {});
 		const host: SubagentRuntimeHost = {
 			createRlmSubagentRuntime: async () => {
 				throw new Error("unexpected child creation");
 			},
+			deleteRlmSubagentRuntime: async () => {},
 			disposeRlmSubagentRuntimes,
 		};
 		const { runtime } = await createRuntimeForTest(() => {});

--- a/packages/coding-agent/test/suite/regressions/4519-heartbeat-rebirth.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4519-heartbeat-rebirth.test.ts
@@ -263,6 +263,7 @@ describe("ENG-4519 heartbeat rebirth", () => {
 		const activeSessionId = "active-session";
 		const runtime = { session: original.session };
 		const state = { activeSessionId, runtime } as unknown as ActiveSessionState;
+		internals.sessions.set(activeSessionId, state);
 		let releaseLock: () => void = () => {};
 		const lock = new Promise<void>((resolve) => {
 			releaseLock = resolve;

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -126,7 +126,7 @@ describe("buildRlmPrompt", () => {
 		expect(prompt).not.toContain("Each skill is an async function");
 	});
 
-	test("mentions agent observation recovery only when the skill is installed", () => {
+	test("exposes the automatic child registry independently of observation skills", () => {
 		const withoutObserve = buildRlmPrompt({
 			cwd: "/repo",
 			messagesPath: "/repo/.pi/sessions/session.jsonl",
@@ -139,11 +139,12 @@ describe("buildRlmPrompt", () => {
 			activeTools: ["ipython"],
 		});
 
-		expect(withoutObserve).toContain(
-			"Write a small disk registry under `os.environ.get('RLM_SESSION_DIR')` when set",
-		);
-		expect(withoutObserve).not.toContain("recover status later with `agent_observe`");
-		expect(withObserve).toContain("recover status later with `agent_observe`");
+		for (const prompt of [withoutObserve, withObserve]) {
+			expect(prompt).toContain("await rlm.list_subagents()");
+			expect(prompt).toContain("await rlm.delete_subagent(child)");
+			expect(prompt).toContain("automatic child registry");
+			expect(prompt).not.toContain("Write a small disk registry");
+		}
 	});
 
 	test("documents the %%bash first-line rule when ipython is active", () => {
@@ -379,18 +380,28 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("asyncio.create_task");
 		expect(prompt).toContain("Sub-agents should not block Prime Agent by default");
 		expect(prompt).toContain("Default to non-blocking subagents");
-		expect(prompt).toContain("disk-backed registry");
-		expect(prompt).toContain("RLM_SESSION_DIR");
-		expect(prompt).toContain("from pathlib import Path");
-		expect(prompt).toContain("import os");
-		expect(prompt).toContain("kernel restarts, state restore, or compaction");
-		expect(prompt).toContain("agent_observe.list_agents");
-		expect(prompt).toContain('runtimeKind == "subagent"');
-		expect(prompt).toContain("parentSessionId");
-		expect(prompt).toContain("parentActiveSessionId");
+		expect(prompt).toContain("automatic child registry");
+		expect(prompt).toContain("parent-scoped subagent registry");
+		expect(prompt).toContain("kernel restarts, state restore, and compaction");
+		expect(prompt).toContain("rlm.list_subagents");
+		expect(prompt).toContain("rlm.delete_subagent");
+		expect(prompt).toContain("rlm_child_id");
+		expect(prompt).toContain("active_session_id");
+		expect(prompt).toContain("session_name");
+		expect(prompt).toContain("name='api-reviewer'");
+		expect(prompt).toContain("names must be non-empty and unique");
+		expect(prompt).toContain("session_dir");
+		expect(prompt).toContain("`agent_observe` skill is installed and a registry entry has `active_session_id`");
+		expect(prompt).toContain("agent_observe.get_agent");
 		expect(prompt).toContain("agent_observe.recent_messages");
-		expect(prompt).toContain("agent_message.list_agents");
+		expect(prompt).toContain("Successful subagent sessions remain in that registry");
+		expect(prompt).toContain("current parent session remains open");
+		expect(prompt).toContain("retained children close when their parent session closes");
 		expect(prompt).toContain("agent_message.send");
+		expect(prompt).toContain("agent_message.send(child.session_name");
+		expect(prompt).toContain("readable, unique default `session_name`");
+		expect(prompt).toContain("same child");
+		expect(prompt).not.toContain("disk-backed registry");
 		expect(prompt).toContain("mode='steer'");
 		expect(prompt).toContain("sub-agent work that can run in the background");
 		expect(prompt).toContain("do not block the main execution path");

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -102,6 +102,34 @@ describe("ToolExecutionComponent parity", () => {
 		}
 	});
 
+	test("renders Ghostty inline images before reserved spacer rows", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		try {
+			const onePixelPng =
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+			const component = new ToolExecutionComponent(
+				"custom_tool",
+				"tool-image-ghostty",
+				{},
+				{ showImages: true },
+				undefined,
+				createFakeTui(),
+				process.cwd(),
+			);
+			component.setImageWidthCells(20);
+			component.updateResult({ content: [{ type: "image", data: onePixelPng, mimeType: "image/png" }], isError: false });
+
+			const rendered = component.render(120);
+			const imageLineIndex = rendered.findIndex((line) => line.includes("\x1b_G"));
+			expect(imageLineIndex).toBeGreaterThanOrEqual(0);
+			expect(rendered[imageLineIndex]).toMatch(/^\x1b_G/);
+			expect(rendered[imageLineIndex]).not.toContain("\x1b[A");
+			expect(rendered[imageLineIndex]).not.toContain("\x1b[B");
+		} finally {
+			resetCapabilitiesCache();
+		}
+	});
+
 	test("can suppress inline image escape sequences for session history", () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		try {

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -82,19 +82,26 @@ export class Image implements Component {
 					this.imageId = result.imageId;
 				}
 
-				// Return `rows` lines so TUI accounts for image height.
-				// First (rows-1) lines are empty and cleared before the image is drawn.
-				// Last line: move cursor back up, draw the image, then move back down
-				// for Kitty (this component disables Kitty's terminal-side cursor movement)
-				// so TUI cursor accounting stays inside the scroll area.
 				lines = [];
-				for (let i = 0; i < result.rows - 1; i++) {
-					lines.push("");
+				if (caps.images === "kitty" && caps.imagePlacement === "first-row") {
+					lines.push(result.sequence);
+					for (let i = 1; i < result.rows; i++) {
+						lines.push("");
+					}
+				} else {
+					// Return `rows` lines so TUI accounts for image height.
+					// First (rows-1) lines are empty and cleared before the image is drawn.
+					// Last line: move cursor back up, draw the image, then move back down
+					// for Kitty (this component disables Kitty's terminal-side cursor movement)
+					// so TUI cursor accounting stays inside the scroll area.
+					for (let i = 0; i < result.rows - 1; i++) {
+						lines.push("");
+					}
+					const rowOffset = result.rows - 1;
+					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
+					const moveDown = caps.images === "kitty" && rowOffset > 0 ? `\x1b[${rowOffset}B` : "";
+					lines.push(moveUp + result.sequence + moveDown);
 				}
-				const rowOffset = result.rows - 1;
-				const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
-				const moveDown = caps.images === "kitty" && rowOffset > 0 ? `\x1b[${rowOffset}B` : "";
-				lines.push(moveUp + result.sequence + moveDown);
 			} else {
 				const fallback = imageFallback(this.mimeType, this.dimensions, this.options.filename);
 				lines = [this.theme.fallbackColor(fallback)];

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -5,7 +5,7 @@
  * scroll position is application state, not terminal scrollback.
  */
 
-import { getCapabilities, isImageLine } from "./terminal-image.js";
+import { deleteKittyImage, getCapabilities, isImageLine } from "./terminal-image.js";
 import { sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
@@ -38,7 +38,32 @@ function kittyImageRows(line: string): number | null {
 	return 1;
 }
 
-function canRenderImageInFullscreen(window: readonly string[], index: number): boolean {
+function kittyImageIds(line: string): number[] {
+	const ids: number[] = [];
+	let searchFrom = 0;
+	while (searchFrom < line.length) {
+		const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX, searchFrom);
+		if (sequenceStart === -1) break;
+		const paramsStart = sequenceStart + KITTY_SEQUENCE_PREFIX.length;
+		const paramsEnd = line.indexOf(";", paramsStart);
+		if (paramsEnd === -1) break;
+		const params = line.slice(paramsStart, paramsEnd);
+		for (const param of params.split(",")) {
+			const [key, value] = param.split("=", 2);
+			if (key !== "i" || value === undefined) continue;
+			const id = Number(value);
+			if (Number.isInteger(id) && id > 0 && id <= 0xffffffff) {
+				ids.push(id);
+			}
+		}
+		searchFrom = paramsEnd + 1;
+	}
+	return ids;
+}
+
+function canRenderImageInFullscreen(window: readonly string[], index: number, following: boolean): boolean {
+	if (!following) return false;
+
 	const caps = getCapabilities();
 	if (caps.images !== "kitty" || caps.imagePlacement !== "first-row") return false;
 
@@ -130,7 +155,7 @@ export class FullscreenViewport {
 
 		const window = transcript.slice(this.scrollTop, this.scrollTop + windowHeight);
 		for (let i = 0; i < window.length; i++) {
-			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i)) {
+			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i, this.following)) {
 				window[i] = IMAGE_PLACEHOLDER;
 			}
 		}
@@ -486,13 +511,27 @@ export class FullscreenViewport {
 		}
 
 		let buffer = "\x1b[?2026h";
+		const deletedImageIds = new Set<number>();
+		const deleteImagesInLine = (line: string | undefined): void => {
+			if (line === undefined) return;
+			for (const id of kittyImageIds(line)) {
+				if (deletedImageIds.has(id)) continue;
+				deletedImageIds.add(id);
+				buffer += deleteKittyImage(id);
+			}
+		};
+
 		if (width !== this.prevWidth || height !== this.prevHeight || this.prevFrame.length === 0) {
+			for (const line of this.prevFrame) {
+				deleteImagesInLine(line);
+			}
 			buffer += "\x1b[2J\x1b[H";
 			this.prevFrame = [];
 		}
 		for (let row = 0; row < height; row++) {
 			const line = frame[row] ?? "";
 			if (this.prevFrame[row] === line) continue;
+			deleteImagesInLine(this.prevFrame[row]);
 			buffer += `\x1b[${row + 1};1H\x1b[2K`;
 			// an overwide line would wrap and shear the grid; clamp instead of crash
 			buffer += visibleWidth(line) > width ? sliceByColumn(line, 0, width, true) : line;

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -5,7 +5,7 @@
  * scroll position is application state, not terminal scrollback.
  */
 
-import { isImageLine } from "./terminal-image.js";
+import { getCapabilities, isImageLine } from "./terminal-image.js";
 import { sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
@@ -15,8 +15,41 @@ export function clippedFullscreenDockHeight(dockLength: number, height: number):
 	return Math.min(dockLength, maxDock);
 }
 
-// Kitty images span multiple physical rows and cannot be clipped to a window.
+const KITTY_SEQUENCE_PREFIX = "\x1b_G";
+
+// Kitty images can span multiple physical rows and cannot be partially clipped.
 const IMAGE_PLACEHOLDER = "\x1b[2m[image — view in inline mode]\x1b[0m";
+
+function kittyImageRows(line: string): number | null {
+	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
+	if (sequenceStart === -1) return null;
+
+	const paramsStart = sequenceStart + KITTY_SEQUENCE_PREFIX.length;
+	const paramsEnd = line.indexOf(";", paramsStart);
+	if (paramsEnd === -1) return null;
+
+	const params = line.slice(paramsStart, paramsEnd);
+	for (const param of params.split(",")) {
+		const [key, value] = param.split("=", 2);
+		if (key !== "r" || value === undefined) continue;
+		const rows = Number(value);
+		if (Number.isInteger(rows) && rows > 0) return rows;
+	}
+	return 1;
+}
+
+function canRenderImageInFullscreen(window: readonly string[], index: number): boolean {
+	const caps = getCapabilities();
+	if (caps.images !== "kitty" || caps.imagePlacement !== "first-row") return false;
+
+	const line = window[index] ?? "";
+	if (!line.startsWith(KITTY_SEQUENCE_PREFIX)) return false;
+
+	const rows = kittyImageRows(line);
+	if (rows === null) return false;
+
+	return index + rows <= window.length;
+}
 
 export interface ScrollInfo {
 	following: boolean;
@@ -97,7 +130,9 @@ export class FullscreenViewport {
 
 		const window = transcript.slice(this.scrollTop, this.scrollTop + windowHeight);
 		for (let i = 0; i < window.length; i++) {
-			if (isImageLine(window[i])) window[i] = IMAGE_PLACEHOLDER;
+			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i)) {
+				window[i] = IMAGE_PLACEHOLDER;
+			}
 		}
 		this.highlightSelection(window);
 		while (window.length < windowHeight) {

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -61,9 +61,7 @@ function kittyImageIds(line: string): number[] {
 	return ids;
 }
 
-function canRenderImageInFullscreen(window: readonly string[], index: number, following: boolean): boolean {
-	if (!following) return false;
-
+function canRenderImageInFullscreen(window: readonly string[], index: number): boolean {
 	const caps = getCapabilities();
 	if (caps.images !== "kitty" || caps.imagePlacement !== "first-row") return false;
 
@@ -155,7 +153,7 @@ export class FullscreenViewport {
 
 		const window = transcript.slice(this.scrollTop, this.scrollTop + windowHeight);
 		for (let i = 0; i < window.length; i++) {
-			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i, this.following)) {
+			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i)) {
 				window[i] = IMAGE_PLACEHOLDER;
 			}
 		}
@@ -511,19 +509,21 @@ export class FullscreenViewport {
 		}
 
 		let buffer = "\x1b[?2026h";
+		const imageDeletes: string[] = [];
 		const deletedImageIds = new Set<number>();
-		const deleteImagesInLine = (line: string | undefined): void => {
+		const queueImageDeletesInLine = (line: string | undefined): void => {
 			if (line === undefined) return;
 			for (const id of kittyImageIds(line)) {
 				if (deletedImageIds.has(id)) continue;
 				deletedImageIds.add(id);
-				buffer += deleteKittyImage(id);
+				imageDeletes.push(deleteKittyImage(id));
 			}
 		};
 
+		const changedRows: number[] = [];
 		if (width !== this.prevWidth || height !== this.prevHeight || this.prevFrame.length === 0) {
 			for (const line of this.prevFrame) {
-				deleteImagesInLine(line);
+				queueImageDeletesInLine(line);
 			}
 			buffer += "\x1b[2J\x1b[H";
 			this.prevFrame = [];
@@ -531,7 +531,12 @@ export class FullscreenViewport {
 		for (let row = 0; row < height; row++) {
 			const line = frame[row] ?? "";
 			if (this.prevFrame[row] === line) continue;
-			deleteImagesInLine(this.prevFrame[row]);
+			queueImageDeletesInLine(this.prevFrame[row]);
+			changedRows.push(row);
+		}
+		buffer += imageDeletes.join("");
+		for (const row of changedRows) {
+			const line = frame[row] ?? "";
 			buffer += `\x1b[${row + 1};1H\x1b[2K`;
 			// an overwide line would wrap and shear the grid; clamp instead of crash
 			buffer += visibleWidth(line) > width ? sliceByColumn(line, 0, width, true) : line;

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -17,7 +17,8 @@ export function clippedFullscreenDockHeight(dockLength: number, height: number):
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
-// Kitty images can span multiple physical rows and cannot be partially clipped.
+// Kitty images span physical rows. Ghostty first-row placements can be safely
+// resized to the visible row count in fullscreen; cursor-shim placements cannot.
 const IMAGE_PLACEHOLDER = "\x1b[2m[image — view in inline mode]\x1b[0m";
 
 function kittyImageRows(line: string): number | null {
@@ -36,6 +37,28 @@ function kittyImageRows(line: string): number | null {
 		if (Number.isInteger(rows) && rows > 0) return rows;
 	}
 	return 1;
+}
+
+function resizeKittyImageRows(line: string, rows: number): string {
+	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
+	if (sequenceStart === -1) return line;
+
+	const paramsStart = sequenceStart + KITTY_SEQUENCE_PREFIX.length;
+	const paramsEnd = line.indexOf(";", paramsStart);
+	if (paramsEnd === -1) return line;
+
+	const params = line.slice(paramsStart, paramsEnd).split(",");
+	let foundRows = false;
+	for (let i = 0; i < params.length; i++) {
+		if (params[i].startsWith("r=")) {
+			params[i] = `r=${rows}`;
+			foundRows = true;
+			break;
+		}
+	}
+	if (!foundRows) params.push(`r=${rows}`);
+
+	return line.slice(0, paramsStart) + params.join(",") + line.slice(paramsEnd);
 }
 
 function kittyImageIds(line: string): number[] {
@@ -61,17 +84,57 @@ function kittyImageIds(line: string): number[] {
 	return ids;
 }
 
-function canRenderImageInFullscreen(window: readonly string[], index: number): boolean {
+function canRenderImageInFullscreen(line: string): boolean {
 	const caps = getCapabilities();
 	if (caps.images !== "kitty" || caps.imagePlacement !== "first-row") return false;
 
-	const line = window[index] ?? "";
 	if (!line.startsWith(KITTY_SEQUENCE_PREFIX)) return false;
 
 	const rows = kittyImageRows(line);
 	if (rows === null) return false;
 
-	return index + rows <= window.length;
+	return true;
+}
+
+function prepareFullscreenImages(window: string[], transcript: readonly string[], scrollTop: number, windowHeight: number): void {
+	const caps = getCapabilities();
+	const canRenderFirstRowKitty = caps.images === "kitty" && caps.imagePlacement === "first-row";
+
+	if (!canRenderFirstRowKitty) {
+		for (let i = 0; i < window.length; i++) {
+			if (isImageLine(window[i])) window[i] = IMAGE_PLACEHOLDER;
+		}
+		return;
+	}
+
+	for (let i = scrollTop - 1; i >= 0; i--) {
+		const line = transcript[i] ?? "";
+		if (line.length > 0 && !isImageLine(line)) break;
+		if (!canRenderImageInFullscreen(line)) continue;
+		const rows = kittyImageRows(line);
+		if (rows === null) break;
+		if (i + rows > scrollTop) {
+			const visibleRows = Math.min(i + rows - scrollTop, windowHeight);
+			if (visibleRows > 0) window[0] = resizeKittyImageRows(line, visibleRows);
+		}
+		break;
+	}
+
+	for (let i = 0; i < window.length; i++) {
+		const line = window[i];
+		if (!isImageLine(line)) continue;
+		if (!canRenderImageInFullscreen(line)) {
+			window[i] = IMAGE_PLACEHOLDER;
+			continue;
+		}
+		const rows = kittyImageRows(line);
+		if (rows === null) {
+			window[i] = IMAGE_PLACEHOLDER;
+			continue;
+		}
+		const visibleRows = Math.min(rows, windowHeight - i);
+		window[i] = visibleRows > 0 ? resizeKittyImageRows(line, visibleRows) : "";
+	}
 }
 
 export interface ScrollInfo {
@@ -152,11 +215,7 @@ export class FullscreenViewport {
 		this.lastTranscript = transcript;
 
 		const window = transcript.slice(this.scrollTop, this.scrollTop + windowHeight);
-		for (let i = 0; i < window.length; i++) {
-			if (isImageLine(window[i]) && !canRenderImageInFullscreen(window, i)) {
-				window[i] = IMAGE_PLACEHOLDER;
-			}
-		}
+		prepareFullscreenImages(window, transcript, this.scrollTop, windowHeight);
 		this.highlightSelection(window);
 		while (window.length < windowHeight) {
 			window.push("");
@@ -536,10 +595,13 @@ export class FullscreenViewport {
 		}
 		buffer += imageDeletes.join("");
 		for (const row of changedRows) {
-			const line = frame[row] ?? "";
 			buffer += `\x1b[${row + 1};1H\x1b[2K`;
+		}
+		for (const row of changedRows) {
+			const line = frame[row] ?? "";
 			// an overwide line would wrap and shear the grid; clamp instead of crash
-			buffer += visibleWidth(line) > width ? sliceByColumn(line, 0, width, true) : line;
+			const drawable = visibleWidth(line) > width ? sliceByColumn(line, 0, width, true) : line;
+			if (drawable.length > 0) buffer += `\x1b[${row + 1};1H${drawable}`;
 		}
 		if (cursorPos) {
 			buffer += `\x1b[${Math.min(cursorPos.row, height - 1) + 1};${cursorPos.col + 1}H`;

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -4,6 +4,13 @@ export interface TerminalCapabilities {
 	images: ImageProtocol;
 	trueColor: boolean;
 	hyperlinks: boolean;
+	/**
+	 * Kitty-compatible terminals do not all handle cursor-shim image placement
+	 * the same way. Most are drawn from the last reserved row after clearing the
+	 * block above it. Ghostty is more reliable when the image escape is emitted
+	 * on the first reserved row and the TUI advances through the remaining rows.
+	 */
+	imagePlacement?: "first-row";
 }
 
 export interface CellDimensions {
@@ -59,7 +66,7 @@ export function detectCapabilities(): TerminalCapabilities {
 	}
 
 	if (termProgram === "ghostty" || term.includes("ghostty") || process.env.GHOSTTY_RESOURCES_DIR) {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+		return { images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" };
 	}
 
 	if (process.env.WEZTERM_PANE || termProgram === "wezterm") {

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { TerminalStopOptions } from "../src/terminal.js";
-import { encodeKitty, resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.js";
+import { deleteKittyImage, encodeKitty, resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.js";
 import { type Component, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
@@ -153,6 +153,29 @@ describe("TUI fullscreen mode", () => {
 			const writes = terminal.getWrites();
 			assert.ok(!writes.includes(image), "clipped first-row image should not be emitted inside fullscreen");
 			assert.ok(writes.includes("view in inline mode"), "clipped first-row image should use the safe placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("uses the placeholder for Ghostty images while fullscreen history is scrolled", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 58, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup([...lines(11), image, "", "after", "tail"], 80, 8);
+		try {
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+			assert.ok(terminal.getWrites().includes(image), "image is rendered while following");
+			terminal.clearWrites();
+
+			terminal.sendInput(WHEEL_UP);
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes(deleteKittyImage(58)), "scrolling should delete the old visible image placement");
+			assert.ok(!writes.includes(image), "scrolled history should not re-emit the image");
+			assert.ok(writes.includes("view in inline mode"), "scrolled history should use the placeholder");
 		} finally {
 			tui.stop();
 			resetCapabilitiesCache();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -159,10 +159,10 @@ describe("TUI fullscreen mode", () => {
 		}
 	});
 
-	it("uses the placeholder for Ghostty images while fullscreen history is scrolled", async () => {
+	it("keeps complete Ghostty images rendered while fullscreen history is scrolled", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
 		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 58, moveCursor: false });
-		const { terminal, tui, chat, dock } = setup([...lines(11), image, "", "after", "tail"], 80, 8);
+		const { terminal, tui, chat, dock } = setup([...lines(10), image, "", "after", "tail", "tail 2"], 80, 8);
 		try {
 			tui.enterFullscreen({ scroll: [chat], dock });
 			await terminal.waitForRender();
@@ -174,8 +174,61 @@ describe("TUI fullscreen mode", () => {
 
 			const writes = terminal.getWrites();
 			assert.ok(writes.includes(deleteKittyImage(58)), "scrolling should delete the old visible image placement");
-			assert.ok(!writes.includes(image), "scrolled history should not re-emit the image");
-			assert.ok(writes.includes("view in inline mode"), "scrolled history should use the placeholder");
+			assert.ok(writes.includes(image), "complete image should be re-emitted in scrolled history");
+			assert.ok(!writes.includes("view in inline mode"), "complete scrolled image should not use the placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("uses the placeholder for clipped Ghostty images while fullscreen history is scrolled", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 61, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup([...lines(11), image, "", "after", "tail"], 80, 8);
+		try {
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+			assert.ok(terminal.getWrites().includes(image), "image is rendered while following");
+			terminal.clearWrites();
+
+			terminal.sendInput(WHEEL_UP);
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes(deleteKittyImage(61)), "scrolling should delete the old visible image placement");
+			assert.ok(!writes.includes(image), "clipped scrolled image should not be re-emitted");
+			assert.ok(writes.includes("view in inline mode"), "clipped scrolled image should use the placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("deletes old fullscreen image placements before drawing moved and sequential Ghostty images", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const firstImage = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 59, moveCursor: false });
+		const secondImage = encodeKitty("BBBB", { columns: 2, rows: 2, imageId: 60, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["lead", firstImage, "", "after first", "gap", "tail"], 80, 10);
+		try {
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+			assert.ok(terminal.getWrites().includes(firstImage), "initial image is rendered while following");
+			terminal.clearWrites();
+
+			chat.lines = [...chat.lines, secondImage, "", "after second"];
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			const deleteIndex = writes.indexOf(deleteKittyImage(59));
+			const firstDrawIndex = writes.indexOf(firstImage);
+			const secondDrawIndex = writes.indexOf(secondImage);
+			assert.ok(deleteIndex >= 0, "old first image placement should be deleted when it moves");
+			assert.ok(firstDrawIndex >= 0, "moved first image should be redrawn");
+			assert.ok(secondDrawIndex >= 0, "sequential second image should be drawn");
+			assert.ok(deleteIndex < firstDrawIndex, "delete must happen before moved first image is redrawn");
+			assert.ok(deleteIndex < secondDrawIndex, "delete must happen before later sequential images are drawn");
 		} finally {
 			tui.stop();
 			resetCapabilitiesCache();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -139,9 +139,10 @@ describe("TUI fullscreen mode", () => {
 		}
 	});
 
-	it("keeps the inline-mode placeholder for clipped Ghostty image blocks", async () => {
+	it("renders bottom-clipped Ghostty image blocks with the visible row count", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
 		const image = encodeKitty("AAAA", { columns: 2, rows: 5, imageId: 57, moveCursor: false });
+		const clippedImage = encodeKitty("AAAA", { columns: 2, rows: 3, imageId: 57, moveCursor: false });
 		const { terminal, tui, chat, dock } = setup(["Line 0", "Line 1", "Line 2", "Line 3", image, "", ""], 80, 8);
 		try {
 			await terminal.waitForRender();
@@ -151,8 +152,28 @@ describe("TUI fullscreen mode", () => {
 			await terminal.waitForRender();
 
 			const writes = terminal.getWrites();
-			assert.ok(!writes.includes(image), "clipped first-row image should not be emitted inside fullscreen");
-			assert.ok(writes.includes("view in inline mode"), "clipped first-row image should use the safe placeholder");
+			assert.ok(writes.includes(clippedImage), "bottom-clipped first-row image should be resized to visible rows");
+			assert.ok(!writes.includes(image), "bottom-clipped first-row image should not overdraw into the dock");
+			assert.ok(!writes.includes("view in inline mode"), "bottom-clipped first-row image should not use the placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("renders top-clipped Ghostty image blocks with the remaining visible row count", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 5, imageId: 62, moveCursor: false });
+		const clippedImage = encodeKitty("AAAA", { columns: 2, rows: 3, imageId: 62, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["lead 0", "lead 1", image, "", "", "", "", "after", "tail", "tail 2"], 80, 8);
+		try {
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes(clippedImage), "top-clipped first-row image should be redrawn from the first visible row");
+			assert.ok(!writes.includes(image), "top-clipped first-row image should not use the offscreen full-height placement");
+			assert.ok(!writes.includes("view in inline mode"), "top-clipped first-row image should not use the placeholder");
 		} finally {
 			tui.stop();
 			resetCapabilitiesCache();
@@ -182,9 +203,10 @@ describe("TUI fullscreen mode", () => {
 		}
 	});
 
-	it("uses the placeholder for clipped Ghostty images while fullscreen history is scrolled", async () => {
+	it("renders clipped Ghostty images while fullscreen history is scrolled", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
 		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 61, moveCursor: false });
+		const clippedImage = encodeKitty("AAAA", { columns: 2, rows: 1, imageId: 61, moveCursor: false });
 		const { terminal, tui, chat, dock } = setup([...lines(11), image, "", "after", "tail"], 80, 8);
 		try {
 			tui.enterFullscreen({ scroll: [chat], dock });
@@ -197,8 +219,35 @@ describe("TUI fullscreen mode", () => {
 
 			const writes = terminal.getWrites();
 			assert.ok(writes.includes(deleteKittyImage(61)), "scrolling should delete the old visible image placement");
-			assert.ok(!writes.includes(image), "clipped scrolled image should not be re-emitted");
-			assert.ok(writes.includes("view in inline mode"), "clipped scrolled image should use the placeholder");
+			assert.ok(!writes.includes(image), "clipped scrolled image should not overdraw with the full-height placement");
+			assert.ok(writes.includes(clippedImage), "clipped scrolled image should be redrawn with the visible row count");
+			assert.ok(!writes.includes("view in inline mode"), "clipped scrolled image should not use the placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("renders multiple Ghostty images in the same fullscreen frame", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const firstImage = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 63, moveCursor: false });
+		const secondImage = encodeKitty("BBBB", { columns: 2, rows: 2, imageId: 64, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["lead", firstImage, "", "between", secondImage, "", "after"], 80, 10);
+		try {
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			const firstDrawIndex = writes.indexOf(firstImage);
+			const secondDrawIndex = writes.indexOf(secondImage);
+			assert.ok(firstDrawIndex >= 0, "first image should be drawn");
+			assert.ok(secondDrawIndex >= 0, "second image should be drawn");
+			assert.ok(!writes.includes("view in inline mode"), "multiple images should not force placeholders");
+			const clearAfterFirstDraw = writes.indexOf("\x1b[3;1H\x1b[2K", firstDrawIndex);
+			assert.strictEqual(clearAfterFirstDraw, -1, "reserved rows should be cleared before image drawing, not after");
 		} finally {
 			tui.stop();
 			resetCapabilitiesCache();

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { TerminalStopOptions } from "../src/terminal.js";
+import { encodeKitty, resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.js";
 import { type Component, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
@@ -98,6 +99,66 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void
 }
 
 describe("TUI fullscreen mode", () => {
+	it("renders complete Ghostty first-row Kitty images in fullscreen", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 55, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["before", image, "", "after"], 80, 8);
+		try {
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes(image), "Ghostty first-row image should be rendered in fullscreen");
+			assert.ok(!writes.includes("view in inline mode"), "complete first-row image should not be replaced");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("keeps the inline-mode placeholder for cursor-shim Kitty images in fullscreen", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 2, imageId: 56, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["before", "", image, "after"], 80, 8);
+		try {
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(!writes.includes(image), "cursor-shim image should not be emitted inside fullscreen");
+			assert.ok(writes.includes("view in inline mode"), "cursor-shim image should use the safe placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
+	it("keeps the inline-mode placeholder for clipped Ghostty image blocks", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		const image = encodeKitty("AAAA", { columns: 2, rows: 5, imageId: 57, moveCursor: false });
+		const { terminal, tui, chat, dock } = setup(["Line 0", "Line 1", "Line 2", "Line 3", image, "", ""], 80, 8);
+		try {
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			tui.enterFullscreen({ scroll: [chat], dock });
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(!writes.includes(image), "clipped first-row image should not be emitted inside fullscreen");
+			assert.ok(writes.includes("view in inline mode"), "clipped first-row image should use the safe placeholder");
+		} finally {
+			tui.stop();
+			resetCapabilitiesCache();
+		}
+	});
+
 	it("enters the alt screen and lays out transcript window above the dock", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(20));
 		await terminal.waitForRender();

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -240,6 +240,16 @@ describe("detectCapabilities", () => {
 		withEnv({ TERM_PROGRAM: "ghostty", CMUX_WORKSPACE_ID: "workspace" }, () => {
 			const caps = detectCapabilities();
 			assert.strictEqual(caps.images, "kitty");
+			assert.strictEqual(caps.imagePlacement, "first-row");
+			assert.strictEqual(caps.hyperlinks, true);
+		});
+	});
+
+	it("uses first-row image placement for Ghostty", () => {
+		withEnv({ TERM_PROGRAM: "ghostty" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.images, "kitty");
+			assert.strictEqual(caps.imagePlacement, "first-row");
 			assert.strictEqual(caps.hyperlinks, true);
 		});
 	});
@@ -331,6 +341,33 @@ describe("Kitty image cursor movement", () => {
 			assert.ok(lines[1].includes(",C=1,"));
 			assert.ok(lines[1].includes(`,i=${imageId}`));
 			assert.ok(lines[1].endsWith("\x1b[1B"));
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("places Ghostty Kitty images on the first reserved row without cursor shims", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true, imagePlacement: "first-row" });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const lines = image.render(4);
+			const imageId = image.getImageId();
+			assert.strictEqual(typeof imageId, "number");
+			assert.strictEqual(lines.length, 2);
+			assert.ok(lines[0].startsWith("\x1b_G"));
+			assert.ok(lines[0].includes(",C=1,"));
+			assert.ok(lines[0].includes(`,i=${imageId}`));
+			assert.strictEqual(lines[1], "");
+			assert.ok(!lines.join("").includes("\x1b[1A"));
+			assert.ok(!lines.join("").includes("\x1b[1B"));
 		} finally {
 			resetCapabilitiesCache();
 			setCellDimensions({ widthPx: 9, heightPx: 18 });

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -43,6 +43,16 @@ class RLMResult:
     turns: int = 0
 
 
+@dataclass(frozen=True)
+class RLMSubagent:
+    rlm_child_id: str
+    active_session_id: str | None
+    session_id: str | None
+    session_name: str
+    session_dir: Path
+    status: str
+
+
 def _env_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -164,6 +174,60 @@ async def run(prompt: str, **kwargs: Any) -> RLMResult:
     return _result_from_payload(payload)
 
 
+def _subagent_from_payload(payload: Any, operation: str = "rlm.list_subagents") -> RLMSubagent:
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{operation} returned an invalid subagent entry")
+    child_id = payload.get("rlm_child_id")
+    active_session_id = payload.get("active_session_id")
+    session_id = payload.get("session_id")
+    session_name = payload.get("session_name")
+    session_dir = payload.get("session_dir")
+    status = payload.get("status")
+    if not isinstance(child_id, str) or not child_id:
+        raise RuntimeError(f"{operation} entry is missing rlm_child_id")
+    if active_session_id is not None and not isinstance(active_session_id, str):
+        raise RuntimeError(f"{operation} entry has invalid active_session_id")
+    if session_id is not None and not isinstance(session_id, str):
+        raise RuntimeError(f"{operation} entry has invalid session_id")
+    if not isinstance(session_name, str) or not session_name:
+        raise RuntimeError(f"{operation} entry is missing session_name")
+    if not isinstance(session_dir, str) or not session_dir:
+        raise RuntimeError(f"{operation} entry is missing session_dir")
+    if status not in {"running", "completed"}:
+        raise RuntimeError(f"{operation} entry has invalid status")
+    return RLMSubagent(
+        rlm_child_id=child_id,
+        active_session_id=active_session_id,
+        session_id=session_id,
+        session_name=session_name,
+        session_dir=Path(session_dir),
+        status=status,
+    )
+
+
+async def list_subagents() -> list[RLMSubagent]:
+    """List direct RLM children retained by the current parent session."""
+    payload = await host_request("rlm.list_subagents")
+    entries = payload.get("subagents")
+    if not isinstance(entries, list):
+        raise RuntimeError("rlm.list_subagents returned an invalid subagents registry")
+    return [_subagent_from_payload(entry) for entry in entries]
+
+
+async def delete_subagent(target: str | RLMSubagent) -> RLMSubagent:
+    """Delete one running or retained direct child from the current parent session."""
+    if isinstance(target, RLMSubagent):
+        selector = target.rlm_child_id
+    elif isinstance(target, str):
+        selector = target.strip()
+        if not selector:
+            raise ValueError("target must not be empty")
+    else:
+        raise TypeError(f"target must be str or RLMSubagent, got {type(target).__name__}")
+    payload = await host_request("rlm.delete_subagent", {"target": selector})
+    return _subagent_from_payload(payload.get("subagent"), "rlm.delete_subagent")
+
+
 class _HarnessProxy:
     """Resolve the harness state against the current environment on every access.
 
@@ -222,6 +286,12 @@ class _RLMCallable:
     async def run(self, prompt: str, **kwargs: Any) -> RLMResult:
         return await run(prompt, **kwargs)
 
+    async def list_subagents(self) -> list[RLMSubagent]:
+        return await list_subagents()
+
+    async def delete_subagent(self, target: str | RLMSubagent) -> RLMSubagent:
+        return await delete_subagent(target)
+
     async def __call__(self, prompt: str, **kwargs: Any) -> RLMResult:
         return await run(prompt, **kwargs)
 
@@ -245,11 +315,14 @@ __all__ = [
     "McpToolError",
     "NotEnabled",
     "RLMResult",
+    "RLMSubagent",
     "RefinementEvent",
     "TokenUsage",
+    "delete_subagent",
     "get_harness_state",
     "harness",
     "host_request",
+    "list_subagents",
     "rlm",
     "run",
 ]

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+rlm_module = importlib.import_module("rlm")
+
+
+class RlmSubagentRegistryTest(unittest.TestCase):
+    def test_lists_parent_scoped_subagents_from_host(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "subagents": [
+                    {
+                        "rlm_child_id": "sub-a1b2c3d4",
+                        "active_session_id": "active-child",
+                        "session_id": "session-child",
+                        "session_name": "subagent-check-api-a1b2c3d4",
+                        "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                        "status": "completed",
+                    }
+                ]
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            subagents = asyncio.run(rlm_module.rlm.list_subagents())
+
+        self.assertEqual(len(subagents), 1)
+        self.assertEqual(subagents[0].rlm_child_id, "sub-a1b2c3d4")
+        self.assertEqual(subagents[0].active_session_id, "active-child")
+        self.assertEqual(subagents[0].session_id, "session-child")
+        self.assertEqual(subagents[0].session_name, "subagent-check-api-a1b2c3d4")
+        self.assertEqual(subagents[0].session_dir, Path("/tmp/parent/sub-a1b2c3d4"))
+        self.assertEqual(subagents[0].status, "completed")
+        host_request.assert_awaited_once_with("rlm.list_subagents")
+
+    def test_forwards_orchestrator_chosen_name_to_host(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "answer": "done",
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "turns": 1,
+                "session_dir": "/tmp/parent/sub-a1b2c3d4",
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            asyncio.run(rlm_module.rlm("check the API", name="api-reviewer"))
+
+        host_request.assert_awaited_once_with(
+            "rlm.run",
+            {"prompt": "check the API", "kwargs": {"name": "api-reviewer"}},
+        )
+
+    def test_deletes_subagent_by_name_through_host(self) -> None:
+        deleted_payload = {
+            "rlm_child_id": "sub-a1b2c3d4",
+            "active_session_id": "active-child",
+            "session_id": "session-child",
+            "session_name": "api-reviewer",
+            "session_dir": "/tmp/parent/sub-a1b2c3d4",
+            "status": "completed",
+        }
+        host_request = AsyncMock(return_value={"subagent": deleted_payload})
+
+        with patch.object(rlm_module, "host_request", host_request):
+            deleted = asyncio.run(rlm_module.rlm.delete_subagent("  api-reviewer  "))
+
+        self.assertEqual(deleted.rlm_child_id, "sub-a1b2c3d4")
+        self.assertEqual(deleted.session_name, "api-reviewer")
+        host_request.assert_awaited_once_with(
+            "rlm.delete_subagent",
+            {"target": "api-reviewer"},
+        )
+
+    def test_deletes_subagent_object_by_child_id(self) -> None:
+        subagent = rlm_module.RLMSubagent(
+            rlm_child_id="sub-a1b2c3d4",
+            active_session_id=None,
+            session_id="session-child",
+            session_name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            status="running",
+        )
+        host_request = AsyncMock(
+            return_value={
+                "subagent": {
+                    "rlm_child_id": subagent.rlm_child_id,
+                    "active_session_id": subagent.active_session_id,
+                    "session_id": subagent.session_id,
+                    "session_name": subagent.session_name,
+                    "session_dir": str(subagent.session_dir),
+                    "status": subagent.status,
+                }
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            asyncio.run(rlm_module.delete_subagent(subagent))
+
+        host_request.assert_awaited_once_with(
+            "rlm.delete_subagent",
+            {"target": "sub-a1b2c3d4"},
+        )
+
+    def test_rejects_invalid_delete_response_and_target(self) -> None:
+        host_request = AsyncMock(return_value={"subagent": {"status": "completed"}})
+
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "rlm.delete_subagent entry is missing rlm_child_id"):
+                asyncio.run(rlm_module.delete_subagent("api-reviewer"))
+
+        with self.assertRaisesRegex(ValueError, "target must not be empty"):
+            asyncio.run(rlm_module.delete_subagent("   "))
+        with self.assertRaisesRegex(TypeError, "target must be str or RLMSubagent"):
+            asyncio.run(rlm_module.delete_subagent(123))
+
+    def test_rejects_invalid_registry_payload(self) -> None:
+        host_request = AsyncMock(return_value={"subagents": [{"status": "completed"}]})
+
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "missing rlm_child_id"):
+                asyncio.run(rlm_module.list_subagents())
+
+    def test_requires_a_default_session_name(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "subagents": [
+                    {
+                        "rlm_child_id": "sub-a1b2c3d4",
+                        "active_session_id": None,
+                        "session_id": "session-child",
+                        "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                        "status": "running",
+                    }
+                ]
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "missing session_name"):
+                asyncio.run(rlm_module.list_subagents())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix Ghostty Kitty placement by emitting inline images on the first reserved row, avoiding the old cursor-up/down shim that created the blank gap locally
- allow Ghostty first-row image blocks to render inside fullscreen mode while following, while scrolling history, and when partially clipped at the top or bottom by resizing the placement to the visible row count
- clear all changed fullscreen rows before drawing any frame content, so reserved image rows cannot erase the image that was just drawn
- delete all stale fullscreen Kitty image ids before drawing any new frame rows, so moved or sequential images are not deleted after being redrawn
- render only the latest historical image tool result on resume, so image-heavy sessions do not replay every old image but the current visual context still appears
- fix a worker crash found while investigating image-heavy sessions: concurrent file-backed snapshot transcript caches with the same snapshot id now use isolated backing directories, so one streamed snapshot cannot dispose another reader's chunks
- make best-effort UI image conversion catch failures instead of allowing an unhandled rejection from display-only work

## Testing
- npm --prefix packages/tui test -- fullscreen.test.ts terminal-image.test.ts
- npm --prefix packages/coding-agent test -- snapshot-transcript-cache.test.ts tool-execution-component.test.ts marquee-components.test.ts interactive-mode-status.test.ts
- npm --prefix packages/tui run build
- npm --prefix packages/coding-agent run build

## Manual verification / diagnosis
- verified raw Kitty graphics render in local Ghostty 1.3.1
- verified Prime Agent replay in an isolated debug session renders the RGB image inline in fullscreen with no placeholder and no giant blank gap
- verified fullscreen scroll path deletes stale image ids before redraw and re-emits scrolled images
- verified bottom-clipped, top-clipped, and multiple same-frame Ghostty images use inline rendering instead of the placeholder path
- verified sequential image updates draw both the moved first image and the new second image, with deletes ordered before all draws
- inspected local daemon/worker logs and found repeated worker restarts from `SnapshotTranscriptCache.readChunk()` ENOENT under `~/.prime/agent/worker-snapshot-cache/.../*.jsonl`; the new cache-isolation regression covers that failure mode
- debug run used isolated state under /tmp/prime-agent-image-debug and did not touch the default Prime Agent daemon/sessions

## Stack note
This branch is currently stacked on the retained-subagent branch, so GitHub/Macroscope may show those base commits until the stack is rebased or the base PR merges.
