### PR TITLE
fix(coding-agent): make subagent cancellation explicit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed subagent stop controls to acknowledge cancellation immediately, close daemon-hosted child runtimes, and keep a visible terminal status instead of reporting completion races as errors.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.
 - Changed `/context` tree connectors from `├ `/`└ ` to `├─ `/`└─ ` to match the tree selector and session picker.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -678,6 +678,8 @@ interface RlmChildRun {
 	sessionName: string;
 	sessionDir: string;
 	status: RlmChildAgentStatus;
+	startedAt: number;
+	durationMs?: number;
 	result?: RlmRunResult;
 	error?: string;
 	releaseError?: unknown;
@@ -689,7 +691,7 @@ interface RlmChildRun {
 	emitUpdate?: () => void;
 	/** Idempotent child-event forwarder cleanup, once the child runtime exists. */
 	unsubscribe?: () => void;
-	/** Rejects the public rlm.run promise when deletion detaches stuck underlying work. */
+	/** Rejects the public rlm.run promise when cancellation detaches stuck underlying work. */
 	rejectTask?: (error: Error) => void;
 	/** Snapshot retained until an in-flight runtime creation is released after early deletion. */
 	detachedDeletion?: RlmSubagentRegistryEntry;
@@ -6395,11 +6397,16 @@ export class AgentSession {
 	}
 
 	private _cancelRlmChildRun(run: RlmChildRun, reason: string): boolean {
+		if (run.status === "cancelled") {
+			return true;
+		}
 		if (run.status !== "running" && run.status !== "queued") {
 			return false;
 		}
 		run.status = "cancelled";
+		run.durationMs = Date.now() - run.startedAt;
 		run.error = reason;
+		run.rejectTask?.(new Error(reason));
 		run.abort();
 		// Surface the cancellation immediately; the run's own terminal update is
 		// delayed indefinitely when the child is stuck mid-stream, which is
@@ -6864,7 +6871,6 @@ export class AgentSession {
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
-		let durationMs: number | undefined;
 		let toolUseCount = 0;
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
@@ -6877,12 +6883,14 @@ export class AgentSession {
 			sessionName,
 			sessionDir: childSessionDir,
 			status: "running",
+			startedAt,
 			abort: noopRlmChildAbort,
 		};
 		this._activeRlmChildRuns.set(run.id, run);
 		// Status-only relay; the conversation is read from the child's own session.
 		const emitChildUpdate = () => {
 			const childModel = childSession?.model ?? modelSelection.model;
+			const active = run.status === "running" || run.status === "queued";
 			this._emit({
 				type: "rlm_child_update",
 				child: {
@@ -6892,13 +6900,13 @@ export class AgentSession {
 					model: `${childModel.provider}/${childModel.id}`,
 					label,
 					status: run.status,
-					durationMs,
+					durationMs: run.durationMs,
 					answerPreview,
 					toolUseCount: toolUseCount > 0 ? toolUseCount : undefined,
 					tokenCount: childSession?._contextTokensForCurrentMessages(),
 					recap: childSession?.getCurrentRecap(),
 					sessionDir: childSessionDir,
-					activity,
+					activity: active ? activity : undefined,
 					error: run.error,
 				},
 			});
@@ -7002,15 +7010,17 @@ export class AgentSession {
 				}
 				await child.prompt(prompt, { expandPromptTemplates: false, source: "extension" });
 				await child.agent.waitForIdle();
-				if (isRlmChildRunCancelled(run)) {
-					throw new Error(run.error ?? "RLM child cancelled");
-				}
 				const answer = child.getLastAssistantText() ?? "";
 				const usage = child._usageForCurrentMessages();
 				const assistantUsage = child._assistantUsageForCurrentMessages();
-				this._attributeRlmChildUsageToParent(assistantUsage, parentAssistantForUsage);
+				// Result collection can invoke synchronous observers. Make this the
+				// completion linearization point so cancellation cannot become done.
+				if (isRlmChildRunCancelled(run)) {
+					throw new Error(run.error ?? "RLM child cancelled");
+				}
 				run.status = "done";
-				durationMs = Date.now() - startedAt;
+				run.durationMs = Date.now() - run.startedAt;
+				this._attributeRlmChildUsageToParent(assistantUsage, parentAssistantForUsage);
 				activity = undefined;
 				const compactAnswer = compactRlmText(answer);
 				if (compactAnswer) {
@@ -7030,9 +7040,9 @@ export class AgentSession {
 			} catch (error) {
 				if (run.status !== "cancelled") {
 					run.status = "error";
+					run.durationMs = Date.now() - run.startedAt;
+					run.error = error instanceof Error ? error.message : String(error);
 				}
-				durationMs = Date.now() - startedAt;
-				run.error = error instanceof Error ? error.message : String(error);
 				activity = undefined;
 				emitChildUpdate();
 				throw error;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3077,6 +3077,17 @@ export class AgentDaemon {
 			case "cancel_rlm_child": {
 				const state = this.getSessionState(command.activeSessionId);
 				const cancelled = state.runtime.session.cancelRlmChildRun(command.childId);
+				if (cancelled) {
+					const child = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.rlmChildId === command.childId &&
+							this.isRlmAncestorState(candidate, state),
+					);
+					if (child) {
+						void this.closeSession(child, "killed").catch(() => undefined);
+					}
+				}
 				return success(command.id, "cancel_rlm_child", { cancelled });
 			}
 

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -192,6 +192,9 @@ function formatChildAgentDuration(durationMs: number | undefined): string {
 }
 
 function childAgentRecap(node: ChildAgentInspectorNode): string {
+	if (node.status === "cancelled") {
+		return "Cancelled";
+	}
 	const recap = node.recap?.replace(/\s+/g, " ").trim();
 	return recap || (node.hasActiveHeartbeat ? "Heartbeat active" : nodeActivityLabel(node));
 }
@@ -708,7 +711,7 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 			}
 			lines.push(...loader.render(width).map((line) => this.indent(line, width, 1)));
 		}
-		const recap = node.recap?.trim();
+		const recap = node.status === "cancelled" ? "Cancelled" : node.recap?.trim();
 		if (recap) {
 			lines.push("");
 			lines.push(this.indent(this.truncate(theme.fg("dim", `Recap: ${recap}`), width - CONTENT_INDENT), width));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -333,6 +333,9 @@ export function mergeChildAgentSnapshots(
 	};
 }
 
+function isDeletedChildAgentSnapshot(child: AgentConnectionRlmChildAgentSnapshot): boolean {
+	return child.status === "cancelled" && child.error === "Deleted by parent orchestrator";
+}
 function childAgentSummaryChanged(
 	previous: AgentConnectionRlmChildAgentSnapshot,
 	next: AgentConnectionRlmChildAgentSnapshot,
@@ -894,6 +897,7 @@ export class InteractiveMode {
 	private childAgentSummary: ChildAgentSummaryComponent;
 	private childAgentDetail: ChildAgentDetailComponent;
 	private childAgentSnapshots = new Map<string, AgentConnectionRlmChildAgentSnapshot>();
+	private readonly stoppingChildAgentIds = new Set<string>();
 	private childAgentNodes: ChildAgentInspectorNode[] = [];
 	private childAgentDetailNodeId: string | undefined;
 	private childAgentPanelMode: "detail" | undefined;
@@ -5343,8 +5347,7 @@ export class InteractiveMode {
 	}
 
 	private updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void {
-		// Cancellation is also the lifecycle tombstone for deleted subagents.
-		if (child.status === "cancelled") {
+		if (isDeletedChildAgentSnapshot(child)) {
 			this.removeChildAgentSnapshot(child.id);
 			this.refreshChildAgentInspector();
 			return;
@@ -5394,6 +5397,7 @@ export class InteractiveMode {
 	}
 
 	private resetChildAgentInspector(): void {
+		this.stoppingChildAgentIds.clear();
 		this.childAgentSnapshots.clear();
 		this.childAgentNodes = [];
 		this.childAgentSummary.setNodes([]);
@@ -5576,13 +5580,18 @@ export class InteractiveMode {
 	}
 
 	private async killChildAgent(nodeId: string): Promise<void> {
+		if (this.stoppingChildAgentIds.has(nodeId)) {
+			return;
+		}
+		this.stoppingChildAgentIds.add(nodeId);
+		this.showStatus("Stopping subagent...");
 		try {
 			const cancelled = await this.agentConnection.cancelRlmChild(nodeId);
-			if (!cancelled) {
-				this.showError("Subagent already finished");
-			}
+			this.showStatus(cancelled ? "Subagent stopped" : "Subagent is no longer running");
 		} catch (error) {
 			this.showError(`Failed to stop subagent: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			this.stoppingChildAgentIds.delete(nodeId);
 		}
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -856,10 +856,10 @@ describe("AgentSession rlm recursion", () => {
 				return stream;
 			},
 		});
-		const childStatuses: string[] = [];
+		const childSnapshots: Array<{ status: string; durationMs?: number; activity?: unknown }> = [];
 		root.subscribe((event) => {
 			if (event.type === "rlm_child_update") {
-				childStatuses.push(event.child.status);
+				childSnapshots.push(event.child);
 			}
 		});
 
@@ -876,19 +876,66 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.cancelRlmChildRun("unknown-child")).toBe(false);
 		expect(run?.status).toBe("running");
 
+		const rejection = expect(runPromise).rejects.toThrow("Cancelled by user");
 		expect(root.cancelRlmChildRun(childId)).toBe(true);
 		expect(run?.status).toBe("cancelled");
 		expect(run?.error).toBe("Cancelled by user");
 		// The cancelled update is pushed at cancel time, before the (possibly
 		// stuck) child unwinds; viewers must not keep showing a running child.
-		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");
+		expect(childSnapshots[childSnapshots.length - 1]).toMatchObject({
+			status: "cancelled",
+			durationMs: expect.any(Number),
+		});
+		expect(childSnapshots[childSnapshots.length - 1]?.activity).toBeUndefined();
+		// Duplicate requests that race teardown acknowledge the same cancellation.
+		expect(root.cancelRlmChildRun(childId)).toBe(true);
+		await rejection;
 		releaseChild();
-		await expect(runPromise).rejects.toThrow("Cancelled by user");
-		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");
+		await waitFor(() => !runs.has(childId));
+		expect(childSnapshots[childSnapshots.length - 1]?.activity).toBeUndefined();
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 
-		// The run has finished; a second cancel finds nothing to stop.
+		// Once teardown removes the run, a later cancel finds nothing to stop.
 		expect(root.cancelRlmChildRun(childId)).toBe(false);
+	});
+
+	it("does not let result collection overwrite cancellation with done", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const root = createSession({
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(userText(context)) });
+				});
+				return stream;
+			},
+		});
+		const statuses: string[] = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") statuses.push(event.child.status);
+		});
+
+		const runPromise = root.runRlmChild("finish concurrently");
+		await waitFor(() => childStarted);
+		const run = [...(root as unknown as InspectableRlmSession)._activeRlmChildRuns.values()][0];
+		if (!run?.session) throw new Error("Missing running child");
+		const child = run.session as unknown as { _assistantUsageForCurrentMessages(): Usage };
+		const readUsage = child._assistantUsageForCurrentMessages.bind(run.session);
+		vi.spyOn(child, "_assistantUsageForCurrentMessages").mockImplementation(() => {
+			expect(root.cancelRlmChildRun(run.id)).toBe(true);
+			return readUsage();
+		});
+
+		const rejection = expect(runPromise).rejects.toThrow("Cancelled by user");
+		releaseChild();
+		await rejection;
+		expect(statuses.at(-1)).toBe("cancelled");
+		expect(statuses).not.toContain("done");
 	});
 
 	it("does not let completion retention resurrect a child being deleted", async () => {
@@ -1114,6 +1161,7 @@ describe("AgentSession rlm recursion", () => {
 		releaseChild();
 
 		await expect(runPromise).rejects.toThrow();
+		await waitFor(() => disposeHostedChild.mock.calls.length === 1);
 		expect(disposeHostedChild).toHaveBeenCalledOnce();
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 	});

--- a/packages/coding-agent/test/child-agent-summary-list.test.ts
+++ b/packages/coding-agent/test/child-agent-summary-list.test.ts
@@ -53,6 +53,22 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		expect(out).not.toContain(" a ");
 	});
 
+	it("shows cancellation instead of stale activity in summary and detail", () => {
+		const cancelled = {
+			...node("cancelled task", "cancelled"),
+			recap: "Executing a stale task",
+			hasActiveHeartbeat: true,
+		};
+		const summary = new ChildAgentSummaryComponent();
+		summary.setNodes([cancelled]);
+		const detail = new ChildAgentDetailComponent();
+		detail.setNode(cancelled);
+
+		const output = stripAnsi([...summary.render(80), ...detail.render(80)].join("\n"));
+		expect(output).toContain("Cancelled");
+		expect(output).not.toContain("Executing a stale task");
+	});
+
 	it("shows the model and token usage without a tool column", () => {
 		const summary = new ChildAgentSummaryComponent();
 		summary.setNodes([{ ...node("a"), model: "openai/gpt-5.4", toolUseCount: 3, tokenCount: 41_000 }]);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -37,6 +37,50 @@ describe("daemon mode helpers", () => {
 		expect(getChildActiveSessionStates(sessions, parent).map((state) => state.activeSessionId)).toEqual(["child"]);
 	});
 
+	it("acknowledges cancellation before awaiting hosted child shutdown", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const parent = makeState("parent");
+		const direct = makeState("direct", "parent", "direct-child");
+		const nested = makeState("nested", "direct", "nested-child");
+		parent.runtime = {
+			...parent.runtime,
+			session: { cancelRlmChildRun: vi.fn(() => true) },
+		} as unknown as ActiveSessionState["runtime"];
+		let finishClose: () => void = () => {};
+		const closeSession = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishClose = resolve;
+				}),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: typeof closeSession;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(parent.activeSessionId, parent);
+		internals.sessions.set(direct.activeSessionId, direct);
+		internals.sessions.set(nested.activeSessionId, nested);
+		internals.closeSession = closeSession;
+
+		await expect(
+			internals.handleCommand(makeClient("client", parent.activeSessionId), {
+				id: "cancel",
+				type: "cancel_rlm_child",
+				activeSessionId: parent.activeSessionId,
+				childId: "nested-child",
+			}),
+		).resolves.toMatchObject({ data: { cancelled: true } });
+		await Promise.resolve();
+		expect(closeSession).toHaveBeenCalledWith(nested, "killed");
+		finishClose();
+	});
+
 	it("cancels pending extension UI requests when the last client detaches", () => {
 		const firstClient = makeClient("client-1", "active");
 		const secondClient = makeClient("client-2", "active");
@@ -5642,7 +5686,7 @@ function makeRuntimeSession(
 	} as unknown as Awaited<ReturnType<CreateAgentSessionRuntimeFactory>>["session"];
 }
 
-function makeState(activeSessionId: string, parentActiveSessionId?: string): ActiveSessionState {
+function makeState(activeSessionId: string, parentActiveSessionId?: string, rlmChildId?: string): ActiveSessionState {
 	return {
 		activeSessionId,
 		clients: new Set(),
@@ -5652,6 +5696,7 @@ function makeState(activeSessionId: string, parentActiveSessionId?: string): Act
 				kind: "subagent",
 				createdAt: 1,
 				parentActiveSessionId,
+				rlmChildId,
 			},
 		},
 	} as unknown as ActiveSessionState;

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -167,6 +167,83 @@ describe("mergeChildAgentSnapshots", () => {
 	});
 });
 
+describe("InteractiveMode subagent cancellation", () => {
+	type CancellationHarness = {
+		stoppingChildAgentIds: Set<string>;
+		childAgentSnapshots: Map<string, AgentConnectionRlmChildAgentSnapshot>;
+		childAgentDetailNodeId: string | undefined;
+		agentConnection: { cancelRlmChild(childId: string): Promise<boolean> };
+		refreshChildAgentInspector(): void;
+		removeChildAgentSnapshot(id: string): void;
+		showStatus(message: string): void;
+		showError(message: string): void;
+		ui: { requestRender(): void };
+		killChildAgent(nodeId: string): Promise<void>;
+		updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void;
+	};
+	const prototype = InteractiveMode.prototype as unknown as CancellationHarness;
+	const snapshot: AgentConnectionRlmChildAgentSnapshot = {
+		id: "child-1",
+		label: "Investigate cancellation",
+		status: "running",
+		sessionDir: "/tmp/child-1",
+		activity: { kind: "writing" },
+	};
+
+	function createHarness(result: boolean | Promise<boolean>): CancellationHarness {
+		return {
+			stoppingChildAgentIds: new Set(),
+			childAgentSnapshots: new Map([[snapshot.id, snapshot]]),
+			childAgentDetailNodeId: undefined,
+			agentConnection: { cancelRlmChild: vi.fn(async () => await result) },
+			refreshChildAgentInspector: vi.fn(),
+			removeChildAgentSnapshot: prototype.removeChildAgentSnapshot,
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			killChildAgent: prototype.killChildAgent,
+			updateChildAgentInspector: prototype.updateChildAgentInspector,
+		};
+	}
+
+	test("shows progress immediately and coalesces duplicate stop input", async () => {
+		const deferred = createDeferred<boolean>();
+		const harness = createHarness(deferred.promise);
+
+		const stopping = harness.killChildAgent(snapshot.id);
+		await harness.killChildAgent(snapshot.id);
+		expect(harness.showStatus).toHaveBeenCalledWith("Stopping subagent...");
+		expect(harness.agentConnection.cancelRlmChild).toHaveBeenCalledOnce();
+		deferred.resolve(true);
+		await stopping;
+
+		expect(harness.showStatus).toHaveBeenLastCalledWith("Subagent stopped");
+		expect(harness.stoppingChildAgentIds).toEqual(new Set());
+	});
+
+	test.each([
+		{ result: "finished", status: "Subagent is no longer running", error: undefined },
+		{ result: "failed", status: undefined, error: "Failed to stop subagent: transport unavailable" },
+	] as const)("reports completion races and failures without mutating the row", async ({ result, status, error }) => {
+		const harness = createHarness(result === "finished" ? false : Promise.reject(new Error("transport unavailable")));
+		await harness.killChildAgent(snapshot.id);
+
+		expect(harness.childAgentSnapshots.get(snapshot.id)).toBe(snapshot);
+		if (status) expect(harness.showStatus).toHaveBeenLastCalledWith(status);
+		if (error) expect(harness.showError).toHaveBeenCalledWith(error);
+	});
+
+	test("keeps user cancellation visible but removes deletion tombstones", () => {
+		const harness = createHarness(true);
+		const cancelled = { ...snapshot, status: "cancelled" as const, activity: undefined, error: "Cancelled by user" };
+		harness.updateChildAgentInspector(cancelled);
+		expect(harness.childAgentSnapshots.get(snapshot.id)).toMatchObject({ status: "cancelled", activity: undefined });
+
+		harness.updateChildAgentInspector({ ...cancelled, error: "Deleted by parent orchestrator" });
+		expect(harness.childAgentSnapshots.has(snapshot.id)).toBe(false);
+	});
+});
+
 describe("InteractiveMode update notifications", () => {
 	beforeAll(() => {
 		initTheme("dark");


### PR DESCRIPTION
## Problem

Stopping a subagent had four confusing or unreliable outcomes:

- completion could win the race and be reported as an error (`Subagent already finished`);
- repeated stop input could send duplicate requests;
- a parent awaiting `rlm(...)` could remain blocked when child work ignored abort;
- a daemon-hosted child could remain resident after cancellation.

## What changes

### Session lifecycle

Cancellation is idempotent while the run remains tracked. It rejects the public `rlm(...)` waiter immediately, aborts the child, emits the authoritative `cancelled` update, keeps terminal activity clear, and does not let a late provider error replace the cancellation reason/status.

### Daemon cleanup

After acknowledging `cancel_rlm_child`, the daemon asynchronously closes the matching hosted descendant runtime with reason `killed`. The response does not wait for shutdown, and the ancestor check prevents an unrelated session from being closed.

### Interactive UX

The TUI:

- shows `Stopping subagent...` immediately;
- coalesces duplicate stop input while the request is pending;
- reports `Subagent stopped` on success;
- reports `Subagent is no longer running` when completion wins the race, without treating it as an error;
- displays the session-owned `Cancelled` update without stale activity/recap;
- removes explicit orchestrator deletion tombstones normally.

The UI does not maintain a second optimistic child-state machine. `AgentSession` remains authoritative for cancellation state, and later daemon roster refreshes may remove the transient cancelled row after runtime release.

## Scope and consolidation

This branch is one commit on current `main` and intentionally excludes the earlier kernel/process-group cleanup work.

Tests follow the consolidation approach from #498, #499, and #500:

- no new test files or harnesses;
- session assertions extend the existing RLM lifecycle test;
- daemon teardown is tested at the command boundary;
- cancellation rendering is checked through the existing summary/detail components;
- interactive success, completion-race, failure, coalescing, and tombstone behavior live in the existing InteractiveMode suite.

## Validation

- `npm run check`
- 195 focused session/interactive/rendering tests
- focused daemon cancellation command test


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make subagent cancellation explicit with immediate feedback and race-condition fixes
> - Cancelling a subagent now immediately marks it as cancelled, rejects the public run promise, records `durationMs`, and emits a terminal UI update before the child finishes unwinding.
> - Fixes a race in `AgentSession.runRlmChild` where result collection could overwrite a concurrent cancellation with a `done` status.
> - The daemon now closes the daemon-hosted child session matching the cancelled subagent after the parent acknowledges cancellation.
> - The interactive UI shows a "Cancelled" recap immediately, avoids duplicate stop requests via a `stoppingChildAgentIds` set, and keeps cancelled snapshots visible unless explicitly deleted by the orchestrator.
> - Behavioral Change: previously cancelled subagents were removed from the inspector; they now remain visible unless marked as deleted by the parent orchestrator.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae977bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RLM child lifecycle, daemon session teardown, and promise rejection paths where races previously caused stuck waiters or wrong terminal status; behavior is well covered by new/extended tests.
> 
> **Overview**
> **Subagent stop** now treats cancellation as authoritative end-to-end: `AgentSession` rejects the public `rlm.run` waiter immediately, emits a terminal `cancelled` update (with duration, no stale activity), idempotently acknowledges repeat cancels, and re-checks cancellation after usage collection so a late finish cannot flip status to `done`.
> 
> **Daemon** `cancel_rlm_child` still returns `{ cancelled: true }` right away, then asynchronously closes the matching hosted descendant session (`killed`) using ancestor checks so unrelated sessions are not torn down.
> 
> **Interactive TUI** shows immediate “Stopping subagent…”, coalesces duplicate stop input, reports success or “no longer running” without erroring on completion races, keeps user-cancelled rows visible (only orchestrator deletion tombstones are removed), and the child inspector shows **Cancelled** instead of stale recap/activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae977bce16b31dd88448cb1e9c4e16699c8d7883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
