### PR TITLE
show subagent heartbeat status in chat

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed agents with heartbeat-owning subagents appearing completed and showing completion checkmarks in the Agents View.
+- Fixed heartbeat-owning subagents appearing completed, showing completion checkmarks below the prompt, or being omitted from active subagent counts.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Fixed incompatible daemon builds crashing startup or respawning after shutdown, with capability negotiation, verified provenance, and convergent force shutdown ([ENG-4687](https://linear.app/primeintellect/issue/ENG-4687/make-daemon-version-mismatches-self-healing)).
 - Changed tool-result and announcement images to show compact metadata instead of terminal graphics ([#437](https://github.com/PrimeIntellect-ai/prime-agent/pull/437) by [@snimu](https://github.com/snimu)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Changed interactive, print, JSON, RPC, piped-stdin, and no-session clients to use the same daemon-owned runtime while preserving their existing commands, output protocols, and lifecycle behavior ([ENG-4685](https://linear.app/primeintellect/issue/ENG-4685)).
 - Added RPC controls for schedules, heartbeats, agent messaging, and live session observation ([ENG-4685](https://linear.app/primeintellect/issue/ENG-4685)).
 - Fixed daemon-backed headless startup, rollback routing, RPC wire compatibility, and duplicate client runtime preparation ([ENG-4685](https://linear.app/primeintellect/issue/ENG-4685)).
-- Fixed heartbeat-owning subagents appearing completed, showing completion checkmarks below the prompt, or being omitted from active subagent counts.
+- Fixed heartbeat-owning subagents appearing completed, showing completion checkmarks below the prompt, being omitted from active subagent counts, or remaining visible after deletion.
 - Fixed the heartbeat tray and manager showing heartbeats from unrelated sessions.
 - Fixed daemon backpressure triggering redundant catch-up snapshots for events already queued by the socket.
 - Added dedicated stable and beta installers, with stable advancing on version bumps and beta advancing on every commit to `main`.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6550,11 +6550,29 @@ export class AgentSession {
 		}
 	}
 
+	private _emitRlmSubagentRemoval(subagent: RlmSubagentRegistryEntry): void {
+		this._emit({
+			type: "rlm_child_update",
+			child: {
+				id: subagent.rlm_child_id,
+				parentId: this._rlmParentNodeId,
+				activeSessionId: subagent.active_session_id ?? undefined,
+				sessionName: subagent.session_name,
+				label: subagent.session_name,
+				status: "cancelled",
+				sessionDir: subagent.session_dir,
+				error: "Deleted by parent orchestrator",
+			},
+		});
+	}
+
 	private async _deleteResolvedRlmSubagent(subagent: RlmSubagentRegistryEntry): Promise<RlmDeleteSubagentResult> {
 		const childId = subagent.rlm_child_id;
 		const run = this._activeRlmChildRuns.get(childId);
 		if (run) {
-			this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
+				this._emitRlmSubagentRemoval(subagent);
+			}
 			const liveSession = run.session;
 			if (liveSession) {
 				try {
@@ -6601,6 +6619,8 @@ export class AgentSession {
 			// open guard tear the half-bound runtime down before it becomes addressable.
 			return { subagent };
 		}
+
+		this._emitRlmSubagentRemoval(subagent);
 
 		const retained = this._retainedRlmChildSessions.get(childId);
 		if (retained) {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -148,7 +148,7 @@ export function buildAgentsViewRows(
 			continue;
 		}
 		parentByChild.set(row, parent);
-		if (row.summary.activity === "working") {
+		if (row.summary.activity === "working" || row.summary.hasActiveHeartbeat) {
 			parent.runningSubagentCount += 1;
 		}
 		const siblings = childrenByParent.get(parent) ?? [];

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -37,6 +37,7 @@ export interface ChildAgentInspectorNode {
 	recap?: string;
 	sessionDir: string;
 	activity?: ChildAgentActivity;
+	hasActiveHeartbeat?: boolean;
 	error?: string;
 	children?: readonly ChildAgentInspectorNode[];
 }
@@ -63,14 +64,14 @@ function isExpandableComponent(component: Component): component is ExpandableCom
 }
 
 // Active before finished, so completed agents settle to the bottom.
-function childAgentSortRank(status: ChildAgentStatus): number {
-	return status === "running" || status === "queued" ? 0 : 1;
+function childAgentSortRank(node: ChildAgentInspectorNode): number {
+	return node.status === "running" || node.status === "queued" || node.hasActiveHeartbeat ? 0 : 1;
 }
 
 function flattenChildAgentNodes(nodes: readonly ChildAgentInspectorNode[]): FlatChildAgentNode[] {
 	const result: FlatChildAgentNode[] = [];
 	const walk = (items: readonly ChildAgentInspectorNode[]): void => {
-		const ordered = [...items].sort((a, b) => childAgentSortRank(a.status) - childAgentSortRank(b.status));
+		const ordered = [...items].sort((a, b) => childAgentSortRank(a) - childAgentSortRank(b));
 		for (const node of ordered) {
 			result.push({ node });
 			walk(node.children ?? []);
@@ -131,8 +132,11 @@ export function nodeActivityLabel(node: ChildAgentInspectorNode): string {
 }
 
 // Subagent list entries mirror the agents view row format: icon, title, right-aligned time.
-function childAgentStatusIcon(status: ChildAgentStatus): string {
-	switch (status) {
+function childAgentStatusIcon(node: ChildAgentInspectorNode): string {
+	if (node.hasActiveHeartbeat) {
+		return "♥";
+	}
+	switch (node.status) {
 		case "queued":
 			return "◇";
 		case "running":
@@ -143,14 +147,17 @@ function childAgentStatusIcon(status: ChildAgentStatus): string {
 		case "cancelled":
 			return "✗";
 		default: {
-			const _exhaustive: never = status;
+			const _exhaustive: never = node.status;
 			return _exhaustive;
 		}
 	}
 }
 
-function formatChildAgentStatusIcon(status: ChildAgentStatus, icon: string): string {
-	switch (status) {
+function formatChildAgentStatusIcon(node: ChildAgentInspectorNode, icon: string): string {
+	if (node.hasActiveHeartbeat) {
+		return theme.fg("error", icon);
+	}
+	switch (node.status) {
 		case "queued":
 			return theme.fg("dim", icon);
 		case "running":
@@ -162,7 +169,7 @@ function formatChildAgentStatusIcon(status: ChildAgentStatus, icon: string): str
 		case "cancelled":
 			return theme.fg("warning", icon);
 		default: {
-			const _exhaustive: never = status;
+			const _exhaustive: never = node.status;
 			return _exhaustive;
 		}
 	}
@@ -185,7 +192,7 @@ function formatChildAgentDuration(durationMs: number | undefined): string {
 
 function childAgentRecap(node: ChildAgentInspectorNode): string {
 	const recap = node.recap?.replace(/\s+/g, " ").trim();
-	return recap || nodeActivityLabel(node);
+	return recap || (node.hasActiveHeartbeat ? "Heartbeat active" : nodeActivityLabel(node));
 }
 
 function padTableCell(value: string, width: number, ellipsis = ""): string {
@@ -259,8 +266,10 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		}
 		if (!this.focused || !this.selectedId || !flat.some((entry) => entry.node.id === this.selectedId)) {
 			this.selectedId =
-				flat.find((entry) => entry.node.status === "running" || entry.node.status === "queued")?.node.id ??
-				flat[0]?.node.id;
+				flat.find(
+					(entry) =>
+						entry.node.status === "running" || entry.node.status === "queued" || entry.node.hasActiveHeartbeat,
+				)?.node.id ?? flat[0]?.node.id;
 		}
 	}
 
@@ -461,11 +470,12 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 	): string {
 		const indent = " ".repeat(SUMMARY_LIST_INDENT);
 		// Running rows pulse the shared working glyph; other states stay static.
-		const rawIcon =
-			entry.node.status === "running"
+		const rawIcon = entry.node.hasActiveHeartbeat
+			? childAgentStatusIcon(entry.node)
+			: entry.node.status === "running"
 				? workingIconFrame(getWorkingPulseFrame())
-				: childAgentStatusIcon(entry.node.status);
-		const icon = formatChildAgentStatusIcon(entry.node.status, rawIcon);
+				: childAgentStatusIcon(entry.node);
+		const icon = formatChildAgentStatusIcon(entry.node, rawIcon);
 		const agentLabel = `S${number}`;
 		const agentCell = theme.fg("muted", padTableCell(agentLabel, agentWidth));
 		const promptCell = this.elidePrompt(this.entryLabel(entry), sharedPrefix, sharedSuffix, promptWidth);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2366,8 +2366,7 @@ export class InteractiveMode {
 		this.heartbeats = heartbeats;
 		this.heartbeatManager?.setHeartbeats(heartbeats);
 		this.scheduleHeartbeatManagerRefresh();
-		this.childAgentSummary.invalidate();
-		this.ui.requestRender();
+		this.refreshChildAgentInspector();
 	}
 
 	private applyConnectionStateSnapshot(state: AgentConnectionState): void {
@@ -5652,6 +5651,11 @@ export class InteractiveMode {
 	}
 
 	private buildChildAgentInspectorNodes(): ChildAgentInspectorNode[] {
+		const activeHeartbeatSessionIds = new Set(
+			this.heartbeats
+				.filter((heartbeat) => heartbeat.job.status === "active")
+				.map((heartbeat) => heartbeat.job.activeSessionId),
+		);
 		const childrenByParent = new Map<string | undefined, AgentConnectionRlmChildAgentSnapshot[]>();
 		for (const child of this.childAgentSnapshots.values()) {
 			const siblings = childrenByParent.get(child.parentId) ?? [];
@@ -5673,6 +5677,8 @@ export class InteractiveMode {
 			recap: child.recap,
 			sessionDir: child.sessionDir,
 			activity: child.activity,
+			hasActiveHeartbeat:
+				child.activeSessionId !== undefined && activeHeartbeatSessionIds.has(child.activeSessionId),
 			error: child.error,
 			children: childrenByParent.get(child.id)?.map(build),
 		});

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5276,8 +5276,7 @@ export class InteractiveMode {
 	}
 
 	private updateChildAgentInspector(child: AgentConnectionRlmChildAgentSnapshot): void {
-		// Cancelled subagents were deliberately stopped; drop them from the
-		// viewer instead of keeping a dead row around.
+		// Cancellation is also the lifecycle tombstone for deleted subagents.
 		if (child.status === "cancelled") {
 			this.removeChildAgentSnapshot(child.id);
 			this.refreshChildAgentInspector();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -351,6 +351,12 @@ describe("AgentSession rlm recursion", () => {
 		child.setSessionName("restored-worker");
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		const root = createSession();
+		const childStatuses: string[] = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update" && event.child.id === childId) {
+				childStatuses.push(event.child.status);
+			}
+		});
 
 		expect(root.retainFinishedRlmChildSession(childId, child)).toBe(true);
 		expect(root.listRlmSubagents().subagents).toEqual([
@@ -366,6 +372,7 @@ describe("AgentSession rlm recursion", () => {
 		});
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(childStatuses).toEqual(["cancelled"]);
 	});
 
 	it("hides a retained child after failed deletion and keeps it selector-retryable", async () => {

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -257,13 +257,48 @@ describe("agents view state", () => {
 		expect(collapsed[1]).toMatchObject({
 			kind: "subagent-summary",
 			section: "heartbeats",
-			title: "1 subagent · 1 heartbeat active",
+			title: "1 subagent running · 1 heartbeat active",
+			runningSubagentCount: 1,
 		});
 		const expanded = buildAgentsViewRows(summaries, new Set([collapsed[0]?.identity ?? ""]));
 		expect(expanded[1]).toMatchObject({
 			kind: "subagent",
 			section: "heartbeats",
 			statusLabel: "heartbeat active",
+		});
+	});
+
+	test("counts every idle heartbeating subagent as running", () => {
+		const heartbeatChildren = Array.from({ length: 10 }, (_, index) =>
+			makeSummary({
+				id: `heartbeat-child-${index}`,
+				activeSessionId: `heartbeat-child-${index}`,
+				sessionId: `heartbeat-child-session-${index}`,
+				sessionName: `Heartbeat child ${index}`,
+				runtimeKind: "subagent",
+				parentActiveSessionId: "parent-active",
+				hasActiveHeartbeat: true,
+				activity: "idle",
+				taskState: "completed",
+			}),
+		);
+		const rows = buildAgentsViewRows([
+			...heartbeatChildren,
+			makeSummary({
+				id: "parent-active",
+				activeSessionId: "parent-active",
+				sessionId: "parent-session",
+				sessionName: "Parent",
+				activity: "idle",
+				taskState: "completed",
+			}),
+		]);
+
+		expect(rows[0]).toMatchObject({ section: "heartbeats", runningSubagentCount: 10 });
+		expect(rows[1]).toMatchObject({
+			kind: "subagent-summary",
+			title: "10 subagents running · 10 heartbeats active",
+			runningSubagentCount: 10,
 		});
 	});
 

--- a/packages/coding-agent/test/child-agent-summary-list.test.ts
+++ b/packages/coding-agent/test/child-agent-summary-list.test.ts
@@ -108,6 +108,17 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		expect(frame0).not.toBe(frame1);
 	});
 
+	it("shows heartbeating completed subagents as active with heartbeat icons", () => {
+		const summary = new ChildAgentSummaryComponent();
+		summary.setNodes([{ ...node("done", "done") }, { ...node("heartbeat", "done"), hasActiveHeartbeat: true }]);
+		const lines = summary.render(80).map(stripAnsi);
+
+		expect(lines[0]).toContain("♥");
+		expect(lines[0]).toContain("heartbeat");
+		expect(lines[0]).toContain("Heartbeat active");
+		expect(lines[1]).toContain("✓");
+	});
+
 	it("can reselect a node by id when returning from its detail view", () => {
 		const summary = new ChildAgentSummaryComponent();
 		summary.focused = true;

--- a/packages/coding-agent/test/interactive-heartbeat-management.test.ts
+++ b/packages/coding-agent/test/interactive-heartbeat-management.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentCronJob, AgentHeartbeatManagementAction } from "../src/core/cron-jobs.js";
-import type { AgentConnectionHeartbeat } from "../src/modes/agent-connection/types.js";
+import type {
+	AgentConnectionHeartbeat,
+	AgentConnectionRlmChildAgentSnapshot,
+} from "../src/modes/agent-connection/types.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 
 interface HeartbeatManagementHarness {
@@ -27,6 +30,20 @@ interface HeartbeatRefreshHarness {
 	scheduleHeartbeatManagerRefresh(): void;
 }
 
+interface HeartbeatChildHarness {
+	heartbeats: AgentConnectionHeartbeat[];
+	childAgentSnapshots: Map<string, AgentConnectionRlmChildAgentSnapshot>;
+	buildChildAgentInspectorNodes(): Array<{ id: string; hasActiveHeartbeat?: boolean }>;
+}
+
+interface HeartbeatCatalogHarness {
+	heartbeats: AgentConnectionHeartbeat[];
+	heartbeatManager: undefined;
+	applyHeartbeatCatalog(heartbeats: AgentConnectionHeartbeat[]): void;
+	scheduleHeartbeatManagerRefresh(): void;
+	refreshChildAgentInspector(): void;
+}
+
 function heartbeat(): AgentCronJob {
 	return {
 		id: "heartbeat-1",
@@ -46,6 +63,48 @@ function heartbeat(): AgentCronJob {
 }
 
 describe("interactive heartbeat management", () => {
+	it("maps only active heartbeat jobs onto below-prompt subagent rows", () => {
+		const harness = Object.create(InteractiveMode.prototype) as HeartbeatChildHarness;
+		harness.heartbeats = [
+			{ job: { ...heartbeat(), activeSessionId: "active-child" } },
+			{ job: { ...heartbeat(), id: "paused", activeSessionId: "paused-child", status: "paused" } },
+		];
+		harness.childAgentSnapshots = new Map(
+			[
+				["active", "active-child"],
+				["paused", "paused-child"],
+			].map(([id, activeSessionId]) => [
+				id,
+				{
+					id,
+					activeSessionId,
+					label: id,
+					status: "done",
+					sessionDir: `/tmp/${id}`,
+				} satisfies AgentConnectionRlmChildAgentSnapshot,
+			]),
+		);
+
+		expect(harness.buildChildAgentInspectorNodes()).toEqual([
+			expect.objectContaining({ id: "active", hasActiveHeartbeat: true }),
+			expect.objectContaining({ id: "paused", hasActiveHeartbeat: false }),
+		]);
+	});
+
+	it("refreshes below-prompt subagent rows when the heartbeat catalog changes", () => {
+		const harness = Object.create(InteractiveMode.prototype) as HeartbeatCatalogHarness;
+		const activeHeartbeat = { job: { ...heartbeat(), activeSessionId: "active-child" } };
+		harness.heartbeats = [];
+		harness.heartbeatManager = undefined;
+		harness.scheduleHeartbeatManagerRefresh = vi.fn();
+		harness.refreshChildAgentInspector = vi.fn();
+
+		harness.applyHeartbeatCatalog([activeHeartbeat]);
+
+		expect(harness.heartbeats).toEqual([activeHeartbeat]);
+		expect(harness.refreshChildAgentInspector).toHaveBeenCalledOnce();
+	});
+
 	it("clears local user-heartbeat state after stopping from the manager", async () => {
 		const current = heartbeat();
 		const stopped = { ...current, status: "cancelled" as const, nextRunAt: undefined };


### PR DESCRIPTION
- heartbeating subagents now keep heart icons and active ordering below the chat prompt.
- agents view counts idle heartbeat owners instead of only the currently streaming child.
- added regressions for heartbeat catalog updates and ten-child fanout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and lifecycle signaling for subagents/heartbeats only; no changes to auth, persistence, or daemon protocol beyond emitting removal updates.
> 
> **Overview**
> Fixes **heartbeat-owning subagents** being shown as finished (checkmarks, bottom of the list) and miscounted as idle in Agents View and the below-prompt child list.
> 
> Interactive mode now marks subagent rows **`hasActiveHeartbeat`** when their `activeSessionId` matches an **active** scoped heartbeat job (paused jobs excluded), refreshes that list when the heartbeat catalog changes, and treats those rows like running work: **♥** icon, active sort order, and **"Heartbeat active"** recap. Agents View **`runningSubagentCount`** increments for subagents with an active heartbeat even when `activity` is idle or the task is completed, so summary titles reflect **N subagents running · M heartbeats active**.
> 
> On delete, **`AgentSession`** emits a **`cancelled`** `rlm_child_update` when cancellation cannot run on a non-running retained child so the chat inspector drops the row; cancelled updates are treated as the tombstone for deleted subagents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195b54338c16a24b57e9378282fc1ed67ca4d8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show subagent heartbeat status in the interactive chat UI
> - Adds a `hasActiveHeartbeat` flag to `ChildAgentInspectorNode` and sets it for subagents with an active (non-paused) heartbeat job in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/473/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316).
> - Heartbeating subagents display a heart icon (♥) with distinct error-themed coloring, are sorted to the top of the subagent list, and show "Heartbeat active" as their recap text when no other recap exists.
> - Parent rows in the agents view count heartbeating subagents toward `runningSubagentCount` even when their activity is not "working".
> - Deleting an RLM subagent now always emits an `rlm_child_update` event with `status="cancelled"` so the UI drops the row immediately, even when no active run exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 195b543.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->