### PR TITLE
Show live elapsed-time timers for tool calls and subagents

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added optional start timestamps to tool-execution start events.
 - Fixed recovery event listener failures replacing the original agent lifecycle failure.
 
 ## [0.3.2] - 2026-07-20

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -639,6 +639,7 @@ async function executeToolCallsSequential(
 			toolCallId: toolCall.id,
 			toolName: toolCall.name,
 			args: toolCall.arguments,
+			startedAt: Date.now(),
 		});
 
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
@@ -694,6 +695,7 @@ async function executeToolCallsParallel(
 			toolCallId: toolCall.id,
 			toolName: toolCall.name,
 			args: toolCall.arguments,
+			startedAt: Date.now(),
 		});
 
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,15 +57,24 @@ const DEFAULT_MODEL = {
 
 type QueueMode = "all" | "one-at-a-time";
 
-type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "pendingToolCalls" | "errorMessage"> & {
+type MutableAgentState = Omit<
+	AgentState,
+	"isStreaming" | "streamingMessage" | "pendingToolCalls" | "runningToolStartedAt" | "errorMessage"
+> & {
 	isStreaming: boolean;
 	streamingMessage?: AgentMessage;
 	pendingToolCalls: Set<string>;
+	runningToolStartedAt: Map<string, number>;
 	errorMessage?: string;
 };
 
 function createMutableAgentState(
-	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>,
+	initialState?: Partial<
+		Omit<
+			AgentState,
+			"pendingToolCalls" | "runningToolStartedAt" | "isStreaming" | "streamingMessage" | "errorMessage"
+		>
+	>,
 ): MutableAgentState {
 	let tools = initialState?.tools?.slice() ?? [];
 	let messages = initialState?.messages?.slice() ?? [];
@@ -90,13 +99,19 @@ function createMutableAgentState(
 		isStreaming: false,
 		streamingMessage: undefined,
 		pendingToolCalls: new Set<string>(),
+		runningToolStartedAt: new Map<string, number>(),
 		errorMessage: undefined,
 	};
 }
 
 /** Options for constructing an {@link Agent}. */
 export interface AgentOptions {
-	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>;
+	initialState?: Partial<
+		Omit<
+			AgentState,
+			"pendingToolCalls" | "runningToolStartedAt" | "isStreaming" | "streamingMessage" | "errorMessage"
+		>
+	>;
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	streamFn?: StreamFn;
@@ -339,6 +354,7 @@ export class Agent {
 		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;
 		this._state.pendingToolCalls = new Set<string>();
+		this._state.runningToolStartedAt = new Map<string, number>();
 		this._state.errorMessage = undefined;
 		this.clearFollowUpQueue();
 		this.clearSteeringQueue();
@@ -546,6 +562,7 @@ export class Agent {
 		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;
 		this._state.pendingToolCalls = new Set<string>();
+		this._state.runningToolStartedAt = new Map<string, number>();
 		this.activeRun?.resolve();
 		this.activeRun = undefined;
 	}
@@ -573,9 +590,13 @@ export class Agent {
 				break;
 
 			case "tool_execution_start": {
+				event.startedAt ??= Date.now();
 				const pendingToolCalls = new Set(this._state.pendingToolCalls);
 				pendingToolCalls.add(event.toolCallId);
 				this._state.pendingToolCalls = pendingToolCalls;
+				const runningToolStartedAt = new Map(this._state.runningToolStartedAt);
+				runningToolStartedAt.set(event.toolCallId, event.startedAt);
+				this._state.runningToolStartedAt = runningToolStartedAt;
 				break;
 			}
 
@@ -583,6 +604,9 @@ export class Agent {
 				const pendingToolCalls = new Set(this._state.pendingToolCalls);
 				pendingToolCalls.delete(event.toolCallId);
 				this._state.pendingToolCalls = pendingToolCalls;
+				const runningToolStartedAt = new Map(this._state.runningToolStartedAt);
+				runningToolStartedAt.delete(event.toolCallId);
+				this._state.runningToolStartedAt = runningToolStartedAt;
 				break;
 			}
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -328,6 +328,8 @@ export interface AgentState {
 	readonly streamingMessage?: AgentMessage;
 	/** Tool call ids currently executing. */
 	readonly pendingToolCalls: ReadonlySet<string>;
+	/** Canonical start timestamp for each currently executing tool call. */
+	readonly runningToolStartedAt: ReadonlyMap<string, number>;
 	/** Error message from the most recent failed or aborted assistant turn, if any. */
 	readonly errorMessage?: string;
 }
@@ -404,6 +406,6 @@ export type AgentEvent =
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
 	| { type: "message_end"; message: AgentMessage }
 	// Tool execution lifecycle
-	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
+	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any; startedAt?: number }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
 	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -77,7 +77,23 @@ describe("Agent", () => {
 		expect(agent.state.isStreaming).toBe(false);
 		expect(agent.state.streamingMessage).toBe(undefined);
 		expect(agent.state.pendingToolCalls).toEqual(new Set());
+		expect(agent.state.runningToolStartedAt).toEqual(new Map());
 		expect(agent.state.errorMessage).toBeUndefined();
+	});
+
+	it("should reset pending tool lifecycle state together", () => {
+		const agent = new Agent();
+		const state = agent.state as unknown as {
+			pendingToolCalls: Set<string>;
+			runningToolStartedAt: Map<string, number>;
+		};
+		state.pendingToolCalls.add("tool-1");
+		state.runningToolStartedAt.set("tool-1", 1_000);
+
+		agent.reset();
+
+		expect(agent.state.pendingToolCalls.size).toBe(0);
+		expect(agent.state.runningToolStartedAt.size).toBe(0);
 	});
 
 	it("should create an agent instance with custom initial state", () => {
@@ -355,6 +371,8 @@ describe("Agent", () => {
 		});
 		agent.subscribe((event) => {
 			if (event.type === "tool_execution_start") {
+				expect(event.startedAt).toEqual(expect.any(Number));
+				expect(agent.state.runningToolStartedAt.get(event.toolCallId)).toBe(event.startedAt);
 				toolStarted();
 			}
 		});
@@ -373,6 +391,7 @@ describe("Agent", () => {
 			expect(toolResult.content).toEqual([{ type: "text", text: "Tool execution aborted" }]);
 		}
 		expect(agent.state.pendingToolCalls.size).toBe(0);
+		expect(agent.state.runningToolStartedAt.size).toBe(0);
 		expect(agent.state.isStreaming).toBe(false);
 	});
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added live elapsed-time timers to running tool calls, showing the final duration when they settle.
+- Added live incrementing elapsed-time timers to running subagents, with final duration preserved after completion.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.
 - Changed `/context` tree connectors from `├ `/`└ ` to `├─ `/`└─ ` to match the tree selector and session picker.
@@ -10,7 +12,6 @@
 - Fixed cancelled extension commands remaining alive when spawned processes ignored SIGTERM ([#458](https://github.com/PrimeIntellect-ai/prime-agent/pull/458) by [@snimu](https://github.com/snimu)).
 - Fixed OAuth browser launch URLs being interpreted by the system shell.
 - Changed long live session opens to render a bounded recent transcript tail while preserving full prompt history ([#343](https://github.com/PrimeIntellect-ai/prime-agent/pull/343) by [@sethkarten](https://github.com/sethkarten)).
-
 
 ## [0.3.2] - 2026-07-20
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -261,6 +261,7 @@ export interface RlmChildAgentSnapshot {
 	label: string;
 	status: RlmChildAgentStatus;
 	durationMs?: number;
+	startedAt?: number;
 	answerPreview?: string;
 	/** Number of tool executions the subagent has started so far. */
 	toolUseCount?: number;
@@ -678,6 +679,8 @@ interface RlmChildRun {
 	sessionName: string;
 	sessionDir: string;
 	status: RlmChildAgentStatus;
+	startedAt: number;
+	durationMs?: number;
 	result?: RlmRunResult;
 	error?: string;
 	releaseError?: unknown;
@@ -905,6 +908,7 @@ export class AgentSession {
 	// Inline mode keeps finished child sessions so the inspector can still read them;
 	// the daemon does the same by leaving the child session resident in its registry.
 	private _retainedRlmChildSessions = new Map<string, AgentSession>();
+	private _retainedRlmChildTiming = new Map<string, { startedAt: number; durationMs?: number }>();
 	private _deletedRlmChildIds = new Set<string>();
 	private _retryableRlmSubagentDeletions = new Map<string, RlmSubagentRegistryEntry>();
 	private _deletingRlmChildren = new Map<
@@ -2585,6 +2589,7 @@ export class AgentSession {
 			await session.disposeAsync().catch(() => undefined);
 		}
 		this._retainedRlmChildSessions.clear();
+		this._retainedRlmChildTiming.clear();
 		this._deletedRlmChildIds.clear();
 		this._retryableRlmSubagentDeletions.clear();
 		try {
@@ -2616,6 +2621,7 @@ export class AgentSession {
 				session.dispose();
 			}
 			this._retainedRlmChildSessions.clear();
+			this._retainedRlmChildTiming.clear();
 			this._deletedRlmChildIds.clear();
 			this._retryableRlmSubagentDeletions.clear();
 			this._pendingNextTurnMessages = [];
@@ -2691,6 +2697,10 @@ export class AgentSession {
 	 * Get the names of currently active tools.
 	 * Returns the names of tools currently set on the agent.
 	 */
+	getRunningToolStartedAt(): Record<string, number> {
+		return Object.fromEntries(this.agent.state.runningToolStartedAt);
+	}
+
 	getActiveToolNames(): string[] {
 		return this.agent.state.tools.map((t) => t.name);
 	}
@@ -6399,6 +6409,7 @@ export class AgentSession {
 			return false;
 		}
 		run.status = "cancelled";
+		run.durationMs = Date.now() - run.startedAt;
 		run.error = reason;
 		run.abort();
 		// Surface the cancellation immediately; the run's own terminal update is
@@ -6408,9 +6419,18 @@ export class AgentSession {
 		return true;
 	}
 
-	/** Status of a direct RLM child run, while the run is still tracked. */
+	/** Canonical lifecycle and timing state for an active or retained direct RLM child. */
+	getRlmChildRunState(
+		childId: string,
+	): { status: RlmChildAgentStatus; startedAt: number; durationMs?: number } | undefined {
+		const run = this._activeRlmChildRuns.get(childId);
+		if (run) return { status: run.status, startedAt: run.startedAt, durationMs: run.durationMs };
+		const timing = this._retainedRlmChildTiming.get(childId);
+		return timing ? { status: "done", ...timing } : undefined;
+	}
+
 	getRlmChildRunStatus(childId: string): RlmChildAgentStatus | undefined {
-		return this._activeRlmChildRuns.get(childId)?.status;
+		return this.getRlmChildRunState(childId)?.status;
 	}
 
 	/** Current direct-child registry for the model-facing rlm.list_subagents API. */
@@ -6538,6 +6558,7 @@ export class AgentSession {
 		this._retainedRlmChildUnsubscribes.get(childId)?.();
 		this._retainedRlmChildUnsubscribes.delete(childId);
 		this._retainedRlmChildSessions.delete(childId);
+		this._retainedRlmChildTiming.delete(childId);
 		this._retryableRlmSubagentDeletions.delete(childId);
 		if (!run || this._activeRlmChildRuns.get(childId) === run) {
 			this._activeRlmChildRuns.delete(childId);
@@ -6649,17 +6670,31 @@ export class AgentSession {
 	 * the child) when the parent is already tearing down, so the caller can drop the
 	 * matching event forwarder too.
 	 */
-	retainFinishedRlmChildSession(childId: string, session: AgentSession): boolean {
+	retainFinishedRlmChildSession(
+		childId: string,
+		session: AgentSession,
+		timing: { startedAt: number; durationMs?: number } | undefined = this._activeRlmChildRuns.get(childId),
+	): boolean {
 		// A child can finish concurrently while the parent is (or has) torn down; don't
 		// resurrect the map (it would never be disposed), just drop the child now.
 		if (this._disposed || this._disposing) {
 			void session.disposeAsync().catch(() => undefined);
 			return false;
 		}
-		if (this._deletingRlmChildren.has(childId) || this._deletedRlmChildIds.has(childId)) {
+		if (
+			this._deletingRlmChildren.has(childId) ||
+			this._deletedRlmChildIds.has(childId) ||
+			this._retryableRlmSubagentDeletions.has(childId)
+		) {
 			return false;
 		}
 		this._retainedRlmChildSessions.set(childId, session);
+		if (timing) {
+			this._retainedRlmChildTiming.set(childId, {
+				startedAt: timing.startedAt,
+				durationMs: timing.durationMs,
+			});
+		}
 		return true;
 	}
 
@@ -6864,7 +6899,6 @@ export class AgentSession {
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
-		let durationMs: number | undefined;
 		let toolUseCount = 0;
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
@@ -6877,6 +6911,7 @@ export class AgentSession {
 			sessionName,
 			sessionDir: childSessionDir,
 			status: "running",
+			startedAt,
 			abort: noopRlmChildAbort,
 		};
 		this._activeRlmChildRuns.set(run.id, run);
@@ -6892,7 +6927,8 @@ export class AgentSession {
 					model: `${childModel.provider}/${childModel.id}`,
 					label,
 					status: run.status,
-					durationMs,
+					durationMs: run.durationMs,
+					startedAt,
 					answerPreview,
 					toolUseCount: toolUseCount > 0 ? toolUseCount : undefined,
 					tokenCount: childSession?._contextTokensForCurrentMessages(),
@@ -7010,7 +7046,7 @@ export class AgentSession {
 				const assistantUsage = child._assistantUsageForCurrentMessages();
 				this._attributeRlmChildUsageToParent(assistantUsage, parentAssistantForUsage);
 				run.status = "done";
-				durationMs = Date.now() - startedAt;
+				run.durationMs = Date.now() - run.startedAt;
 				activity = undefined;
 				const compactAnswer = compactRlmText(answer);
 				if (compactAnswer) {
@@ -7030,9 +7066,9 @@ export class AgentSession {
 			} catch (error) {
 				if (run.status !== "cancelled") {
 					run.status = "error";
+					run.durationMs = Date.now() - run.startedAt;
+					run.error = error instanceof Error ? error.message : String(error);
 				}
-				durationMs = Date.now() - startedAt;
-				run.error = error instanceof Error ? error.message : String(error);
 				activity = undefined;
 				emitChildUpdate();
 				throw error;
@@ -7078,7 +7114,7 @@ export class AgentSession {
 						!this._disposing &&
 						!this._deletedRlmChildIds.has(run.id)
 					) {
-						this._retainedRlmChildSessions.set(run.id, childSession);
+						this.retainFinishedRlmChildSession(run.id, childSession, run);
 					} else if (
 						run.releaseError &&
 						releaseStatus !== "done" &&

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1891,6 +1891,7 @@ function mapDaemonSessionSnapshot(snapshot: DaemonSessionSnapshot, replay?: Daem
 		state: snapshot.state,
 		messages: snapshot.messages,
 		...(snapshot.summary.streamingMessage ? { streamingMessage: snapshot.summary.streamingMessage } : {}),
+		...(snapshot.runningToolStartedAt ? { runningToolStartedAt: snapshot.runningToolStartedAt } : {}),
 		lastEventSequence: snapshot.lastEventSequence,
 		lastEventCursor: snapshot.lastEventCursor,
 	};

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -69,6 +69,7 @@ export function createAgentConnectionSnapshot(
 		state: createAgentConnectionState(runtime, activeSessionId),
 		messages: [...session.messages],
 		...(session.state?.streamingMessage ? { streamingMessage: session.state.streamingMessage } : {}),
+		runningToolStartedAt: session.getRunningToolStartedAt(),
 		sessionContext: session.buildSessionContext(),
 		sessionTree: {
 			tree: sessionManager.getTree(),

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -290,6 +290,8 @@ export interface AgentConnectionSnapshot {
 	messages: AgentMessage[];
 	/** In-flight assistant message, kept separate from finalized transcript messages. */
 	streamingMessage?: AgentMessage;
+	/** Start times for tool calls that are actively executing in the streaming message. */
+	runningToolStartedAt?: Record<string, number>;
 	sessionContext?: AgentConnectionSessionContext;
 	sessionTree?: { tree: AgentConnectionSessionTreeNode[]; leafId: string | null };
 	parent?: AgentConnectionParentMetadata;
@@ -511,6 +513,7 @@ export interface AgentConnectionRlmChildAgentSnapshot {
 	label: string;
 	status: AgentConnectionRlmChildAgentStatus;
 	durationMs?: number;
+	startedAt?: number;
 	answerPreview?: string;
 	/** Number of tool executions the subagent has started so far. */
 	toolUseCount?: number;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1807,7 +1807,8 @@ export class AgentDaemon {
 					// Retention can decline if deletion or parent teardown won while the trace
 					// flush was in flight. Persist completion only after retention succeeds, so
 					// a late completion cannot overwrite a durable deletion tombstone.
-					if (options.parentSession.retainFinishedRlmChildSession(options.id, runtime.session)) {
+					const timing = options.parentSession.getRlmChildRunState(options.id);
+					if (options.parentSession.retainFinishedRlmChildSession(options.id, runtime.session, timing)) {
 						if (runtime.session.sessionFile) {
 							this.recordRlmSubagentRegistryEntry(parentState, {
 								childId: options.id,
@@ -3569,6 +3570,7 @@ export class AgentDaemon {
 			summary: summaryForActiveSession(state),
 			state: connectionState,
 			messages: state.runtime.session.messages,
+			runningToolStartedAt: state.runtime.session.getRunningToolStartedAt(),
 			// Omit duplicate heavy payloads from attach. The client can derive render
 			// context from messages + state, and fetch the full session tree lazily
 			// when the tree/branch selector opens.

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -49,8 +49,8 @@ import type { SessionSummary } from "./daemon-session-list.js";
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
 export const DAEMON_PROTOCOL_VERSION = 4;
 export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 2;
-export const DAEMON_SCHEMA_REVISION = 2;
-export const DAEMON_SCHEMA_ID = "protocol-4-schema-2-cbdbe20e7ce4";
+export const DAEMON_SCHEMA_REVISION = 3;
+export const DAEMON_SCHEMA_ID = "protocol-4-schema-3-cbdbe20e7ce4";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -232,6 +232,8 @@ export interface DaemonSessionSnapshot {
 	summary: SessionSummary;
 	state: AgentConnectionState;
 	messages: AgentMessage[];
+	/** Start times for tool calls actively executing in the streaming message. */
+	runningToolStartedAt?: Record<string, number>;
 	sessionContext?: AgentConnectionSessionContext;
 	sessionTree?: { tree: AgentConnectionSessionTreeNode[]; leafId: string | null };
 	lastEventSequence: DaemonEventSequence;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -311,10 +311,9 @@ function rlmChildSnapshotForActiveSession(
 	// a daemon-hosted child whose agent is momentarily idle is still part of an
 	// active run. The streaming heuristic only covers parents the daemon does
 	// not host (e.g. children attributed to a session created by an older build).
-	const runStatus = metadata.rlmChildId
-		? parent?.runtime.session.getRlmChildRunStatus(metadata.rlmChildId)
-		: undefined;
-	const status = runStatus ?? (session.isStreaming || effectivePendingMessageCount(session) > 0 ? "running" : "done");
+	const runState = metadata.rlmChildId ? parent?.runtime.session.getRlmChildRunState(metadata.rlmChildId) : undefined;
+	const status =
+		runState?.status ?? (session.isStreaming || effectivePendingMessageCount(session) > 0 ? "running" : "done");
 	return {
 		id: metadata.rlmChildId ?? activeSession.activeSessionId,
 		parentId: parentNodeId,
@@ -323,6 +322,8 @@ function rlmChildSnapshotForActiveSession(
 		model: session.model ? `${session.model.provider}/${session.model.id}` : undefined,
 		label: rlmChildLabel(metadata.prompt ?? ""),
 		status,
+		startedAt: runState?.startedAt ?? metadata.createdAt,
+		durationMs: runState?.durationMs,
 		answerPreview,
 		toolUseCount: toolUseCount > 0 ? toolUseCount : undefined,
 		tokenCount: session._contextTokensForCurrentMessages(),

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -11,7 +11,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { AGENT_ACTIVITY_LABELS, formatTokenCount } from "../agent-activity.js";
 import { theme } from "../theme/theme.js";
-import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
+import { formatDuration, formatLiveDuration, getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
 import { keyText } from "./keybinding-hints.js";
 
 export type ChildAgentStatus = "queued" | "running" | "done" | "error" | "cancelled";
@@ -32,6 +32,7 @@ export interface ChildAgentInspectorNode {
 	label: string;
 	status: ChildAgentStatus;
 	durationMs?: number;
+	startedAt?: number;
 	answerPreview?: string;
 	toolUseCount?: number;
 	tokenCount?: number;
@@ -176,19 +177,14 @@ function formatChildAgentStatusIcon(node: ChildAgentInspectorNode, icon: string)
 	}
 }
 
-function formatChildAgentDuration(durationMs: number | undefined): string {
-	if (durationMs === undefined) {
+function formatChildAgentDuration(node: ChildAgentInspectorNode): string {
+	if (node.status === "running" || node.status === "queued") {
+		if (node.startedAt !== undefined) return formatLiveDuration(Date.now() - node.startedAt);
+		// Fall back to durationMs for daemon-seeded snapshots that lack startedAt.
+		if (node.durationMs !== undefined) return formatDuration(node.durationMs);
 		return "";
 	}
-	const seconds = Math.max(0, Math.floor(durationMs / 1000));
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const minutes = Math.floor(seconds / 60);
-	if (minutes < 60) {
-		return `${minutes}m`;
-	}
-	return `${Math.floor(minutes / 60)}h`;
+	return node.durationMs !== undefined ? formatDuration(node.durationMs) : "";
 }
 
 function childAgentRecap(node: ChildAgentInspectorNode): string {
@@ -242,10 +238,9 @@ const SUMMARY_PROMPT_MAX_WIDTH = 24;
 const SUMMARY_RECAP_MIN_WIDTH = 12;
 const SUMMARY_MODEL_WIDTH = 20;
 const SUMMARY_TOKENS_WIDTH = 8;
-const SUMMARY_DURATION_WIDTH = 4;
+const SUMMARY_DURATION_MIN_WIDTH = 4;
 const SUMMARY_TOKEN_TIME_GAP = 2;
-const SUMMARY_METRICS_WIDTH =
-	SUMMARY_MODEL_WIDTH + 1 + SUMMARY_TOKENS_WIDTH + SUMMARY_TOKEN_TIME_GAP + SUMMARY_DURATION_WIDTH;
+const SUMMARY_METRICS_BASE_WIDTH = SUMMARY_MODEL_WIDTH + 1 + SUMMARY_TOKENS_WIDTH + SUMMARY_TOKEN_TIME_GAP;
 // Opening chars of the prompt kept for context before eliding a shared prefix.
 const PROMPT_LEADING_CONTEXT = 6;
 // Words of context kept on each side of the divergence.
@@ -400,7 +395,13 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const window = flat.slice(clampedStart, clampedStart + SUMMARY_VISIBLE_ROWS);
 
 		const agentWidth = `S${flat.length}`.length;
-		const fixedWidth = SUMMARY_LIST_INDENT + 2 + agentWidth + SUMMARY_COLUMN_GAP * 3 + SUMMARY_METRICS_WIDTH;
+		const durations = new Map(window.map((entry) => [entry.node.id, formatChildAgentDuration(entry.node)]));
+		const durationWidth = Math.max(
+			SUMMARY_DURATION_MIN_WIDTH,
+			...[...durations.values()].map((duration) => visibleWidth(duration)),
+		);
+		const fixedWidth =
+			SUMMARY_LIST_INDENT + 2 + agentWidth + SUMMARY_COLUMN_GAP * 3 + SUMMARY_METRICS_BASE_WIDTH + durationWidth;
 		const flexibleWidth = Math.max(0, contentWidth - fixedWidth);
 		const recapMinimum = Math.min(SUMMARY_RECAP_MIN_WIDTH, Math.floor(flexibleWidth / 2));
 		const promptTarget = Math.min(SUMMARY_PROMPT_MAX_WIDTH, Math.max(10, Math.floor(flexibleWidth * 0.34)));
@@ -415,7 +416,17 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 			const number = flat.indexOf(entry) + 1;
 			lines.push(
 				this.panelLine(
-					this.renderListEntry(entry, number, agentWidth, promptPrefix, promptSuffix, promptWidth, recapWidth),
+					this.renderListEntry(
+						entry,
+						number,
+						agentWidth,
+						promptPrefix,
+						promptSuffix,
+						promptWidth,
+						recapWidth,
+						durations.get(entry.node.id) ?? "",
+						durationWidth,
+					),
 					width,
 					selected,
 				),
@@ -481,6 +492,8 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		sharedSuffix: string,
 		promptWidth: number,
 		recapWidth: number,
+		duration: string,
+		durationWidth: number,
 	): string {
 		const indent = " ".repeat(SUMMARY_LIST_INDENT);
 		// Running rows pulse the shared working glyph; other states stay static.
@@ -496,10 +509,9 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const recapCell = theme.fg("muted", padTableCell(childAgentRecap(entry.node), recapWidth, "…"));
 		const model = childAgentModelLabel(entry.node.model);
 		const tokens = entry.node.tokenCount === undefined ? "" : `${formatTokenCount(entry.node.tokenCount)} tok`;
-		const duration = formatChildAgentDuration(entry.node.durationMs);
 		const modelCell = padTableCell(truncateModelLabel(model, SUMMARY_MODEL_WIDTH), SUMMARY_MODEL_WIDTH);
 		const tokensCell = padTableCell(tokens, SUMMARY_TOKENS_WIDTH, "…");
-		const durationCell = padTableCell(duration, SUMMARY_DURATION_WIDTH, "…");
+		const durationCell = padTableCell(duration, durationWidth, "…");
 		const metrics = `${modelCell} ${tokensCell}${" ".repeat(SUMMARY_TOKEN_TIME_GAP)}${durationCell}`;
 		const gap = " ".repeat(SUMMARY_COLUMN_GAP);
 		return `${indent}${icon} ${agentCell}${gap}${promptCell}${gap}${recapCell}${gap}${theme.fg("muted", metrics)}`;
@@ -730,17 +742,11 @@ export class ChildAgentDetailComponent implements Component, Focusable {
 	}
 
 	private panelStatusLabel(node: ChildAgentInspectorNode): string {
-		if (node.status === "queued") {
-			return AGENT_ACTIVITY_LABELS.waiting;
-		}
-		switch (node.activity?.kind) {
-			case "executing":
-				return AGENT_ACTIVITY_LABELS.executing;
-			case "writing":
-				return AGENT_ACTIVITY_LABELS.writing;
-			default:
-				return AGENT_ACTIVITY_LABELS.waiting;
-		}
+		const activity = node.status === "queued" ? "waiting" : (node.activity?.kind ?? "waiting");
+		const label = activity === "executing" ? AGENT_ACTIVITY_LABELS.executing : AGENT_ACTIVITY_LABELS[activity];
+		return node.startedAt === undefined
+			? label
+			: `${label} ${formatLiveDuration(Date.now() - node.startedAt).padStart(7)}`;
 	}
 
 	private indent(line: string, width: number, spaces = CONTENT_INDENT): string {

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -8,7 +8,7 @@ import { createAllToolDefinitions } from "../../../core/tools/index.js";
 import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/render-utils.js";
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
 import { type Theme, theme } from "../theme/theme.js";
-import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
+import { formatDuration, formatLiveDuration, getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
 import { ToolPanel } from "./tool-panel.js";
 
@@ -87,6 +87,8 @@ export class ToolExecutionComponent extends Container {
 	private ui: TUI;
 	private cwd: string;
 	private executionStarted = false;
+	private executionStartedAt: number | undefined;
+	private finalDurationMs: number | undefined;
 	private argsComplete = false;
 	private pendingSentAgentMessages: KernelSentAgentMessage[] = [];
 	private result?: {
@@ -212,8 +214,9 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
-	markExecutionStarted(): void {
+	markExecutionStarted(startedAt?: number): void {
 		this.executionStarted = true;
+		this.executionStartedAt ??= startedAt;
 		this.updateDisplay();
 		this.ui.requestRender();
 	}
@@ -248,6 +251,9 @@ export class ToolExecutionComponent extends Container {
 		}
 		this.result = sentAgentMessages.length > 0 ? { ...result, details: { ...details, sentAgentMessages } } : result;
 		this.isPartial = isPartial;
+		if (!isPartial && this.executionStartedAt !== undefined && this.finalDurationMs === undefined) {
+			this.finalDurationMs = Date.now() - this.executionStartedAt;
+		}
 		this.updateDisplay();
 	}
 
@@ -461,13 +467,21 @@ export class ToolExecutionComponent extends Container {
 
 	private panelStatus(): string {
 		if (this.result && !this.isPartial) {
-			return this.result.isError ? theme.fg("error", "error") : theme.fg("success", "done");
+			const statusText = this.result.isError ? "error" : "done";
+			const statusColor = this.result.isError ? "error" : "success";
+			const timer =
+				this.finalDurationMs !== undefined ? formatDuration(this.finalDurationMs).padStart(4) : undefined;
+			return timer !== undefined
+				? `${theme.fg(statusColor, statusText)} ${theme.fg("muted", timer)}`
+				: theme.fg(statusColor, statusText);
 		}
 		if (this.result?.isError) {
 			return theme.fg("error", "error");
 		}
 		if (this.executionStarted) {
-			return theme.fg("bashMode", `${workingIconFrame(getWorkingPulseFrame())} running`);
+			const status = theme.fg("bashMode", `${workingIconFrame(getWorkingPulseFrame())} running`);
+			if (this.executionStartedAt === undefined) return status;
+			return `${status} ${theme.fg("muted", formatLiveDuration(Date.now() - this.executionStartedAt).padStart(7))}`;
 		}
 		return theme.fg("muted", "queued");
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -233,7 +233,7 @@ import {
 	type ThemeColor,
 	theme,
 } from "./theme/theme.js";
-import { setWorkingPulseFrame, WORKING_ICON_INTERVAL_MS } from "./theme/working-icon.js";
+import { formatLiveDuration, setWorkingPulseFrame, WORKING_ICON_INTERVAL_MS } from "./theme/working-icon.js";
 
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
@@ -321,6 +321,12 @@ export function mergeChildAgentSnapshots(
 		sessionName: incoming.sessionName ?? previous.sessionName,
 		model: incoming.model ?? previous.model,
 		durationMs: incoming.durationMs ?? previous.durationMs,
+		startedAt:
+			incoming.startedAt === undefined
+				? previous.startedAt
+				: previous.startedAt === undefined
+					? incoming.startedAt
+					: Math.min(previous.startedAt, incoming.startedAt),
 		answerPreview: incoming.answerPreview ?? previous.answerPreview,
 		toolUseCount:
 			incoming.toolUseCount === undefined
@@ -347,6 +353,7 @@ function childAgentSummaryChanged(
 		previous.label !== next.label ||
 		previous.status !== next.status ||
 		previous.durationMs !== next.durationMs ||
+		previous.startedAt !== next.startedAt ||
 		previous.toolUseCount !== next.toolUseCount ||
 		previousTokens !== nextTokens ||
 		previous.recap !== next.recap ||
@@ -885,7 +892,7 @@ export class InteractiveMode {
 	private ipythonToolComponents = new Map<string, ToolExecutionComponent>();
 	private lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
 	private pendingToolCreations = new Set<string>();
-	private startedToolCalls = new Set<string>();
+	private toolExecutionStarts = new Map<string, number>();
 	private pendingToolGeneration = 0;
 	private toolDefinitionCache = new Map<string, ToolExecutionDefinition | undefined>();
 	private agentRunFileChanges = new Map<string, FileChangeSummary>();
@@ -2728,7 +2735,7 @@ export class InteractiveMode {
 		this.pendingToolGeneration++;
 		this.pendingTools.clear();
 		this.pendingToolCreations.clear();
-		this.startedToolCalls.clear();
+		this.toolExecutionStarts.clear();
 	}
 
 	private async renderCurrentSessionState(): Promise<void> {
@@ -2747,6 +2754,7 @@ export class InteractiveMode {
 		await this.renderSessionContext(this.getSessionContextFromConnectionSnapshot(snapshot), {
 			clearChat: true,
 			updateFooter: true,
+			...(snapshot.runningToolStartedAt ? { runningToolStartedAt: snapshot.runningToolStartedAt } : {}),
 		});
 		await this.restoreStreamingMessageFromSnapshot(snapshot.streamingMessage);
 		await this.refreshConnectionQueue();
@@ -2838,9 +2846,8 @@ export class InteractiveMode {
 				this.getCurrentCwd(),
 			);
 			component.setExpanded(this.toolOutputExpanded);
-			if (this.startedToolCalls.has(latestToolCall.id)) {
-				component.markExecutionStarted();
-			}
+			const startedAt = this.toolExecutionStarts.get(latestToolCall.id);
+			if (startedAt !== undefined) component.markExecutionStarted(startedAt);
 			selectLatestToolExpandHint(this.chatContainer.children, component);
 			this.chatContainer.addChild(component);
 			this.pendingTools.set(latestToolCall.id, component);
@@ -2963,9 +2970,7 @@ export class InteractiveMode {
 
 	private getWorkingLoaderMessage(): string {
 		const elapsed =
-			this.workingStartedAt === undefined
-				? undefined
-				: this.formatWorkingElapsed(Date.now() - this.workingStartedAt);
+			this.workingStartedAt === undefined ? undefined : formatLiveDuration(Date.now() - this.workingStartedAt);
 		const status = this.activityTracker.getStatus();
 		// The subagent count/recaps live in the tree above the loader, so the loader
 		// message itself no longer repeats "N subagents running".
@@ -2994,16 +2999,6 @@ export class InteractiveMode {
 			this.getWorkingLoaderMessage(),
 			this.workingIndicatorOptions,
 		);
-	}
-
-	private formatWorkingElapsed(elapsedMs: number): string {
-		const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
-		if (totalSeconds < 60) {
-			return `${totalSeconds}s`;
-		}
-		const minutes = Math.floor(totalSeconds / 60);
-		const seconds = totalSeconds % 60;
-		return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
 	}
 
 	private updateWorkingLoaderMessage(): void {
@@ -4907,7 +4902,7 @@ export class InteractiveMode {
 						const elapsedSuffix =
 							this.workingStartedAt === undefined
 								? ""
-								: ` · ${this.formatWorkingElapsed(Date.now() - this.workingStartedAt)}`;
+								: ` · ${formatLiveDuration(Date.now() - this.workingStartedAt)}`;
 						errorMessage =
 							retryAttempt > 0
 								? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}${elapsedSuffix}`
@@ -4941,7 +4936,7 @@ export class InteractiveMode {
 				break;
 
 			case "tool_execution_start": {
-				this.startedToolCalls.add(event.toolCallId);
+				if (event.startedAt !== undefined) this.toolExecutionStarts.set(event.toolCallId, event.startedAt);
 				let component = this.pendingTools.get(event.toolCallId);
 				if (!component) {
 					component = await this.getOrCreatePendingToolComponent({
@@ -4950,9 +4945,7 @@ export class InteractiveMode {
 						arguments: event.args,
 					});
 				}
-				if (component) {
-					component.markExecutionStarted();
-				}
+				component?.markExecutionStarted(event.startedAt);
 				this.ui.requestRender();
 				break;
 			}
@@ -4971,7 +4964,7 @@ export class InteractiveMode {
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
 					this.pendingTools.delete(event.toolCallId);
-					this.startedToolCalls.delete(event.toolCallId);
+					this.toolExecutionStarts.delete(event.toolCallId);
 					this.ui.requestRender();
 				}
 				break;
@@ -5775,6 +5768,7 @@ export class InteractiveMode {
 			label: child.label,
 			status: child.status,
 			durationMs: child.durationMs,
+			startedAt: child.startedAt,
 			answerPreview: child.answerPreview,
 			toolUseCount: child.toolUseCount,
 			tokenCount: child.tokenCount,
@@ -6053,9 +6047,13 @@ export class InteractiveMode {
 			populateHistory?: boolean;
 			clearChat?: boolean;
 			limitTranscript?: boolean;
+			runningToolStartedAt?: Record<string, number>;
 		} = {},
 	): Promise<void> {
 		this.resetPendingToolState();
+		for (const [toolCallId, startedAt] of Object.entries(options.runningToolStartedAt ?? {})) {
+			this.toolExecutionStarts.set(toolCallId, startedAt);
+		}
 		const messagesToRender = options.limitTranscript
 			? initialRenderMessages(sessionContext.messages)
 			: sessionContext.messages;
@@ -6126,6 +6124,8 @@ export class InteractiveMode {
 							this.getCurrentCwd(),
 						);
 						component.setExpanded(this.toolOutputExpanded);
+						const startedAt = options.runningToolStartedAt?.[content.id];
+						if (startedAt !== undefined) component.markExecutionStarted(startedAt);
 						selectLatestToolExpandHint(this.chatContainer.children, component);
 						this.chatContainer.addChild(component);
 						this.registerIpythonToolComponent(content.name, content.id, component);
@@ -6181,6 +6181,7 @@ export class InteractiveMode {
 			updateFooter: true,
 			populateHistory: true,
 			limitTranscript: true,
+			...(snapshot.runningToolStartedAt ? { runningToolStartedAt: snapshot.runningToolStartedAt } : {}),
 		});
 		await this.restoreStreamingMessageFromSnapshot(streamingMessage);
 
@@ -6197,7 +6198,6 @@ export class InteractiveMode {
 			this.startAssistantStreamingMessage(message);
 			for (const content of message.content) {
 				if (content.type === "toolCall") {
-					this.startedToolCalls.add(content.id);
 					await this.getOrCreatePendingToolComponent(content);
 				}
 			}

--- a/packages/coding-agent/src/modes/interactive/theme/working-icon.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/working-icon.ts
@@ -8,6 +8,30 @@ export function workingIconFrame(frame: number): string {
 	return frames[((frame % frames.length) + frames.length) % frames.length] ?? frames[0];
 }
 
+// Second-precise clock used by live timers so the display keeps moving.
+export function formatLiveDuration(durationMs: number): string {
+	const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+	const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+	const totalMinutes = Math.floor(totalSeconds / 60);
+	if (totalMinutes < 60) return `${totalMinutes}:${seconds}`;
+	const minutes = (totalMinutes % 60).toString().padStart(2, "0");
+	return `${Math.floor(totalMinutes / 60)}:${minutes}:${seconds}`;
+}
+
+// Compact human-readable duration for settled work.
+export function formatDuration(durationMs: number): string {
+	const seconds = Math.max(0, Math.floor(durationMs / 1000));
+	if (seconds < 60) {
+		return `${seconds}s`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) {
+		return `${minutes}m`;
+	}
+	return `${Math.floor(minutes / 60)}h`;
+}
+
 // Process-wide frame counter for in-place chat tool markers, advanced by the
 // interactive mode's single ticker and read during render.
 let pulseFrame = 0;

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -571,6 +571,7 @@ interface CreateAttachResultOptions {
 	state?: AgentConnectionState;
 	messages?: AgentMessage[];
 	streamingMessage?: AgentMessage;
+	runningToolStartedAt?: Record<string, number>;
 	sessionContext?: DaemonAttachResult["snapshot"]["sessionContext"];
 	omitSessionContext?: boolean;
 	sessionTree?: DaemonAttachResult["snapshot"]["sessionTree"];
@@ -612,6 +613,7 @@ function createAttachResult(
 			summary,
 			state,
 			messages,
+			...(options.runningToolStartedAt ? { runningToolStartedAt: options.runningToolStartedAt } : {}),
 			...(options.omitSessionContext
 				? {}
 				: {
@@ -1254,6 +1256,7 @@ describe("DaemonAgentConnection", () => {
 			state: { ...createConnectionState("active-1", "session-current"), isStreaming: true },
 			messages,
 			streamingMessage,
+			runningToolStartedAt: { "tool-1": 1_000 },
 		}).snapshot;
 
 		fakeClient.emitMessage({
@@ -1277,6 +1280,7 @@ describe("DaemonAgentConnection", () => {
 					state: expect.objectContaining({ sessionId: "session-current" }),
 					messages,
 					streamingMessage,
+					runningToolStartedAt: { "tool-1": 1_000 },
 					lastEventSequence: 13,
 				}),
 			},

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -106,6 +106,7 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 		},
 		scopedModels: [],
 		getActiveToolNames: () => ["ipython"],
+		getRunningToolStartedAt: () => ({}),
 		getContextUsage: () => undefined,
 		cancelRlmChildRun: (childId: string) => childId === "child-1",
 		getToolDefinition: (toolName: string) => ({

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -463,9 +463,36 @@ describe("AgentSession rlm recursion", () => {
 		expect(childUpdates[0]?.label).toBe("summarize shard 1");
 		const doneUpdate = [...childUpdates].reverse().find((update) => update.status === "done");
 		expect(doneUpdate?.answerPreview).toBe("child answer: summarize shard 1");
+		const childId = root.listRlmSubagents().subagents[0]?.rlm_child_id;
+		expect(childId ? root.getRlmChildRunState(childId) : undefined).toMatchObject({
+			status: "done",
+			startedAt: expect.any(Number),
+			durationMs: expect.any(Number),
+		});
 		// Context tokens from the child's own assistant usage (input 7 + output 3); no tools ran.
 		expect(doneUpdate?.tokenCount).toBe(10);
 		expect(doneUpdate?.toolUseCount).toBeUndefined();
+	});
+
+	it("retains canonical timing when successful runtime release fails", async () => {
+		const hostedChild = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
+				deleteRlmSubagentRuntime: async () => {},
+				releaseRlmSubagentRuntime: async () => {
+					throw new Error("release failed");
+				},
+			},
+		});
+
+		await expect(root.runRlmChild("successful work")).rejects.toThrow("release failed");
+		const childId = root.listRlmSubagents().subagents[0]?.rlm_child_id;
+		expect(childId ? root.getRlmChildRunState(childId) : undefined).toMatchObject({
+			status: "done",
+			startedAt: expect.any(Number),
+			durationMs: expect.any(Number),
+		});
 	});
 
 	it("lists a completed child with its parent-scoped messaging identity until disposal", async () => {
@@ -974,11 +1001,15 @@ describe("AgentSession rlm recursion", () => {
 
 		const runPromise = root.runRlmChild("slow release", { name: "release-worker" });
 		await waitFor(() => childStarted);
+		const childId = root.listRlmSubagents().subagents[0]?.rlm_child_id;
+		if (!childId) throw new Error("Missing running child");
 		const runFailure = expect(runPromise).rejects.toThrow("Deleted by parent orchestrator");
 		const deletion = root.deleteRlmSubagent("release-worker");
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 		await expect(deletion).rejects.toThrow("close failed");
 		await runFailure;
+		// Completion must not retain or re-publish a child hidden behind a failed deletion.
+		expect(root.retainFinishedRlmChildSession(childId, hostedChild)).toBe(false);
 		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns.size).toBe(0);
 		expect(root.listRlmSubagents()).toEqual({ subagents: [] });
 

--- a/packages/coding-agent/test/child-agent-summary-list.test.ts
+++ b/packages/coding-agent/test/child-agent-summary-list.test.ts
@@ -1,5 +1,5 @@
 import { setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	ChildAgentDetailComponent,
@@ -204,6 +204,28 @@ describe("ChildAgentSummaryComponent inline list", () => {
 		summary.setNodes([{ ...node("a"), tokenCount: 41_000, durationMs: 5_000 }]);
 		const out = stripAnsi(summary.render(80).join("\n"));
 		expect(out).toMatch(/41k tok\s{3}5s/);
+	});
+
+	it("renders the full live clock when its width grows", () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(600_000);
+			const summary = new ChildAgentSummaryComponent();
+			summary.setNodes([{ ...node("a"), startedAt: 0 }]);
+			const output = stripAnsi(summary.render(80).join("\n"));
+			expect(output).toContain("10:00");
+			expect(output).not.toContain("10:…");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("preserves running detail timers across refreshes", () => {
+		const detail = new ChildAgentDetailComponent();
+		const startedAt = Date.now() - 61_000;
+		detail.setNode({ ...node("a"), startedAt });
+		detail.setNode({ ...node("a"), startedAt, activity: { kind: "executing", toolName: "ipython" } });
+		expect(stripAnsi(detail.render(100).join("\n"))).toContain("   1:01");
 	});
 
 	it("shows the model to the right of the back action in detail view", () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -270,6 +270,11 @@ describe("daemon mode helpers", () => {
 			});
 			const parentState = makeState("parent");
 			const parentSession = makeRuntimeSession(parentManager);
+			vi.mocked(parentSession.getRlmChildRunState).mockReturnValue({
+				status: "done",
+				startedAt: 500,
+				durationMs: 750,
+			});
 			parentState.runtime = {
 				...parentState.runtime,
 				metadata: { kind: "top-level", createdAt: 1 },
@@ -353,7 +358,11 @@ describe("daemon mode helpers", () => {
 				status: "active",
 				runCount: 0,
 			});
-			expect(parentSession.retainFinishedRlmChildSession).toHaveBeenCalledWith("child-1", childSession);
+			expect(parentSession.retainFinishedRlmChildSession).toHaveBeenCalledWith("child-1", childSession, {
+				status: "done",
+				startedAt: 500,
+				durationMs: 750,
+			});
 			const dueRuns = await internals.cronScheduler.runDue(new Date("2026-07-16T00:00:00.000Z"));
 			expect(dueRuns).toBe(1);
 			expect(promptHeartbeat).toHaveBeenCalledOnce();
@@ -5631,6 +5640,7 @@ function makeRuntimeSession(
 		},
 		setSubagentRuntimeHost: vi.fn(),
 		getRlmChildRunStatus: vi.fn(() => "running"),
+		getRlmChildRunState: vi.fn(() => undefined),
 		retainFinishedRlmChildSession: vi.fn(() => true),
 		subscribe: vi.fn(() => vi.fn()),
 		bindExtensions: vi.fn(async () => {}),

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -434,31 +434,32 @@ describe("buildRlmChildSnapshots", () => {
 		});
 	});
 
-	it("prefers the parent's run status over the streaming heuristic", () => {
-		// An idle child session is still part of an active run; only the parent's
-		// run tracker knows that.
+	it.each([
+		{
+			state: { status: "running" as const, startedAt: 500 },
+			expected: { status: "running", startedAt: 500 },
+		},
+		{
+			state: { status: "done" as const, startedAt: 500, durationMs: 750 },
+			expected: { status: "done", startedAt: 500, durationMs: 750 },
+		},
+	])("uses canonical parent timing for $state.status child seeds", ({ state, expected }) => {
 		const parent = makeState({
 			activeSessionId: "parent",
-			sessionFile: "/tmp/parent.jsonl",
-			childRunStatuses: { "sub-aaa": "running" },
+			childRunStates: { "sub-aaa": state },
 		});
-		const idleChild = makeState({
+		const child = makeState({
 			activeSessionId: "child",
 			isStreaming: false,
 			metadata: {
 				kind: "subagent",
-				createdAt: 1,
+				createdAt: 1_000,
 				parentActiveSessionId: "parent",
 				rlmChildId: "sub-aaa",
-				rlmParentNodeId: "sub-aaa",
-				prompt: "Slow task",
-				sessionDir: "/tmp/artifacts/sub-aaa",
 			},
 		});
 
-		const snapshots = buildRlmChildSnapshots("parent", [parent, idleChild]);
-
-		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
+		expect(buildRlmChildSnapshots("parent", [parent, child])).toMatchObject([{ id: "sub-aaa", ...expected }]);
 	});
 
 	it("includes in-flight assistant output in child snapshots", () => {
@@ -540,7 +541,10 @@ interface StateOptions {
 	messages?: AgentMessage[];
 	hasUserContent?: boolean;
 	summaryState?: ActiveSessionState["summaryState"];
-	childRunStatuses?: Record<string, "queued" | "running" | "done" | "error" | "cancelled">;
+	childRunStates?: Record<
+		string,
+		{ status: "queued" | "running" | "done" | "error" | "cancelled"; startedAt: number; durationMs?: number }
+	>;
 	hasRunningRlmChildren?: boolean;
 	hasAcceptedPromptInFlight?: boolean;
 	contextTokens?: number;
@@ -586,7 +590,7 @@ function makeState(options: StateOptions): ActiveSessionState {
 					hasUserContent: () => options.hasUserContent ?? false,
 				},
 				messages: options.messages ?? ([] as AgentMessage[]),
-				getRlmChildRunStatus: (childId: string) => options.childRunStatuses?.[childId],
+				getRlmChildRunState: (childId: string) => options.childRunStates?.[childId],
 				hasRunningRlmChildren: () => options.hasRunningRlmChildren ?? false,
 				hasAcceptedPromptInFlight: options.hasAcceptedPromptInFlight ?? false,
 				getCurrentRecap: () => undefined,

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -33,12 +33,10 @@ import type {
 	AgentConnectionResourceSnapshot,
 	AgentConnectionRlmChildAgentSnapshot,
 	AgentConnectionSessionContext,
-	AgentConnectionSessionEvent,
 	AgentConnectionSnapshot,
 	AgentConnectionSourceInfo,
 	AgentConnectionState,
 } from "../src/modes/agent-connection/types.js";
-import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import type { AuthenticationResult } from "../src/modes/interactive/auth-flows.js";
 import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
 import type { ConfigurationMenuComponent } from "../src/modes/interactive/components/configuration-menu.js";
@@ -124,6 +122,7 @@ describe("mergeChildAgentSnapshots", () => {
 		model: "openai/gpt-5.4",
 		label: "Inspect the scheduler",
 		status: "running",
+		startedAt: 1_000,
 		durationMs: 5_000,
 		answerPreview: "Reading the queue",
 		toolUseCount: 4,
@@ -138,11 +137,13 @@ describe("mergeChildAgentSnapshots", () => {
 			id: "child-1",
 			label: "Inspect the scheduler",
 			status: "running",
+			startedAt: 2_000,
 			sessionDir: "/tmp/child-1",
 		});
 
 		expect(merged).toMatchObject({
 			activeSessionId: "active-child-1",
+			startedAt: 1_000,
 			model: "openai/gpt-5.4",
 			durationMs: 5_000,
 			answerPreview: "Reading the queue",
@@ -266,6 +267,7 @@ describe("InteractiveMode.showStatus", () => {
 
 type RenderSessionContextHarness = {
 	pendingTools: Map<string, ToolExecutionComponent>;
+	toolExecutionStarts: Map<string, number>;
 	ipythonToolComponents: Map<string, unknown>;
 	lateIpythonSentAgentMessages: Map<string, unknown[]>;
 	toolOutputExpanded: boolean;
@@ -289,6 +291,7 @@ type RenderSessionContextOptions = {
 	populateHistory?: boolean;
 	clearChat?: boolean;
 	limitTranscript?: boolean;
+	runningToolStartedAt?: Record<string, number>;
 };
 
 const renderSessionContext = (
@@ -308,12 +311,15 @@ function createRenderSessionContextHarness(overrides: Partial<RenderSessionConte
 	addToHistory: ReturnType<typeof vi.fn>;
 } {
 	const chatContainer = overrides.chatContainer ?? new Container();
+	const pendingTools = overrides.pendingTools ?? new Map<string, ToolExecutionComponent>();
+	const toolExecutionStarts = overrides.toolExecutionStarts ?? new Map<string, number>();
 	const addMessageToChat = vi.fn(() => {
 		chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
 	});
 	const addToHistory = vi.fn();
 	const harness: RenderSessionContextHarness = {
-		pendingTools: new Map<string, ToolExecutionComponent>(),
+		pendingTools,
+		toolExecutionStarts,
 		ipythonToolComponents: new Map<string, unknown>(),
 		lateIpythonSentAgentMessages: new Map<string, unknown[]>(),
 		toolOutputExpanded: false,
@@ -321,7 +327,10 @@ function createRenderSessionContextHarness(overrides: Partial<RenderSessionConte
 		editor: { addToHistory },
 		footer: { invalidate: vi.fn() },
 		updateEditorBorderColor: vi.fn(),
-		resetPendingToolState: vi.fn(),
+		resetPendingToolState: vi.fn(() => {
+			pendingTools.clear();
+			toolExecutionStarts.clear();
+		}),
 		preloadToolDefinitions: vi.fn(async () => {}),
 		settingsManager: { getShowImages: () => true },
 		getCachedToolDefinition: () => undefined,
@@ -1115,6 +1124,7 @@ describe("InteractiveMode connection events", () => {
 			state: createConnectionState({ isCompacting: true, isBashRunning: true, isStreaming: true }),
 			messages: [],
 			streamingMessage,
+			runningToolStartedAt: { "tool-1": 1_000 },
 		};
 		const startAssistantStreamingMessage = vi.fn();
 		const restoreStreamingMessageFromSnapshot = vi.fn((message: AgentConnectionSnapshot["streamingMessage"]) => {
@@ -1166,7 +1176,11 @@ describe("InteractiveMode connection events", () => {
 		expect((fakeThis as unknown as { activeBashComponent: unknown }).activeBashComponent).toBe(activeBashComponent);
 		expect(
 			(fakeThis as unknown as { renderSessionContext: ReturnType<typeof vi.fn> }).renderSessionContext,
-		).toHaveBeenCalledWith(expect.anything(), { clearChat: true, updateFooter: true });
+		).toHaveBeenCalledWith(expect.anything(), {
+			clearChat: true,
+			updateFooter: true,
+			runningToolStartedAt: { "tool-1": 1_000 },
+		});
 		expect(startAssistantStreamingMessage).toHaveBeenCalledWith(streamingMessage);
 	});
 
@@ -1321,86 +1335,69 @@ describe("InteractiveMode key handlers", () => {
 });
 
 describe("InteractiveMode tool event rendering", () => {
-	test("reserves streaming tool call ids before loading tool definitions", async () => {
-		let resolveDefinition!: () => void;
-		const definitionPromise = new Promise<undefined>((resolve) => {
-			resolveDefinition = () => resolve(undefined);
-		});
-		const fakeThis = Object.assign(Object.create(InteractiveMode.prototype), {
-			isInitialized: true,
-			init: vi.fn(async () => {}),
-			footer: { invalidate: vi.fn() },
-			updateConnectionStateFromEvent: vi.fn(),
-			activityTracker: new AgentActivityTracker(),
-			streamingComponent: { updateContent: vi.fn() },
-			streamingMessage: undefined,
-			chatContainer: new Container(),
-			pendingTools: new Map<string, ToolExecutionComponent>(),
-			pendingToolCreations: new Set<string>(),
-			startedToolCalls: new Set<string>(),
-			ipythonToolComponents: new Map(),
-			lateIpythonSentAgentMessages: new Map(),
-			loadToolDefinition: vi.fn(() => definitionPromise),
-			uiServices: {
-				settingsManager: {
-					getShowImages: () => true,
-				},
-			},
-			toolOutputExpanded: false,
-			ui: { requestRender: vi.fn() },
-			getCurrentCwd: () => "/tmp/project",
-		});
-		const message = {
-			role: "assistant",
-			content: [
-				{
-					type: "toolCall",
-					id: "tool-1",
-					name: "ipython",
-					arguments: { code: "print(1)" },
-				},
-			],
-			api: "anthropic-messages",
-			provider: "anthropic",
-			model: "claude-sonnet-4-5",
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					total: 0,
-				},
-			},
-			stopReason: "stop",
-			timestamp: 1,
-		};
-		const event = {
-			type: "message_update",
-			message,
-			assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, partial: message },
-		} as unknown as AgentConnectionSessionEvent;
-		const handleEvent = (
-			InteractiveMode.prototype as unknown as {
-				handleEvent(this: typeof fakeThis, event: AgentConnectionSessionEvent): Promise<void>;
-			}
-		).handleEvent;
+	test("reserves one component and preserves start time across asynchronous definition loading", async () => {
+		vi.useFakeTimers();
+		try {
+			let resolveDefinition!: () => void;
+			const definitionPromise = new Promise<undefined>((resolve) => {
+				resolveDefinition = () => resolve(undefined);
+			});
+			const fakeThis = Object.assign(Object.create(InteractiveMode.prototype), {
+				streamingMessage: undefined,
+				chatContainer: new Container(),
+				pendingTools: new Map<string, ToolExecutionComponent>(),
+				pendingToolCreations: new Set<string>(),
+				pendingToolGeneration: 0,
+				toolExecutionStarts: new Map([["tool-1", Date.now()]]),
+				ipythonToolComponents: new Map(),
+				lateIpythonSentAgentMessages: new Map(),
+				loadToolDefinition: vi.fn(() => definitionPromise),
+				uiServices: { settingsManager: { getShowImages: () => true } },
+				toolOutputExpanded: false,
+				ui: { requestRender: vi.fn() },
+				getCurrentCwd: () => "/tmp/project",
+			});
+			const create = (
+				InteractiveMode.prototype as unknown as {
+					getOrCreatePendingToolComponent(
+						this: typeof fakeThis,
+						toolCall: { id: string; name: string; arguments: unknown },
+					): Promise<ToolExecutionComponent | undefined>;
+				}
+			).getOrCreatePendingToolComponent;
+			const toolCall = { id: "tool-1", name: "bash", arguments: { command: "sleep 5" } };
 
-		const firstUpdate = handleEvent.call(fakeThis, event);
-		const secondUpdate = handleEvent.call(fakeThis, event);
-		await Promise.resolve();
-		expect(fakeThis.loadToolDefinition).toHaveBeenCalledTimes(1);
+			const first = create.call(fakeThis, toolCall);
+			const second = create.call(fakeThis, toolCall);
+			await Promise.resolve();
+			expect(fakeThis.loadToolDefinition).toHaveBeenCalledOnce();
+			await vi.advanceTimersByTimeAsync(61_000);
+			resolveDefinition();
+			await Promise.all([first, second]);
 
-		resolveDefinition();
-		await Promise.all([firstUpdate, secondUpdate]);
+			expect(fakeThis.pendingTools.size).toBe(1);
+			expect(fakeThis.chatContainer.children).toHaveLength(1);
+			expect(fakeThis.pendingTools.get("tool-1")?.render(100).join("\n")).toContain("1:01");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 
-		expect(fakeThis.pendingTools.size).toBe(1);
-		expect(fakeThis.chatContainer.children).toHaveLength(1);
+	test("restores transcript-resident in-flight tool timers from canonical timestamps", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(6_000);
+			const { harness } = createRenderSessionContextHarness();
+			const message = toolCallMessage("tool-restored", "bash");
+
+			await renderMessages(harness, [message], { runningToolStartedAt: { "tool-restored": 1_000 } });
+			expect(harness.pendingTools.get("tool-restored")?.render(100).join("\n")).toContain("5s");
+
+			await renderMessages(harness, [message]);
+			expect(harness.pendingTools.get("tool-restored")?.render(100).join("\n")).not.toContain("0s");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -35,7 +35,7 @@ type RenderSessionContextThis = {
 	ipythonToolComponents: Map<string, ToolExecutionComponent>;
 	lateIpythonSentAgentMessages: Map<string, unknown[]>;
 	pendingToolCreations: Set<string>;
-	startedToolCalls: Set<string>;
+	toolExecutionStarts: Map<string, number | undefined>;
 	resetPendingToolState(): void;
 	chatContainer: Container;
 	footer: { invalidate(): void };
@@ -68,17 +68,17 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 	const chatContainer = new Container();
 	const pendingTools = new Map<string, ToolExecutionComponent>();
 	const pendingToolCreations = new Set<string>();
-	const startedToolCalls = new Set<string>();
+	const toolExecutionStarts = new Map<string, number | undefined>();
 	const fakeThis: RenderSessionContextThis = {
 		pendingTools,
 		ipythonToolComponents: new Map(),
 		lateIpythonSentAgentMessages: new Map(),
 		pendingToolCreations,
-		startedToolCalls,
+		toolExecutionStarts,
 		resetPendingToolState() {
 			pendingTools.clear();
 			pendingToolCreations.clear();
-			startedToolCalls.clear();
+			toolExecutionStarts.clear();
 		},
 		chatContainer,
 		footer: { invalidate: vi.fn() },
@@ -188,6 +188,9 @@ describe("InteractiveMode.renderSessionContext", () => {
 		);
 
 		expect(fakeThis.pendingTools.size).toBe(0);
-		expect(renderChat(fakeThis.chatContainer)).toContain("HISTORICAL_RESULT");
+		const rendered = renderChat(fakeThis.chatContainer);
+		expect(rendered).toContain("HISTORICAL_RESULT");
+		expect(rendered).toContain(`${TOOL_NAME} · done`);
+		expect(rendered).not.toContain("done   0s");
 	});
 });

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -1,7 +1,7 @@
 import { Container, resetCapabilitiesCache, setCapabilities, Text, TUI } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { Type } from "typebox";
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.js";
 import type { ToolDefinition } from "../src/core/extensions/types.js";
 import { type BashOperations, createBashTool, createBashToolDefinition } from "../src/core/tools/bash.js";
@@ -73,6 +73,27 @@ describe("ToolExecutionComponent parity", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("custom call");
 		expect(rendered).toContain("custom result");
+	});
+
+	test("freezes the final duration when a timed tool settles", () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(6_000);
+			const component = new ToolExecutionComponent(
+				"bash",
+				"tool-timed",
+				{ command: "sleep 5" },
+				{},
+				undefined,
+				createFakeTui(),
+				process.cwd(),
+			);
+			component.markExecutionStarted(1_000);
+			component.updateResult({ content: [{ type: "text", text: "done" }], isError: false });
+			expect(stripAnsi(component.render(100).join("\n"))).toContain("done   5s");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test.each(["kitty", null] as const)("renders one compact image metadata row for %s capability", (protocol) => {

--- a/packages/coding-agent/test/working-icon-animation.test.ts
+++ b/packages/coding-agent/test/working-icon-animation.test.ts
@@ -2,6 +2,8 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { IPythonCellComponent } from "../src/modes/interactive/components/ipython-cell.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 import {
+	formatDuration,
+	formatLiveDuration,
 	setWorkingPulseFrame,
 	WORKING_ICON_FRAMES,
 	workingIconFrame,
@@ -18,6 +20,26 @@ describe("workingIconFrame", () => {
 		}
 		expect(workingIconFrame(WORKING_ICON_FRAMES.length)).toBe(WORKING_ICON_FRAMES[0]);
 		expect(workingIconFrame(-1)).toBe(WORKING_ICON_FRAMES[WORKING_ICON_FRAMES.length - 1]);
+	});
+});
+
+describe("timer duration formatting", () => {
+	it.each([
+		[59_000, "59s"],
+		[60_000, "1:00"],
+		[61_000, "1:01"],
+		[3_600_000, "1:00:00"],
+		[3_661_000, "1:01:01"],
+	])("keeps live timers second-precise for %i ms", (durationMs, expected) => {
+		expect(formatLiveDuration(durationMs)).toBe(expected);
+	});
+
+	it.each([
+		[59_000, "59s"],
+		[60_000, "1m"],
+		[3_600_000, "1h"],
+	])("keeps settled durations compact for %i ms", (durationMs, expected) => {
+		expect(formatDuration(durationMs)).toBe(expected);
 	});
 });
 


### PR DESCRIPTION
## What changes

Adds live elapsed timers to running tool calls and subagents, then freezes the final duration when work settles.

## State ownership

### Tools

The existing agent-core tool lifecycle owns timing:

- `AgentState.pendingToolCalls` and `AgentState.runningToolStartedAt` are updated together by the existing tool start/end reducer.
- The existing `finishRun()` and `reset()` boundaries clear IDs and timestamps atomically, including abnormal/aborted runs.
- `AgentSession` only serializes this canonical state into connection snapshots.
- Reconnect/resync seeds timestamps before rebuilding transcript and streaming tool components.
- Older events/snapshots without timestamps omit the timer instead of fabricating `0s`.

### Subagents

The parent `AgentSession` owns subagent timing:

- active runs own `startedAt` and terminal `durationMs`;
- successful retention carries timing alongside the retained child session;
- sparse daemon seeds transport the same state;
- failed deletion blocks late completion retention;
- timing is removed with child tracking.

Terminal timing is intentionally in-memory only. Older daemon-restored completed children without timing remain compatible and omit the timer rather than receiving a guessed duration.

## Presentation

- Compact shared duration formatting (`s`, `m`, `h`).
- Timers appear in tool panel status, subagent summary rows, and subagent detail status.
- One existing UI pulse invalidates active timers; no per-row intervals are introduced.
- Historical replay without canonical timestamps remains timer-free.

## Consolidation

The branch is one commit on current `main` and follows the test-consolidation approach from #498–#500:

- no new test files or harnesses;
- tool lifecycle timing extends existing agent reset/abort coverage;
- deferred component creation and timestamp preservation share one fixture;
- running and terminal daemon seed cases are table-driven together;
- historical no-`0s` behavior lives in the existing transcript reconstruction regression;
- redundant timestamp assertions in unrelated activity tests were removed.

The consolidated diff is 441 additions / 187 deletions across 26 files, down from 424 additions / 73 deletions and ten accumulated commits.

## Validation

- `npm run check`
- 24 focused agent-core tests
- focused coding-agent timer, lifecycle, snapshot, and reconstruction tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional fields and UI timing; daemon schema revision bump is backward-compatible for clients that tolerate unknown snapshot fields.
> 
> **Overview**
> Adds **live elapsed-time display** for in-flight tool calls and RLM subagents, with **frozen final durations** when work completes.
> 
> **Agent core:** `tool_execution_start` now carries optional `startedAt`; `Agent.state` exposes `runningToolStartedAt` alongside `pendingToolCalls`, cleared on tool end, run finish, and reset.
> 
> **Coding-agent UI:** Tool panels and subagent summary/detail use shared `formatLiveDuration` / `formatDuration` helpers. Daemon and connection snapshots include `runningToolStartedAt` so timers survive attach/resync; daemon schema revision bumps to **3**. Subagent runs track `startedAt` and terminal `durationMs`, retained with finished child sessions; parent timing feeds daemon child seeds instead of guessing from idle streaming state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27697376abf9ae5d76139586f4c098f94fe80334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live elapsed-time timers for running tool calls and subagents
> - `tool_execution_start` events now carry a `startedAt` timestamp; `Agent` tracks per-tool start times in `runningToolStartedAt` and clears them on completion, reset, or abort.
> - `ToolExecutionComponent` shows a live `M:SS` timer while a tool runs and freezes the final duration on completion using new `formatLiveDuration` and `formatDuration` helpers in `working-icon.ts`.
> - Child agent summary and detail views display live elapsed timers for running/queued agents, with dynamic column sizing in the summary list.
> - Daemon attach snapshots now include `runningToolStartedAt`; resync restores tool timers from canonical start times so reconnecting clients show accurate elapsed time.
> - RLM child run snapshots gain `startedAt` and `durationMs`; `AgentSession` tracks and exposes this timing via `getRlmChildRunState`, persisting it through retention and failure paths.
> - Behavioral Change: daemon protocol schema bumped to revision 3; clients on revision 2 will not receive `runningToolStartedAt` in attach payloads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2769737.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
