### PR TITLE
resume heartbeats after agent updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed the fullscreen follow shortcut from `Alt+Down` to `Ctrl+Shift+Down` for more reliable terminal input ([ENG-4684](https://linear.app/primeintellect/issue/ENG-4684/altdown-doesnt-work)).
+- Fixed active heartbeats not resuming after Prime Agent updates ([ENG-4657](https://linear.app/primeintellect/issue/ENG-4657/heartbeats-dont-survive-updatesdaemon-reboots)).
 - Fixed the Agents View reordering sessions whenever prompts or heartbeats updated their activity timestamps ([ENG-4650](https://linear.app/primeintellect/issue/ENG-4650/agents-view-shifts-session-list-constantly)).
 - Added parent-scoped subagent lifecycle APIs: create children with readable default or orchestrator-chosen names, recover running or completed children through `rlm.list_subagents()`, continue them through agent messaging, and close/remove them with `rlm.delete_subagent()`.
 - Changed shell commands to use discoverable agent, schedule, package, model, session, update, doctor, and full-shutdown verbs without exposing the background daemon hierarchy ([ENG-4538](https://linear.app/primeintellect/issue/ENG-4538/standardize-bash-command-conventions-and-improve-command-discovery)).

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -985,6 +985,7 @@ export class AgentDaemon {
 		}
 		if (this.cronStore.registerSessionArtifact(session.sessionId, artifactDir)) {
 			this.cronStore.recoverSessionArtifact(session.sessionId);
+			this.cronScheduler.wake();
 		}
 	}
 

--- a/packages/coding-agent/test/suite/regressions/4657-update-heartbeat-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4657-update-heartbeat-recovery.test.ts
@@ -1,0 +1,102 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.js";
+import { AgentCronJobStore, type AgentCronScheduler } from "../../../src/core/cron-jobs.js";
+import type { ActiveSessionState } from "../../../src/modes/daemon/active-session-state.js";
+import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
+import { createHarness, type Harness } from "../harness.js";
+
+type AgentDaemonCronInternals = {
+	sessions: Map<string, ActiveSessionState>;
+	cronStore: AgentCronJobStore;
+	cronScheduler: AgentCronScheduler;
+	registerCronStoreForState(state: ActiveSessionState): void;
+	rebindCronJobsToState(state: ActiveSessionState): void;
+};
+
+describe("ENG-4657 update heartbeat recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("runs an overdue heartbeat after an unchanged worker session is restored", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("heartbeat recovered")]);
+		const sessionFile = harness.session.sessionFile;
+		const artifactDir = harness.sessionManager.getSessionArtifactDir();
+		if (!sessionFile || !artifactDir) {
+			throw new Error("Test session was not persisted");
+		}
+
+		const activeSessionId = "restored-active";
+		const persistedStore = AgentCronJobStore.forSessionArtifacts();
+		persistedStore.registerSessionArtifact(harness.session.sessionId, artifactDir);
+		const heartbeat = persistedStore.createHeartbeat({
+			activeSessionId,
+			sessionId: harness.session.sessionId,
+			sessionFile,
+			cwd: harness.tempDir,
+			scheduleText: "every 10s",
+			prompt: "continue after the update",
+			now: new Date(Date.now() - 20_000),
+		});
+
+		const daemon = new AgentDaemon(`${harness.tempDir}/worker.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+			worker: { authenticationToken: "test-token", restoreActiveSessionId: activeSessionId },
+		});
+		const internals = daemon as unknown as AgentDaemonCronInternals;
+		const state: ActiveSessionState = {
+			activeSessionId,
+			runtime: {
+				session: harness.session,
+				metadata: { kind: "top-level", createdAt: Date.now() },
+				runtimeConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+				cwd: harness.tempDir,
+				diagnostics: [],
+				dispose: async () => {},
+			} as unknown as AgentSessionRuntime,
+			clients: new Set(),
+			extensionUiRequests: new Map(),
+			eventGeneration: "restored-generation",
+			lastEventSequence: 0,
+		};
+		internals.sessions.set(activeSessionId, state);
+		internals.cronScheduler.start();
+
+		try {
+			internals.registerCronStoreForState(state);
+			internals.rebindCronJobsToState(state);
+			await waitFor(() => internals.cronStore.list().find((job) => job.id === heartbeat.id)?.runCount === 1);
+
+			const recovered = internals.cronStore.list().find((job) => job.id === heartbeat.id);
+			expect(recovered).toMatchObject({
+				status: "active",
+				runCount: 1,
+				prompt: "continue after the update",
+			});
+			expect(Date.parse(recovered?.nextRunAt ?? "")).toBeGreaterThan(Date.now());
+		} finally {
+			internals.cronScheduler.stop();
+		}
+	});
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		if (predicate()) {
+			return;
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("Timed out waiting for the restored heartbeat");
+}


### PR DESCRIPTION
- worker schedulers now rearm when restored session artifacts expose persisted heartbeat jobs.
- overdue heartbeats coalesce into one immediate run and continue on a fresh schedule.
- added regression coverage for unchanged worker sessions restored across updates.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume overdue heartbeats after agent updates by waking the cron scheduler
> After recovering cron jobs for a session, `AgentDaemon.registerCronStoreForState` now calls `cronScheduler.wake()` so overdue jobs (e.g., heartbeats) run promptly instead of waiting for the next scheduled tick. A regression test in [4657-update-heartbeat-recovery.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/450/files#diff-01c4d52d66567b2772f46b7dd38a239d9a70f25d91013eee27316470a7b6d59b) verifies that an overdue heartbeat fires once and reschedules after store registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3d53ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->