### PR TITLE
feat(daemon): checkpoint session inputs for restart

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed the bundled orchestration heartbeat skill from the model system prompt.
 - Fixed feature hints crowding queued messages and side questions by placing them below the recap and hiding them while messages are queued ([ENG-4741](https://linear.app/primeintellect/issue/ENG-4741/recap-queuefollow-upmessage-hint-looks-cluttered)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
+- Unified prompt, steering, follow-up, and session-command scheduling under session-owned admission with durable queue state and coordinated update/restart checkpoints.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.
 - Changed `/context` tree connectors from `├ `/`└ ` to `├─ `/`└─ ` to match the tree selector and session picker.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -996,10 +996,13 @@ export class AgentSession {
 				lane: SessionInputSchedule;
 				items: PreparedPromptInput[];
 				phase: "preparing" | "handedOff";
+				checkpointInputMessages: Set<AgentMessage>;
+				persistedInputMessages: Set<AgentMessage>;
 				cancelled?: boolean;
 		  }
 		| { kind: "command"; lane: SessionInputSchedule; item: PreparedCommandInput; phase: "executing" }
 		| undefined;
+	private readonly _sessionInputCheckpointWaiters = new Set<() => void>();
 	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
@@ -3185,6 +3188,20 @@ export class AgentSession {
 				this.sessionManager.appendMessage(event.message);
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
+			if (this._activeSessionInput?.kind === "prompt") {
+				const activeInput = this._activeSessionInput;
+				if (activeInput.checkpointInputMessages.has(event.message)) {
+					activeInput.persistedInputMessages.add(event.message);
+					if (
+						[...activeInput.checkpointInputMessages].every((message) =>
+							activeInput.persistedInputMessages.has(message),
+						)
+					) {
+						activeInput.phase = "handedOff";
+						this._notifySessionInputCheckpointChange();
+					}
+				}
+			}
 
 			// Track assistant message for auto-compaction (checked on agent_end)
 			if (event.message.role === "assistant") {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5028,11 +5028,8 @@ export class AgentSession {
 							this._rejectAgentMessage(first.agentMessageId, this._asError(error));
 						} finally {
 							this._activeSessionInput = undefined;
-<<<<<<< HEAD
 							this._syncSteeringStopPending();
-=======
 							this._notifySessionInputCheckpointChange();
->>>>>>> ca6ec2cc9 (feat(daemon): checkpoint session inputs for restart)
 						}
 						continue;
 					}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -947,6 +947,33 @@ function readAssistantText(message: AssistantMessage): string {
 		.join("");
 }
 
+function waitForPromiseOrAbort<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | undefined,
+	abortMessage: string,
+): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(new Error(abortMessage));
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			cleanup();
+			reject(new Error(abortMessage));
+		};
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error: unknown) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
+}
+
 function attributeChildUsage(parentUsage: Usage, childUsage: Usage): void {
 	const parentContextTokens =
 		parentUsage.totalTokens ||
@@ -5575,9 +5602,10 @@ export class AgentSession {
 			});
 		}
 		if (signal?.aborted) throw new Error("Update restart preparation cancelled");
