### PR TITLE
keep agents view session order stable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the Agents View reordering sessions whenever prompts or heartbeats updated their activity timestamps ([ENG-4650](https://linear.app/primeintellect/issue/ENG-4650/agents-view-shifts-session-list-constantly)).
 - Fixed unsupported Node versions crashing before startup by requiring Node 22.8.0 or newer and showing upgrade guidance before loading the CLI ([ENG-4260](https://linear.app/primeintellect/issue/ENG-4260/incorrect-node-version-breaks-first-launch)).
 - Added `@` file-path autocomplete to new-agent and reply prompts in the Agents View.
 - Added a combined heartbeat indicator and manager for pausing, resuming, or stopping user and agent heartbeats ([ENG-4536](https://linear.app/primeintellect/issue/ENG-4536/add-heartbeat-observability-and-management-ui)).

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -281,11 +281,15 @@ function compareAgentsViewRows(a: AgentsViewRow, b: AgentsViewRow): number {
 	if (sectionDiff !== 0) {
 		return sectionDiff;
 	}
-	const modifiedDiff = getTimestamp(b.summary.modified) - getTimestamp(a.summary.modified);
-	if (modifiedDiff !== 0) {
-		return modifiedDiff;
+	const createdDiff = getTimestamp(b.summary.created) - getTimestamp(a.summary.created);
+	if (createdDiff !== 0) {
+		return createdDiff;
 	}
-	return a.title.localeCompare(b.title);
+	const titleDiff = a.title.localeCompare(b.title);
+	if (titleDiff !== 0) {
+		return titleDiff;
+	}
+	return a.summary.sessionId.localeCompare(b.summary.sessionId);
 }
 
 function buildRowKeyMap(rows: readonly MutableAgentsViewRow[]): Map<string, MutableAgentsViewRow> {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -62,31 +62,75 @@ describe("agents view state", () => {
 		expect(classifyAgentsViewSession(makeSummary({ activity: "idle", taskState: undefined }))).toBe("needs-input");
 	});
 
-	test("sorts rows by section and most recent modified time", () => {
+	test("sorts rows by section and creation time", () => {
 		const rows = buildAgentsViewRows([
 			makeSummary({
+				id: "completed",
+				sessionId: "completed",
 				sessionName: "completed",
 				activity: "idle",
 				taskState: "completed",
 				messageCount: 2,
-				modified: "2026-01-01T00:00:00Z",
+				created: "2026-01-03T00:00:00Z",
 			}),
 			makeSummary({
+				id: "older-working",
+				sessionId: "older-working",
 				sessionName: "older working",
 				activity: "working",
 				isStreaming: true,
-				modified: "2026-01-01T00:00:00Z",
+				created: "2026-01-01T00:00:00Z",
 			}),
 			makeSummary({
+				id: "newer-working",
+				sessionId: "newer-working",
 				sessionName: "newer working",
 				activity: "working",
 				isStreaming: true,
-				modified: "2026-01-02T00:00:00Z",
+				created: "2026-01-02T00:00:00Z",
 			}),
 		]);
 
 		expect(rows.map((row) => row.title)).toEqual(["newer working", "older working", "completed"]);
 		expect(rows.map((row) => row.section)).toEqual(["working", "working", "completed"]);
+	});
+
+	test("keeps row order stable when modification times and daemon input order change", () => {
+		const older = makeSummary({
+			id: "older",
+			sessionId: "older",
+			sessionName: "older",
+			activity: "working",
+			created: "2026-01-01T00:00:00Z",
+			modified: "2026-01-04T00:00:00Z",
+		});
+		const newer = makeSummary({
+			id: "newer",
+			sessionId: "newer",
+			sessionName: "newer",
+			activity: "working",
+			created: "2026-01-02T00:00:00Z",
+			modified: "2026-01-03T00:00:00Z",
+		});
+
+		const initialOrder = buildAgentsViewRows([older, newer]).map((row) => row.summary.sessionId);
+		const refreshedOrder = buildAgentsViewRows([
+			{ ...newer, modified: "2026-01-05T00:00:00Z" },
+			{ ...older, modified: "2026-01-06T00:00:00Z" },
+		]).map((row) => row.summary.sessionId);
+
+		expect(initialOrder).toEqual(["newer", "older"]);
+		expect(refreshedOrder).toEqual(initialOrder);
+	});
+
+	test("uses deterministic fallbacks when creation times are unavailable", () => {
+		const rows = buildAgentsViewRows([
+			makeSummary({ id: "beta-2", sessionId: "beta-2", sessionName: "beta", modified: "2026-01-03T00:00:00Z" }),
+			makeSummary({ id: "alpha", sessionId: "alpha", sessionName: "alpha", modified: "2026-01-02T00:00:00Z" }),
+			makeSummary({ id: "beta-1", sessionId: "beta-1", sessionName: "beta", modified: "2026-01-01T00:00:00Z" }),
+		]);
+
+		expect(rows.map((row) => row.summary.sessionId)).toEqual(["alpha", "beta-1", "beta-2"]);
 	});
 
 	test("summarizes subagents on their parent and omits subagent rows", () => {
@@ -712,14 +756,10 @@ printf 'src/referenced.ts\n'
 		const identity = `file:${opened.sessionFile}`;
 		const key = getAgentsViewSelectionKey(opened);
 
-		test("re-finds the session after the list reorders", () => {
-			// Returning bumps the opened session's modified time so it sorts first.
-			const rows = buildAgentsViewRows([
-				{ ...opened, modified: "2026-01-02T00:00:00Z" },
-				{ ...other, modified: "2026-01-01T00:00:00Z" },
-			]);
-			expect(rows[0]?.summary.sessionId).toBe("session-open");
-			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(0);
+		test("re-finds the session after a section change reorders the list", () => {
+			const rows = buildAgentsViewRows([{ ...opened, activity: "working" }, other]);
+			expect(rows[1]?.summary.sessionId).toBe("session-open");
+			expect(resolveAgentsViewSelectionIndex(rows, identity, key)).toBe(1);
 		});
 
 		test("falls back to activeSessionId when the row identity changed", () => {


### PR DESCRIPTION
- prompt and heartbeat activity updates no longer reorder agents within the same section.
- creation time and deterministic fallbacks keep refreshed session lists stable.
- section transitions remain unchanged and compose with the heartbeat section from #440.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Agents View row comparison and tests; no auth, daemon protocol, or session persistence impact.
> 
> **Overview**
> Fixes **Agents View** sessions jumping around when prompts or heartbeats bump `modified` timestamps.
> 
> Within each section, row order now sorts by **creation time** (newest first) instead of last modified. **Title** and **`sessionId`** tiebreakers keep ordering deterministic when creation time is missing or equal. Section grouping (Working, Heartbeats, etc.) is unchanged—only intra-section order is stable on refresh.
> 
> Tests cover unchanged order across modified-time updates, creation-based sorting, and selection resolution when sections reorder rather than modified-time bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4f2f355add183131439115ae26919adce52f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Agents View session order to sort by creation time instead of modified time
> - Changes `compareAgentsViewRows` in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/446/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1) to sort by creation timestamp (descending) after section rank, replacing the previous sort by last-modified time.
> - Adds deterministic tiebreakers by title then `sessionId` to prevent reordering when two sessions share the same creation time.
> - Behavioral Change: sessions no longer reorder in the Agents View when prompt or heartbeat updates change their activity timestamps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd4f2f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->