### PR TITLE
propagate subagent heartbeat status to parent agents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed agents with heartbeat-owning subagents appearing completed and showing completion checkmarks in the Agents View.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed tool-result and announcement images to show compact metadata instead of terminal graphics ([#437](https://github.com/PrimeIntellect-ai/prime-agent/pull/437) by [@snimu](https://github.com/snimu)).

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -135,6 +135,7 @@ export function buildAgentsViewRows(
 	);
 	const rowsByKey = buildRowKeyMap(baseRows);
 	const childrenByParent = new Map<MutableAgentsViewRow, MutableAgentsViewRow[]>();
+	const parentByChild = new Map<MutableAgentsViewRow, MutableAgentsViewRow>();
 	const nestedRows = new Set<MutableAgentsViewRow>();
 
 	for (const row of baseRows) {
@@ -146,6 +147,7 @@ export function buildAgentsViewRows(
 		if (!parent || parent === row) {
 			continue;
 		}
+		parentByChild.set(row, parent);
 		if (row.summary.activity === "working") {
 			parent.runningSubagentCount += 1;
 		}
@@ -153,6 +155,7 @@ export function buildAgentsViewRows(
 		siblings.push(row);
 		childrenByParent.set(parent, siblings);
 	}
+	propagateHeartbeatStateToAncestors(baseRows, parentByChild);
 
 	const roots = baseRows.filter((row) => !nestedRows.has(row));
 	const flattened: AgentsViewRow[] = [];
@@ -186,6 +189,25 @@ export function buildAgentsViewRows(
 		emit(root, 0);
 	}
 	return flattened;
+}
+
+function propagateHeartbeatStateToAncestors(
+	rows: readonly MutableAgentsViewRow[],
+	parentByChild: ReadonlyMap<MutableAgentsViewRow, MutableAgentsViewRow>,
+): void {
+	for (const row of rows) {
+		if (!row.summary.hasActiveHeartbeat) {
+			continue;
+		}
+		const visited = new Set<MutableAgentsViewRow>([row]);
+		let ancestor = parentByChild.get(row);
+		while (ancestor && !visited.has(ancestor)) {
+			visited.add(ancestor);
+			ancestor.section = "heartbeats";
+			ancestor.statusLabel = getSessionStatusLabel(ancestor.summary, true);
+			ancestor = parentByChild.get(ancestor);
+		}
+	}
 }
 
 type MutableAgentsViewRow = AgentsViewRow;
@@ -395,7 +417,7 @@ function getSessionSubtitle(summary: SessionSummary): string {
 	return parts.join("  ");
 }
 
-function getSessionStatusLabel(summary: SessionSummary): string {
+function getSessionStatusLabel(summary: SessionSummary, hasActiveHeartbeat = summary.hasActiveHeartbeat): string {
 	if (summary.isCompacting) {
 		return "compacting";
 	}
@@ -408,7 +430,7 @@ function getSessionStatusLabel(summary: SessionSummary): string {
 	if (summary.lifecycle === "archived") {
 		return "archived";
 	}
-	if (summary.hasActiveHeartbeat) {
+	if (hasActiveHeartbeat) {
 		return "heartbeat active";
 	}
 	if (summary.activity === "working") {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -234,6 +234,7 @@ describe("agents view state", () => {
 				parentActiveSessionId: "parent-active",
 				hasActiveHeartbeat: true,
 				activity: "idle",
+				taskState: "completed",
 				messageCount: 2,
 			}),
 			makeSummary({
@@ -242,13 +243,20 @@ describe("agents view state", () => {
 				sessionId: "parent-session",
 				sessionName: "Parent",
 				activity: "idle",
+				taskState: "completed",
 				messageCount: 2,
 			}),
 		];
 
 		const collapsed = buildAgentsViewRows(summaries);
+		expect(collapsed[0]).toMatchObject({
+			kind: "agent",
+			section: "heartbeats",
+			statusLabel: "heartbeat active",
+		});
 		expect(collapsed[1]).toMatchObject({
 			kind: "subagent-summary",
+			section: "heartbeats",
 			title: "1 subagent · 1 heartbeat active",
 		});
 		const expanded = buildAgentsViewRows(summaries, new Set([collapsed[0]?.identity ?? ""]));
@@ -257,6 +265,58 @@ describe("agents view state", () => {
 			section: "heartbeats",
 			statusLabel: "heartbeat active",
 		});
+	});
+
+	test("propagates a descendant heartbeat through completed subagent ancestors", () => {
+		const summaries = [
+			makeSummary({
+				id: "heartbeat-grandchild",
+				activeSessionId: "heartbeat-grandchild",
+				sessionId: "heartbeat-grandchild-session",
+				sessionName: "Heartbeat grandchild",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "child-active",
+				hasActiveHeartbeat: true,
+				activity: "idle",
+				taskState: "completed",
+			}),
+			makeSummary({
+				id: "child-active",
+				activeSessionId: "child-active",
+				sessionId: "child-session",
+				sessionName: "Child",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "root-active",
+				activity: "idle",
+				taskState: "completed",
+			}),
+			makeSummary({
+				id: "root-active",
+				activeSessionId: "root-active",
+				sessionId: "root-session",
+				sessionName: "Root",
+				activity: "idle",
+				taskState: "completed",
+			}),
+		];
+
+		const rootIdentity = buildAgentsViewRows(summaries)[0]?.identity ?? "";
+		const oneLevel = buildAgentsViewRows(summaries, new Set([rootIdentity]));
+		const child = oneLevel.find((row) => row.title === "Child");
+		expect(oneLevel[0]).toMatchObject({ section: "heartbeats", statusLabel: "heartbeat active" });
+		expect(child).toMatchObject({ section: "heartbeats", statusLabel: "heartbeat active" });
+
+		const childIdentity = child?.identity ?? "";
+		const expanded = buildAgentsViewRows(summaries, new Set([rootIdentity, childIdentity]));
+		expect(
+			expanded
+				.filter((row) => row.kind === "agent" || row.kind === "subagent")
+				.map((row) => [row.title, row.section, row.statusLabel]),
+		).toEqual([
+			["Root", "heartbeats", "heartbeat active"],
+			["Child", "heartbeats", "heartbeat active"],
+			["Heartbeat grandchild", "heartbeats", "heartbeat active"],
+		]);
 	});
 
 	test("expands subagent rows for expanded parents and collapses otherwise", () => {


### PR DESCRIPTION
- parent agents now inherit the heartbeat section when any retained descendant has an active heartbeat.
- completed ancestor rows use heartbeat status and icons instead of misleading completion checkmarks.
- added regression coverage for direct and nested subagent heartbeat hierarchies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agents View row classification and status labels only; no daemon, auth, or session lifecycle changes.
> 
> **Overview**
> Fixes **Agents View** showing parent agents as **completed** (with checkmarks) when a retained subagent still has an **active heartbeat**.
> 
> When building the session tree, heartbeat state now **walks up** the parent chain: any ancestor of a heartbeat-owning session is moved into the **Heartbeats** section and labeled **heartbeat active**, even if that ancestor is idle with `taskState: "completed"`. `getSessionStatusLabel` accepts an optional propagated heartbeat flag so ancestors don’t keep the misleading completed label.
> 
> Regression tests cover a direct parent/child case and a **nested** grandchild heartbeat through completed subagent ancestors (collapsed and expanded rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dadc2fdb0dbd81e884657cb37d15e5f1575253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate subagent heartbeat status to completed ancestor agents in Agents View
> - Completed parent agents with active-heartbeat subagents were incorrectly shown as completed (with a checkmark) in the Agents View instead of appearing in the heartbeats section.
> - Adds `propagateHeartbeatStateToAncestors` in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/471/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1) to walk up the ancestor chain from any row with an active heartbeat, marking each ancestor's section as `'heartbeats'` and updating its status label to `'heartbeat active'`.
> - Extends `getSessionStatusLabel` to accept an optional `hasActiveHeartbeat` override so ancestor rows can be relabeled without modifying their underlying summary data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86dadc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->