### PR TITLE
prevent repeated r2 release uploads

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Resolve release context
@@ -58,7 +59,7 @@ jobs:
             version=$(node -p "require('./package.json').version")
             release_tag="v${version}"
             build_ref="$GITHUB_SHA_VALUE"
-            if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            if git show-ref --verify --quiet "refs/tags/${release_tag}"; then
               echo "Tag ${release_tag} already exists; skipping release."
               should_release=false
             fi


### PR DESCRIPTION
- release runs published existing versions after every main commit because the remote tag lookup lacked credentials.
- fetch release tags during checkout and check local refs while keeping stored git credentials disabled.
- ordinary main commits now skip publishing when the version tag already exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release gating logic; no application runtime or credential handling changes beyond making tag detection reliable with disabled stored credentials.
> 
> **Overview**
> Stops **Release Prime Agent** from re-publishing the same semver on every push to `main` when the version tag is already on the remote.
> 
> The **release-context** job now enables **`fetch-tags: true`** on checkout (with **`persist-credentials: false`** unchanged) so tags are available in the runner clone. For branch pushes (not tag pushes), it replaces **`git ls-remote`** against `origin` with **`git show-ref --verify --quiet`** on **`refs/tags/${release_tag}`**, so the existing-tag check works without remote credentials and sets **`should_release=false`** when the tag is present—skipping build, GitHub release, and R2 upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18986e3d09e846d59c4c449db0af83dc072954c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix repeated R2 release uploads by checking tags via local refs
> The [build-binaries.yml](.github/workflows/build-binaries.yml) workflow was checking for existing release tags using `git ls-remote`, which queries the remote. It now fetches tags during checkout (`fetch-tags: true`) and uses `git show-ref --verify --quiet` to check local refs instead, ensuring the `should_release` guard works reliably.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d18986e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->