### PR TITLE
scope heartbeat display to agent sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed agents with heartbeat-owning subagents appearing completed and showing completion checkmarks in the Agents View.
+- Fixed the heartbeat tray and manager showing heartbeats from unrelated sessions.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed tool-result and announcement images to show compact metadata instead of terminal graphics ([#437](https://github.com/PrimeIntellect-ai/prime-agent/pull/437) by [@snimu](https://github.com/snimu)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed agents with heartbeat-owning subagents appearing completed and showing completion checkmarks in the Agents View.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed tool-result and announcement images to show compact metadata instead of terminal graphics ([#437](https://github.com/PrimeIntellect-ai/prime-agent/pull/437) by [@snimu](https://github.com/snimu)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the heartbeat tray and manager showing heartbeats from unrelated sessions.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed tool-result and announcement images to show compact metadata instead of terminal graphics ([#437](https://github.com/PrimeIntellect-ai/prime-agent/pull/437) by [@snimu](https://github.com/snimu)).

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -135,6 +135,7 @@ export function buildAgentsViewRows(
 	);
 	const rowsByKey = buildRowKeyMap(baseRows);
 	const childrenByParent = new Map<MutableAgentsViewRow, MutableAgentsViewRow[]>();
+	const parentByChild = new Map<MutableAgentsViewRow, MutableAgentsViewRow>();
 	const nestedRows = new Set<MutableAgentsViewRow>();
 
 	for (const row of baseRows) {
@@ -146,6 +147,7 @@ export function buildAgentsViewRows(
 		if (!parent || parent === row) {
 			continue;
 		}
+		parentByChild.set(row, parent);
 		if (row.summary.activity === "working") {
 			parent.runningSubagentCount += 1;
 		}
@@ -153,6 +155,7 @@ export function buildAgentsViewRows(
 		siblings.push(row);
 		childrenByParent.set(parent, siblings);
 	}
+	propagateHeartbeatStateToAncestors(baseRows, parentByChild);
 
 	const roots = baseRows.filter((row) => !nestedRows.has(row));
 	const flattened: AgentsViewRow[] = [];
@@ -186,6 +189,25 @@ export function buildAgentsViewRows(
 		emit(root, 0);
 	}
 	return flattened;
+}
+
+function propagateHeartbeatStateToAncestors(
+	rows: readonly MutableAgentsViewRow[],
+	parentByChild: ReadonlyMap<MutableAgentsViewRow, MutableAgentsViewRow>,
+): void {
+	for (const row of rows) {
+		if (!row.summary.hasActiveHeartbeat) {
+			continue;
+		}
+		const visited = new Set<MutableAgentsViewRow>([row]);
+		let ancestor = parentByChild.get(row);
+		while (ancestor && !visited.has(ancestor)) {
+			visited.add(ancestor);
+			ancestor.section = "heartbeats";
+			ancestor.statusLabel = getSessionStatusLabel(ancestor.summary, true);
+			ancestor = parentByChild.get(ancestor);
+		}
+	}
 }
 
 type MutableAgentsViewRow = AgentsViewRow;
@@ -395,7 +417,7 @@ function getSessionSubtitle(summary: SessionSummary): string {
 	return parts.join("  ");
 }
 
-function getSessionStatusLabel(summary: SessionSummary): string {
+function getSessionStatusLabel(summary: SessionSummary, hasActiveHeartbeat = summary.hasActiveHeartbeat): string {
 	if (summary.isCompacting) {
 		return "compacting";
 	}
@@ -408,7 +430,7 @@ function getSessionStatusLabel(summary: SessionSummary): string {
 	if (summary.lifecycle === "archived") {
 		return "archived";
 	}
-	if (summary.hasActiveHeartbeat) {
+	if (hasActiveHeartbeat) {
 		return "heartbeat active";
 	}
 	if (summary.activity === "working") {

--- a/packages/coding-agent/src/modes/interactive/heartbeat-scope.ts
+++ b/packages/coding-agent/src/modes/interactive/heartbeat-scope.ts
@@ -1,0 +1,31 @@
+import type { AgentConnectionHeartbeat, AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
+
+interface HeartbeatSessionIdentity {
+	activeSessionId?: string;
+	sessionId: string;
+}
+
+export function scopeHeartbeatsToSession(
+	heartbeats: readonly AgentConnectionHeartbeat[],
+	session: HeartbeatSessionIdentity | undefined,
+	children: Iterable<Pick<AgentConnectionRlmChildAgentSnapshot, "activeSessionId">>,
+): AgentConnectionHeartbeat[] {
+	if (!session) {
+		return [];
+	}
+
+	const activeSessionIds = new Set<string>();
+	if (session.activeSessionId) {
+		activeSessionIds.add(session.activeSessionId);
+	}
+	for (const child of children) {
+		if (child.activeSessionId) {
+			activeSessionIds.add(child.activeSessionId);
+		}
+	}
+
+	return heartbeats.filter(
+		(heartbeat) =>
+			heartbeat.job.sessionId === session.sessionId || activeSessionIds.has(heartbeat.job.activeSessionId),
+	);
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -340,6 +340,7 @@ function childAgentSummaryChanged(
 	const nextTokens = next.tokenCount === undefined ? undefined : formatTokenCount(next.tokenCount);
 	return (
 		previous.parentId !== next.parentId ||
+		previous.activeSessionId !== next.activeSessionId ||
 		previous.sessionName !== next.sessionName ||
 		previous.model !== next.model ||
 		previous.label !== next.label ||

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -206,6 +206,7 @@ import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
 import { FeatureHintDeck } from "./feature-hints.js";
+import { scopeHeartbeatsToSession } from "./heartbeat-scope.js";
 import { collectMarkedImages, evictImagesToBudget, formatImageMarker, imageMarkerIds } from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
@@ -830,6 +831,7 @@ export class InteractiveMode {
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
 	private sessionHasMessages = false;
+	private heartbeatCatalog: AgentConnectionHeartbeat[] = [];
 	private heartbeats: AgentConnectionHeartbeat[] = [];
 	private heartbeatRefreshPromise: Promise<void> | undefined;
 	private heartbeatRefreshRequested = false;
@@ -2363,6 +2365,22 @@ export class InteractiveMode {
 	}
 
 	private applyHeartbeatCatalog(heartbeats: AgentConnectionHeartbeat[]): void {
+		this.heartbeatCatalog = heartbeats;
+		this.updateScopedHeartbeats();
+	}
+
+	private updateScopedHeartbeats(): void {
+		const heartbeats = scopeHeartbeatsToSession(
+			this.heartbeatCatalog,
+			this.connectionState,
+			this.childAgentSnapshots.values(),
+		);
+		if (
+			heartbeats.length === this.heartbeats.length &&
+			heartbeats.every((heartbeat, index) => heartbeat === this.heartbeats[index])
+		) {
+			return;
+		}
 		this.heartbeats = heartbeats;
 		this.heartbeatManager?.setHeartbeats(heartbeats);
 		this.scheduleHeartbeatManagerRefresh();
@@ -2373,6 +2391,7 @@ export class InteractiveMode {
 	private applyConnectionStateSnapshot(state: AgentConnectionState): void {
 		this.bindPromptStashSession(state.sessionId);
 		this.connectionState = state;
+		this.updateScopedHeartbeats();
 		// Don't touch contextUsageTokenBaseline: a mid-stream snapshot reflects only completed
 		// turns (the in-flight message isn't persisted yet), so the in-flight delta must keep
 		// accumulating. The baseline is managed at turn end (refreshConnectionContextUsage) and
@@ -5261,6 +5280,7 @@ export class InteractiveMode {
 	private refreshChildAgentInspector(): void {
 		this.childAgentNodes = this.buildChildAgentInspectorNodes();
 		this.childAgentSummary.setNodes(this.childAgentNodes);
+		this.updateScopedHeartbeats();
 		this.updateWorkingPulse();
 		this.syncWorkingLoader();
 		this.updateWorkingLoaderMessage();
@@ -5297,6 +5317,7 @@ export class InteractiveMode {
 		this.childAgentSnapshots.clear();
 		this.childAgentNodes = [];
 		this.childAgentSummary.setNodes([]);
+		this.updateScopedHeartbeats();
 		this.childAgentSummary.setHidden(false);
 		this.childAgentDetail.setNode(undefined);
 		this.childAgentDetailNodeId = undefined;
@@ -8911,7 +8932,7 @@ export class InteractiveMode {
 		if (updated.source === "heartbeat" && updated.activeSessionId === this.connectionState?.activeSessionId) {
 			this.patchConnectionState({ heartbeat: action === "stop" ? null : updated });
 		}
-		const remaining = this.heartbeats.filter((entry) => entry.job.id !== updated.id);
+		const remaining = this.heartbeatCatalog.filter((entry) => entry.job.id !== updated.id);
 		this.applyHeartbeatCatalog(
 			updated.status === "active" || updated.status === "paused"
 				? [...remaining, { ...heartbeat, job: updated }]

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -234,6 +234,7 @@ describe("agents view state", () => {
 				parentActiveSessionId: "parent-active",
 				hasActiveHeartbeat: true,
 				activity: "idle",
+				taskState: "completed",
 				messageCount: 2,
 			}),
 			makeSummary({
@@ -242,13 +243,20 @@ describe("agents view state", () => {
 				sessionId: "parent-session",
 				sessionName: "Parent",
 				activity: "idle",
+				taskState: "completed",
 				messageCount: 2,
 			}),
 		];
 
 		const collapsed = buildAgentsViewRows(summaries);
+		expect(collapsed[0]).toMatchObject({
+			kind: "agent",
+			section: "heartbeats",
+			statusLabel: "heartbeat active",
+		});
 		expect(collapsed[1]).toMatchObject({
 			kind: "subagent-summary",
+			section: "heartbeats",
 			title: "1 subagent · 1 heartbeat active",
 		});
 		const expanded = buildAgentsViewRows(summaries, new Set([collapsed[0]?.identity ?? ""]));
@@ -257,6 +265,58 @@ describe("agents view state", () => {
 			section: "heartbeats",
 			statusLabel: "heartbeat active",
 		});
+	});
+
+	test("propagates a descendant heartbeat through completed subagent ancestors", () => {
+		const summaries = [
+			makeSummary({
+				id: "heartbeat-grandchild",
+				activeSessionId: "heartbeat-grandchild",
+				sessionId: "heartbeat-grandchild-session",
+				sessionName: "Heartbeat grandchild",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "child-active",
+				hasActiveHeartbeat: true,
+				activity: "idle",
+				taskState: "completed",
+			}),
+			makeSummary({
+				id: "child-active",
+				activeSessionId: "child-active",
+				sessionId: "child-session",
+				sessionName: "Child",
+				runtimeKind: "subagent",
+				parentActiveSessionId: "root-active",
+				activity: "idle",
+				taskState: "completed",
+			}),
+			makeSummary({
+				id: "root-active",
+				activeSessionId: "root-active",
+				sessionId: "root-session",
+				sessionName: "Root",
+				activity: "idle",
+				taskState: "completed",
+			}),
+		];
+
+		const rootIdentity = buildAgentsViewRows(summaries)[0]?.identity ?? "";
+		const oneLevel = buildAgentsViewRows(summaries, new Set([rootIdentity]));
+		const child = oneLevel.find((row) => row.title === "Child");
+		expect(oneLevel[0]).toMatchObject({ section: "heartbeats", statusLabel: "heartbeat active" });
+		expect(child).toMatchObject({ section: "heartbeats", statusLabel: "heartbeat active" });
+
+		const childIdentity = child?.identity ?? "";
+		const expanded = buildAgentsViewRows(summaries, new Set([rootIdentity, childIdentity]));
+		expect(
+			expanded
+				.filter((row) => row.kind === "agent" || row.kind === "subagent")
+				.map((row) => [row.title, row.section, row.statusLabel]),
+		).toEqual([
+			["Root", "heartbeats", "heartbeat active"],
+			["Child", "heartbeats", "heartbeat active"],
+			["Heartbeat grandchild", "heartbeats", "heartbeat active"],
+		]);
 	});
 
 	test("expands subagent rows for expanded parents and collapses otherwise", () => {

--- a/packages/coding-agent/test/interactive-heartbeat-management.test.ts
+++ b/packages/coding-agent/test/interactive-heartbeat-management.test.ts
@@ -35,6 +35,13 @@ interface HeartbeatScopeHarness {
 	applyHeartbeatCatalog(heartbeats: AgentConnectionHeartbeat[]): void;
 }
 
+interface ChildIdentityUpdateHarness {
+	childAgentSnapshots: Map<string, AgentConnectionRlmChildAgentSnapshot>;
+	childAgentDetailNodeId: string | undefined;
+	refreshChildAgentInspector(): void;
+	updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void;
+}
+
 interface HeartbeatRefreshHarness {
 	heartbeats: AgentConnectionHeartbeat[];
 	heartbeatManager: object | undefined;
@@ -141,6 +148,24 @@ describe("interactive heartbeat management", () => {
 		expect(harness.heartbeatCatalog).toEqual([own, child, unrelated]);
 		expect(harness.heartbeats).toEqual([own, child]);
 		expect(harness.heartbeatManager.setHeartbeats).toHaveBeenCalledWith([own, child]);
+	});
+
+	it("refreshes heartbeat scope when a known subagent gains its active session id", () => {
+		const existing: AgentConnectionRlmChildAgentSnapshot = {
+			id: "child-1",
+			label: "child",
+			status: "running",
+			sessionDir: "/tmp/child-1",
+		};
+		const harness = Object.create(InteractiveMode.prototype) as ChildIdentityUpdateHarness;
+		harness.childAgentSnapshots = new Map([[existing.id, existing]]);
+		harness.childAgentDetailNodeId = undefined;
+		harness.refreshChildAgentInspector = vi.fn();
+
+		harness.updateChildAgentInspector({ ...existing, activeSessionId: "active-2" });
+
+		expect(harness.childAgentSnapshots.get(existing.id)?.activeSessionId).toBe("active-2");
+		expect(harness.refreshChildAgentInspector).toHaveBeenCalledOnce();
 	});
 
 	it("refreshes an open manager after the next scheduled run", async () => {

--- a/packages/coding-agent/test/interactive-heartbeat-management.test.ts
+++ b/packages/coding-agent/test/interactive-heartbeat-management.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentCronJob, AgentHeartbeatManagementAction } from "../src/core/cron-jobs.js";
-import type { AgentConnectionHeartbeat } from "../src/modes/agent-connection/types.js";
+import type {
+	AgentConnectionHeartbeat,
+	AgentConnectionRlmChildAgentSnapshot,
+} from "../src/modes/agent-connection/types.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 
 interface HeartbeatManagementHarness {
+	heartbeatCatalog: AgentConnectionHeartbeat[];
 	heartbeats: AgentConnectionHeartbeat[];
 	agentConnection: {
 		manageHeartbeat(
@@ -19,6 +23,18 @@ interface HeartbeatManagementHarness {
 	manageHeartbeat(heartbeat: AgentConnectionHeartbeat, action: AgentHeartbeatManagementAction): Promise<void>;
 }
 
+interface HeartbeatScopeHarness {
+	heartbeatCatalog: AgentConnectionHeartbeat[];
+	heartbeats: AgentConnectionHeartbeat[];
+	connectionState: { activeSessionId: string; sessionId: string };
+	childAgentSnapshots: Map<string, AgentConnectionRlmChildAgentSnapshot>;
+	heartbeatManager: { setHeartbeats(heartbeats: AgentConnectionHeartbeat[]): void } | undefined;
+	childAgentSummary: { invalidate(): void };
+	ui: { requestRender(): void };
+	scheduleHeartbeatManagerRefresh(): void;
+	applyHeartbeatCatalog(heartbeats: AgentConnectionHeartbeat[]): void;
+}
+
 interface HeartbeatRefreshHarness {
 	heartbeats: AgentConnectionHeartbeat[];
 	heartbeatManager: object | undefined;
@@ -27,7 +43,7 @@ interface HeartbeatRefreshHarness {
 	scheduleHeartbeatManagerRefresh(): void;
 }
 
-function heartbeat(): AgentCronJob {
+function heartbeat(overrides: Partial<AgentCronJob> = {}): AgentCronJob {
 	return {
 		id: "heartbeat-1",
 		status: "active",
@@ -42,6 +58,7 @@ function heartbeat(): AgentCronJob {
 		updatedAt: "2026-01-01T00:00:00.000Z",
 		nextRunAt: "2026-01-01T00:05:00.000Z",
 		runCount: 0,
+		...overrides,
 	};
 }
 
@@ -52,6 +69,7 @@ describe("interactive heartbeat management", () => {
 		const patches: Array<{ heartbeat: AgentCronJob | null }> = [];
 		const harness = Object.create(InteractiveMode.prototype) as HeartbeatManagementHarness;
 		harness.heartbeats = [{ job: current }];
+		harness.heartbeatCatalog = harness.heartbeats;
 		harness.connectionState = { activeSessionId: current.activeSessionId };
 		harness.agentConnection = {
 			manageHeartbeat: vi.fn(async () => stopped),
@@ -72,6 +90,7 @@ describe("interactive heartbeat management", () => {
 		const paused = { ...current, status: "paused" as const, nextRunAt: undefined };
 		const harness = Object.create(InteractiveMode.prototype) as HeartbeatManagementHarness;
 		harness.heartbeats = [{ job: current, sessionName: "Primary session" }];
+		harness.heartbeatCatalog = harness.heartbeats;
 		harness.connectionState = { activeSessionId: current.activeSessionId };
 		harness.agentConnection = { manageHeartbeat: vi.fn(async () => paused) };
 		harness.patchConnectionState = vi.fn();
@@ -86,6 +105,42 @@ describe("interactive heartbeat management", () => {
 
 		expect(harness.applyHeartbeatCatalog).toHaveBeenCalledWith([{ job: paused, sessionName: "Primary session" }]);
 		expect(harness.refreshHeartbeatCatalog).toHaveBeenCalledOnce();
+	});
+
+	it("scopes the catalog to the current session and its subagents", () => {
+		const own = { job: heartbeat() };
+		const child = {
+			job: heartbeat({ id: "heartbeat-2", activeSessionId: "active-2", sessionId: "session-2" }),
+		};
+		const unrelated = {
+			job: heartbeat({ id: "heartbeat-3", activeSessionId: "active-3", sessionId: "session-3" }),
+		};
+		const harness = Object.create(InteractiveMode.prototype) as HeartbeatScopeHarness;
+		harness.heartbeatCatalog = [];
+		harness.heartbeats = [];
+		harness.connectionState = { activeSessionId: "active-1", sessionId: "session-1" };
+		harness.childAgentSnapshots = new Map([
+			[
+				"child-1",
+				{
+					id: "child-1",
+					activeSessionId: "active-2",
+					label: "child",
+					status: "running",
+					sessionDir: "/tmp/child-1",
+				},
+			],
+		]);
+		harness.heartbeatManager = { setHeartbeats: vi.fn() };
+		harness.childAgentSummary = { invalidate: vi.fn() };
+		harness.ui = { requestRender: vi.fn() };
+		harness.scheduleHeartbeatManagerRefresh = vi.fn();
+
+		harness.applyHeartbeatCatalog([own, child, unrelated]);
+
+		expect(harness.heartbeatCatalog).toEqual([own, child, unrelated]);
+		expect(harness.heartbeats).toEqual([own, child]);
+		expect(harness.heartbeatManager.setHeartbeats).toHaveBeenCalledWith([own, child]);
 	});
 
 	it("refreshes an open manager after the next scheduled run", async () => {


### PR DESCRIPTION
- heartbeat controls now show only jobs owned by the current session and its descendant subagents.
- unrelated session heartbeats remain cached but are excluded from the tray and manager.
- added regression coverage for own, subagent, and unrelated heartbeat visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-scoped UI filtering and Agents View classification for nested subagents; incorrect scoping could hide valid heartbeats or mislabel session state, but does not alter cron execution or auth.
> 
> **Overview**
> Fixes two heartbeat UX bugs: the interactive **heartbeat tray/manager** no longer lists jobs from other sessions, and the **Agents View** no longer marks parent agents as completed when a descendant still owns an active heartbeat.
> 
> Interactive mode keeps the full daemon **heartbeat catalog** but derives a scoped list via `scopeHeartbeatsToSession` (current `sessionId` plus subagent `activeSessionId`s). That subset drives the tray, manager, and UI refresh; catalog updates, connection state, and child snapshot changes (including new `activeSessionId`) recompute scope. Pause/stop/resume mutates the catalog so the authoritative job list stays correct.
> 
> Agents View row building walks parent chains when any row has `hasActiveHeartbeat`, moving ancestors into the **Heartbeats** section and forcing **heartbeat active** status labels even when those ancestors are otherwise idle/completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8905edb0e9fca94ceb7ef412403c58f29beabd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope heartbeat display to the current agent session and its subagents
> - The heartbeat tray/manager now filters to only heartbeats belonging to the current session or its child agents via a new `scopeHeartbeatsToSession` helper in [heartbeat-scope.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/472/files#diff-201c467faa797bf277b012cfd8ffb638ded2f7890c35761a55287775119a8464).
> - `InteractiveMode` maintains a full `heartbeatCatalog` alongside the scoped display list; `manageHeartbeat` updates the catalog to avoid losing entries when scoping is applied.
> - In the Agents View, parent rows now move to the `heartbeats` section when any descendant subagent has an active heartbeat, propagated by a new `propagateHeartbeatStateToAncestors` pass in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/472/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8905edb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->