### PR TITLE
fix long-retention cache cost estimates

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Added Kimi K3 to the Prime Inference and OpenRouter model catalogs with multimodal input and mandatory max reasoning.
-- Fixed prompt caching and default cache-cost estimates for Anthropic models routed through Prime Inference ([ENG-4723](https://linear.app/primeintellect/issue/ENG-4723)).
+- Fixed prompt caching and retention-aware cache-cost estimates for Anthropic models routed through Prime Inference ([ENG-4723](https://linear.app/primeintellect/issue/ENG-4723)).
 
 ## [0.3.1] - 2026-07-15
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { getAnthropicCacheCosts } from "../src/cache-pricing.js";
 import {
 	CLOUDFLARE_AI_GATEWAY_ANTHROPIC_BASE_URL,
 	CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL,
@@ -116,9 +117,6 @@ const PRIME_INFERENCE_COMPAT: OpenAICompletionsCompat = {
 	maxTokensField: "max_tokens",
 	supportsStrictMode: false,
 };
-const ANTHROPIC_CACHE_READ_COST_DIVISOR = 10;
-const ANTHROPIC_FIVE_MINUTE_CACHE_WRITE_COST_MULTIPLIER = 1.25;
-
 interface PrimeInferenceCatalogEntry {
 	id: string;
 	input: number;
@@ -419,10 +417,7 @@ function getPrimeInferenceHeaders(apiKey: string | undefined, teamId: string | u
 
 function getPrimeInferenceCacheCosts(modelId: string, inputCost: number): { cacheRead: number; cacheWrite: number } {
 	return modelId.toLowerCase().startsWith("anthropic/")
-		? {
-				cacheRead: inputCost / ANTHROPIC_CACHE_READ_COST_DIVISOR,
-				cacheWrite: inputCost * ANTHROPIC_FIVE_MINUTE_CACHE_WRITE_COST_MULTIPLIER,
-			}
+		? getAnthropicCacheCosts(inputCost, "5m")
 		: { cacheRead: 0, cacheWrite: 0 };
 }
 

--- a/packages/ai/src/cache-pricing.ts
+++ b/packages/ai/src/cache-pricing.ts
@@ -1,0 +1,48 @@
+export type AnthropicCacheDuration = "5m" | "1h";
+
+export interface AnthropicCacheCreationUsage {
+	ephemeral_5m_input_tokens: number;
+	ephemeral_1h_input_tokens: number;
+}
+
+const ANTHROPIC_CACHE_READ_COST_MULTIPLIER = 0.1;
+const ANTHROPIC_FIVE_MINUTE_CACHE_WRITE_COST_MULTIPLIER = 1.25;
+const ANTHROPIC_ONE_HOUR_CACHE_WRITE_COST_MULTIPLIER = 2;
+
+export function getAnthropicCacheCosts(
+	inputCost: number,
+	duration: AnthropicCacheDuration,
+): { cacheRead: number; cacheWrite: number } {
+	return {
+		cacheRead: inputCost * ANTHROPIC_CACHE_READ_COST_MULTIPLIER,
+		cacheWrite:
+			inputCost *
+			(duration === "1h"
+				? ANTHROPIC_ONE_HOUR_CACHE_WRITE_COST_MULTIPLIER
+				: ANTHROPIC_FIVE_MINUTE_CACHE_WRITE_COST_MULTIPLIER),
+	};
+}
+
+export function getAnthropicCacheWriteCost(
+	inputCost: number,
+	duration: AnthropicCacheDuration,
+	cacheCreation?: AnthropicCacheCreationUsage | null,
+): number {
+	if (!cacheCreation) {
+		return getAnthropicCacheCosts(inputCost, duration).cacheWrite;
+	}
+
+	const fiveMinuteTokens = cacheCreation.ephemeral_5m_input_tokens;
+	const oneHourTokens = cacheCreation.ephemeral_1h_input_tokens;
+	const totalTokens = fiveMinuteTokens + oneHourTokens;
+	if (totalTokens === 0) {
+		return getAnthropicCacheCosts(inputCost, duration).cacheWrite;
+	}
+
+	return (
+		(inputCost *
+			(fiveMinuteTokens * ANTHROPIC_FIVE_MINUTE_CACHE_WRITE_COST_MULTIPLIER +
+				oneHourTokens * ANTHROPIC_ONE_HOUR_CACHE_WRITE_COST_MULTIPLIER)) /
+		totalTokens
+	);
+}

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -44,11 +44,19 @@ export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean 
 	);
 }
 
-export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+export interface CostOverrides {
+	cacheWrite?: number;
+}
+
+export function calculateCost<TApi extends Api>(
+	model: Model<TApi>,
+	usage: Usage,
+	overrides?: CostOverrides,
+): Usage["cost"] {
 	usage.cost.input = (model.cost.input / 1000000) * usage.input;
 	usage.cost.output = (model.cost.output / 1000000) * usage.output;
 	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * usage.cacheRead;
-	usage.cost.cacheWrite = (model.cost.cacheWrite / 1000000) * usage.cacheWrite;
+	usage.cost.cacheWrite = ((overrides?.cacheWrite ?? model.cost.cacheWrite) / 1000000) * usage.cacheWrite;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
 }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -6,6 +6,7 @@ import type {
 	MessageParam,
 	RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages.js";
+import { getAnthropicCacheWriteCost } from "../cache-pricing.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
@@ -510,7 +511,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 				client = created.client;
 				isOAuth = created.isOAuthToken;
 			}
-			let params = buildParams(model, context, isOAuth, options);
+			const { cacheControl } = getCacheControl(model, options?.cacheRetention);
+			let cacheWriteCost = cacheControl
+				? getAnthropicCacheWriteCost(model.cost.input, cacheControl.ttl === "1h" ? "1h" : "5m")
+				: undefined;
+			let params = buildParams(model, context, isOAuth, options, cacheControl);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
 				params = nextParams as MessageCreateParamsStreaming;
@@ -540,7 +545,18 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
+					if (cacheControl) {
+						cacheWriteCost = getAnthropicCacheWriteCost(
+							model.cost.input,
+							cacheControl.ttl === "1h" ? "1h" : "5m",
+							event.message.usage.cache_creation,
+						);
+					}
+					calculateCost(
+						model,
+						output.usage,
+						cacheWriteCost === undefined ? undefined : { cacheWrite: cacheWriteCost },
+					);
 				} else if (event.type === "content_block_start") {
 					if (event.content_block.type === "text") {
 						const block: Block = {
@@ -685,7 +701,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
+					calculateCost(
+						model,
+						output.usage,
+						cacheWriteCost === undefined ? undefined : { cacheWrite: cacheWriteCost },
+					);
 				}
 			}
 
@@ -934,8 +954,8 @@ function buildParams(
 	context: Context,
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
+	cacheControl?: CacheControlEphemeral,
 ): MessageCreateParamsStreaming {
-	const { cacheControl } = getCacheControl(model, options?.cacheRetention);
 	const params: MessageCreateParamsStreaming = {
 		model: model.id,
 		messages: convertMessages(context.messages, model, isOAuthToken, cacheControl),

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -10,6 +10,7 @@ import type {
 	ChatCompletionSystemMessageParam,
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
+import { getAnthropicCacheWriteCost } from "../cache-pricing.js";
 import { getEnvApiKey, getPrimeTeamId } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
@@ -138,9 +139,13 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const compat = getCompat(model);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+			const cacheControl = getCompatCacheControl(compat, cacheRetention);
+			const cacheWriteCost = cacheControl
+				? getAnthropicCacheWriteCost(model.cost.input, cacheControl.ttl === "1h" ? "1h" : "5m")
+				: undefined;
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
 			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
-			let params = buildParams(model, context, options, compat, cacheRetention);
+			let params = buildParams(model, context, options, compat, cacheRetention, cacheControl);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
 				params = nextParams as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
@@ -270,7 +275,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					output.responseModel ||= chunk.model;
 				}
 				if (chunk.usage) {
-					output.usage = parseChunkUsage(chunk.usage, model);
+					output.usage = parseChunkUsage(chunk.usage, model, cacheWriteCost);
 				}
 
 				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
@@ -279,7 +284,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				// Fallback: some providers (e.g., Moonshot) return usage
 				// in choice.usage instead of the standard chunk.usage
 				if (!chunk.usage && (choice as any).usage) {
-					output.usage = parseChunkUsage((choice as any).usage, model);
+					output.usage = parseChunkUsage((choice as any).usage, model, cacheWriteCost);
 				}
 
 				if (choice.finish_reason) {
@@ -501,9 +506,9 @@ function buildParams(
 	options?: OpenAICompletionsOptions,
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
 	cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
+	cacheControl: OpenAICompatCacheControl | undefined = getCompatCacheControl(compat, cacheRetention),
 ) {
 	const messages = convertMessages(model, context, compat);
-	const cacheControl = getCompatCacheControl(compat, cacheRetention);
 
 	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 		model: model.id,
@@ -1004,6 +1009,7 @@ function parseChunkUsage(
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 	},
 	model: Model<"openai-completions">,
+	cacheWriteCost?: number,
 ): AssistantMessage["usage"] {
 	const promptTokens = rawUsage.prompt_tokens || 0;
 	const reportedCachedTokens = rawUsage.prompt_tokens_details?.cached_tokens ?? rawUsage.prompt_cache_hit_tokens ?? 0;
@@ -1028,7 +1034,7 @@ function parseChunkUsage(
 		totalTokens: input + outputTokens + cacheReadTokens + cacheWriteTokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
-	calculateCost(model, usage);
+	calculateCost(model, usage, cacheWriteCost === undefined ? undefined : { cacheWrite: cacheWriteCost });
 	return usage;
 }
 

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -78,7 +78,81 @@ function createFakeAnthropicClient(response: Response): Anthropic {
 	} as unknown as Anthropic;
 }
 
+function createCacheUsageEvents(cacheCreation: {
+	ephemeral_5m_input_tokens: number;
+	ephemeral_1h_input_tokens: number;
+}): Array<{ event: string; data: string }> {
+	const cacheWriteTokens = cacheCreation.ephemeral_5m_input_tokens + cacheCreation.ephemeral_1h_input_tokens;
+	return [
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_cache_test",
+					usage: {
+						input_tokens: 12,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: cacheWriteTokens,
+						cache_creation: cacheCreation,
+					},
+				},
+			}),
+		},
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: {
+					input_tokens: 12,
+					output_tokens: 5,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: cacheWriteTokens,
+				},
+			}),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	];
+}
+
 describe("Anthropic raw SSE parsing", () => {
+	it.each([
+		{
+			name: "five-minute writes",
+			cacheRetention: "short" as const,
+			cacheCreation: { ephemeral_5m_input_tokens: 1000, ephemeral_1h_input_tokens: 0 },
+			expectedCacheWriteCost: 0.00125,
+		},
+		{
+			name: "one-hour writes",
+			cacheRetention: "long" as const,
+			cacheCreation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 1000 },
+			expectedCacheWriteCost: 0.002,
+		},
+		{
+			name: "mixed TTL writes",
+			cacheRetention: "long" as const,
+			cacheCreation: { ephemeral_5m_input_tokens: 250, ephemeral_1h_input_tokens: 750 },
+			expectedCacheWriteCost: 0.0018125,
+		},
+	])("prices $name from the reported Anthropic usage breakdown", async (testCase) => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const response = createSseResponse(createCacheUsageEvents(testCase.cacheCreation));
+		const result = await streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }] },
+			{
+				client: createFakeAnthropicClient(response),
+				cacheRetention: testCase.cacheRetention,
+			},
+		).result();
+
+		expect(result.usage.cacheWrite).toBe(1000);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(testCase.expectedCacheWriteCost);
+	});
+
 	it("repairs malformed SSE JSON and malformed streamed tool JSON", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
 		const context: Context = {

--- a/packages/ai/test/openai-completions-cache-control-format.test.ts
+++ b/packages/ai/test/openai-completions-cache-control-format.test.ts
@@ -2,7 +2,7 @@ import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getModel } from "../src/models.js";
 import { streamOpenAICompletions } from "../src/providers/openai-completions.js";
-import type { Model } from "../src/types.js";
+import type { AssistantMessage, Model } from "../src/types.js";
 
 interface CacheControl {
 	type: "ephemeral";
@@ -38,15 +38,19 @@ vi.mock("openai", () => {
 			completions: {
 				create: (params: CapturedParams) => {
 					mockState.lastParams = params;
+					const hasCacheControl = JSON.stringify(params).includes("cache_control");
 					const stream = {
 						async *[Symbol.asyncIterator]() {
 							yield {
 								id: "chatcmpl-test",
 								choices: [{ delta: {}, finish_reason: "stop" }],
 								usage: {
-									prompt_tokens: 1,
-									completion_tokens: 1,
-									prompt_tokens_details: { cached_tokens: 0 },
+									prompt_tokens: 100,
+									completion_tokens: 10,
+									prompt_tokens_details: {
+										cached_tokens: hasCacheControl ? 80 : 0,
+										cache_write_tokens: hasCacheControl ? 80 : 0,
+									},
 									completion_tokens_details: { reasoning_tokens: 0 },
 								},
 							};
@@ -71,13 +75,13 @@ vi.mock("openai", () => {
 	return { default: FakeOpenAI };
 });
 
-async function capturePayload(
+async function runCompletion(
 	model: Model<"openai-completions">,
 	options?: { cacheRetention?: "none" | "short" | "long" },
-): Promise<CapturedParams> {
+): Promise<{ params: CapturedParams; result: AssistantMessage }> {
 	const timestamp = Date.now();
 
-	await streamOpenAICompletions(
+	const result = await streamOpenAICompletions(
 		model,
 		{
 			systemPrompt: "System prompt",
@@ -99,26 +103,36 @@ async function capturePayload(
 		throw new Error("Expected payload to be captured");
 	}
 
-	return mockState.lastParams;
+	return { params: mockState.lastParams, result };
+}
+
+async function capturePayload(
+	model: Model<"openai-completions">,
+	options?: { cacheRetention?: "none" | "short" | "long" },
+): Promise<CapturedParams> {
+	return (await runCompletion(model, options)).params;
 }
 
 function getInstructionMessage(params: CapturedParams) {
 	return params.messages.find((message) => message.role === "system" || message.role === "developer");
 }
 
-function expectAnthropicCacheMarkers(params: CapturedParams): void {
+function expectAnthropicCacheMarkers(
+	params: CapturedParams,
+	expectedCacheControl: CacheControl = { type: "ephemeral" },
+): void {
 	const instructionMessage = getInstructionMessage(params);
 	expect(instructionMessage).toBeDefined();
 	expect(Array.isArray(instructionMessage?.content)).toBe(true);
-	expect((instructionMessage?.content as TextPart[])[0]?.cache_control).toEqual({ type: "ephemeral" });
+	expect((instructionMessage?.content as TextPart[])[0]?.cache_control).toEqual(expectedCacheControl);
 
 	expect(params.tools).toHaveLength(1);
-	expect(params.tools?.[0]?.cache_control).toEqual({ type: "ephemeral" });
+	expect(params.tools?.[0]?.cache_control).toEqual(expectedCacheControl);
 
 	const lastMessage = params.messages[params.messages.length - 1];
 	expect(lastMessage.role).toBe("user");
 	expect(Array.isArray(lastMessage.content)).toBe(true);
-	expect((lastMessage.content as TextPart[])[0]?.cache_control).toEqual({ type: "ephemeral" });
+	expect((lastMessage.content as TextPart[])[0]?.cache_control).toEqual(expectedCacheControl);
 }
 
 function expectNoAnthropicCacheMarkers(params: CapturedParams): void {
@@ -167,8 +181,46 @@ describe("openai-completions cacheControlFormat", () => {
 
 	it("applies Anthropic-style cache markers for Prime Inference Anthropic models", async () => {
 		const model = getModel("prime-inference", "anthropic/claude-fable-5");
-		const params = await capturePayload(model);
+		const { params, result } = await runCompletion(model);
 		expectAnthropicCacheMarkers(params);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.input * 1.25) / 1_000_000);
+	});
+
+	it("prices one-hour Prime Inference cache writes at twice the input rate", async () => {
+		const model = getModel("prime-inference", "anthropic/claude-fable-5");
+		const { params, result } = await runCompletion(model, { cacheRetention: "long" });
+		expectAnthropicCacheMarkers(params, { type: "ephemeral", ttl: "1h" });
+		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.input * 2) / 1_000_000);
+	});
+
+	it("prices one-hour OpenRouter Anthropic cache writes at twice the input rate", async () => {
+		const model = getModel("openrouter", "anthropic/claude-sonnet-4");
+		const { params, result } = await runCompletion(model, { cacheRetention: "long" });
+		expectAnthropicCacheMarkers(params, { type: "ephemeral", ttl: "1h" });
+		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.input * 2) / 1_000_000);
+	});
+
+	it("uses five-minute pricing when a model cannot apply long retention", async () => {
+		const model: Model<"openai-completions"> = {
+			id: "custom-anthropic-proxy",
+			name: "Custom Anthropic Proxy",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://example.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 4, output: 12, cacheRead: 0.4, cacheWrite: 5 },
+			contextWindow: 128000,
+			maxTokens: 32000,
+			compat: {
+				cacheControlFormat: "anthropic",
+				supportsLongCacheRetention: false,
+			},
+		};
+
+		const { params, result } = await runCompletion(model, { cacheRetention: "long" });
+		expectAnthropicCacheMarkers(params);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.input * 1.25) / 1_000_000);
 	});
 
 	it("does not apply Anthropic-style cache markers to other Prime Inference models", async () => {


### PR DESCRIPTION
- one-hour anthropic cache writes now use the documented two-times input rate across direct and compatible providers.
- mixed ttl usage is weighted from the provider response instead of using a single five-minute rate.
- adds regression coverage for anthropic, openrouter, and prime inference cache accounting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to usage/cost accounting for prompt caching with shared helpers and tests; no auth or request-shape changes beyond existing cache retention behavior.
> 
> **Overview**
> **Anthropic prompt-cache billing** now distinguishes **5-minute vs 1-hour** write rates and can weight **mixed TTL** usage from provider responses instead of always using a single 5m multiplier.
> 
> A shared **`cache-pricing`** module centralizes read (0.1× input) and write multipliers (1.25× for 5m, 2× for 1h). **`calculateCost`** accepts optional **`CostOverrides.cacheWrite`** so runtime usage can override catalog **`model.cost.cacheWrite`**.
> 
> The **Anthropic** provider recomputes write cost from **`cache_creation`** breakdown on **`message_start`**. **OpenAI-completions** paths (Prime Inference, OpenRouter Anthropic proxies) pick write cost from **`cacheRetention`** / **`cache_control` TTL** and pass it through **`parseChunkUsage`**. Prime Inference model generation reuses **`getAnthropicCacheCosts`** for default catalog cache fields.
> 
> Regression tests cover direct Anthropic SSE (5m, 1h, mixed) and OpenRouter / Prime Inference long retention, including models that cannot apply long retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4717f9f6ead67a8f1cdbc1cea960a53e034b3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cache write cost estimates to use retention-aware pricing for Anthropic models
> - Replaces static model-level `cacheWrite` cost with a dynamic per-request price based on cache TTL (5m = 1.25x, 1h = 2x input cost) for both `streamAnthropic` and `streamOpenAICompletions`.
> - Adds [`cache-pricing.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/481/files#diff-ff901e5d18a275953394b41e1327acdbd3ec407c0719a6502c799cc9b62fc1c1) with `getAnthropicCacheCosts` and `getAnthropicCacheWriteCost` helpers, including blended-rate computation when Anthropic returns a `cache_creation` TTL breakdown in usage.
> - Extends `calculateCost` in [`models.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/481/files#diff-9d03087de13641e60bdb725ae786441aa71caf6626582728660f2a30328138b7) to accept a `CostOverrides` object so callers can supply a per-request `cacheWrite` unit price.
> - Behavioral Change: cache write costs in `usage.cost.cacheWrite` will now vary per request based on the TTL negotiated with Anthropic rather than always using the static model cost.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d4717f9. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->