### PR TITLE
keep edit diffs visible in collapsed mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Changed wrapped diff rows to use a blank hanging gutter.
 - Fixed team-gated Prime Inference routes being missing from model selectors by merging the authenticated team catalog during model refresh ([ENG-4645](https://linear.app/primeintellect/issue/ENG-4645/internalglm-52-fast-isnt-working)).
 - Added confirmation when fullscreen text selection copies to the clipboard ([ENG-4644](https://linear.app/primeintellect/issue/ENG-4644/copy-issues)).
-- Added compact file change stats to collapsed tool calls and an agent-run edit total above the recap.
+- Added an agent-run edit total above the recap.
+- Changed edit tool calls to always show full diffs while keeping IPython source collapsed until Ctrl+O expands it.
 - Changed tool expansion hints to appear only on the latest tool row instead of every tool call ([ENG-4583](https://linear.app/primeintellect/issue/ENG-4583/too-many-ctrlo-alerts)).
 - Changed IPython kernels to set `NO_COLOR=1`, preventing ANSI color escapes from inflating `%%bash` output.
 - Fixed update restarts starting concurrent daemon supervisors or unlinking a replacement supervisor's socket ([ENG-4600](https://linear.app/primeintellect/issue/ENG-4600/prevent-concurrent-daemon-supervisors-after-update-restart)).

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -4,7 +4,6 @@ import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { type Static, Type } from "typebox";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
-import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import {
 	applyEditsToNormalizedContent,
@@ -252,25 +251,14 @@ function buildEditCallComponent(
 	component: EditCallRenderComponent,
 	args: RenderableEditArgs | undefined,
 	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
-	expanded: boolean,
-	showExpandHint: boolean,
 ): EditCallRenderComponent {
 	component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
 	component.clear();
-	const canExpand = component.preview !== undefined && !("error" in component.preview);
-	const expandHint =
-		canExpand && showExpandHint
-			? `${theme.fg("dim", " · ")}${keyHint("app.tools.expand", expanded ? "to collapse" : "to expand")}`
-			: "";
-	component.addChild(new Text(`${formatEditCall(args, theme)}${expandHint}`, 0, 0));
+	component.addChild(new Text(formatEditCall(args, theme), 0, 0));
 
 	const body =
 		component.preview &&
-		("error" in component.preview
-			? theme.fg("error", component.preview.error)
-			: expanded
-				? renderDiff(component.preview.diff)
-				: undefined);
+		("error" in component.preview ? theme.fg("error", component.preview.error) : renderDiff(component.preview.diff));
 	if (body) {
 		component.addChild(new Spacer(1));
 		component.addChild(new Text(body, 0, 0));
@@ -449,7 +437,7 @@ export function createEditToolDefinition(
 				});
 			}
 
-			return buildEditCallComponent(component, args, theme, context.expanded, context.showExpandHint !== false);
+			return buildEditCallComponent(component, args, theme);
 		},
 		renderResult(result, _options, theme, context) {
 			const callComponent = context.state.callComponent;
@@ -474,13 +462,7 @@ export function createEditToolDefinition(
 					changed = true;
 				}
 				if (changed) {
-					buildEditCallComponent(
-						callComponent,
-						context.args as RenderableEditArgs | undefined,
-						theme,
-						context.expanded,
-						context.showExpandHint !== false,
-					);
+					buildEditCallComponent(callComponent, context.args as RenderableEditArgs | undefined, theme);
 				}
 			}
 

--- a/packages/coding-agent/src/modes/interactive/components/edit-summary.ts
+++ b/packages/coding-agent/src/modes/interactive/components/edit-summary.ts
@@ -1,12 +1,10 @@
-import { isAbsolute } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
-import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { EditToolDetails } from "../../../core/tools/edit.js";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import type { IpythonToolDetails } from "../../../core/tools/ipython.js";
 import { resolveToCwd } from "../../../core/tools/path-utils.js";
-import { canonicalizePath, formatPathRelativeToCwdOrAbsolute } from "../../../utils/paths.js";
+import { canonicalizePath } from "../../../utils/paths.js";
 import { theme } from "../theme/theme.js";
 
 export interface FileChangeSummary {
@@ -14,8 +12,6 @@ export interface FileChangeSummary {
 	added: number;
 	removed: number;
 }
-
-const FILE_SUMMARY_LIMIT = 5;
 
 function countChangedLines(diff: string): { added: number; removed: number } {
 	let added = 0;
@@ -37,15 +33,6 @@ function mergeFileChange(target: Map<string, FileChangeSummary>, change: FileCha
 	} else {
 		target.set(key, { ...change });
 	}
-}
-
-function formatFileChangePath(path: string, cwd: string): string {
-	const resolvedPath = resolveToCwd(path, cwd);
-	const lexicalPath = formatPathRelativeToCwdOrAbsolute(resolvedPath, cwd);
-	if (!isAbsolute(lexicalPath)) {
-		return lexicalPath;
-	}
-	return formatPathRelativeToCwdOrAbsolute(canonicalizePath(resolvedPath), canonicalizePath(cwd));
 }
 
 export function getToolFileChanges(
@@ -92,42 +79,6 @@ export function mergeTurnFileChanges(
 
 function counts(change: Pick<FileChangeSummary, "added" | "removed">): string {
 	return `${theme.fg("toolDiffAdded", `+${change.added}`)} ${theme.fg("toolDiffRemoved", `-${change.removed}`)}`;
-}
-
-export class FileChangeSummaryComponent implements Component {
-	constructor(
-		private readonly changes: readonly FileChangeSummary[],
-		private readonly cwd: string,
-	) {}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(1, width);
-		const prefix = theme.fg("dim", "    ╰─ ");
-		const shown = this.changes.slice(0, FILE_SUMMARY_LIMIT).map((change) => {
-			const suffix = `${theme.fg("dim", " ")}${counts(change)}`;
-			const available = Math.max(1, safeWidth - visibleWidth(prefix) - visibleWidth(suffix));
-			const path = truncateToWidth(formatFileChangePath(change.path, this.cwd), available, "…");
-			return truncateToWidth(`${prefix}${theme.fg("muted", path)}${suffix}`, safeWidth, "");
-		});
-		if (this.changes.length > FILE_SUMMARY_LIMIT) {
-			const hidden = this.changes.slice(FILE_SUMMARY_LIMIT);
-			const hiddenTotals = hidden.reduce(
-				(sum, change) => ({ added: sum.added + change.added, removed: sum.removed + change.removed }),
-				{ added: 0, removed: 0 },
-			);
-			const files = `${hidden.length} more file${hidden.length === 1 ? "" : "s"}`;
-			shown.push(
-				truncateToWidth(
-					`${prefix}${theme.fg("muted", `[${files}`)}${theme.fg("dim", " ")}${counts(hiddenTotals)}${theme.fg("muted", "]")}`,
-					safeWidth,
-					"",
-				),
-			);
-		}
-		return shown;
-	}
-
-	invalidate(): void {}
 }
 
 export function formatTotalChangeSummary(changes: readonly FileChangeSummary[]): string {

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -358,8 +358,8 @@ export class IPythonCellComponent implements Component {
 		// Cached by state version so unrelated repaints don't re-render (flicker).
 		const lines = [truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "")];
 
-		const hasDiffs = (details.diffs?.length ?? 0) > 0;
-		if (hasDiffs && this.state.expanded) {
+		const hasCode = this.state.expanded ? this.renderCode(lines, safeWidth) : false;
+		if ((details.diffs?.length ?? 0) > 0) {
 			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
 		}
 		if ((details.sentAgentMessages?.length ?? 0) > 0) {
@@ -370,7 +370,6 @@ export class IPythonCellComponent implements Component {
 			return this.renderCache.set(safeWidth, cacheVersion, lines);
 		}
 
-		const hasCode = this.renderCode(lines, safeWidth);
 		this.renderOutput(lines, safeWidth, details, hasCode);
 		return this.renderCache.set(safeWidth, cacheVersion, lines);
 	}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -10,7 +10,6 @@ import { convertToPng } from "../../../utils/image-convert.js";
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
 import { type Theme, theme } from "../theme/theme.js";
 import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
-import { FileChangeSummaryComponent, getToolFileChanges } from "./edit-summary.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
 import { ToolPanel } from "./tool-panel.js";
 
@@ -447,18 +446,6 @@ export class ToolExecutionComponent extends Container {
 					this.imageComponents.push(imageComponent);
 					this.addChild(imageComponent);
 				}
-			}
-		}
-
-		const isBuiltInEdit =
-			this.toolName === "edit" &&
-			(this.toolDefinition === undefined || this.toolDefinition.replayBuiltInToolName === "edit");
-		if (!this.expanded && this.result && (isBuiltInEdit || this.shouldUseIpythonRenderer())) {
-			const changes = getToolFileChanges(this.toolName, this.args, this.result, this.cwd);
-			if (changes.length > 0) {
-				const container = this.usesSelfRenderShell() ? this.selfRenderContainer : this.contentPanel;
-				container.addChild(new FileChangeSummaryComponent(changes, this.cwd));
-				hasContent = true;
 			}
 		}
 

--- a/packages/coding-agent/test/edit-summary.test.ts
+++ b/packages/coding-agent/test/edit-summary.test.ts
@@ -5,7 +5,6 @@ import type { AssistantMessage, ToolResultMessage, Usage } from "@earendil-works
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test } from "vitest";
 import {
-	FileChangeSummaryComponent,
 	formatTotalChangeSummary,
 	getToolFileChanges,
 	mergeTurnFileChanges,
@@ -61,19 +60,6 @@ describe("edit summaries", () => {
 		).toEqual([{ path: "b.ts", added: 1, removed: 1 }]);
 	});
 
-	test("limits a collapsed tool summary to five files plus hidden totals", () => {
-		const changes = Array.from({ length: 7 }, (_, index) => ({
-			path: `src/${index}.ts`,
-			added: index + 1,
-			removed: 1,
-		}));
-		const lines = new FileChangeSummaryComponent(changes, "/tmp").render(80).map(stripAnsi);
-		expect(lines).toHaveLength(6);
-		expect(lines[0]).toBe("    ╰─ src/0.ts +1 -1");
-		expect(lines[4]).toBe("    ╰─ src/4.ts +5 -1");
-		expect(lines[5]).toBe("    ╰─ [2 more files +13 -2]");
-	});
-
 	test("renders one total line for all changed files in an agent run", () => {
 		const line = formatTotalChangeSummary([
 			{ path: "a.ts", added: 2, removed: 1 },
@@ -119,7 +105,7 @@ describe("edit summaries", () => {
 		expect([...changes.values()]).toEqual([{ path: "~/same.ts", added: 2, removed: 2 }]);
 	});
 
-	test("coalesces canonical paths and renders them relative to a symlinked cwd", () => {
+	test("coalesces canonical paths across a symlinked cwd", () => {
 		const root = mkdtempSync(join(tmpdir(), "edit-summary-symlink-"));
 		try {
 			const realCwd = join(root, "real");
@@ -145,8 +131,6 @@ describe("edit summaries", () => {
 			);
 
 			expect([...changes.values()]).toEqual([{ path: realpathSync(file), added: 2, removed: 2 }]);
-			const lines = new FileChangeSummaryComponent([...changes.values()], linkedCwd).render(80).map(stripAnsi);
-			expect(lines).toEqual(["    ╰─ same.ts +2 -2"]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -201,7 +201,7 @@ describe("IPythonCellComponent diff rendering", () => {
 		expect(addedRows.slice(1).every((line) => !line.includes("+"))).toBe(true);
 	});
 
-	it("separates the diff from the summary line with a blank line", () => {
+	it("renders expanded source before the always-visible diff", () => {
 		const out = renderCell({
 			code: "await edit(...)",
 			details: { status: "ok", durationMs: 4, diffs: [{ path: "a.ts", oldStr: "x", newStr: "X", startLine: 1 }] },
@@ -211,10 +211,11 @@ describe("IPythonCellComponent diff rendering", () => {
 		}).split("\n");
 		expect(out[0]).toContain("to collapse");
 		expect(out[1].trim()).toBe("");
-		expect(out[2]).toContain("a.ts");
+		expect(out[2]).toContain("await edit(...)");
+		expect(out.findIndex((line) => line.includes("a.ts"))).toBeGreaterThan(2);
 	});
 
-	it("hides the full diff when collapsed", () => {
+	it("shows the full diff when collapsed", () => {
 		const collapsed = renderCell({
 			code: "await edit(...)",
 			details: { status: "ok", diffs: [{ path: "big.py", oldStr: "old", newStr: "NEW", startLine: 1 }] },
@@ -223,8 +224,9 @@ describe("IPythonCellComponent diff rendering", () => {
 			expanded: false,
 		});
 		expect(collapsed).toContain("to expand");
-		expect(collapsed).not.toContain("big.py");
-		expect(collapsed).not.toContain("NEW");
+		expect(collapsed).toContain("big.py");
+		expect(collapsed).toContain("old");
+		expect(collapsed).toContain("NEW");
 	});
 
 	it("hides edit source when collapsed and shows it when globally expanded", () => {
@@ -238,8 +240,13 @@ describe("IPythonCellComponent diff rendering", () => {
 		const expanded = renderCell({ ...state, expanded: true });
 
 		expect(collapsed).not.toContain("hidden_side_effect");
+		expect(collapsed).toContain("a.py");
 		expect(expanded).toContain('hidden_side_effect = "only in full source"');
 		expect(expanded).toContain("a.py");
+		const expandedLines = expanded.split("\n");
+		expect(expandedLines.findIndex((line) => line.includes("hidden_side_effect ="))).toBeLessThan(
+			expandedLines.findIndex((line) => /✓ a\.py\s+\+1 -1/.test(line)),
+		);
 	});
 
 	it("keeps non-edit cells collapsed to a single summary line", () => {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -598,16 +598,22 @@ describe("ToolExecutionComponent parity", () => {
 
 		const collapsed = stripAnsi(component.render(120).join("\n"));
 		expect(collapsed).not.toContain("hidden_side_effect");
-		expect(collapsed).toContain("README.md +1 -1");
+		expect(collapsed).toMatch(/✓ README\.md\s+\+1 -1/);
+		expect(collapsed).toMatch(/1 - before/);
+		expect(collapsed).toMatch(/1 \+ after/);
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(120).join("\n"));
 		expect(expanded).toContain('hidden_side_effect = "only in full source"');
 		expect(expanded).toContain("before");
 		expect(expanded).toContain("after");
+		const expandedLines = expanded.split("\n");
+		expect(expandedLines.findIndex((line) => line.includes("hidden_side_effect ="))).toBeLessThan(
+			expandedLines.findIndex((line) => /✓ README\.md\s+\+1 -1/.test(line)),
+		);
 	});
 
-	test("collapses built-in edit diffs to a one-line file stat", () => {
+	test("always renders built-in edit diffs", () => {
 		const component = new ToolExecutionComponent(
 			"edit",
 			"tool-collapsed-edit",
@@ -624,20 +630,13 @@ describe("ToolExecutionComponent parity", () => {
 		);
 
 		const collapsed = stripAnsi(component.render(120).join("\n"));
-		expect(collapsed).toContain("╰─ README.md +1 -1");
-		expect(collapsed).toContain("to expand");
-		expect(collapsed).not.toContain("before");
-		expect(collapsed).not.toContain("after");
+		expect(collapsed).toContain("before");
+		expect(collapsed).toContain("after");
+		expect(collapsed).not.toContain("╰─ README.md +1 -1");
+		expect(collapsed).not.toContain("to expand");
 
-		component.setShowExpandHint(false);
-		expect(stripAnsi(component.render(120).join("\n"))).not.toContain("to expand");
-
-		component.setShowExpandHint(true);
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(120).join("\n"));
-		expect(expanded).toContain("before");
-		expect(expanded).toContain("after");
-		expect(expanded).toContain("to collapse");
-		expect(expanded).not.toContain("README.md +1 -1");
+		expect(expanded).toBe(collapsed);
 	});
 });


### PR DESCRIPTION
- edit diffs now remain fully visible in both collapsed and expanded tool views.
- ipython edit calls keep source collapsed until ctrl+o reveals it above the diff.
- obsolete compact per-tool summaries were removed while preserving the recap edit total.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only presentation changes for tool and IPython rendering; no changes to edit execution, file I/O, or session logic.
> 
> **Overview**
> **Edit diffs stay visible** in the interactive TUI instead of hiding behind expand/collapse. The built-in **edit** tool always renders the full unified diff in the call/result view and no longer shows Ctrl+O expand hints for the diff body.
> 
> **IPython edit cells** follow a split rule: file **diffs are always shown** (collapsed or expanded), while **cell source** stays hidden until global expand (Ctrl+O). When expanded, source appears **above** the diff.
> 
> **Collapsed per-tool file summaries** (`╰─ path +n -m` under edit/IPython rows) are **removed** from `ToolExecutionComponent`. Run-level aggregation (`getToolFileChanges`, `mergeTurnFileChanges`) is unchanged; the **agent-run edit total** above the recap (`formatTotalChangeSummary`) remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981c5db6c9c122e89e2b6ef4364e8e7c0dce6eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep edit diffs visible in collapsed tool call rows
> - Edit tool calls in [edit.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/428/files#diff-64402f2abfe7a1c0c56ebb951df914be2717f2dd36237d9201c353067d40d87a) now always render the full diff preview regardless of expanded state; the expand/collapse hint and `expanded`/`showExpandHint` parameters are removed from `buildEditCallComponent`.
> - IPython cell rows in [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/428/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) also always show diffs when collapsed; when expanded, source code renders before the diff.
> - The `FileChangeSummaryComponent` (per-file +/− summary injected into collapsed tool rows) is removed from [edit-summary.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/428/files#diff-cade1f5aed8ea0721ac6b97b32304ba7255a570d289b8e1dee03e85057da323f) and [tool-execution.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/428/files#diff-21ea0d0f595d9f9cf9801e771170bcf8d1b06e81a2bc4bdd05a50eab6c3f849b).
> - Behavioral Change: collapsed edit and IPython tool calls now show full diffs instead of a compact one-line file summary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 981c5db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->