-		// Handed-off inputs reach the transcript through the event queue; drain it so
-		// the flush below persists them before the snapshot is taken.
-		await this._agentEventQueue;
+		// Handed-off inputs reach the transcript through the event queue; drain the
+		// current snapshot so the flush below persists them before the snapshot is taken.
+		await waitForPromiseOrAbort(this._agentEventQueue, signal, "Update restart preparation cancelled");
+		if (signal?.aborted) throw new Error("Update restart preparation cancelled");
 		this.sessionManager.flushNow();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4243,10 +4243,9 @@ export class AgentSession {
 		// Settle the preflight outcome at the handoff, not after the whole turn: the
 		// direct-prompt section must keep fencing update-restart checkpoints until
 		// message_start proves the input reached the run's event stream, and a
-		// rejected dispatch must still release the section. A resolved prompt is
-		// not proof by itself: Agent.prompt() converts lifecycle failures into a
-		// synthetic error turn, so on resolution confirm the message reached
-		// agent state before releasing the checkpoint fence.
+		// rejected dispatch must still release the section. A resolved prompt alone
+		// is not proof: Agent.prompt() converts lifecycle failures into a synthetic
+		// error turn without the message ever reaching agent state.
 		const dispatched = await Promise.race([
 			promptPromise.then(
 				() => dispatchObserver.wasObserved() || this.agent.state.messages.includes(message),

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5467,6 +5467,38 @@ export class AgentSession {
 		return this._followUpMessages.map((message) => createQueuedAgentInputSnapshot(message));
 	}
 
+	private _notifySessionInputCheckpointChange(): void {
+		for (const resolve of this._sessionInputCheckpointWaiters) resolve();
+		this._sessionInputCheckpointWaiters.clear();
+	}
+
+	async waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void> {
+		while (
+			this._activeSessionInput?.kind === "command" ||
+			(this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing")
+		) {
+			if (signal?.aborted) throw new Error("Update restart preparation cancelled");
+			await new Promise<void>((resolve, reject) => {
+				const onChange = () => {
+					cleanup();
+					resolve();
+				};
+				const onAbort = () => {
+					cleanup();
+					reject(new Error("Update restart preparation cancelled"));
+				};
+				const cleanup = () => {
+					this._sessionInputCheckpointWaiters.delete(onChange);
+					signal?.removeEventListener("abort", onAbort);
+				};
+				this._sessionInputCheckpointWaiters.add(onChange);
+				signal?.addEventListener("abort", onAbort, { once: true });
+			});
+		}
+		if (signal?.aborted) throw new Error("Update restart preparation cancelled");
+		this.sessionManager.flushNow();
+	}
+
 	acquireQueuedWorkPause(): { release(): void } {
 		const token = Symbol("queued-work-pause");
 		this._queuedWorkPauses.add(token);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4922,6 +4922,7 @@ export class AgentSession {
 						queue.shift();
 						this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
 						this._syncSteeringStopPending();
+						this._notifySessionInputCheckpointChange();
 						this._emitQueueUpdate();
 						try {
 							await this._executeQueuedSessionCommand(first);
@@ -4930,7 +4931,11 @@ export class AgentSession {
 							this._rejectAgentMessage(first.agentMessageId, this._asError(error));
 						} finally {
 							this._activeSessionInput = undefined;
+<<<<<<< HEAD
 							this._syncSteeringStopPending();
+=======
+							this._notifySessionInputCheckpointChange();
+>>>>>>> ca6ec2cc9 (feat(daemon): checkpoint session inputs for restart)
 						}
 						continue;
 					}
@@ -4944,13 +4949,25 @@ export class AgentSession {
 						this._syncSteeringStopPending();
 						return;
 					}
-					this._activeSessionInput = { kind: "prompt", lane, items: prompts, phase: "preparing" };
+					this._activeSessionInput = {
+						kind: "prompt",
+						lane,
+						items: prompts,
+						phase: "preparing",
+						checkpointInputMessages: new Set(prompts.map((prompt) => prompt.message)),
+						persistedInputMessages: new Set(),
+					};
 					this._syncSteeringStopPending();
+					this._notifySessionInputCheckpointChange();
 					this._emitQueueUpdate();
 					try {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
 						for (const prompt of prompts) {
 							this._settleAgentMessage(prompt.agentMessageId, "completion");
+						}
+						if (this._activeSessionInput?.kind === "prompt") {
+							this._activeSessionInput.phase = "handedOff";
+							this._notifySessionInputCheckpointChange();
 						}
 					} catch (error) {
 						const delivered = new Set(this.agent.state.messages);
@@ -4979,6 +4996,7 @@ export class AgentSession {
 					} finally {
 						this._activeSessionInput = undefined;
 						this._syncSteeringStopPending();
+						this._notifySessionInputCheckpointChange();
 					}
 				} finally {
 					admission.release();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4166,18 +4166,30 @@ export class AgentSession {
 			return;
 		}
 
+		if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
+		const promptPromise = options?.suppressAutonomousContinuation
+			? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
+			: this.agent.prompt(messages);
+		releaseAdmission();
+		// Settle the preflight outcome at the handoff, exactly like the direct path:
+		// the direct-prompt section must not fence checkpoints for the whole turn,
+		// and a rejected dispatch must still release it.
+		const dispatched = await Promise.race([
+			promptPromise.then(
+				() => true,
+				() => false,
+			),
+			new Promise<true>((resolve) => {
+				setTimeout(() => resolve(true), 0);
+			}),
+		]);
+		reportPreflight(dispatched);
 		try {
-			if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
-			const promptPromise = options?.suppressAutonomousContinuation
-				? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
-				: this.agent.prompt(messages);
-			releaseAdmission();
 			await promptPromise;
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
 			throw error;
 		}
-		reportPreflight(true);
 		await this.waitForRetry();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5579,7 +5579,10 @@ export class AgentSession {
 	}
 
 	async waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void> {
-		while (this._activeSessionInput !== undefined || this._directPromptSectionCount > 0) {
+		while (
+			(this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing") ||
+			this._directPromptSectionCount > 0
+		) {
 			if (signal?.aborted) throw new Error("Update restart preparation cancelled");
 			await new Promise<void>((resolve, reject) => {
 				const onChange = () => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4068,14 +4068,26 @@ export class AgentSession {
 		});
 	}
 
-	private _observeDirectDispatch(message: AgentMessage): { observed: Promise<true>; stop(): void } {
+	private _observeDirectDispatch(message: AgentMessage): {
+		observed: Promise<true>;
+		wasObserved(): boolean;
+		stop(): void;
+	} {
+		let fired = false;
 		let observer!: { message: AgentMessage; resolve: () => void };
 		const observed = new Promise<true>((resolve) => {
-			observer = { message, resolve: () => resolve(true) };
+			observer = {
+				message,
+				resolve: () => {
+					fired = true;
+					resolve(true);
+				},
+			};
 		});
 		this._directDispatchObservers.add(observer);
 		return {
 			observed,
+			wasObserved: () => fired,
 			stop: () => this._directDispatchObservers.delete(observer),
 		};
 	}
@@ -4231,10 +4243,13 @@ export class AgentSession {
 		// Settle the preflight outcome at the handoff, not after the whole turn: the
 		// direct-prompt section must keep fencing update-restart checkpoints until
 		// message_start proves the input reached the run's event stream, and a
-		// rejected dispatch must still release the section.
+		// rejected dispatch must still release the section. A resolved prompt is
+		// not proof by itself: Agent.prompt() converts lifecycle failures into a
+		// synthetic error turn, so on resolution confirm the message reached
+		// agent state before releasing the checkpoint fence.
 		const dispatched = await Promise.race([
 			promptPromise.then(
-				() => true,
+				() => dispatchObserver.wasObserved() || this.agent.state.messages.includes(message),
 				() => false,
 			),
 			dispatchObserver.observed,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1001,6 +1001,8 @@ export class AgentSession {
 		| { kind: "command"; lane: SessionInputSchedule; item: PreparedCommandInput; phase: "executing" }
 		| undefined;
 	private readonly _sessionInputCheckpointWaiters = new Set<() => void>();
+	/** Direct prompts between admission and agent handoff; restart checkpoints wait for zero. */
+	private _directPromptSectionCount = 0;
 	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
@@ -4058,7 +4060,12 @@ export class AgentSession {
 		options: InternalPromptOptions | undefined,
 		releaseAdmission: () => void,
 	): Promise<void> {
-		const reportPreflight = oncePreflight(options?.preflightResult);
+		const endDirectPromptSection = this._enterDirectPromptSection();
+		const reportInput = oncePreflight(options?.preflightResult);
+		const reportPreflight: typeof reportInput = (success, queued) => {
+			endDirectPromptSection();
+			reportInput(success, queued);
+		};
 
 		let messages: AgentMessage[] | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
@@ -4124,6 +4131,7 @@ export class AgentSession {
 		}
 
 		if (!messages) {
+			endDirectPromptSection();
 			return;
 		}
 
@@ -4208,7 +4216,12 @@ export class AgentSession {
 	): Promise<void> {
 		const isInternalPrompt = options?.internalPrompt === true;
 		const expandPromptTemplates = isInternalPrompt ? false : (options?.expandPromptTemplates ?? true);
-		const reportPreflight = oncePreflight(options?.preflightResult);
+		const endDirectPromptSection = this._enterDirectPromptSection();
+		const reportInput = oncePreflight(options?.preflightResult);
+		const reportPreflight: typeof reportInput = (success, queued) => {
+			endDirectPromptSection();
+			reportInput(success, queued);
+		};
 		let messages: AgentMessage[] | undefined;
 		let acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
@@ -4423,6 +4436,7 @@ export class AgentSession {
 		}
 
 		if (!messages) {
+			endDirectPromptSection();
 			return;
 		}
 
@@ -5468,8 +5482,25 @@ export class AgentSession {
 		this._sessionInputCheckpointWaiters.clear();
 	}
 
+	/**
+	 * Marks a direct prompt as being between admission and its preflight outcome
+	 * (queued, handed off to the agent, or failed). Restart checkpoints wait for
+	 * these sections so an accepted input cannot fall between the queue snapshot
+	 * and the transcript flush.
+	 */
+	private _enterDirectPromptSection(): () => void {
+		this._directPromptSectionCount++;
+		let ended = false;
+		return () => {
+			if (ended) return;
+			ended = true;
+			this._directPromptSectionCount--;
+			this._notifySessionInputCheckpointChange();
+		};
+	}
+
 	async waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void> {
-		while (this._activeSessionInput !== undefined) {
+		while (this._activeSessionInput !== undefined || this._directPromptSectionCount > 0) {
 			if (signal?.aborted) throw new Error("Update restart preparation cancelled");
 			await new Promise<void>((resolve, reject) => {
 				const onChange = () => {
@@ -5489,6 +5520,9 @@ export class AgentSession {
 			});
 		}
 		if (signal?.aborted) throw new Error("Update restart preparation cancelled");
+		// Handed-off inputs reach the transcript through the event queue; drain it so
+		// the flush below persists them before the snapshot is taken.
+		await this._agentEventQueue;
 		this.sessionManager.flushNow();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4041,6 +4041,18 @@ export class AgentSession {
 		});
 	}
 
+	private _observeDirectDispatch(message: AgentMessage): { observed: Promise<true>; stop(): void } {
+		let observer!: { message: AgentMessage; resolve: () => void };
+		const observed = new Promise<true>((resolve) => {
+			observer = { message, resolve: () => resolve(true) };
+		});
+		this._directDispatchObservers.add(observer);
+		return {
+			observed,
+			stop: () => this._directDispatchObservers.delete(observer),
+		};
+	}
+
 	private async _promptInjectedMessage(
 		text: string,
 		message: CustomMessage,
@@ -4184,11 +4196,7 @@ export class AgentSession {
 		if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
 		// Register the observer before dispatch so a synchronously-emitted
 		// message_start cannot be missed.
-		let observer: { message: AgentMessage; resolve: () => void } | undefined;
-		const observed = new Promise<true>((resolve) => {
-			observer = { message, resolve: () => resolve(true) };
-		});
-		if (observer) this._directDispatchObservers.add(observer);
+		const dispatchObserver = this._observeDirectDispatch(message);
 		const promptPromise = options?.suppressAutonomousContinuation
 			? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
 			: this.agent.prompt(messages);
@@ -4202,9 +4210,9 @@ export class AgentSession {
 				() => true,
 				() => false,
 			),
-			observed,
+			dispatchObserver.observed,
 		]);
-		if (observer) this._directDispatchObservers.delete(observer);
+		dispatchObserver.stop();
 		reportPreflight(dispatched);
 		try {
 			await promptPromise;
@@ -4257,6 +4265,7 @@ export class AgentSession {
 			reportInput(success, queued);
 		};
 		let messages: AgentMessage[] | undefined;
+		let primaryPromptMessage: QueuedAgentMessage | undefined;
 		let acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
 		let expandedText = text;
@@ -4393,14 +4402,14 @@ export class AgentSession {
 					messages.push(msg);
 				}
 				this._pendingNextTurnMessages = [];
-				const promptMessage: QueuedAgentMessage = options.customMessage
+				primaryPromptMessage = options.customMessage
 					? cloneCustomMessage(options.customMessage)
 					: {
 							role: "user",
 							content: buildUserContent(),
 							timestamp: Date.now(),
 						};
-				messages.push(promptMessage);
+				messages.push(primaryPromptMessage);
 				if (options.agentMessageId !== undefined && options.returnAfterAccepted) {
 					let resolveAccepted = () => {};
 					let rejectAccepted = (_error: Error) => {};
@@ -4411,8 +4420,8 @@ export class AgentSession {
 					acceptedAgentMessagePrompt = {
 						text: expandedText,
 						agentMessageId: options.agentMessageId,
-						message: promptMessage,
-						messages: new Set<AgentMessage>([...drainedNextTurnMessages, promptMessage]),
+						message: primaryPromptMessage,
+						messages: new Set<AgentMessage>([...drainedNextTurnMessages, primaryPromptMessage]),
 						pendingNextTurnMessages: drainedNextTurnMessages,
 						deliveredPendingNextTurnMessages: new Set(),
 						accepted,
@@ -4439,15 +4448,14 @@ export class AgentSession {
 				}
 				this._pendingNextTurnMessages = [];
 
-				if (options?.customMessage) {
-					messages.push(cloneCustomMessage(options.customMessage));
-				} else {
-					messages.push({
-						role: "user",
-						content: buildUserContent(),
-						timestamp: Date.now(),
-					});
-				}
+				primaryPromptMessage = options?.customMessage
+					? cloneCustomMessage(options.customMessage)
+					: {
+							role: "user",
+							content: buildUserContent(),
+							timestamp: Date.now(),
+						};
+				messages.push(primaryPromptMessage);
 
 				// Emit before_agent_start extension event
 				basePromptSnapshot = this._baseSystemPrompt;
@@ -4530,6 +4538,13 @@ export class AgentSession {
 				this._markAutonomousContinuationSuppressed(message);
 			}
 		}
+		if (!primaryPromptMessage) {
+			reportPreflight(false);
+			throw new Error("Direct prompt is missing its primary message");
+		}
+		const dispatchObserver = acceptedAgentMessagePrompt
+			? undefined
+			: this._observeDirectDispatch(primaryPromptMessage);
 		const promptPromise = options?.suppressAutonomousContinuation
 			? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
 			: this.agent.prompt(messages);
@@ -4540,9 +4555,7 @@ export class AgentSession {
 					() => promptAccepted,
 					(error: unknown) => error,
 				)
-			: new Promise<typeof promptAccepted>((resolve) => {
-					setTimeout(() => resolve(promptAccepted), 0);
-				});
+			: dispatchObserver!.observed.then(() => promptAccepted);
 		const firstOutcome = await Promise.race([
 			promptPromise.then(
 				() => undefined,
@@ -4550,6 +4563,7 @@ export class AgentSession {
 			),
 			acceptance,
 		]);
+		dispatchObserver?.stop();
 		if (firstOutcome !== undefined && firstOutcome !== promptAccepted) {
 			// A cleared prompt stays set until the aborted run's agent_end cleanup nulls it;
 			// nulling here would let the run's late events re-persist cleared messages.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1003,6 +1003,8 @@ export class AgentSession {
 	private readonly _sessionInputCheckpointWaiters = new Set<() => void>();
 	/** Direct prompts between admission and agent handoff; restart checkpoints wait for zero. */
 	private _directPromptSectionCount = 0;
+	/** One-shot waiters resolved when a dispatched message reaches message_start. */
+	private _directDispatchObservers = new Set<{ messages: ReadonlySet<AgentMessage>; resolve: () => void }>();
 	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
@@ -3039,6 +3041,12 @@ export class AgentSession {
 					? this._activeSessionInput.items.find((input) => input.message === event.message)
 					: undefined;
 			this._settleAgentMessage(activeInput?.agentMessageId, "delivery");
+			for (const observer of this._directDispatchObservers) {
+				if (observer.messages.has(event.message)) {
+					this._directDispatchObservers.delete(observer);
+					observer.resolve();
+				}
+			}
 		}
 		this._agentEventQueue = this._agentEventQueue.then(
 			() => this._processAgentEvent(event),
@@ -4155,34 +4163,49 @@ export class AgentSession {
 					"Agent became busy before prompt delivery. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
 				);
 			}
-			await this._queueWithPendingNextTurnMessages(text, options.streamingBehavior, reportPreflight, {
-				message,
-				queueKey: options.followUpQueueKey,
-				previewLabel,
-				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-				resumeIfIdle: options.resumeIfIdle,
-			});
+			try {
+				await this._queueWithPendingNextTurnMessages(text, options.streamingBehavior, reportPreflight, {
+					message,
+					queueKey: options.followUpQueueKey,
+					previewLabel,
+					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+					resumeIfIdle: options.resumeIfIdle,
+				});
+			} catch (error) {
+				// A failed enqueue must still settle the preflight outcome, or the
+				// direct-prompt section would fence checkpoints forever.
+				reportPreflight(false);
+				throw error;
+			}
 
 			return;
 		}
 
 		if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
+		// Register the observer before dispatch so a synchronously-emitted
+		// message_start cannot be missed.
+		const dispatchedMessages: ReadonlySet<AgentMessage> = new Set(messages);
+		let observer: { messages: ReadonlySet<AgentMessage>; resolve: () => void } | undefined;
+		const observed = new Promise<true>((resolve) => {
+			observer = { messages: dispatchedMessages, resolve: () => resolve(true) };
+		});
+		if (observer) this._directDispatchObservers.add(observer);
 		const promptPromise = options?.suppressAutonomousContinuation
 			? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
 			: this.agent.prompt(messages);
 		releaseAdmission();
-		// Settle the preflight outcome at the handoff, exactly like the direct path:
-		// the direct-prompt section must not fence checkpoints for the whole turn,
-		// and a rejected dispatch must still release it.
+		// Settle the preflight outcome at the handoff, not after the whole turn: the
+		// direct-prompt section must keep fencing update-restart checkpoints until
+		// message_start proves the input reached the run's event stream, and a
+		// rejected dispatch must still release the section.
 		const dispatched = await Promise.race([
 			promptPromise.then(
 				() => true,
 				() => false,
 			),
-			new Promise<true>((resolve) => {
-				setTimeout(() => resolve(true), 0);
-			}),
+			observed,
 		]);
+		if (observer) this._directDispatchObservers.delete(observer);
 		reportPreflight(dispatched);
 		try {
 			await promptPromise;
@@ -4485,14 +4508,21 @@ export class AgentSession {
 					"Agent became busy before prompt delivery. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
 				);
 			}
-			await this._queueWithPendingNextTurnMessages(expandedText, options.streamingBehavior, reportPreflight, {
-				images: currentImages,
-				queueKey: options.followUpQueueKey,
-				agentMessageId: options.agentMessageId,
-				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-				message: options.customMessage,
-				resumeIfIdle: options.resumeIfIdle,
-			});
+			try {
+				await this._queueWithPendingNextTurnMessages(expandedText, options.streamingBehavior, reportPreflight, {
+					images: currentImages,
+					queueKey: options.followUpQueueKey,
+					agentMessageId: options.agentMessageId,
+					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+					message: options.customMessage,
+					resumeIfIdle: options.resumeIfIdle,
+				});
+			} catch (error) {
+				// A failed enqueue must still settle the preflight outcome, or the
+				// direct-prompt section would fence checkpoints forever.
+				reportPreflight(false);
+				throw error;
+			}
 
 			return;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -996,8 +996,6 @@ export class AgentSession {
 				lane: SessionInputSchedule;
 				items: PreparedPromptInput[];
 				phase: "preparing" | "handedOff";
-				checkpointInputMessages: Set<AgentMessage>;
-				persistedInputMessages: Set<AgentMessage>;
 				cancelled?: boolean;
 		  }
 		| { kind: "command"; lane: SessionInputSchedule; item: PreparedCommandInput; phase: "executing" }
@@ -3188,20 +3186,6 @@ export class AgentSession {
 				this.sessionManager.appendMessage(event.message);
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
-			if (this._activeSessionInput?.kind === "prompt") {
-				const activeInput = this._activeSessionInput;
-				if (activeInput.checkpointInputMessages.has(event.message)) {
-					activeInput.persistedInputMessages.add(event.message);
-					if (
-						[...activeInput.checkpointInputMessages].every((message) =>
-							activeInput.persistedInputMessages.has(message),
-						)
-					) {
-						activeInput.phase = "handedOff";
-						this._notifySessionInputCheckpointChange();
-					}
-				}
-			}
 
 			// Track assistant message for auto-compaction (checked on agent_end)
 			if (event.message.role === "assistant") {
@@ -4971,8 +4955,6 @@ export class AgentSession {
 						lane,
 						items: prompts,
 						phase: "preparing",
-						checkpointInputMessages: new Set(prompts.map((prompt) => prompt.message)),
-						persistedInputMessages: new Set(),
 					};
 					this._syncSteeringStopPending();
 					this._notifySessionInputCheckpointChange();
@@ -4981,10 +4963,6 @@ export class AgentSession {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
 						for (const prompt of prompts) {
 							this._settleAgentMessage(prompt.agentMessageId, "completion");
-						}
-						if (this._activeSessionInput?.kind === "prompt") {
-							this._activeSessionInput.phase = "handedOff";
-							this._notifySessionInputCheckpointChange();
 						}
 					} catch (error) {
 						const delivered = new Set(this.agent.state.messages);
@@ -5159,6 +5137,7 @@ export class AgentSession {
 			releaseAdmission();
 			await promptPromise;
 			await this.waitForRetry();
+			await this._agentEventQueue;
 			this._forgetConsumedPostCompactionContinuations(prompts.map((prompt) => prompt.message));
 		} catch (error) {
 			const delivered = new Set(this.agent.state.messages);
@@ -5490,10 +5469,7 @@ export class AgentSession {
 	}
 
 	async waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void> {
-		while (
-			this._activeSessionInput?.kind === "command" ||
-			(this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing")
-		) {
+		while (this._activeSessionInput !== undefined) {
 			if (signal?.aborted) throw new Error("Update restart preparation cancelled");
 			await new Promise<void>((resolve, reject) => {
 				const onChange = () => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5216,7 +5216,6 @@ export class AgentSession {
 			result?.systemPrompt !== undefined && preparation !== undefined
 				? this._refreshExtensionSystemPrompt(result.systemPrompt, preparation.basePromptSnapshot)
 				: this._baseSystemPrompt;
-		if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 		try {
 			if (this.isStreaming) {
 				// agent.prompt() would reject with its already-processing error; defer instead.
@@ -5225,6 +5224,7 @@ export class AgentSession {
 			if (this._activeSessionInput?.kind === "prompt") {
 				this._activeSessionInput.phase = "handedOff";
 				this._syncSteeringStopPending();
+				this._notifySessionInputCheckpointChange();
 			}
 			const promptPromise = this.agent.prompt(messages);
 			releaseAdmission();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1004,7 +1004,7 @@ export class AgentSession {
 	/** Direct prompts between admission and agent handoff; restart checkpoints wait for zero. */
 	private _directPromptSectionCount = 0;
 	/** One-shot waiters resolved when a dispatched message reaches message_start. */
-	private _directDispatchObservers = new Set<{ messages: ReadonlySet<AgentMessage>; resolve: () => void }>();
+	private _directDispatchObservers = new Set<{ message: AgentMessage; resolve: () => void }>();
 	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
@@ -3042,7 +3042,7 @@ export class AgentSession {
 					: undefined;
 			this._settleAgentMessage(activeInput?.agentMessageId, "delivery");
 			for (const observer of this._directDispatchObservers) {
-				if (observer.messages.has(event.message)) {
+				if (observer.message === event.message) {
 					this._directDispatchObservers.delete(observer);
 					observer.resolve();
 				}
@@ -4184,10 +4184,9 @@ export class AgentSession {
 		if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
 		// Register the observer before dispatch so a synchronously-emitted
 		// message_start cannot be missed.
-		const dispatchedMessages: ReadonlySet<AgentMessage> = new Set(messages);
-		let observer: { messages: ReadonlySet<AgentMessage>; resolve: () => void } | undefined;
+		let observer: { message: AgentMessage; resolve: () => void } | undefined;
 		const observed = new Promise<true>((resolve) => {
-			observer = { messages: dispatchedMessages, resolve: () => resolve(true) };
+			observer = { message, resolve: () => resolve(true) };
 		});
 		if (observer) this._directDispatchObservers.add(observer);
 		const promptPromise = options?.suppressAutonomousContinuation

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -763,6 +763,16 @@ export class AgentCronJobStore {
 		return recovered;
 	}
 
+	recoverInterruptedDispatchesById(dispatchIds: readonly string[], now = new Date()): AgentCronJob[] {
+		const recovered: AgentCronJob[] = [];
+		const interruptedDispatchIds = new Set(dispatchIds);
+		this.mutateStates((state) => {
+			recoverInterruptedInState(state, now, recovered, interruptedDispatchIds);
+			return [];
+		});
+		return recovered;
+	}
+
 	getDueJob(id: string, now = new Date()): AgentCronJob | undefined {
 		return this.readJobs().find((job) => job.id === id && isDueJob(job, now));
 	}
@@ -962,12 +972,20 @@ export class AgentCronScheduler {
 		}
 		this.running = true;
 		const dispatches: Array<{ dispatch: AgentCronDispatch; endDispatch?: () => void }> = [];
+		let claimedDispatches: AgentCronDispatch[] | undefined;
 		try {
-			for (const dispatch of this.store.claimDue(now, this.now())) {
+			claimedDispatches = this.store.claimDue(now, this.now());
+			for (const dispatch of claimedDispatches) {
 				dispatches.push({ dispatch, endDispatch: this.hooks.beginDispatch?.(dispatch) });
 			}
 		} catch (error) {
 			for (const claimed of dispatches) claimed.endDispatch?.();
+			if (claimedDispatches) {
+				this.store.recoverInterruptedDispatchesById(
+					claimedDispatches.map((dispatch) => dispatch.id),
+					this.now(),
+				);
+			}
 			throw error;
 		} finally {
 			this.running = false;
@@ -1581,12 +1599,20 @@ function claimDueInState(state: CronJobsState, dueAt: Date, claimedAt: Date): Ag
 	return dispatches;
 }
 
-function recoverInterruptedInState(state: CronJobsState, now: Date, recovered: AgentCronJob[]): void {
-	if (state.dispatches.length === 0) {
+function recoverInterruptedInState(
+	state: CronJobsState,
+	now: Date,
+	recovered: AgentCronJob[],
+	dispatchIds?: ReadonlySet<string>,
+): void {
+	const interrupted = dispatchIds
+		? state.dispatches.filter((dispatch) => dispatchIds.has(dispatch.id))
+		: state.dispatches;
+	if (interrupted.length === 0) {
 		return;
 	}
-	const interruptedIds = new Set(state.dispatches.map((dispatch) => dispatch.jobId));
-	state.dispatches = [];
+	const interruptedIds = new Set(interrupted.map((dispatch) => dispatch.jobId));
+	state.dispatches = dispatchIds ? state.dispatches.filter((dispatch) => !dispatchIds.has(dispatch.id)) : [];
 	state.jobs = state.jobs.map((job) => {
 		if (!interruptedIds.has(job.id) || job.status !== "active") {
 			return job;

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -77,6 +77,7 @@ export interface AgentCronDispatch {
 
 export interface AgentCronSchedulerHooks {
 	runJob: (job: AgentCronJob) => Promise<AgentCronJobRunResult | undefined>;
+	beginDispatch?: (dispatch: AgentCronDispatch) => (() => void) | undefined;
 	now?: () => Date;
 	onError?: (job: AgentCronJob, error: unknown) => void;
 }
@@ -956,48 +957,62 @@ export class AgentCronScheduler {
 	}
 
 	async runDue(now = this.now()): Promise<number> {
-		if (this.running) {
+		if (this.running || (this.stopped && this.hasStarted)) {
 			return 0;
 		}
 		this.running = true;
-		let dispatches: AgentCronDispatch[] = [];
+		const dispatches: Array<{ dispatch: AgentCronDispatch; endDispatch?: () => void }> = [];
 		try {
-			dispatches = this.store.claimDue(now, this.now());
+			for (const dispatch of this.store.claimDue(now, this.now())) {
+				dispatches.push({ dispatch, endDispatch: this.hooks.beginDispatch?.(dispatch) });
+			}
+		} catch (error) {
+			for (const claimed of dispatches) claimed.endDispatch?.();
+			throw error;
 		} finally {
 			this.running = false;
 			if (!this.stopped) {
 				this.scheduleNext();
 			}
 		}
-		const results = await Promise.all(dispatches.map((dispatch) => this.queueDispatch(dispatch)));
+		const results = await Promise.all(
+			dispatches.map(({ dispatch, endDispatch }) => this.queueDispatch(dispatch, endDispatch)),
+		);
 		return results.filter((result) => result !== "skipped").length;
 	}
 
-	private queueDispatch(dispatch: AgentCronDispatch): Promise<AgentCronJobRunResult | undefined> {
+	private queueDispatch(
+		dispatch: AgentCronDispatch,
+		endDispatch?: () => void,
+	): Promise<AgentCronJobRunResult | undefined> {
 		const laneKey = dispatch.job.activeSessionId;
 		const previous = this.dispatchLanes.get(laneKey) ?? Promise.resolve();
 		const task = previous
 			.catch(() => undefined)
 			.then(async (): Promise<AgentCronJobRunResult | undefined> => {
-				const job = this.store.getClaimedJob(dispatch.job.id);
-				if (!job) {
-					this.store.recordDispatchResult(dispatch.id, { now: this.now(), outcome: "skipped" });
-					return "skipped";
-				}
-				let runResult: AgentCronJobRunResult | undefined;
-				let error: unknown;
 				try {
-					runResult = await this.hooks.runJob(job);
-				} catch (runError) {
-					error = runError;
-					this.hooks.onError?.(job, runError);
+					const job = this.store.getClaimedJob(dispatch.job.id);
+					if (!job) {
+						this.store.recordDispatchResult(dispatch.id, { now: this.now(), outcome: "skipped" });
+						return "skipped";
+					}
+					let runResult: AgentCronJobRunResult | undefined;
+					let error: unknown;
+					try {
+						runResult = await this.hooks.runJob(job);
+					} catch (runError) {
+						error = runError;
+						this.hooks.onError?.(job, runError);
+					}
+					this.store.recordDispatchResult(dispatch.id, {
+						now: this.now(),
+						outcome: runResult === "skipped" && error === undefined ? "skipped" : "ran",
+						error,
+					});
+					return runResult;
+				} finally {
+					endDispatch?.();
 				}
-				this.store.recordDispatchResult(dispatch.id, {
-					now: this.now(),
-					outcome: runResult === "skipped" && error === undefined ? "skipped" : "ran",
-					error,
-				});
-				return runResult;
 			});
 		const lane = task.then(
 			() => undefined,

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -59,15 +59,21 @@ export class CommandRecoveryJournal {
 		this.load();
 	}
 
-	begin(clientId: DaemonClientId, commandId: DaemonCommandId, commandType: string): CommandJournalBeginResult {
-		const key = createCommandIdempotencyKey(clientId, commandId);
-		const existing = this.entries.get(key);
+	lookup(
+		clientId: DaemonClientId,
+		commandId: DaemonCommandId,
+	): Exclude<CommandJournalBeginResult, { status: "new" }> | undefined {
+		const existing = this.entries.get(createCommandIdempotencyKey(clientId, commandId));
 		if (existing?.response) {
 			return { status: "complete", response: existing.response };
 		}
-		if (existing) {
-			return { status: "pending" };
-		}
+		return existing ? { status: "pending" } : undefined;
+	}
+
+	begin(clientId: DaemonClientId, commandId: DaemonCommandId, commandType: string): CommandJournalBeginResult {
+		const key = createCommandIdempotencyKey(clientId, commandId);
+		const existing = this.lookup(clientId, commandId);
+		if (existing) return existing;
 		const received: ReceivedRecord = {
 			version: 1,
 			type: "received",

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -414,7 +414,7 @@ export class AgentDaemon {
 		owner?: DaemonSocketClient;
 		abort: AbortController;
 		deadline?: ReturnType<typeof setTimeout>;
-		phase: "preparing" | "prepared" | "publishing";
+		phase: "preparing" | "fencing" | "prepared" | "publishing";
 		manifest?: DaemonUpdateRestartManifest;
 	};
 	private ownsSocketPath = false;
@@ -2643,6 +2643,9 @@ export class AgentDaemon {
 
 		const mutation = command.type !== "prepare_update_restart" && isDaemonMutatingCommand(command);
 		const restartPhase = this.updateRestart?.phase;
+		// Mirror the supervisor's drain/fence split: abort-style commands stay
+		// admitted only while mutations drain; once the checkpoint is being
+		// captured they could race the snapshot and are rejected too.
 		const restartRejected =
 			restartPhase === "preparing"
 				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
@@ -2742,7 +2745,7 @@ export class AgentDaemon {
 				}
 				case "worker_commit_update": {
 					const transaction = this.updateRestart;
-					if (!transaction || transaction.phase === "preparing") {
+					if (!transaction || transaction.phase === "preparing" || transaction.phase === "fencing") {
 						throw new Error("Daemon has no prepared update checkpoint");
 					}
 					if (transaction.phase === "publishing") {
@@ -4613,6 +4616,8 @@ export class AgentDaemon {
 	): Promise<DaemonUpdateRestartManifest> {
 		try {
 			await this.mutationDrain.waitForDrain(0, transaction.abort.signal, "Update restart preparation cancelled");
+			this.assertUpdateRestartNotCancelled(transaction);
+			transaction.phase = "fencing";
 			const manifest = await this.prepareUpdateRestartCheckpoint(transaction);
 			this.assertUpdateRestartNotCancelled(transaction);
 			transaction.manifest = manifest;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2581,7 +2581,10 @@ export class AgentDaemon {
 						claimCheck,
 						parsedAdmission?.controller?.signal,
 					);
-					if (this.supervisorClaims.get(client) !== boundClaim || client.socket.destroyed) return;
+					if (this.supervisorClaims.get(client) !== boundClaim || client.socket.destroyed) {
+						clearParsedAdmission();
+						return;
+					}
 					boundClaim.ownerFingerprint = ownerFingerprint;
 				} catch (error) {
 					const admissionCancelled = error instanceof DaemonPromptAdmissionCancelledError;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -629,11 +629,13 @@ export class AgentDaemon {
 		return this.supervisorClaims.size > 0;
 	}
 
-	private revokeSupervisorClaim(client: DaemonSocketClient): void {
-		this.supervisorClaims.delete(client);
+	private revokeSupervisorClaim(client: DaemonSocketClient, expected?: BoundSupervisorGenerationClaim): boolean {
+		if (expected && this.supervisorClaims.get(client) !== expected) return false;
+		if (!this.supervisorClaims.delete(client)) return false;
 		if (this.options.worker && this.updateRestart?.owner === client) {
 			this.cancelPreparedUpdateRestart(this.updateRestart.id);
 		}
+		return true;
 	}
 
 	private clearSupervisorAvailabilityCheck(): void {
@@ -665,8 +667,7 @@ export class AgentDaemon {
 					boundClaim.ownerFingerprint,
 				);
 			} catch {
-				this.revokeSupervisorClaim(client);
-				client.socket.end();
+				if (this.revokeSupervisorClaim(client, boundClaim)) client.socket.end();
 			}
 		}
 		this.scheduleSupervisorFenceCheck();
@@ -2603,8 +2604,7 @@ export class AgentDaemon {
 					);
 					// Cancelling this prompt only abandons its admission wait. A genuine
 					// stale supervisor claim fences only the binding that it checked.
-					if (!admissionCancelled && this.supervisorClaims.get(client) === boundClaim) {
-						this.revokeSupervisorClaim(client);
+					if (!admissionCancelled && this.revokeSupervisorClaim(client, boundClaim)) {
 						client.socket.end();
 					}
 					return;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -179,6 +179,7 @@ import {
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
+import { MutationDrainLatch } from "./mutation-drain-latch.js";
 import {
 	createSnapshotTranscriptChunks,
 	SNAPSHOT_TARGET_CHUNK_BYTES,
@@ -406,18 +407,16 @@ export async function runDaemonMode(options: DaemonModeOptions): Promise<never> 
 export class AgentDaemon {
 	private server?: Server;
 	private shuttingDown = false;
-	private updateRestartPreparing = false;
 	private readonly updateRestartQueuePauses = new Map<string, { release(): void }>();
-	private activeMutations = 0;
-	private readonly mutationDrainWaiters = new Set<() => void>();
-	private updateRestartTransaction?: {
+	private readonly mutationDrain = new MutationDrainLatch();
+	private updateRestart?: {
 		id: symbol;
 		owner?: DaemonSocketClient;
 		abort: AbortController;
 		deadline?: ReturnType<typeof setTimeout>;
+		phase: "preparing" | "prepared" | "publishing";
+		manifest?: DaemonUpdateRestartManifest;
 	};
-	private updateRestartPublishing?: symbol;
-	private preparedUpdateRestart?: { id: symbol; manifest: DaemonUpdateRestartManifest };
 	private ownsSocketPath = false;
 	private socketIdentity?: DaemonSocketIdentity;
 	private readonly clients = new Set<DaemonSocketClient>();
@@ -1235,7 +1234,7 @@ export class AgentDaemon {
 	}
 
 	private async runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> {
-		if (this.updateRestartPreparing) {
+		if (this.updateRestart) {
 			return "skipped";
 		}
 		const requirePersistedJob = this.cronStore.list().some((candidate) => candidate.id === job.id);
@@ -1248,7 +1247,7 @@ export class AgentDaemon {
 		if (
 			!state ||
 			!runnableJob ||
-			this.updateRestartPreparing ||
+			this.updateRestart !== undefined ||
 			!this.isCronJobRunnableForState(runnableJob, state, requirePersistedJob)
 		) {
 			return "skipped";
@@ -1662,7 +1661,7 @@ export class AgentDaemon {
 		job: AgentCronJob,
 		requirePersistedJob: boolean,
 	): Promise<ActiveSessionState | undefined> {
-		if (this.updateRestartPreparing) {
+		if (this.updateRestart) {
 			return undefined;
 		}
 		const dueJob = requirePersistedJob ? this.getRunnableCronJob(job.id) : job;
@@ -2420,8 +2419,8 @@ export class AgentDaemon {
 			client.detachInput();
 			this.clients.delete(client);
 			this.supervisorClaims.delete(client);
-			if (this.options.worker && this.updateRestartTransaction?.owner === client) {
-				this.cancelPreparedUpdateRestart(this.updateRestartTransaction.id);
+			if (this.options.worker && this.updateRestart?.owner === client) {
+				this.cancelPreparedUpdateRestart(this.updateRestart.id);
 			}
 			const supervisorSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			if (this.options.worker && client.authenticated === true && supervisorSocketPath) {
@@ -2614,18 +2613,18 @@ export class AgentDaemon {
 					workerCommand.type === "worker_prepare_update" ||
 					workerCommand.type === "worker_commit_update" ||
 					workerCommand.type === "worker_cancel_update";
-				if (this.updateRestartPreparing && !updateLifecycle) {
+				if (this.updateRestart && !updateLifecycle) {
 					this.write(
 						client,
 						failure(workerCommand.id, workerCommand.type, "Daemon is preparing an update restart"),
 					);
 					return;
 				}
-				if (!updateLifecycle) this.beginMutation();
+				if (!updateLifecycle) this.mutationDrain.begin();
 				try {
 					await this.handleWorkerCommand(client, workerCommand);
 				} finally {
-					if (!updateLifecycle) this.endMutation();
+					if (!updateLifecycle) this.mutationDrain.end();
 				}
 				return;
 			}
@@ -2643,20 +2642,16 @@ export class AgentDaemon {
 		}
 
 		const mutation = command.type !== "prepare_update_restart" && isDaemonMutatingCommand(command);
-		if (
-			mutation &&
-			this.updateRestartPreparing &&
-			(command.type !== "shutdown" || !this.preparedUpdateRestart) &&
-			!(
-				this.preparedUpdateRestart === undefined &&
-				this.updateRestartPublishing === undefined &&
-				UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
-			)
-		) {
+		const restartPhase = this.updateRestart?.phase;
+		const restartRejected =
+			restartPhase === "preparing"
+				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
+				: restartPhase !== undefined && command.type !== "shutdown";
+		if (mutation && restartRejected) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}
-		if (mutation) this.beginMutation();
+		if (mutation) this.mutationDrain.begin();
 		try {
 			const response = await this.handleCommand(client, command, () => {
 				promptHandlerOwnsAdmission = true;
@@ -2674,40 +2669,18 @@ export class AgentDaemon {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));
 		} finally {
 			if (!promptHandlerOwnsAdmission) clearParsedAdmission();
-			if (mutation) this.endMutation();
+			if (mutation) this.mutationDrain.end();
 		}
 	}
 
-	private beginMutation(): void {
-		this.activeMutations++;
-	}
-
-	private endMutation(): void {
-		this.activeMutations--;
-		for (const resolve of this.mutationDrainWaiters) resolve();
-		this.mutationDrainWaiters.clear();
-	}
-
-	private async waitForMutationDrain(remaining: number, signal: AbortSignal): Promise<void> {
-		while (this.activeMutations > remaining) {
-			if (signal.aborted) throw new Error("Update restart preparation cancelled");
-			await new Promise<void>((resolve, reject) => {
-				const onDrained = () => {
-					cleanup();
-					resolve();
-				};
-				const onAbort = () => {
-					cleanup();
-					reject(new Error("Update restart preparation cancelled"));
-				};
-				const cleanup = () => {
-					this.mutationDrainWaiters.delete(onDrained);
-					signal.removeEventListener("abort", onAbort);
-				};
-				this.mutationDrainWaiters.add(onDrained);
-				signal.addEventListener("abort", onAbort, { once: true });
-			});
-		}
+	private writeWorkerSuccess(client: DaemonSocketClient, command: DaemonWorkerCommand, data?: unknown): void {
+		this.write(client, {
+			id: command.id,
+			type: "response",
+			command: command.type,
+			success: true,
+			...(data !== undefined ? { data } : {}),
+		});
 	}
 
 	private async handleWorkerCommand(client: DaemonSocketClient, command: DaemonWorkerCommand): Promise<void> {
@@ -2739,23 +2712,13 @@ export class AgentDaemon {
 					for (const peer of command.peers) {
 						this.remoteAgentPeers.set(peer.activeSessionId, peer);
 					}
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-					});
+					this.writeWorkerSuccess(client, command);
 					return;
 				case "worker_archive_and_shutdown": {
 					for (const state of [...this.sessions.values()]) {
 						await this.closeSession(state, "killed");
 					}
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-					});
+					this.writeWorkerSuccess(client, command);
 					setImmediate(() => void this.shutdown(0));
 					return;
 				}
@@ -2768,97 +2731,49 @@ export class AgentDaemon {
 						deliveryMode: command.deliveryMode,
 						origin: "agent",
 					});
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-						data: receipt,
-					});
+					this.writeWorkerSuccess(client, command, receipt);
 					return;
 				}
 				case "worker_prepare_update": {
-					if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
-					const transaction: NonNullable<AgentDaemon["updateRestartTransaction"]> = {
-						id: Symbol("update-restart"),
-						owner: client,
-						abort: new AbortController(),
-					};
-					this.updateRestartTransaction = transaction;
-					this.updateRestartPreparing = true;
-					this.cronScheduler.stop();
-					transaction.deadline = setTimeout(() => {
-						transaction.abort.abort();
-						this.cancelPreparedUpdateRestart(transaction.id);
-					}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
-					transaction.deadline.unref();
-					try {
-						await this.waitForMutationDrain(0, transaction.abort.signal);
-						const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
-						if (!this.isUpdateRestartTransaction(transaction.id) || transaction.abort.signal.aborted) {
-							throw new Error("Update restart preparation cancelled");
-						}
-						this.preparedUpdateRestart = { id: transaction.id, manifest };
-						this.write(client, {
-							id: command.id,
-							type: "response",
-							command: command.type,
-							success: true,
-							data: manifest,
-						});
-					} catch (error) {
-						this.cancelPreparedUpdateRestart(transaction.id);
-						throw error;
-					}
+					const transaction = this.beginUpdateRestartTransaction(client);
+					const manifest = await this.runUpdateRestartPreparation(transaction);
+					this.writeWorkerSuccess(client, command, manifest);
 					return;
 				}
 				case "worker_commit_update": {
-					const prepared = this.preparedUpdateRestart;
-					const transaction = this.updateRestartTransaction;
-					if (!prepared || !transaction || transaction.id !== prepared.id) {
+					const transaction = this.updateRestart;
+					if (!transaction || transaction.phase === "preparing") {
 						throw new Error("Daemon has no prepared update checkpoint");
 					}
-					if (this.updateRestartPublishing !== undefined) {
+					if (transaction.phase === "publishing") {
 						throw new Error("Daemon update checkpoint is already committing");
 					}
 					if (transaction.owner !== client)
 						throw new Error("Daemon update checkpoint belongs to another supervisor");
 					if (transaction.deadline) clearTimeout(transaction.deadline);
 					transaction.deadline = undefined;
-					this.updateRestartPublishing = prepared.id;
+					transaction.phase = "publishing";
 					let manifest: DaemonUpdateRestartManifest;
 					try {
-						manifest = await this.commitPreparedUpdateRestart(prepared.id);
+						manifest = await this.commitPreparedUpdateRestart(transaction.id);
 					} catch (error) {
-						if (this.updateRestartPublishing === prepared.id) this.updateRestartPublishing = undefined;
+						if (this.updateRestart === transaction) transaction.phase = "prepared";
 						if (transaction.abort.signal.aborted) this.cancelPreparedUpdateRestart(transaction.id);
 						throw error;
 					}
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-						data: manifest,
-					});
+					this.writeWorkerSuccess(client, command, manifest);
 					return;
 				}
 				case "worker_cancel_update": {
-					const transaction = this.updateRestartTransaction;
+					const transaction = this.updateRestart;
 					if (transaction && transaction.owner !== client) {
 						throw new Error("Daemon update checkpoint belongs to another supervisor");
 					}
-					const transactionId = transaction?.id;
-					if (transactionId && this.updateRestartPublishing === transactionId) {
+					if (transaction?.phase === "publishing") {
 						throw new Error("Daemon update checkpoint is already committing");
 					}
-					if (transactionId) this.cancelPreparedUpdateRestart(transactionId);
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-					});
+					if (transaction) this.cancelPreparedUpdateRestart(transaction.id);
+					this.writeWorkerSuccess(client, command);
 					return;
 				}
 			}
@@ -2872,18 +2787,6 @@ export class AgentDaemon {
 		command: DaemonCommand,
 		onPromptHandlerOwnsAdmission: () => void = () => {},
 	): Promise<DaemonResponse | undefined> {
-		if (
-			this.updateRestartPreparing &&
-			command.type !== "ack_result" &&
-			(command.type !== "shutdown" || !this.preparedUpdateRestart) &&
-			!(
-				this.preparedUpdateRestart === undefined &&
-				this.updateRestartPublishing === undefined &&
-				UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
-			)
-		) {
-			throw new Error("Daemon is preparing an update restart");
-		}
 		if ("agentMessageId" in command && command.agentMessageId === "") {
 			throw new Error("agentMessageId must not be empty");
 		}
@@ -4681,14 +4584,50 @@ export class AgentDaemon {
 		return depth;
 	}
 
-	private isUpdateRestartTransaction(id: symbol): boolean {
-		return this.updateRestartTransaction?.id === id;
+	private assertUpdateRestartNotCancelled(transaction: { id: symbol; abort: AbortController }): void {
+		if (transaction.abort.signal.aborted || this.updateRestart?.id !== transaction.id) {
+			throw new Error("Update restart preparation cancelled");
+		}
+	}
+
+	private beginUpdateRestartTransaction(owner?: DaemonSocketClient): NonNullable<AgentDaemon["updateRestart"]> {
+		if (this.updateRestart) throw new Error("Daemon is already preparing an update restart");
+		const transaction: NonNullable<AgentDaemon["updateRestart"]> = {
+			id: Symbol("update-restart"),
+			...(owner ? { owner } : {}),
+			abort: new AbortController(),
+			phase: "preparing",
+		};
+		this.updateRestart = transaction;
+		this.cronScheduler.stop();
+		transaction.deadline = setTimeout(() => {
+			transaction.abort.abort();
+			this.cancelPreparedUpdateRestart(transaction.id);
+		}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
+		transaction.deadline.unref();
+		return transaction;
+	}
+
+	private async runUpdateRestartPreparation(
+		transaction: NonNullable<AgentDaemon["updateRestart"]>,
+	): Promise<DaemonUpdateRestartManifest> {
+		try {
+			await this.mutationDrain.waitForDrain(0, transaction.abort.signal, "Update restart preparation cancelled");
+			const manifest = await this.prepareUpdateRestartCheckpoint(transaction);
+			this.assertUpdateRestartNotCancelled(transaction);
+			transaction.manifest = manifest;
+			transaction.phase = "prepared";
+			return manifest;
+		} catch (error) {
+			this.cancelPreparedUpdateRestart(transaction.id);
+			throw error;
+		}
 	}
 
 	private async prepareUpdateRestartCheckpoint(
-		signal: AbortSignal,
-		transactionId: symbol,
+		transaction: NonNullable<AgentDaemon["updateRestart"]>,
 	): Promise<DaemonUpdateRestartManifest> {
+		const signal = transaction.abort.signal;
 		try {
 			const states = [...this.sessions.values()];
 			this.updateRestartQueuePauses.clear();
@@ -4696,9 +4635,7 @@ export class AgentDaemon {
 				this.updateRestartQueuePauses.set(state.activeSessionId, state.runtime.session.acquireQueuedWorkPause());
 			}
 			await Promise.all(states.map((state) => state.runtime.session.waitForSessionInputCheckpoint(signal)));
-			if (signal.aborted || !this.isUpdateRestartTransaction(transactionId)) {
-				throw new Error("Update restart preparation cancelled");
-			}
+			this.assertUpdateRestartNotCancelled(transaction);
 			const snapshottedIds = new Set(states.map((state) => state.activeSessionId));
 			const addedSession = [...this.sessions.keys()].find((activeSessionId) => !snapshottedIds.has(activeSessionId));
 			if (addedSession) throw new Error(`Session ${addedSession} became resident during update preparation`);
@@ -4715,9 +4652,7 @@ export class AgentDaemon {
 						(rightState ? this.getUpdateRestartSessionDepth(rightState) : 0)
 					);
 				});
-			if (signal.aborted || !this.isUpdateRestartTransaction(transactionId)) {
-				throw new Error("Update restart preparation cancelled");
-			}
+			this.assertUpdateRestartNotCancelled(transaction);
 			const includedActiveSessionIds = new Set(restartSessions.map((session) => session.activeSessionId));
 			const discardedActiveSessionIds = states
 				.filter(
@@ -4732,17 +4667,17 @@ export class AgentDaemon {
 				...(discardedActiveSessionIds.length > 0 ? { discardedActiveSessionIds } : {}),
 			};
 		} catch (error) {
-			this.cancelPreparedUpdateRestart(transactionId);
+			this.cancelPreparedUpdateRestart(transaction.id);
 			throw error;
 		}
 	}
 
 	private async commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest> {
-		const prepared = this.preparedUpdateRestart;
-		if (!this.updateRestartPreparing || !prepared || prepared.id !== transactionId) {
+		const transaction = this.updateRestart;
+		if (transaction?.id !== transactionId || !transaction.manifest) {
 			throw new Error("Daemon has no prepared update checkpoint");
 		}
-		const manifest = prepared.manifest;
+		const manifest = transaction.manifest;
 		const restartByActiveSessionId = new Map(manifest.sessions.map((session) => [session.activeSessionId, session]));
 		for (const state of this.sessions.values()) {
 			const restartSession = restartByActiveSessionId.get(state.activeSessionId);
@@ -4761,48 +4696,31 @@ export class AgentDaemon {
 	}
 
 	private cancelPreparedUpdateRestart(transactionId?: symbol): void {
-		const transaction = this.updateRestartTransaction;
+		const transaction = this.updateRestart;
 		if (!transaction || (transactionId && transaction.id !== transactionId)) return;
 		if (transaction.deadline) clearTimeout(transaction.deadline);
 		transaction.deadline = undefined;
 		transaction.abort.abort();
-		if (this.updateRestartPublishing === transaction.id) return;
-		this.updateRestartTransaction = undefined;
-		this.preparedUpdateRestart = undefined;
-		this.updateRestartPreparing = false;
+		if (transaction.phase === "publishing") return;
+		this.updateRestart = undefined;
 		for (const pause of this.updateRestartQueuePauses.values()) pause.release();
 		this.updateRestartQueuePauses.clear();
 		if (!this.shuttingDown) this.cronScheduler.start();
 	}
 
 	private async prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
-		const transaction: NonNullable<AgentDaemon["updateRestartTransaction"]> = {
-			id: Symbol("update-restart"),
-			abort: new AbortController(),
-		};
-		this.updateRestartTransaction = transaction;
-		this.updateRestartPreparing = true;
-		this.cronScheduler.stop();
-		transaction.deadline = setTimeout(() => {
-			transaction.abort.abort();
-			this.cancelPreparedUpdateRestart(transaction.id);
-		}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
-		transaction.deadline.unref();
+		const transaction = this.beginUpdateRestartTransaction();
 		try {
-			await this.waitForMutationDrain(0, transaction.abort.signal);
-			const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
-			if (transaction.abort.signal.aborted || !this.isUpdateRestartTransaction(transaction.id)) {
-				throw new Error("Update restart preparation cancelled");
-			}
-			this.preparedUpdateRestart = { id: transaction.id, manifest };
+			const manifest = await this.runUpdateRestartPreparation(transaction);
 			if (transaction.deadline) clearTimeout(transaction.deadline);
 			transaction.deadline = undefined;
-			this.updateRestartPublishing = transaction.id;
+			transaction.phase = "publishing";
 			this.writeUpdateRestartManifest(manifest);
 			return await this.commitPreparedUpdateRestart(transaction.id);
 		} catch (error) {
-			if (this.updateRestartPublishing === transaction.id) this.updateRestartPublishing = undefined;
+			if (this.updateRestart === transaction && transaction.phase === "publishing") {
+				transaction.phase = "prepared";
+			}
 			this.cancelPreparedUpdateRestart(transaction.id);
 			throw error;
 		}
@@ -5390,7 +5308,7 @@ export class AgentDaemon {
 			this.supervisorFenceTimer = undefined;
 		}
 		this.log(`shutting down (exit ${exitCode}); closing ${this.sessions.size} active session(s)`);
-		const closingReason: DaemonClosingReason = this.updateRestartPreparing ? "update" : "shutdown";
+		const closingReason: DaemonClosingReason = this.updateRestart ? "update" : "shutdown";
 		for (const client of this.clients) {
 			abortClientSnapshotStreaming(client);
 			this.write(client, { type: "daemon_closing", reason: closingReason });

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2592,7 +2592,7 @@ export class AgentDaemon {
 						// The fence check remains authoritative after cancellation. Its rejection
 						// revokes only the exact binding that initiated it; replacements survive.
 						void claimCheck.catch(() => {
-							if (this.supervisorClaims.get(client) === boundClaim) client.socket.end();
+							if (this.revokeSupervisorClaim(client, boundClaim)) client.socket.end();
 						});
 					}
 					clearParsedAdmission();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -408,8 +408,8 @@ export class AgentDaemon {
 	private shuttingDown = false;
 	private updateRestartPreparing = false;
 	private readonly updateRestartQueuePauses = new Map<string, { release(): void }>();
-	private activeWorkerMutations = 0;
-	private readonly workerMutationDrainWaiters = new Set<() => void>();
+	private activeMutations = 0;
+	private readonly mutationDrainWaiters = new Set<() => void>();
 	private updateRestartTransaction?: {
 		id: symbol;
 		owner?: DaemonSocketClient;
@@ -2621,11 +2621,11 @@ export class AgentDaemon {
 					);
 					return;
 				}
-				if (!updateLifecycle) this.beginWorkerMutation();
+				if (!updateLifecycle) this.beginMutation();
 				try {
 					await this.handleWorkerCommand(client, workerCommand);
 				} finally {
-					if (!updateLifecycle) this.endWorkerMutation();
+					if (!updateLifecycle) this.endMutation();
 				}
 				return;
 			}
@@ -2642,9 +2642,9 @@ export class AgentDaemon {
 			return;
 		}
 
-		const workerMutation = this.options.worker !== undefined && isDaemonMutatingCommand(command);
+		const mutation = command.type !== "prepare_update_restart" && isDaemonMutatingCommand(command);
 		if (
-			workerMutation &&
+			mutation &&
 			this.updateRestartPreparing &&
 			(command.type !== "shutdown" || !this.preparedUpdateRestart) &&
 			!(
@@ -2656,7 +2656,7 @@ export class AgentDaemon {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}
-		if (workerMutation) this.beginWorkerMutation();
+		if (mutation) this.beginMutation();
 		try {
 			const response = await this.handleCommand(client, command, () => {
 				promptHandlerOwnsAdmission = true;
@@ -2674,24 +2674,22 @@ export class AgentDaemon {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));
 		} finally {
 			if (!promptHandlerOwnsAdmission) clearParsedAdmission();
-			if (workerMutation) this.endWorkerMutation();
+			if (mutation) this.endMutation();
 		}
 	}
 
-	private beginWorkerMutation(): void {
-		this.activeWorkerMutations++;
+	private beginMutation(): void {
+		this.activeMutations++;
 	}
 
-	private endWorkerMutation(): void {
-		this.activeWorkerMutations--;
-		if (this.activeWorkerMutations === 0) {
-			for (const resolve of this.workerMutationDrainWaiters) resolve();
-			this.workerMutationDrainWaiters.clear();
-		}
+	private endMutation(): void {
+		this.activeMutations--;
+		for (const resolve of this.mutationDrainWaiters) resolve();
+		this.mutationDrainWaiters.clear();
 	}
 
-	private async waitForWorkerMutations(signal: AbortSignal): Promise<void> {
-		while (this.activeWorkerMutations > 0) {
+	private async waitForMutationDrain(remaining: number, signal: AbortSignal): Promise<void> {
+		while (this.activeMutations > remaining) {
 			if (signal.aborted) throw new Error("Update restart preparation cancelled");
 			await new Promise<void>((resolve, reject) => {
 				const onDrained = () => {
@@ -2703,10 +2701,10 @@ export class AgentDaemon {
 					reject(new Error("Update restart preparation cancelled"));
 				};
 				const cleanup = () => {
-					this.workerMutationDrainWaiters.delete(onDrained);
+					this.mutationDrainWaiters.delete(onDrained);
 					signal.removeEventListener("abort", onAbort);
 				};
-				this.workerMutationDrainWaiters.add(onDrained);
+				this.mutationDrainWaiters.add(onDrained);
 				signal.addEventListener("abort", onAbort, { once: true });
 			});
 		}
@@ -2795,7 +2793,7 @@ export class AgentDaemon {
 					}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
 					transaction.deadline.unref();
 					try {
-						await this.waitForWorkerMutations(transaction.abort.signal);
+						await this.waitForMutationDrain(0, transaction.abort.signal);
 						const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
 						if (!this.isUpdateRestartTransaction(transaction.id) || transaction.abort.signal.aborted) {
 							throw new Error("Update restart preparation cancelled");
@@ -2820,6 +2818,9 @@ export class AgentDaemon {
 					if (!prepared || !transaction || transaction.id !== prepared.id) {
 						throw new Error("Daemon has no prepared update checkpoint");
 					}
+					if (this.updateRestartPublishing !== undefined) {
+						throw new Error("Daemon update checkpoint is already committing");
+					}
 					if (transaction.owner !== client)
 						throw new Error("Daemon update checkpoint belongs to another supervisor");
 					if (transaction.deadline) clearTimeout(transaction.deadline);
@@ -2830,6 +2831,7 @@ export class AgentDaemon {
 						manifest = await this.commitPreparedUpdateRestart(prepared.id);
 					} catch (error) {
 						if (this.updateRestartPublishing === prepared.id) this.updateRestartPublishing = undefined;
+						if (transaction.abort.signal.aborted) this.cancelPreparedUpdateRestart(transaction.id);
 						throw error;
 					}
 					this.write(client, {
@@ -4788,6 +4790,7 @@ export class AgentDaemon {
 		}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
 		transaction.deadline.unref();
 		try {
+			await this.waitForMutationDrain(0, transaction.abort.signal);
 			const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
 			if (transaction.abort.signal.aborted || !this.isUpdateRestartTransaction(transaction.id)) {
 				throw new Error("Update restart preparation cancelled");

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2772,6 +2772,9 @@ export class AgentDaemon {
 						throw error;
 					}
 					this.writeWorkerSuccess(client, command, manifest);
+					if (!this.supervisorClaims.has(client)) {
+						setImmediate(() => void this.shutdown(0));
+					}
 					return;
 				}
 				case "worker_cancel_update": {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4802,7 +4802,7 @@ export class AgentDaemon {
 			this.writeUpdateRestartManifest(manifest);
 			return await this.commitPreparedUpdateRestart(transaction.id);
 		} catch (error) {
-			this.updateRestartPublishing = undefined;
+			if (this.updateRestartPublishing === transaction.id) this.updateRestartPublishing = undefined;
 			this.cancelPreparedUpdateRestart(transaction.id);
 			throw error;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -416,6 +416,11 @@ export class AgentDaemon {
 		deadline?: ReturnType<typeof setTimeout>;
 		phase: "preparing" | "fencing" | "prepared" | "publishing";
 		manifest?: DaemonUpdateRestartManifest;
+		deferredClientEnv: Array<{
+			client: DaemonSocketClient;
+			state: ActiveSessionState;
+			env: Record<string, string>;
+		}>;
 	};
 	private ownsSocketPath = false;
 	private socketIdentity?: DaemonSocketIdentity;
@@ -2907,11 +2912,12 @@ export class AgentDaemon {
 				const streamsSnapshot =
 					client.transport === "private-framed" &&
 					daemonClientCapabilitiesForSession(client, state.activeSessionId).has("chunked_snapshot");
-				// Attach is admitted during update-restart preparation as a read, but env
-				// adoption is a session mutation: adopting after the manifest snapshot
-				// would strand the identity on a checkpoint that no longer includes it.
-				// The client re-attaches after restart and adopts env then.
-				if (!this.updateRestart) this.adoptClientEnv(state, filterClientEnv(command.env));
+				// Attach is admitted during update-restart preparation as a read. Env
+				// adoption remains safe while mutations are only draining; after fencing,
+				// defer it until rollback so the checkpoint never omits a live identity.
+				const clientEnv = filterClientEnv(command.env);
+				const deferClientEnv = this.updateRestart && this.updateRestart.phase !== "preparing";
+				if (!deferClientEnv) this.adoptClientEnv(state, clientEnv);
 				const snapshotSignal = streamsSnapshot
 					? markClientSnapshotStreaming(client, state.activeSessionId)
 					: undefined;
@@ -2928,6 +2934,9 @@ export class AgentDaemon {
 						finishClientSnapshotStreaming(client, state.activeSessionId);
 					}
 					throw error;
+				}
+				if (deferClientEnv && clientEnv) {
+					this.updateRestart?.deferredClientEnv.push({ client, state, env: clientEnv });
 				}
 				if (streamsSnapshot) {
 					const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
@@ -4614,6 +4623,7 @@ export class AgentDaemon {
 			...(owner ? { owner } : {}),
 			abort: new AbortController(),
 			phase: "preparing",
+			deferredClientEnv: [],
 		};
 		this.updateRestart = transaction;
 		this.cronScheduler.stop();
@@ -4724,6 +4734,16 @@ export class AgentDaemon {
 		transaction.abort.abort();
 		if (transaction.phase === "publishing") return;
 		this.updateRestart = undefined;
+		for (const deferred of transaction.deferredClientEnv) {
+			if (
+				this.sessions.get(deferred.state.activeSessionId) === deferred.state &&
+				deferred.state.clients.has(deferred.client) &&
+				deferred.client.attachedActiveSessionIds.has(deferred.state.activeSessionId)
+			) {
+				this.adoptClientEnv(deferred.state, deferred.env);
+			}
+		}
+		transaction.deferredClientEnv.length = 0;
 		for (const pause of this.updateRestartQueuePauses.values()) pause.release();
 		this.updateRestartQueuePauses.clear();
 		if (!this.shuttingDown) this.cronScheduler.start();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5335,6 +5335,10 @@ export class AgentDaemon {
 		this.signalCleanupHandlers.push(() => process.off("exit", exitHandler));
 	}
 
+	private getShutdownClosingReason(): DaemonClosingReason {
+		return this.updateRestart?.phase === "publishing" ? "update" : "shutdown";
+	}
+
 	private async shutdown(exitCode: number): Promise<never> {
 		if (this.shuttingDown) {
 			process.exit(exitCode);
@@ -5349,7 +5353,7 @@ export class AgentDaemon {
 			this.supervisorFenceTimer = undefined;
 		}
 		this.log(`shutting down (exit ${exitCode}); closing ${this.sessions.size} active session(s)`);
-		const closingReason: DaemonClosingReason = this.updateRestart ? "update" : "shutdown";
+		const closingReason = this.getShutdownClosingReason();
 		for (const client of this.clients) {
 			abortClientSnapshotStreaming(client);
 			this.write(client, { type: "daemon_closing", reason: closingReason });

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4625,6 +4625,8 @@ export class AgentDaemon {
 			await this.mutationDrain.waitForDrain(0, transaction.abort.signal, "Update restart preparation cancelled");
 			this.assertUpdateRestartNotCancelled(transaction);
 			transaction.phase = "fencing";
+			await this.mutationDrain.waitForDrain(0, transaction.abort.signal, "Update restart preparation cancelled");
+			this.assertUpdateRestartNotCancelled(transaction);
 			const manifest = await this.prepareUpdateRestartCheckpoint(transaction);
 			this.assertUpdateRestartNotCancelled(transaction);
 			transaction.manifest = manifest;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -146,6 +146,7 @@ import {
 	failure,
 	isDaemonCommandEnvelope,
 	isDaemonDialogExtensionUiRequest,
+	isDaemonMutatingCommand,
 	success,
 } from "./daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
@@ -200,6 +201,14 @@ export { defaultDaemonSocketPath } from "./daemon-socket.js";
 
 const structuredLog = getLogger("coding-agent.daemon");
 const WORKER_SNAPSHOT_TERMINAL_DRAIN_TIMEOUT_MS = 1_000;
+const UPDATE_RESTART_PREPARE_TIMEOUT_MS = 90_000;
+const UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS = new Set<DaemonCommand["type"]>([
+	"extension_ui_response",
+	"abort",
+	"abort_bash",
+	"abort_compaction",
+	"abort_retry",
+]);
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -404,6 +413,12 @@ export class AgentDaemon {
 	private server?: Server;
 	private shuttingDown = false;
 	private updateRestartPreparing = false;
+	private readonly updateRestartQueuePauses = new Map<string, { release(): void }>();
+	private activeWorkerMutations = 0;
+	private readonly workerMutationDrainWaiters = new Set<() => void>();
+	private updateRestartPrepareAbort?: AbortController;
+	private updateRestartPrepareInFlight = false;
+	private updateRestartCommitInFlight = false;
 	private preparedUpdateRestartManifest?: DaemonUpdateRestartManifest;
 	private ownsSocketPath = false;
 	private socketIdentity?: DaemonSocketIdentity;
@@ -2407,6 +2422,15 @@ export class AgentDaemon {
 			client.detachInput();
 			this.clients.delete(client);
 			this.supervisorClaims.delete(client);
+			if (
+				this.options.worker &&
+				this.updateRestartPreparing &&
+				!this.updateRestartCommitInFlight &&
+				this.supervisorClaims.size === 0
+			) {
+				this.updateRestartPrepareAbort?.abort();
+				this.cancelPreparedUpdateRestart();
+			}
 			const supervisorSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			if (this.options.worker && client.authenticated === true && supervisorSocketPath) {
 				this.scheduleSupervisorAvailabilityCheck(supervisorSocketPath, 100);
@@ -2593,7 +2617,24 @@ export class AgentDaemon {
 				}
 			}
 			if (this.options.worker && typeof parsed.type === "string" && parsed.type.startsWith("worker_")) {
-				await this.handleWorkerCommand(client, parsed as DaemonWorkerCommand);
+				const workerCommand = parsed as DaemonWorkerCommand;
+				const updateLifecycle =
+					workerCommand.type === "worker_prepare_update" ||
+					workerCommand.type === "worker_commit_update" ||
+					workerCommand.type === "worker_cancel_update";
+				if (this.updateRestartPreparing && !updateLifecycle) {
+					this.write(
+						client,
+						failure(workerCommand.id, workerCommand.type, "Daemon is preparing an update restart"),
+					);
+					return;
+				}
+				if (!updateLifecycle) this.beginWorkerMutation();
+				try {
+					await this.handleWorkerCommand(client, workerCommand);
+				} finally {
+					if (!updateLifecycle) this.endWorkerMutation();
+				}
 				return;
 			}
 
@@ -2609,6 +2650,17 @@ export class AgentDaemon {
 			return;
 		}
 
+		const workerMutation = this.options.worker !== undefined && isDaemonMutatingCommand(command);
+		if (
+			workerMutation &&
+			this.updateRestartPreparing &&
+			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+		) {
+			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
+			return;
+		}
+		if (workerMutation) this.beginWorkerMutation();
 		try {
 			const response = await this.handleCommand(client, command, () => {
 				promptHandlerOwnsAdmission = true;
@@ -2626,6 +2678,41 @@ export class AgentDaemon {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));
 		} finally {
 			if (!promptHandlerOwnsAdmission) clearParsedAdmission();
+			if (workerMutation) this.endWorkerMutation();
+		}
+	}
+
+	private beginWorkerMutation(): void {
+		this.activeWorkerMutations++;
+	}
+
+	private endWorkerMutation(): void {
+		this.activeWorkerMutations--;
+		if (this.activeWorkerMutations === 0) {
+			for (const resolve of this.workerMutationDrainWaiters) resolve();
+			this.workerMutationDrainWaiters.clear();
+		}
+	}
+
+	private async waitForWorkerMutations(signal: AbortSignal): Promise<void> {
+		while (this.activeWorkerMutations > 0) {
+			if (signal.aborted) throw new Error("Update restart preparation cancelled");
+			await new Promise<void>((resolve, reject) => {
+				const onDrained = () => {
+					cleanup();
+					resolve();
+				};
+				const onAbort = () => {
+					cleanup();
+					reject(new Error("Update restart preparation cancelled"));
+				};
+				const cleanup = () => {
+					this.workerMutationDrainWaiters.delete(onDrained);
+					signal.removeEventListener("abort", onAbort);
+				};
+				this.workerMutationDrainWaiters.add(onDrained);
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
 		}
 	}
 
@@ -2697,7 +2784,26 @@ export class AgentDaemon {
 					return;
 				}
 				case "worker_prepare_update": {
-					const manifest = this.prepareUpdateRestartCheckpoint();
+					if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
+					const abort = new AbortController();
+					this.updateRestartPrepareAbort = abort;
+					this.updateRestartPrepareInFlight = true;
+					this.updateRestartPreparing = true;
+					this.cronScheduler.stop();
+					const deadline = setTimeout(() => abort.abort(), UPDATE_RESTART_PREPARE_TIMEOUT_MS);
+					deadline.unref();
+					let manifest: DaemonUpdateRestartManifest;
+					try {
+						await this.waitForWorkerMutations(abort.signal);
+						manifest = await this.prepareUpdateRestartCheckpoint(abort.signal, true);
+					} catch (error) {
+						if (this.updateRestartPrepareAbort === abort) this.cancelPreparedUpdateRestart();
+						throw error;
+					} finally {
+						this.updateRestartPrepareInFlight = false;
+						clearTimeout(deadline);
+					}
+
 					this.write(client, {
 						id: command.id,
 						type: "response",
@@ -2708,7 +2814,15 @@ export class AgentDaemon {
 					return;
 				}
 				case "worker_commit_update": {
-					const manifest = await this.commitPreparedUpdateRestart();
+					if (!this.preparedUpdateRestartManifest) throw new Error("Daemon has no prepared update checkpoint");
+					this.updateRestartCommitInFlight = true;
+					let manifest: DaemonUpdateRestartManifest;
+					try {
+						manifest = await this.commitPreparedUpdateRestart();
+					} catch (error) {
+						this.updateRestartCommitInFlight = false;
+						throw error;
+					}
 					this.write(client, {
 						id: command.id,
 						type: "response",
@@ -2719,6 +2833,10 @@ export class AgentDaemon {
 					return;
 				}
 				case "worker_cancel_update":
+					if (this.updateRestartCommitInFlight) {
+						throw new Error("Daemon update checkpoint is already committing");
+					}
+					this.updateRestartPrepareAbort?.abort();
 					this.cancelPreparedUpdateRestart();
 					this.write(client, {
 						id: command.id,
@@ -2738,7 +2856,12 @@ export class AgentDaemon {
 		command: DaemonCommand,
 		onPromptHandlerOwnsAdmission: () => void = () => {},
 	): Promise<DaemonResponse | undefined> {
-		if (this.updateRestartPreparing && command.type !== "shutdown" && command.type !== "ack_result") {
+		if (
+			this.updateRestartPreparing &&
+			command.type !== "ack_result" &&
+			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+		) {
 			throw new Error("Daemon is preparing an update restart");
 		}
 		if ("agentMessageId" in command && command.agentMessageId === "") {
@@ -4538,8 +4661,11 @@ export class AgentDaemon {
 		return depth;
 	}
 
-	private prepareUpdateRestartCheckpoint(): DaemonUpdateRestartManifest {
-		if (this.updateRestartPreparing) {
+	private async prepareUpdateRestartCheckpoint(
+		signal?: AbortSignal,
+		alreadyFenced = false,
+	): Promise<DaemonUpdateRestartManifest> {
+		if (this.updateRestartPreparing && !alreadyFenced) {
 			throw new Error("Daemon is already preparing an update restart");
 		}
 		this.updateRestartPreparing = true;
@@ -4548,6 +4674,15 @@ export class AgentDaemon {
 		this.cronScheduler.stop();
 		try {
 			const states = [...this.sessions.values()];
+			this.updateRestartQueuePauses.clear();
+			for (const state of states) {
+				this.updateRestartQueuePauses.set(state.activeSessionId, state.runtime.session.acquireQueuedWorkPause());
+			}
+			await Promise.all(states.map((state) => state.runtime.session.waitForSessionInputCheckpoint(signal)));
+			const snapshottedIds = new Set(states.map((state) => state.activeSessionId));
+			const addedSession = [...this.sessions.keys()].find((activeSessionId) => !snapshottedIds.has(activeSessionId));
+			if (addedSession) throw new Error(`Session ${addedSession} became resident during update preparation`);
+
 			const restartSessions = states
 				.map((state) => this.createUpdateRestartSession(state))
 				.filter((session): session is DaemonUpdateRestartSession => session !== undefined)
@@ -4595,15 +4730,20 @@ export class AgentDaemon {
 	}
 
 	private cancelPreparedUpdateRestart(): void {
+		this.updateRestartPrepareAbort = undefined;
+		this.updateRestartPrepareInFlight = false;
 		this.preparedUpdateRestartManifest = undefined;
 		this.updateRestartPreparing = false;
+		for (const pause of this.updateRestartQueuePauses.values()) pause.release();
+		this.updateRestartQueuePauses.clear();
+
 		if (!this.shuttingDown) {
 			this.cronScheduler.start();
 		}
 	}
 
 	private async prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		const manifest = this.prepareUpdateRestartCheckpoint();
+		const manifest = await this.prepareUpdateRestartCheckpoint();
 		try {
 			this.writeUpdateRestartManifest(manifest);
 			return await this.commitPreparedUpdateRestart();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -148,6 +148,7 @@ import {
 	isDaemonDialogExtensionUiRequest,
 	isDaemonMutatingCommand,
 	success,
+	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
 import {
@@ -202,13 +203,6 @@ export { defaultDaemonSocketPath } from "./daemon-socket.js";
 const structuredLog = getLogger("coding-agent.daemon");
 const WORKER_SNAPSHOT_TERMINAL_DRAIN_TIMEOUT_MS = 1_000;
 const UPDATE_RESTART_PREPARE_TIMEOUT_MS = 90_000;
-const UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS = new Set<DaemonCommand["type"]>([
-	"extension_ui_response",
-	"abort",
-	"abort_bash",
-	"abort_compaction",
-	"abort_retry",
-]);
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -416,10 +410,14 @@ export class AgentDaemon {
 	private readonly updateRestartQueuePauses = new Map<string, { release(): void }>();
 	private activeWorkerMutations = 0;
 	private readonly workerMutationDrainWaiters = new Set<() => void>();
-	private updateRestartPrepareAbort?: AbortController;
-	private updateRestartPrepareInFlight = false;
-	private updateRestartCommitInFlight = false;
-	private preparedUpdateRestartManifest?: DaemonUpdateRestartManifest;
+	private updateRestartTransaction?: {
+		id: symbol;
+		owner?: DaemonSocketClient;
+		abort: AbortController;
+		deadline?: ReturnType<typeof setTimeout>;
+	};
+	private updateRestartPublishing?: symbol;
+	private preparedUpdateRestart?: { id: symbol; manifest: DaemonUpdateRestartManifest };
 	private ownsSocketPath = false;
 	private socketIdentity?: DaemonSocketIdentity;
 	private readonly clients = new Set<DaemonSocketClient>();
@@ -2422,14 +2420,8 @@ export class AgentDaemon {
 			client.detachInput();
 			this.clients.delete(client);
 			this.supervisorClaims.delete(client);
-			if (
-				this.options.worker &&
-				this.updateRestartPreparing &&
-				!this.updateRestartCommitInFlight &&
-				this.supervisorClaims.size === 0
-			) {
-				this.updateRestartPrepareAbort?.abort();
-				this.cancelPreparedUpdateRestart();
+			if (this.options.worker && this.updateRestartTransaction?.owner === client) {
+				this.cancelPreparedUpdateRestart(this.updateRestartTransaction.id);
 			}
 			const supervisorSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			if (this.options.worker && client.authenticated === true && supervisorSocketPath) {
@@ -2589,9 +2581,8 @@ export class AgentDaemon {
 						claimCheck,
 						parsedAdmission?.controller?.signal,
 					);
-					if (this.supervisorClaims.get(client) === boundClaim) {
-						boundClaim.ownerFingerprint = ownerFingerprint;
-					}
+					if (this.supervisorClaims.get(client) !== boundClaim || client.socket.destroyed) return;
+					boundClaim.ownerFingerprint = ownerFingerprint;
 				} catch (error) {
 					const admissionCancelled = error instanceof DaemonPromptAdmissionCancelledError;
 					if (admissionCancelled) {
@@ -2602,6 +2593,7 @@ export class AgentDaemon {
 						});
 					}
 					clearParsedAdmission();
+					if (this.supervisorClaims.get(client) !== boundClaim || client.socket.destroyed) return;
 					this.write(
 						client,
 						failure(
@@ -2654,8 +2646,12 @@ export class AgentDaemon {
 		if (
 			workerMutation &&
 			this.updateRestartPreparing &&
-			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+			(command.type !== "shutdown" || !this.preparedUpdateRestart) &&
+			!(
+				this.preparedUpdateRestart === undefined &&
+				this.updateRestartPublishing === undefined &&
+				UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
+			)
 		) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
@@ -2785,42 +2781,55 @@ export class AgentDaemon {
 				}
 				case "worker_prepare_update": {
 					if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
-					const abort = new AbortController();
-					this.updateRestartPrepareAbort = abort;
-					this.updateRestartPrepareInFlight = true;
+					const transaction: NonNullable<AgentDaemon["updateRestartTransaction"]> = {
+						id: Symbol("update-restart"),
+						owner: client,
+						abort: new AbortController(),
+					};
+					this.updateRestartTransaction = transaction;
 					this.updateRestartPreparing = true;
 					this.cronScheduler.stop();
-					const deadline = setTimeout(() => abort.abort(), UPDATE_RESTART_PREPARE_TIMEOUT_MS);
-					deadline.unref();
-					let manifest: DaemonUpdateRestartManifest;
+					transaction.deadline = setTimeout(() => {
+						transaction.abort.abort();
+						this.cancelPreparedUpdateRestart(transaction.id);
+					}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
+					transaction.deadline.unref();
 					try {
-						await this.waitForWorkerMutations(abort.signal);
-						manifest = await this.prepareUpdateRestartCheckpoint(abort.signal, true);
+						await this.waitForWorkerMutations(transaction.abort.signal);
+						const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
+						if (!this.isUpdateRestartTransaction(transaction.id) || transaction.abort.signal.aborted) {
+							throw new Error("Update restart preparation cancelled");
+						}
+						this.preparedUpdateRestart = { id: transaction.id, manifest };
+						this.write(client, {
+							id: command.id,
+							type: "response",
+							command: command.type,
+							success: true,
+							data: manifest,
+						});
 					} catch (error) {
-						if (this.updateRestartPrepareAbort === abort) this.cancelPreparedUpdateRestart();
+						this.cancelPreparedUpdateRestart(transaction.id);
 						throw error;
-					} finally {
-						this.updateRestartPrepareInFlight = false;
-						clearTimeout(deadline);
 					}
-
-					this.write(client, {
-						id: command.id,
-						type: "response",
-						command: command.type,
-						success: true,
-						data: manifest,
-					});
 					return;
 				}
 				case "worker_commit_update": {
-					if (!this.preparedUpdateRestartManifest) throw new Error("Daemon has no prepared update checkpoint");
-					this.updateRestartCommitInFlight = true;
+					const prepared = this.preparedUpdateRestart;
+					const transaction = this.updateRestartTransaction;
+					if (!prepared || !transaction || transaction.id !== prepared.id) {
+						throw new Error("Daemon has no prepared update checkpoint");
+					}
+					if (transaction.owner !== client)
+						throw new Error("Daemon update checkpoint belongs to another supervisor");
+					if (transaction.deadline) clearTimeout(transaction.deadline);
+					transaction.deadline = undefined;
+					this.updateRestartPublishing = prepared.id;
 					let manifest: DaemonUpdateRestartManifest;
 					try {
-						manifest = await this.commitPreparedUpdateRestart();
+						manifest = await this.commitPreparedUpdateRestart(prepared.id);
 					} catch (error) {
-						this.updateRestartCommitInFlight = false;
+						if (this.updateRestartPublishing === prepared.id) this.updateRestartPublishing = undefined;
 						throw error;
 					}
 					this.write(client, {
@@ -2832,12 +2841,16 @@ export class AgentDaemon {
 					});
 					return;
 				}
-				case "worker_cancel_update":
-					if (this.updateRestartCommitInFlight) {
+				case "worker_cancel_update": {
+					const transaction = this.updateRestartTransaction;
+					if (transaction && transaction.owner !== client) {
+						throw new Error("Daemon update checkpoint belongs to another supervisor");
+					}
+					const transactionId = transaction?.id;
+					if (transactionId && this.updateRestartPublishing === transactionId) {
 						throw new Error("Daemon update checkpoint is already committing");
 					}
-					this.updateRestartPrepareAbort?.abort();
-					this.cancelPreparedUpdateRestart();
+					if (transactionId) this.cancelPreparedUpdateRestart(transactionId);
 					this.write(client, {
 						id: command.id,
 						type: "response",
@@ -2845,6 +2858,7 @@ export class AgentDaemon {
 						success: true,
 					});
 					return;
+				}
 			}
 		} catch (error) {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));
@@ -2859,8 +2873,12 @@ export class AgentDaemon {
 		if (
 			this.updateRestartPreparing &&
 			command.type !== "ack_result" &&
-			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+			(command.type !== "shutdown" || !this.preparedUpdateRestart) &&
+			!(
+				this.preparedUpdateRestart === undefined &&
+				this.updateRestartPublishing === undefined &&
+				UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
+			)
 		) {
 			throw new Error("Daemon is preparing an update restart");
 		}
@@ -4661,17 +4679,14 @@ export class AgentDaemon {
 		return depth;
 	}
 
+	private isUpdateRestartTransaction(id: symbol): boolean {
+		return this.updateRestartTransaction?.id === id;
+	}
+
 	private async prepareUpdateRestartCheckpoint(
-		signal?: AbortSignal,
-		alreadyFenced = false,
+		signal: AbortSignal,
+		transactionId: symbol,
 	): Promise<DaemonUpdateRestartManifest> {
-		if (this.updateRestartPreparing && !alreadyFenced) {
-			throw new Error("Daemon is already preparing an update restart");
-		}
-		this.updateRestartPreparing = true;
-		// Keep persisted jobs for the replacement daemon, but stop this process
-		// from accepting another scheduled mutation while its checkpoint is held.
-		this.cronScheduler.stop();
 		try {
 			const states = [...this.sessions.values()];
 			this.updateRestartQueuePauses.clear();
@@ -4679,41 +4694,57 @@ export class AgentDaemon {
 				this.updateRestartQueuePauses.set(state.activeSessionId, state.runtime.session.acquireQueuedWorkPause());
 			}
 			await Promise.all(states.map((state) => state.runtime.session.waitForSessionInputCheckpoint(signal)));
+			if (signal.aborted || !this.isUpdateRestartTransaction(transactionId)) {
+				throw new Error("Update restart preparation cancelled");
+			}
 			const snapshottedIds = new Set(states.map((state) => state.activeSessionId));
 			const addedSession = [...this.sessions.keys()].find((activeSessionId) => !snapshottedIds.has(activeSessionId));
 			if (addedSession) throw new Error(`Session ${addedSession} became resident during update preparation`);
 
 			const restartSessions = states
+				.filter((state) => this.sessions.get(state.activeSessionId) === state)
 				.map((state) => this.createUpdateRestartSession(state))
 				.filter((session): session is DaemonUpdateRestartSession => session !== undefined)
-				.sort(
-					(left, right) =>
-						this.getUpdateRestartSessionDepth(this.getSessionState(left.activeSessionId)) -
-						this.getUpdateRestartSessionDepth(this.getSessionState(right.activeSessionId)),
-				);
-			const manifest = {
+				.sort((left, right) => {
+					const leftState = this.sessions.get(left.activeSessionId);
+					const rightState = this.sessions.get(right.activeSessionId);
+					return (
+						(leftState ? this.getUpdateRestartSessionDepth(leftState) : 0) -
+						(rightState ? this.getUpdateRestartSessionDepth(rightState) : 0)
+					);
+				});
+			if (signal.aborted || !this.isUpdateRestartTransaction(transactionId)) {
+				throw new Error("Update restart preparation cancelled");
+			}
+			const includedActiveSessionIds = new Set(restartSessions.map((session) => session.activeSessionId));
+			const discardedActiveSessionIds = states
+				.filter(
+					(state) =>
+						this.sessions.get(state.activeSessionId) === state &&
+						!includedActiveSessionIds.has(state.activeSessionId),
+				)
+				.map((state) => state.activeSessionId);
+			return {
 				createdAt: new Date().toISOString(),
 				sessions: restartSessions,
+				...(discardedActiveSessionIds.length > 0 ? { discardedActiveSessionIds } : {}),
 			};
-			this.preparedUpdateRestartManifest = manifest;
-			return manifest;
 		} catch (error) {
-			this.cancelPreparedUpdateRestart();
+			this.cancelPreparedUpdateRestart(transactionId);
 			throw error;
 		}
 	}
 
-	private async commitPreparedUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		const manifest = this.preparedUpdateRestartManifest;
-		if (!this.updateRestartPreparing || !manifest) {
+	private async commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest> {
+		const prepared = this.preparedUpdateRestart;
+		if (!this.updateRestartPreparing || !prepared || prepared.id !== transactionId) {
 			throw new Error("Daemon has no prepared update checkpoint");
 		}
+		const manifest = prepared.manifest;
 		const restartByActiveSessionId = new Map(manifest.sessions.map((session) => [session.activeSessionId, session]));
 		for (const state of this.sessions.values()) {
 			const restartSession = restartByActiveSessionId.get(state.activeSessionId);
-			if (restartSession) {
-				this.appendUpdateRestartMarker(state, restartSession);
-			}
+			if (restartSession) this.appendUpdateRestartMarker(state, restartSession);
 		}
 		const closeStates = [...this.sessions.values()].sort(
 			(left, right) => this.getUpdateRestartSessionDepth(right) - this.getUpdateRestartSessionDepth(left),
@@ -4723,32 +4754,53 @@ export class AgentDaemon {
 				await this.closeSession(state, restartByActiveSessionId.has(state.activeSessionId) ? "update" : "killed");
 			}
 		}
-		for (const state of [...this.sessions.values()]) {
-			await this.closeSession(state, "killed");
-		}
+		for (const state of [...this.sessions.values()]) await this.closeSession(state, "killed");
 		return manifest;
 	}
 
-	private cancelPreparedUpdateRestart(): void {
-		this.updateRestartPrepareAbort = undefined;
-		this.updateRestartPrepareInFlight = false;
-		this.preparedUpdateRestartManifest = undefined;
+	private cancelPreparedUpdateRestart(transactionId?: symbol): void {
+		const transaction = this.updateRestartTransaction;
+		if (!transaction || (transactionId && transaction.id !== transactionId)) return;
+		if (transaction.deadline) clearTimeout(transaction.deadline);
+		transaction.deadline = undefined;
+		transaction.abort.abort();
+		if (this.updateRestartPublishing === transaction.id) return;
+		this.updateRestartTransaction = undefined;
+		this.preparedUpdateRestart = undefined;
 		this.updateRestartPreparing = false;
 		for (const pause of this.updateRestartQueuePauses.values()) pause.release();
 		this.updateRestartQueuePauses.clear();
-
-		if (!this.shuttingDown) {
-			this.cronScheduler.start();
-		}
+		if (!this.shuttingDown) this.cronScheduler.start();
 	}
 
 	private async prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		const manifest = await this.prepareUpdateRestartCheckpoint();
+		if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
+		const transaction: NonNullable<AgentDaemon["updateRestartTransaction"]> = {
+			id: Symbol("update-restart"),
+			abort: new AbortController(),
+		};
+		this.updateRestartTransaction = transaction;
+		this.updateRestartPreparing = true;
+		this.cronScheduler.stop();
+		transaction.deadline = setTimeout(() => {
+			transaction.abort.abort();
+			this.cancelPreparedUpdateRestart(transaction.id);
+		}, UPDATE_RESTART_PREPARE_TIMEOUT_MS);
+		transaction.deadline.unref();
 		try {
+			const manifest = await this.prepareUpdateRestartCheckpoint(transaction.abort.signal, transaction.id);
+			if (transaction.abort.signal.aborted || !this.isUpdateRestartTransaction(transaction.id)) {
+				throw new Error("Update restart preparation cancelled");
+			}
+			this.preparedUpdateRestart = { id: transaction.id, manifest };
+			if (transaction.deadline) clearTimeout(transaction.deadline);
+			transaction.deadline = undefined;
+			this.updateRestartPublishing = transaction.id;
 			this.writeUpdateRestartManifest(manifest);
-			return await this.commitPreparedUpdateRestart();
+			return await this.commitPreparedUpdateRestart(transaction.id);
 		} catch (error) {
-			this.cancelPreparedUpdateRestart();
+			this.updateRestartPublishing = undefined;
+			this.cancelPreparedUpdateRestart(transaction.id);
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2657,6 +2657,7 @@ export class AgentDaemon {
 				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
 				: restartPhase !== undefined && command.type !== "shutdown";
 		if (mutation && restartRejected) {
+			clearParsedAdmission();
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -497,6 +497,10 @@ export class AgentDaemon {
 		}
 		this.cronScheduler = new AgentCronScheduler(this.cronStore, {
 			runJob: (job) => this.runCronJob(job),
+			beginDispatch: () => {
+				this.mutationDrain.begin();
+				return () => this.mutationDrain.end();
+			},
 			onError: (job, error) => {
 				this.log(`Cron job ${job.id} failed: ${error instanceof Error ? error.message : String(error)}`);
 			},
@@ -625,6 +629,13 @@ export class AgentDaemon {
 		return this.supervisorClaims.size > 0;
 	}
 
+	private revokeSupervisorClaim(client: DaemonSocketClient): void {
+		this.supervisorClaims.delete(client);
+		if (this.options.worker && this.updateRestart?.owner === client) {
+			this.cancelPreparedUpdateRestart(this.updateRestart.id);
+		}
+	}
+
 	private clearSupervisorAvailabilityCheck(): void {
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
@@ -654,6 +665,7 @@ export class AgentDaemon {
 					boundClaim.ownerFingerprint,
 				);
 			} catch {
+				this.revokeSupervisorClaim(client);
 				client.socket.end();
 			}
 		}
@@ -1234,9 +1246,6 @@ export class AgentDaemon {
 	}
 
 	private async runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> {
-		if (this.updateRestart) {
-			return "skipped";
-		}
 		const requirePersistedJob = this.cronStore.list().some((candidate) => candidate.id === job.id);
 		const dueJob = requirePersistedJob ? this.getRunnableCronJob(job.id) : job;
 		if (!dueJob) {
@@ -1244,12 +1253,7 @@ export class AgentDaemon {
 		}
 		const state = await this.getOrCreateCronJobSession(dueJob, requirePersistedJob);
 		const runnableJob = requirePersistedJob ? this.getRunnableCronJob(job.id) : dueJob;
-		if (
-			!state ||
-			!runnableJob ||
-			this.updateRestart !== undefined ||
-			!this.isCronJobRunnableForState(runnableJob, state, requirePersistedJob)
-		) {
+		if (!state || !runnableJob || !this.isCronJobRunnableForState(runnableJob, state, requirePersistedJob)) {
 			return "skipped";
 		}
 		const session = state.runtime.session;
@@ -1661,9 +1665,6 @@ export class AgentDaemon {
 		job: AgentCronJob,
 		requirePersistedJob: boolean,
 	): Promise<ActiveSessionState | undefined> {
-		if (this.updateRestart) {
-			return undefined;
-		}
 		const dueJob = requirePersistedJob ? this.getRunnableCronJob(job.id) : job;
 		if (!dueJob) {
 			return undefined;
@@ -2418,12 +2419,10 @@ export class AgentDaemon {
 			this.detachClient(client);
 			client.detachInput();
 			this.clients.delete(client);
-			this.supervisorClaims.delete(client);
-			if (this.options.worker && this.updateRestart?.owner === client) {
-				this.cancelPreparedUpdateRestart(this.updateRestart.id);
-			}
+			const wasAuthenticated = client.authenticated === true;
+			this.revokeSupervisorClaim(client);
 			const supervisorSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
-			if (this.options.worker && client.authenticated === true && supervisorSocketPath) {
+			if (this.options.worker && wasAuthenticated && supervisorSocketPath) {
 				this.scheduleSupervisorAvailabilityCheck(supervisorSocketPath, 100);
 			}
 		};
@@ -2546,6 +2545,7 @@ export class AgentDaemon {
 				}
 				for (const previous of this.supervisorClaims.keys()) {
 					if (previous !== client) {
+						this.revokeSupervisorClaim(previous);
 						previous.socket.end();
 					}
 				}
@@ -2603,7 +2603,10 @@ export class AgentDaemon {
 					);
 					// Cancelling this prompt only abandons its admission wait. A genuine
 					// stale supervisor claim fences only the binding that it checked.
-					if (!admissionCancelled && this.supervisorClaims.get(client) === boundClaim) client.socket.end();
+					if (!admissionCancelled && this.supervisorClaims.get(client) === boundClaim) {
+						this.revokeSupervisorClaim(client);
+						client.socket.end();
+					}
 					return;
 				}
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2897,7 +2897,11 @@ export class AgentDaemon {
 				const streamsSnapshot =
 					client.transport === "private-framed" &&
 					daemonClientCapabilitiesForSession(client, state.activeSessionId).has("chunked_snapshot");
-				this.adoptClientEnv(state, filterClientEnv(command.env));
+				// Attach is admitted during update-restart preparation as a read, but env
+				// adoption is a session mutation: adopting after the manifest snapshot
+				// would strand the identity on a checkpoint that no longer includes it.
+				// The client re-attaches after restart and adopts env then.
+				if (!this.updateRestart) this.adoptClientEnv(state, filterClientEnv(command.env));
 				const snapshotSignal = streamsSnapshot
 					? markClientSnapshotStreaming(client, state.activeSessionId)
 					: undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -331,6 +331,7 @@ export interface DaemonUpdateRestartSession {
 export interface DaemonUpdateRestartManifest {
 	createdAt: string;
 	sessions: DaemonUpdateRestartSession[];
+	discardedActiveSessionIds?: string[];
 }
 
 export type DaemonSavedSessionListCommand =
@@ -995,6 +996,15 @@ const READ_ONLY_DAEMON_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
 export function isDaemonMutatingCommand(command: Pick<DaemonCommand, "type">): boolean {
 	return !READ_ONLY_DAEMON_COMMANDS.has(command.type);
 }
+
+export const UPDATE_RESTART_DRAIN_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
+	"extension_ui_response",
+	"abort",
+	"abort_bash",
+	"abort_branch_summary",
+	"abort_compaction",
+	"abort_retry",
+]);
 
 export function createDaemonEventEnvelope<TEvent extends DaemonOutbound>(
 	event: TEvent,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -94,6 +94,7 @@ import {
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
+import { MutationDrainLatch } from "./mutation-drain-latch.js";
 import { SNAPSHOT_TARGET_CHUNK_BYTES, SnapshotTranscriptCache } from "./snapshot-transcript-cache.js";
 import { WorkerRecoveryJournal } from "./worker-recovery-journal.js";
 
@@ -581,11 +582,8 @@ export class DaemonSupervisor {
 	private ownership?: Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
 	private cleanupPromise?: Promise<void>;
 	private shuttingDown = false;
-	private updateRestartPreparing = false;
-	private updateRestartPrepareInFlight = false;
-	private updateRestartDrainAdmissionOpen = false;
-	private activeMutations = 0;
-	private readonly mutationDrainWaiters = new Set<() => void>();
+	private updateRestartPhase?: "draining" | "fencing" | "prepared";
+	private readonly mutationDrain = new MutationDrainLatch();
 	private readonly clients = new Set<DaemonSocketClient>();
 	private readonly protocolClientIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly workers = new Map<string, ResidentWorker>();
@@ -1113,12 +1111,12 @@ export class DaemonSupervisor {
 			return;
 		}
 
-		if (
-			this.updateRestartPreparing &&
-			isDaemonMutatingCommand(command) &&
-			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartDrainAdmissionOpen && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
-		) {
+		const phase = this.updateRestartPhase;
+		const restartRejected =
+			phase === "draining"
+				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
+				: phase !== undefined && !(phase === "prepared" && command.type === "shutdown");
+		if (restartRejected && isDaemonMutatingCommand(command)) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}
@@ -1148,7 +1146,7 @@ export class DaemonSupervisor {
 		}
 
 		const mutation = isDaemonMutatingCommand(command);
-		if (mutation) this.activeMutations++;
+		if (mutation) this.mutationDrain.begin();
 		try {
 			const response = await this.handleCommand(client, command, cancellationAdmission);
 			if (response) {
@@ -1171,11 +1169,7 @@ export class DaemonSupervisor {
 			}
 			this.write(client, response);
 		} finally {
-			if (mutation) {
-				this.activeMutations--;
-				for (const resolve of this.mutationDrainWaiters ?? []) resolve();
-				this.mutationDrainWaiters?.clear();
-			}
+			if (mutation) this.mutationDrain.end();
 		}
 	}
 
@@ -1184,15 +1178,6 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 		cancellationAdmission?: SupervisorPromptAdmission,
 	): Promise<DaemonResponse | undefined> {
-		if (
-			this.updateRestartPreparing &&
-			command.type !== "ack_result" &&
-			isDaemonMutatingCommand(command) &&
-			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartDrainAdmissionOpen && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
-		) {
-			throw new Error("Daemon is preparing an update restart");
-		}
 		switch (command.type) {
 			case "cancel_prompt_admission": {
 				const admission =
@@ -3786,44 +3771,18 @@ export class DaemonSupervisor {
 	}
 
 	private async prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
-		this.updateRestartPreparing = true;
-		this.updateRestartPrepareInFlight = true;
-		this.updateRestartDrainAdmissionOpen = true;
+		if (this.updateRestartPhase !== undefined) throw new Error("Daemon is already preparing an update restart");
+		this.updateRestartPhase = "draining";
 		try {
 			const abort = AbortSignal.timeout(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS);
-			await this.waitForMutationDrain(1, abort);
-			this.updateRestartDrainAdmissionOpen = false;
+			await this.mutationDrain.waitForDrain(1, abort, "Timed out draining daemon mutations for update restart");
+			this.updateRestartPhase = "fencing";
 			const manifest = await this.prepareUpdateRestartFenced();
-			this.updateRestartPrepareInFlight = false;
+			this.updateRestartPhase = "prepared";
 			return manifest;
 		} catch (error) {
-			this.updateRestartDrainAdmissionOpen = false;
-			this.updateRestartPrepareInFlight = false;
-			this.updateRestartPreparing = false;
+			this.updateRestartPhase = undefined;
 			throw error;
-		}
-	}
-
-	private async waitForMutationDrain(remaining: number, signal: AbortSignal): Promise<void> {
-		while (this.activeMutations > remaining) {
-			if (signal.aborted) throw new Error("Timed out draining daemon mutations for update restart");
-			await new Promise<void>((resolve, reject) => {
-				const onDrained = () => {
-					cleanup();
-					resolve();
-				};
-				const onAbort = () => {
-					cleanup();
-					reject(new Error("Timed out draining daemon mutations for update restart"));
-				};
-				const cleanup = () => {
-					this.mutationDrainWaiters.delete(onDrained);
-					signal.removeEventListener("abort", onAbort);
-				};
-				this.mutationDrainWaiters.add(onDrained);
-				signal.addEventListener("abort", onAbort, { once: true });
-			});
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1115,41 +1115,42 @@ export class DaemonSupervisor {
 			return;
 		}
 
+		const mutation = isDaemonMutatingCommand(command);
+		const journalIdentity =
+			envelopeClientId && command.id && mutation ? { clientId: envelopeClientId, commandId: command.id } : undefined;
+		const existing = journalIdentity
+			? this.commandJournal.lookup(journalIdentity.clientId, journalIdentity.commandId)
+			: undefined;
+		if (existing?.status === "complete") {
+			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
+			this.write(client, existing.response);
+			return;
+		}
+		if (existing?.status === "pending" && journalIdentity) {
+			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
+			this.write(
+				client,
+				failure(command.id, command.type, "The previous command result is uncertain and was not replayed", {
+					code: "command_result_uncertain",
+					...journalIdentity,
+				}),
+			);
+			return;
+		}
+
 		const phase = this.updateRestartPhase;
 		const restartRejected =
 			phase === "draining"
 				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
 				: phase !== undefined && !(phase === "prepared" && command.type === "shutdown");
-		if (restartRejected && isDaemonMutatingCommand(command)) {
+		if (restartRejected && mutation) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}
-
-		const journalIdentity =
-			envelopeClientId && command.id && isDaemonMutatingCommand(command)
-				? { clientId: envelopeClientId, commandId: command.id }
-				: undefined;
 		if (journalIdentity) {
-			const existing = this.commandJournal.begin(journalIdentity.clientId, journalIdentity.commandId, command.type);
-			if (existing.status === "complete") {
-				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
-				this.write(client, existing.response);
-				return;
-			}
-			if (existing.status === "pending") {
-				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
-				this.write(
-					client,
-					failure(command.id, command.type, "The previous command result is uncertain and was not replayed", {
-						code: "command_result_uncertain",
-						...journalIdentity,
-					}),
-				);
-				return;
-			}
+			this.commandJournal.begin(journalIdentity.clientId, journalIdentity.commandId, command.type);
 		}
 
-		const mutation = isDaemonMutatingCommand(command);
 		if (mutation) this.mutationDrain.begin();
 		try {
 			const response = await this.handleCommand(client, command, cancellationAdmission);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -102,6 +102,15 @@ type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
 const structuredLog = getLogger("coding-agent.daemon-supervisor");
 const WORKER_CONNECT_TIMEOUT_MS = 30_000;
 const WORKER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS = 80_000;
+const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
+const UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS = new Set<DaemonCommand["type"]>([
+	"extension_ui_response",
+	"abort",
+	"abort_bash",
+	"abort_compaction",
+	"abort_retry",
+]);
 const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
@@ -577,6 +586,10 @@ export class DaemonSupervisor {
 	private ownership?: Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
 	private cleanupPromise?: Promise<void>;
 	private shuttingDown = false;
+	private updateRestartPreparing = false;
+	private updateRestartPrepareInFlight = false;
+	private activeMutations = 0;
+	private readonly mutationDrainWaiters = new Set<() => void>();
 	private readonly clients = new Set<DaemonSocketClient>();
 	private readonly protocolClientIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly workers = new Map<string, ResidentWorker>();
@@ -1104,6 +1117,16 @@ export class DaemonSupervisor {
 			return;
 		}
 
+		if (
+			this.updateRestartPreparing &&
+			isDaemonMutatingCommand(command) &&
+			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+		) {
+			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
+			return;
+		}
+
 		const journalIdentity =
 			envelopeClientId && command.id && isDaemonMutatingCommand(command)
 				? { clientId: envelopeClientId, commandId: command.id }
@@ -1128,6 +1151,8 @@ export class DaemonSupervisor {
 			}
 		}
 
+		const mutation = isDaemonMutatingCommand(command);
+		if (mutation) this.activeMutations++;
 		try {
 			const response = await this.handleCommand(client, command, cancellationAdmission);
 			if (response) {
@@ -1149,6 +1174,12 @@ export class DaemonSupervisor {
 				}
 			}
 			this.write(client, response);
+		} finally {
+			if (mutation) {
+				this.activeMutations--;
+				for (const resolve of this.mutationDrainWaiters ?? []) resolve();
+				this.mutationDrainWaiters?.clear();
+			}
 		}
 	}
 
@@ -1157,6 +1188,15 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 		cancellationAdmission?: SupervisorPromptAdmission,
 	): Promise<DaemonResponse | undefined> {
+		if (
+			this.updateRestartPreparing &&
+			command.type !== "ack_result" &&
+			isDaemonMutatingCommand(command) &&
+			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+		) {
+			throw new Error("Daemon is preparing an update restart");
+		}
 		switch (command.type) {
 			case "cancel_prompt_admission": {
 				const admission =
@@ -3750,20 +3790,74 @@ export class DaemonSupervisor {
 	}
 
 	private async prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest> {
-		const workers = [...this.workers.values()].filter(
-			(worker): worker is ResidentWorker & { client: DaemonWorkerClient } => worker.client !== undefined,
+		if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
+		this.updateRestartPreparing = true;
+		this.updateRestartPrepareInFlight = true;
+		try {
+			const abort = AbortSignal.timeout(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS);
+			await this.waitForMutationDrain(1, abort);
+			const manifest = await this.prepareUpdateRestartFenced();
+			this.updateRestartPrepareInFlight = false;
+			return manifest;
+		} catch (error) {
+			this.updateRestartPrepareInFlight = false;
+			this.updateRestartPreparing = false;
+			throw error;
+		}
+	}
+
+	private async waitForMutationDrain(remaining: number, signal: AbortSignal): Promise<void> {
+		while (this.activeMutations > remaining) {
+			if (signal.aborted) throw new Error("Timed out draining daemon mutations for update restart");
+			await new Promise<void>((resolve, reject) => {
+				const onDrained = () => {
+					cleanup();
+					resolve();
+				};
+				const onAbort = () => {
+					cleanup();
+					reject(new Error("Timed out draining daemon mutations for update restart"));
+				};
+				const cleanup = () => {
+					this.mutationDrainWaiters.delete(onDrained);
+					signal.removeEventListener("abort", onAbort);
+				};
+				this.mutationDrainWaiters.add(onDrained);
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
+		}
+	}
+
+	private async prepareUpdateRestartFenced(): Promise<DaemonUpdateRestartManifest> {
+		const residents = [...this.workers.values()];
+		const unavailable = residents.find(
+			(worker) => worker.descriptor.lifecycle !== "ready" || worker.client === undefined,
 		);
+		if (unavailable) {
+			throw new Error(
+				`Cannot prepare update restart while resident worker ${unavailable.descriptor.workerId} is ${unavailable.descriptor.lifecycle}${unavailable.client ? "" : " and disconnected"}`,
+			);
+		}
+		const workers = residents as Array<ResidentWorker & { client: DaemonWorkerClient }>;
 		const prepared: Array<ResidentWorker & { client: DaemonWorkerClient }> = [];
 		const preparationResults = await Promise.allSettled(
 			workers.map(async (worker) => {
 				const response = await worker.client.requestWorker(
 					{ type: "worker_prepare_update" },
-					WORKER_REQUEST_TIMEOUT_MS,
+					UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS,
 				);
 				if (!response.success || !response.data || typeof response.data !== "object") {
 					throw new Error(response.success ? "Worker returned an invalid update manifest" : response.error);
 				}
-				return { worker, manifest: response.data as DaemonUpdateRestartManifest };
+				const manifest = response.data as DaemonUpdateRestartManifest;
+				if (
+					!manifest.sessions.some((session) => session.activeSessionId === worker.descriptor.rootActiveSessionId)
+				) {
+					throw new Error(
+						`Worker ${worker.descriptor.workerId} omitted its root session from the update manifest`,
+					);
+				}
+				return { worker, manifest };
 			}),
 		);
 		for (const result of preparationResults) {
@@ -3799,18 +3893,32 @@ export class DaemonSupervisor {
 			);
 			throw error;
 		}
-		await Promise.all(
+		const commitResults = await Promise.allSettled(
 			prepared.map(async (worker) => {
 				const response = await worker.client.requestWorker(
 					{ type: "worker_commit_update" },
-					WORKER_REQUEST_TIMEOUT_MS,
+					UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS,
 				);
-				if (!response.success) {
-					throw new Error(response.error);
-				}
+				if (!response.success) throw new Error(response.error);
 			}),
 		);
-		await Promise.all(prepared.map((worker) => this.stopWorker(worker, false)));
+		const commitFailure = commitResults.find(
+			(result): result is PromiseRejectedResult => result.status === "rejected",
+		);
+		if (commitFailure) {
+			// A successful commit may already have destroyed a worker's live state. The
+			// aggregate manifest is durable, so remain fenced and finish stopping every
+			// resident. Returning the full manifest forces restart completion instead of
+			// exposing this partially committed generation again.
+			this.log(`Update restart commit response failed; forcing restart completion: ${String(commitFailure.reason)}`);
+			await Promise.allSettled(prepared.map((worker) => this.stopWorker(worker, false, true)));
+			return manifest;
+		}
+		const stopResults = await Promise.allSettled(prepared.map((worker) => this.stopWorker(worker, false)));
+		if (stopResults.some((result) => result.status === "rejected")) {
+			this.log("A committed update worker did not stop gracefully; forcing restart completion");
+			await Promise.allSettled(prepared.map((worker) => this.stopWorker(worker, false, true)));
+		}
 		return manifest;
 	}
 
@@ -3824,7 +3932,7 @@ export class DaemonSupervisor {
 			if (activeSessionIds.has(session.activeSessionId)) {
 				throw new Error(`Update manifest contains duplicate active session ${session.activeSessionId}`);
 			}
-			const sessionFile = resolve(session.sessionFile);
+			const sessionFile = canonicalSessionPath(session.sessionFile);
 			if (sessionFiles.has(sessionFile)) {
 				throw new Error(`Update manifest contains duplicate session file ${sessionFile}`);
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -583,6 +583,7 @@ export class DaemonSupervisor {
 	private shuttingDown = false;
 	private updateRestartPreparing = false;
 	private updateRestartPrepareInFlight = false;
+	private updateRestartDrainAdmissionOpen = false;
 	private activeMutations = 0;
 	private readonly mutationDrainWaiters = new Set<() => void>();
 	private readonly clients = new Set<DaemonSocketClient>();
@@ -1116,7 +1117,7 @@ export class DaemonSupervisor {
 			this.updateRestartPreparing &&
 			isDaemonMutatingCommand(command) &&
 			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
+			!(this.updateRestartDrainAdmissionOpen && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
 		) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
@@ -1188,7 +1189,7 @@ export class DaemonSupervisor {
 			command.type !== "ack_result" &&
 			isDaemonMutatingCommand(command) &&
 			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
+			!(this.updateRestartDrainAdmissionOpen && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
 		) {
 			throw new Error("Daemon is preparing an update restart");
 		}
@@ -3788,13 +3789,16 @@ export class DaemonSupervisor {
 		if (this.updateRestartPreparing) throw new Error("Daemon is already preparing an update restart");
 		this.updateRestartPreparing = true;
 		this.updateRestartPrepareInFlight = true;
+		this.updateRestartDrainAdmissionOpen = true;
 		try {
 			const abort = AbortSignal.timeout(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS);
 			await this.waitForMutationDrain(1, abort);
+			this.updateRestartDrainAdmissionOpen = false;
 			const manifest = await this.prepareUpdateRestartFenced();
 			this.updateRestartPrepareInFlight = false;
 			return manifest;
 		} catch (error) {
+			this.updateRestartDrainAdmissionOpen = false;
 			this.updateRestartPrepareInFlight = false;
 			this.updateRestartPreparing = false;
 			throw error;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -106,6 +106,10 @@ const WORKER_CONNECT_TIMEOUT_MS = 30_000;
 const WORKER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS = 80_000;
 const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
+// The whole pre-commit prepare (drain + worker fencing) must finish inside the
+// caller's 120s prepare_update_restart request timeout, or roll back; otherwise
+// an abandoned prepare leaves the daemon permanently fenced with workers stopped.
+const UPDATE_RESTART_PREPARE_DEADLINE_MS = 100_000;
 const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
@@ -3774,10 +3778,11 @@ export class DaemonSupervisor {
 		if (this.updateRestartPhase !== undefined) throw new Error("Daemon is already preparing an update restart");
 		this.updateRestartPhase = "draining";
 		try {
-			const abort = AbortSignal.timeout(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS);
+			const deadline = Date.now() + UPDATE_RESTART_PREPARE_DEADLINE_MS;
+			const abort = AbortSignal.timeout(Math.min(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS, deadline - Date.now()));
 			await this.mutationDrain.waitForDrain(1, abort, "Timed out draining daemon mutations for update restart");
 			this.updateRestartPhase = "fencing";
-			const manifest = await this.prepareUpdateRestartFenced();
+			const manifest = await this.prepareUpdateRestartFenced(deadline);
 			this.updateRestartPhase = "prepared";
 			return manifest;
 		} catch (error) {
@@ -3786,7 +3791,7 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private async prepareUpdateRestartFenced(): Promise<DaemonUpdateRestartManifest> {
+	private async prepareUpdateRestartFenced(deadline: number): Promise<DaemonUpdateRestartManifest> {
 		const residents = [...this.workers.values()];
 		const unavailable = residents.find(
 			(worker) => worker.descriptor.lifecycle !== "ready" || worker.client === undefined,
@@ -3803,7 +3808,7 @@ export class DaemonSupervisor {
 				const client = worker.client;
 				const response = await client.requestWorker(
 					{ type: "worker_prepare_update" },
-					UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS,
+					Math.max(1, Math.min(UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS, deadline - Date.now())),
 				);
 				if (!response.success) throw new Error(response.error);
 				worker.updateRestartPrepareClient = client;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -58,6 +58,7 @@ import {
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
 	success,
+	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
 import { matchesSessionIdSuffix } from "./daemon-session-id.js";
@@ -104,13 +105,6 @@ const WORKER_CONNECT_TIMEOUT_MS = 30_000;
 const WORKER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS = 80_000;
 const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
-const UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS = new Set<DaemonCommand["type"]>([
-	"extension_ui_response",
-	"abort",
-	"abort_bash",
-	"abort_compaction",
-	"abort_retry",
-]);
 const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
@@ -231,6 +225,7 @@ interface ResidentWorker {
 	launchEnv?: Record<string, string>;
 	ownerCleanupTimer?: ReturnType<typeof setTimeout>;
 	promotedOwnerClientId?: string;
+	updateRestartPrepareClient?: DaemonWorkerClient;
 }
 
 interface SnapshotDuplicateValidation {
@@ -1121,7 +1116,7 @@ export class DaemonSupervisor {
 			this.updateRestartPreparing &&
 			isDaemonMutatingCommand(command) &&
 			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
 		) {
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
@@ -1193,7 +1188,7 @@ export class DaemonSupervisor {
 			command.type !== "ack_result" &&
 			isDaemonMutatingCommand(command) &&
 			(command.type !== "shutdown" || this.updateRestartPrepareInFlight) &&
-			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_ALLOWED_COMMANDS.has(command.type))
+			!(this.updateRestartPrepareInFlight && UPDATE_RESTART_DRAIN_COMMANDS.has(command.type))
 		) {
 			throw new Error("Daemon is preparing an update restart");
 		}
@@ -3839,63 +3834,87 @@ export class DaemonSupervisor {
 			);
 		}
 		const workers = residents as Array<ResidentWorker & { client: DaemonWorkerClient }>;
-		const prepared: Array<ResidentWorker & { client: DaemonWorkerClient }> = [];
+		const acknowledged: ResidentWorker[] = [];
 		const preparationResults = await Promise.allSettled(
 			workers.map(async (worker) => {
-				const response = await worker.client.requestWorker(
+				const client = worker.client;
+				const response = await client.requestWorker(
 					{ type: "worker_prepare_update" },
 					UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS,
 				);
-				if (!response.success || !response.data || typeof response.data !== "object") {
-					throw new Error(response.success ? "Worker returned an invalid update manifest" : response.error);
+				if (!response.success) throw new Error(response.error);
+				worker.updateRestartPrepareClient = client;
+				acknowledged.push(worker);
+				if (!response.data || typeof response.data !== "object") {
+					throw new Error("Worker returned an invalid update manifest");
+				}
+				if (worker.client !== client || worker.descriptor.lifecycle !== "ready") {
+					throw new Error(`Worker ${worker.descriptor.workerId} disconnected during update preparation`);
 				}
 				const manifest = response.data as DaemonUpdateRestartManifest;
 				if (
-					!manifest.sessions.some((session) => session.activeSessionId === worker.descriptor.rootActiveSessionId)
+					!manifest.sessions.some(
+						(session) => session.activeSessionId === worker.descriptor.rootActiveSessionId,
+					) &&
+					!manifest.discardedActiveSessionIds?.includes(worker.descriptor.rootActiveSessionId)
 				) {
 					throw new Error(
-						`Worker ${worker.descriptor.workerId} omitted its root session from the update manifest`,
+						`Worker ${worker.descriptor.workerId} omitted its root disposition from the update manifest`,
 					);
 				}
 				return { worker, manifest };
 			}),
 		);
-		for (const result of preparationResults) {
-			if (result.status === "fulfilled") {
-				prepared.push(result.value.worker);
-			}
-		}
+		const cancelAcknowledged = async () => {
+			await Promise.all(
+				acknowledged.map(async (worker) => {
+					const prepareClient = worker.updateRestartPrepareClient;
+					worker.updateRestartPrepareClient = undefined;
+					if (!prepareClient) return;
+					try {
+						const response = await prepareClient.requestWorker({ type: "worker_cancel_update" }, 5000);
+						if (!response.success) throw new Error(response.error);
+					} catch (error) {
+						this.log(
+							`Could not cancel prepared worker ${worker.descriptor.workerId}; reconnecting it: ${String(error)}`,
+						);
+						prepareClient.close();
+						if (worker.client && worker.client !== prepareClient) worker.client.close();
+					}
+				}),
+			);
+		};
 		const preparationFailure = preparationResults.find(
 			(result): result is PromiseRejectedResult => result.status === "rejected",
 		);
 		if (preparationFailure) {
-			await Promise.all(
-				prepared.map((worker) =>
-					worker.client.requestWorker({ type: "worker_cancel_update" }, 5000).catch(() => undefined),
-				),
-			);
+			await cancelAcknowledged();
 			throw preparationFailure.reason;
 		}
+		const prepared = preparationResults.flatMap((result) =>
+			result.status === "fulfilled" ? [result.value.worker] : [],
+		);
 		const responses = preparationResults.flatMap((result) =>
 			result.status === "fulfilled" ? [result.value.manifest] : [],
 		);
+		const discardedActiveSessionIds = responses.flatMap((manifest) => manifest.discardedActiveSessionIds ?? []);
 		const manifest = {
 			createdAt: new Date().toISOString(),
 			sessions: responses.flatMap((manifest) => manifest.sessions),
+			...(discardedActiveSessionIds.length > 0 ? { discardedActiveSessionIds } : {}),
 		};
 		try {
 			this.validateAndPersistUpdateManifest(manifest);
 		} catch (error) {
-			await Promise.all(
-				prepared.map((worker) =>
-					worker.client.requestWorker({ type: "worker_cancel_update" }, 5000).catch(() => undefined),
-				),
-			);
+			await cancelAcknowledged();
 			throw error;
 		}
+		for (const worker of prepared) worker.updateRestartPrepareClient = undefined;
 		const commitResults = await Promise.allSettled(
 			prepared.map(async (worker) => {
-				const response = await worker.client.requestWorker(
+				const client = worker.client;
+				if (!client) throw new Error(`Worker ${worker.descriptor.workerId} disconnected before update commit`);
+				const response = await client.requestWorker(
 					{ type: "worker_commit_update" },
 					UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS,
 				);
@@ -3906,10 +3925,6 @@ export class DaemonSupervisor {
 			(result): result is PromiseRejectedResult => result.status === "rejected",
 		);
 		if (commitFailure) {
-			// A successful commit may already have destroyed a worker's live state. The
-			// aggregate manifest is durable, so remain fenced and finish stopping every
-			// resident. Returning the full manifest forces restart completion instead of
-			// exposing this partially committed generation again.
 			this.log(`Update restart commit response failed; forcing restart completion: ${String(commitFailure.reason)}`);
 			await Promise.allSettled(prepared.map((worker) => this.stopWorker(worker, false, true)));
 			return manifest;
@@ -3925,6 +3940,12 @@ export class DaemonSupervisor {
 	private validateAndPersistUpdateManifest(manifest: DaemonUpdateRestartManifest): void {
 		const activeSessionIds = new Set<string>();
 		const sessionFiles = new Set<string>();
+		for (const discardedActiveSessionId of manifest.discardedActiveSessionIds ?? []) {
+			if (!discardedActiveSessionId || activeSessionIds.has(discardedActiveSessionId)) {
+				throw new Error("Update manifest contains an invalid discarded session disposition");
+			}
+			activeSessionIds.add(discardedActiveSessionId);
+		}
 		for (const session of manifest.sessions) {
 			if (!session.activeSessionId || !session.sessionFile) {
 				throw new Error("Update manifest contains an incomplete session checkpoint");

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3782,6 +3782,7 @@ export class DaemonSupervisor {
 			const abort = AbortSignal.timeout(Math.min(UPDATE_RESTART_MUTATION_DRAIN_TIMEOUT_MS, deadline - Date.now()));
 			await this.mutationDrain.waitForDrain(1, abort, "Timed out draining daemon mutations for update restart");
 			this.updateRestartPhase = "fencing";
+			await this.mutationDrain.waitForDrain(1, abort, "Timed out draining daemon mutations for update restart");
 			const manifest = await this.prepareUpdateRestartFenced(deadline);
 			this.updateRestartPhase = "prepared";
 			return manifest;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1081,6 +1081,10 @@ export class DaemonSupervisor {
 		}
 		const command = preParsed.command;
 		const parsedAdmission = preParsed.admission;
+		if (command.type === "cancel_prompt_admission" && this.updateRestartPhase !== undefined) {
+			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
+			return;
+		}
 		const cancellationAdmission =
 			command.type === "cancel_prompt_admission"
 				? this.getPromptAdmission(client, command.activeSessionId, command.admissionId)
@@ -1149,7 +1153,23 @@ export class DaemonSupervisor {
 			return;
 		}
 		if (journalIdentity) {
-			this.commandJournal.begin(journalIdentity.clientId, journalIdentity.commandId, command.type);
+			const admitted = this.commandJournal.begin(journalIdentity.clientId, journalIdentity.commandId, command.type);
+			if (admitted.status === "complete") {
+				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
+				this.write(client, admitted.response);
+				return;
+			}
+			if (admitted.status === "pending") {
+				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
+				this.write(
+					client,
+					failure(command.id, command.type, "The previous command result is uncertain and was not replayed", {
+						code: "command_result_uncertain",
+						...journalIdentity,
+					}),
+				);
+				return;
+			}
 		}
 
 		if (mutation) this.mutationDrain.begin();

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3871,16 +3871,31 @@ export class DaemonSupervisor {
 			sessions: responses.flatMap((manifest) => manifest.sessions),
 			...(discardedActiveSessionIds.length > 0 ? { discardedActiveSessionIds } : {}),
 		};
+		// A worker that disconnected after preparing cancelled its checkpoint with
+		// the old client; a recovered replacement may have admitted inputs past the
+		// captured manifest. Abort before the manifest is persisted so the caller's
+		// fallback cannot restore from the stale checkpoint.
+		const staleWorker = prepared.find((worker) => worker.client !== worker.updateRestartPrepareClient);
+		if (staleWorker) {
+			await cancelAcknowledged();
+			throw new Error(
+				`Worker ${staleWorker.descriptor.workerId} reconnected during update preparation; its checkpoint is stale`,
+			);
+		}
 		try {
 			this.validateAndPersistUpdateManifest(manifest);
 		} catch (error) {
 			await cancelAcknowledged();
 			throw error;
 		}
+		// Commit through the connection that owns the prepared transaction; a client
+		// swapped in after the check above must fail the commit rather than reach a
+		// worker that no longer holds the checkpoint.
+		const commitClients = new Map(prepared.map((worker) => [worker, worker.updateRestartPrepareClient]));
 		for (const worker of prepared) worker.updateRestartPrepareClient = undefined;
 		const commitResults = await Promise.allSettled(
 			prepared.map(async (worker) => {
-				const client = worker.client;
+				const client = commitClients.get(worker);
 				if (!client) throw new Error(`Worker ${worker.descriptor.workerId} disconnected before update commit`);
 				const response = await client.requestWorker(
 					{ type: "worker_commit_update" },

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1144,6 +1144,7 @@ export class DaemonSupervisor {
 				? !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)
 				: phase !== undefined && !(phase === "prepared" && command.type === "shutdown");
 		if (restartRejected && mutation) {
+			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 			this.write(client, failure(command.id, command.type, "Daemon is preparing an update restart"));
 			return;
 		}

--- a/packages/coding-agent/src/modes/daemon/mutation-drain-latch.ts
+++ b/packages/coding-agent/src/modes/daemon/mutation-drain-latch.ts
@@ -14,10 +14,13 @@ export class MutationDrainLatch {
 	}
 
 	async waitForDrain(remaining: number, signal: AbortSignal, abortMessage: string): Promise<void> {
+		if (signal.aborted) throw new Error(abortMessage);
 		while (this.active > remaining) {
-			if (signal.aborted) throw new Error(abortMessage);
 			await new Promise<void>((resolve, reject) => {
+				let settled = false;
 				const settle = (error?: Error) => {
+					if (settled) return;
+					settled = true;
 					this.waiters.delete(onDrained);
 					signal.removeEventListener("abort", onAbort);
 					if (error) reject(error);
@@ -28,6 +31,7 @@ export class MutationDrainLatch {
 				this.waiters.add(onDrained);
 				signal.addEventListener("abort", onAbort, { once: true });
 			});
+			if (signal.aborted) throw new Error(abortMessage);
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/daemon/mutation-drain-latch.ts
+++ b/packages/coding-agent/src/modes/daemon/mutation-drain-latch.ts
@@ -1,0 +1,33 @@
+/** Counts in-flight mutating commands so update-restart preparation can wait for them to drain. */
+export class MutationDrainLatch {
+	private active = 0;
+	private readonly waiters = new Set<() => void>();
+
+	begin(): void {
+		this.active++;
+	}
+
+	end(): void {
+		this.active--;
+		for (const resolve of this.waiters) resolve();
+		this.waiters.clear();
+	}
+
+	async waitForDrain(remaining: number, signal: AbortSignal, abortMessage: string): Promise<void> {
+		while (this.active > remaining) {
+			if (signal.aborted) throw new Error(abortMessage);
+			await new Promise<void>((resolve, reject) => {
+				const settle = (error?: Error) => {
+					this.waiters.delete(onDrained);
+					signal.removeEventListener("abort", onAbort);
+					if (error) reject(error);
+					else resolve();
+				};
+				const onDrained = () => settle();
+				const onAbort = () => settle(new Error(abortMessage));
+				this.waiters.add(onDrained);
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
+		}
+	}
+}

--- a/packages/coding-agent/test/command-recovery-journal.test.ts
+++ b/packages/coding-agent/test/command-recovery-journal.test.ts
@@ -25,6 +25,13 @@ describe("CommandRecoveryJournal", () => {
 		expect(journal.begin("client-a", "command-a", "prompt")).toEqual({ status: "pending" });
 	});
 
+	it("looks up prior commands without inserting new receipts", () => {
+		const journal = new CommandRecoveryJournal(createPath());
+		expect(journal.lookup("client-a", "missing")).toBeUndefined();
+		expect(journal.begin("client-a", "pending", "prompt")).toEqual({ status: "new" });
+		expect(journal.lookup("client-a", "pending")).toEqual({ status: "pending" });
+	});
+
 	it("does not collide when client and command ids contain separators", () => {
 		const journal = new CommandRecoveryJournal(createPath());
 		expect(journal.begin("client:a", "command", "prompt")).toEqual({ status: "new" });

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -972,9 +972,20 @@ describe("AgentCronScheduler", () => {
 		expect(store.list()[0]).toMatchObject({ id: job.id, status: "active", runCount: 0 });
 	});
 
-	it("releases acquired dispatch leases when later setup fails", async () => {
+	it("releases leases and recovers the whole claimed batch when setup fails", async () => {
 		const store = new AgentCronJobStore(makeStorePath(tempDirs));
-		for (const activeSessionId of ["active-1", "active-2"]) {
+		const unrelated = store.create({
+			activeSessionId: "unrelated",
+			sessionId: "unrelated",
+			sessionFile: "/tmp/unrelated.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "every 10s",
+			prompt: "unrelated",
+			now: start,
+		});
+		const [unrelatedDispatch] = store.claimDue(new Date("2026-01-01T12:34:10.000Z"));
+		if (!unrelatedDispatch) throw new Error("Expected unrelated dispatch");
+		const batch = ["active-1", "active-2", "active-3"].map((activeSessionId) =>
 			store.create({
 				activeSessionId,
 				sessionId: activeSessionId,
@@ -983,19 +994,33 @@ describe("AgentCronScheduler", () => {
 				scheduleText: "in 1m",
 				prompt: activeSessionId,
 				now: start,
-			});
-		}
+			}),
+		);
 		const endDispatch = vi.fn();
+		const beginDispatch = vi.fn((dispatch) => {
+			if (dispatch.job.activeSessionId === "active-2") throw new Error("lease setup failed");
+			return endDispatch;
+		});
 		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:35:00.000Z"),
 			runJob: vi.fn(async () => undefined),
-			beginDispatch: (dispatch) => {
-				if (dispatch.job.activeSessionId === "active-2") throw new Error("lease setup failed");
-				return endDispatch;
-			},
+			beginDispatch,
 		});
 
 		await expect(scheduler.runDue(new Date("2026-01-01T12:35:00.000Z"))).rejects.toThrow("lease setup failed");
+		expect(beginDispatch).toHaveBeenCalledTimes(2);
 		expect(endDispatch).toHaveBeenCalledOnce();
+		for (const job of batch) {
+			expect(store.getClaimedJob(job.id)).toBeUndefined();
+			expect(store.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+				status: "completed",
+				lastError: "Interrupted before scheduled operation completion",
+			});
+		}
+		expect(store.getClaimedJob(unrelated.id)).toMatchObject({ id: unrelated.id });
+		expect(store.recordDispatchResult(unrelatedDispatch.id, { outcome: "ran" })).toMatchObject({
+			id: unrelated.id,
+		});
 	});
 
 	it("reschedules recurring jobs after each run", async () => {

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type AgentCronJob,
 	AgentCronJobStore,
@@ -949,6 +949,53 @@ describe("AgentCronScheduler", () => {
 			lastRunAt: "2026-01-01T12:35:00.000Z",
 		});
 		expect(store.list()[0]).not.toHaveProperty("nextRunAt");
+	});
+
+	it("does not claim new jobs after a started scheduler is stopped", async () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		const job = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1m",
+			prompt: "do not claim",
+			now: start,
+		});
+		const runJob = vi.fn(async () => undefined);
+		const scheduler = new AgentCronScheduler(store, { runJob });
+		scheduler.start();
+		scheduler.stop();
+
+		expect(await scheduler.runDue(new Date("2026-01-01T12:35:00.000Z"))).toBe(0);
+		expect(runJob).not.toHaveBeenCalled();
+		expect(store.list()[0]).toMatchObject({ id: job.id, status: "active", runCount: 0 });
+	});
+
+	it("releases acquired dispatch leases when later setup fails", async () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		for (const activeSessionId of ["active-1", "active-2"]) {
+			store.create({
+				activeSessionId,
+				sessionId: activeSessionId,
+				sessionFile: `/tmp/${activeSessionId}.jsonl`,
+				cwd: "/tmp/project",
+				scheduleText: "in 1m",
+				prompt: activeSessionId,
+				now: start,
+			});
+		}
+		const endDispatch = vi.fn();
+		const scheduler = new AgentCronScheduler(store, {
+			runJob: vi.fn(async () => undefined),
+			beginDispatch: (dispatch) => {
+				if (dispatch.job.activeSessionId === "active-2") throw new Error("lease setup failed");
+				return endDispatch;
+			},
+		});
+
+		await expect(scheduler.runDue(new Date("2026-01-01T12:35:00.000Z"))).rejects.toThrow("lease setup failed");
+		expect(endDispatch).toHaveBeenCalledOnce();
 	});
 
 	it("reschedules recurring jobs after each run", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4790,6 +4790,36 @@ describe("daemon mode helpers", () => {
 		expect(internals.promptAdmissions.size).toBe(0);
 	});
 
+	it("clears prompt admission when restart fencing rejects before dispatch", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const client = makeClient("client", "active-1");
+		client.socket = { destroyed: false, write: vi.fn(() => true), end: vi.fn() } as unknown as Socket;
+		const internals = daemon as unknown as {
+			promptAdmissions: Map<string, unknown>;
+			updateRestart: { phase: "fencing" };
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+		internals.updateRestart = { phase: "fencing" };
+
+		await internals.handleLine(
+			client,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "active-1",
+				message: "blocked",
+				admissionId: "retryable-admission",
+			}),
+		);
+
+		expect(internals.promptAdmissions.size).toBe(0);
+	});
+
 	it.each(["success", "late-failure", "replacement"] as const)(
 		"handles cancellation followed by supervisor-claim %s without affecting the wrong socket binding",
 		async (outcome) => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4853,9 +4853,15 @@ describe("daemon mode helpers", () => {
 			await Promise.resolve();
 			await Promise.resolve();
 
-			if (outcome === "late-failure") expect(end).toHaveBeenCalledOnce();
-			else expect(end).not.toHaveBeenCalled();
+			if (outcome === "late-failure") {
+				expect(end).toHaveBeenCalledOnce();
+				expect(internals.supervisorClaims.has(client)).toBe(false);
+			} else {
+				expect(end).not.toHaveBeenCalled();
+			}
 			if (outcome === "success") expect(originalBinding.ownerFingerprint).toBe("owner");
+			if (outcome === "replacement")
+				expect(internals.supervisorClaims.get(client)?.ownerFingerprint).toBe("replacement");
 		},
 	);
 

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -142,6 +142,25 @@ describe("daemon supervisor prompt admission ownership", () => {
 		expect(admissionFor(supervisor, owner)).toBeUndefined();
 	});
 
+	it("cleans up restart-fenced prompt admissions so the same id can retry", async () => {
+		const supervisor = createHarness();
+		(supervisor as unknown as { updateRestartPhase: "fencing" }).updateRestartPhase = "fencing";
+		const owner = client("connection-owner");
+		const prompt = {
+			id: "prompt-1",
+			type: "prompt",
+			activeSessionId: "session-1",
+			admissionId: "retryable-admission",
+			message: "hello",
+		} satisfies DaemonCommand;
+
+		await supervisor.handleLine(owner, JSON.stringify(prompt));
+		expect(supervisor.promptAdmissions.size).toBe(0);
+
+		await supervisor.handleLine(owner, JSON.stringify({ ...prompt, id: "prompt-2" }));
+		expect(supervisor.promptAdmissions.size).toBe(0);
+	});
+
 	it("lets the originating connection cancel before worker lookup starts", async () => {
 		const ready = deferred<void>();
 		const findWorker = vi.fn(async () => {

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -8,6 +8,7 @@ import {
 	type DaemonResponse,
 } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor, waitForSupervisorPromptAdmission } from "../src/modes/daemon/daemon-supervisor.js";
+import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
 
 interface AdmissionRecord {
 	client: DaemonSocketClient;
@@ -30,14 +31,17 @@ interface SupervisorHarness {
 interface Deferred<T> {
 	promise: Promise<T>;
 	resolve(value: T): void;
+	reject(error: unknown): void;
 }
 
 function deferred<T>(): Deferred<T> {
 	let resolve!: (value: T) => void;
-	const promise = new Promise<T>((resolvePromise) => {
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
 		resolve = resolvePromise;
+		reject = rejectPromise;
 	});
-	return { promise, resolve };
+	return { promise, resolve, reject };
 }
 
 function client(id: string): DaemonSocketClient {
@@ -74,7 +78,9 @@ function createHarness(
 		clients: new Set(),
 		protocolClientIds: new WeakMap(),
 		promptAdmissions: new Map(),
+		mutationDrain: new MutationDrainLatch(),
 		commandJournal: {
+			lookup: vi.fn(() => undefined),
 			begin: vi.fn(() => ({ status: "new" })),
 			recordResult: vi.fn(),
 			acknowledge: vi.fn(),
@@ -131,7 +137,7 @@ describe("daemon supervisor prompt admission ownership", () => {
 		ownership.resolve();
 		await Promise.resolve();
 		expect(admissionFor(supervisor, owner)).toBe(admission);
-		workerLookup.resolve(Promise.reject(new Error("worker lookup stopped")));
+		workerLookup.reject(new Error("worker lookup stopped"));
 		await pendingPrompt;
 		expect(admissionFor(supervisor, owner)).toBeUndefined();
 	});

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -66,6 +66,13 @@ function createHarness(
 		assertCurrent?: () => Promise<void>;
 		findWorker?: (client: DaemonSocketClient, selector: string) => Promise<unknown>;
 		forwardToWorker?: (worker: unknown, command: DaemonCommand) => Promise<DaemonResponse>;
+		commandJournal?: {
+			lookup: ReturnType<typeof vi.fn>;
+			begin: ReturnType<typeof vi.fn>;
+			recordResult: ReturnType<typeof vi.fn>;
+			acknowledge: ReturnType<typeof vi.fn>;
+		};
+		updateRestartPhase?: "draining" | "fencing" | "prepared";
 	} = {},
 ): SupervisorHarness {
 	return Object.assign(Object.create(DaemonSupervisor.prototype), {
@@ -79,12 +86,13 @@ function createHarness(
 		protocolClientIds: new WeakMap(),
 		promptAdmissions: new Map(),
 		mutationDrain: new MutationDrainLatch(),
-		commandJournal: {
+		commandJournal: options.commandJournal ?? {
 			lookup: vi.fn(() => undefined),
 			begin: vi.fn(() => ({ status: "new" })),
 			recordResult: vi.fn(),
 			acknowledge: vi.fn(),
 		},
+		updateRestartPhase: options.updateRestartPhase,
 		findWorkerForClient: options.findWorker,
 		forwardToWorker: options.forwardToWorker,
 		write: vi.fn(),
@@ -159,6 +167,71 @@ describe("daemon supervisor prompt admission ownership", () => {
 
 		await supervisor.handleLine(owner, JSON.stringify({ ...prompt, id: "prompt-2" }));
 		expect(supervisor.promptAdmissions.size).toBe(0);
+	});
+
+	it("rejects restart-fenced cancellation before mutating its admission", async () => {
+		const supervisor = createHarness({ updateRestartPhase: "fencing" });
+		const owner = client("connection-owner");
+		const admission: AdmissionRecord = {
+			client: owner,
+			activeSessionId: "session-1",
+			publicAdmissionId: "public-admission",
+			workerAdmissionId: "worker-admission",
+			status: "waiting",
+			controller: new AbortController(),
+		};
+		supervisor.promptAdmissions.set(owner, new Map([["session-1\0public-admission", admission]]));
+
+		await supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "cancel-1",
+				type: "cancel_prompt_admission",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+			} satisfies DaemonCommand),
+		);
+
+		expect(admission.status).toBe("waiting");
+		expect(admission.controller.signal.aborted).toBe(false);
+	});
+
+	it("admits only one concurrent mutation with the same journal identity", async () => {
+		let begun = false;
+		const commandJournal = {
+			lookup: vi.fn(() => undefined),
+			begin: vi.fn(() => {
+				if (begun) return { status: "pending" as const };
+				begun = true;
+				return { status: "new" as const };
+			}),
+			recordResult: vi.fn(),
+			acknowledge: vi.fn(),
+		};
+		const forward = deferred<DaemonResponse>();
+		const supervisor = createHarness({
+			commandJournal,
+			findWorker: vi.fn(async () => ({
+				worker: { descriptor: { lifecycle: "ready", rootActiveSessionId: "session-1" } },
+				summary: { id: "session-1", activeSessionId: "session-1" },
+			})),
+			forwardToWorker: vi.fn(() => forward.promise),
+		});
+		const owner = client("connection-owner");
+		const command = createDaemonCommandEnvelope(
+			{ id: "prompt-1", type: "prompt", activeSessionId: "session-1", message: "hello" },
+			"prompt-1",
+			"logical-client",
+		);
+
+		const first = supervisor.handleLine(owner, JSON.stringify(command));
+		const second = supervisor.handleLine(owner, JSON.stringify(command));
+		await waitFor(() => commandJournal.begin.mock.calls.length === 2);
+		expect(
+			(supervisor as unknown as { forwardToWorker: ReturnType<typeof vi.fn> }).forwardToWorker,
+		).toHaveBeenCalledOnce();
+		forward.resolve({ type: "response", command: "prompt", success: true });
+		await Promise.all([first, second]);
 	});
 
 	it("lets the originating connection cancel before worker lookup starts", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1,5 +1,7 @@
 import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -13,6 +15,7 @@ import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js"
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
 	DAEMON_WORKER_STARTUP_GATE_COMMIT,
+	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
 	type DaemonWorkerFrameHeader,
 } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
@@ -285,6 +288,121 @@ describe("daemon worker supervisor monitoring", () => {
 		} else {
 			process.env[supervisorRegistryDirEnv] = previousSupervisorRegistryDir;
 		}
+	});
+
+	it("schedules recovery when the sole supervisor fails a fence check", async () => {
+		const previousSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+		process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = "/tmp/supervisor.sock";
+		try {
+			const daemon = new AgentDaemon("/tmp/worker.sock", {
+				defaultSessionConfig: { agentDir: "/tmp/agent", cwd: "/tmp" },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				worker: { authenticationToken: "token" },
+			});
+			const socket = Object.assign(new EventEmitter(), {
+				destroyed: false,
+				write: vi.fn(() => true),
+				end: vi.fn(function (this: EventEmitter) {
+					this.emit("close");
+				}),
+			}) as unknown as Socket;
+			const internals = daemon as unknown as {
+				clients: Set<DaemonSocketClient>;
+				supervisorClaims: Map<DaemonSocketClient, object>;
+				handleConnection(socket: Socket): void;
+				checkSupervisorFences(): Promise<void>;
+				assertSupervisorClaimCurrent: ReturnType<typeof vi.fn>;
+				scheduleSupervisorAvailabilityCheck: ReturnType<typeof vi.fn>;
+			};
+			internals.handleConnection(socket);
+			const client = [...internals.clients][0]!;
+			client.authenticated = true;
+			internals.supervisorClaims.set(client, {
+				claim: {},
+				ownerFingerprint: "old",
+			});
+			internals.assertSupervisorClaimCurrent = vi.fn(async () => {
+				throw new Error("stale fence");
+			});
+			internals.scheduleSupervisorAvailabilityCheck = vi.fn();
+
+			await internals.checkSupervisorFences();
+
+			expect(internals.supervisorClaims.has(client)).toBe(false);
+			expect(client.authenticated).toBe(true);
+			expect(internals.scheduleSupervisorAvailabilityCheck).toHaveBeenCalledOnce();
+			expect(internals.scheduleSupervisorAvailabilityCheck).toHaveBeenCalledWith("/tmp/supervisor.sock", 100);
+		} finally {
+			if (previousSocketPath === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSocketPath;
+		}
+	});
+
+	it("revokes an old supervisor before ending its socket when a replacement authenticates", async () => {
+		let markOldAssertionReached = () => {};
+		const oldAssertionReached = new Promise<void>((resolve) => {
+			markOldAssertionReached = resolve;
+		});
+		let releaseOldAssertion = () => {};
+		const oldAssertionGate = new Promise<void>((resolve) => {
+			releaseOldAssertion = resolve;
+		});
+		let assertionCount = 0;
+		const handleWorkerCommand = vi.fn(async () => undefined);
+		const daemon = Object.assign(Object.create(AgentDaemon.prototype), {
+			options: { worker: { authenticationToken: "token" } },
+			supervisorClaims: new Map(),
+			shuttingDown: false,
+			clearSupervisorAvailabilityCheck: vi.fn(),
+			scheduleSupervisorFenceCheck: vi.fn(),
+			handleWorkerCommand,
+			assertSupervisorClaimCurrent: vi.fn(async () => {
+				assertionCount++;
+				if (assertionCount === 2) {
+					markOldAssertionReached();
+					await oldAssertionGate;
+				}
+				return `fingerprint-${assertionCount}`;
+			}),
+		}) as unknown as {
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+		const makeClient = () =>
+			({
+				id: "supervisor",
+				authenticated: false,
+				socket: { destroyed: false, write: vi.fn(() => true), end: vi.fn() },
+				attachedActiveSessionIds: new Set(),
+				detachInput: vi.fn(),
+				supportsExtensionUi: false,
+				capabilities: new Set(),
+			}) as unknown as DaemonSocketClient;
+		const auth = (generation: string) =>
+			JSON.stringify({
+				type: "worker_auth",
+				token: "token",
+				supervisorGeneration: generation,
+				supervisorPid: 123,
+				supervisorSocketPath: "/tmp/supervisor.sock",
+			});
+		const oldClient = makeClient();
+		const replacementClient = makeClient();
+
+		await daemon.handleLine(oldClient, auth("old"));
+		const staleCommand = daemon.handleLine(
+			oldClient,
+			JSON.stringify({ type: "worker_subscribe", activeSessionId: "active-1" }),
+		);
+		await oldAssertionReached;
+		await daemon.handleLine(replacementClient, auth("replacement"));
+
+		expect(oldClient.authenticated).toBe(true);
+		expect(oldClient.socket.end).toHaveBeenCalledOnce();
+		releaseOldAssertion();
+		await staleCommand;
+		expect(handleWorkerCommand).not.toHaveBeenCalled();
 	});
 
 	it.each([

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -7,10 +7,11 @@ import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
+import { CommandRecoveryJournal } from "../src/modes/daemon/command-recovery-journal.js";
 import { DaemonCatalogClient } from "../src/modes/daemon/daemon-catalog-process.js";
 import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
 import { AgentDaemon } from "../src/modes/daemon/daemon-mode.js";
-import type { DaemonAttachResult } from "../src/modes/daemon/daemon-protocol.js";
+import { createDaemonCommandEnvelope, type DaemonAttachResult, success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
@@ -1808,6 +1809,99 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.prepareUpdateRestartFenced()).resolves.toMatchObject({
 			discardedActiveSessionIds: ["root"],
 		});
+	});
+
+	it("replays completed journaled mutations during restart preparation without taking a mutation lease", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-command-replay-"));
+		const commandJournal = new CommandRecoveryJournal(join(root, "commands.jsonl"));
+		const response = success("command-1", "kill");
+		commandJournal.begin("client-1", "command-1", "kill");
+		commandJournal.recordResult("client-1", "command-1", response);
+		const writes: string[] = [];
+		const client = {
+			id: "socket-client",
+			socket: {
+				destroyed: false,
+				write: vi.fn((chunk: string) => {
+					writes.push(chunk);
+					return true;
+				}),
+			},
+		} as unknown as DaemonSocketClient;
+		const mutationDrain = { begin: vi.fn(), end: vi.fn() };
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			ready: Promise.resolve(),
+			workers: new Map(),
+			protocolClientIds: new WeakMap(),
+			commandJournal,
+			mutationDrain,
+			updateRestartPhase: "fencing",
+			assertCurrentOwnership: vi.fn(async () => undefined),
+			cancelOwnedWorkerCleanup: vi.fn(),
+			handleCommand: vi.fn(async () => {
+				throw new Error("completed command was dispatched again");
+			}),
+		}) as unknown as {
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		try {
+			await supervisor.handleLine(
+				client,
+				JSON.stringify(
+					createDaemonCommandEnvelope({ type: "kill", activeSessionId: "session-1" }, "command-1", "client-1"),
+				),
+			);
+			expect(writes).toEqual([`${JSON.stringify(response)}\n`]);
+			expect(mutationDrain.begin).not.toHaveBeenCalled();
+			expect(mutationDrain.end).not.toHaveBeenCalled();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects genuinely new mutations during restart preparation without journaling or leasing them", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-command-reject-"));
+		const commandJournal = new CommandRecoveryJournal(join(root, "commands.jsonl"));
+		const writes: string[] = [];
+		const client = {
+			id: "socket-client",
+			socket: {
+				destroyed: false,
+				write: vi.fn((chunk: string) => {
+					writes.push(chunk);
+					return true;
+				}),
+			},
+		} as unknown as DaemonSocketClient;
+		const mutationDrain = { begin: vi.fn(), end: vi.fn() };
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			ready: Promise.resolve(),
+			workers: new Map(),
+			protocolClientIds: new WeakMap(),
+			commandJournal,
+			mutationDrain,
+			updateRestartPhase: "fencing",
+			assertCurrentOwnership: vi.fn(async () => undefined),
+			cancelOwnedWorkerCleanup: vi.fn(),
+		}) as unknown as {
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		try {
+			await supervisor.handleLine(
+				client,
+				JSON.stringify(
+					createDaemonCommandEnvelope({ type: "kill", activeSessionId: "session-1" }, "command-2", "client-1"),
+				),
+			);
+			expect(writes.join(" ")).toContain("Daemon is preparing an update restart");
+			expect(commandJournal.lookup("client-1", "command-2")).toBeUndefined();
+			expect(mutationDrain.begin).not.toHaveBeenCalled();
+			expect(mutationDrain.end).not.toHaveBeenCalled();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("fences and drains a mutation admitted at the first drain boundary before worker prepare", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1552,4 +1552,19 @@ describe("daemon worker supervisor monitoring", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+	it("rejects update prepare when a resident worker is recovering or disconnected", async () => {
+		const requestWorker = vi.fn();
+		const worker = {
+			descriptor: { workerId: "resident-1", lifecycle: "recovering" },
+			client: undefined,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([["resident-1", worker]]),
+		}) as {
+			prepareUpdateRestartFenced(): Promise<unknown>;
+		};
+
+		await expect(supervisor.prepareUpdateRestartFenced()).rejects.toThrow(/resident-1.*recovering.*disconnected/);
+		expect(requestWorker).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -18,6 +18,7 @@ import {
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
 	type DaemonWorkerFrameHeader,
 } from "../src/modes/daemon/daemon-worker-protocol.js";
+import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
 import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
 import type { PrivateFrame } from "../src/modes/session-worker/private-framing.js";
 import { createDeferred } from "./suite/scheduling.js";
@@ -1807,6 +1808,39 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.prepareUpdateRestartFenced()).resolves.toMatchObject({
 			discardedActiveSessionIds: ["root"],
 		});
+	});
+
+	it("fences and drains a mutation admitted at the first drain boundary before worker prepare", async () => {
+		const mutationDrain = new MutationDrainLatch();
+		const firstDrain = createDeferred();
+		const originalWaitForDrain = mutationDrain.waitForDrain.bind(mutationDrain);
+		vi.spyOn(mutationDrain, "waitForDrain").mockImplementationOnce(async (...args) => {
+			await originalWaitForDrain(...args);
+			mutationDrain.begin();
+			firstDrain.resolve();
+		});
+		mutationDrain.begin(); // The prepare command itself remains in flight at the supervisor boundary.
+		const prepareFenced = vi.fn(async () => ({ createdAt: "now", sessions: [] }));
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			mutationDrain,
+			workers: new Map(),
+			prepareUpdateRestartFenced: prepareFenced,
+		}) as {
+			updateRestartPhase?: "draining" | "fencing" | "prepared";
+			prepareUpdateRestart(): Promise<unknown>;
+		};
+
+		const prepare = supervisor.prepareUpdateRestart();
+		await firstDrain.promise;
+		await Promise.resolve();
+
+		expect(supervisor.updateRestartPhase).toBe("fencing");
+		expect(prepareFenced).not.toHaveBeenCalled();
+
+		mutationDrain.end();
+		await prepare;
+		expect(prepareFenced).toHaveBeenCalledOnce();
+		mutationDrain.end();
 	});
 
 	it("limits abort admission to mutation drain", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1552,6 +1552,49 @@ describe("daemon worker supervisor monitoring", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+	it.each([
+		{ name: "malformed data", data: undefined, error: /invalid update manifest/ },
+		{ name: "missing root disposition", data: { createdAt: "now", sessions: [] }, error: /root disposition/ },
+	])("cancels a prepare acknowledgement with $name", async ({ data, error }) => {
+		const client = {
+			requestWorker: vi.fn(async ({ type }: { type: string }) =>
+				type === "worker_prepare_update" ? { success: true, data } : { success: true },
+			),
+			close: vi.fn(),
+		};
+		const worker = {
+			descriptor: { workerId: "worker", lifecycle: "ready", rootActiveSessionId: "root" },
+			client,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([["worker", worker]]),
+		}) as { prepareUpdateRestartFenced(): Promise<unknown> };
+		await expect(supervisor.prepareUpdateRestartFenced()).rejects.toThrow(error);
+		expect(client.requestWorker).toHaveBeenCalledWith({ type: "worker_cancel_update" }, 5000);
+	});
+
+	it("accepts an explicitly discarded empty root", async () => {
+		const client = {
+			requestWorker: vi.fn(async ({ type }: { type: string }) =>
+				type === "worker_prepare_update"
+					? { success: true, data: { createdAt: "now", sessions: [], discardedActiveSessionIds: ["root"] } }
+					: { success: true },
+			),
+		};
+		const worker = {
+			descriptor: { workerId: "worker", lifecycle: "ready", rootActiveSessionId: "root" },
+			client,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([["worker", worker]]),
+			validateAndPersistUpdateManifest: vi.fn(),
+			stopWorker: vi.fn(async () => undefined),
+		}) as { prepareUpdateRestartFenced(): Promise<{ discardedActiveSessionIds?: string[] }> };
+		await expect(supervisor.prepareUpdateRestartFenced()).resolves.toMatchObject({
+			discardedActiveSessionIds: ["root"],
+		});
+	});
+
 	it("rejects update prepare when a resident worker is recovering or disconnected", async () => {
 		const requestWorker = vi.fn();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
+import { DaemonCatalogClient } from "../src/modes/daemon/daemon-catalog-process.js";
+import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
 import { AgentDaemon } from "../src/modes/daemon/daemon-mode.js";
 import type { DaemonAttachResult } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
@@ -1593,6 +1595,33 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.prepareUpdateRestartFenced()).resolves.toMatchObject({
 			discardedActiveSessionIds: ["root"],
 		});
+	});
+
+	it("limits abort admission to mutation drain", async () => {
+		const root = mkdtempSync(`/tmp/prime-update-drain-${process.pid}-`);
+		const socketPath = join(root, "supervisor.sock");
+		const supervisor = new DaemonSupervisor(socketPath, {
+			defaultSessionConfig: { cwd: root, agentDir: root },
+			descriptorDir: join(root, "workers"),
+		});
+		const client = new DaemonClient(socketPath);
+		vi.spyOn(DaemonCatalogClient.prototype, "start").mockResolvedValue();
+		try {
+			await supervisor.start();
+			await client.connect();
+			const prepare = client.request({ type: "prepare_update_restart" });
+			expect(await client.request({ type: "abort", activeSessionId: "missing" })).not.toMatchObject({
+				error: "Daemon is preparing an update restart",
+			});
+			await prepare;
+			await expect(client.request({ type: "abort", activeSessionId: "missing" })).resolves.toMatchObject({
+				error: "Daemon is preparing an update restart",
+			});
+		} finally {
+			client.close();
+			await Reflect.apply(Reflect.get(supervisor, "cleanupSupervisorResources"), supervisor, []);
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("rejects update prepare when a resident worker is recovering or disconnected", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
 import type { PrivateFrame } from "../src/modes/session-worker/private-framing.js";
+import { createDeferred } from "./suite/scheduling.js";
 
 const workerLaunchTestState = vi.hoisted(() => ({
 	capture: false,
@@ -338,6 +339,99 @@ describe("daemon worker supervisor monitoring", () => {
 			if (previousSocketPath === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSocketPath;
 		}
+	});
+
+	it("does not revoke a newer same-client claim when an older periodic fence fails", async () => {
+		const assertionReached = createDeferred<void>();
+		const assertionGate = createDeferred<void>();
+		const client = {
+			authenticated: true,
+			socket: { destroyed: false, end: vi.fn() },
+		} as unknown as DaemonSocketClient;
+		const oldClaim = { claim: {}, ownerFingerprint: "old" };
+		const newerClaim = { claim: {}, ownerFingerprint: "new" };
+		const transaction = {
+			id: Symbol("update-restart"),
+			owner: client,
+			abort: new AbortController(),
+			phase: "prepared",
+		};
+		const daemon = Object.assign(Object.create(AgentDaemon.prototype), {
+			options: { worker: { authenticationToken: "token" } },
+			supervisorClaims: new Map([[client, oldClaim]]),
+			updateRestart: transaction,
+			shuttingDown: false,
+			scheduleSupervisorFenceCheck: vi.fn(),
+			assertSupervisorClaimCurrent: vi.fn(async () => {
+				assertionReached.resolve();
+				await assertionGate.promise;
+				throw new Error("stale fence");
+			}),
+		}) as unknown as {
+			supervisorClaims: Map<DaemonSocketClient, object>;
+			updateRestart: object;
+			checkSupervisorFences(): Promise<void>;
+		};
+
+		const check = daemon.checkSupervisorFences();
+		await assertionReached.promise;
+		daemon.supervisorClaims.set(client, newerClaim);
+		assertionGate.resolve();
+		await check;
+
+		expect(daemon.supervisorClaims.get(client)).toBe(newerClaim);
+		expect(daemon.updateRestart).toBe(transaction);
+		expect(client.socket.end).not.toHaveBeenCalled();
+	});
+
+	it("does not revoke a newer same-client claim when an older command fence fails", async () => {
+		const assertionReached = createDeferred<void>();
+		const assertionGate = createDeferred<void>();
+		const client = {
+			id: "supervisor",
+			authenticated: true,
+			socket: { destroyed: false, write: vi.fn(() => true), end: vi.fn() },
+			attachedActiveSessionIds: new Set(),
+			detachInput: vi.fn(),
+			supportsExtensionUi: false,
+			capabilities: new Set(),
+		} as unknown as DaemonSocketClient;
+		const oldClaim = { claim: {}, ownerFingerprint: "old" };
+		const newerClaim = { claim: {}, ownerFingerprint: "new" };
+		const transaction = {
+			id: Symbol("update-restart"),
+			owner: client,
+			abort: new AbortController(),
+			phase: "prepared",
+		};
+		const daemon = Object.assign(Object.create(AgentDaemon.prototype), {
+			options: { worker: { authenticationToken: "token" } },
+			supervisorClaims: new Map([[client, oldClaim]]),
+			updateRestart: transaction,
+			handleWorkerCommand: vi.fn(async () => undefined),
+			assertSupervisorClaimCurrent: vi.fn(async () => {
+				assertionReached.resolve();
+				await assertionGate.promise;
+				throw new Error("stale fence");
+			}),
+		}) as unknown as {
+			supervisorClaims: Map<DaemonSocketClient, object>;
+			updateRestart: object;
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		const command = daemon.handleLine(
+			client,
+			JSON.stringify({ type: "worker_subscribe", activeSessionId: "active-1" }),
+		);
+		await assertionReached.promise;
+		daemon.supervisorClaims.set(client, newerClaim);
+		assertionGate.resolve();
+		await command;
+
+		expect(daemon.supervisorClaims.get(client)).toBe(newerClaim);
+		expect(daemon.updateRestart).toBe(transaction);
+		expect(client.socket.end).not.toHaveBeenCalled();
 	});
 
 	it("revokes an old supervisor before ending its socket when a replacement authenticates", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import type { DaemonCommand, DaemonResponse } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
 
 interface SupervisorHarness {
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
@@ -24,6 +25,7 @@ describe("daemon supervisor side-question routing", () => {
 			workers: new Map(),
 			clients: new Set(),
 			protocolClientIds: new WeakMap(),
+			mutationDrain: new MutationDrainLatch(),
 			handleCommand,
 			write,
 			log: vi.fn(),

--- a/packages/coding-agent/test/mutation-drain-latch.test.ts
+++ b/packages/coding-agent/test/mutation-drain-latch.test.ts
@@ -1,0 +1,33 @@
+import { getEventListeners } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
+
+describe("MutationDrainLatch", () => {
+	it("rejects an already-aborted wait even when no mutations are active", async () => {
+		const latch = new MutationDrainLatch();
+		const controller = new AbortController();
+		controller.abort();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+
+		await expect(latch.waitForDrain(0, controller.signal, "drain cancelled")).rejects.toThrow("drain cancelled");
+		expect(addEventListener).not.toHaveBeenCalled();
+	});
+
+	it("keeps abort terminal when draining and aborting concurrently without leaking its listener", async () => {
+		const latch = new MutationDrainLatch();
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
+		latch.begin();
+
+		const drained = latch.waitForDrain(0, controller.signal, "drain cancelled");
+		latch.end();
+		controller.abort();
+
+		await expect(drained).rejects.toThrow("drain cancelled");
+		expect(addEventListener).toHaveBeenCalledOnce();
+		expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+		expect(removeEventListener).toHaveBeenCalledOnce();
+		expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1571,6 +1571,65 @@ stale post-hook extension instructions`,
 		unsubscribe();
 	});
 
+	it("aborts while an extension event is pending without flushing or cancelling its queue", async () => {
+		const extensionReached = createDeferred();
+		const extensionGate = createDeferred();
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("message_start", async (event) => {
+						if (event.message.role !== "user") return;
+						extensionReached.resolve();
+						await extensionGate.promise;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		const prompt = harness.session.prompt("pending extension event");
+		await extensionReached.promise;
+		const checkpointInternals = harness.session as unknown as {
+			_activeSessionInput?: unknown;
+			_directPromptSectionCount: number;
+		};
+		expect(checkpointInternals._activeSessionInput).toBeUndefined();
+		expect(checkpointInternals._directPromptSectionCount).toBe(0);
+		const eventQueue = (harness.session as unknown as { _agentEventQueue: Promise<void> })._agentEventQueue;
+		let queueDrained = false;
+		void eventQueue.then(() => {
+			queueDrained = true;
+		});
+		const flushNow = vi.spyOn(harness.sessionManager, "flushNow");
+		const controller = new AbortController();
+		const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
+
+		const checkpoint = harness.session.waitForSessionInputCheckpoint(controller.signal);
+		controller.abort();
+
+		await expect(checkpoint).rejects.toThrow("Update restart preparation cancelled");
+		expect(queueDrained).toBe(false);
+		expect(flushNow).not.toHaveBeenCalled();
+		expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+		extensionGate.resolve();
+		await prompt;
+		await eventQueue;
+		expect(queueDrained).toBe(true);
+		expect(flushNow).not.toHaveBeenCalled();
+	});
+
+	it("propagates a snapshotted event queue rejection without flushing", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		(harness.session as unknown as { _agentEventQueue: Promise<void> })._agentEventQueue = Promise.reject(
+			new Error("event queue failed"),
+		);
+		const flushNow = vi.spyOn(harness.sessionManager, "flushNow");
+
+		await expect(harness.session.waitForSessionInputCheckpoint()).rejects.toThrow("event queue failed");
+		expect(flushNow).not.toHaveBeenCalled();
+	});
+
 	it("releases the direct prompt section when an injected dispatch fails", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1482,6 +1482,45 @@ stale post-hook extension instructions`,
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
+	it("keeps an ordinary direct prompt fenced until its primary message starts", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		await harness.session.sendCustomMessage(
+			{ customType: "earlier-next-turn", content: "earlier", display: true, details: {} },
+			{ deliverAs: "nextTurn" },
+		);
+		const earlierStarted = createDeferred();
+		const earlierStartGate = createDeferred();
+		const primaryStarted = createDeferred();
+		const unsubscribe = harness.session.agent.subscribe(async (event) => {
+			if (event.type !== "message_start") return;
+			if (event.message.role === "user" && getMessageText(event.message) === "ordinary prompt") {
+				primaryStarted.resolve();
+				return;
+			}
+			if (event.message.role === "custom" && event.message.customType === "earlier-next-turn") {
+				earlierStarted.resolve();
+				await earlierStartGate.promise;
+			}
+		});
+
+		const prompt = harness.session.prompt("ordinary prompt");
+		await earlierStarted.promise;
+		let checkpointReleased = false;
+		const checkpoint = harness.session.waitForSessionInputCheckpoint().then(() => {
+			checkpointReleased = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(checkpointReleased).toBe(false);
+
+		earlierStartGate.resolve();
+		await primaryStarted.promise;
+		await checkpoint;
+		await prompt;
+		unsubscribe();
+	});
+
 	it("keeps an injected direct prompt fenced until the injected message starts", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -1562,6 +1601,15 @@ stale post-hook extension instructions`,
 		).rejects.toThrow("dispatch failed");
 
 		// A leaked section would keep update-restart checkpoints waiting forever.
+		await expect(harness.session.waitForSessionInputCheckpoint(AbortSignal.timeout(1000))).resolves.toBeUndefined();
+	});
+
+	it("releases the direct prompt section when an ordinary dispatch fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		vi.spyOn(harness.session.agent, "prompt").mockRejectedValue(new Error("dispatch failed"));
+
+		await expect(harness.session.prompt("ordinary prompt")).rejects.toThrow("dispatch failed");
 		await expect(harness.session.waitForSessionInputCheckpoint(AbortSignal.timeout(1000))).resolves.toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -11,7 +11,7 @@ import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
 import { createTestResourceLoader } from "../utilities.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
-import { createWaitingHarness, gatedHook } from "./scheduling.js";
+import { createDeferred, createWaitingHarness, gatedHook } from "./scheduling.js";
 
 // acceptAgentMessagePrompt admission is asynchronous. Pause after agent.prompt has
 // synchronously claimed the run, but before its prompt messages become delivered.
@@ -1480,6 +1480,56 @@ stale post-hook extension instructions`,
 		expect(harness.session.getFollowUpMessages()).toEqual(["/review keep literal", "/testcmd keep literal"]);
 		expect(commandRuns).toEqual([]);
 		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("keeps an injected direct prompt fenced until the injected message starts", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		await harness.session.sendCustomMessage(
+			{ customType: "earlier-next-turn", content: "earlier", display: true, details: {} },
+			{ deliverAs: "nextTurn" },
+		);
+		const injectedMessage = {
+			role: "custom" as const,
+			customType: "injected-test",
+			content: "injected prompt",
+			display: true,
+			details: {},
+			timestamp: Date.now(),
+		};
+		const earlierStarted = createDeferred();
+		const earlierStartGate = createDeferred();
+		const injectedStarted = createDeferred();
+		const unsubscribe = harness.session.agent.subscribe(async (event) => {
+			if (event.type !== "message_start") return;
+			if (event.message === injectedMessage) {
+				injectedStarted.resolve();
+				return;
+			}
+			if (event.message.role === "custom" && event.message.customType === "earlier-next-turn") {
+				earlierStarted.resolve();
+				await earlierStartGate.promise;
+			}
+		});
+		const internals = harness.session as unknown as {
+			_promptInjectedMessage(text: string, message: typeof injectedMessage): Promise<void>;
+		};
+
+		const prompt = internals._promptInjectedMessage("injected prompt", injectedMessage);
+		await earlierStarted.promise;
+		let checkpointReleased = false;
+		const checkpoint = harness.session.waitForSessionInputCheckpoint().then(() => {
+			checkpointReleased = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(checkpointReleased).toBe(false);
+
+		earlierStartGate.resolve();
+		await injectedStarted.promise;
+		await checkpoint;
+		await prompt;
+		unsubscribe();
 	});
 
 	it("releases the direct prompt section when an injected dispatch fails", async () => {

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1571,6 +1571,56 @@ stale post-hook extension instructions`,
 		unsubscribe();
 	});
 
+	it("releases a queued prompt checkpoint after handoff while its turn remains active", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const responseGate = createDeferred<ReturnType<typeof fauxAssistantMessage>>();
+		harness.setResponses([() => responseGate.promise]);
+		const promptStarted = createDeferred();
+		const unsubscribe = harness.session.agent.subscribe((event) => {
+			if (event.type === "message_start" && event.message.role === "user") promptStarted.resolve();
+		});
+
+		await harness.session.restoreFollowUpMessage("queued prompt");
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await promptStarted.promise;
+
+		await expect(harness.session.waitForSessionInputCheckpoint(AbortSignal.timeout(1000))).resolves.toBeUndefined();
+		expect(harness.session.isStreaming).toBe(true);
+		responseGate.resolve(fauxAssistantMessage("done"));
+		await harness.session.waitForIdle();
+		unsubscribe();
+	});
+
+	it("aborts while a queued prompt is still preparing without consuming its snapshot", async () => {
+		const preparationReached = createDeferred();
+		const preparationGate = createDeferred();
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async () => {
+						preparationReached.resolve();
+						await preparationGate.promise;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		await harness.session.restoreFollowUpMessage("queued prompt");
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await preparationReached.promise;
+		const controller = new AbortController();
+
+		const checkpoint = harness.session.waitForSessionInputCheckpoint(controller.signal);
+		controller.abort();
+
+		await expect(checkpoint).rejects.toThrow("Update restart preparation cancelled");
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: ["queued prompt"] });
+		preparationGate.resolve();
+		await harness.session.waitForIdle();
+	});
+
 	it("aborts while an extension event is pending without flushing or cancelling its queue", async () => {
 		const extensionReached = createDeferred();
 		const extensionGate = createDeferred();

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1482,6 +1482,39 @@ stale post-hook extension instructions`,
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
+	it("releases the direct prompt section when an injected dispatch fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as {
+			_promptInjectedMessage(
+				text: string,
+				message: {
+					role: "custom";
+					customType: string;
+					content: string;
+					display: boolean;
+					details: Record<string, never>;
+					timestamp: number;
+				},
+			): Promise<void>;
+		};
+		vi.spyOn(harness.session.agent, "prompt").mockRejectedValue(new Error("dispatch failed"));
+
+		await expect(
+			internals._promptInjectedMessage("injected prompt", {
+				role: "custom",
+				customType: "injected-test",
+				content: "injected prompt",
+				display: true,
+				details: {},
+				timestamp: Date.now(),
+			}),
+		).rejects.toThrow("dispatch failed");
+
+		// A leaked section would keep update-restart checkpoints waiting forever.
+		await expect(harness.session.waitForSessionInputCheckpoint(AbortSignal.timeout(1000))).resolves.toBeUndefined();
+	});
+
 	it("throws when prompting without a model", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1541,6 +1541,37 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.getPendingResponseCount()).toBe(1);
 	});
 
+	it("releases restart checkpoint waiters when preparation hands off", async () => {
+		const hook = gatedHook({ prompt: "checkpoint handoff" });
+		const harness = await createHarness({ extensionFactories: [hook.factory] });
+		harnesses.push(harness);
+		let releaseResponse = () => {};
+		harness.setResponses([
+			async () => {
+				await new Promise<void>((resolve) => {
+					releaseResponse = resolve;
+				});
+				return fauxAssistantMessage("done");
+			},
+		]);
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.steer("checkpoint handoff", undefined, { resumeIfIdle: true });
+		pause.release();
+		await hook.reached;
+
+		let checkpointSettled = false;
+		const checkpoint = harness.session.waitForSessionInputCheckpoint().then(() => {
+			checkpointSettled = true;
+		});
+		await Promise.resolve();
+		expect(checkpointSettled).toBe(false);
+		hook.release();
+		await vi.waitFor(() => expect(checkpointSettled).toBe(true));
+		releaseResponse();
+		await checkpoint;
+		await harness.session.waitForIdle();
+	});
+
 	it("keeps steering stop pending while a steering handoff is still preparing", async () => {
 		const hook = gatedHook({ prompt: "active steering" });
 		const harness = await createHarness({ extensionFactories: [hook.factory] });

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -224,7 +224,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 			if (existsSync(tempDir)) {
 				// Spawned fixture processes may still be flushing their final registry
 				// writes; retry briefly instead of failing the suite on ENOTEMPTY.
-				rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+				rmSync(tempDir, { recursive: true, force: true, maxRetries: 40, retryDelay: 50 });
 			}
 		},
 	};

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -343,7 +343,7 @@ describe("issue #4257 update restart resume", () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("scheduled response")]);
-		const promptSpy = vi.spyOn(harness.session, "promptAndWait");
+		const promptSpy = vi.spyOn(harness.session, "promptUntilAccepted");
 		const state = createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() });
 		const internals = createDaemonInternals(harness);
 		internals.sessions.set(state.activeSessionId, state);

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -4,7 +4,7 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getDaemonUpdateRestartManifestPath } from "../../../src/config.js";
 import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.js";
-import type { AgentCronJobStore, AgentCronScheduler } from "../../../src/core/cron-jobs.js";
+import type { AgentCronJob, AgentCronJobStore, AgentCronScheduler } from "../../../src/core/cron-jobs.js";
 import { type CustomMessage, createSessionSlashCommandMessage } from "../../../src/core/messages.js";
 import { parseSessionSlashCommand } from "../../../src/core/slash-commands.js";
 import type { BashOperations } from "../../../src/core/tools/bash.js";
@@ -18,6 +18,7 @@ type AgentDaemonUpdateInternals = {
 	sessions: Map<string, ActiveSessionState>;
 	cronStore: AgentCronJobStore;
 	cronScheduler: AgentCronScheduler;
+	runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
 	handleWorkerCommand(client: DaemonSocketClient, command: { id: string; type: string }): Promise<void>;
@@ -72,6 +73,7 @@ function createState(
 	const runtime = {
 		session: harness.session,
 		metadata,
+		cwd: harness.tempDir,
 		runtimeConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
 		diagnostics: [],
 		dispose: async () => {
@@ -291,6 +293,66 @@ describe("issue #4257 update restart resume", () => {
 		internals.mutationDrain.end();
 		await prepare;
 		expect(settled).toBe(true);
+	});
+
+	it("waits for an already-claimed one-shot dispatch and runs it exactly once", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("scheduled response")]);
+		const promptSpy = vi.spyOn(harness.session, "promptAndWait");
+		const state = createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() });
+		const internals = createDaemonInternals(harness);
+		internals.sessions.set(state.activeSessionId, state);
+		const now = new Date("2026-01-01T12:00:00.000Z");
+		const job = internals.cronStore.create({
+			activeSessionId: state.activeSessionId,
+			sessionId: harness.session.sessionId,
+			sessionFile: harness.session.sessionFile ?? "",
+			cwd: harness.tempDir,
+			scheduleText: "in 1m",
+			prompt: "claimed before restart",
+			now,
+		});
+		let markDispatchReached = () => {};
+		const dispatchReached = new Promise<void>((resolve) => {
+			markDispatchReached = resolve;
+		});
+		let releaseDispatch = () => {};
+		const dispatchGate = new Promise<void>((resolve) => {
+			releaseDispatch = resolve;
+		});
+		const originalRunCronJob = internals.runCronJob.bind(internals);
+		let runResult: "skipped" | undefined;
+		vi.spyOn(internals, "runCronJob").mockImplementation(async (claimedJob) => {
+			markDispatchReached();
+			await dispatchGate;
+			runResult = await originalRunCronJob(claimedJob);
+			return runResult;
+		});
+
+		const dispatch = internals.cronScheduler.runDue(new Date("2026-01-01T12:01:00.000Z"));
+		await dispatchReached;
+		let prepareSettled = false;
+		const prepare = internals.prepareUpdateRestart().then((manifest) => {
+			prepareSettled = true;
+			return manifest;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(prepareSettled).toBe(false);
+
+		releaseDispatch();
+		await dispatch;
+		await prepare;
+		expect(runResult).toBeUndefined();
+		expect(promptSpy).toHaveBeenCalledOnce();
+		expect(promptSpy).toHaveBeenCalledWith(
+			"claimed before restart",
+			expect.objectContaining({ streamingBehavior: "followUp", source: "rpc" }),
+		);
+		expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+			status: "completed",
+			runCount: 1,
+		});
 	});
 
 	type OwnershipContext = {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -24,6 +24,11 @@ type AgentDaemonUpdateInternals = {
 	activeWorkerMutations: number;
 	updateRestartPreparing: boolean;
 	updateRestartPrepareAbort?: AbortController;
+	preparedUpdateRestart?: { id: symbol; manifest: DaemonUpdateRestartManifest };
+	handleCommand(
+		client: DaemonSocketClient,
+		command: { id: string; type: "abort"; activeSessionId: string },
+	): Promise<unknown>;
 };
 
 type QueueInternals = {
@@ -160,11 +165,13 @@ describe("issue #4257 update restart resume", () => {
 		expect(internals._activeSessionInput.items).toEqual([input]);
 		expect(internals._followUpMessages).toEqual([]);
 
+		harness.sessionManager.appendMessage(message);
 		internals._activeSessionInput.persistedInputMessages.add(message);
 		internals._activeSessionInput.phase = "handedOff";
 		internals._notifySessionInputCheckpointChange();
 		await checkpoint;
 		expect(checkpointSettled).toBe(true);
+		expect(readFileSync(harness.session.sessionFile!, "utf8")).toContain("blocked prestart update");
 	});
 
 	it("worker cancel releases a prepare blocked on an executing mutation", async () => {
@@ -199,6 +206,62 @@ describe("issue #4257 update restart resume", () => {
 		expect(internals.updateRestartPreparing).toBe(false);
 		expect(writes.join(" ")).toContain("Update restart preparation cancelled");
 		expect(writes.join(" ")).toContain('"command":"worker_cancel_update","success":true');
+	});
+
+	it.each(["worker_commit_update", "worker_cancel_update"])(
+		"rejects %s from a different prepare owner",
+		async (type) => {
+			const harness = await createHarness({ persistSession: true });
+			harnesses.push(harness);
+			const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+				defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+				worker: { authenticationToken: "token" },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			const internals = daemon as unknown as AgentDaemonUpdateInternals;
+			const writes: string[] = [];
+			const client = (id: string) =>
+				({
+					id,
+					socket: {
+						destroyed: false,
+						write: (chunk: string) => {
+							writes.push(chunk);
+							return true;
+						},
+					},
+				}) as unknown as DaemonSocketClient;
+			const owner = client("owner");
+			await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+			await internals.handleWorkerCommand(client("other"), { id: "foreign", type });
+			expect(writes.at(-1)).toContain("belongs to another supervisor");
+			expect(internals.preparedUpdateRestart).toBeDefined();
+			await internals.handleWorkerCommand(owner, { id: "cleanup", type: "worker_cancel_update" });
+		},
+	);
+
+	it("rejects drain mutations after this worker publishes its prepare snapshot", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			worker: { authenticationToken: "token" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const client = {
+			id: "owner",
+			socket: { destroyed: false, write: vi.fn(() => true) },
+		} as unknown as DaemonSocketClient;
+		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
+		await expect(
+			internals.handleCommand(client, { id: "abort", type: "abort", activeSessionId: "missing" }),
+		).rejects.toThrow("preparing an update restart");
+		await internals.handleWorkerCommand(client, { id: "cancel", type: "worker_cancel_update" });
 	});
 
 	it("captures a restart manifest and aborts running bash without archiving the session", async () => {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -169,7 +169,7 @@ describe("issue #4257 update restart resume", () => {
 		}
 	});
 
-	it("waits for the full admitted prompt checkpoint before preparing restart", async () => {
+	it("waits for the admitted prompt event checkpoint before preparing restart", async () => {
 		let releaseAssistantMessageEnd: (() => void) | undefined;
 		const assistantMessageEndBlocked = new Promise<void>((resolve) => {
 			releaseAssistantMessageEnd = resolve;

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -22,6 +22,7 @@ type AgentDaemonUpdateInternals = {
 	cronScheduler: AgentCronScheduler;
 	runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
+	beginUpdateRestartTransaction(owner?: DaemonSocketClient): NonNullable<AgentDaemonUpdateInternals["updateRestart"]>;
 	runUpdateRestartPreparation(
 		transaction: NonNullable<AgentDaemonUpdateInternals["updateRestart"]>,
 	): Promise<DaemonUpdateRestartManifest>;
@@ -37,6 +38,11 @@ type AgentDaemonUpdateInternals = {
 		phase: "preparing" | "fencing" | "prepared" | "publishing";
 		manifest?: DaemonUpdateRestartManifest;
 		owner?: DaemonSocketClient;
+		deferredClientEnv: Array<{
+			client: DaemonSocketClient;
+			state: ActiveSessionState;
+			env: Record<string, string>;
+		}>;
 	};
 	supervisorClaims: Map<DaemonSocketClient, unknown>;
 	revokeSupervisorClaim(client: DaemonSocketClient): boolean;
@@ -316,6 +322,7 @@ describe("issue #4257 update restart resume", () => {
 			id: Symbol("update-restart"),
 			abort: new AbortController(),
 			phase: "preparing" as const,
+			deferredClientEnv: [],
 		};
 		internals.updateRestart = transaction;
 		const firstDrain = createDeferred();
@@ -484,6 +491,7 @@ describe("issue #4257 update restart resume", () => {
 					id: Symbol("newer-update-restart"),
 					abort: new AbortController(),
 					phase: "publishing" as const,
+					deferredClientEnv: [],
 				};
 				vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
 					internals.updateRestart = newerTransaction;
@@ -1340,6 +1348,35 @@ describe("issue #4257 update restart resume", () => {
 		]);
 		expect(getUserTexts(harness)).toEqual(["restored follow-up"]);
 		expect(harness.session.getFollowUpQueueSnapshots()).toEqual([]);
+	});
+
+	it("adopts attach env after a fenced update preparation rolls back", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const internals = createDaemonInternals(harness);
+		const state = createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() });
+		internals.sessions.set(state.activeSessionId, state);
+		const transaction = internals.beginUpdateRestartTransaction();
+		transaction.phase = "fencing";
+		const writes: string[] = [];
+		const client = createWriteClient(writes);
+
+		await internals.handleLine(
+			client,
+			JSON.stringify({
+				id: "attach-1",
+				type: "attach",
+				activeSessionId: state.activeSessionId,
+				env: { HERDR_PANE_ID: "w1:p1", PATH: "/ignored" },
+			}),
+		);
+
+		expect(state.clientEnv).toBeUndefined();
+		expect(state.clients.has(client)).toBe(true);
+		expect(transaction.deferredClientEnv).toHaveLength(1);
+		internals.cancelPreparedUpdateRestart(transaction.id);
+		expect(state.clientEnv).toEqual({ HERDR_PANE_ID: "w1:p1" });
+		expect(transaction.deferredClientEnv).toEqual([]);
 	});
 
 	it("reports resume_queue failure when no work can resume", async () => {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -20,6 +20,10 @@ type AgentDaemonUpdateInternals = {
 	cronScheduler: AgentCronScheduler;
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+	handleWorkerCommand(client: DaemonSocketClient, command: { id: string; type: string }): Promise<void>;
+	activeWorkerMutations: number;
+	updateRestartPreparing: boolean;
+	updateRestartPrepareAbort?: AbortController;
 };
 
 type QueueInternals = {
@@ -38,6 +42,16 @@ type QueueInternals = {
 		message: UserMessage | CustomMessage;
 	}>;
 	_pendingNextTurnMessages: CustomMessage[];
+	_activeSessionInput?: {
+		kind: "prompt";
+		lane: "steer" | "followUp";
+		items: QueueInternals["_followUpMessages"];
+		phase: "preparing" | "handedOff";
+		checkpointInputMessages: Set<UserMessage | CustomMessage>;
+		persistedInputMessages: Set<UserMessage | CustomMessage>;
+	};
+	waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void>;
+	_notifySessionInputCheckpointChange(): void;
 	_acceptedAgentMessagePrompt?: {
 		text: string;
 		agentMessageId: string;
@@ -112,6 +126,79 @@ describe("issue #4257 update restart resume", () => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
+	});
+
+	it("keeps a prestart input in the manifest exactly once until message_end persistence", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const internals = harness.session as unknown as QueueInternals;
+		const message: UserMessage = {
+			role: "user",
+			content: [{ type: "text", text: "blocked prestart update" }],
+			timestamp: Date.now(),
+		};
+		const input = {
+			text: "blocked prestart update",
+			prefixMessages: [],
+			message,
+		};
+		internals._activeSessionInput = {
+			kind: "prompt",
+			lane: "followUp",
+			items: [input],
+			phase: "preparing",
+			checkpointInputMessages: new Set([message]),
+			persistedInputMessages: new Set(),
+		};
+
+		let checkpointSettled = false;
+		const checkpoint = internals.waitForSessionInputCheckpoint().then(() => {
+			checkpointSettled = true;
+		});
+		await Promise.resolve();
+		expect(checkpointSettled).toBe(false);
+		expect(internals._activeSessionInput.items).toEqual([input]);
+		expect(internals._followUpMessages).toEqual([]);
+
+		internals._activeSessionInput.persistedInputMessages.add(message);
+		internals._activeSessionInput.phase = "handedOff";
+		internals._notifySessionInputCheckpointChange();
+		await checkpoint;
+		expect(checkpointSettled).toBe(true);
+	});
+
+	it("worker cancel releases a prepare blocked on an executing mutation", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			worker: { authenticationToken: "token" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		internals.activeWorkerMutations = 1;
+		const writes: string[] = [];
+		const client = {
+			id: "supervisor",
+			socket: {
+				destroyed: false,
+				write: (chunk: string) => {
+					writes.push(chunk);
+					return true;
+				},
+			},
+		} as unknown as DaemonSocketClient;
+
+		const prepare = internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
+		await vi.waitFor(() => expect(internals.updateRestartPreparing).toBe(true));
+		await internals.handleWorkerCommand(client, { id: "cancel", type: "worker_cancel_update" });
+		await prepare;
+
+		expect(internals.updateRestartPreparing).toBe(false);
+		expect(writes.join(" ")).toContain("Update restart preparation cancelled");
+		expect(writes.join(" ")).toContain('"command":"worker_cancel_update","success":true');
 	});
 
 	it("captures a restart manifest and aborts running bash without archiving the session", async () => {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -21,10 +21,14 @@ type AgentDaemonUpdateInternals = {
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
 	handleWorkerCommand(client: DaemonSocketClient, command: { id: string; type: string }): Promise<void>;
-	activeWorkerMutations: number;
+	activeMutations: number;
 	updateRestartPreparing: boolean;
-	updateRestartPrepareAbort?: AbortController;
+	updateRestartTransaction?: { id: symbol; abort: AbortController };
+	updateRestartPublishing?: symbol;
 	preparedUpdateRestart?: { id: symbol; manifest: DaemonUpdateRestartManifest };
+	endMutation(): void;
+	cancelPreparedUpdateRestart(transactionId?: symbol): void;
+	commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest>;
 	handleCommand(
 		client: DaemonSocketClient,
 		command: { id: string; type: "abort"; activeSessionId: string },
@@ -185,7 +189,7 @@ describe("issue #4257 update restart resume", () => {
 			},
 		});
 		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		internals.activeWorkerMutations = 1;
+		internals.activeMutations = 1;
 		const writes: string[] = [];
 		const client = {
 			id: "supervisor",
@@ -206,6 +210,31 @@ describe("issue #4257 update restart resume", () => {
 		expect(internals.updateRestartPreparing).toBe(false);
 		expect(writes.join(" ")).toContain("Update restart preparation cancelled");
 		expect(writes.join(" ")).toContain('"command":"worker_cancel_update","success":true');
+	});
+
+	it("standalone prepare waits for an executing daemon mutation", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		internals.activeMutations = 1;
+
+		let settled = false;
+		const prepare = internals.prepareUpdateRestart().then((manifest) => {
+			settled = true;
+			return manifest;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		internals.endMutation();
+		await prepare;
+		expect(settled).toBe(true);
 	});
 
 	it.each(["worker_commit_update", "worker_cancel_update"])(
@@ -241,6 +270,70 @@ describe("issue #4257 update restart resume", () => {
 			await internals.handleWorkerCommand(owner, { id: "cleanup", type: "worker_cancel_update" });
 		},
 	);
+
+	it("rejects a duplicate worker commit while publishing", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			worker: { authenticationToken: "token" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const writes: string[] = [];
+		const client = {
+			id: "owner",
+			socket: {
+				destroyed: false,
+				write: (chunk: string) => {
+					writes.push(chunk);
+					return true;
+				},
+			},
+		} as unknown as DaemonSocketClient;
+		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
+		const prepared = internals.preparedUpdateRestart;
+		expect(prepared).toBeDefined();
+		internals.updateRestartPublishing = prepared?.id;
+
+		await internals.handleWorkerCommand(client, { id: "duplicate", type: "worker_commit_update" });
+
+		expect(writes.at(-1)).toContain("already committing");
+		internals.updateRestartPublishing = undefined;
+		internals.cancelPreparedUpdateRestart(prepared?.id);
+	});
+
+	it("finishes cancelled transaction cleanup after a failed publish", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			worker: { authenticationToken: "token" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const client = {
+			id: "owner",
+			socket: { destroyed: false, write: vi.fn(() => true) },
+		} as unknown as DaemonSocketClient;
+		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
+		const transaction = internals.updateRestartTransaction;
+		expect(transaction).toBeDefined();
+		vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
+			internals.cancelPreparedUpdateRestart(transaction?.id);
+			throw new Error("publish failed");
+		});
+
+		await internals.handleWorkerCommand(client, { id: "commit", type: "worker_commit_update" });
+
+		expect(internals.updateRestartPreparing).toBe(false);
+		expect(internals.updateRestartTransaction).toBeUndefined();
+		expect(internals.updateRestartPublishing).toBeUndefined();
+	});
 
 	it("rejects drain mutations after this worker publishes its prepare snapshot", async () => {
 		const harness = await createHarness({ persistSession: true });

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -21,18 +21,15 @@ type AgentDaemonUpdateInternals = {
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
 	handleWorkerCommand(client: DaemonSocketClient, command: { id: string; type: string }): Promise<void>;
-	activeMutations: number;
-	updateRestartPreparing: boolean;
-	updateRestartTransaction?: { id: symbol; abort: AbortController };
-	updateRestartPublishing?: symbol;
-	preparedUpdateRestart?: { id: symbol; manifest: DaemonUpdateRestartManifest };
-	endMutation(): void;
+	mutationDrain: { begin(): void; end(): void };
+	updateRestart?: {
+		id: symbol;
+		abort: AbortController;
+		phase: "preparing" | "prepared" | "publishing";
+		manifest?: DaemonUpdateRestartManifest;
+	};
 	cancelPreparedUpdateRestart(transactionId?: symbol): void;
 	commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest>;
-	handleCommand(
-		client: DaemonSocketClient,
-		command: { id: string; type: "abort"; activeSessionId: string },
-	): Promise<unknown>;
 };
 
 type QueueInternals = {
@@ -90,6 +87,41 @@ function createState(
 		lastEventSequence: 0,
 		...(options.clientEnv ? { clientEnv: options.clientEnv } : {}),
 	};
+}
+
+function createDaemonInternals(
+	harness: Harness,
+	options: { sessionDir?: string; worker?: boolean } = {},
+): AgentDaemonUpdateInternals {
+	const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+		defaultSessionConfig: {
+			cwd: harness.tempDir,
+			agentDir: harness.tempDir,
+			...(options.sessionDir ? { sessionDir: options.sessionDir } : {}),
+		},
+		...(options.worker ? { worker: { authenticationToken: "token" } } : {}),
+		createRuntime: async () => {
+			throw new Error("unexpected runtime creation");
+		},
+	});
+	return daemon as unknown as AgentDaemonUpdateInternals;
+}
+
+function createWriteClient(writes: string[], options: { id?: string; attached?: string[] } = {}): DaemonSocketClient {
+	return {
+		id: options.id ?? "client-1",
+		socket: {
+			destroyed: false,
+			write: vi.fn((chunk: string) => {
+				writes.push(chunk);
+				return true;
+			}),
+		} as unknown as DaemonSocketClient["socket"],
+		attachedActiveSessionIds: new Set(options.attached ?? []),
+		detachInput: vi.fn(),
+		supportsExtensionUi: false,
+		capabilities: new Set(),
+	} as DaemonSocketClient;
 }
 
 function hasArchivedState(harness: Harness): boolean {
@@ -156,13 +188,7 @@ describe("issue #4257 update restart resume", () => {
 		expect(harness.session.resumeQueuedWork()).toBe(true);
 		await vi.waitFor(() => expect(promptAdmitted).toBe(true));
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -223,18 +249,14 @@ describe("issue #4257 update restart resume", () => {
 		).toBe(true);
 	});
 
-	it("worker cancel releases a prepare blocked on an executing mutation", async () => {
+	it.each([
+		{ name: "worker cancel releases a prepare blocked on an executing mutation", release: "cancel" },
+		{ name: "standalone prepare waits for an executing daemon mutation", release: "drain" },
+	] as const)("$name", async ({ release }) => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			worker: { authenticationToken: "token" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		internals.activeMutations = 1;
+		const internals = createDaemonInternals(harness, { worker: true });
+		internals.mutationDrain.begin();
 		const writes: string[] = [];
 		const client = {
 			id: "supervisor",
@@ -247,28 +269,17 @@ describe("issue #4257 update restart resume", () => {
 			},
 		} as unknown as DaemonSocketClient;
 
-		const prepare = internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
-		await vi.waitFor(() => expect(internals.updateRestartPreparing).toBe(true));
-		await internals.handleWorkerCommand(client, { id: "cancel", type: "worker_cancel_update" });
-		await prepare;
+		if (release === "cancel") {
+			const prepare = internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
+			await vi.waitFor(() => expect(internals.updateRestart).toBeDefined());
+			await internals.handleWorkerCommand(client, { id: "cancel", type: "worker_cancel_update" });
+			await prepare;
 
-		expect(internals.updateRestartPreparing).toBe(false);
-		expect(writes.join(" ")).toContain("Update restart preparation cancelled");
-		expect(writes.join(" ")).toContain('"command":"worker_cancel_update","success":true');
-	});
-
-	it("standalone prepare waits for an executing daemon mutation", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		internals.activeMutations = 1;
-
+			expect(internals.updateRestart).toBeUndefined();
+			expect(writes.join(" ")).toContain("Update restart preparation cancelled");
+			expect(writes.join(" ")).toContain('"command":"worker_cancel_update","success":true');
+			return;
+		}
 		let settled = false;
 		const prepare = internals.prepareUpdateRestart().then((manifest) => {
 			settled = true;
@@ -277,152 +288,112 @@ describe("issue #4257 update restart resume", () => {
 		await Promise.resolve();
 		expect(settled).toBe(false);
 
-		internals.endMutation();
+		internals.mutationDrain.end();
 		await prepare;
 		expect(settled).toBe(true);
 	});
 
-	it.each(["worker_commit_update", "worker_cancel_update"])(
-		"rejects %s from a different prepare owner",
-		async (type) => {
-			const harness = await createHarness({ persistSession: true });
-			harnesses.push(harness);
-			const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-				defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-				worker: { authenticationToken: "token" },
-				createRuntime: async () => {
-					throw new Error("unexpected runtime creation");
-				},
-			});
-			const internals = daemon as unknown as AgentDaemonUpdateInternals;
-			const writes: string[] = [];
-			const client = (id: string) =>
-				({
-					id,
-					socket: {
-						destroyed: false,
-						write: (chunk: string) => {
-							writes.push(chunk);
-							return true;
-						},
-					},
-				}) as unknown as DaemonSocketClient;
-			const owner = client("owner");
-			await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
-			await internals.handleWorkerCommand(client("other"), { id: "foreign", type });
-			expect(writes.at(-1)).toContain("belongs to another supervisor");
-			expect(internals.preparedUpdateRestart).toBeDefined();
-			await internals.handleWorkerCommand(owner, { id: "cleanup", type: "worker_cancel_update" });
+	type OwnershipContext = {
+		internals: AgentDaemonUpdateInternals;
+		makeClient: (id: string) => DaemonSocketClient;
+		writes: string[];
+	};
+
+	it.each<{ name: string; run: (context: OwnershipContext) => Promise<void> }>([
+		...(["worker_commit_update", "worker_cancel_update"] as const).map((type) => ({
+			name: `rejects ${type} from a different prepare owner`,
+			run: async ({ internals, makeClient, writes }: OwnershipContext) => {
+				const owner = makeClient("owner");
+				await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+				await internals.handleWorkerCommand(makeClient("other"), { id: "foreign", type });
+				expect(writes.at(-1)).toContain("belongs to another supervisor");
+				expect(internals.updateRestart?.phase).toBe("prepared");
+				await internals.handleWorkerCommand(owner, { id: "cleanup", type: "worker_cancel_update" });
+			},
+		})),
+		{
+			name: "rejects a duplicate worker commit while publishing",
+			run: async ({ internals, makeClient, writes }) => {
+				const owner = makeClient("owner");
+				await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+				const transaction = internals.updateRestart;
+				expect(transaction).toBeDefined();
+				transaction!.phase = "publishing";
+
+				await internals.handleWorkerCommand(owner, { id: "duplicate", type: "worker_commit_update" });
+
+				expect(writes.at(-1)).toContain("already committing");
+				transaction!.phase = "prepared";
+				internals.cancelPreparedUpdateRestart(transaction?.id);
+			},
 		},
-	);
+		{
+			name: "finishes cancelled transaction cleanup after a failed publish",
+			run: async ({ internals, makeClient }) => {
+				const owner = makeClient("owner");
+				await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+				const transaction = internals.updateRestart;
+				expect(transaction).toBeDefined();
+				vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
+					internals.cancelPreparedUpdateRestart(transaction?.id);
+					throw new Error("publish failed");
+				});
 
-	it("rejects a duplicate worker commit while publishing", async () => {
+				await internals.handleWorkerCommand(owner, { id: "commit", type: "worker_commit_update" });
+
+				expect(internals.updateRestart).toBeUndefined();
+			},
+		},
+		{
+			name: "does not let stale standalone cleanup clear a newer publishing owner",
+			run: async ({ internals }) => {
+				const newerTransaction = {
+					id: Symbol("newer-update-restart"),
+					abort: new AbortController(),
+					phase: "publishing" as const,
+				};
+				vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
+					internals.updateRestart = newerTransaction;
+					throw new Error("stale publish failed");
+				});
+
+				await expect(internals.prepareUpdateRestart()).rejects.toThrow("stale publish failed");
+
+				expect(internals.updateRestart).toBe(newerTransaction);
+			},
+		},
+		{
+			name: "rejects drain mutations but admits reads after this worker publishes its prepare snapshot",
+			run: async ({ internals, makeClient, writes }) => {
+				const owner = makeClient("owner");
+				await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+				await internals.handleLine(
+					owner,
+					JSON.stringify({ id: "abort", type: "abort", activeSessionId: "missing" }),
+				);
+				expect(writes.at(-1)).toContain("Daemon is preparing an update restart");
+				await internals.handleLine(owner, JSON.stringify({ id: "late-list", type: "list" }));
+				expect(JSON.parse(writes.at(-1) ?? "{}")).toMatchObject({ id: "late-list", success: true });
+				await internals.handleWorkerCommand(owner, { id: "cancel", type: "worker_cancel_update" });
+			},
+		},
+	])("$name", async ({ run }) => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			worker: { authenticationToken: "token" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		const writes: string[] = [];
-		const client = {
-			id: "owner",
-			socket: {
-				destroyed: false,
-				write: (chunk: string) => {
-					writes.push(chunk);
-					return true;
+		const makeClient = (id: string) =>
+			({
+				id,
+				socket: {
+					destroyed: false,
+					write: (chunk: string) => {
+						writes.push(chunk);
+						return true;
+					},
 				},
-			},
-		} as unknown as DaemonSocketClient;
-		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
-		const prepared = internals.preparedUpdateRestart;
-		expect(prepared).toBeDefined();
-		internals.updateRestartPublishing = prepared?.id;
-
-		await internals.handleWorkerCommand(client, { id: "duplicate", type: "worker_commit_update" });
-
-		expect(writes.at(-1)).toContain("already committing");
-		internals.updateRestartPublishing = undefined;
-		internals.cancelPreparedUpdateRestart(prepared?.id);
-	});
-
-	it("finishes cancelled transaction cleanup after a failed publish", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			worker: { authenticationToken: "token" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		const client = {
-			id: "owner",
-			socket: { destroyed: false, write: vi.fn(() => true) },
-		} as unknown as DaemonSocketClient;
-		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
-		const transaction = internals.updateRestartTransaction;
-		expect(transaction).toBeDefined();
-		vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
-			internals.cancelPreparedUpdateRestart(transaction?.id);
-			throw new Error("publish failed");
-		});
-
-		await internals.handleWorkerCommand(client, { id: "commit", type: "worker_commit_update" });
-
-		expect(internals.updateRestartPreparing).toBe(false);
-		expect(internals.updateRestartTransaction).toBeUndefined();
-		expect(internals.updateRestartPublishing).toBeUndefined();
-	});
-
-	it("does not let stale standalone cleanup clear a newer publishing owner", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		const newerTransaction = { id: Symbol("newer-update-restart"), abort: new AbortController() };
-		vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
-			internals.updateRestartTransaction = newerTransaction;
-			internals.updateRestartPublishing = newerTransaction.id;
-			throw new Error("stale publish failed");
-		});
-
-		await expect(internals.prepareUpdateRestart()).rejects.toThrow("stale publish failed");
-
-		expect(internals.updateRestartTransaction).toBe(newerTransaction);
-		expect(internals.updateRestartPublishing).toBe(newerTransaction.id);
-	});
-
-	it("rejects drain mutations after this worker publishes its prepare snapshot", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			worker: { authenticationToken: "token" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
-		const client = {
-			id: "owner",
-			socket: { destroyed: false, write: vi.fn(() => true) },
-		} as unknown as DaemonSocketClient;
-		await internals.handleWorkerCommand(client, { id: "prepare", type: "worker_prepare_update" });
-		await expect(
-			internals.handleCommand(client, { id: "abort", type: "abort", activeSessionId: "missing" }),
-		).rejects.toThrow("preparing an update restart");
-		await internals.handleWorkerCommand(client, { id: "cancel", type: "worker_cancel_update" });
+			}) as unknown as DaemonSocketClient;
+		await run({ internals, makeClient, writes });
 	});
 
 	it("captures a restart manifest and aborts running bash without archiving the session", async () => {
@@ -466,13 +437,7 @@ describe("issue #4257 update restart resume", () => {
 				},
 			},
 		);
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(state.activeSessionId, state);
 		const schedulerStopSpy = vi.spyOn(internals.cronScheduler, "stop");
 		const now = new Date("2026-01-01T12:00:00.000Z");
@@ -581,20 +546,7 @@ describe("issue #4257 update restart resume", () => {
 
 		await internals.prepareUpdateRestart();
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes);
 
 		await internals.handleLine(client, JSON.stringify({ id: "late-create", type: "create" }));
 
@@ -647,13 +599,7 @@ describe("issue #4257 update restart resume", () => {
 			truncated: false,
 		});
 
-		const daemon = new AgentDaemon(`${parentHarness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: parentHarness.tempDir, agentDir: parentHarness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(parentHarness);
 		internals.sessions.set(
 			"parent-active",
 			createState(
@@ -768,13 +714,7 @@ describe("issue #4257 update restart resume", () => {
 			cleared: false,
 		};
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -812,13 +752,7 @@ describe("issue #4257 update restart resume", () => {
 		});
 
 		const sessionDir = `${harness.tempDir}/sessions`;
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir, sessionDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness, { sessionDir });
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -848,13 +782,7 @@ describe("issue #4257 update restart resume", () => {
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
 
 		const sessionDir = `${harness.tempDir}/sessions`;
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir, sessionDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness, { sessionDir });
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -901,13 +829,7 @@ describe("issue #4257 update restart resume", () => {
 			cleared: false,
 		};
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -929,33 +851,14 @@ describe("issue #4257 update restart resume", () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 		const restoredMessage = createCustomMessage("restored next turn");
 
 		await internals.handleLine(
@@ -982,13 +885,7 @@ describe("issue #4257 update restart resume", () => {
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("accepted restored prompt")]);
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -999,20 +896,7 @@ describe("issue #4257 update restart resume", () => {
 			{ type: "text", text: "accepted work" },
 		];
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,
@@ -1043,13 +927,7 @@ describe("issue #4257 update restart resume", () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
@@ -1069,20 +947,7 @@ describe("issue #4257 update restart resume", () => {
 			agentMessageId: "agentmsg_existing",
 		});
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,
@@ -1164,32 +1029,13 @@ describe("issue #4257 update restart resume", () => {
 		]);
 		await harness.session.prompt("start");
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,
@@ -1255,32 +1101,13 @@ describe("issue #4257 update restart resume", () => {
 		harness.setResponses([fauxAssistantMessage("handled continuation"), fauxAssistantMessage("handled follow-up")]);
 		harness.session.agent.state.messages.push(createCustomMessage("update interrupted"));
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,
@@ -1339,32 +1166,13 @@ describe("issue #4257 update restart resume", () => {
 		harness.setResponses([fauxAssistantMessage("handled restored follow-up")]);
 		harness.session.agent.state.messages.push(createCustomMessage("update interrupted"));
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,
@@ -1405,32 +1213,13 @@ describe("issue #4257 update restart resume", () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
 
-		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
-			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const internals = createDaemonInternals(harness);
 		internals.sessions.set(
 			"active-1",
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 		const writes: string[] = [];
-		const client: DaemonSocketClient = {
-			id: "client-1",
-			socket: {
-				destroyed: false,
-				write: vi.fn((chunk: string) => {
-					writes.push(chunk);
-					return true;
-				}),
-			} as unknown as DaemonSocketClient["socket"],
-			attachedActiveSessionIds: new Set(["active-1"]),
-			detachInput: vi.fn(),
-			supportsExtensionUi: false,
-			capabilities: new Set(),
-		};
+		const client = createWriteClient(writes, { attached: ["active-1"] });
 
 		await internals.handleLine(
 			client,

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -380,6 +380,29 @@ describe("issue #4257 update restart resume", () => {
 		expect(internals.updateRestartPublishing).toBeUndefined();
 	});
 
+	it("does not let stale standalone cleanup clear a newer publishing owner", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		const newerTransaction = { id: Symbol("newer-update-restart"), abort: new AbortController() };
+		vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(async () => {
+			internals.updateRestartTransaction = newerTransaction;
+			internals.updateRestartPublishing = newerTransaction.id;
+			throw new Error("stale publish failed");
+		});
+
+		await expect(internals.prepareUpdateRestart()).rejects.toThrow("stale publish failed");
+
+		expect(internals.updateRestartTransaction).toBe(newerTransaction);
+		expect(internals.updateRestartPublishing).toBe(newerTransaction.id);
+	});
+
 	it("rejects drain mutations after this worker publishes its prepare snapshot", async () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -36,7 +36,11 @@ type AgentDaemonUpdateInternals = {
 		abort: AbortController;
 		phase: "preparing" | "fencing" | "prepared" | "publishing";
 		manifest?: DaemonUpdateRestartManifest;
+		owner?: DaemonSocketClient;
 	};
+	supervisorClaims: Map<DaemonSocketClient, unknown>;
+	revokeSupervisorClaim(client: DaemonSocketClient): boolean;
+	shutdown(exitCode: number): Promise<never>;
 	cancelPreparedUpdateRestart(transactionId?: symbol): void;
 	commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest>;
 };
@@ -448,6 +452,29 @@ describe("issue #4257 update restart resume", () => {
 				await internals.handleWorkerCommand(owner, { id: "commit", type: "worker_commit_update" });
 
 				expect(internals.updateRestart).toBeUndefined();
+			},
+		},
+		{
+			name: "finishes publishing then exits when its owning supervisor is replaced",
+			run: async ({ internals, makeClient }) => {
+				const owner = makeClient("owner");
+				internals.supervisorClaims.set(owner, {});
+				await internals.handleWorkerCommand(owner, { id: "prepare", type: "worker_prepare_update" });
+				const transaction = internals.updateRestart;
+				expect(transaction).toBeDefined();
+				const publish = createDeferred<DaemonUpdateRestartManifest>();
+				vi.spyOn(internals, "commitPreparedUpdateRestart").mockImplementationOnce(() => publish.promise);
+				const shutdown = vi.spyOn(internals, "shutdown").mockImplementation(() => new Promise<never>(() => {}));
+
+				const commit = internals.handleWorkerCommand(owner, { id: "commit", type: "worker_commit_update" });
+				await vi.waitFor(() => expect(transaction?.phase).toBe("publishing"));
+				internals.revokeSupervisorClaim(owner);
+				expect(transaction?.phase).toBe("publishing");
+				publish.resolve(transaction!.manifest!);
+				await commit;
+				await new Promise<void>((resolve) => setImmediate(resolve));
+
+				expect(shutdown).toHaveBeenCalledWith(0);
 			},
 		},
 		{

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -47,6 +47,7 @@ type AgentDaemonUpdateInternals = {
 	supervisorClaims: Map<DaemonSocketClient, unknown>;
 	revokeSupervisorClaim(client: DaemonSocketClient): boolean;
 	shutdown(exitCode: number): Promise<never>;
+	getShutdownClosingReason(): "update" | "shutdown";
 	cancelPreparedUpdateRestart(transactionId?: symbol): void;
 	commitPreparedUpdateRestart(transactionId: symbol): Promise<DaemonUpdateRestartManifest>;
 };
@@ -177,6 +178,28 @@ describe("issue #4257 update restart resume", () => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
+	});
+
+	it.each([
+		[undefined, "shutdown"],
+		["preparing", "shutdown"],
+		["fencing", "shutdown"],
+		["prepared", "shutdown"],
+		["publishing", "update"],
+	] as const)("uses %s restart phase as %s shutdown", async (phase, expected) => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const internals = createDaemonInternals(harness);
+		if (phase) {
+			internals.updateRestart = {
+				id: Symbol("update-restart"),
+				abort: new AbortController(),
+				phase,
+				deferredClientEnv: [],
+			};
+		}
+
+		expect(internals.getShutdownClosingReason()).toBe(expected);
 	});
 
 	it("waits for the admitted prompt event checkpoint before preparing restart", async () => {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -11,8 +11,10 @@ import type { BashOperations } from "../../../src/core/tools/bash.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
 import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
 import type { DaemonUpdateRestartManifest } from "../../../src/modes/daemon/daemon-protocol.js";
+import { MutationDrainLatch } from "../../../src/modes/daemon/mutation-drain-latch.js";
 import { prepareDaemonUpdateRestart } from "../../../src/package-manager-cli.js";
 import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
+import { createDeferred } from "../scheduling.js";
 
 type AgentDaemonUpdateInternals = {
 	sessions: Map<string, ActiveSessionState>;
@@ -20,13 +22,19 @@ type AgentDaemonUpdateInternals = {
 	cronScheduler: AgentCronScheduler;
 	runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 	prepareUpdateRestart(): Promise<DaemonUpdateRestartManifest>;
+	runUpdateRestartPreparation(
+		transaction: NonNullable<AgentDaemonUpdateInternals["updateRestart"]>,
+	): Promise<DaemonUpdateRestartManifest>;
+	prepareUpdateRestartCheckpoint(
+		transaction: NonNullable<AgentDaemonUpdateInternals["updateRestart"]>,
+	): Promise<DaemonUpdateRestartManifest>;
 	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
 	handleWorkerCommand(client: DaemonSocketClient, command: { id: string; type: string }): Promise<void>;
 	mutationDrain: { begin(): void; end(): void };
 	updateRestart?: {
 		id: symbol;
 		abort: AbortController;
-		phase: "preparing" | "prepared" | "publishing";
+		phase: "preparing" | "fencing" | "prepared" | "publishing";
 		manifest?: DaemonUpdateRestartManifest;
 	};
 	cancelPreparedUpdateRestart(transactionId?: symbol): void;
@@ -293,6 +301,42 @@ describe("issue #4257 update restart resume", () => {
 		internals.mutationDrain.end();
 		await prepare;
 		expect(settled).toBe(true);
+	});
+
+	it("fences and drains a mutation admitted at the first drain boundary before checkpointing", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		const internals = createDaemonInternals(harness);
+		const mutationDrain = new MutationDrainLatch();
+		const transaction = {
+			id: Symbol("update-restart"),
+			abort: new AbortController(),
+			phase: "preparing" as const,
+		};
+		internals.updateRestart = transaction;
+		const firstDrain = createDeferred();
+		const originalWaitForDrain = mutationDrain.waitForDrain.bind(mutationDrain);
+		vi.spyOn(mutationDrain, "waitForDrain").mockImplementationOnce(async (...args) => {
+			await originalWaitForDrain(...args);
+			mutationDrain.begin();
+			firstDrain.resolve();
+		});
+		Reflect.set(internals, "mutationDrain", mutationDrain);
+		const checkpoint = vi.spyOn(internals, "prepareUpdateRestartCheckpoint").mockResolvedValue({
+			createdAt: "now",
+			sessions: [],
+		});
+
+		const prepare = internals.runUpdateRestartPreparation(transaction);
+		await firstDrain.promise;
+		await Promise.resolve();
+
+		expect(internals.updateRestart?.phase).toBe("fencing");
+		expect(checkpoint).not.toHaveBeenCalled();
+
+		mutationDrain.end();
+		await prepare;
+		expect(checkpoint).toHaveBeenCalledOnce();
 	});
 
 	it("waits for an already-claimed one-shot dispatch and runs it exactly once", async () => {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -12,7 +12,7 @@ import type { ActiveSessionState, DaemonSocketClient } from "../../../src/modes/
 import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
 import type { DaemonUpdateRestartManifest } from "../../../src/modes/daemon/daemon-protocol.js";
 import { prepareDaemonUpdateRestart } from "../../../src/package-manager-cli.js";
-import { createHarness, getUserTexts, type Harness } from "../harness.js";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.js";
 
 type AgentDaemonUpdateInternals = {
 	sessions: Map<string, ActiveSessionState>;
@@ -51,16 +51,6 @@ type QueueInternals = {
 		message: UserMessage | CustomMessage;
 	}>;
 	_pendingNextTurnMessages: CustomMessage[];
-	_activeSessionInput?: {
-		kind: "prompt";
-		lane: "steer" | "followUp";
-		items: QueueInternals["_followUpMessages"];
-		phase: "preparing" | "handedOff";
-		checkpointInputMessages: Set<UserMessage | CustomMessage>;
-		persistedInputMessages: Set<UserMessage | CustomMessage>;
-	};
-	waitForSessionInputCheckpoint(signal?: AbortSignal): Promise<void>;
-	_notifySessionInputCheckpointChange(): void;
 	_acceptedAgentMessagePrompt?: {
 		text: string;
 		agentMessageId: string;
@@ -137,45 +127,100 @@ describe("issue #4257 update restart resume", () => {
 		}
 	});
 
-	it("keeps a prestart input in the manifest exactly once until message_end persistence", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		const internals = harness.session as unknown as QueueInternals;
-		const message: UserMessage = {
-			role: "user",
-			content: [{ type: "text", text: "blocked prestart update" }],
-			timestamp: Date.now(),
-		};
-		const input = {
-			text: "blocked prestart update",
-			prefixMessages: [],
-			message,
-		};
-		internals._activeSessionInput = {
-			kind: "prompt",
-			lane: "followUp",
-			items: [input],
-			phase: "preparing",
-			checkpointInputMessages: new Set([message]),
-			persistedInputMessages: new Set(),
-		};
-
-		let checkpointSettled = false;
-		const checkpoint = internals.waitForSessionInputCheckpoint().then(() => {
-			checkpointSettled = true;
+	it("waits for the full admitted prompt checkpoint before preparing restart", async () => {
+		let releaseAssistantMessageEnd: (() => void) | undefined;
+		const assistantMessageEndBlocked = new Promise<void>((resolve) => {
+			releaseAssistantMessageEnd = resolve;
 		});
-		await Promise.resolve();
-		expect(checkpointSettled).toBe(false);
-		expect(internals._activeSessionInput.items).toEqual([input]);
-		expect(internals._followUpMessages).toEqual([]);
+		const harness = await createHarness({
+			persistSession: true,
+			extensionFactories: [
+				(pi) => {
+					pi.on("message_end", async (event) => {
+						if (event.message.role === "assistant") {
+							await assistantMessageEndBlocked;
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("restart response")]);
+		let promptAdmitted = false;
+		const originalPrompt = harness.session.agent.prompt.bind(harness.session.agent);
+		vi.spyOn(harness.session.agent, "prompt").mockImplementation((...args) => {
+			promptAdmitted = true;
+			return originalPrompt(...args);
+		});
+		await harness.session.restoreFollowUpMessage("admitted restart input");
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await vi.waitFor(() => expect(promptAdmitted).toBe(true));
 
-		harness.sessionManager.appendMessage(message);
-		internals._activeSessionInput.persistedInputMessages.add(message);
-		internals._activeSessionInput.phase = "handedOff";
-		internals._notifySessionInputCheckpointChange();
-		await checkpoint;
-		expect(checkpointSettled).toBe(true);
-		expect(readFileSync(harness.session.sessionFile!, "utf8")).toContain("blocked prestart update");
+		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+			defaultSessionConfig: { cwd: harness.tempDir, agentDir: harness.tempDir },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as AgentDaemonUpdateInternals;
+		internals.sessions.set(
+			"active-1",
+			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
+		);
+		let checkpointWaitEntered = false;
+		const originalCheckpointWait = harness.session.waitForSessionInputCheckpoint.bind(harness.session);
+		vi.spyOn(harness.session, "waitForSessionInputCheckpoint").mockImplementation((signal) => {
+			checkpointWaitEntered = true;
+			return originalCheckpointWait(signal);
+		});
+		let prepareSettled = false;
+		const prepare = internals.prepareUpdateRestart().then((manifest) => {
+			prepareSettled = true;
+			return manifest;
+		});
+		await vi.waitFor(() => expect(checkpointWaitEntered).toBe(true));
+		await harness.session.restoreFollowUpMessage("paused restart input");
+		await vi.waitFor(() =>
+			expect(
+				harness.sessionManager
+					.getEntries()
+					.some(
+						(entry) =>
+							entry.type === "message" &&
+							entry.message.role === "user" &&
+							getMessageText(entry.message) === "admitted restart input",
+					),
+			).toBe(true),
+		);
+		expect(prepareSettled).toBe(false);
+
+		releaseAssistantMessageEnd?.();
+		const manifest = await prepare;
+
+		expect(manifest.sessions).toHaveLength(1);
+		expect(manifest.sessions[0]).toMatchObject({
+			queue: { steering: [], nextTurn: [] },
+			shouldResume: true,
+			wasStreaming: false,
+			wasRetrying: false,
+			hadAcceptedPromptInFlight: false,
+		});
+		expect(manifest.sessions[0]?.queue.followUp).toEqual([
+			{
+				message: "paused restart input",
+				content: [{ type: "text", text: "paused restart input" }],
+			},
+		]);
+		expect(
+			harness.sessionManager
+				.getEntries()
+				.some(
+					(entry) =>
+						entry.type === "message" &&
+						entry.message.role === "assistant" &&
+						getMessageText(entry.message) === "restart response",
+				),
+		).toBe(true);
 	});
 
 	it("worker cancel releases a prepare blocked on an executing mutation", async () => {

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
@@ -5,6 +5,7 @@ import { startSideQuestion } from "../../../src/core/side-question.js";
 import type { DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
 import type { DaemonCommand, DaemonResponse } from "../../../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js";
+import { MutationDrainLatch } from "../../../src/modes/daemon/mutation-drain-latch.js";
 import { createHarness } from "../harness.js";
 
 const fastModel = {
@@ -34,6 +35,7 @@ describe("ENG-4620 fast mode child agents", () => {
 			workers: new Map(),
 			clients: new Set(),
 			protocolClientIds: new WeakMap(),
+			mutationDrain: new MutationDrainLatch(),
 			handleCommand,
 			write,
 			log: vi.fn(),


### PR DESCRIPTION
## Why

Steering and follow-up are delivery policies, not separate kinds of prompts. Previously, ordinary input could travel through the normal prompt path, direct steer/follow-up paths, or a TUI-owned compaction queue. That split preprocessing and queue ownership, causing immediate and queued input to diverge in ordering, persistence, restart behavior, and UI lifecycle.

This is therefore more than a code-size simplification: it consolidates scheduling into one source of truth while adding durable-input and restart-correctness guarantees that the old paths did not provide.

## What the repository gains

- one canonical `AgentSession` admission and scheduling path for normal prompts, steering, follow-ups, and typed session commands
- consistent preprocessing and execution across delivery modes; steering and follow-up decide **when** prepared input runs, not **how** it is interpreted
- typed `/compact`, `/refine`, `/goal`, and `/autonomous` queue items instead of reparsing arbitrary persisted slash-prefixed text
- durable, model-excluded command rows and failure outcomes that survive redraw, reconnect, and resume
- lossless update/restart checkpoints for queued and in-flight prompts, including images, prefixes, queue keys, agent-message IDs, and delivery lanes
- explicit ordering around compaction, refinement, goals, autonomous mode, retries, bash, and update boundaries
- removal of the TUI-owned compaction scheduler and redispatch logic, leaving `AgentSession` as the sole queue owner
- regression coverage for dropped or duplicated input, command boundaries, queue ordering, and restart restoration

## What the harness gains

- harness-backed `/goal`, `/refine`, `/compact`, and `/autonomous` actions use the same scheduler and lifecycle as ordinary user input
- goal context is delivered at its command boundary before later follow-ups
- queued refinement and goal work resumes reliably instead of racing active turns, compaction, or update preparation
- command intent and outcomes remain durable and visible without contaminating model context
- restart and reconnect preserve harness-related queued work through the prompt-handoff window

## Architecture

Admission classifies and prepares each input once. Scheduling then decides only when that prepared input runs:

- **steering** stops after the current complete tool turn and runs before another parent model turn
- **follow-up** waits for the parent to finish naturally
- **session commands** execute at the same typed queue boundary without becoming model input

Queued prompts are not mirrored into low-level Agent queues. The session scheduler starts them through the same prepared prompt execution path as idle prompts, avoiding release/reclaim bookkeeping between two queue owners. A small generic pre-turn Agent hook stops late steering before another model turn while restoring already-polled messages to their original lane.

Daemon update preparation pauses admission, waits until active input is either safely requeued or represented in persisted Agent state, drains admitted mutations, and snapshots typed inputs without reparsing stored text.

Client-owned commands such as settings, navigation, and selectors remain on the immediate UI path.

## Scope

Slash-command highlighting across all user and pending-message surfaces remains intentionally deferred to a small stacked presentation PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Checkpoint session inputs for coordinated daemon update-restart with drain/fence phases
> - Implements a multi-phase update-restart transaction in the daemon (`daemon-mode.ts`, `daemon-supervisor.ts`) with distinct draining, fencing, prepared, and publishing phases, enforcing which commands are admitted in each phase.
> - Adds `waitForSessionInputCheckpoint` to `AgentSession` so update preparation can wait until in-flight direct prompts reach `message_start` and transcript events are flushed before capturing a consistent restart manifest.
> - Introduces `MutationDrainLatch` to count in-flight mutations and await their completion with abort support across both daemon and supervisor.
> - Adds `CommandRecoveryJournal.lookup` to query command status without inserting journal records, enabling de-duplication of mutating commands during fencing.
> - Extends `AgentCronScheduler` with a `beginDispatch` hook so the daemon can wrap cron dispatches in mutation drain accounting.
> - Risk: mutating daemon commands (e.g. prompts, session commands) are now rejected during the fencing and prepared phases; only abort-style commands and `shutdown` are admitted, which is a breaking behavioral change for callers that do not handle these errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eefbae7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core session scheduling, daemon update-restart fencing, and mutating-command admission—incorrect checkpoint or drain logic could drop or duplicate prompts across restarts.
> 
> **Overview**
> **AgentSession** now exposes `waitForSessionInputCheckpoint`, which blocks until queued prompt preparation finishes, direct prompts clear a new “direct prompt section” fence, and the agent event queue is drained before `flushNow`. Direct and injected prompts settle preflight at **handoff** (waiting for `message_start` via dispatch observers), not after the full turn, and failed enqueues always release the fence so restart preparation cannot hang.
> 
> **Daemon and supervisor** replace the old `updateRestartPreparing` flag with a multi-phase **update-restart transaction** (`preparing` → `fencing` → `prepared` → `publishing`), coordinated with a new **`MutationDrainLatch`** on mutating RPCs and cron `beginDispatch` hooks. During restart, only **`UPDATE_RESTART_DRAIN_COMMANDS`** (abort-style) are admitted while draining; other mutations are rejected once fenced. Worker prepare/commit/cancel is owner-scoped, timed, and rolls back deferred attach env and queue pauses on cancel.
> 
> **Supporting changes:** `CommandRecoveryJournal.lookup` for idempotent replay without new journal rows; targeted cron recovery when claim setup fails; manifest may list **`discardedActiveSessionIds`**; supervisor prepare validates worker root disposition and stale reconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eefbae77c8e14eeacb3536c9a3a0e8cde966249b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->