### PR TITLE
polish subagent model labels and viewer hints

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -1,3 +1,4 @@
+import { getModels, type KnownProvider } from "@earendil-works/pi-ai";
 import {
 	type Component,
 	type Focusable,
@@ -193,7 +194,20 @@ function padTableCell(value: string, width: number, ellipsis = ""): string {
 	return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
 }
 
-function truncateModelSelector(value: string, width: number): string {
+function childAgentModelLabel(selector: string | undefined): string {
+	if (!selector) {
+		return "";
+	}
+	const separatorIndex = selector.indexOf("/");
+	if (separatorIndex === -1) {
+		return selector;
+	}
+	const provider = selector.slice(0, separatorIndex);
+	const modelId = selector.slice(separatorIndex + 1);
+	return getModels(provider as KnownProvider).find((model) => model.id === modelId)?.name ?? modelId;
+}
+
+function truncateModelLabel(value: string, width: number): string {
 	if (visibleWidth(value) <= width) {
 		return value;
 	}
@@ -470,10 +484,10 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const agentCell = theme.fg("muted", padTableCell(agentLabel, agentWidth));
 		const promptCell = this.elidePrompt(this.entryLabel(entry), sharedPrefix, sharedSuffix, promptWidth);
 		const recapCell = theme.fg("muted", padTableCell(childAgentRecap(entry.node), recapWidth, "…"));
-		const model = entry.node.model ?? "";
+		const model = childAgentModelLabel(entry.node.model);
 		const tokens = entry.node.tokenCount === undefined ? "" : `${formatTokenCount(entry.node.tokenCount)} tok`;
 		const duration = formatChildAgentDuration(entry.node.durationMs);
-		const modelCell = padTableCell(truncateModelSelector(model, SUMMARY_MODEL_WIDTH), SUMMARY_MODEL_WIDTH);
+		const modelCell = padTableCell(truncateModelLabel(model, SUMMARY_MODEL_WIDTH), SUMMARY_MODEL_WIDTH);
 		const tokensCell = padTableCell(tokens, SUMMARY_TOKENS_WIDTH, "…");
 		const durationCell = padTableCell(duration, SUMMARY_DURATION_WIDTH, "…");
 		const metrics = `${modelCell} ${tokensCell}${" ".repeat(SUMMARY_TOKEN_TIME_GAP)}${durationCell}`;
@@ -833,10 +847,9 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 		const actions = [backAction, expandAction, stopAction];
 		const separatorWidth = visibleWidth(joinHints(["", ""]));
 		const modelWidth = Math.max(0, width - visibleWidth(joinHints(actions)) - separatorWidth);
+		const modelLabel = childAgentModelLabel(this.node?.model);
 		const model =
-			this.node?.model && modelWidth >= 4
-				? theme.fg("muted", truncateToWidth(this.node.model, modelWidth, "…"))
-				: undefined;
+			modelLabel && modelWidth >= 4 ? theme.fg("muted", truncateToWidth(modelLabel, modelWidth, "…")) : undefined;
 		return hintLine([backAction, model, expandAction, stopAction], width);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3631,8 +3631,9 @@ export class InteractiveMode {
 			this.enteredSessionViaSubagentDetail = false;
 			this.childAgentDetail.setBackHintLabel("back to chat");
 			this.childAgentDetail.setNode(undefined);
+			this.childAgentPanelMode = undefined;
+			this.resumeFeatureHintPresentation();
 		}
-		this.childAgentPanelMode = undefined;
 		this.childAgentSummary.setHidden(false);
 
 		// Save text from current editor before switching

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2958,6 +2958,9 @@ export class InteractiveMode {
 
 	private startFeatureHintPresentation(): void {
 		this.clearFeatureHintPresentation();
+		if (this.childAgentPanelMode) {
+			return;
+		}
 		if (this.featureHintEligibleAt === 0) {
 			this.featureHintEligibleAt = Date.now() + FEATURE_HINT_DELAY_MS;
 		}
@@ -3016,6 +3019,16 @@ export class InteractiveMode {
 		if (this.featureHintComponent) {
 			this.featureHintContainer.removeChild(this.featureHintComponent);
 			this.featureHintComponent = undefined;
+		}
+	}
+
+	private resumeFeatureHintPresentation(): void {
+		if (
+			this.loadingAnimation &&
+			this.shouldShowWorkingLoader() &&
+			this.statusContainer.children.includes(this.loadingAnimation)
+		) {
+			this.startFeatureHintPresentation();
 		}
 	}
 
@@ -5497,6 +5510,7 @@ export class InteractiveMode {
 			return false;
 		}
 		this.childAgentPanelMode = "detail";
+		this.clearFeatureHintPresentation();
 		this.childAgentDetailNodeId = nodeId;
 		this.childAgentDetail.setNode(node);
 		this.childAgentDetail.setBodyComponents([]);
@@ -5636,6 +5650,7 @@ export class InteractiveMode {
 		this.childAgentDetail.setBodyComponents([]);
 		this.childAgentSummary.setHidden(false);
 		this.restoreMainAgentView();
+		this.resumeFeatureHintPresentation();
 		// Restore the parent recap that was suppressed while the panel was open.
 		this.renderRecap();
 		// Re-render queued previews cleared on panel entry; the queue may still hold messages.

--- a/packages/coding-agent/test/child-agent-summary-list.test.ts
+++ b/packages/coding-agent/test/child-agent-summary-list.test.ts
@@ -57,17 +57,18 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		const summary = new ChildAgentSummaryComponent();
 		summary.setNodes([{ ...node("a"), model: "openai/gpt-5.4", toolUseCount: 3, tokenCount: 41_000 }]);
 		const out = stripAnsi(summary.render(80).join("\n"));
-		expect(out).toContain("openai/gpt-5.4");
+		expect(out).toContain("GPT-5.4");
+		expect(out).not.toContain("openai/gpt-5.4");
 		expect(out).toContain("41k tok");
 		expect(out).not.toContain("tools");
 	});
 
-	it("preserves the model suffix when its selector is truncated", () => {
+	it("preserves nested model ids when the label is truncated", () => {
 		const summary = new ChildAgentSummaryComponent();
 		summary.setNodes([{ ...node("a"), model: "prime-inference/internal/glm-5.2-fast" }]);
 		const out = stripAnsi(summary.render(80).join("\n"));
-		expect(out).toContain("prime-…/glm-5.2-fast");
-		expect(out).not.toContain("prime-inference/int…");
+		expect(out).toContain("intern…/glm-5.2-fast");
+		expect(out).not.toContain("prime-inference");
 	});
 
 	it("shows recaps in a fixed column and falls back to activity", () => {
@@ -199,8 +200,9 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		detail.setNode({ ...node("a"), model: "anthropic/claude-opus-4-7" });
 		const hint = stripAnsi(detail.render(100).at(-1) ?? "");
 		expect(hint).toContain("back to chat");
-		expect(hint).toContain("anthropic/claude-opus-4-7");
-		expect(hint.indexOf("anthropic/claude-opus-4-7")).toBeGreaterThan(hint.indexOf("back to chat"));
+		expect(hint).toContain("Claude Opus 4.7");
+		expect(hint).not.toContain("anthropic/claude-opus-4-7");
+		expect(hint.indexOf("Claude Opus 4.7")).toBeGreaterThan(hint.indexOf("back to chat"));
 	});
 
 	it("truncates long models before hiding detail actions", () => {
@@ -211,7 +213,8 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		});
 		const hint = stripAnsi(detail.render(60).at(-1) ?? "");
 		expect(hint).toContain("back to chat");
-		expect(hint).toContain("provider-…");
+		expect(hint).toContain("model-wit…");
+		expect(hint).not.toContain("provider-with-a-long-name");
 		expect(hint).toContain("to expand");
 		expect(hint).toContain("stop");
 	});

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -43,6 +43,7 @@ function createMode() {
 		featureHintAnimationTimer: undefined,
 		featureHintComponent: undefined,
 		featureHintRunPending: false,
+		childAgentPanelMode: undefined,
 		options: { returnToAgentsView: true },
 		ui: { requestRender },
 	};
@@ -168,6 +169,22 @@ describe("InteractiveMode feature hints", () => {
 		expect(featureHintContainer.children).toHaveLength(0);
 		expect(featureHintDeck.next).not.toHaveBeenCalled();
 		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	it("suspends hints in subagent detail and resumes them in the parent view", () => {
+		const { mode, featureHintContainer, featureHintDeck } = createMode();
+		Reflect.set(mode, "childAgentPanelMode", "detail");
+
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(5_000);
+		expect(featureHintContainer.children).toHaveLength(0);
+		expect(featureHintDeck.next).not.toHaveBeenCalled();
+
+		Reflect.set(mode, "childAgentPanelMode", undefined);
+		callPrivate(mode, "resumeFeatureHintPresentation");
+		vi.advanceTimersByTime(5_000);
+		expect(featureHintContainer.children).toHaveLength(1);
+		expect(featureHintDeck.next).toHaveBeenCalledOnce();
 	});
 
 	it("retains the hint and remaining delay when the loader is recreated", () => {

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -187,6 +187,32 @@ describe("InteractiveMode feature hints", () => {
 		expect(featureHintDeck.next).toHaveBeenCalledOnce();
 	});
 
+	it("resumes hints when an editor switch closes subagent detail", () => {
+		const resumeFeatureHintPresentation = vi.fn();
+		const defaultEditor = { setText: vi.fn() };
+		const mode = {
+			childAgentPanelMode: "detail",
+			childAgentDetailNodeId: "subagent-1",
+			enteredSessionViaSubagentDetail: true,
+			childAgentDetail: { setBackHintLabel: vi.fn(), setNode: vi.fn() },
+			childAgentSummary: { setHidden: vi.fn() },
+			editor: { getText: () => "draft" },
+			defaultEditor,
+			editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			restoreMainAgentView: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			resumeFeatureHintPresentation,
+		};
+		Object.setPrototypeOf(mode, InteractiveMode.prototype);
+
+		Reflect.get(InteractiveMode.prototype, "setCustomEditorComponent").call(mode, undefined);
+
+		expect(Reflect.get(mode, "childAgentPanelMode")).toBeUndefined();
+		expect(defaultEditor.setText).toHaveBeenCalledWith("draft");
+		expect(resumeFeatureHintPresentation).toHaveBeenCalledOnce();
+	});
+
 	it("retains the hint and remaining delay when the loader is recreated", () => {
 		const { mode, statusContainer, featureHintContainer, featureHintDeck } = createMode();
 

--- a/packages/coding-agent/test/marquee-components.test.ts
+++ b/packages/coding-agent/test/marquee-components.test.ts
@@ -459,7 +459,8 @@ describe("marquee TUI components", () => {
 		expect(summaryText).toContain("37% context left");
 		expect(summaryText).toContain("S1");
 		expect(summaryText).toContain("inspect train…");
-		expect(summaryText).toContain("openai/gpt-5.4");
+		expect(summaryText).toContain("GPT-5.4");
+		expect(summaryText).not.toContain("openai/gpt-5.4");
 		const infoRow = summary.render(90)[0] ?? "";
 		expect(visibleWidth(infoRow)).toBe(90);
 
@@ -488,7 +489,8 @@ describe("marquee TUI components", () => {
 		expect(detail).toContain("inspect training logs");
 		expect(detail).toContain("reading shard metrics");
 		expect(detail).toContain("← back to chat");
-		expect(stripAnsi(detailComponent.render(80).at(-1) ?? "")).toContain("openai/gpt-5.4");
+		expect(stripAnsi(detailComponent.render(80).at(-1) ?? "")).toContain("GPT-5.4");
+		expect(stripAnsi(detailComponent.render(80).at(-1) ?? "")).not.toContain("openai/gpt-5.4");
 		expect(detail).not.toContain("user: inspect training logs");
 		expect(detail).not.toContain("assistant: reading shard metrics");
 	});


### PR DESCRIPTION
- subagent lists and detail views now show catalog display names instead of provider-qualified selectors.
- feature hints pause while viewing a subagent and resume after returning to the parent chat.
- adds focused coverage for label formatting, truncation, and hint visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI display and hint timing only; no auth, data, or API behavior changes.
> 
> **Overview**
> Subagent **summary rows** and **detail hint bars** no longer show raw `provider/model` selectors; they resolve through the model catalog (`getModels`) to **human-readable names** (e.g. `GPT-5.4`, `Claude Opus 4.7`). Truncation for narrow columns now runs on that display label (`truncateModelLabel`), so long nested model ids elide on the **model id** portion rather than the provider prefix.
> 
> **Feature hints** are suppressed while a subagent panel is open: starting hints bails when `childAgentPanelMode` is set, opening detail clears the hint UI, and closing the panel calls **`resumeFeatureHintPresentation`** so hints can continue if the working loader is still active.
> 
> Tests were updated for label formatting, truncation expectations, and hint suspend/resume behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc94f84d2ecd6ea47fcab4dcf0c28dc963b1b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish subagent model labels and feature hint lifecycle in the child agent inspector
> - Adds `childAgentModelLabel` helper in [child-agent-inspector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/470/files#diff-c6e80ba5fe28e36eaaf2f0d66307dec3db0481b56d24b214c31d2530d49517a1) to resolve a `provider/modelId` selector to a friendly model name, falling back to the model ID if no match is found.
> - Updates both the summary list and detail footer to display the resolved friendly name instead of the raw selector string.
> - Renames `truncateModelSelector` to `truncateModelLabel` so truncation operates on the resolved label, preserving the tail of the string.
> - Suppresses feature hint presentation while a subagent detail panel is open and resumes it when the panel is closed or replaced by an editor swap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fe6235.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->