### PR TITLE
add subtle feature hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed the fullscreen follow shortcut from `Alt+Down` to `Ctrl+Shift+Down` for more reliable terminal input ([ENG-4684](https://linear.app/primeintellect/issue/ENG-4684/altdown-doesnt-work)).
+- Added subtle feature hints to longer-running agent turns ([ENG-4521](https://linear.app/primeintellect/issue/ENG-4521/add-subtle-hints-for-new-prime-agent-features)).
 - Fixed the Agents View reordering sessions whenever prompts or heartbeats updated their activity timestamps ([ENG-4650](https://linear.app/primeintellect/issue/ENG-4650/agents-view-shifts-session-list-constantly)).
 - Added parent-scoped subagent lifecycle APIs: create children with readable default or orchestrator-chosen names, recover running or completed children through `rlm.list_subagents()`, continue them through agent messaging, and close/remove them with `rlm.delete_subagent()`.
 - Changed shell commands to use discoverable agent, schedule, package, model, session, update, doctor, and full-shutdown verbs without exposing the background daemon hierarchy ([ENG-4538](https://linear.app/primeintellect/issue/ENG-4538/standardize-bash-command-conventions-and-improve-command-discovery)).

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -1,9 +1,10 @@
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
 
-const HIGHLIGHT_WIDTH = 6;
+const SHIMMER_RADIUS = 4;
+const SHIMMER_CORE_RADIUS = 1;
 
-export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 120;
+export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 24;
 
 export class FeatureHintComponent implements Component {
 	private frame = 0;
@@ -21,18 +22,22 @@ export class FeatureHintComponent implements Component {
 		const availableWidth = Math.max(1, width - paddingX * 2);
 		const displayText = truncateToWidth(`Hint: ${this.text}`, availableWidth);
 		const characters = Array.from(displayText);
-		const highlightWidth = Math.min(HIGHLIGHT_WIDTH, characters.length);
-		const maxStart = Math.max(0, characters.length - highlightWidth);
-		const cycleLength = maxStart * 2;
+		const maxCenter = Math.max(0, characters.length - 1);
+		const cycleLength = maxCenter * 2;
 		const phase = cycleLength === 0 ? 0 : this.frame % cycleLength;
-		const highlightStart = phase <= maxStart ? phase : cycleLength - phase;
-		const highlightEnd = highlightStart + highlightWidth;
-		const before = characters.slice(0, highlightStart).join("");
-		const highlight = characters.slice(highlightStart, highlightEnd).join("");
-		const after = characters.slice(highlightEnd).join("");
-		const styledText = theme.fg("dim", before) + theme.fg("muted", highlight) + theme.fg("dim", after);
+		const center = phase <= maxCenter ? phase : cycleLength - phase;
+		const shimmerStart = Math.max(0, center - SHIMMER_RADIUS);
+		const coreStart = Math.max(shimmerStart, center - SHIMMER_CORE_RADIUS);
+		const coreEnd = Math.min(characters.length, center + SHIMMER_CORE_RADIUS + 1);
+		const shimmerEnd = Math.min(characters.length, center + SHIMMER_RADIUS + 1);
+		const styledText =
+			theme.fg("dim", characters.slice(0, shimmerStart).join("")) +
+			theme.fg("muted", characters.slice(shimmerStart, coreStart).join("")) +
+			theme.fg("text", characters.slice(coreStart, coreEnd).join("")) +
+			theme.fg("muted", characters.slice(coreEnd, shimmerEnd).join("")) +
+			theme.fg("dim", characters.slice(shimmerEnd).join(""));
 		const line = `${" ".repeat(paddingX)}${styledText}`;
 
-		return [line + " ".repeat(Math.max(0, width - visibleWidth(line)))];
+		return [line + " ".repeat(Math.max(0, width - visibleWidth(line))), " ".repeat(width)];
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -5,7 +5,7 @@ const LABEL = "Hint:";
 const SHIMMER_RADIUS = 1;
 const SHIMMER_PAUSE_FRAMES = 14;
 
-export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 120;
+export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 160;
 
 function renderLabelShimmer(characters: string[], frame: number): string {
 	if (characters.length === 0) return "";
@@ -38,7 +38,7 @@ export class FeatureHintComponent implements Component {
 		const characters = Array.from(displayText);
 		const labelLength = Math.min(LABEL.length, characters.length);
 		const label = renderLabelShimmer(characters.slice(0, labelLength), this.frame);
-		const hint = theme.fg("thinkingText", characters.slice(labelLength).join(""));
+		const hint = theme.fg("muted", characters.slice(labelLength).join(""));
 		const line = `${" ".repeat(paddingX)}${label}${hint}`;
 
 		return [line + " ".repeat(Math.max(0, width - visibleWidth(line))), " ".repeat(width)];

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -3,8 +3,47 @@ import { theme } from "../theme/theme.js";
 
 const SHIMMER_RADIUS = 4;
 const SHIMMER_CORE_RADIUS = 1;
+const SHIMMER_SPACING = 28;
 
 export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 24;
+
+type ShimmerColor = "dim" | "muted" | "text";
+
+function shimmerColor(index: number, length: number, frame: number): ShimmerColor {
+	const highlightCount = Math.min(3, Math.max(1, Math.ceil(length / SHIMMER_SPACING)));
+	const phase = frame % length;
+	let nearestDistance = length;
+
+	for (let highlight = 0; highlight < highlightCount; highlight++) {
+		const center = (phase + (highlight * length) / highlightCount) % length;
+		const distance = Math.abs(index - center);
+		nearestDistance = Math.min(nearestDistance, distance, length - distance);
+	}
+
+	if (nearestDistance <= SHIMMER_CORE_RADIUS) return "text";
+	if (nearestDistance <= SHIMMER_RADIUS) return "muted";
+	return "dim";
+}
+
+function renderShimmer(characters: string[], frame: number): string {
+	if (characters.length === 0) return "";
+
+	let output = "";
+	let run = "";
+	let runColor = shimmerColor(0, characters.length, frame);
+
+	for (let index = 0; index < characters.length; index++) {
+		const color = shimmerColor(index, characters.length, frame);
+		if (color !== runColor) {
+			output += theme.fg(runColor, run);
+			run = "";
+			runColor = color;
+		}
+		run += characters[index]!;
+	}
+
+	return output + theme.fg(runColor, run);
+}
 
 export class FeatureHintComponent implements Component {
 	private frame = 0;
@@ -22,21 +61,7 @@ export class FeatureHintComponent implements Component {
 		const availableWidth = Math.max(1, width - paddingX * 2);
 		const displayText = truncateToWidth(`Hint: ${this.text}`, availableWidth);
 		const characters = Array.from(displayText);
-		const maxCenter = Math.max(0, characters.length - 1);
-		const cycleLength = maxCenter * 2;
-		const phase = cycleLength === 0 ? 0 : this.frame % cycleLength;
-		const center = phase <= maxCenter ? phase : cycleLength - phase;
-		const shimmerStart = Math.max(0, center - SHIMMER_RADIUS);
-		const coreStart = Math.max(shimmerStart, center - SHIMMER_CORE_RADIUS);
-		const coreEnd = Math.min(characters.length, center + SHIMMER_CORE_RADIUS + 1);
-		const shimmerEnd = Math.min(characters.length, center + SHIMMER_RADIUS + 1);
-		const styledText =
-			theme.fg("dim", characters.slice(0, shimmerStart).join("")) +
-			theme.fg("muted", characters.slice(shimmerStart, coreStart).join("")) +
-			theme.fg("text", characters.slice(coreStart, coreEnd).join("")) +
-			theme.fg("muted", characters.slice(coreEnd, shimmerEnd).join("")) +
-			theme.fg("dim", characters.slice(shimmerEnd).join(""));
-		const line = `${" ".repeat(paddingX)}${styledText}`;
+		const line = `${" ".repeat(paddingX)}${renderShimmer(characters, this.frame)}`;
 
 		return [line + " ".repeat(Math.max(0, width - visibleWidth(line))), " ".repeat(width)];
 	}

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -1,0 +1,38 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+
+const HIGHLIGHT_WIDTH = 6;
+
+export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 120;
+
+export class FeatureHintComponent implements Component {
+	private frame = 0;
+
+	constructor(private readonly text: string) {}
+
+	advance(): void {
+		this.frame++;
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const paddingX = width > 2 ? 1 : 0;
+		const availableWidth = Math.max(1, width - paddingX * 2);
+		const displayText = truncateToWidth(`Hint: ${this.text}`, availableWidth);
+		const characters = Array.from(displayText);
+		const highlightWidth = Math.min(HIGHLIGHT_WIDTH, characters.length);
+		const maxStart = Math.max(0, characters.length - highlightWidth);
+		const cycleLength = maxStart * 2;
+		const phase = cycleLength === 0 ? 0 : this.frame % cycleLength;
+		const highlightStart = phase <= maxStart ? phase : cycleLength - phase;
+		const highlightEnd = highlightStart + highlightWidth;
+		const before = characters.slice(0, highlightStart).join("");
+		const highlight = characters.slice(highlightStart, highlightEnd).join("");
+		const after = characters.slice(highlightEnd).join("");
+		const styledText = theme.fg("dim", before) + theme.fg("muted", highlight) + theme.fg("dim", after);
+		const line = `${" ".repeat(paddingX)}${styledText}`;
+
+		return [line + " ".repeat(Math.max(0, width - visibleWidth(line)))];
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -1,48 +1,21 @@
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
 
-const SHIMMER_RADIUS = 4;
-const SHIMMER_CORE_RADIUS = 1;
-const SHIMMER_SPACING = 28;
+const LABEL = "Hint:";
+const SHIMMER_RADIUS = 1;
+const SHIMMER_PAUSE_FRAMES = 14;
 
-export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 24;
+export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 80;
 
-type ShimmerColor = "dim" | "muted" | "text";
-
-function shimmerColor(index: number, length: number, frame: number): ShimmerColor {
-	const highlightCount = Math.min(3, Math.max(1, Math.ceil(length / SHIMMER_SPACING)));
-	const phase = frame % length;
-	let nearestDistance = length;
-
-	for (let highlight = 0; highlight < highlightCount; highlight++) {
-		const center = (phase + (highlight * length) / highlightCount) % length;
-		const distance = Math.abs(index - center);
-		nearestDistance = Math.min(nearestDistance, distance, length - distance);
-	}
-
-	if (nearestDistance <= SHIMMER_CORE_RADIUS) return "text";
-	if (nearestDistance <= SHIMMER_RADIUS) return "muted";
-	return "dim";
-}
-
-function renderShimmer(characters: string[], frame: number): string {
+function renderLabelShimmer(characters: string[], frame: number): string {
 	if (characters.length === 0) return "";
 
-	let output = "";
-	let run = "";
-	let runColor = shimmerColor(0, characters.length, frame);
-
-	for (let index = 0; index < characters.length; index++) {
-		const color = shimmerColor(index, characters.length, frame);
-		if (color !== runColor) {
-			output += theme.fg(runColor, run);
-			run = "";
-			runColor = color;
-		}
-		run += characters[index]!;
-	}
-
-	return output + theme.fg(runColor, run);
+	const travelFrames = characters.length + SHIMMER_RADIUS * 2;
+	const phase = frame % (travelFrames + SHIMMER_PAUSE_FRAMES);
+	const center = phase - SHIMMER_RADIUS;
+	return characters
+		.map((character, index) => theme.fg(Math.abs(index - center) <= SHIMMER_RADIUS ? "muted" : "dim", character))
+		.join("");
 }
 
 export class FeatureHintComponent implements Component {
@@ -59,9 +32,12 @@ export class FeatureHintComponent implements Component {
 	render(width: number): string[] {
 		const paddingX = width > 2 ? 1 : 0;
 		const availableWidth = Math.max(1, width - paddingX * 2);
-		const displayText = truncateToWidth(`Hint: ${this.text}`, availableWidth);
+		const displayText = truncateToWidth(`${LABEL} ${this.text}`, availableWidth);
 		const characters = Array.from(displayText);
-		const line = `${" ".repeat(paddingX)}${renderShimmer(characters, this.frame)}`;
+		const labelLength = Math.min(LABEL.length, characters.length);
+		const label = renderLabelShimmer(characters.slice(0, labelLength), this.frame);
+		const hint = theme.fg("dim", characters.slice(labelLength).join(""));
+		const line = `${" ".repeat(paddingX)}${label}${hint}`;
 
 		return [line + " ".repeat(Math.max(0, width - visibleWidth(line))), " ".repeat(width)];
 	}

--- a/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
+++ b/packages/coding-agent/src/modes/interactive/components/feature-hint.ts
@@ -5,7 +5,7 @@ const LABEL = "Hint:";
 const SHIMMER_RADIUS = 1;
 const SHIMMER_PAUSE_FRAMES = 14;
 
-export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 80;
+export const FEATURE_HINT_ANIMATION_INTERVAL_MS = 120;
 
 function renderLabelShimmer(characters: string[], frame: number): string {
 	if (characters.length === 0) return "";
@@ -14,7 +14,9 @@ function renderLabelShimmer(characters: string[], frame: number): string {
 	const phase = frame % (travelFrames + SHIMMER_PAUSE_FRAMES);
 	const center = phase - SHIMMER_RADIUS;
 	return characters
-		.map((character, index) => theme.fg(Math.abs(index - center) <= SHIMMER_RADIUS ? "muted" : "dim", character))
+		.map((character, index) =>
+			theme.fg(Math.abs(index - center) <= SHIMMER_RADIUS ? "muted" : "thinkingText", character),
+		)
 		.join("");
 }
 
@@ -36,7 +38,7 @@ export class FeatureHintComponent implements Component {
 		const characters = Array.from(displayText);
 		const labelLength = Math.min(LABEL.length, characters.length);
 		const label = renderLabelShimmer(characters.slice(0, labelLength), this.frame);
-		const hint = theme.fg("dim", characters.slice(labelLength).join(""));
+		const hint = theme.fg("thinkingText", characters.slice(labelLength).join(""));
 		const line = `${" ".repeat(paddingX)}${label}${hint}`;
 
 		return [line + " ".repeat(Math.max(0, width - visibleWidth(line))), " ".repeat(width)];

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -39,12 +39,33 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "subagents",
-		getText: ({ getKeybinding }) => {
-			const key = getKeybinding("app.subagents.focus");
-			return key
-				? `Ask Prime Agent to delegate independent work to subagents, then press ${key} to inspect them.`
-				: "Ask Prime Agent to delegate independent work to subagents.";
-		},
+		getText: () => "Ask Prime Agent to delegate independent work to subagents so tasks can run in parallel.",
+	},
+	{
+		id: "goal",
+		getText: () =>
+			"Use /goal <objective> to let Prime Agent keep working across turns until a longer-running outcome is complete.",
+	},
+	{
+		id: "refine",
+		getText: () =>
+			"Use /refine after a reusable discovery to update Prime Agent's local skills, memory, prompts, or subagents.",
+	},
+	{
+		id: "persistent-ipython",
+		getText: () => "Prime Agent's IPython kernel preserves variables and helpers across turns and compaction.",
+	},
+	{
+		id: "context-usage",
+		getText: () => "Use /context to inspect token, cost, and context usage across the agent and its subagents.",
+	},
+	{
+		id: "session-fork",
+		getText: () => "Use /fork to branch from an earlier prompt without losing the current session.",
+	},
+	{
+		id: "compaction",
+		getText: () => "Use /compact <instructions> to summarize older context around the details you want to preserve.",
 	},
 ] as const;
 

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -1,0 +1,83 @@
+import type { AppKeybinding } from "../../core/keybindings.js";
+
+export interface FeatureHintContext {
+	getKeybinding(action: AppKeybinding): string | undefined;
+}
+
+interface FeatureHintDefinition {
+	id: string;
+	getText(context: FeatureHintContext): string | undefined;
+}
+
+export interface FeatureHint {
+	id: string;
+	text: string;
+}
+
+export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
+	{
+		id: "side-question",
+		getText: () => "Use /btw <question> to ask a side question without changing the main session.",
+	},
+	{
+		id: "prompt-stash",
+		getText: ({ getKeybinding }) => {
+			const key = getKeybinding("app.prompt.stash");
+			return key ? `Press ${key} to stash a draft, run another prompt, and restore it afterward.` : undefined;
+		},
+	},
+	{
+		id: "follow-up",
+		getText: ({ getKeybinding }) => {
+			const key = getKeybinding("app.message.followUp");
+			return key ? `Press ${key} to queue a follow-up after the current work finishes.` : undefined;
+		},
+	},
+	{
+		id: "heartbeat",
+		getText: () => "Use /heartbeat every 10m <instruction> to schedule recurring agent work.",
+	},
+	{
+		id: "subagents",
+		getText: ({ getKeybinding }) => {
+			const key = getKeybinding("app.subagents.focus");
+			return key
+				? `Ask Prime Agent to delegate independent work to subagents, then press ${key} to inspect them.`
+				: "Ask Prime Agent to delegate independent work to subagents.";
+		},
+	},
+] as const;
+
+export class FeatureHintDeck {
+	private remaining: FeatureHint[] = [];
+	private previousId: string | undefined;
+
+	constructor(private readonly random: () => number = Math.random) {}
+
+	next(context: FeatureHintContext): FeatureHint | undefined {
+		if (this.remaining.length === 0) {
+			this.refill(context);
+		}
+		const hint = this.remaining.pop();
+		if (hint) {
+			this.previousId = hint.id;
+		}
+		return hint;
+	}
+
+	private refill(context: FeatureHintContext): void {
+		const hints = FEATURE_HINTS.flatMap((hint) => {
+			const text = hint.getText(context);
+			return text ? [{ id: hint.id, text }] : [];
+		});
+		for (let index = hints.length - 1; index > 0; index--) {
+			const random = Math.min(0.999999999, Math.max(0, this.random()));
+			const target = Math.floor(random * (index + 1));
+			[hints[index], hints[target]] = [hints[target]!, hints[index]!];
+		}
+		if (hints.length > 1 && hints[hints.length - 1]?.id === this.previousId) {
+			[hints[0], hints[hints.length - 1]] = [hints[hints.length - 1]!, hints[0]!];
+		}
+		this.remaining = hints;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -92,7 +92,7 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "auto-refine",
-		getText: () => "Prime Agent's self-improvement refines skills, memory, prompts, and subagents.",
+		getText: () => "Prime Agent self-improves by refining skills, memories, prompts, and subagents.",
 	},
 	{
 		id: "background-running",

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -88,24 +88,16 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "auto-compaction",
-		getText: () => "Prime Agent automatically summarizes long sessions before context fills up.",
+		getText: () => "Prime Agent automatically compacts long sessions before context fills up.",
 	},
 	{
 		id: "auto-refine",
-		getText: () => "Prime Agent automatically saves useful lessons from longer sessions.",
+		getText: () => "Prime Agent automatically refines skills, memory, prompts, and subagents.",
 	},
 	{
 		id: "background-running",
 		getText: ({ isResidentSession }) =>
 			isResidentSession ? "You can close the terminal while your agent keeps running in the background." : undefined,
-	},
-	{
-		id: "auto-retry",
-		getText: () => "Prime Agent automatically retries temporary provider errors.",
-	},
-	{
-		id: "session-autosave",
-		getText: () => "Prime Agent automatically saves sessions so you can resume them later.",
 	},
 ] as const;
 

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -17,72 +17,72 @@ export interface FeatureHint {
 export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	{
 		id: "side-question",
-		getText: () => "Use /btw <question> for a side question that won't change the main session.",
+		getText: () => "Use /btw <question> to ask questions without interrupting your agent.",
 	},
 	{
 		id: "prompt-stash",
 		getText: ({ getKeybinding }) => {
 			const key = getKeybinding("app.prompt.stash");
-			return key ? `Press ${key} to stash your draft and restore it later.` : undefined;
+			return key ? `Press ${key} to stash your prompt and restore it later.` : undefined;
 		},
 	},
 	{
 		id: "follow-up",
 		getText: ({ getKeybinding }) => {
 			const key = getKeybinding("app.message.followUp");
-			return key ? `Press ${key} to queue a message after the current task.` : undefined;
+			return key ? `Press ${key} to send a message after your agent finishes.` : undefined;
 		},
 	},
 	{
 		id: "heartbeat",
-		getText: () => "Use /heartbeat every 10m <instruction> to schedule recurring work.",
+		getText: () => "Use /heartbeat every 10m <instruction> to repeat a task on a schedule.",
 	},
 	{
 		id: "subagents",
-		getText: () => "Prime Agent can delegate independent tasks to subagents in parallel.",
+		getText: () => "Prime Agent can delegate tasks to subagents and run them in parallel.",
 	},
 	{
 		id: "agents-view",
-		getText: () => "The Agents View shows your working, waiting, and completed agents.",
-	},
-	{
-		id: "session-rewind",
 		getText: ({ getKeybinding }) => {
-			const key = getKeybinding("app.input.clear");
-			return key ? `Press ${key} twice on an empty prompt to open the tree and rewind.` : undefined;
+			const key = getKeybinding("app.agents.back");
+			return key ? `Hit ${key} for Agents View, where you can manage all your running agents.` : undefined;
 		},
 	},
 	{
+		id: "session-rewind",
+		getText: () => "Run /tree to open the session tree and return to a previous message.",
+	},
+	{
 		id: "steering",
-		getText: () => "Messages sent during active work steer the current task.",
+		getText: () => "Send a message while your agent works to steer its current task.",
 	},
 	{
 		id: "agent-messaging",
-		getText: () => "Agents can message each other to share context and coordinate work.",
+		getText: () => "Agents can message each other to share context and coordinate their work.",
 	},
 	{
 		id: "goal",
-		getText: () => "Use /goal <objective> for work that should continue across turns.",
+		getText: () => "Use /goal <objective> to keep your agent working until the goal is complete.",
 	},
 	{
 		id: "refine",
-		getText: () => "Use /refine to save useful lessons as skills, memory, prompts, or subagents.",
+		getText: () => "Use /refine to turn useful lessons into reusable skills, memory, and prompts.",
 	},
 	{
 		id: "persistent-ipython",
-		getText: () => "IPython keeps variables and helpers available across turns and compaction.",
+		getText: () => "Prime Agent keeps IPython variables and helpers between turns and compactions.",
 	},
 	{
 		id: "context-usage",
-		getText: () => "Use /context to see token, cost, and context usage.",
+		getText: () => "Use /context to check token usage, cost, and remaining context.",
 	},
 	{
 		id: "session-fork",
-		getText: () => "Use /fork to branch from an earlier prompt without losing the current session.",
+		getText: () => "Use /fork to start a new session from an earlier prompt.",
 	},
 	{
 		id: "compaction",
-		getText: () => "Use /compact <instructions> to summarize old context around what matters.",
+		getText: () => "Use /compact <instructions> to summarize old messages and free up context.",
 	},
 ] as const;
 

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -2,6 +2,7 @@ import type { AppKeybinding } from "../../core/keybindings.js";
 
 export interface FeatureHintContext {
 	getKeybinding(action: AppKeybinding): string | undefined;
+	isResidentSession: boolean;
 }
 
 interface FeatureHintDefinition {
@@ -43,7 +44,8 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "agents-view",
-		getText: ({ getKeybinding }) => {
+		getText: ({ getKeybinding, isResidentSession }) => {
+			if (!isResidentSession) return undefined;
 			const key = getKeybinding("app.agents.back");
 			return key ? `Hit ${key} for Agents View, where you can manage all your running agents.` : undefined;
 		},
@@ -83,6 +85,27 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	{
 		id: "compaction",
 		getText: () => "Use /compact <instructions> to summarize old messages and free up context.",
+	},
+	{
+		id: "auto-compaction",
+		getText: () => "Prime Agent automatically summarizes long sessions before context fills up.",
+	},
+	{
+		id: "auto-refine",
+		getText: () => "Prime Agent automatically saves useful lessons from longer sessions.",
+	},
+	{
+		id: "background-running",
+		getText: ({ isResidentSession }) =>
+			isResidentSession ? "You can close the terminal while your agent keeps running in the background." : undefined,
+	},
+	{
+		id: "auto-retry",
+		getText: () => "Prime Agent automatically retries temporary provider errors.",
+	},
+	{
+		id: "session-autosave",
+		getText: () => "Prime Agent automatically saves sessions so you can resume them later.",
 	},
 ] as const;
 

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -92,7 +92,7 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "auto-refine",
-		getText: () => "Prime Agent automatically refines skills, memory, prompts, and subagents.",
+		getText: () => "Prime Agent's self-improvement refines skills, memory, prompts, and subagents.",
 	},
 	{
 		id: "background-running",

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -39,7 +39,31 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "subagents",
-		getText: () => "Ask Prime Agent to delegate independent work to subagents so tasks can run in parallel.",
+		getText: () => "Prime Agent can delegate independent work to subagents so tasks can run in parallel.",
+	},
+	{
+		id: "agents-view",
+		getText: () =>
+			"The Agents View brings active, waiting, and completed agents together for monitoring and management.",
+	},
+	{
+		id: "session-rewind",
+		getText: ({ getKeybinding }) => {
+			const key = getKeybinding("app.input.clear");
+			return key
+				? `Press ${key} twice from an empty prompt to open the tree view and rewind the session.`
+				: undefined;
+		},
+	},
+	{
+		id: "steering",
+		getText: () =>
+			"Messages sent while Prime Agent is working steer the current task after its active tool calls finish.",
+	},
+	{
+		id: "agent-messaging",
+		getText: () =>
+			"Agents can message one another to share context, coordinate dependencies, and orchestrate parallel work.",
 	},
 	{
 		id: "goal",

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -17,71 +17,64 @@ export interface FeatureHint {
 export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	{
 		id: "side-question",
-		getText: () => "Use /btw <question> to ask a side question without changing the main session.",
+		getText: () => "Use /btw <question> for a side question that won't change the main session.",
 	},
 	{
 		id: "prompt-stash",
 		getText: ({ getKeybinding }) => {
 			const key = getKeybinding("app.prompt.stash");
-			return key ? `Press ${key} to stash a draft, run another prompt, and restore it afterward.` : undefined;
+			return key ? `Press ${key} to stash your draft and restore it later.` : undefined;
 		},
 	},
 	{
 		id: "follow-up",
 		getText: ({ getKeybinding }) => {
 			const key = getKeybinding("app.message.followUp");
-			return key ? `Press ${key} to queue a follow-up after the current work finishes.` : undefined;
+			return key ? `Press ${key} to queue a message after the current task.` : undefined;
 		},
 	},
 	{
 		id: "heartbeat",
-		getText: () => "Use /heartbeat every 10m <instruction> to schedule recurring agent work.",
+		getText: () => "Use /heartbeat every 10m <instruction> to schedule recurring work.",
 	},
 	{
 		id: "subagents",
-		getText: () => "Prime Agent can delegate independent work to subagents so tasks can run in parallel.",
+		getText: () => "Prime Agent can delegate independent tasks to subagents in parallel.",
 	},
 	{
 		id: "agents-view",
-		getText: () =>
-			"The Agents View brings active, waiting, and completed agents together for monitoring and management.",
+		getText: () => "The Agents View shows your working, waiting, and completed agents.",
 	},
 	{
 		id: "session-rewind",
 		getText: ({ getKeybinding }) => {
 			const key = getKeybinding("app.input.clear");
-			return key
-				? `Press ${key} twice from an empty prompt to open the tree view and rewind the session.`
-				: undefined;
+			return key ? `Press ${key} twice on an empty prompt to open the tree and rewind.` : undefined;
 		},
 	},
 	{
 		id: "steering",
-		getText: () =>
-			"Messages sent while Prime Agent is working steer the current task after its active tool calls finish.",
+		getText: () => "Messages sent during active work steer the current task.",
 	},
 	{
 		id: "agent-messaging",
-		getText: () =>
-			"Agents can message one another to share context, coordinate dependencies, and orchestrate parallel work.",
+		getText: () => "Agents can message each other to share context and coordinate work.",
 	},
 	{
 		id: "goal",
-		getText: () =>
-			"Use /goal <objective> to let Prime Agent keep working across turns until a longer-running outcome is complete.",
+		getText: () => "Use /goal <objective> for work that should continue across turns.",
 	},
 	{
 		id: "refine",
-		getText: () =>
-			"Use /refine after a reusable discovery to update Prime Agent's local skills, memory, prompts, or subagents.",
+		getText: () => "Use /refine to save useful lessons as skills, memory, prompts, or subagents.",
 	},
 	{
 		id: "persistent-ipython",
-		getText: () => "Prime Agent's IPython kernel preserves variables and helpers across turns and compaction.",
+		getText: () => "IPython keeps variables and helpers available across turns and compaction.",
 	},
 	{
 		id: "context-usage",
-		getText: () => "Use /context to inspect token, cost, and context usage across the agent and its subagents.",
+		getText: () => "Use /context to see token, cost, and context usage.",
 	},
 	{
 		id: "session-fork",
@@ -89,7 +82,7 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "compaction",
-		getText: () => "Use /compact <instructions> to summarize older context around the details you want to preserve.",
+		getText: () => "Use /compact <instructions> to summarize old context around what matters.",
 	},
 ] as const;
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -203,6 +203,7 @@ import {
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
+import { FeatureHintDeck } from "./feature-hints.js";
 import { collectMarkedImages, evictImagesToBudget, formatImageMarker, imageMarkerIds } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
@@ -244,6 +245,7 @@ interface PendingToolCallRenderInput {
 const HEARTBEAT_LEGACY_PROMPT_MIN_TOLERANCE_MS = 15_000;
 const HEARTBEAT_LEGACY_PROMPT_MAX_TOLERANCE_MS = 120_000;
 const MODEL_CATALOG_REFRESH_TTL_MS = 60_000;
+const FEATURE_HINT_DELAY_MS = 5_000;
 
 export const START_HINTS = [
 	'Try "refactor @<filepath>"',
@@ -735,6 +737,11 @@ export class InteractiveMode {
 	private workingIndicatorOptions: LoaderIndicatorOptions | undefined = undefined;
 	private workingStartedAt: number | undefined = undefined;
 	private workingTimer: NodeJS.Timeout | undefined = undefined;
+	private readonly featureHintDeck = new FeatureHintDeck();
+	private currentFeatureHint: string | undefined;
+	private featureHintEligibleAt = 0;
+	private featureHintTimer: NodeJS.Timeout | undefined;
+	private featureHintComponent: TruncatedText | undefined;
 	private pulseTimer: NodeJS.Timeout | undefined = undefined;
 	private pulseFrame = 0;
 	private readonly activityTracker = new AgentActivityTracker();
@@ -2578,6 +2585,7 @@ export class InteractiveMode {
 	}
 
 	private resetCurrentSessionRenderState(options?: { clearPromptStash?: boolean }): void {
+		this.endFeatureHintRun();
 		this.chatContainer.clear();
 		this.shortcutGuideContainer.clear();
 		this.pendingMessagesContainer.clear();
@@ -2921,9 +2929,11 @@ export class InteractiveMode {
 		this.loadingAnimation = this.createWorkingLoader();
 		this.statusContainer.addChild(this.loadingAnimation);
 		this.startWorkingTimer();
+		this.startFeatureHintPresentation();
 	}
 
 	private stopWorkingLoader(): void {
+		this.clearFeatureHintPresentation();
 		if (this.workingTimer) {
 			clearInterval(this.workingTimer);
 			this.workingTimer = undefined;
@@ -2934,6 +2944,70 @@ export class InteractiveMode {
 			this.loadingAnimation = undefined;
 		}
 		this.statusContainer.clear();
+	}
+
+	private startFeatureHintPresentation(): void {
+		this.clearFeatureHintPresentation();
+		if (!this.currentFeatureHint) {
+			const hint = this.featureHintDeck.next({
+				getKeybinding: (action) => {
+					const key = keyText(action);
+					return key ? this.capitalizeKey(key) : undefined;
+				},
+			});
+			this.currentFeatureHint = hint?.text;
+			this.featureHintEligibleAt = Date.now() + FEATURE_HINT_DELAY_MS;
+		}
+		if (!this.currentFeatureHint) {
+			return;
+		}
+		const delay = Math.max(0, this.featureHintEligibleAt - Date.now());
+		if (delay === 0) {
+			this.showFeatureHint();
+			return;
+		}
+		this.featureHintTimer = setTimeout(() => {
+			this.featureHintTimer = undefined;
+			this.showFeatureHint();
+		}, delay);
+		this.featureHintTimer.unref?.();
+	}
+
+	private showFeatureHint(): void {
+		if (
+			!this.currentFeatureHint ||
+			!this.loadingAnimation ||
+			!this.shouldShowWorkingLoader() ||
+			!this.statusContainer.children.includes(this.loadingAnimation)
+		) {
+			return;
+		}
+		this.featureHintComponent = new TruncatedText(theme.fg("dim", `Hint: ${this.currentFeatureHint}`), 1, 0);
+		this.statusContainer.addChild(this.featureHintComponent);
+		this.ui.requestRender();
+	}
+
+	private clearFeatureHintPresentation(): void {
+		if (this.featureHintTimer) {
+			clearTimeout(this.featureHintTimer);
+			this.featureHintTimer = undefined;
+		}
+		if (this.featureHintComponent) {
+			this.statusContainer.removeChild(this.featureHintComponent);
+			this.featureHintComponent = undefined;
+		}
+	}
+
+	private endFeatureHintRun(): void {
+		this.clearFeatureHintPresentation();
+		this.currentFeatureHint = undefined;
+		this.featureHintEligibleAt = 0;
+	}
+
+	private prepareFeatureHintRun(): void {
+		if (this.getRetryAttempt() === 0) {
+			this.endFeatureHintRun();
+		}
 	}
 
 	private updateWorkingPulse(): void {
@@ -4574,6 +4648,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				this.prepareFeatureHintRun();
 				this.resetPendingToolState();
 				this.renderRecap();
 				if (this.settingsManager.getShowTerminalProgress()) {
@@ -9236,6 +9311,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 			this.ui.terminal.setProgress(false);
 		}
 		this.stopWorkingLoader();
+		this.endFeatureHintRun();
 		this.stopWorkingPulse();
 		this.stopGoalTrayTimer();
 		this.closeHeartbeatManager();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -183,6 +183,7 @@ import { type FileChangeSummary, formatTotalChangeSummary, mergeTurnFileChanges 
 import { ExtensionEditorComponent } from "./components/extension-editor.js";
 import { ExtensionInputComponent } from "./components/extension-input.js";
 import { ExtensionSelectorComponent } from "./components/extension-selector.js";
+import { FEATURE_HINT_ANIMATION_INTERVAL_MS, FeatureHintComponent } from "./components/feature-hint.js";
 import { FooterComponent } from "./components/footer.js";
 import { HeartbeatManagerComponent } from "./components/heartbeat-manager.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./components/injected-prompt-message.js";
@@ -705,6 +706,7 @@ export class InteractiveMode {
 	private statusContainer: Container;
 	private queuedMessagesContainer: Container;
 	private sideQuestionContainer: Container;
+	private featureHintContainer: Container;
 	private defaultEditor: CustomEditor;
 	private editor: EditorComponent;
 	private readonly promptStashStore: ClientPromptStashStore | undefined;
@@ -741,7 +743,8 @@ export class InteractiveMode {
 	private currentFeatureHint: string | undefined;
 	private featureHintEligibleAt = 0;
 	private featureHintTimer: NodeJS.Timeout | undefined;
-	private featureHintComponent: TruncatedText | undefined;
+	private featureHintAnimationTimer: NodeJS.Timeout | undefined;
+	private featureHintComponent: FeatureHintComponent | undefined;
 	private pulseTimer: NodeJS.Timeout | undefined = undefined;
 	private pulseFrame = 0;
 	private readonly activityTracker = new AgentActivityTracker();
@@ -935,6 +938,7 @@ export class InteractiveMode {
 		this.statusContainer = new Container();
 		this.queuedMessagesContainer = new Container();
 		this.sideQuestionContainer = new Container();
+		this.featureHintContainer = new Container();
 		this.childAgentDetail = new ChildAgentDetailComponent(() => this.getChildAgentPanelRows(), {
 			ui: this.ui,
 		});
@@ -1269,12 +1273,14 @@ export class InteractiveMode {
 		this.mainContainer.addChild(this.recapContainer);
 		this.mainContainer.addChild(this.queuedMessagesContainer);
 		this.mainContainer.addChild(this.sideQuestionContainer);
+		this.mainContainer.addChild(this.featureHintContainer);
 		this.mainContainer.addChild(this.editorContainer);
 		this.mainContainer.addChild(this.childAgentSummary);
 		this.mainContainer.addChild(this.widgetContainerBelow);
 		this.footerSlot.addChild(this.footer);
 		this.mainContainer.addChild(this.footerSlot);
 		this.promptDock.addChild(this.sideQuestionContainer);
+		this.promptDock.addChild(this.featureHintContainer);
 		this.promptDock.addChild(this.editorContainer);
 		this.promptDock.addChild(this.childAgentSummary);
 		this.promptDock.addChild(this.footerSlot);
@@ -2983,8 +2989,13 @@ export class InteractiveMode {
 		) {
 			return;
 		}
-		this.featureHintComponent = new TruncatedText(theme.fg("dim", `Hint: ${this.currentFeatureHint}`), 1, 0);
-		this.statusContainer.addChild(this.featureHintComponent);
+		this.featureHintComponent = new FeatureHintComponent(this.currentFeatureHint);
+		this.featureHintContainer.addChild(this.featureHintComponent);
+		this.featureHintAnimationTimer = setInterval(() => {
+			this.featureHintComponent?.advance();
+			this.ui.requestRender();
+		}, FEATURE_HINT_ANIMATION_INTERVAL_MS);
+		this.featureHintAnimationTimer.unref?.();
 		this.ui.requestRender();
 	}
 
@@ -2993,8 +3004,12 @@ export class InteractiveMode {
 			clearTimeout(this.featureHintTimer);
 			this.featureHintTimer = undefined;
 		}
+		if (this.featureHintAnimationTimer) {
+			clearInterval(this.featureHintAnimationTimer);
+			this.featureHintAnimationTimer = undefined;
+		}
 		if (this.featureHintComponent) {
-			this.statusContainer.removeChild(this.featureHintComponent);
+			this.featureHintContainer.removeChild(this.featureHintComponent);
 			this.featureHintComponent = undefined;
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2954,19 +2954,8 @@ export class InteractiveMode {
 
 	private startFeatureHintPresentation(): void {
 		this.clearFeatureHintPresentation();
-		if (!this.currentFeatureHint) {
-			const hint = this.featureHintDeck.next({
-				getKeybinding: (action) => {
-					const key = keyText(action);
-					return key ? this.capitalizeKey(key) : undefined;
-				},
-				isResidentSession: this.options.returnToAgentsView === true,
-			});
-			this.currentFeatureHint = hint?.text;
+		if (this.featureHintEligibleAt === 0) {
 			this.featureHintEligibleAt = Date.now() + FEATURE_HINT_DELAY_MS;
-		}
-		if (!this.currentFeatureHint) {
-			return;
 		}
 		const delay = Math.max(0, this.featureHintEligibleAt - Date.now());
 		if (delay === 0) {
@@ -2982,11 +2971,23 @@ export class InteractiveMode {
 
 	private showFeatureHint(): void {
 		if (
-			!this.currentFeatureHint ||
 			!this.loadingAnimation ||
 			!this.shouldShowWorkingLoader() ||
 			!this.statusContainer.children.includes(this.loadingAnimation)
 		) {
+			return;
+		}
+		if (!this.currentFeatureHint) {
+			const hint = this.featureHintDeck.next({
+				getKeybinding: (action) => {
+					const key = keyText(action);
+					return key ? this.capitalizeKey(key) : undefined;
+				},
+				isResidentSession: this.options.returnToAgentsView === true,
+			});
+			this.currentFeatureHint = hint?.text;
+		}
+		if (!this.currentFeatureHint) {
 			return;
 		}
 		this.featureHintComponent = new FeatureHintComponent(this.currentFeatureHint);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2954,6 +2954,7 @@ export class InteractiveMode {
 					const key = keyText(action);
 					return key ? this.capitalizeKey(key) : undefined;
 				},
+				isResidentSession: this.options.returnToAgentsView === true,
 			});
 			this.currentFeatureHint = hint?.text;
 			this.featureHintEligibleAt = Date.now() + FEATURE_HINT_DELAY_MS;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3022,9 +3022,7 @@ export class InteractiveMode {
 	}
 
 	private prepareFeatureHintRun(): void {
-		if (this.getRetryAttempt() === 0) {
-			this.endFeatureHintRun();
-		}
+		this.endFeatureHintRun();
 	}
 
 	private updateWorkingPulse(): void {
@@ -4654,6 +4652,7 @@ export class InteractiveMode {
 		// A new user message resets the activity tracker to 0, so the in-flight baseline must
 		// reset with it. (agent_start on auto-retry does not reset the tracker.)
 		if (event.type === "message_start" && (event.message.role === "user" || isAgentSessionMessage(event.message))) {
+			this.prepareFeatureHintRun();
 			this.contextUsageTokenBaseline = 0;
 			this.setSessionHasMessages(true);
 			this.clearShortcutGuide();
@@ -4665,7 +4664,6 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
-				this.prepareFeatureHintRun();
 				this.resetPendingToolState();
 				this.renderRecap();
 				if (this.settingsManager.getShowTerminalProgress()) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -101,6 +101,7 @@ import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.j
 import {
 	createCompactionSummaryMessage,
 	createHeartbeatPromptMessage,
+	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
@@ -745,6 +746,7 @@ export class InteractiveMode {
 	private featureHintTimer: NodeJS.Timeout | undefined;
 	private featureHintAnimationTimer: NodeJS.Timeout | undefined;
 	private featureHintComponent: FeatureHintComponent | undefined;
+	private featureHintRunPending = false;
 	private pulseTimer: NodeJS.Timeout | undefined = undefined;
 	private pulseFrame = 0;
 	private readonly activityTracker = new AgentActivityTracker();
@@ -3019,10 +3021,25 @@ export class InteractiveMode {
 		this.clearFeatureHintPresentation();
 		this.currentFeatureHint = undefined;
 		this.featureHintEligibleAt = 0;
+		this.featureHintRunPending = false;
 	}
 
-	private prepareFeatureHintRun(): void {
+	private prepareFeatureHintRun(message: AgentMessage): void {
+		if (!this.featureHintRunPending) return;
+		if (message.role === "assistant") {
+			this.featureHintRunPending = false;
+			return;
+		}
+		const startsNewRun =
+			message.role === "user" ||
+			isAgentSessionMessage(message) ||
+			(message.role === "custom" && message.customType === HEARTBEAT_PROMPT_CUSTOM_TYPE);
+		if (!startsNewRun) return;
+
 		this.endFeatureHintRun();
+		if (this.shouldShowWorkingLoader()) {
+			this.startFeatureHintPresentation();
+		}
 	}
 
 	private updateWorkingPulse(): void {
@@ -4651,8 +4668,10 @@ export class InteractiveMode {
 		this.updateConnectionStateFromEvent(event);
 		// A new user message resets the activity tracker to 0, so the in-flight baseline must
 		// reset with it. (agent_start on auto-retry does not reset the tracker.)
+		if (event.type === "message_start") {
+			this.prepareFeatureHintRun(event.message);
+		}
 		if (event.type === "message_start" && (event.message.role === "user" || isAgentSessionMessage(event.message))) {
-			this.prepareFeatureHintRun();
 			this.contextUsageTokenBaseline = 0;
 			this.setSessionHasMessages(true);
 			this.clearShortcutGuide();
@@ -4664,6 +4683,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				this.featureHintRunPending = this.getRetryAttempt() === 0;
 				this.resetPendingToolState();
 				this.renderRecap();
 				if (this.settingsManager.getShowTerminalProgress()) {

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -90,7 +90,7 @@ describe("feature hint deck", () => {
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
 		expect(textById.get("auto-compaction")).toContain("automatically compacts");
-		expect(textById.get("auto-refine")).toContain("skills, memory, prompts, and subagents");
+		expect(textById.get("auto-refine")).toContain("self-improvement");
 		expect(textById.get("background-running")).toContain("close the terminal");
 	});
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -1,0 +1,150 @@
+import { type Component, Container, visibleWidth } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FEATURE_HINTS, FeatureHintDeck } from "../src/modes/interactive/feature-hints.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+class FakeLoader implements Component {
+	readonly stop = vi.fn();
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return ["loader".padEnd(width)];
+	}
+}
+
+function callPrivate(mode: object, name: string): void {
+	Reflect.get(InteractiveMode.prototype, name).call(mode);
+}
+
+function createMode() {
+	const statusContainer = new Container();
+	const loader = new FakeLoader();
+	statusContainer.addChild(loader);
+	const hint = { id: "test", text: "This is a deliberately long feature hint for narrow terminals." };
+	const featureHintDeck = { next: vi.fn(() => hint) };
+	const requestRender = vi.fn();
+	const mode = {
+		statusContainer,
+		loadingAnimation: loader,
+		workingVisible: true,
+		connectionState: { isStreaming: true },
+		workingTimer: undefined,
+		workingStartedAt: 0,
+		featureHintDeck,
+		currentFeatureHint: undefined,
+		featureHintEligibleAt: 0,
+		featureHintTimer: undefined,
+		featureHintComponent: undefined,
+		ui: { requestRender },
+	};
+	Object.setPrototypeOf(mode, InteractiveMode.prototype);
+	return { mode, statusContainer, loader, featureHintDeck, requestRender };
+}
+
+describe("feature hint deck", () => {
+	it("shows every available hint before repeating and avoids a boundary repeat", () => {
+		const deck = new FeatureHintDeck(() => 0);
+		const context = { getKeybinding: (action: string) => `Custom ${action}` };
+		const firstCycle = FEATURE_HINTS.map(() => deck.next(context));
+
+		expect(firstCycle.every((hint) => hint !== undefined)).toBe(true);
+		expect(new Set(firstCycle.map((hint) => hint?.id)).size).toBe(FEATURE_HINTS.length);
+		expect(deck.next(context)?.id).not.toBe(firstCycle.at(-1)?.id);
+	});
+
+	it("uses configured shortcuts in keybinding-based hints", () => {
+		const deck = new FeatureHintDeck(() => 0);
+		const context = {
+			getKeybinding: (action: string) =>
+				action === "app.prompt.stash" ? "Meta+S" : action === "app.message.followUp" ? "Meta+Enter" : "Meta+A",
+		};
+		const hints = FEATURE_HINTS.map(() => deck.next(context));
+
+		expect(hints.find((hint) => hint?.id === "prompt-stash")?.text).toContain("Meta+S");
+		expect(hints.find((hint) => hint?.id === "follow-up")?.text).toContain("Meta+Enter");
+	});
+});
+
+describe("InteractiveMode feature hints", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("adds one truncated hint after a sustained agent run", () => {
+		const { mode, statusContainer, featureHintDeck, requestRender } = createMode();
+
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(4_999);
+		expect(statusContainer.children).toHaveLength(1);
+
+		vi.advanceTimersByTime(1);
+		expect(statusContainer.children).toHaveLength(2);
+		const lines = statusContainer.children[1]?.render(24) ?? [];
+		expect(lines).toHaveLength(1);
+		expect(stripAnsi(lines[0] ?? "")).toContain("Hint:");
+		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
+		expect(featureHintDeck.next).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("cancels a pending hint when the loader stops", () => {
+		const { mode, statusContainer, requestRender } = createMode();
+
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(2_000);
+		callPrivate(mode, "stopWorkingLoader");
+		vi.advanceTimersByTime(5_000);
+
+		expect(statusContainer.children).toHaveLength(0);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	it("retains the hint and remaining delay when the loader is recreated", () => {
+		const { mode, statusContainer, featureHintDeck } = createMode();
+
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(3_000);
+		callPrivate(mode, "stopWorkingLoader");
+
+		const replacement = new FakeLoader();
+		Reflect.set(mode, "loadingAnimation", replacement);
+		statusContainer.addChild(replacement);
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(1_999);
+		expect(statusContainer.children).toHaveLength(1);
+
+		vi.advanceTimersByTime(1);
+		expect(statusContainer.children).toHaveLength(2);
+		expect(featureHintDeck.next).toHaveBeenCalledTimes(1);
+
+		callPrivate(mode, "endFeatureHintRun");
+		expect(statusContainer.children).toHaveLength(1);
+		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
+	});
+
+	it("keeps the current hint for retries and clears it for new runs", () => {
+		const { mode } = createMode();
+		Reflect.set(mode, "currentFeatureHint", "Existing hint");
+		Reflect.set(mode, "featureHintEligibleAt", 5_000);
+		Reflect.set(mode, "connectionState", { isStreaming: true, retryAttempt: 1 });
+
+		callPrivate(mode, "prepareFeatureHintRun");
+		expect(Reflect.get(mode, "currentFeatureHint")).toBe("Existing hint");
+
+		Reflect.set(mode, "connectionState", { isStreaming: true, retryAttempt: 0 });
+		callPrivate(mode, "prepareFeatureHintRun");
+		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -42,6 +42,7 @@ function createMode() {
 		featureHintTimer: undefined,
 		featureHintAnimationTimer: undefined,
 		featureHintComponent: undefined,
+		featureHintRunPending: false,
 		options: { returnToAgentsView: true },
 		ui: { requestRender },
 	};
@@ -196,15 +197,34 @@ describe("InteractiveMode feature hints", () => {
 		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
 	});
 
-	it("keeps the current hint across loader restarts and clears it for new runs", () => {
+	it("keeps hints for steering and continuations, then restarts the delay for new runs", () => {
 		const { mode } = createMode();
 		Reflect.set(mode, "currentFeatureHint", "Existing hint");
 		Reflect.set(mode, "featureHintEligibleAt", 5_000);
 
-		callPrivate(mode, "clearFeatureHintPresentation");
+		Reflect.get(InteractiveMode.prototype, "prepareFeatureHintRun").call(mode, {
+			role: "user",
+			content: [{ type: "text", text: "steer" }],
+			timestamp: 0,
+		});
 		expect(Reflect.get(mode, "currentFeatureHint")).toBe("Existing hint");
 
-		callPrivate(mode, "prepareFeatureHintRun");
+		Reflect.set(mode, "featureHintRunPending", true);
+		Reflect.get(InteractiveMode.prototype, "prepareFeatureHintRun").call(mode, {
+			role: "assistant",
+			content: [],
+		});
+		expect(Reflect.get(mode, "currentFeatureHint")).toBe("Existing hint");
+		expect(Reflect.get(mode, "featureHintRunPending")).toBe(false);
+
+		Reflect.set(mode, "featureHintRunPending", true);
+		Reflect.get(InteractiveMode.prototype, "prepareFeatureHintRun").call(mode, {
+			role: "user",
+			content: [{ type: "text", text: "new run" }],
+			timestamp: 0,
+		});
 		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
+		expect(Reflect.get(mode, "featureHintEligibleAt")).toBe(5_000);
+		expect(Reflect.get(mode, "featureHintTimer")).toBeDefined();
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -135,6 +135,7 @@ describe("InteractiveMode feature hints", () => {
 		vi.advanceTimersByTime(4_999);
 		expect(statusContainer.children).toHaveLength(1);
 		expect(featureHintContainer.children).toHaveLength(0);
+		expect(featureHintDeck.next).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(1);
 		expect(statusContainer.children).toHaveLength(1);
@@ -155,7 +156,7 @@ describe("InteractiveMode feature hints", () => {
 	});
 
 	it("cancels a pending hint when the loader stops", () => {
-		const { mode, statusContainer, featureHintContainer, requestRender } = createMode();
+		const { mode, statusContainer, featureHintContainer, featureHintDeck, requestRender } = createMode();
 
 		callPrivate(mode, "startFeatureHintPresentation");
 		vi.advanceTimersByTime(2_000);
@@ -164,6 +165,7 @@ describe("InteractiveMode feature hints", () => {
 
 		expect(statusContainer.children).toHaveLength(0);
 		expect(featureHintContainer.children).toHaveLength(0);
+		expect(featureHintDeck.next).not.toHaveBeenCalled();
 		expect(requestRender).not.toHaveBeenCalled();
 	});
 
@@ -181,6 +183,7 @@ describe("InteractiveMode feature hints", () => {
 		vi.advanceTimersByTime(1_999);
 		expect(statusContainer.children).toHaveLength(1);
 		expect(featureHintContainer.children).toHaveLength(0);
+		expect(featureHintDeck.next).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(1);
 		expect(statusContainer.children).toHaveLength(1);

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -58,14 +58,17 @@ describe("feature hint deck", () => {
 	it("uses configured shortcuts in keybinding-based hints", () => {
 		const deck = new FeatureHintDeck(() => 0);
 		const context = {
-			getKeybinding: (action: string) =>
-				action === "app.prompt.stash" ? "Meta+S" : action === "app.message.followUp" ? "Meta+Enter" : "Meta+Escape",
+			getKeybinding: (action: string) => {
+				if (action === "app.prompt.stash") return "Meta+S";
+				if (action === "app.message.followUp") return "Meta+Enter";
+				return "Meta+Left";
+			},
 		};
 		const hints = FEATURE_HINTS.map(() => deck.next(context));
 
 		expect(hints.find((hint) => hint?.id === "prompt-stash")?.text).toContain("Meta+S");
 		expect(hints.find((hint) => hint?.id === "follow-up")?.text).toContain("Meta+Enter");
-		expect(hints.find((hint) => hint?.id === "session-rewind")?.text).toContain("Meta+Escape twice");
+		expect(hints.find((hint) => hint?.id === "agents-view")?.text).toContain("Meta+Left");
 	});
 
 	it("covers Prime Agent workflows with capability-focused copy", () => {
@@ -73,9 +76,9 @@ describe("feature hint deck", () => {
 		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A" }));
 		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
 
-		expect(textById.get("subagents")).toBe("Prime Agent can delegate independent tasks to subagents in parallel.");
+		expect(textById.get("subagents")).toBe("Prime Agent can delegate tasks to subagents and run them in parallel.");
 		expect(textById.get("agents-view")).toContain("Agents View");
-		expect(textById.get("session-rewind")).toContain("tree");
+		expect(textById.get("session-rewind")).toContain("/tree");
 		expect(textById.get("steering")).toContain("steer");
 		expect(textById.get("agent-messaging")).toContain("message each other");
 		expect(textById.get("goal")).toContain("/goal");

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -66,6 +66,20 @@ describe("feature hint deck", () => {
 		expect(hints.find((hint) => hint?.id === "prompt-stash")?.text).toContain("Meta+S");
 		expect(hints.find((hint) => hint?.id === "follow-up")?.text).toContain("Meta+Enter");
 	});
+
+	it("covers Prime Agent workflows without advertising a subagent shortcut", () => {
+		const deck = new FeatureHintDeck(() => 0);
+		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A" }));
+		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
+
+		expect(textById.get("goal")).toContain("/goal");
+		expect(textById.get("refine")).toContain("/refine");
+		expect(textById.get("persistent-ipython")).toContain("IPython");
+		expect(textById.get("context-usage")).toContain("/context");
+		expect(textById.get("session-fork")).toContain("/fork");
+		expect(textById.get("compaction")).toContain("/compact");
+		expect(textById.get("subagents")).not.toContain("Meta+A");
+	});
 });
 
 describe("InteractiveMode feature hints", () => {

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -196,16 +196,14 @@ describe("InteractiveMode feature hints", () => {
 		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
 	});
 
-	it("keeps the current hint for retries and clears it for new runs", () => {
+	it("keeps the current hint across loader restarts and clears it for new runs", () => {
 		const { mode } = createMode();
 		Reflect.set(mode, "currentFeatureHint", "Existing hint");
 		Reflect.set(mode, "featureHintEligibleAt", 5_000);
-		Reflect.set(mode, "connectionState", { isStreaming: true, retryAttempt: 1 });
 
-		callPrivate(mode, "prepareFeatureHintRun");
+		callPrivate(mode, "clearFeatureHintPresentation");
 		expect(Reflect.get(mode, "currentFeatureHint")).toBe("Existing hint");
 
-		Reflect.set(mode, "connectionState", { isStreaming: true, retryAttempt: 0 });
 		callPrivate(mode, "prepareFeatureHintRun");
 		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
 	});

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -38,6 +38,7 @@ function createMode() {
 		featureHintEligibleAt: 0,
 		featureHintTimer: undefined,
 		featureHintComponent: undefined,
+		options: { returnToAgentsView: true },
 		ui: { requestRender },
 	};
 	Object.setPrototypeOf(mode, InteractiveMode.prototype);
@@ -47,7 +48,7 @@ function createMode() {
 describe("feature hint deck", () => {
 	it("shows every available hint before repeating and avoids a boundary repeat", () => {
 		const deck = new FeatureHintDeck(() => 0);
-		const context = { getKeybinding: (action: string) => `Custom ${action}` };
+		const context = { getKeybinding: (action: string) => `Custom ${action}`, isResidentSession: true };
 		const firstCycle = FEATURE_HINTS.map(() => deck.next(context));
 
 		expect(firstCycle.every((hint) => hint !== undefined)).toBe(true);
@@ -63,6 +64,7 @@ describe("feature hint deck", () => {
 				if (action === "app.message.followUp") return "Meta+Enter";
 				return "Meta+Left";
 			},
+			isResidentSession: true,
 		};
 		const hints = FEATURE_HINTS.map(() => deck.next(context));
 
@@ -73,7 +75,7 @@ describe("feature hint deck", () => {
 
 	it("covers Prime Agent workflows with capability-focused copy", () => {
 		const deck = new FeatureHintDeck(() => 0);
-		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A" }));
+		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A", isResidentSession: true }));
 		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
 
 		expect(textById.get("subagents")).toBe("Prime Agent can delegate tasks to subagents and run them in parallel.");
@@ -87,13 +89,26 @@ describe("feature hint deck", () => {
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
+		expect(textById.get("auto-compaction")).toContain("automatically summarizes");
+		expect(textById.get("auto-refine")).toContain("automatically saves useful lessons");
+		expect(textById.get("background-running")).toContain("close the terminal");
+		expect(textById.get("auto-retry")).toContain("automatically retries");
+		expect(textById.get("session-autosave")).toContain("automatically saves sessions");
 	});
 
 	it("keeps every hint concise", () => {
 		const deck = new FeatureHintDeck(() => 0);
-		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Ctrl+Key" }));
+		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Ctrl+Key", isResidentSession: true }));
 
 		expect(hints.every((hint) => hint !== undefined && hint.text.length <= 80)).toBe(true);
+	});
+
+	it("hides resident-only hints in ephemeral sessions", () => {
+		const context = { getKeybinding: () => "Left", isResidentSession: false };
+		const textById = new Map(FEATURE_HINTS.map((hint) => [hint.id, hint.getText(context)]));
+
+		expect(textById.get("agents-view")).toBeUndefined();
+		expect(textById.get("background-running")).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -89,11 +89,9 @@ describe("feature hint deck", () => {
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
-		expect(textById.get("auto-compaction")).toContain("automatically summarizes");
-		expect(textById.get("auto-refine")).toContain("automatically saves useful lessons");
+		expect(textById.get("auto-compaction")).toContain("automatically compacts");
+		expect(textById.get("auto-refine")).toContain("skills, memory, prompts, and subagents");
 		expect(textById.get("background-running")).toContain("close the terminal");
-		expect(textById.get("auto-retry")).toContain("automatically retries");
-		expect(textById.get("session-autosave")).toContain("automatically saves sessions");
 	});
 
 	it("keeps every hint concise", () => {

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -1,6 +1,7 @@
 import { type Component, Container, visibleWidth } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FEATURE_HINT_ANIMATION_INTERVAL_MS } from "../src/modes/interactive/components/feature-hint.js";
 import { FEATURE_HINTS, FeatureHintDeck } from "../src/modes/interactive/feature-hints.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -21,6 +22,7 @@ function callPrivate(mode: object, name: string): void {
 
 function createMode() {
 	const statusContainer = new Container();
+	const featureHintContainer = new Container();
 	const loader = new FakeLoader();
 	statusContainer.addChild(loader);
 	const hint = { id: "test", text: "This is a deliberately long feature hint for narrow terminals." };
@@ -28,6 +30,7 @@ function createMode() {
 	const requestRender = vi.fn();
 	const mode = {
 		statusContainer,
+		featureHintContainer,
 		loadingAnimation: loader,
 		workingVisible: true,
 		connectionState: { isStreaming: true },
@@ -37,12 +40,13 @@ function createMode() {
 		currentFeatureHint: undefined,
 		featureHintEligibleAt: 0,
 		featureHintTimer: undefined,
+		featureHintAnimationTimer: undefined,
 		featureHintComponent: undefined,
 		options: { returnToAgentsView: true },
 		ui: { requestRender },
 	};
 	Object.setPrototypeOf(mode, InteractiveMode.prototype);
-	return { mode, statusContainer, loader, featureHintDeck, requestRender };
+	return { mode, statusContainer, featureHintContainer, loader, featureHintDeck, requestRender };
 }
 
 describe("feature hint deck", () => {
@@ -124,25 +128,33 @@ describe("InteractiveMode feature hints", () => {
 		vi.useRealTimers();
 	});
 
-	it("adds one truncated hint after a sustained agent run", () => {
-		const { mode, statusContainer, featureHintDeck, requestRender } = createMode();
+	it("adds one animated truncated hint above the prompt after a sustained agent run", () => {
+		const { mode, statusContainer, featureHintContainer, featureHintDeck, requestRender } = createMode();
 
 		callPrivate(mode, "startFeatureHintPresentation");
 		vi.advanceTimersByTime(4_999);
 		expect(statusContainer.children).toHaveLength(1);
+		expect(featureHintContainer.children).toHaveLength(0);
 
 		vi.advanceTimersByTime(1);
-		expect(statusContainer.children).toHaveLength(2);
-		const lines = statusContainer.children[1]?.render(24) ?? [];
+		expect(statusContainer.children).toHaveLength(1);
+		expect(featureHintContainer.children).toHaveLength(1);
+		const lines = featureHintContainer.children[0]?.render(24) ?? [];
 		expect(lines).toHaveLength(1);
 		expect(stripAnsi(lines[0] ?? "")).toContain("Hint:");
 		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
 		expect(featureHintDeck.next).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(FEATURE_HINT_ANIMATION_INTERVAL_MS);
+		const animatedLines = featureHintContainer.children[0]?.render(24) ?? [];
+		expect(stripAnsi(animatedLines[0] ?? "")).toBe(stripAnsi(lines[0] ?? ""));
+		expect(animatedLines[0]).not.toBe(lines[0]);
+		expect(requestRender).toHaveBeenCalledTimes(2);
 	});
 
 	it("cancels a pending hint when the loader stops", () => {
-		const { mode, statusContainer, requestRender } = createMode();
+		const { mode, statusContainer, featureHintContainer, requestRender } = createMode();
 
 		callPrivate(mode, "startFeatureHintPresentation");
 		vi.advanceTimersByTime(2_000);
@@ -150,11 +162,12 @@ describe("InteractiveMode feature hints", () => {
 		vi.advanceTimersByTime(5_000);
 
 		expect(statusContainer.children).toHaveLength(0);
+		expect(featureHintContainer.children).toHaveLength(0);
 		expect(requestRender).not.toHaveBeenCalled();
 	});
 
 	it("retains the hint and remaining delay when the loader is recreated", () => {
-		const { mode, statusContainer, featureHintDeck } = createMode();
+		const { mode, statusContainer, featureHintContainer, featureHintDeck } = createMode();
 
 		callPrivate(mode, "startFeatureHintPresentation");
 		vi.advanceTimersByTime(3_000);
@@ -166,13 +179,16 @@ describe("InteractiveMode feature hints", () => {
 		callPrivate(mode, "startFeatureHintPresentation");
 		vi.advanceTimersByTime(1_999);
 		expect(statusContainer.children).toHaveLength(1);
+		expect(featureHintContainer.children).toHaveLength(0);
 
 		vi.advanceTimersByTime(1);
-		expect(statusContainer.children).toHaveLength(2);
+		expect(statusContainer.children).toHaveLength(1);
+		expect(featureHintContainer.children).toHaveLength(1);
 		expect(featureHintDeck.next).toHaveBeenCalledTimes(1);
 
 		callPrivate(mode, "endFeatureHintRun");
 		expect(statusContainer.children).toHaveLength(1);
+		expect(featureHintContainer.children).toHaveLength(0);
 		expect(Reflect.get(mode, "currentFeatureHint")).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -73,19 +73,24 @@ describe("feature hint deck", () => {
 		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A" }));
 		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
 
-		expect(textById.get("subagents")).toBe(
-			"Prime Agent can delegate independent work to subagents so tasks can run in parallel.",
-		);
+		expect(textById.get("subagents")).toBe("Prime Agent can delegate independent tasks to subagents in parallel.");
 		expect(textById.get("agents-view")).toContain("Agents View");
-		expect(textById.get("session-rewind")).toContain("tree view");
+		expect(textById.get("session-rewind")).toContain("tree");
 		expect(textById.get("steering")).toContain("steer");
-		expect(textById.get("agent-messaging")).toContain("message one another");
+		expect(textById.get("agent-messaging")).toContain("message each other");
 		expect(textById.get("goal")).toContain("/goal");
 		expect(textById.get("refine")).toContain("/refine");
 		expect(textById.get("persistent-ipython")).toContain("IPython");
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
+	});
+
+	it("keeps every hint concise", () => {
+		const deck = new FeatureHintDeck(() => 0);
+		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Ctrl+Key" }));
+
+		expect(hints.every((hint) => hint !== undefined && hint.text.length <= 80)).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -90,7 +90,7 @@ describe("feature hint deck", () => {
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
 		expect(textById.get("auto-compaction")).toContain("automatically compacts");
-		expect(textById.get("auto-refine")).toContain("self-improvement");
+		expect(textById.get("auto-refine")).toContain("self-improves");
 		expect(textById.get("background-running")).toContain("close the terminal");
 	});
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -140,8 +140,9 @@ describe("InteractiveMode feature hints", () => {
 		expect(statusContainer.children).toHaveLength(1);
 		expect(featureHintContainer.children).toHaveLength(1);
 		const lines = featureHintContainer.children[0]?.render(24) ?? [];
-		expect(lines).toHaveLength(1);
+		expect(lines).toHaveLength(2);
 		expect(stripAnsi(lines[0] ?? "")).toContain("Hint:");
+		expect(lines[1]?.trim()).toBe("");
 		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
 		expect(featureHintDeck.next).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -59,26 +59,33 @@ describe("feature hint deck", () => {
 		const deck = new FeatureHintDeck(() => 0);
 		const context = {
 			getKeybinding: (action: string) =>
-				action === "app.prompt.stash" ? "Meta+S" : action === "app.message.followUp" ? "Meta+Enter" : "Meta+A",
+				action === "app.prompt.stash" ? "Meta+S" : action === "app.message.followUp" ? "Meta+Enter" : "Meta+Escape",
 		};
 		const hints = FEATURE_HINTS.map(() => deck.next(context));
 
 		expect(hints.find((hint) => hint?.id === "prompt-stash")?.text).toContain("Meta+S");
 		expect(hints.find((hint) => hint?.id === "follow-up")?.text).toContain("Meta+Enter");
+		expect(hints.find((hint) => hint?.id === "session-rewind")?.text).toContain("Meta+Escape twice");
 	});
 
-	it("covers Prime Agent workflows without advertising a subagent shortcut", () => {
+	it("covers Prime Agent workflows with capability-focused copy", () => {
 		const deck = new FeatureHintDeck(() => 0);
 		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A" }));
 		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
 
+		expect(textById.get("subagents")).toBe(
+			"Prime Agent can delegate independent work to subagents so tasks can run in parallel.",
+		);
+		expect(textById.get("agents-view")).toContain("Agents View");
+		expect(textById.get("session-rewind")).toContain("tree view");
+		expect(textById.get("steering")).toContain("steer");
+		expect(textById.get("agent-messaging")).toContain("message one another");
 		expect(textById.get("goal")).toContain("/goal");
 		expect(textById.get("refine")).toContain("/refine");
 		expect(textById.get("persistent-ipython")).toContain("IPython");
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");
 		expect(textById.get("compaction")).toContain("/compact");
-		expect(textById.get("subagents")).not.toContain("Meta+A");
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -636,7 +636,9 @@ describe("InteractiveMode pending bash components", () => {
 		expect(loader.intervalId).not.toBeNull();
 
 		const editorStub = { clearHistory: vi.fn(), setText: vi.fn() };
+		const endFeatureHintRun = vi.fn();
 		const fakeThis = {
+			endFeatureHintRun,
 			chatContainer: new Container(),
 			shortcutGuideContainer: new Container(),
 			pendingMessagesContainer: new Container(),
@@ -668,6 +670,7 @@ describe("InteractiveMode pending bash components", () => {
 		).resetCurrentSessionRenderState.call(fakeThis);
 
 		expect(loader.intervalId).toBeNull();
+		expect(endFeatureHintRun).toHaveBeenCalledOnce();
 		expect((fakeThis as unknown as { activeBashComponent: unknown }).activeBashComponent).toBeUndefined();
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Changed the fullscreen follow shortcut from `Alt+Down` to `Ctrl+Shift+Down` for more reliable terminal input ([ENG-4684](https://linear.app/primeintellect/issue/ENG-4684/altdown-doesnt-work)).
+- Fixed autocomplete popups overlapping the prompt's top edge.
+
 ## [0.3.1] - 2026-07-15
 
 - Fixed fullscreen Markdown table selections copying borders instead of tab-separated cell content ([ENG-4629](https://linear.app/primeintellect/issue/ENG-4629/respect-table-boundaries-when-selecting)).

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2463,6 +2463,7 @@ export class Editor implements Component, Focusable {
 			this.autocompleteOverlay = this.tui.showOverlay(this.autocompleteOverlayComponent, {
 				width: "100%",
 				aboveMarker: this.autocompleteAnchorMarker,
+				offsetY: -1,
 				nonCapturing: true,
 				visible: () => this.focused && this.autocompleteState !== null,
 			});

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -18,6 +18,7 @@ import {
 	normalizeTerminalOutput,
 	sliceByColumn,
 	sliceWithWidth,
+	stripAnsi,
 	visibleContentSpan,
 	visibleWidth,
 } from "./utils.js";
@@ -1198,13 +1199,14 @@ export class TUI extends Container {
 			const { component, w, scrollback, aboveMarker } = renderedOverlay;
 			let { overlayLines, row, col } = renderedOverlay;
 			if (aboveMarker) {
-				const markerViewportRow = aboveMarker.line - viewportStart;
-				const requestedMarkerRow = markerViewportRow + aboveMarker.offsetY;
-				const markerRow =
-					aboveMarker.offsetY < 0 && overlayLines.length > requestedMarkerRow
-						? markerViewportRow
-						: requestedMarkerRow;
+				const markerRow = aboveMarker.line - viewportStart + aboveMarker.offsetY;
 				if (markerRow <= 0 || markerRow >= termHeight) continue;
+				while (overlayLines.length > markerRow && stripAnsi(overlayLines[0] ?? "").trim().length === 0) {
+					overlayLines = overlayLines.slice(1);
+				}
+				while (overlayLines.length > markerRow && stripAnsi(overlayLines.at(-1) ?? "").trim().length === 0) {
+					overlayLines = overlayLines.slice(0, -1);
+				}
 				if (overlayLines.length > markerRow) {
 					overlayLines = overlayLines.slice(overlayLines.length - markerRow);
 				}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1198,7 +1198,12 @@ export class TUI extends Container {
 			const { component, w, scrollback, aboveMarker } = renderedOverlay;
 			let { overlayLines, row, col } = renderedOverlay;
 			if (aboveMarker) {
-				const markerRow = aboveMarker.line - viewportStart + aboveMarker.offsetY;
+				const markerViewportRow = aboveMarker.line - viewportStart;
+				const requestedMarkerRow = markerViewportRow + aboveMarker.offsetY;
+				const markerRow =
+					aboveMarker.offsetY < 0 && overlayLines.length > requestedMarkerRow
+						? markerViewportRow
+						: requestedMarkerRow;
 				if (markerRow <= 0 || markerRow >= termHeight) continue;
 				if (overlayLines.length > markerRow) {
 					overlayLines = overlayLines.slice(overlayLines.length - markerRow);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1199,8 +1199,8 @@ export class TUI extends Container {
 			const { component, w, scrollback, aboveMarker } = renderedOverlay;
 			let { overlayLines, row, col } = renderedOverlay;
 			if (aboveMarker) {
-				const markerRow = aboveMarker.line - viewportStart + aboveMarker.offsetY;
-				if (markerRow <= 0 || markerRow >= termHeight) continue;
+				const markerRow = Math.max(1, aboveMarker.line - viewportStart + aboveMarker.offsetY);
+				if (markerRow >= termHeight) continue;
 				while (overlayLines.length > markerRow && stripAnsi(overlayLines[0] ?? "").trim().length === 0) {
 					overlayLines = overlayLines.slice(1);
 				}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1134,7 +1134,7 @@ export class TUI extends Container {
 			col: number;
 			w: number;
 			scrollback: boolean;
-			aboveMarker?: { line: number; col: number };
+			aboveMarker?: { line: number; col: number; offsetY: number };
 		}[] = [];
 		let minLinesNeeded = result.length;
 
@@ -1143,12 +1143,16 @@ export class TUI extends Container {
 		for (const entry of visibleEntries) {
 			const { component, options } = entry;
 			const scrollback = options?.scrollback === true;
-			let aboveMarker: { line: number; col: number } | undefined;
+			let aboveMarker: { line: number; col: number; offsetY: number } | undefined;
 			if (options?.aboveMarker) {
 				for (let line = result.length - 1; line >= 0; line--) {
 					const markerIndex = result[line].indexOf(options.aboveMarker);
 					if (markerIndex === -1) continue;
-					aboveMarker = { line, col: visibleWidth(result[line].slice(0, markerIndex)) };
+					aboveMarker = {
+						line,
+						col: visibleWidth(result[line].slice(0, markerIndex)),
+						offsetY: options.offsetY ?? 0,
+					};
 					result[line] =
 						result[line].slice(0, markerIndex) + result[line].slice(markerIndex + options.aboveMarker.length);
 					break;
@@ -1194,7 +1198,7 @@ export class TUI extends Container {
 			const { component, w, scrollback, aboveMarker } = renderedOverlay;
 			let { overlayLines, row, col } = renderedOverlay;
 			if (aboveMarker) {
-				const markerRow = aboveMarker.line - viewportStart;
+				const markerRow = aboveMarker.line - viewportStart + aboveMarker.offsetY;
 				if (markerRow <= 0 || markerRow >= termHeight) continue;
 				if (overlayLines.length > markerRow) {
 					overlayLines = overlayLines.slice(overlayLines.length - markerRow);

--- a/packages/tui/test/editor-autocomplete-overlay.test.ts
+++ b/packages/tui/test/editor-autocomplete-overlay.test.ts
@@ -72,7 +72,8 @@ describe("editor autocomplete overlay", () => {
 		await terminal.waitForRender();
 
 		const viewport = terminal.getViewport();
-		assert.ok(viewport.some((line) => line.includes("help")));
+		assert.ok(viewport[0]?.includes("help"));
+		assert.ok(viewport[1]?.includes("hotkeys"));
 		assert.ok(viewport[3]?.includes("/"));
 		tui.stop();
 	});

--- a/packages/tui/test/editor-autocomplete-overlay.test.ts
+++ b/packages/tui/test/editor-autocomplete-overlay.test.ts
@@ -77,4 +77,25 @@ describe("editor autocomplete overlay", () => {
 		assert.ok(viewport[3]?.includes("/"));
 		tui.stop();
 	});
+
+	it("keeps one suggestion visible when the editor is at the terminal top edge", async () => {
+		const terminal = new VirtualTerminal(40, 3);
+		const tui = new TUI(terminal);
+		const editor = new Editor(tui, defaultEditorTheme);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		editor.setAutocompleteProvider(autocompleteProvider);
+		tui.start();
+
+		editor.handleInput("/");
+		await Promise.resolve();
+		await new Promise((resolve) => setImmediate(resolve));
+		tui.requestRender(true);
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("hotkeys"));
+		assert.ok(viewport[1]?.includes("/"));
+		tui.stop();
+	});
 });

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2055,6 +2055,36 @@ describe("Editor component", () => {
 			assert.equal(tui.hasOverlay(), false);
 		});
 
+		it("keeps the prompt top edge visible below autocomplete", async () => {
+			const terminal = new VirtualTerminal(60, 12);
+			const tui = new TUI(terminal);
+			const editor = new Editor(tui, defaultEditorTheme);
+			tui.addChild(editor);
+			tui.start();
+			tui.enterFullscreen({ scroll: [], dock: editor, mouse: false });
+			tui.setFocus(editor);
+			editor.setAutocompleteProvider({
+				getSuggestions: async () => ({
+					items: [
+						{ value: "/model", label: "model", description: "Change model" },
+						{ value: "/help", label: "help", description: "Show help" },
+					],
+					prefix: "/",
+				}),
+				applyCompletion,
+			});
+
+			editor.handleInput("/");
+			await flushAutocomplete();
+			tui.requestRender(true);
+			await new Promise<void>((resolve) => process.nextTick(resolve));
+			await terminal.waitForRender();
+
+			const viewport = terminal.getViewport();
+			assert.match(viewport[9] ?? "", /^─+$/);
+			tui.stop();
+		});
+
 		it("auto-applies single force-file suggestion without showing menu", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 

--- a/packages/tui/test/overlay-options.test.ts
+++ b/packages/tui/test/overlay-options.test.ts
@@ -535,6 +535,39 @@ describe("TUI overlay options", () => {
 			tui.stop();
 		});
 
+		it("applies vertical offsets to marker-anchored overlays", async () => {
+			const terminal = new VirtualTerminal(20, 8);
+			const tui = new TUI(terminal);
+			const marker = "\x1b_pi:offset-overlay\x07";
+			const content = new StaticOverlay([
+				"transcript 1",
+				"transcript 2",
+				"transcript 3",
+				"underlay 1",
+				"prompt edge",
+				`${marker}input`,
+				"footer 1",
+				"footer 2",
+			]);
+
+			tui.addChild(content);
+			tui.showOverlay(new StaticOverlay(["suggestion", "description"]), {
+				width: "100%",
+				aboveMarker: marker,
+				offsetY: -1,
+				nonCapturing: true,
+			});
+			tui.start();
+			await renderAndFlush(tui, terminal);
+
+			const viewport = terminal.getViewport();
+			assert.equal(viewport[2]?.trimEnd(), "suggestion");
+			assert.equal(viewport[3]?.trimEnd(), "description");
+			assert.equal(viewport[4], "prompt edge");
+			assert.equal(viewport[5], "input");
+			tui.stop();
+		});
+
 		it("anchors above fullscreen dock content", async () => {
 			const terminal = new VirtualTerminal(20, 8);
 			const tui = new TUI(terminal);


### PR DESCRIPTION
- longer agent turns now surface one unobtrusive feature hint after a short delay.
- hints rotate without immediate repetition and reflect configured shortcuts where applicable.
- loader transitions and automatic retries retain the current hint without flicker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation and overlay positioning only; behavior is covered by new unit tests and does not touch auth, persistence, or agent execution logic.
> 
> **Overview**
> Long-running agent turns in interactive mode now show **one rotating feature hint** above the prompt after a **5s delay**, tied to the working loader.
> 
> A **`FeatureHintDeck`** shuffles contextual copy (slash commands, subagents, compaction, etc.), skips hints when keybindings or resident-session context do not apply, and avoids back-to-back repeats across cycles. **`FeatureHintComponent`** renders a width-truncated, subtly animated **"Hint:"** line. Hints clear when the loader stops; steering and continuations keep the current hint, while a new user/heartbeat/agent run resets and reschedules. Automatic retries do not re-arm hints until a fresh `agent_start` on attempt 0.
> 
> In **`@earendil-works/pi-tui`**, marker-anchored overlays support **`offsetY`**; the editor autocomplete uses **`offsetY: -1`** and trims blank overlay rows so suggestion popups no longer cover the prompt’s top edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646d199171160be11af77a5e905a8272809e1e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add animated feature hints to long-running agent turns in interactive mode
> - After ~5 seconds of agent work, a shimmering `Hint:` line appears above the prompt while the working loader is visible, cycling through context-aware tips (keybinding-aware, resident-session-aware) without immediate repetition.
> - The hint deck ([feature-hints.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/452/files#diff-031f07d5a709bbcd6852e0ca041ca0b03ea9d8ddaf2009f5e8556550419250f0)) shuffles all available hints and refills when exhausted; the animated component ([feature-hint.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/452/files#diff-3e0b8b38f5195e9e87d0cc9970effee010ab96deb2b9386b971917d04f36326b)) renders a frame-based shimmer around the label.
> - Hints are cleared on loader stop or session render state reset, persist across loader recreation, and only start on the first retry attempt per run.
> - Also fixes autocomplete overlays overlapping the prompt's top edge in the TUI by anchoring them one row higher via a new `offsetY` parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 646d199.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->