### PR TITLE
add production and beta release channels

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to create or update (e.g., v0.0.1)'
+        description: 'Production release tag to create or update (e.g., v0.0.1)'
         required: true
         type: string
 
@@ -22,9 +22,11 @@ jobs:
     permissions:
       contents: read
     outputs:
+      beta_version: ${{ steps.context.outputs.beta_version }}
       build_ref: ${{ steps.context.outputs.build_ref }}
-      release_tag: ${{ steps.context.outputs.release_tag }}
-      should_release: ${{ steps.context.outputs.should_release }}
+      production_version: ${{ steps.context.outputs.production_version }}
+      publish_beta: ${{ steps.context.outputs.publish_beta }}
+      publish_production: ${{ steps.context.outputs.publish_production }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -36,64 +38,82 @@ jobs:
       - name: Resolve release context
         id: context
         env:
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
-          GITHUB_SHA_VALUE: ${{ github.sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          should_release=true
+          beta_version=
+          build_ref=
+          production_version=
+          publish_beta=false
+          publish_production=false
 
           if [ "$EVENT_NAME" = workflow_dispatch ]; then
             if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
               echo "Manual releases must run from the default branch (${DEFAULT_BRANCH}), not ${REF_NAME}." >&2
               exit 1
             fi
-            release_tag="$INPUT_RELEASE_TAG"
+            production_version="${INPUT_RELEASE_TAG#v}"
             build_ref="$GITHUB_SHA_VALUE"
+            publish_production=true
           elif [ "$REF_TYPE" = tag ]; then
-            release_tag="$REF_NAME"
+            production_version="${REF_NAME#v}"
             build_ref="$REF_NAME"
+            publish_production=true
           else
-            version=$(node -p "require('./package.json').version")
-            release_tag="v${version}"
+            production_version=$(node -p "require('./package.json').version")
             build_ref="$GITHUB_SHA_VALUE"
-            if git show-ref --verify --quiet "refs/tags/${release_tag}"; then
-              echo "Tag ${release_tag} already exists; skipping release."
-              should_release=false
+            beta_version="${production_version}-beta.${RUN_NUMBER}.${RUN_ATTEMPT}.${GITHUB_SHA_VALUE::7}"
+            publish_beta=true
+
+            previous_version=
+            if [ -n "$BEFORE_SHA" ] && ! printf '%s\n' "$BEFORE_SHA" | grep -Eq '^0+$' && git cat-file -e "${BEFORE_SHA}:package.json"; then
+              git show "${BEFORE_SHA}:package.json" > /tmp/previous-package.json
+              previous_version=$(node -p "require('/tmp/previous-package.json').version")
+            fi
+
+            if [ -z "$previous_version" ] || [ "$production_version" != "$previous_version" ]; then
+              if git show-ref --verify --quiet "refs/tags/v${production_version}"; then
+                echo "Production v${production_version} already exists; only beta will advance."
+              else
+                publish_production=true
+              fi
+            else
+              echo "Package version is unchanged at ${production_version}; only beta will advance."
             fi
           fi
 
-          case "$release_tag" in
-            v*) ;;
-            *) release_tag="v${release_tag}" ;;
-          esac
-          if ! printf '%s\n' "$release_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Release tag must be a plain semver tag like v0.0.1: ${release_tag}" >&2
+          if [ "$publish_production" = true ] && ! printf '%s\n' "$production_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Production version must be plain semver like 0.0.1: ${production_version}" >&2
             exit 1
           fi
 
-          if [ -z "$build_ref" ]; then
-            build_ref="$release_tag"
-          fi
-
+          echo "beta_version=$beta_version" >> "$GITHUB_OUTPUT"
           echo "build_ref=$build_ref" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
-          echo "Release tag: $release_tag"
+          echo "production_version=$production_version" >> "$GITHUB_OUTPUT"
+          echo "publish_beta=$publish_beta" >> "$GITHUB_OUTPUT"
+          echo "publish_production=$publish_production" >> "$GITHUB_OUTPUT"
           echo "Build ref: $build_ref"
-          echo "Should release: $should_release"
+          echo "Production: $publish_production ${production_version:+v${production_version}}"
+          echo "Beta: $publish_beta ${beta_version:+v${beta_version}}"
 
   build:
     runs-on: ubuntu-latest
     needs: release-context
-    if: needs.release-context.outputs.should_release == 'true'
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
+      BETA_VERSION: ${{ needs.release-context.outputs.beta_version }}
       BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
+      PRODUCTION_VERSION: ${{ needs.release-context.outputs.production_version }}
+      PUBLISH_BETA: ${{ needs.release-context.outputs.publish_beta }}
+      PUBLISH_PRODUCTION: ${{ needs.release-context.outputs.publish_production }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -116,33 +136,60 @@ jobs:
       - name: Check
         run: npm run check
 
-      - name: Pack private npm tarball
+      - name: Pack production release
+        if: env.PUBLISH_PRODUCTION == 'true'
         env:
           PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
         run: |
-          VERSION="${RELEASE_TAG#v}"
-          test -n "${PRIME_AGENT_DOWNLOAD_BASE_URL}"
-          npm run release:pack -- --version "${VERSION}" --base-url "${PRIME_AGENT_DOWNLOAD_BASE_URL}"
+          test -n "$PRIME_AGENT_DOWNLOAD_BASE_URL"
+          npm run release:pack -- \
+            --channel stable \
+            --version "$PRODUCTION_VERSION" \
+            --base-url "$PRIME_AGENT_DOWNLOAD_BASE_URL" \
+            --out-dir packages/coding-agent/release/production
 
-      - name: Upload release artifacts
+      - name: Pack beta release
+        if: env.PUBLISH_BETA == 'true'
+        env:
+          PRIME_AGENT_DOWNLOAD_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
+        run: |
+          test -n "$PRIME_AGENT_DOWNLOAD_BASE_URL"
+          npm run release:pack -- \
+            --channel beta \
+            --version "$BETA_VERSION" \
+            --base-url "$PRIME_AGENT_DOWNLOAD_BASE_URL" \
+            --out-dir packages/coding-agent/release/beta
+
+      - name: Upload production artifacts
+        if: env.PUBLISH_PRODUCTION == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: prime-agent-release
-          path: packages/coding-agent/release/artifacts/*
+          name: prime-agent-production
+          path: packages/coding-agent/release/production/artifacts/*
+          if-no-files-found: error
+
+      - name: Upload beta artifacts
+        if: env.PUBLISH_BETA == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: prime-agent-beta
+          path: packages/coding-agent/release/beta/artifacts/*
           if-no-files-found: error
 
   publish:
     runs-on: ubuntu-latest
     needs: [release-context, build]
-    if: needs.release-context.outputs.should_release == 'true'
     permissions:
       contents: write
     env:
-      RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
-      BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      BETA_VERSION: ${{ needs.release-context.outputs.beta_version }}
+      BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
+      PRODUCTION_VERSION: ${{ needs.release-context.outputs.production_version }}
+      PUBLISH_BETA: ${{ needs.release-context.outputs.publish_beta }}
+      PUBLISH_PRODUCTION: ${{ needs.release-context.outputs.publish_production }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
       R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
@@ -153,90 +200,201 @@ jobs:
           ref: ${{ env.BUILD_REF }}
           persist-credentials: false
 
-      - name: Download release artifacts
+      - name: Download production artifacts
+        if: env.PUBLISH_PRODUCTION == 'true'
         uses: actions/download-artifact@v8
         with:
-          name: prime-agent-release
-          path: release-artifacts
+          name: prime-agent-production
+          path: release-artifacts/production
 
-      - name: Extract changelog for this version
+      - name: Download beta artifacts
+        if: env.PUBLISH_BETA == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: prime-agent-beta
+          path: release-artifacts/beta
+
+      - name: Prepare installer
         run: |
-          VERSION="${RELEASE_TAG#v}"
-          awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" packages/coding-agent/CHANGELOG.md > /tmp/release-notes.md
-          if [ ! -s /tmp/release-notes.md ]; then
-            echo "Release ${RELEASE_TAG}" > /tmp/release-notes.md
-          fi
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          target_args=()
-          if [ "${BUILD_REF}" != "${RELEASE_TAG}" ]; then
-            target_args=(--target "${BUILD_REF}")
-          fi
-
-          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-            gh release upload "${RELEASE_TAG}" release-artifacts/* --clobber
-          else
-            gh release create "${RELEASE_TAG}" \
-              --title "${RELEASE_TAG}" \
-              "${target_args[@]}" \
-              --notes-file /tmp/release-notes.md \
-              release-artifacts/*
-          fi
-
-      - name: Publish to R2
-        run: |
-          VERSION="${RELEASE_TAG#v}"
-          RELEASE_PREFIX="releases/v${VERSION}"
-          TARBALL="release-artifacts/prime-agent-${VERSION}.tgz"
-          INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL}"
-          INSTALL_BASE_URL="${INSTALL_BASE_URL%/}"
+          INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL%/}"
           export INSTALL_BASE_URL
-
-          test -f "${TARBALL}"
-          test -f release-artifacts/SHA256SUMS
-          test -f release-artifacts/stable
-          test -f release-artifacts/latest.json
-          test -n "${INSTALL_BASE_URL}"
-          test -n "${R2_BUCKET}"
-          test -n "${R2_ENDPOINT_URL}"
+          test -n "$INSTALL_BASE_URL"
 
           node - <<'NODE'
           const fs = require("node:fs");
           const baseUrl = process.env.INSTALL_BASE_URL;
           if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
-          const installer = fs.readFileSync("install.sh", "utf8")
-            .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl);
-          fs.writeFileSync("/tmp/prime-agent-install.sh", installer);
+          const installer = fs.readFileSync("install.sh", "utf8");
+          const renderInstaller = (channel) => installer
+            .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
+            .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
+          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller("stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller("beta"));
           NODE
 
-          for artifact in release-artifacts/*.tgz; do
-            aws s3 cp "${artifact}" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "${artifact}")" \
-              --endpoint-url "${R2_ENDPOINT_URL}" \
-              --content-type "application/gzip" \
-              --cache-control "public, max-age=31536000, immutable"
+      - name: Extract production release notes
+        if: env.PUBLISH_PRODUCTION == 'true'
+        run: |
+          awk "/^## \[${PRODUCTION_VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" packages/coding-agent/CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Release v${PRODUCTION_VERSION}" > /tmp/release-notes.md
+          fi
+
+      - name: Create production GitHub release
+        if: env.PUBLISH_PRODUCTION == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG="v${PRODUCTION_VERSION}"
+          PRODUCTION_DIR=release-artifacts/production
+          target_args=()
+          if [ "$BUILD_REF" != "$RELEASE_TAG" ]; then
+            target_args=(--target "$BUILD_REF")
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "$PRODUCTION_DIR"/* --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              "${target_args[@]}" \
+              --notes-file /tmp/release-notes.md \
+              "$PRODUCTION_DIR"/*
+          fi
+
+      - name: Publish production channel to R2
+        if: env.PUBLISH_PRODUCTION == 'true'
+        run: |
+          PRODUCTION_DIR=release-artifacts/production
+          RELEASE_PREFIX="releases/v${PRODUCTION_VERSION}"
+          TARBALL="$PRODUCTION_DIR/prime-agent-${PRODUCTION_VERSION}.tgz"
+
+          test -f "$TARBALL"
+          test -f "$PRODUCTION_DIR/SHA256SUMS"
+          test -f "$PRODUCTION_DIR/stable"
+          test -f "$PRODUCTION_DIR/latest.json"
+          test -n "$R2_BUCKET"
+          test -n "$R2_ENDPOINT_URL"
+
+          for artifact in "$PRODUCTION_DIR"/*.tgz; do
+            aws s3 cp "$artifact" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$artifact")" \
+              --endpoint-url "$R2_ENDPOINT_URL" \
+              --content-type application/gzip \
+              --cache-control 'public, max-age=31536000, immutable'
           done
 
-          aws s3 cp release-artifacts/SHA256SUMS "s3://${R2_BUCKET}/${RELEASE_PREFIX}/SHA256SUMS" \
-            --endpoint-url "${R2_ENDPOINT_URL}" \
-            --content-type "text/plain" \
-            --cache-control "public, max-age=31536000, immutable"
+          aws s3 cp "$PRODUCTION_DIR/SHA256SUMS" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/SHA256SUMS" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control 'public, max-age=31536000, immutable'
 
-          aws s3 cp release-artifacts/latest.json "s3://${R2_BUCKET}/latest.json" \
-            --endpoint-url "${R2_ENDPOINT_URL}" \
-            --content-type "application/json" \
-            --cache-control "no-cache"
+          aws s3 cp "$PRODUCTION_DIR/latest.json" "s3://${R2_BUCKET}/latest.json" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type application/json \
+            --cache-control no-cache
 
-          aws s3 cp release-artifacts/stable "s3://${R2_BUCKET}/stable" \
-            --endpoint-url "${R2_ENDPOINT_URL}" \
-            --content-type "text/plain" \
-            --cache-control "no-cache"
+          aws s3 cp "$PRODUCTION_DIR/stable" "s3://${R2_BUCKET}/stable" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
 
           aws s3 cp /tmp/prime-agent-install.sh "s3://${R2_BUCKET}/install.sh" \
-            --endpoint-url "${R2_ENDPOINT_URL}" \
-            --content-type "text/x-shellscript" \
-            --cache-control "no-cache"
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/x-shellscript \
+            --cache-control no-cache
 
-          echo "Installer: ${INSTALL_BASE_URL}/install.sh"
+          aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/x-shellscript \
+            --cache-control no-cache
+
+      - name: Publish immutable beta artifacts to R2
+        if: env.PUBLISH_BETA == 'true'
+        run: |
+          BETA_DIR=release-artifacts/beta
+          RELEASE_PREFIX="releases/v${BETA_VERSION}"
+          TARBALL="$BETA_DIR/prime-agent-${BETA_VERSION}.tgz"
+
+          test -f "$TARBALL"
+          test -f "$BETA_DIR/SHA256SUMS"
+          test -f "$BETA_DIR/beta"
+          test -f "$BETA_DIR/beta.json"
+          test -n "$R2_BUCKET"
+          test -n "$R2_ENDPOINT_URL"
+
+          for artifact in "$BETA_DIR"/*.tgz; do
+            aws s3 cp "$artifact" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/$(basename "$artifact")" \
+              --endpoint-url "$R2_ENDPOINT_URL" \
+              --content-type application/gzip \
+              --cache-control 'public, max-age=31536000, immutable'
+          done
+
+          aws s3 cp "$BETA_DIR/SHA256SUMS" "s3://${R2_BUCKET}/${RELEASE_PREFIX}/SHA256SUMS" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control 'public, max-age=31536000, immutable'
+
+      - name: Advance beta release
+        if: env.PUBLISH_BETA == 'true'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha)
+          if [ "$latest_main_sha" != "$BUILD_REF" ]; then
+            echo "A newer main commit exists; keeping its beta pointers in place."
+            exit 0
+          fi
+
+          BETA_DIR=release-artifacts/beta
+          aws s3 cp "$BETA_DIR/beta.json" "s3://${R2_BUCKET}/beta.json" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type application/json \
+            --cache-control no-cache
+
+          aws s3 cp "$BETA_DIR/beta" "s3://${R2_BUCKET}/beta" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install.sh "s3://${R2_BUCKET}/install.sh" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          printf 'Automated beta build from `%s` (`%s`).\n' "$DEFAULT_BRANCH" "$BUILD_REF" > /tmp/beta-release-notes.md
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/beta" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/beta" \
+              -F sha="$BUILD_REF" \
+              -F force=true >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref=refs/tags/beta \
+              -f sha="$BUILD_REF" >/dev/null
+          fi
+
+          if release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/beta" --jq .id 2>/dev/null); then
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets" --jq '.[].id' | while read -r asset_id; do
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+            done
+            gh release edit beta \
+              --title "Beta (v${BETA_VERSION})" \
+              --target "$BUILD_REF" \
+              --notes-file /tmp/beta-release-notes.md \
+              --prerelease
+          else
+            gh release create beta \
+              --title "Beta (v${BETA_VERSION})" \
+              --target "$BUILD_REF" \
+              --notes-file /tmp/beta-release-notes.md \
+              --prerelease
+          fi
+
+          gh release upload beta "$BETA_DIR"/* --clobber
+          echo "Beta installer: ${R2_PUBLIC_BASE_URL%/}/install-beta.sh"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-prime-agent
+  cancel-in-progress: false
+  queue: max
+
 permissions:
   contents: read
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -85,10 +85,14 @@ jobs:
 
             if [ -z "$previous_version" ] || [ "$production_version" != "$previous_version" ]; then
               if git show-ref --verify --quiet "refs/tags/v${production_version}"; then
-                echo "Production v${production_version} already exists; only beta will advance."
-              else
-                publish_production=true
+                tagged_commit=$(git rev-list -n 1 "v${production_version}")
+                if [ "$tagged_commit" != "$GITHUB_SHA_VALUE" ]; then
+                  echo "Production v${production_version} already points to ${tagged_commit}, not ${GITHUB_SHA_VALUE}." >&2
+                  exit 1
+                fi
+                echo "Retrying production v${production_version} for ${GITHUB_SHA_VALUE}."
               fi
+              publish_production=true
             else
               echo "Package version is unchanged at ${production_version}; only beta will advance."
             fi
@@ -245,28 +249,6 @@ jobs:
             echo "Release v${PRODUCTION_VERSION}" > /tmp/release-notes.md
           fi
 
-      - name: Create production GitHub release
-        if: env.PUBLISH_PRODUCTION == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_TAG="v${PRODUCTION_VERSION}"
-          PRODUCTION_DIR=release-artifacts/production
-          target_args=()
-          if [ "$BUILD_REF" != "$RELEASE_TAG" ]; then
-            target_args=(--target "$BUILD_REF")
-          fi
-
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" "$PRODUCTION_DIR"/* --clobber
-          else
-            gh release create "$RELEASE_TAG" \
-              --title "$RELEASE_TAG" \
-              "${target_args[@]}" \
-              --notes-file /tmp/release-notes.md \
-              "$PRODUCTION_DIR"/*
-          fi
-
       - name: Publish production channel to R2
         if: env.PUBLISH_PRODUCTION == 'true'
         run: |
@@ -312,6 +294,28 @@ jobs:
             --endpoint-url "$R2_ENDPOINT_URL" \
             --content-type text/x-shellscript \
             --cache-control no-cache
+
+      - name: Create production GitHub release
+        if: env.PUBLISH_PRODUCTION == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG="v${PRODUCTION_VERSION}"
+          PRODUCTION_DIR=release-artifacts/production
+          target_args=()
+          if [ "$BUILD_REF" != "$RELEASE_TAG" ]; then
+            target_args=(--target "$BUILD_REF")
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "$PRODUCTION_DIR"/* --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              "${target_args[@]}" \
+              --notes-file /tmp/release-notes.md \
+              "$PRODUCTION_DIR"/*
+          fi
 
       - name: Publish immutable beta artifacts to R2
         if: env.PUBLISH_BETA == 'true'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Install the latest stable release:
 curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
 ```
 
+Install the latest beta built from `main`:
+
+```bash
+curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install-beta.sh | sh
+```
+
+Stable advances when a version bump lands on `main`; beta advances on every commit to `main`.
+
 Then start Prime Agent:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -2,11 +2,17 @@
 
 set -eu
 
-# Keep this sentinel split so release publishing only rewrites the install URL
-# below; local or unpublished copies still need an unreplaced value to compare.
+# Keep these sentinels split so release publishing only rewrites the configured
+# values below; local or unpublished copies still need unreplaced values to compare.
 prime_agent_unconfigured_base_url="__PRIME_AGENT_DOWNLOAD_BASE""_URL__"
+prime_agent_unconfigured_default_release_channel="__PRIME_AGENT_DEFAULT_RELEASE_""CHANNEL__"
 prime_agent_base_url="${PRIME_AGENT_DOWNLOAD_BASE_URL:-__PRIME_AGENT_DOWNLOAD_BASE_URL__}"
 prime_agent_base_url="${prime_agent_base_url%/}"
+prime_agent_default_release_channel="__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"
+if [ "$prime_agent_default_release_channel" = "$prime_agent_unconfigured_default_release_channel" ]; then
+	prime_agent_default_release_channel=stable
+fi
+prime_agent_release_channel="${PRIME_AGENT_RELEASE_CHANNEL:-$prime_agent_default_release_channel}"
 prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
 prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
 prime_agent_esc=$(printf '\033')
@@ -27,7 +33,7 @@ prime_agent_color_dim="${prime_agent_esc}[38;2;113;113;122m"
 prime_agent_color_primary="${prime_agent_esc}[38;2;127;91;213m"
 prime_agent_color_scan="${prime_agent_esc}[38;2;14;165;233m"
 prime_agent_color_warning="${prime_agent_esc}[38;2;245;158;11m"
-readonly prime_agent_unconfigured_base_url prime_agent_base_url prime_agent_package prime_agent_cmd prime_agent_esc prime_agent_original_path
+readonly prime_agent_unconfigured_base_url prime_agent_unconfigured_default_release_channel prime_agent_base_url prime_agent_default_release_channel prime_agent_release_channel prime_agent_package prime_agent_cmd prime_agent_esc prime_agent_original_path
 readonly prime_agent_reset prime_agent_bold prime_agent_italic prime_agent_hide_cursor prime_agent_show_cursor prime_agent_home_cursor prime_agent_clear_screen prime_agent_clear_line
 readonly prime_agent_sync_start prime_agent_sync_end
 readonly prime_agent_color_text prime_agent_color_muted prime_agent_color_dim prime_agent_color_primary prime_agent_color_scan prime_agent_color_warning
@@ -917,8 +923,15 @@ run_preflight_checks() {
 
 resolve_prime_agent_version() {
 	if [ "${1:-}" ]; then
-		normalize_version "$1"
-		return
+		case "$1" in
+			stable|beta) release_channel="$1" ;;
+			*)
+				normalize_version "$1"
+				return
+				;;
+		esac
+	else
+		release_channel="$prime_agent_release_channel"
 	fi
 
 	if [ "${PRIME_AGENT_VERSION:-}" ]; then
@@ -931,24 +944,32 @@ resolve_prime_agent_version() {
 		exit 1
 	fi
 
-	stable_dir=$(create_temp_dir)
-	stable_path="$stable_dir/stable"
+	case "$release_channel" in
+		stable|beta) ;;
+		*)
+			printf 'error: invalid Prime Agent release channel: %s\n' "$release_channel" >&2
+			exit 1
+			;;
+	esac
+
+	channel_dir=$(create_temp_dir)
+	channel_path="$channel_dir/$release_channel"
 	if ! prime_agent_run_quiet_with_animation \
 		"Resolving latest release" \
 		"Resolving latest release" \
-		"Checking the stable release channel." \
-		curl -fsSL "$prime_agent_base_url/stable" -o "$stable_path"; then
-		rm -rf "$stable_dir"
-		printf 'error: could not resolve latest Prime Agent version from %s/stable\n' "$prime_agent_base_url" >&2
+		"Checking the $release_channel release channel." \
+		curl -fsSL "$prime_agent_base_url/$release_channel" -o "$channel_path"; then
+		rm -rf "$channel_dir"
+		printf 'error: could not resolve latest Prime Agent version from %s/%s\n' "$prime_agent_base_url" "$release_channel" >&2
 		exit 1
 	fi
-	stable_version="$(tr -d '[:space:]' <"$stable_path")"
-	rm -rf "$stable_dir"
-	if [ -z "$stable_version" ]; then
-		printf 'error: could not resolve latest Prime Agent version from %s/stable\n' "$prime_agent_base_url" >&2
+	channel_version="$(tr -d '[:space:]' <"$channel_path")"
+	rm -rf "$channel_dir"
+	if [ -z "$channel_version" ]; then
+		printf 'error: could not resolve latest Prime Agent version from %s/%s\n' "$prime_agent_base_url" "$release_channel" >&2
 		exit 1
 	fi
-	normalize_version "$stable_version"
+	normalize_version "$channel_version"
 }
 
 normalize_version() {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
+- Added dedicated stable and beta installers, with stable advancing on version bumps and beta advancing on every commit to `main`.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed top-level CLI help to show concise common options and commands without loading runtime resources ([ENG-4688](https://linear.app/primeintellect/issue/ENG-4688/help-command-is-obscenely-verbose)).
 - Fixed completed subagents cancelling their RLM heartbeats before the first run ([ENG-4652](https://linear.app/primeintellect/issue/ENG-4652/subagent-heartbeats-dont-work)).

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -46,6 +46,12 @@ This workspace still keeps an inherited source package name internally. The dist
 curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
 ```
 
+To install the beta built from the latest commit on `main`:
+
+```bash
+curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install-beta.sh | sh
+```
+
 Authenticate with an API key:
 
 ```bash
@@ -249,7 +255,7 @@ See [docs/settings.md](docs/settings.md) for all options.
 
 ### Update checks
 
-Prime Agent can fetch the release manifest at `https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json` to check whether a newer version exists. Override the base URL with `PRIME_AGENT_DOWNLOAD_BASE_URL`. Disable it with `PI_SKIP_VERSION_CHECK=1`.
+Prime Agent stable builds fetch `https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json` to check whether a newer version exists. Beta builds fetch `beta.json` and remain on the beta channel. Override the base URL with `PRIME_AGENT_DOWNLOAD_BASE_URL`. Disable version checks with `PI_SKIP_VERSION_CHECK=1`.
 
 Use `--offline` or `PI_OFFLINE=1` to disable startup network operations, including update checks and package update checks.
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -48,11 +48,11 @@ Edit directly or use `/settings` for common options.
 
 ### Update Checks
 
-Prime Agent fetches the release manifest at `https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json` to check whether a newer version exists. Override the base URL with `PRIME_AGENT_DOWNLOAD_BASE_URL`.
+Stable builds fetch the release manifest at `https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json`. Beta builds fetch `beta.json` and continue following beta updates. Override the base URL with `PRIME_AGENT_DOWNLOAD_BASE_URL`.
 
 Set `PI_SKIP_VERSION_CHECK=1` to disable the Prime Agent version update check. Use `--offline` or `PI_OFFLINE=1` to disable startup network operations, including update checks and package update checks.
 
-The temporary R2 manifest is JSON:
+The stable `latest.json` and beta `beta.json` manifests use the same JSON shape:
 
 ```json
 {

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -1,7 +1,8 @@
 import { getPiUserAgent } from "./pi-user-agent.js";
 
 const DEFAULT_PRIME_AGENT_DOWNLOAD_BASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev";
-const LATEST_VERSION_MANIFEST_PATH = "latest.json";
+const STABLE_VERSION_MANIFEST_PATH = "latest.json";
+const BETA_VERSION_MANIFEST_PATH = "beta.json";
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
 
 export interface LatestPiRelease {
@@ -15,6 +16,36 @@ interface ParsedVersion {
 	minor: number;
 	patch: number;
 	prerelease?: string;
+}
+
+function comparePrereleaseIdentifiers(leftPrerelease: string, rightPrerelease: string): number {
+	const leftIdentifiers = leftPrerelease.split(".");
+	const rightIdentifiers = rightPrerelease.split(".");
+	const length = Math.max(leftIdentifiers.length, rightIdentifiers.length);
+
+	for (let index = 0; index < length; index += 1) {
+		const left = leftIdentifiers[index];
+		const right = rightIdentifiers[index];
+		if (left === right) continue;
+		if (left === undefined) return -1;
+		if (right === undefined) return 1;
+
+		const leftIsNumeric = /^\d+$/.test(left);
+		const rightIsNumeric = /^\d+$/.test(right);
+		if (leftIsNumeric && rightIsNumeric) {
+			const leftNumber = left.replace(/^0+(?=\d)/, "");
+			const rightNumber = right.replace(/^0+(?=\d)/, "");
+			if (leftNumber.length !== rightNumber.length) return leftNumber.length - rightNumber.length;
+			const comparison = leftNumber.localeCompare(rightNumber);
+			if (comparison !== 0) return comparison;
+			continue;
+		}
+		if (leftIsNumeric) return -1;
+		if (rightIsNumeric) return 1;
+		return left.localeCompare(right);
+	}
+
+	return 0;
 }
 
 function parsePackageVersion(version: string): ParsedVersion | undefined {
@@ -43,7 +74,7 @@ export function comparePackageVersions(leftVersion: string, rightVersion: string
 	if (left.prerelease === right.prerelease) return 0;
 	if (!left.prerelease) return 1;
 	if (!right.prerelease) return -1;
-	return left.prerelease.localeCompare(right.prerelease);
+	return comparePrereleaseIdentifiers(left.prerelease, right.prerelease);
 }
 
 export function isNewerPackageVersion(candidateVersion: string, currentVersion: string): boolean {
@@ -65,6 +96,11 @@ function normalizeReleaseVersion(version: string): string {
 	return version.trim().replace(/^v/, "");
 }
 
+function getReleaseManifestPath(currentVersion: string): string {
+	const prerelease = parsePackageVersion(currentVersion)?.prerelease;
+	return prerelease?.match(/^beta(?:\.|$)/) ? BETA_VERSION_MANIFEST_PATH : STABLE_VERSION_MANIFEST_PATH;
+}
+
 function resolveReleaseUrl(baseUrl: string, pathOrUrl: string): string | undefined {
 	const trimmed = pathOrUrl.trim();
 	if (!trimmed) return undefined;
@@ -82,7 +118,7 @@ export async function getLatestPiRelease(
 	if (process.env.PI_SKIP_VERSION_CHECK || process.env.PI_OFFLINE) return undefined;
 
 	const baseUrl = getPrimeAgentDownloadBaseUrl();
-	const response = await fetch(`${baseUrl}/${LATEST_VERSION_MANIFEST_PATH}`, {
+	const response = await fetch(`${baseUrl}/${getReleaseManifestPath(currentVersion)}`, {
 		headers: {
 			"User-Agent": getPiUserAgent(currentVersion),
 			accept: "application/json",

--- a/packages/coding-agent/test/version-check.test.ts
+++ b/packages/coding-agent/test/version-check.test.ts
@@ -32,6 +32,7 @@ describe("version checks", () => {
 		expect(comparePackageVersions("0.70.6", "0.70.5")).toBeGreaterThan(0);
 		expect(comparePackageVersions("0.70.5", "0.70.5")).toBe(0);
 		expect(comparePackageVersions("0.70.4", "0.70.5")).toBeLessThan(0);
+		expect(comparePackageVersions("0.70.5-beta.10.1.abcdef0", "0.70.5-beta.9.1.1234567")).toBeGreaterThan(0);
 		expect(isNewerPackageVersion("0.70.5", "0.70.5")).toBe(false);
 		expect(isNewerPackageVersion("0.70.6", "0.70.5")).toBe(true);
 	});
@@ -58,6 +59,14 @@ describe("version checks", () => {
 				}),
 			}),
 		);
+	});
+
+	it("keeps beta installations on the beta release manifest", async () => {
+		const fetchMock = vi.fn(async () => Response.json({ version: "v1.2.4-beta.124.1.abcdef0" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(getLatestPiVersion("1.2.4-beta.123.1.1234567")).resolves.toBe("1.2.4-beta.124.1.abcdef0");
+		expect(fetchMock).toHaveBeenCalledWith(`${defaultPrimeAgentDownloadBaseUrl}/beta.json`, expect.any(Object));
 	});
 
 	it("returns the active package and tarball install spec from the release manifest", async () => {

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -23,6 +23,7 @@ const defaultOutputDir = join(root, "packages", "coding-agent", "release");
 const defaultBaseUrl = process.env.PRIME_AGENT_DOWNLOAD_BASE_URL;
 const publicPackageName = process.env.PRIME_AGENT_PACKAGE_NAME || "prime-agent";
 const publicCommandName = process.env.PRIME_AGENT_CMD || "prime-agent";
+const releaseChannels = new Set(["stable", "beta"]);
 
 const releasePackages = [
 	{ packageDir: "ai", publicName: undefined, artifactName: "prime-agent-ai" },
@@ -34,6 +35,7 @@ const releasePackages = [
 function parseArgs(args) {
 	const parsed = {
 		baseUrl: defaultBaseUrl,
+		channel: "stable",
 		outDir: defaultOutputDir,
 		version: undefined,
 	};
@@ -41,6 +43,15 @@ function parseArgs(args) {
 	for (let i = 0; i < args.length; i += 1) {
 		const arg = args[i];
 		switch (arg) {
+			case "--channel": {
+				const value = args[i + 1];
+				if (!value || !releaseChannels.has(value)) {
+					throw new Error("--channel must be stable or beta");
+				}
+				parsed.channel = value;
+				i += 1;
+				break;
+			}
 			case "--base-url": {
 				const value = args[i + 1];
 				if (!value) throw new Error("--base-url requires a value");
@@ -81,7 +92,7 @@ function parseArgs(args) {
 }
 
 function printHelp() {
-	console.log(`Usage: node scripts/pack-prime-agent-release.mjs --base-url url [--version x.y.z] [--out-dir path]
+	console.log(`Usage: node scripts/pack-prime-agent-release.mjs --base-url url [--channel stable|beta] [--version x.y.z] [--out-dir path]
 
 Creates private npm tarballs for R2 distribution:
 
@@ -90,8 +101,8 @@ Creates private npm tarballs for R2 distribution:
   <out-dir>/artifacts/prime-agent-core-<version>.tgz
   <out-dir>/artifacts/prime-agent-tui-<version>.tgz
   <out-dir>/artifacts/SHA256SUMS
-  <out-dir>/artifacts/stable
-  <out-dir>/artifacts/latest.json
+  <out-dir>/artifacts/<channel>
+  <out-dir>/artifacts/latest.json (stable) or beta.json (beta)
 `);
 }
 
@@ -315,8 +326,9 @@ function main() {
 		join(artifactsDir, "SHA256SUMS"),
 		tarballs.map((tarball) => `${tarball.sha256}  ${tarball.file}`).join("\n") + "\n",
 	);
-	writeFileSync(join(artifactsDir, "stable"), `v${releaseVersion}\n`);
-	writeJson(join(artifactsDir, "latest.json"), {
+	writeFileSync(join(artifactsDir, args.channel), `v${releaseVersion}\n`);
+	const manifestName = args.channel === "stable" ? "latest.json" : "beta.json";
+	writeJson(join(artifactsDir, manifestName), {
 		version: `v${releaseVersion}`,
 		package: publicPackageName,
 		tarball: `releases/v${releaseVersion}/${artifactFiles.get("coding-agent")}`,


### PR DESCRIPTION
- production releases publish only when the package version changes and create a versioned github tag.
- beta builds publish from every main commit with separate r2 pointers, manifests, and a moving prerelease.
- dedicated stable and beta installers keep each installation on its selected update channel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release gating, R2/GitHub publish paths, and self-update manifest selection; misconfiguration could ship wrong channel pointers or skip/block production releases.
> 
> **Overview**
> Introduces **stable** and **beta** distribution so `main` can ship continuous prereleases without treating every commit as a production semver release.
> 
> The **release workflow** now resolves separate `publish_production` and `publish_beta` flags: production builds run on version-tag pushes, manual production tags from `main`, or when `package.json` version changes on `main` (with guards if an existing `vX.Y.Z` tag points at another commit); every `main` push also packs a unique beta version (`{semver}-beta.{run}.{attempt}.{sha7}`) and only advances the moving `beta` / `beta.json` R2 pointers and GitHub prerelease when the build still matches the latest `main` commit. Workflow concurrency is serialized via `release-prime-agent`.
> 
> **Packaging** gains `--channel stable|beta`, writing channel pointer files (`stable` / `beta`) and `latest.json` vs `beta.json`. CI uploads separate production and beta artifact bundles.
> 
> **Installers**: `install.sh` resolves versions from a configurable release channel (`PRIME_AGENT_RELEASE_CHANNEL`, default `stable`); publish renders `install-beta.sh` with beta as the default channel. Docs describe `install-beta.sh` for latest `main`.
> 
> **In-app updates**: `version-check` loads `beta.json` for beta-tagged installs and fixes semver prerelease segment ordering (e.g. `beta.10` &gt; `beta.9`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717a2cf9de10b234352786a9017c690821e0f1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add production and beta release channels to the build pipeline and installer
> - The CI workflow in [build-binaries.yml](.github/workflows/build-binaries.yml) now builds and publishes two independent channels: production (stable) on version bumps and beta on every commit to `main`, with separate artifacts, R2 uploads, manifests (`latest.json` / `beta.json`), channel pointers (`stable` / `beta`), installers (`install.sh` / `install-beta.sh`), and GitHub releases.
> - The [pack script](scripts/pack-prime-agent-release.mjs) accepts a `--channel stable|beta` flag and writes the correct manifest and channel marker file per channel.
> - The [installer](install.sh) resolves the version from the selected channel marker (`stable` or `beta`) via `PRIME_AGENT_RELEASE_CHANNEL`, defaulting to stable.
> - Version checks in [version-check.ts](packages/coding-agent/src/utils/version-check.ts) now fetch `beta.json` for beta installs and `latest.json` for stable installs, and prerelease comparison follows semver precedence rules.
> - Behavioral Change: beta installations will no longer receive stable-channel update offers; stable installations will not see beta releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 717a2cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->