### PR TITLE
recover sessions after interrupted updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed interrupted updates leaving prepared daemon sessions unrestored on the next launch ([ENG-4746](https://linear.app/primeintellect/issue/ENG-4746/updating-still-doesnt-restore-old-running-sessions)).
+
 ## [0.3.2] - 2026-07-20
 
 - Fixed invalid `--resume` session IDs being submitted as prompts, with nearest-session guidance instead ([ENG-4722](https://linear.app/primeintellect/issue/ENG-4722/prime-agent-resume-accepts-incorrect-session-ids)).
@@ -33,7 +35,6 @@
 - Changed `/traces upload-all` to pace requests within the platform rate limit, honor bounded `Retry-After` responses, and support interruption.
 - Fixed resuming a daemon-resident session to attach the requesting client to its existing worker without disturbing other clients ([ENG-4656](https://linear.app/primeintellect/issue/ENG-4656/resuming-prime-agent-sessions-should-attach)).
 - Fixed daemon-owned updates terminating their updater before the daemon restart and session restore completed ([ENG-4606](https://linear.app/primeintellect/issue/ENG-4606/benign-error-on-prime-agent-update)).
-- Fixed interrupted updates leaving prepared daemon sessions unrestored on the next launch ([ENG-4746](https://linear.app/primeintellect/issue/ENG-4746/updating-still-doesnt-restore-old-running-sessions)).
 - Fixed first-launch Prime login and kept onboarding visible between team and model selection ([ENG-4658](https://linear.app/primeintellect/issue/ENG-4658/fix-onboarding-login-enter-key-and-model-selector-flicker)).
 - Fixed active heartbeat sessions appearing under Needs Input or Completed instead of a dedicated Heartbeats section ([ENG-4654](https://linear.app/primeintellect/issue/ENG-4654/categorize-heartbeat-sessions-as-working)).
 - Fixed stashed prompts being lost when leaving and reopening a session from the Agents View ([ENG-4659](https://linear.app/primeintellect/issue/ENG-4659/stashed-prompts-should-persist)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Changed `/traces upload-all` to pace requests within the platform rate limit, honor bounded `Retry-After` responses, and support interruption.
 - Fixed resuming a daemon-resident session to attach the requesting client to its existing worker without disturbing other clients ([ENG-4656](https://linear.app/primeintellect/issue/ENG-4656/resuming-prime-agent-sessions-should-attach)).
 - Fixed daemon-owned updates terminating their updater before the daemon restart and session restore completed ([ENG-4606](https://linear.app/primeintellect/issue/ENG-4606/benign-error-on-prime-agent-update)).
+- Fixed interrupted updates leaving prepared daemon sessions unrestored on the next launch ([ENG-4746](https://linear.app/primeintellect/issue/ENG-4746/updating-still-doesnt-restore-old-running-sessions)).
 - Fixed first-launch Prime login and kept onboarding visible between team and model selection ([ENG-4658](https://linear.app/primeintellect/issue/ENG-4658/fix-onboarding-login-enter-key-and-model-selector-flicker)).
 - Fixed active heartbeat sessions appearing under Needs Input or Completed instead of a dedicated Heartbeats section ([ENG-4654](https://linear.app/primeintellect/issue/ENG-4654/categorize-heartbeat-sessions-as-working)).
 - Fixed stashed prompts being lost when leaving and reopening a session from the Agents View ([ENG-4659](https://linear.app/primeintellect/issue/ENG-4659/stashed-prompts-should-persist)).

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -4,7 +4,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import chalk from "chalk";
 import { spawn } from "child_process";
-import { expandTildePath } from "../config.js";
+import { expandTildePath, getAgentDir } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
 import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
@@ -17,6 +17,7 @@ import { isLocalPath } from "../utils/paths.js";
 import { isValidThinkingLevel } from "./args.js";
 import { formatSessionListTable } from "./daemon-list-format.js";
 import { runPs, runReap } from "./daemon-ps.js";
+import { recoverPendingDaemonUpdateRestart } from "./daemon-update-recovery.js";
 
 interface ParsedDaemonClientCommand {
 	command: string;
@@ -130,6 +131,10 @@ function parseDaemonClientCommand(args: string[]): ParsedDaemonClientCommand {
 }
 
 async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promise<void> {
+	if (parsed.command !== "ps" && parsed.command !== "shutdown") {
+		await recoverPendingDaemonUpdateRestart(parsed.socketPath, getAgentDir(), process.cwd());
+	}
+
 	if (parsed.command === "open") {
 		await runOpen(parsed);
 		return;

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -8,7 +8,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { appendRotatingLog, expandTildePath, getClientErrorLogPath, VERSION } from "../config.js";
+import { appendRotatingLog, expandTildePath, getAgentDir, getClientErrorLogPath, VERSION } from "../config.js";
 import { getProcessStartId } from "../core/session-lease.js";
 import { DaemonClient, type DaemonHello } from "../modes/daemon/daemon-client.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../modes/daemon/daemon-protocol.js";
@@ -16,6 +16,7 @@ import { getDaemonRuntimeIdentity } from "../modes/daemon/daemon-runtime-identit
 import { isSessionSummaryBusy, type SessionSummary } from "../modes/daemon/daemon-session-list.js";
 import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
 import { isHelpCommandRequest, PUBLIC_COMMAND_NAMES, REMOVED_COMMAND_NAMES } from "./command-registry.js";
+import { hasPendingDaemonUpdateRestartManifest } from "./daemon-update-manifest.js";
 import { createCliSubprocessEnv, formatCurrentCliCommand } from "./subprocess-launch.js";
 
 const DAEMON_STARTUP_TIMEOUT_MS = 30_000;
@@ -476,8 +477,12 @@ function findFirstEarlyLaunchPositional(args: readonly string[]): { index: numbe
 	return undefined;
 }
 
-export function shouldStartDaemonEarly(args: readonly string[], startupBenchmark: boolean): boolean {
-	if (startupBenchmark) {
+export function shouldStartDaemonEarly(
+	args: readonly string[],
+	startupBenchmark: boolean,
+	pendingUpdateRecovery = false,
+): boolean {
+	if (startupBenchmark || pendingUpdateRecovery) {
 		return false;
 	}
 	const modeIndex = args.indexOf("--mode");
@@ -508,12 +513,16 @@ export function shouldStartDaemonEarly(args: readonly string[], startupBenchmark
 export function maybeStartDaemonEarly(args: readonly string[]): void {
 	const benchmarkFlag = (process.env.PI_STARTUP_BENCHMARK ?? "").toLowerCase();
 	const startupBenchmark = benchmarkFlag === "1" || benchmarkFlag === "true" || benchmarkFlag === "yes";
-	if (!shouldStartDaemonEarly(args, startupBenchmark)) {
-		return;
-	}
 	const socketIndex = args.indexOf("--daemon-socket");
 	const socketPath =
 		socketIndex !== -1 && args[socketIndex + 1] ? (args[socketIndex + 1] as string) : defaultDaemonSocketPath();
+	const pendingUpdateRecovery = hasPendingDaemonUpdateRestartManifest(socketPath, getAgentDir());
+	if (!shouldStartDaemonEarly(args, startupBenchmark, pendingUpdateRecovery)) {
+		if (pendingUpdateRecovery) {
+			logDaemonLaunch(`deferring daemon startup on ${socketPath} until pending update recovery completes`);
+		}
+		return;
+	}
 	const cwdIndex = args.indexOf("--cwd");
 	const cwdArg = cwdIndex !== -1 ? args[cwdIndex + 1] : undefined;
 	const spawnCwd = cwdArg ? resolve(expandTildePath(cwdArg)) : undefined;

--- a/packages/coding-agent/src/cli/daemon-update-manifest.ts
+++ b/packages/coding-agent/src/cli/daemon-update-manifest.ts
@@ -5,6 +5,12 @@ import { getDaemonUpdateRestartManifestPath, getLegacyDaemonUpdateRestartManifes
 import type { DaemonUpdateRestartManifest, DaemonUpdateRestartSession } from "../modes/daemon/daemon-protocol.js";
 import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
 
+export type DaemonUpdateRestartRecoveryKind = "restart" | "retry";
+
+export interface PreparedDaemonUpdateRestartManifest extends DaemonUpdateRestartManifest {
+	retryOnly?: true;
+}
+
 function normalizedSocketPath(path: string): string {
 	return process.platform === "win32" ? path.toLowerCase() : resolve(path);
 }
@@ -26,24 +32,35 @@ export function getDaemonUpdateRestartManifestCandidates(socketPath: string, age
 	return candidates;
 }
 
-export function hasPendingDaemonUpdateRestartManifest(socketPath: string, agentDir: string): boolean {
+export function getPendingDaemonUpdateRestartRecoveryKind(
+	socketPath: string,
+	agentDir: string,
+): DaemonUpdateRestartRecoveryKind | undefined {
+	let retryPending = false;
 	for (const path of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
 		try {
-			const value = JSON.parse(readFileSync(path, "utf8")) as { sessions?: unknown };
+			const value = JSON.parse(readFileSync(path, "utf8")) as { sessions?: unknown; retryOnly?: unknown };
 			if (Array.isArray(value.sessions) && value.sessions.length > 0) {
-				return true;
+				if (value.retryOnly !== true) {
+					return "restart";
+				}
+				retryPending = true;
 			}
 		} catch {
 			// Full validation and diagnostics happen in the recovery coordinator.
 		}
 	}
-	return false;
+	return retryPending ? "retry" : undefined;
+}
+
+export function hasPendingDaemonUpdateRestartManifest(socketPath: string, agentDir: string): boolean {
+	return getPendingDaemonUpdateRestartRecoveryKind(socketPath, agentDir) !== undefined;
 }
 
 export function writePreparedDaemonUpdateRestartManifest(
 	socketPath: string,
 	agentDir: string,
-	manifest: DaemonUpdateRestartManifest,
+	manifest: PreparedDaemonUpdateRestartManifest,
 ): void {
 	const path = getDaemonUpdateRestartManifestPath(socketPath, agentDir);
 	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
@@ -169,7 +186,7 @@ export function mergeDaemonUpdateRestartManifests(
 export function manifestForFailedDaemonUpdateRestores(
 	manifest: DaemonUpdateRestartManifest,
 	failedSessionFiles: readonly string[],
-): DaemonUpdateRestartManifest | undefined {
+): PreparedDaemonUpdateRestartManifest | undefined {
 	const failed = new Set(failedSessionFiles.map(sessionKey));
 	const retained = new Set(failed);
 	const byActiveSessionId = new Map(manifest.sessions.map((session) => [session.activeSessionId, session]));
@@ -204,5 +221,5 @@ export function manifestForFailedDaemonUpdateRestores(
 				hadAcceptedPromptInFlight: false,
 			};
 		});
-	return sessions.length > 0 ? { createdAt: manifest.createdAt, sessions } : undefined;
+	return sessions.length > 0 ? { createdAt: manifest.createdAt, sessions, retryOnly: true } : undefined;
 }

--- a/packages/coding-agent/src/cli/daemon-update-manifest.ts
+++ b/packages/coding-agent/src/cli/daemon-update-manifest.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { getDaemonUpdateRestartManifestPath, getLegacyDaemonUpdateRestartManifestPath } from "../config.js";
+import type { DaemonUpdateRestartManifest, DaemonUpdateRestartSession } from "../modes/daemon/daemon-protocol.js";
+import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
+
+function normalizedSocketPath(path: string): string {
+	return process.platform === "win32" ? path.toLowerCase() : resolve(path);
+}
+
+function normalizedFilePath(path: string): string {
+	const normalized = resolve(path);
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function sessionKey(sessionFile: string): string {
+	return normalizedFilePath(sessionFile);
+}
+
+export function getDaemonUpdateRestartManifestCandidates(socketPath: string, agentDir: string): string[] {
+	const candidates = [getDaemonUpdateRestartManifestPath(socketPath, agentDir)];
+	if (normalizedSocketPath(socketPath) === normalizedSocketPath(defaultDaemonSocketPath())) {
+		candidates.push(getLegacyDaemonUpdateRestartManifestPath(agentDir));
+	}
+	return candidates;
+}
+
+export function hasPendingDaemonUpdateRestartManifest(socketPath: string, agentDir: string): boolean {
+	for (const path of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
+		try {
+			const value = JSON.parse(readFileSync(path, "utf8")) as { sessions?: unknown };
+			if (Array.isArray(value.sessions) && value.sessions.length > 0) {
+				return true;
+			}
+		} catch {
+			// Full validation and diagnostics happen in the recovery coordinator.
+		}
+	}
+	return false;
+}
+
+export function writePreparedDaemonUpdateRestartManifest(
+	socketPath: string,
+	agentDir: string,
+	manifest: DaemonUpdateRestartManifest,
+): void {
+	const path = getDaemonUpdateRestartManifestPath(socketPath, agentDir);
+	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+	const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		writeFileSync(tempPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+		renameSync(tempPath, path);
+	} catch (error) {
+		rmSync(tempPath, { force: true });
+		throw error;
+	}
+}
+
+export function clearPreparedDaemonUpdateRestartManifest(socketPath: string, agentDir: string): void {
+	for (const path of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
+		try {
+			rmSync(path, { force: true });
+		} catch {
+			// Best effort only. A later recovery can safely reconcile duplicates by session file.
+		}
+	}
+}
+
+function resolveActiveSessionAlias(activeSessionId: string, aliases: ReadonlyMap<string, string>): string {
+	let current = activeSessionId;
+	const visited = new Set<string>();
+	while (!visited.has(current)) {
+		visited.add(current);
+		const next = aliases.get(current);
+		if (!next) {
+			break;
+		}
+		current = next;
+	}
+	return current;
+}
+
+function remapParentActiveSessionId(
+	session: DaemonUpdateRestartSession,
+	aliases: ReadonlyMap<string, string>,
+): DaemonUpdateRestartSession {
+	const runtimeMetadata = session.runtimeMetadata;
+	const parentActiveSessionId = runtimeMetadata?.parentActiveSessionId;
+	if (!parentActiveSessionId) {
+		return session;
+	}
+	const remappedParentActiveSessionId = resolveActiveSessionAlias(parentActiveSessionId, aliases);
+	if (remappedParentActiveSessionId === parentActiveSessionId) {
+		return session;
+	}
+	return {
+		...session,
+		runtimeMetadata: {
+			...runtimeMetadata,
+			parentActiveSessionId: remappedParentActiveSessionId,
+		},
+	};
+}
+
+function orderParentSessionsFirst(sessions: readonly DaemonUpdateRestartSession[]): DaemonUpdateRestartSession[] {
+	const byActiveSessionId = new Map(sessions.map((session) => [session.activeSessionId, session]));
+	const ordered: DaemonUpdateRestartSession[] = [];
+	const visited = new Set<string>();
+	const visiting = new Set<string>();
+	const visit = (session: DaemonUpdateRestartSession) => {
+		if (visited.has(session.activeSessionId)) {
+			return;
+		}
+		if (visiting.has(session.activeSessionId)) {
+			return;
+		}
+		visiting.add(session.activeSessionId);
+		const parentActiveSessionId = session.runtimeMetadata?.parentActiveSessionId;
+		const parent = parentActiveSessionId ? byActiveSessionId.get(parentActiveSessionId) : undefined;
+		if (parent) {
+			visit(parent);
+		}
+		visiting.delete(session.activeSessionId);
+		visited.add(session.activeSessionId);
+		ordered.push(session);
+	};
+	for (const session of sessions) {
+		visit(session);
+	}
+	return ordered;
+}
+
+export function mergeDaemonUpdateRestartManifests(
+	pending: DaemonUpdateRestartManifest,
+	current: DaemonUpdateRestartManifest,
+): DaemonUpdateRestartManifest {
+	const currentBySessionFile = new Map(current.sessions.map((session) => [sessionKey(session.sessionFile), session]));
+	const consumedCurrentSessionFiles = new Set<string>();
+	const aliases = new Map<string, string>();
+	const merged = pending.sessions.map((pendingSession) => {
+		const key = sessionKey(pendingSession.sessionFile);
+		const currentSession = currentBySessionFile.get(key);
+		if (!currentSession) {
+			return pendingSession;
+		}
+		consumedCurrentSessionFiles.add(key);
+		if (pendingSession.activeSessionId !== currentSession.activeSessionId) {
+			aliases.set(pendingSession.activeSessionId, currentSession.activeSessionId);
+		}
+		return currentSession;
+	});
+	for (const currentSession of current.sessions) {
+		if (!consumedCurrentSessionFiles.has(sessionKey(currentSession.sessionFile))) {
+			merged.push(currentSession);
+		}
+	}
+	return {
+		createdAt: current.createdAt,
+		sessions: orderParentSessionsFirst(merged.map((session) => remapParentActiveSessionId(session, aliases))),
+	};
+}
+
+export function manifestForFailedDaemonUpdateRestores(
+	manifest: DaemonUpdateRestartManifest,
+	failedSessionFiles: readonly string[],
+): DaemonUpdateRestartManifest | undefined {
+	const retained = new Set(failedSessionFiles.map(sessionKey));
+	const byActiveSessionId = new Map(manifest.sessions.map((session) => [session.activeSessionId, session]));
+	for (const failedSession of manifest.sessions.filter((session) => retained.has(sessionKey(session.sessionFile)))) {
+		let parentActiveSessionId = failedSession.runtimeMetadata?.parentActiveSessionId;
+		const visited = new Set<string>();
+		while (parentActiveSessionId && !visited.has(parentActiveSessionId)) {
+			visited.add(parentActiveSessionId);
+			const parent = byActiveSessionId.get(parentActiveSessionId);
+			if (!parent) {
+				break;
+			}
+			retained.add(sessionKey(parent.sessionFile));
+			parentActiveSessionId = parent.runtimeMetadata?.parentActiveSessionId;
+		}
+	}
+	const sessions = manifest.sessions.filter((session) => retained.has(sessionKey(session.sessionFile)));
+	return sessions.length > 0 ? { createdAt: manifest.createdAt, sessions } : undefined;
+}

--- a/packages/coding-agent/src/cli/daemon-update-manifest.ts
+++ b/packages/coding-agent/src/cli/daemon-update-manifest.ts
@@ -51,6 +51,11 @@ export function writePreparedDaemonUpdateRestartManifest(
 	try {
 		writeFileSync(tempPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
 		renameSync(tempPath, path);
+		for (const candidate of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
+			if (candidate !== path) {
+				rmSync(candidate, { force: true });
+			}
+		}
 	} catch (error) {
 		rmSync(tempPath, { force: true });
 		throw error;
@@ -165,7 +170,8 @@ export function manifestForFailedDaemonUpdateRestores(
 	manifest: DaemonUpdateRestartManifest,
 	failedSessionFiles: readonly string[],
 ): DaemonUpdateRestartManifest | undefined {
-	const retained = new Set(failedSessionFiles.map(sessionKey));
+	const failed = new Set(failedSessionFiles.map(sessionKey));
+	const retained = new Set(failed);
 	const byActiveSessionId = new Map(manifest.sessions.map((session) => [session.activeSessionId, session]));
 	for (const failedSession of manifest.sessions.filter((session) => retained.has(sessionKey(session.sessionFile)))) {
 		let parentActiveSessionId = failedSession.runtimeMetadata?.parentActiveSessionId;
@@ -180,6 +186,23 @@ export function manifestForFailedDaemonUpdateRestores(
 			parentActiveSessionId = parent.runtimeMetadata?.parentActiveSessionId;
 		}
 	}
-	const sessions = manifest.sessions.filter((session) => retained.has(sessionKey(session.sessionFile)));
+	const sessions = manifest.sessions
+		.filter((session) => retained.has(sessionKey(session.sessionFile)))
+		.map((session) => {
+			if (failed.has(sessionKey(session.sessionFile))) {
+				return session;
+			}
+			return {
+				...session,
+				queue: { steering: [], followUp: [], nextTurn: [] },
+				shouldResume: false,
+				wasStreaming: false,
+				wasCompacting: false,
+				wasBashRunning: false,
+				hadRunningRlmChildren: false,
+				wasRetrying: false,
+				hadAcceptedPromptInFlight: false,
+			};
+		});
 	return sessions.length > 0 ? { createdAt: manifest.createdAt, sessions } : undefined;
 }

--- a/packages/coding-agent/src/cli/daemon-update-recovery.ts
+++ b/packages/coding-agent/src/cli/daemon-update-recovery.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { hasPendingDaemonUpdateRestartManifest } from "./daemon-update-manifest.js";
+import { getPendingDaemonUpdateRestartRecoveryKind } from "./daemon-update-manifest.js";
 import { buildDaemonUpdateRestartReport, launchDaemonUpdateRestartCoordinator } from "./daemon-update-restart.js";
 
 export async function recoverPendingDaemonUpdateRestart(
@@ -7,11 +7,17 @@ export async function recoverPendingDaemonUpdateRestart(
 	agentDir: string,
 	cwd: string,
 ): Promise<void> {
-	if (!hasPendingDaemonUpdateRestartManifest(socketPath, agentDir)) {
+	const recoveryKind = getPendingDaemonUpdateRestartRecoveryKind(socketPath, agentDir);
+	if (!recoveryKind) {
 		return;
 	}
 	try {
-		const status = await launchDaemonUpdateRestartCoordinator({ socketPath, agentDir, cwd });
+		const status = await launchDaemonUpdateRestartCoordinator({
+			socketPath,
+			agentDir,
+			cwd,
+			retryOnly: recoveryKind === "retry",
+		});
 		const report = buildDaemonUpdateRestartReport(status);
 		for (const message of report.info) {
 			console.log(chalk.green(message));

--- a/packages/coding-agent/src/cli/daemon-update-recovery.ts
+++ b/packages/coding-agent/src/cli/daemon-update-recovery.ts
@@ -1,0 +1,26 @@
+import chalk from "chalk";
+import { hasPendingDaemonUpdateRestartManifest } from "./daemon-update-manifest.js";
+import { buildDaemonUpdateRestartReport, launchDaemonUpdateRestartCoordinator } from "./daemon-update-restart.js";
+
+export async function recoverPendingDaemonUpdateRestart(
+	socketPath: string,
+	agentDir: string,
+	cwd: string,
+): Promise<void> {
+	if (!hasPendingDaemonUpdateRestartManifest(socketPath, agentDir)) {
+		return;
+	}
+	try {
+		const status = await launchDaemonUpdateRestartCoordinator({ socketPath, agentDir, cwd });
+		const report = buildDaemonUpdateRestartReport(status);
+		for (const message of report.info) {
+			console.log(chalk.green(message));
+		}
+		for (const warning of report.warnings) {
+			console.error(chalk.yellow(`Warning: ${warning}`));
+		}
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.yellow(`Warning: could not recover sessions from the interrupted update (${message}).`));
+	}
+}

--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -19,6 +19,7 @@ import { createCliSubprocessLaunchSpec } from "./subprocess-launch.js";
 export const DAEMON_UPDATE_RESTART_COORDINATOR_FLAG = "--internal-update-restart-coordinator";
 export const DAEMON_UPDATE_RESTART_STATUS_FLAG = "--internal-update-restart-status";
 export const DAEMON_UPDATE_RESTART_ORIGIN_FLAG = "--internal-update-restart-origin";
+export const DAEMON_UPDATE_RETRY_ONLY_FLAG = "--internal-update-retry-only";
 
 export type DaemonUpdateRestartPhase =
 	| "starting"
@@ -84,6 +85,7 @@ export interface LaunchDaemonUpdateRestartCoordinatorOptions {
 	agentDir: string;
 	cwd?: string;
 	originActiveSessionId?: string;
+	retryOnly?: boolean;
 	timeoutMs?: number;
 }
 
@@ -546,6 +548,7 @@ export async function launchDaemonUpdateRestartCoordinator(
 		DAEMON_UPDATE_RESTART_STATUS_FLAG,
 		statusPath,
 		...(originActiveSessionId ? [DAEMON_UPDATE_RESTART_ORIGIN_FLAG, originActiveSessionId] : []),
+		...(options.retryOnly ? [DAEMON_UPDATE_RETRY_ONLY_FLAG] : []),
 	]);
 	const child = spawn(launch.command, launch.args, {
 		cwd: options.cwd ?? process.cwd(),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -22,6 +22,8 @@ import {
 	shutdownDaemonAndWait,
 } from "./cli/daemon-launch.js";
 import { confirmDaemonSessionLoss, type DaemonSessionLossCopy, pluralizeSessions } from "./cli/daemon-stop-confirm.js";
+import { hasPendingDaemonUpdateRestartManifest } from "./cli/daemon-update-manifest.js";
+import { buildDaemonUpdateRestartReport, launchDaemonUpdateRestartCoordinator } from "./cli/daemon-update-restart.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
 import { listModels } from "./cli/list-models.js";
@@ -403,6 +405,25 @@ async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise
 			return takeOverStaleDaemonOrExit(error.socketPath);
 		}
 		throw error;
+	}
+}
+
+async function recoverPendingDaemonUpdateRestart(socketPath: string, agentDir: string, cwd: string): Promise<void> {
+	if (!hasPendingDaemonUpdateRestartManifest(socketPath, agentDir)) {
+		return;
+	}
+	try {
+		const status = await launchDaemonUpdateRestartCoordinator({ socketPath, agentDir, cwd });
+		const report = buildDaemonUpdateRestartReport(status);
+		for (const message of report.info) {
+			console.log(chalk.green(message));
+		}
+		for (const warning of report.warnings) {
+			console.error(chalk.yellow(`Warning: ${warning}`));
+		}
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.yellow(`Warning: could not recover sessions from the interrupted update (${message}).`));
 	}
 }
 
@@ -1150,6 +1171,9 @@ export async function main(args: string[], options?: MainOptions) {
 		getSessionDirEnvOverride() ??
 		startupSettingsManager.getSessionDir();
 	const daemonSocketPath = parsed.daemonSocket ?? defaultDaemonSocketPath();
+	if (useDaemonClient) {
+		await recoverPendingDaemonUpdateRestart(daemonSocketPath, agentDir, cwd);
+	}
 	// Kick off daemon spawn/readiness immediately so it overlaps session-manager
 	// and runtime-services preparation; attach only connects to an existing daemon.
 	let daemonReady = shouldEnsureInteractiveDaemonForStartup(useDaemonClient, publicCommand.attachAgent)

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -22,8 +22,7 @@ import {
 	shutdownDaemonAndWait,
 } from "./cli/daemon-launch.js";
 import { confirmDaemonSessionLoss, type DaemonSessionLossCopy, pluralizeSessions } from "./cli/daemon-stop-confirm.js";
-import { hasPendingDaemonUpdateRestartManifest } from "./cli/daemon-update-manifest.js";
-import { buildDaemonUpdateRestartReport, launchDaemonUpdateRestartCoordinator } from "./cli/daemon-update-restart.js";
+import { recoverPendingDaemonUpdateRestart } from "./cli/daemon-update-recovery.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
 import { listModels } from "./cli/list-models.js";
@@ -405,25 +404,6 @@ async function awaitDaemonReady(daemonReady: Promise<void> | undefined): Promise
 			return takeOverStaleDaemonOrExit(error.socketPath);
 		}
 		throw error;
-	}
-}
-
-async function recoverPendingDaemonUpdateRestart(socketPath: string, agentDir: string, cwd: string): Promise<void> {
-	if (!hasPendingDaemonUpdateRestartManifest(socketPath, agentDir)) {
-		return;
-	}
-	try {
-		const status = await launchDaemonUpdateRestartCoordinator({ socketPath, agentDir, cwd });
-		const report = buildDaemonUpdateRestartReport(status);
-		for (const message of report.info) {
-			console.log(chalk.green(message));
-		}
-		for (const warning of report.warnings) {
-			console.error(chalk.yellow(`Warning: ${warning}`));
-		}
-	} catch (error: unknown) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.error(chalk.yellow(`Warning: could not recover sessions from the interrupted update (${message}).`));
 	}
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1030,7 +1030,10 @@ export class DaemonSupervisor {
 					}
 					const activeSessionId = response.data.activeSessionId ?? response.data.id;
 					parent.worker.summaries.set(activeSessionId, response.data);
-					await this.syncAgentPeers();
+					await this.subscribeWorker(parent.worker, activeSessionId);
+					await this.syncAgentPeers().catch((error) =>
+						this.log(`Could not synchronize agent peers after subagent creation: ${String(error)}`),
+					);
 					return { ...response, data: this.publicSummary(parent.worker, response.data) };
 				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), command);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1017,6 +1017,22 @@ export class DaemonSupervisor {
 			case "list_saved_sessions":
 				return this.handleSavedSessionList(client, command);
 			case "create": {
+				const parentActiveSessionId =
+					command.runtimeMetadata?.kind === "subagent" ? command.runtimeMetadata.parentActiveSessionId : undefined;
+				if (parentActiveSessionId) {
+					const parent = await this.findWorkerForClient(client, parentActiveSessionId);
+					const response = await this.forwardToWorker(parent.worker, withoutSupervisorCreateFields(command));
+					if (!response.success) {
+						return response;
+					}
+					if (!isSessionSummary(response.data)) {
+						throw new Error("Session worker returned an invalid subagent create response");
+					}
+					const activeSessionId = response.data.activeSessionId ?? response.data.id;
+					parent.worker.summaries.set(activeSessionId, response.data);
+					await this.syncAgentPeers();
+					return { ...response, data: this.publicSummary(parent.worker, response.data) };
+				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), command);
 				const summary = worker.summaries.get(worker.descriptor.rootActiveSessionId);
 				if (!summary) {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -25,6 +25,7 @@ import {
 	DAEMON_UPDATE_RESTART_COORDINATOR_FLAG,
 	DAEMON_UPDATE_RESTART_ORIGIN_FLAG,
 	DAEMON_UPDATE_RESTART_STATUS_FLAG,
+	DAEMON_UPDATE_RETRY_ONLY_FLAG,
 	DaemonUpdateRestartCoordinatorAlreadyRunningError,
 	type DaemonUpdateRestartCounts,
 	type DaemonUpdateRestartFailure,
@@ -60,6 +61,7 @@ import {
 	type DaemonUpdateRestartSession,
 	isUnknownDaemonCommandError,
 } from "./modes/daemon/daemon-protocol.js";
+import type { SessionSummary } from "./modes/daemon/daemon-session-list.js";
 import { defaultDaemonSocketPath } from "./modes/daemon/daemon-socket.js";
 import {
 	acquireDaemonShutdownAdmission,
@@ -92,6 +94,7 @@ interface PackageCommandOptions {
 	help: boolean;
 	daemonSocketPath?: string;
 	restartCoordinator: boolean;
+	restartRetryOnly: boolean;
 	restartStatusPath?: string;
 	restartOriginActiveSessionId?: string;
 	invalidOption?: string;
@@ -213,6 +216,7 @@ function parsePackageCommand(args: string[]): PackageCommandOptions | undefined 
 	let extensionFlagSource: string | undefined;
 	let daemonSocketPath: string | undefined;
 	let restartCoordinator = false;
+	let restartRetryOnly = false;
 	let restartStatusPath: string | undefined;
 	let restartOriginActiveSessionId: string | undefined;
 
@@ -280,6 +284,15 @@ function parsePackageCommand(args: string[]): PackageCommandOptions | undefined 
 		if (arg === DAEMON_UPDATE_RESTART_COORDINATOR_FLAG) {
 			if (command === "update") {
 				restartCoordinator = true;
+			} else {
+				invalidOption = invalidOption ?? arg;
+			}
+			continue;
+		}
+
+		if (arg === DAEMON_UPDATE_RETRY_ONLY_FLAG) {
+			if (command === "update") {
+				restartRetryOnly = true;
 			} else {
 				invalidOption = invalidOption ?? arg;
 			}
@@ -377,6 +390,7 @@ function parsePackageCommand(args: string[]): PackageCommandOptions | undefined 
 		help,
 		daemonSocketPath,
 		restartCoordinator,
+		restartRetryOnly,
 		restartStatusPath,
 		restartOriginActiveSessionId,
 		invalidOption,
@@ -828,7 +842,9 @@ function tryReadPreparedDaemonUpdateRestartManifest(
 	}
 }
 
-function hasRestorableDaemonUpdateRestart(manifest: DaemonUpdateRestartManifest | undefined): boolean {
+function hasRestorableDaemonUpdateRestart(
+	manifest: DaemonUpdateRestartManifest | undefined,
+): manifest is DaemonUpdateRestartManifest {
 	return manifest !== undefined && manifest.sessions.length > 0;
 }
 
@@ -991,6 +1007,11 @@ interface RestoreDaemonUpdateRestartSessionResult {
 
 interface RestoreDaemonUpdateRestartResult extends DaemonUpdateRestartCounts {
 	failures: DaemonUpdateRestartFailure[];
+}
+
+function normalizedSessionFile(sessionFile: string): string {
+	const normalized = resolve(sessionFile);
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
 function remapDaemonUpdateRestartRuntimeMetadata(
@@ -1193,9 +1214,25 @@ async function restoreDaemonUpdateRestart(
 	manifest: DaemonUpdateRestartManifest,
 	restartOriginActiveSessionId?: string,
 	onProgress?: (progress: RestoreDaemonUpdateRestartResult) => void,
+	activeSessions: readonly SessionSummary[] = [],
 ): Promise<RestoreDaemonUpdateRestartResult> {
 	const restoredActiveSessionIds = new Map<string, string>();
-	if (manifest.sessions.length === 0) {
+	const activeBySessionFile = new Map(
+		activeSessions.flatMap((session) =>
+			session.sessionFile && session.activeSessionId
+				? [[normalizedSessionFile(session.sessionFile), session.activeSessionId] as const]
+				: [],
+		),
+	);
+	const sessionsToRestore = manifest.sessions.filter((session) => {
+		const activeSessionId = activeBySessionFile.get(normalizedSessionFile(session.sessionFile));
+		if (!activeSessionId) {
+			return true;
+		}
+		restoredActiveSessionIds.set(session.activeSessionId, activeSessionId);
+		return false;
+	});
+	if (sessionsToRestore.length === 0) {
 		return { total: 0, restored: 0, resumed: 0, failed: 0, failures: [] };
 	}
 	const client = new DaemonClient(socketPath);
@@ -1204,7 +1241,7 @@ async function restoreDaemonUpdateRestart(
 	const failures: DaemonUpdateRestartFailure[] = [];
 	try {
 		await client.connect(10000);
-		for (const session of manifest.sessions) {
+		for (const session of sessionsToRestore) {
 			try {
 				const result = await restoreDaemonUpdateRestartSession(
 					client,
@@ -1230,7 +1267,7 @@ async function restoreDaemonUpdateRestart(
 				failures.push({ sessionFile: session.sessionFile, message });
 			}
 			onProgress?.({
-				total: manifest.sessions.length,
+				total: sessionsToRestore.length,
 				restored,
 				resumed,
 				failed: failures.length,
@@ -1245,10 +1282,10 @@ async function restoreDaemonUpdateRestart(
 		console.log(chalk.green(`Resumed ${resumed} interrupted session${resumed === 1 ? "" : "s"}`));
 	}
 	return {
-		total: manifest.sessions.length,
+		total: sessionsToRestore.length,
 		restored,
 		resumed,
-		failed: manifest.sessions.length - restored,
+		failed: sessionsToRestore.length - restored,
 		failures,
 	};
 }
@@ -1268,6 +1305,26 @@ function persistDaemonUpdateRestartRemainder(
 		return;
 	}
 	clearPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
+}
+
+async function restoreAndPersistDaemonUpdateRestart(
+	socketPath: string,
+	agentDir: string,
+	manifest: DaemonUpdateRestartManifest,
+	restartOriginActiveSessionId?: string,
+	onProgress?: (progress: RestoreDaemonUpdateRestartResult) => void,
+	activeSessions?: readonly SessionSummary[],
+): Promise<{ counts: DaemonUpdateRestartCounts; failures: DaemonUpdateRestartFailure[] }> {
+	const restoreResult = await restoreDaemonUpdateRestart(
+		socketPath,
+		manifest,
+		restartOriginActiveSessionId,
+		onProgress,
+		activeSessions,
+	);
+	const { failures, ...counts } = restoreResult;
+	persistDaemonUpdateRestartRemainder(socketPath, agentDir, manifest, failures);
+	return { counts, failures };
 }
 
 function formatUnknownError(error: unknown): string {
@@ -1337,6 +1394,7 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 	agentDir: string;
 	statusPath: string;
 	originActiveSessionId?: string;
+	retryOnly?: boolean;
 }): Promise<DaemonUpdateRestartStatus> {
 	const statusWriter = new DaemonUpdateRestartStatusWriter(
 		options.statusPath,
@@ -1376,6 +1434,41 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 			const { failures, ...counts } = progress;
 			statusWriter.update({ counts, failures });
 		};
+		if (options.retryOnly && daemonProbe.reachable) {
+			manifest = tryReadPreparedDaemonUpdateRestartManifest(options.socketPath, options.agentDir);
+			if (!hasRestorableDaemonUpdateRestart(manifest)) {
+				statusWriter.update({ phase: "skipped", message: "No failed daemon sessions needed to be retried" });
+				return statusWriter.current();
+			}
+			if (!daemonProbe.activeSessions) {
+				statusWriter.update({
+					phase: "skipped",
+					message: "Could not list live daemon sessions before retrying failed restores",
+				});
+				return statusWriter.current();
+			}
+			await shutdownAdmission.release();
+			shutdownAdmission = undefined;
+			statusWriter.update({ phase: "restoring" });
+			const { counts, failures } = await restoreAndPersistDaemonUpdateRestart(
+				options.socketPath,
+				options.agentDir,
+				manifest,
+				options.originActiveSessionId,
+				reportRestoreProgress,
+				daemonProbe.activeSessions,
+			);
+			statusWriter.update({
+				phase: "complete",
+				counts,
+				...(failures.length > 0 ? { failures } : {}),
+				message:
+					counts.failed > 0
+						? `Retried daemon session restores with ${counts.failed} failure${counts.failed === 1 ? "" : "s"}`
+						: "Retried pending daemon session restores",
+			});
+			return statusWriter.current();
+		}
 		let predecessor: DaemonUpdateRestartProcessIdentity | undefined;
 		if (daemonProbe.reachable) {
 			connectedClient = new DaemonClient(options.socketPath);
@@ -1415,22 +1508,16 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 				if (remainingDaemon.reachable) {
 					if (manifest) {
 						try {
-							const restoreResult = await restoreDaemonUpdateRestart(
+							const { counts, failures } = await restoreAndPersistDaemonUpdateRestart(
 								options.socketPath,
+								options.agentDir,
 								manifest,
 								options.originActiveSessionId,
 								reportRestoreProgress,
 							);
-							const { failures: restoreFailures, ...counts } = restoreResult;
-							persistDaemonUpdateRestartRemainder(
-								options.socketPath,
-								options.agentDir,
-								manifest,
-								restoreFailures,
-							);
 							statusWriter.update({
 								counts,
-								...(restoreFailures.length > 0 ? { failures: restoreFailures } : {}),
+								...(failures.length > 0 ? { failures } : {}),
 							});
 						} catch {
 							// Keep the manifest for a later recovery attempt when fallback restoration fails.
@@ -1467,20 +1554,15 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 		let counts: DaemonUpdateRestartCounts = { total: 0, restored: 0, resumed: 0, failed: 0 };
 		let failures: DaemonUpdateRestartFailure[] = [];
 		if (manifest) {
-			const restoreResult = await restoreDaemonUpdateRestart(
+			const result = await restoreAndPersistDaemonUpdateRestart(
 				options.socketPath,
+				options.agentDir,
 				manifest,
 				options.originActiveSessionId,
 				reportRestoreProgress,
 			);
-			counts = {
-				total: restoreResult.total,
-				restored: restoreResult.restored,
-				resumed: restoreResult.resumed,
-				failed: restoreResult.failed,
-			};
-			failures = restoreResult.failures;
-			persistDaemonUpdateRestartRemainder(options.socketPath, options.agentDir, manifest, failures);
+			counts = result.counts;
+			failures = result.failures;
 		}
 		statusWriter.update({
 			phase: "complete",
@@ -1583,6 +1665,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 			agentDir,
 			statusPath,
 			originActiveSessionId: options.restartOriginActiveSessionId,
+			retryOnly: options.restartRetryOnly,
 		});
 		if (status.phase === "failed") {
 			process.exitCode = 1;
@@ -1590,7 +1673,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 		return true;
 	}
 
-	if (options.restartStatusPath || options.restartOriginActiveSessionId) {
+	if (options.restartStatusPath || options.restartOriginActiveSessionId || options.restartRetryOnly) {
 		console.error(chalk.red("Invalid daemon update restart coordinator invocation."));
 		process.exitCode = 1;
 		return true;

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -769,6 +769,8 @@ function readPreparedDaemonUpdateRestartManifest(
 	notBeforeMs?: number,
 	changedSince?: ReadonlyMap<string, string>,
 ): DaemonUpdateRestartManifest | undefined {
+	const manifests: DaemonUpdateRestartManifest[] = [];
+	let invalidManifestError: unknown;
 	for (const manifestPath of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
 		let stat: ReturnType<typeof statSync>;
 		try {
@@ -782,10 +784,24 @@ function readPreparedDaemonUpdateRestartManifest(
 		if (changedSince?.get(manifestPath) === `${stat.ino}:${stat.size}:${stat.mtimeMs}`) {
 			continue;
 		}
-		const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
-		return parseDaemonUpdateRestartManifest(parsed);
+		try {
+			const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
+			manifests.push(parseDaemonUpdateRestartManifest(parsed));
+		} catch (error: unknown) {
+			invalidManifestError ??= error;
+		}
 	}
-	return undefined;
+	if (manifests.length === 0) {
+		if (invalidManifestError !== undefined) {
+			throw invalidManifestError;
+		}
+		return undefined;
+	}
+	let merged = manifests[manifests.length - 1]!;
+	for (let index = manifests.length - 2; index >= 0; index--) {
+		merged = mergeDaemonUpdateRestartManifests(merged, manifests[index]!);
+	}
+	return merged;
 }
 
 function snapshotPreparedDaemonUpdateRestartManifestFiles(socketPath: string, agentDir: string): Map<string, string> {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { spawn } from "child_process";
-import { readFileSync, rmSync, statSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { resolve, sep } from "path";
 import { selectConfig } from "./cli/config-selector.js";
 import {
@@ -12,6 +12,13 @@ import {
 	shutdownConnectedDaemonAndWait,
 } from "./cli/daemon-launch.js";
 import { confirmDaemonSessionLoss, type DaemonSessionLossCopy, pluralizeSessions } from "./cli/daemon-stop-confirm.js";
+import {
+	clearPreparedDaemonUpdateRestartManifest,
+	getDaemonUpdateRestartManifestCandidates,
+	manifestForFailedDaemonUpdateRestores,
+	mergeDaemonUpdateRestartManifests,
+	writePreparedDaemonUpdateRestartManifest,
+} from "./cli/daemon-update-manifest.js";
 import {
 	acquireDaemonUpdateRestartCoordinator,
 	buildDaemonUpdateRestartReport,
@@ -31,8 +38,6 @@ import {
 	APP_NAME,
 	CONFIG_DIR_NAME,
 	getAgentDir,
-	getDaemonUpdateRestartManifestPath,
-	getLegacyDaemonUpdateRestartManifestPath,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
 	PACKAGE_NAME,
@@ -758,41 +763,42 @@ function parseDaemonUpdateRestartManifest(value: unknown): DaemonUpdateRestartMa
 	};
 }
 
-function clearPreparedDaemonUpdateRestartManifest(socketPath: string, agentDir: string): void {
-	for (const manifestPath of [
-		getDaemonUpdateRestartManifestPath(socketPath, agentDir),
-		getLegacyDaemonUpdateRestartManifestPath(agentDir),
-	]) {
-		try {
-			rmSync(manifestPath, { force: true });
-		} catch {
-			// Best effort only; the mtime guard below prevents stale fallback use.
-		}
-	}
-}
-
 function readPreparedDaemonUpdateRestartManifest(
 	socketPath: string,
 	agentDir: string,
 	notBeforeMs?: number,
+	changedSince?: ReadonlyMap<string, string>,
 ): DaemonUpdateRestartManifest | undefined {
-	for (const manifestPath of [
-		getDaemonUpdateRestartManifestPath(socketPath, agentDir),
-		getLegacyDaemonUpdateRestartManifestPath(agentDir),
-	]) {
-		let modifiedAt: number;
+	for (const manifestPath of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
+		let stat: ReturnType<typeof statSync>;
 		try {
-			modifiedAt = statSync(manifestPath).mtimeMs;
+			stat = statSync(manifestPath);
 		} catch {
 			continue;
 		}
-		if (notBeforeMs !== undefined && modifiedAt < notBeforeMs - 1000) {
+		if (notBeforeMs !== undefined && stat.mtimeMs < notBeforeMs - 1000) {
+			continue;
+		}
+		if (changedSince?.get(manifestPath) === `${stat.ino}:${stat.size}:${stat.mtimeMs}`) {
 			continue;
 		}
 		const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
 		return parseDaemonUpdateRestartManifest(parsed);
 	}
 	return undefined;
+}
+
+function snapshotPreparedDaemonUpdateRestartManifestFiles(socketPath: string, agentDir: string): Map<string, string> {
+	const snapshot = new Map<string, string>();
+	for (const manifestPath of getDaemonUpdateRestartManifestCandidates(socketPath, agentDir)) {
+		try {
+			const stat = statSync(manifestPath);
+			snapshot.set(manifestPath, `${stat.ino}:${stat.size}:${stat.mtimeMs}`);
+		} catch {
+			// A missing candidate has no baseline and is eligible as a newly persisted fallback.
+		}
+	}
+	return snapshot;
 }
 
 function tryReadPreparedDaemonUpdateRestartManifest(
@@ -847,6 +853,7 @@ async function prepareConnectedDaemonUpdateRestart(
 ): Promise<DaemonUpdateRestartManifest> {
 	const pendingManifest = tryReadPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
 	let startedAt: number | undefined;
+	let manifestFilesBeforePrepare: ReadonlyMap<string, string> | undefined;
 	let fixedOwnerIdentity: FixedDaemonSupervisorOwnerIdentity | undefined;
 	let fencePersistenceStarted = false;
 	const persistPreparedRestartFence = async () => {
@@ -874,15 +881,19 @@ async function prepareConnectedDaemonUpdateRestart(
 				return pendingManifest;
 			}
 		}
-		clearPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
 		startedAt = Date.now();
+		manifestFilesBeforePrepare = snapshotPreparedDaemonUpdateRestartManifestFiles(socketPath, agentDir);
 		const response = useLegacyProtocol
 			? await client.requestLegacy({ type: "prepare_update_restart" }, 120000)
 			: await client.request({ type: "prepare_update_restart" }, 120000);
 		if (!response.success) {
 			throw new Error(response.error);
 		}
-		const manifest = parseDaemonUpdateRestartManifest(response.data);
+		const currentManifest = parseDaemonUpdateRestartManifest(response.data);
+		const manifest = pendingManifest
+			? mergeDaemonUpdateRestartManifests(pendingManifest, currentManifest)
+			: currentManifest;
+		writePreparedDaemonUpdateRestartManifest(socketPath, agentDir, manifest);
 		await persistPreparedRestartFence();
 		return manifest;
 	} catch (error) {
@@ -890,10 +901,17 @@ async function prepareConnectedDaemonUpdateRestart(
 			throw error;
 		}
 		if (startedAt !== undefined) {
-			const fallback = readPreparedDaemonUpdateRestartManifest(socketPath, agentDir, startedAt);
+			const fallback = readPreparedDaemonUpdateRestartManifest(
+				socketPath,
+				agentDir,
+				startedAt,
+				manifestFilesBeforePrepare,
+			);
 			if (fallback) {
+				const manifest = pendingManifest ? mergeDaemonUpdateRestartManifests(pendingManifest, fallback) : fallback;
+				writePreparedDaemonUpdateRestartManifest(socketPath, agentDir, manifest);
 				await persistPreparedRestartFence();
-				return fallback;
+				return manifest;
 			}
 		}
 		throw error;
@@ -1219,6 +1237,23 @@ async function restoreDaemonUpdateRestart(
 	};
 }
 
+function persistDaemonUpdateRestartRemainder(
+	socketPath: string,
+	agentDir: string,
+	manifest: DaemonUpdateRestartManifest,
+	failures: readonly DaemonUpdateRestartFailure[],
+): void {
+	const remainder = manifestForFailedDaemonUpdateRestores(
+		manifest,
+		failures.map((failure) => failure.sessionFile),
+	);
+	if (remainder) {
+		writePreparedDaemonUpdateRestartManifest(socketPath, agentDir, remainder);
+		return;
+	}
+	clearPreparedDaemonUpdateRestartManifest(socketPath, agentDir);
+}
+
 function formatUnknownError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -1371,7 +1406,12 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 								reportRestoreProgress,
 							);
 							const { failures: restoreFailures, ...counts } = restoreResult;
-							clearPreparedDaemonUpdateRestartManifest(options.socketPath, options.agentDir);
+							persistDaemonUpdateRestartRemainder(
+								options.socketPath,
+								options.agentDir,
+								manifest,
+								restoreFailures,
+							);
 							statusWriter.update({
 								counts,
 								...(restoreFailures.length > 0 ? { failures: restoreFailures } : {}),
@@ -1424,7 +1464,7 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 				failed: restoreResult.failed,
 			};
 			failures = restoreResult.failures;
-			clearPreparedDaemonUpdateRestartManifest(options.socketPath, options.agentDir);
+			persistDaemonUpdateRestartRemainder(options.socketPath, options.agentDir, manifest, failures);
 		}
 		statusWriter.update({
 			phase: "complete",

--- a/packages/coding-agent/test/daemon-command.test.ts
+++ b/packages/coding-agent/test/daemon-command.test.ts
@@ -90,8 +90,16 @@ const daemonClientMock = vi.hoisted(() => {
 	return { MockDaemonClient, behavior, instances };
 });
 
+const updateRecoveryMock = vi.hoisted(() => ({ calls: [] as Array<[string, string, string]> }));
+
 vi.mock("../src/modes/daemon/daemon-client.js", () => ({
 	DaemonClient: daemonClientMock.MockDaemonClient,
+}));
+
+vi.mock("../src/cli/daemon-update-recovery.js", () => ({
+	recoverPendingDaemonUpdateRestart: async (socketPath: string, agentDir: string, cwd: string) => {
+		updateRecoveryMock.calls.push([socketPath, agentDir, cwd]);
+	},
 }));
 
 import { handleDaemonCommand } from "../src/cli/daemon-command.js";
@@ -105,6 +113,7 @@ describe("daemon command", () => {
 		daemonClientMock.behavior.promptSucceeds = false;
 		daemonClientMock.behavior.emitStaleAgentEndOnAttach = false;
 		daemonClientMock.behavior.sessions = [];
+		updateRecoveryMock.calls.length = 0;
 		consoleErrorMessages = [];
 		vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null | undefined) => {
 			throw new Error(`exit ${code}`);
@@ -133,6 +142,13 @@ describe("daemon command", () => {
 		).toBe(true);
 	});
 
+	it("recovers interrupted updates before connecting public agent commands", async () => {
+		await expect(handleDaemonCommand(["daemon", "--socket", "/tmp/prime-agent.sock", "list"])).resolves.toBe(true);
+
+		expect(updateRecoveryMock.calls).toEqual([["/tmp/prime-agent.sock", expect.any(String), process.cwd()]]);
+		expect(daemonClientMock.instances).toHaveLength(1);
+	});
+
 	it("ignores stale agent_end events before a daemon prompt starts", async () => {
 		daemonClientMock.behavior.promptSucceeds = true;
 		daemonClientMock.behavior.emitStaleAgentEndOnAttach = true;
@@ -148,7 +164,9 @@ describe("daemon command", () => {
 		await flushPromises();
 
 		const client = daemonClientMock.instances[0];
-		expect(client?.requests.map((request) => request.type)).toEqual(["attach", "prompt"]);
+		await vi.waitFor(() => {
+			expect(client?.requests.map((request) => request.type)).toEqual(["attach", "prompt"]);
+		});
 
 		let resolved = false;
 		void command.then(() => {

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -215,6 +215,10 @@ describe("shouldStartDaemonEarly", () => {
 	])("does not start early for %s", (label, args) => {
 		expect(shouldStartDaemonEarly(args, label === "startup benchmark")).toBe(false);
 	});
+
+	it("defers early startup while interrupted update recovery is pending", () => {
+		expect(shouldStartDaemonEarly([], false, true)).toBe(false);
+	});
 });
 
 describe("ensureInteractiveDaemonRunning", () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -286,6 +286,93 @@ async function startBlockingBash(client: DaemonClient, activeSessionId: string, 
 }
 
 describe("daemon supervisor resident workers", () => {
+	it("restores subagents inside their parent worker", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(tmpdir(), `prime-supervisor-subagent-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(projectDir, { recursive: true });
+		const parentManager = SessionManager.create(projectDir, sessionDir);
+		parentManager.newSession();
+		parentManager.appendMessage({ role: "user", content: "parent fixture", timestamp: 1 });
+		const parentSessionFile = parentManager.getSessionFile();
+		const parentArtifactDir = parentManager.getSessionArtifactDir();
+		if (!parentSessionFile || !parentArtifactDir) {
+			throw new Error("Parent fixture did not persist");
+		}
+		const childSessionDir = join(parentArtifactDir, "child-1");
+		const childManager = SessionManager.create(projectDir, childSessionDir);
+		childManager.newSession({ parentSession: parentSessionFile });
+		childManager.appendMessage({ role: "user", content: "child fixture", timestamp: 1 });
+		const childSessionFile = childManager.getSessionFile();
+		if (!childSessionFile) {
+			throw new Error("Child fixture did not persist");
+		}
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const parentResponse = await client.request({
+			type: "create",
+			sessionPath: parentSessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			runtimeMetadata: { kind: "top-level", createdAt: 1 },
+		});
+		if (!parentResponse.success) {
+			throw new Error(parentResponse.error);
+		}
+		const parent = requireSummary(parentResponse.data);
+		if (!parent.workerPid || !parent.activeSessionId) {
+			throw new Error("Parent worker did not expose its process identity");
+		}
+		workerPids.add(parent.workerPid);
+
+		const childResponse = await client.request({
+			type: "create",
+			sessionPath: childSessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir: childSessionDir, noTools: true, noExtensions: true },
+			runtimeMetadata: {
+				kind: "subagent",
+				createdAt: 2,
+				parentActiveSessionId: parent.activeSessionId,
+				parentSessionId: parent.sessionId,
+				parentSessionFile,
+				rlmChildId: "child-1",
+				prompt: "child fixture",
+			},
+		});
+		if (!childResponse.success) {
+			throw new Error(childResponse.error);
+		}
+		const child = requireSummary(childResponse.data);
+		expect(child).toMatchObject({
+			runtimeKind: "subagent",
+			parentActiveSessionId: parent.activeSessionId,
+			workerPid: parent.workerPid,
+		});
+		expect(child.activeSessionId).not.toBe(parent.activeSessionId);
+		expect(countWorkerDescriptors(agentDir)).toBe(1);
+
+		const listed = await client.request({ type: "list" });
+		expect(listed.success).toBe(true);
+		expect(requireSessionList(listed.success ? listed.data : undefined)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ activeSessionId: parent.activeSessionId, runtimeKind: "top-level" }),
+				expect.objectContaining({
+					activeSessionId: child.activeSessionId,
+					runtimeKind: "subagent",
+					parentActiveSessionId: parent.activeSessionId,
+				}),
+			]),
+		);
+
+		await client.request({ type: "shutdown" });
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForProcessGone(parent.workerPid);
+		workerPids.delete(parent.workerPid);
+	}, 60_000);
+
 	it("keeps client-owned workers hidden and removes them without archiving", async () => {
 		const root = tempDir();
 		const agentDir = join(root, "agent");

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -897,6 +897,124 @@ describe("self-update daemon restart", () => {
 		expect(existsSync(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir))).toBe(false);
 	});
 
+	it("merges a pending restart with live daemon sessions before restoring them", async () => {
+		useFixedOwnerHello();
+		const parentSessionFile = join(projectDir, "parent.jsonl");
+		const childSessionFile = join(projectDir, "child.jsonl");
+		const currentSessionFile = join(projectDir, "current.jsonl");
+		const pendingManifest: MockUpdateRestartManifest = {
+			createdAt: "2026-07-06T00:00:00.000Z",
+			sessions: [
+				{
+					activeSessionId: "pending-parent",
+					sessionId: "parent-session",
+					sessionFile: parentSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					runtimeMetadata: { kind: "top-level", createdAt: 1 },
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: true,
+					wasStreaming: true,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: true,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+				{
+					activeSessionId: "pending-child",
+					sessionId: "child-session",
+					sessionFile: childSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					runtimeMetadata: {
+						kind: "subagent",
+						createdAt: 2,
+						parentActiveSessionId: "pending-parent",
+						parentSessionId: "parent-session",
+						parentSessionFile,
+						rlmChildId: "child-1",
+						prompt: "child task",
+					},
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: false,
+					wasStreaming: false,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: false,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+			],
+		};
+		writeFileSync(
+			getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir),
+			JSON.stringify(pendingManifest),
+		);
+		mockState.listResponse = {
+			success: true,
+			data: {
+				sessions: [{ id: "live-parent", isStreaming: false, isCompacting: false, pendingMessageCount: 0 }],
+			},
+		};
+		mockState.prepareManifest = {
+			createdAt: "2026-07-07T00:00:00.000Z",
+			sessions: [
+				{
+					activeSessionId: "live-parent",
+					sessionId: "parent-session",
+					sessionFile: parentSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					runtimeMetadata: { kind: "top-level", createdAt: 1 },
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: false,
+					wasStreaming: false,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: true,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+				{
+					activeSessionId: "live-current",
+					sessionId: "current-session",
+					sessionFile: currentSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: false,
+					wasStreaming: false,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: false,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+			],
+		};
+		mockState.createActiveSessionIds = ["restored-parent", "restored-child", "restored-current"];
+
+		await performUpdateAndRunCoordinator();
+
+		const createRequests = mockState.requestPayloads.filter((request) => request.type === "create");
+		expect(createRequests.map((request) => request.sessionPath)).toEqual([
+			parentSessionFile,
+			childSessionFile,
+			currentSessionFile,
+		]);
+		expect(createRequests[1]).toMatchObject({
+			runtimeMetadata: { parentActiveSessionId: "restored-parent" },
+		});
+		expect(mockState.lastCoordinatorStatus?.counts).toEqual({
+			total: 3,
+			restored: 3,
+			resumed: 0,
+			failed: 0,
+		});
+		expect(existsSync(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir))).toBe(false);
+	});
+
 	it("fences a pending prepared restart only after verifying the live daemon is empty", async () => {
 		useFixedOwnerHello();
 		const pendingManifest: MockUpdateRestartManifest = {
@@ -961,7 +1079,7 @@ describe("self-update daemon restart", () => {
 		await expect(prepareDaemonUpdateRestart(mockState.socketPath, agentDir)).rejects.toThrow(
 			"prepare_update_restart disconnected",
 		);
-		expect(existsSync(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir))).toBe(false);
+		expect(existsSync(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir))).toBe(true);
 	});
 
 	it("skips predecessor fencing when the daemon hello has no fixed-owner identity", async () => {

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -30,6 +30,7 @@ import {
 interface MockSessionSummary {
 	id: string;
 	activeSessionId?: string;
+	sessionFile?: string;
 	isStreaming: boolean;
 	isCompacting: boolean;
 	isBashRunning?: boolean;
@@ -81,6 +82,7 @@ interface MockUpdateRestartSession {
 interface MockUpdateRestartManifest {
 	createdAt: string;
 	sessions: MockUpdateRestartSession[];
+	retryOnly?: true;
 }
 
 interface MockDaemonRequest {
@@ -471,6 +473,90 @@ describe("self-update daemon restart", () => {
 		expect(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir)).not.toBe(
 			getDaemonUpdateRestartManifestPath(otherSocketPath, agentDir),
 		);
+	});
+
+	it("retries failed restores without restarting healthy daemon sessions", async () => {
+		const parentSessionFile = join(projectDir, "parent.jsonl");
+		const childSessionFile = join(projectDir, "child.jsonl");
+		mockState.daemonProbe = {
+			reachable: true,
+			activeSessions: [
+				{
+					id: "live-parent",
+					activeSessionId: "live-parent",
+					sessionFile: parentSessionFile,
+					isStreaming: false,
+					isCompacting: false,
+					pendingMessageCount: 0,
+				},
+			],
+		};
+		const retryManifest: MockUpdateRestartManifest = {
+			createdAt: "2026-07-07T00:00:00.000Z",
+			retryOnly: true,
+			sessions: [
+				{
+					activeSessionId: "old-parent",
+					sessionId: "parent-session",
+					sessionFile: parentSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					runtimeMetadata: { kind: "top-level", createdAt: 1 },
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: false,
+					wasStreaming: false,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: false,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+				{
+					activeSessionId: "old-child",
+					sessionId: "child-session",
+					sessionFile: childSessionFile,
+					cwd: projectDir,
+					config: { cwd: projectDir, agentDir },
+					runtimeMetadata: {
+						kind: "subagent",
+						createdAt: 2,
+						parentActiveSessionId: "old-parent",
+					},
+					queue: { steering: [], followUp: [], nextTurn: [] },
+					shouldResume: false,
+					wasStreaming: false,
+					wasCompacting: false,
+					wasBashRunning: false,
+					hadRunningRlmChildren: false,
+					wasRetrying: false,
+					hadAcceptedPromptInFlight: false,
+				},
+			],
+		};
+		writeFileSync(mockState.preparedManifestPath, JSON.stringify(retryManifest));
+		mockState.createActiveSessionIds = ["restored-child"];
+
+		const status = await runDaemonUpdateRestartCoordinator({
+			socketPath: mockState.socketPath,
+			agentDir,
+			statusPath: join(agentDir, "retry-status.json"),
+			retryOnly: true,
+		});
+
+		expect(status).toMatchObject({
+			phase: "complete",
+			counts: { total: 1, restored: 1, resumed: 0, failed: 0 },
+		});
+		expect(mockState.calls).not.toContain("daemon-request:prepare_update_restart");
+		expect(mockState.calls).not.toContain("shutdown-daemon");
+		expect(mockState.calls).not.toContain("ensure-daemon");
+		expect(mockState.requestPayloads.filter((request) => request.type === "create")).toEqual([
+			expect.objectContaining({
+				sessionPath: childSessionFile,
+				runtimeMetadata: expect.objectContaining({ parentActiveSessionId: "live-parent" }),
+			}),
+		]);
+		expect(existsSync(mockState.preparedManifestPath)).toBe(false);
 	});
 
 	it("uses the interactive no-change sentinel only when self-update is unchanged", async () => {

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -897,6 +897,57 @@ describe("self-update daemon restart", () => {
 		expect(existsSync(getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir))).toBe(false);
 	});
 
+	it("merges a legacy manifest when the scoped manifest is empty", async () => {
+		useFixedOwnerHello();
+		mockState.daemonProbe = { reachable: false };
+		const sessionFile = join(tempDir, "legacy-session.jsonl");
+		const scopedManifestPath = getDaemonUpdateRestartManifestPath(mockState.socketPath, agentDir);
+		const legacyManifestPath = getLegacyDaemonUpdateRestartManifestPath(agentDir);
+		writeFileSync(scopedManifestPath, JSON.stringify({ createdAt: "2026-07-07T00:00:00.000Z", sessions: [] }));
+		writeFileSync(
+			legacyManifestPath,
+			JSON.stringify({
+				createdAt: "2026-07-06T00:00:00.000Z",
+				sessions: [
+					{
+						activeSessionId: "legacy-active",
+						sessionId: "legacy-session",
+						sessionFile,
+						cwd: projectDir,
+						config: { cwd: projectDir, agentDir },
+						runtimeMetadata: { kind: "top-level", createdAt: 1 },
+						queue: { steering: [], followUp: [], nextTurn: [] },
+						shouldResume: false,
+						wasStreaming: false,
+						wasCompacting: false,
+						wasBashRunning: false,
+						hadRunningRlmChildren: false,
+						wasRetrying: false,
+						hadAcceptedPromptInFlight: false,
+					},
+				],
+			}),
+		);
+
+		const statusDirectory = join(agentDir, "update-restarts");
+		mkdirSync(statusDirectory, { recursive: true });
+		const status = await runDaemonUpdateRestartCoordinator({
+			socketPath: mockState.socketPath,
+			agentDir,
+			statusPath: join(statusDirectory, "legacy-merge-status.json"),
+		});
+
+		expect(status).toMatchObject({
+			phase: "complete",
+			counts: { total: 1, restored: 1, resumed: 0, failed: 0 },
+		});
+		expect(mockState.requestPayloads).toContainEqual(
+			expect.objectContaining({ type: "create", sessionPath: sessionFile }),
+		);
+		expect(existsSync(scopedManifestPath)).toBe(false);
+		expect(existsSync(legacyManifestPath)).toBe(false);
+	});
+
 	it("merges a pending restart with live daemon sessions before restoring them", async () => {
 		useFixedOwnerHello();
 		const parentSessionFile = join(projectDir, "parent.jsonl");

--- a/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	getDaemonUpdateRestartManifestCandidates,
+	getPendingDaemonUpdateRestartRecoveryKind,
 	hasPendingDaemonUpdateRestartManifest,
 	manifestForFailedDaemonUpdateRestores,
 	mergeDaemonUpdateRestartManifests,
@@ -92,6 +93,16 @@ describe("ENG-4746 interrupted update recovery", () => {
 			manifest("2026-07-20T23:14:05.579Z", [updateSession("pending", "/sessions/pending.jsonl")]),
 		);
 		expect(hasPendingDaemonUpdateRestartManifest(customSocket, agentDir)).toBe(true);
+		expect(getPendingDaemonUpdateRestartRecoveryKind(customSocket, agentDir)).toBe("restart");
+		const retryManifest = manifestForFailedDaemonUpdateRestores(
+			manifest("2026-07-20T23:15:05.579Z", [updateSession("failed", "/sessions/failed.jsonl")]),
+			["/sessions/failed.jsonl"],
+		);
+		if (!retryManifest) {
+			throw new Error("Expected a retry manifest");
+		}
+		writePreparedDaemonUpdateRestartManifest(customSocket, agentDir, retryManifest);
+		expect(getPendingDaemonUpdateRestartRecoveryKind(customSocket, agentDir)).toBe("retry");
 	});
 
 	it("removes legacy recovery state when persisting canonical default-daemon state", () => {
@@ -122,6 +133,7 @@ describe("ENG-4746 interrupted update recovery", () => {
 		);
 
 		expect(remainder?.sessions).toEqual([failed]);
+		expect(remainder?.retryOnly).toBe(true);
 		expect(manifestForFailedDaemonUpdateRestores(manifest("now", [restored]), [])).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getDaemonUpdateRestartManifestCandidates,
+	hasPendingDaemonUpdateRestartManifest,
+	manifestForFailedDaemonUpdateRestores,
+	mergeDaemonUpdateRestartManifests,
+	writePreparedDaemonUpdateRestartManifest,
+} from "../../../src/cli/daemon-update-manifest.js";
+import { getLegacyDaemonUpdateRestartManifestPath } from "../../../src/config.js";
+import type {
+	DaemonUpdateRestartManifest,
+	DaemonUpdateRestartSession,
+} from "../../../src/modes/daemon/daemon-protocol.js";
+import { defaultDaemonSocketPath } from "../../../src/modes/daemon/daemon-socket.js";
+
+function updateSession(
+	activeSessionId: string,
+	sessionFile: string,
+	parentActiveSessionId?: string,
+): DaemonUpdateRestartSession {
+	return {
+		activeSessionId,
+		sessionId: `session-${activeSessionId}`,
+		sessionFile,
+		cwd: "/workspace",
+		config: { cwd: "/workspace", agentDir: "/agent" },
+		...(parentActiveSessionId
+			? { runtimeMetadata: { kind: "subagent", createdAt: 1, parentActiveSessionId } }
+			: { runtimeMetadata: { kind: "top-level", createdAt: 1 } }),
+		queue: { steering: [], followUp: [], nextTurn: [] },
+		shouldResume: false,
+		wasStreaming: false,
+		wasCompacting: false,
+		wasBashRunning: false,
+		hadRunningRlmChildren: false,
+		wasRetrying: false,
+		hadAcceptedPromptInFlight: false,
+	};
+}
+
+function manifest(createdAt: string, sessions: DaemonUpdateRestartSession[]): DaemonUpdateRestartManifest {
+	return { createdAt, sessions };
+}
+
+describe("ENG-4746 interrupted update recovery", () => {
+	const tempDirs: string[] = [];
+	afterEach(() => {
+		for (const path of tempDirs.splice(0)) {
+			rmSync(path, { recursive: true, force: true });
+		}
+	});
+
+	it("merges orphaned sessions with newer daemon state without replaying duplicate sessions", () => {
+		const pendingParent = updateSession("old-parent", "/sessions/parent.jsonl");
+		pendingParent.shouldResume = true;
+		pendingParent.wasStreaming = true;
+		const pendingChild = updateSession("old-child", "/sessions/child.jsonl", "old-parent");
+		const currentParent = updateSession("new-parent", "/sessions/parent.jsonl");
+		const currentOnly = updateSession("current-only", "/sessions/current.jsonl");
+
+		const merged = mergeDaemonUpdateRestartManifests(
+			manifest("2026-07-20T23:14:05.579Z", [pendingChild, pendingParent]),
+			manifest("2026-07-20T23:14:19.444Z", [currentOnly, currentParent]),
+		);
+
+		expect(merged.createdAt).toBe("2026-07-20T23:14:19.444Z");
+		expect(merged.sessions.map((session) => session.activeSessionId)).toEqual([
+			"new-parent",
+			"old-child",
+			"current-only",
+		]);
+		expect(merged.sessions[0]).toBe(currentParent);
+		expect(merged.sessions[0]?.shouldResume).toBe(false);
+		expect(merged.sessions[1]?.runtimeMetadata?.parentActiveSessionId).toBe("new-parent");
+	});
+
+	it("detects socket-scoped recovery state and scopes legacy manifests to the default daemon", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "eng-4746-manifest-"));
+		tempDirs.push(agentDir);
+		const customSocket = join(agentDir, "custom.sock");
+		const defaultSocket = defaultDaemonSocketPath();
+		const legacyPath = getLegacyDaemonUpdateRestartManifestPath(agentDir);
+
+		expect(getDaemonUpdateRestartManifestCandidates(customSocket, agentDir)).not.toContain(legacyPath);
+		expect(getDaemonUpdateRestartManifestCandidates(defaultSocket, agentDir)).toContain(legacyPath);
+		writePreparedDaemonUpdateRestartManifest(
+			customSocket,
+			agentDir,
+			manifest("2026-07-20T23:14:05.579Z", [updateSession("pending", "/sessions/pending.jsonl")]),
+		);
+		expect(hasPendingDaemonUpdateRestartManifest(customSocket, agentDir)).toBe(true);
+	});
+
+	it("retains only sessions whose restore failed", () => {
+		const restored = updateSession("restored", "/sessions/restored.jsonl");
+		const failed = updateSession("failed", "/sessions/failed.jsonl");
+		const remainder = manifestForFailedDaemonUpdateRestores(
+			manifest("2026-07-20T23:14:05.579Z", [restored, failed]),
+			["/sessions/failed.jsonl"],
+		);
+
+		expect(remainder?.sessions).toEqual([failed]);
+		expect(manifestForFailedDaemonUpdateRestores(manifest("now", [restored]), [])).toBeUndefined();
+	});
+
+	it("retains parent context needed to retry a failed subagent restore", () => {
+		const parent = updateSession("parent", "/sessions/parent.jsonl");
+		const failedChild = updateSession("child", "/sessions/child.jsonl", "parent");
+		const remainder = manifestForFailedDaemonUpdateRestores(
+			manifest("2026-07-20T23:14:05.579Z", [parent, failedChild]),
+			[failedChild.sessionFile],
+		);
+
+		expect(remainder?.sessions).toEqual([parent, failedChild]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4746-update-restart-recovery.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -94,6 +94,25 @@ describe("ENG-4746 interrupted update recovery", () => {
 		expect(hasPendingDaemonUpdateRestartManifest(customSocket, agentDir)).toBe(true);
 	});
 
+	it("removes legacy recovery state when persisting canonical default-daemon state", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "eng-4746-manifest-"));
+		tempDirs.push(agentDir);
+		const defaultSocket = defaultDaemonSocketPath();
+		const legacyPath = getLegacyDaemonUpdateRestartManifestPath(agentDir);
+		writeFileSync(
+			legacyPath,
+			`${JSON.stringify(manifest("old", [updateSession("restored", "/sessions/restored.jsonl")]))}\n`,
+		);
+
+		writePreparedDaemonUpdateRestartManifest(
+			defaultSocket,
+			agentDir,
+			manifest("new", [updateSession("failed", "/sessions/failed.jsonl")]),
+		);
+
+		expect(existsSync(legacyPath)).toBe(false);
+	});
+
 	it("retains only sessions whose restore failed", () => {
 		const restored = updateSession("restored", "/sessions/restored.jsonl");
 		const failed = updateSession("failed", "/sessions/failed.jsonl");
@@ -108,12 +127,48 @@ describe("ENG-4746 interrupted update recovery", () => {
 
 	it("retains parent context needed to retry a failed subagent restore", () => {
 		const parent = updateSession("parent", "/sessions/parent.jsonl");
+		parent.queue = {
+			steering: [{ message: "steer again" }],
+			followUp: [{ message: "follow up again" }],
+			nextTurn: [
+				{
+					role: "custom",
+					customType: "test.next-turn",
+					content: "next turn again",
+					display: true,
+					timestamp: 1,
+				},
+			],
+			acceptedPrompt: { message: "accepted again", nextTurn: [] },
+		};
+		parent.shouldResume = true;
+		parent.wasStreaming = true;
+		parent.wasCompacting = true;
+		parent.wasBashRunning = true;
+		parent.hadRunningRlmChildren = true;
+		parent.wasRetrying = true;
+		parent.hadAcceptedPromptInFlight = true;
 		const failedChild = updateSession("child", "/sessions/child.jsonl", "parent");
+		failedChild.shouldResume = true;
+		failedChild.wasStreaming = true;
 		const remainder = manifestForFailedDaemonUpdateRestores(
 			manifest("2026-07-20T23:14:05.579Z", [parent, failedChild]),
 			[failedChild.sessionFile],
 		);
 
-		expect(remainder?.sessions).toEqual([parent, failedChild]);
+		expect(remainder?.sessions).toEqual([
+			{
+				...parent,
+				queue: { steering: [], followUp: [], nextTurn: [] },
+				shouldResume: false,
+				wasStreaming: false,
+				wasCompacting: false,
+				wasBashRunning: false,
+				hadRunningRlmChildren: false,
+				wasRetrying: false,
+				hadAcceptedPromptInFlight: false,
+			},
+			failedChild,
+		]);
 	});
 });


### PR DESCRIPTION
- interrupted updates now recover prepared daemon sessions on the next launch.
- pending and live restart state is merged without duplicating sessions or breaking parent relationships.
- failed restores remain available for a later recovery attempt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon startup ordering, self-update restart coordination, and session restore persistence; behavior is heavily tested but mistakes could affect live sessions after updates.
> 
> **Overview**
> Fixes **ENG-4746** by restoring daemon sessions that were prepared for an update restart but never finished when the update or coordinator was interrupted.
> 
> **On next launch**, daemon-backed entry points run **`recoverPendingDaemonUpdateRestart`** before connecting (daemon CLI commands except `ps`/`shutdown`, and interactive startup in `main.ts`). **Early background daemon spawn** is skipped while a pending recovery manifest exists so recovery can run first.
> 
> **Restart manifests** are centralized in `daemon-update-manifest.ts`: socket-scoped paths plus legacy default-socket candidates, atomic writes, **merge** of pending and live daemon state by session file (with parent/subagent ID remapping), and **`retryOnly`** manifests that keep only failed restores and required parent context. The update coordinator can do a **full restart** or **retry-only** restore against a still-running daemon without shutting it down; restore skips sessions already live by `sessionFile` and **persists** partial failures instead of clearing the manifest on first error.
> 
> **Subagent `create`** on the supervisor is routed into the **parent worker** so restored parent/child relationships stay in one worker process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecef0cac7b0826771e5d8ae95de4726d678891c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover daemon sessions left unrestored after interrupted updates
> - Adds a recovery flow that detects and re-runs interrupted update-restart manifests before daemon commands execute, skipping `ps` and `shutdown`.
> - Introduces [`daemon-update-manifest.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/485/files#diff-86dda77b8e8f4ff638626a4f85bc817e2f31505d9540188de8ecde321e8bf363) with helpers to read, write, merge, and clear update-restart manifests, including legacy-scoped files.
> - A retry-only mode (`DAEMON_UPDATE_RETRY_ONLY_FLAG`) lets the coordinator re-attempt only previously failed session restores without stopping a healthy daemon.
> - Suppresses early daemon auto-start when a pending recovery is detected, deferring startup until recovery completes.
> - Subagent sessions are now created inside their parent worker process rather than spawning a separate worker, fixing parent-child linkage after restore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fecef0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->