### PR TITLE
fix(tui): unify durable compaction presentation

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3188,7 +3188,6 @@ export class AgentSession {
 		if (event.type === "message_start" && this._isPromptTurnStartMessage(event.message)) {
 			this._overflowRecovery = "idle";
 		}
-		}
 
 		// Emit to extensions first
 		await this._emitExtensionEvent(event);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7337,23 +7337,25 @@ export class AgentSession {
 		reason: CompactionOutcomeReason,
 		outcome: CompactionOutcome,
 		message: string,
-	): boolean {
-		const durableMessage = createCompactionOutcomeMessage(message, { reason, outcome });
-		let persisted = true;
+	): void {
+		let outcomeMessage = createCompactionOutcomeMessage(message, { reason, outcome });
 		try {
-			this.sessionManager.appendCustomMessageEntry(
-				durableMessage.customType,
-				durableMessage.content,
-				durableMessage.display,
-				durableMessage.details,
+			this.sessionManager.appendCustomMessageEntryTransactional(
+				outcomeMessage.customType,
+				outcomeMessage.content,
+				outcomeMessage.display,
+				outcomeMessage.details,
 			);
-		} catch {
-			persisted = false;
+		} catch (error) {
+			const persistenceError = error instanceof Error ? error.message : String(error);
+			outcomeMessage = createCompactionOutcomeMessage(
+				`${message}\n\nThis compaction outcome could not be saved to session history: ${persistenceError}`,
+				{ reason, outcome },
+			);
 		}
-		this.agent.state.messages.push(durableMessage);
-		this._emit({ type: "message_start", message: durableMessage });
-		this._emit({ type: "message_end", message: durableMessage });
-		return persisted;
+		this.agent.state.messages.push(outcomeMessage);
+		this._emit({ type: "message_start", message: outcomeMessage });
+		this._emit({ type: "message_end", message: outcomeMessage });
 	}
 
 	private async _runAutoCompaction(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7331,6 +7331,7 @@ export class AgentSession {
 		message: string,
 		options: { aborted?: boolean; errorSeverity?: "warning" | "error"; customInstructions?: string } = {},
 	): void {
+		this._persistCompactionOutcome(reason, outcome, message);
 		this._emit({
 			type: "compaction_end",
 			reason,
@@ -7342,7 +7343,6 @@ export class AgentSession {
 			errorSeverity: options.errorSeverity,
 			customInstructions: options.customInstructions,
 		});
-		this._persistCompactionOutcome(reason, outcome, message);
 	}
 
 	private _persistCompactionOutcome(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1071,6 +1071,8 @@ export class AgentSession {
 	private _acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined = undefined;
 	private _agentMessageOutcomes = new Map<string, AgentMessageOutcome>();
 	private _lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
+	/** Outcome disclosures whose session-file append failed; retained for context rebuilds. */
+	private readonly _unpersistedCompactionOutcomes: CustomMessage[] = [];
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -3851,6 +3853,9 @@ export class AgentSession {
 		const context = this.sessionManager.buildSessionContext();
 		for (const message of context.messages) {
 			this._applyLateIpythonSentAgentMessages(message);
+		}
+		if (this._unpersistedCompactionOutcomes.length > 0) {
+			context.messages.push(...this._unpersistedCompactionOutcomes);
 		}
 		return context;
 	}
@@ -7393,6 +7398,8 @@ export class AgentSession {
 				`${message}\n\nThis compaction outcome could not be saved to session history: ${persistenceError}`,
 				{ reason, outcome },
 			);
+			// Not in the session file, so context rebuilds would drop the disclosure.
+			this._unpersistedCompactionOutcomes.push(outcomeMessage);
 		}
 		this.agent.state.messages.push(outcomeMessage);
 		this._emit({ type: "message_start", message: outcomeMessage });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3854,8 +3854,14 @@ export class AgentSession {
 		for (const message of context.messages) {
 			this._applyLateIpythonSentAgentMessages(message);
 		}
-		if (this._unpersistedCompactionOutcomes.length > 0) {
-			context.messages.push(...this._unpersistedCompactionOutcomes);
+		// Merge by timestamp: turns persisted after the failed append must stay
+		// below the disclosure, matching where it appeared live.
+		for (const outcome of this._unpersistedCompactionOutcomes) {
+			let insertAt = context.messages.length;
+			while (insertAt > 0 && context.messages[insertAt - 1]!.timestamp > outcome.timestamp) {
+				insertAt -= 1;
+			}
+			context.messages.splice(insertAt, 0, outcome);
 		}
 		return context;
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3854,16 +3854,23 @@ export class AgentSession {
 		for (const message of context.messages) {
 			this._applyLateIpythonSentAgentMessages(message);
 		}
-		// Merge by timestamp: turns persisted after the failed append must stay
-		// below the disclosure, matching where it appeared live.
+		this._mergeUnpersistedCompactionOutcomes(context.messages);
+		return context;
+	}
+
+	/**
+	 * Merge disclosures whose session-file append failed into a rebuilt message
+	 * list by timestamp, so turns persisted after the failure stay below the
+	 * notice exactly where it appeared live.
+	 */
+	private _mergeUnpersistedCompactionOutcomes(messages: AgentMessage[]): void {
 		for (const outcome of this._unpersistedCompactionOutcomes) {
-			let insertAt = context.messages.length;
-			while (insertAt > 0 && context.messages[insertAt - 1]!.timestamp > outcome.timestamp) {
+			let insertAt = messages.length;
+			while (insertAt > 0 && messages[insertAt - 1]!.timestamp > outcome.timestamp) {
 				insertAt -= 1;
 			}
-			context.messages.splice(insertAt, 0, outcome);
+			messages.splice(insertAt, 0, outcome);
 		}
-		return context;
 	}
 
 	/** Current steering mode */
@@ -6503,6 +6510,7 @@ export class AgentSession {
 		);
 		const newEntries = this.sessionManager.getEntries();
 		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		this._mergeUnpersistedCompactionOutcomes(this.agent.state.messages);
 		this._restoreLateIpythonSentAgentMessages();
 
 		// Get the saved compaction entry for the extension event
@@ -9901,6 +9909,7 @@ export class AgentSession {
 			// Update agent state
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._mergeUnpersistedCompactionOutcomes(this.agent.state.messages);
 			this._restoreLateIpythonSentAgentMessages();
 			this._reloadGoalStateFromBranch();
 			this._invalidateQueuedPromptPreparation();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -170,7 +170,10 @@ import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
 	type BashExecutionMessage,
+	type CompactionOutcome,
+	type CompactionOutcomeReason,
 	type CustomMessage,
+	createCompactionOutcomeMessage,
 	createHeartbeatPromptMessage,
 	createSessionSlashCommandMessage,
 	createSessionSlashCommandResultMessage,
@@ -1049,6 +1052,7 @@ export class AgentSession {
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
 	private _compactionOperation: Promise<void> | undefined = undefined;
 	private _overflowRecoveryAttempted = false;
+	private _overflowRecoveryFailureReported = false;
 	private _continueAfterThresholdCompaction = false;
 	private _pendingRequestedCompaction: { customInstructions?: string } | undefined;
 	private _pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
@@ -3183,6 +3187,8 @@ export class AgentSession {
 
 		if (event.type === "message_start" && this._isPromptTurnStartMessage(event.message)) {
 			this._overflowRecoveryAttempted = false;
+			this._overflowRecoveryFailureReported = false;
+		}
 		}
 
 		// Emit to extensions first
@@ -3243,6 +3249,7 @@ export class AgentSession {
 				}
 				if (assistantMsg.stopReason !== "error") {
 					this._overflowRecoveryAttempted = false;
+					this._overflowRecoveryFailureReported = false;
 				}
 				if (this._isConcreteProviderAuthFailure(assistantMsg)) {
 					this._captureRetryAuthFailureSource(assistantMsg);
@@ -7271,15 +7278,20 @@ export class AgentSession {
 			isContextOverflow(assistantMessage, contextWindow)
 		) {
 			if (this._overflowRecoveryAttempted) {
-				this._emit({
-					type: "compaction_end",
-					reason: "overflow",
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-					errorMessage:
-						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
-				});
+				if (!this._overflowRecoveryFailureReported) {
+					this._overflowRecoveryFailureReported = true;
+					const message =
+						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.";
+					this._emit({
+						type: "compaction_end",
+						reason: "overflow",
+						result: undefined,
+						aborted: false,
+						willRetry: false,
+						errorMessage: message,
+					});
+					this._persistCompactionOutcome("overflow", "failed", message);
+				}
 				return false;
 			}
 
@@ -7321,6 +7333,29 @@ export class AgentSession {
 	 * Internal: Run automatic (threshold/overflow) or model-requested compaction
 	 * with events.
 	 */
+	private _persistCompactionOutcome(
+		reason: CompactionOutcomeReason,
+		outcome: CompactionOutcome,
+		message: string,
+	): boolean {
+		const durableMessage = createCompactionOutcomeMessage(message, { reason, outcome });
+		let persisted = true;
+		try {
+			this.sessionManager.appendCustomMessageEntry(
+				durableMessage.customType,
+				durableMessage.content,
+				durableMessage.display,
+				durableMessage.details,
+			);
+		} catch {
+			persisted = false;
+		}
+		this.agent.state.messages.push(durableMessage);
+		this._emit({ type: "message_start", message: durableMessage });
+		this._emit({ type: "message_end", message: durableMessage });
+		return persisted;
+	}
+
 	private async _runAutoCompaction(
 		reason: "overflow" | "threshold" | "requested",
 		willRetry: boolean,
@@ -7350,13 +7385,16 @@ export class AgentSession {
 
 		try {
 			if (!this.model) {
+				const message = "Compaction failed: no model is selected";
 				this._emit({
 					type: "compaction_end",
 					reason,
 					result: undefined,
 					aborted: false,
 					willRetry: false,
+					errorMessage: message,
 				});
+				this._persistCompactionOutcome(reason, "failed", message);
 				this._clearQueuedAutonomousContinuationsAfterSkippedThresholdCompaction(
 					reason === "threshold" && shouldContinueAfterCompaction,
 					queuedAutonomousContinuationsForThisCompaction,
@@ -7367,13 +7405,16 @@ export class AgentSession {
 
 			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
 			if (!authResult.ok || !authResult.apiKey) {
+				const message = `Compaction failed: ${authResult.ok ? "no API key is available" : authResult.error}`;
 				this._emit({
 					type: "compaction_end",
 					reason,
 					result: undefined,
 					aborted: false,
 					willRetry: false,
+					errorMessage: message,
 				});
+				this._persistCompactionOutcome(reason, "failed", message);
 				this._clearQueuedAutonomousContinuationsAfterSkippedThresholdCompaction(
 					reason === "threshold" && shouldContinueAfterCompaction,
 					queuedAutonomousContinuationsForThisCompaction,
@@ -7430,39 +7471,48 @@ export class AgentSession {
 					willRetry: false,
 					customInstructions,
 				});
+				this._persistCompactionOutcome(
+					reason,
+					"cancelled",
+					`${reason === "requested" ? "Requested c" : "C"}ompaction cancelled`,
+				);
 				return false;
 			}
 			if (error instanceof CompactionSkippedError) {
+				const message =
+					reason === "requested"
+						? `Requested compaction skipped: ${errorMessage}`
+						: `Auto-compaction skipped: ${errorMessage}`;
 				this._emit({
 					type: "compaction_end",
 					reason,
 					result: undefined,
 					aborted: false,
 					willRetry: false,
-					errorMessage:
-						reason === "requested"
-							? `Requested compaction skipped: ${errorMessage}`
-							: `Auto-compaction skipped: ${errorMessage}`,
+					errorMessage: message,
 					errorSeverity: "warning",
 					customInstructions,
 				});
+				this._persistCompactionOutcome(reason, "skipped", message);
 				resumeAfterFailure();
 				return false;
 			}
+			const message =
+				reason === "overflow"
+					? `Context overflow recovery failed: ${errorMessage}`
+					: reason === "requested"
+						? `Requested compaction failed: ${errorMessage}`
+						: `Auto-compaction failed: ${errorMessage}`;
 			this._emit({
 				type: "compaction_end",
 				reason,
 				result: undefined,
 				aborted: false,
 				willRetry: false,
-				errorMessage:
-					reason === "overflow"
-						? `Context overflow recovery failed: ${errorMessage}`
-						: reason === "requested"
-							? `Requested compaction failed: ${errorMessage}`
-							: `Auto-compaction failed: ${errorMessage}`,
+				errorMessage: message,
 				customInstructions,
 			});
+			this._persistCompactionOutcome(reason, "failed", message);
 			resumeAfterFailure();
 			return false;
 		} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3860,8 +3860,7 @@ export class AgentSession {
 
 	/**
 	 * Merge disclosures whose session-file append failed into a rebuilt message
-	 * list by timestamp, so turns persisted after the failure stay below the
-	 * notice exactly where it appeared live.
+	 * list at their timestamp position, where they appeared live.
 	 */
 	private _mergeUnpersistedCompactionOutcomes(messages: AgentMessage[]): void {
 		for (const outcome of this._unpersistedCompactionOutcomes) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1051,8 +1051,8 @@ export class AgentSession {
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
 	private _compactionOperation: Promise<void> | undefined = undefined;
-	private _overflowRecoveryAttempted = false;
-	private _overflowRecoveryFailureReported = false;
+	/** One recovery attempt per overflow; "reported" dedups the failure notice. */
+	private _overflowRecovery: "idle" | "attempted" | "reported" = "idle";
 	private _continueAfterThresholdCompaction = false;
 	private _pendingRequestedCompaction: { customInstructions?: string } | undefined;
 	private _pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
@@ -3186,8 +3186,7 @@ export class AgentSession {
 		}
 
 		if (event.type === "message_start" && this._isPromptTurnStartMessage(event.message)) {
-			this._overflowRecoveryAttempted = false;
-			this._overflowRecoveryFailureReported = false;
+			this._overflowRecovery = "idle";
 		}
 		}
 
@@ -3248,8 +3247,7 @@ export class AgentSession {
 					this._maybeStartSerializedBackgroundPlan();
 				}
 				if (assistantMsg.stopReason !== "error") {
-					this._overflowRecoveryAttempted = false;
-					this._overflowRecoveryFailureReported = false;
+					this._overflowRecovery = "idle";
 				}
 				if (this._isConcreteProviderAuthFailure(assistantMsg)) {
 					this._captureRetryAuthFailureSource(assistantMsg);
@@ -7277,25 +7275,19 @@ export class AgentSession {
 			sameModel &&
 			isContextOverflow(assistantMessage, contextWindow)
 		) {
-			if (this._overflowRecoveryAttempted) {
-				if (!this._overflowRecoveryFailureReported) {
-					this._overflowRecoveryFailureReported = true;
-					const message =
-						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.";
-					this._emit({
-						type: "compaction_end",
-						reason: "overflow",
-						result: undefined,
-						aborted: false,
-						willRetry: false,
-						errorMessage: message,
-					});
-					this._persistCompactionOutcome("overflow", "failed", message);
+			if (this._overflowRecovery !== "idle") {
+				if (this._overflowRecovery === "attempted") {
+					this._overflowRecovery = "reported";
+					this._endCompactionUnsuccessfully(
+						"overflow",
+						"failed",
+						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
+					);
 				}
 				return false;
 			}
 
-			this._overflowRecoveryAttempted = true;
+			this._overflowRecovery = "attempted";
 			// Remove the error message from agent state (it IS saved to session for history,
 			// but we don't want it in context for the retry)
 			const messages = this.agent.state.messages;
@@ -7333,6 +7325,27 @@ export class AgentSession {
 	 * Internal: Run automatic (threshold/overflow) or model-requested compaction
 	 * with events.
 	 */
+	/** Emit an unsuccessful compaction_end and durably record the outcome. */
+	private _endCompactionUnsuccessfully(
+		reason: CompactionOutcomeReason,
+		outcome: CompactionOutcome,
+		message: string,
+		options: { aborted?: boolean; errorSeverity?: "warning" | "error"; customInstructions?: string } = {},
+	): void {
+		this._emit({
+			type: "compaction_end",
+			reason,
+			result: undefined,
+			aborted: options.aborted ?? false,
+			willRetry: false,
+			// Aborts are user-initiated; they carry no error message on the event.
+			errorMessage: options.aborted ? undefined : message,
+			errorSeverity: options.errorSeverity,
+			customInstructions: options.customInstructions,
+		});
+		this._persistCompactionOutcome(reason, outcome, message);
+	}
+
 	private _persistCompactionOutcome(
 		reason: CompactionOutcomeReason,
 		outcome: CompactionOutcome,
@@ -7340,7 +7353,7 @@ export class AgentSession {
 	): void {
 		let outcomeMessage = createCompactionOutcomeMessage(message, { reason, outcome });
 		try {
-			this.sessionManager.appendCustomMessageEntryTransactional(
+			this.sessionManager.appendCustomMessageEntryWithRollback(
 				outcomeMessage.customType,
 				outcomeMessage.content,
 				outcomeMessage.display,
@@ -7386,37 +7399,15 @@ export class AgentSession {
 		this._autoCompactionAbortController = new AbortController();
 
 		try {
-			if (!this.model) {
-				const message = "Compaction failed: no model is selected";
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-					errorMessage: message,
-				});
-				this._persistCompactionOutcome(reason, "failed", message);
-				this._clearQueuedAutonomousContinuationsAfterSkippedThresholdCompaction(
-					reason === "threshold" && shouldContinueAfterCompaction,
-					queuedAutonomousContinuationsForThisCompaction,
-				);
-				resumeAfterFailure();
-				return false;
-			}
-
-			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
-			if (!authResult.ok || !authResult.apiKey) {
-				const message = `Compaction failed: ${authResult.ok ? "no API key is available" : authResult.error}`;
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-					errorMessage: message,
-				});
-				this._persistCompactionOutcome(reason, "failed", message);
+			const authResult = this.model ? await this._modelRegistry.getApiKeyAndHeaders(this.model) : undefined;
+			if (!this.model || !authResult || !authResult.ok || !authResult.apiKey) {
+				const detail =
+					!this.model || !authResult
+						? "no model is selected"
+						: authResult.ok
+							? "no API key is available"
+							: authResult.error;
+				this._endCompactionUnsuccessfully(reason, "failed", `Compaction failed: ${detail}`);
 				this._clearQueuedAutonomousContinuationsAfterSkippedThresholdCompaction(
 					reason === "threshold" && shouldContinueAfterCompaction,
 					queuedAutonomousContinuationsForThisCompaction,
@@ -7465,56 +7456,36 @@ export class AgentSession {
 			const aborted =
 				errorMessage === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
 			if (aborted) {
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: true,
-					willRetry: false,
-					customInstructions,
-				});
-				this._persistCompactionOutcome(
+				this._endCompactionUnsuccessfully(
 					reason,
 					"cancelled",
 					`${reason === "requested" ? "Requested c" : "C"}ompaction cancelled`,
+					{ aborted: true, customInstructions },
 				);
 				return false;
 			}
 			if (error instanceof CompactionSkippedError) {
-				const message =
+				this._endCompactionUnsuccessfully(
+					reason,
+					"skipped",
 					reason === "requested"
 						? `Requested compaction skipped: ${errorMessage}`
-						: `Auto-compaction skipped: ${errorMessage}`;
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-					errorMessage: message,
-					errorSeverity: "warning",
-					customInstructions,
-				});
-				this._persistCompactionOutcome(reason, "skipped", message);
+						: `Auto-compaction skipped: ${errorMessage}`,
+					{ errorSeverity: "warning", customInstructions },
+				);
 				resumeAfterFailure();
 				return false;
 			}
-			const message =
+			this._endCompactionUnsuccessfully(
+				reason,
+				"failed",
 				reason === "overflow"
 					? `Context overflow recovery failed: ${errorMessage}`
 					: reason === "requested"
 						? `Requested compaction failed: ${errorMessage}`
-						: `Auto-compaction failed: ${errorMessage}`;
-			this._emit({
-				type: "compaction_end",
-				reason,
-				result: undefined,
-				aborted: false,
-				willRetry: false,
-				errorMessage: message,
-				customInstructions,
-			});
-			this._persistCompactionOutcome(reason, "failed", message);
+						: `Auto-compaction failed: ${errorMessage}`,
+				{ customInstructions },
+			);
 			resumeAfterFailure();
 			return false;
 		} finally {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -30,6 +30,7 @@ export const HEARTBEAT_PROMPT_PREVIEW_LABEL = "Heartbeat prompt";
 export const IPYTHON_STATE_RESTORED_CUSTOM_TYPE = "ipython_state_restored";
 export const SESSION_SLASH_COMMAND_CUSTOM_TYPE = "session_slash_command";
 export const SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE = "session_slash_command_result";
+export const COMPACTION_OUTCOME_CUSTOM_TYPE = "compaction_outcome";
 
 export interface SessionSlashCommandDetails {
 	command: SessionSlashCommand;
@@ -54,6 +55,20 @@ export interface SessionSlashCommandResultMessage extends CustomMessage<SessionS
 	customType: typeof SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE;
 	content: string;
 	details: SessionSlashCommandResultDetails;
+}
+
+export type CompactionOutcomeReason = "threshold" | "overflow" | "requested";
+export type CompactionOutcome = "skipped" | "cancelled" | "failed";
+
+export interface CompactionOutcomeDetails {
+	reason: CompactionOutcomeReason;
+	outcome: CompactionOutcome;
+}
+
+export interface CompactionOutcomeMessage extends CustomMessage<CompactionOutcomeDetails> {
+	customType: typeof COMPACTION_OUTCOME_CUSTOM_TYPE;
+	content: string;
+	details: CompactionOutcomeDetails;
 }
 
 /**
@@ -109,6 +124,8 @@ export interface CompactionSummaryMessage {
 	role: "compactionSummary";
 	summary: string;
 	tokensBefore: number;
+	/** Number of retained messages that precede this summary in transcript presentation. */
+	retainedMessageCount?: number;
 	/** User instructions that guided the summary (from `/compact <instructions>`) */
 	customInstructions?: string;
 	timestamp: number;
@@ -176,11 +193,13 @@ export function createCompactionSummaryMessage(
 	tokensBefore: number,
 	timestamp: string,
 	customInstructions?: string,
+	retainedMessageCount?: number,
 ): CompactionSummaryMessage {
 	return {
 		role: "compactionSummary",
-		summary: summary,
+		summary,
 		tokensBefore,
+		retainedMessageCount,
 		customInstructions,
 		timestamp: new Date(timestamp).getTime(),
 	};
@@ -232,6 +251,22 @@ export function createSessionSlashCommandResultMessage(
 		content,
 		display,
 		details: { ...details, command: { ...details.command } },
+		timestamp,
+	};
+}
+
+export function createCompactionOutcomeMessage(
+	content: string,
+	details: CompactionOutcomeDetails,
+	display = true,
+	timestamp = Date.now(),
+): CompactionOutcomeMessage {
+	return {
+		role: "custom",
+		customType: COMPACTION_OUTCOME_CUSTOM_TYPE,
+		content,
+		display,
+		details: { ...details },
 		timestamp,
 	};
 }
@@ -296,6 +331,19 @@ export function isSessionSlashCommandResultMessage(message: unknown): message is
 	);
 }
 
+export function isCompactionOutcomeMessage(message: unknown): message is CompactionOutcomeMessage {
+	if (!isRecord(message) || !hasValidCustomMessageEnvelope(message, COMPACTION_OUTCOME_CUSTOM_TYPE)) return false;
+	if (!isRecord(message.details)) return false;
+	return (
+		(message.details.reason === "threshold" ||
+			message.details.reason === "overflow" ||
+			message.details.reason === "requested") &&
+		(message.details.outcome === "skipped" ||
+			message.details.outcome === "cancelled" ||
+			message.details.outcome === "failed")
+	);
+}
+
 export function createHeartbeatPromptMessage(
 	job: AgentCronJob,
 	timestamp = Date.now(),
@@ -342,7 +390,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				case "custom": {
 					if (
 						m.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE ||
-						m.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE
+						m.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE ||
+						m.customType === COMPACTION_OUTCOME_CUSTOM_TYPE
 					) {
 						return undefined;
 					}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1609,32 +1609,28 @@ export class SessionManager {
 	}
 
 	/**
-	 * Append a custom message atomically with respect to in-memory session state.
-	 * Intended for best-effort records whose failed persistence must not leave an
-	 * unsaved leaf that later entries can attach to.
+	 * Append a custom message, undoing the append if persistence fails so a
+	 * best-effort record never leaves an unsaved leaf for later entries.
 	 */
-	appendCustomMessageEntryTransactional<T = unknown>(
+	appendCustomMessageEntryWithRollback<T = unknown>(
 		customType: string,
 		content: string | (TextContent | ImageContent)[],
 		display: boolean,
 		details?: T,
 	): string {
-		const previousFileEntries = this.fileEntries;
-		const previousById = this.byId;
 		const previousLeafId = this.leafId;
-
-		// Isolate all append mutations so a failure can restore the exact prior objects.
-		this.fileEntries = [...previousFileEntries];
-		this.byId = new Map(previousById);
 		try {
 			return this.appendCustomMessageEntry(customType, content, display, details);
 		} catch (error) {
-			this.fileEntries = previousFileEntries;
-			this.byId = previousById;
-			this.leafId = previousLeafId;
-			// A failed append may have partially changed the file. Force the next
-			// persisted entry to rewrite the restored state before it is appended.
-			this.flushed = false;
+			// The append indexes the entry before persisting it; undo exactly that.
+			if (this.leafId !== null && this.leafId !== previousLeafId) {
+				this.byId.delete(this.leafId);
+				this.fileEntries.pop();
+				this.leafId = previousLeafId;
+				// The failed append may have partially changed the file. Force the next
+				// persisted entry to rewrite the restored state before it is appended.
+				this.flushed = false;
+			}
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import {
 	appendFileSync,
 	chmodSync,
+	chownSync,
 	createReadStream,
 	existsSync,
 	mkdirSync,
@@ -61,9 +62,10 @@ function realpathIfPresent(path: string): string {
 	}
 }
 
-function statModeIfPresent(path: string): number | undefined {
+function statMetadataIfPresent(path: string): { mode: number; uid: number; gid: number } | undefined {
 	try {
-		return statSync(path).mode & 0o777;
+		const { mode, uid, gid } = statSync(path);
+		return { mode: mode & 0o777, uid, gid };
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
@@ -1224,10 +1226,11 @@ export class SessionManager {
 		mkdirSync(directory, { recursive: true });
 		const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
 		try {
-			const mode = statModeIfPresent(targetPath);
-			writeFileSync(tempPath, content, mode === undefined ? undefined : { mode });
-			if (mode !== undefined) {
-				chmodSync(tempPath, mode);
+			const metadata = statMetadataIfPresent(targetPath);
+			writeFileSync(tempPath, content, metadata === undefined ? undefined : { mode: metadata.mode });
+			if (metadata !== undefined) {
+				chownSync(tempPath, metadata.uid, metadata.gid);
+				chmodSync(tempPath, metadata.mode);
 			}
 			renameSync(tempPath, targetPath);
 		} finally {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -501,39 +501,30 @@ export function buildSessionContext(
 	}
 
 	// Build messages and collect corresponding entries
-	// When there's a compaction, we need to:
-	// 1. Emit summary first (entry = compaction)
-	// 2. Emit kept messages (from firstKeptEntryId up to compaction)
-	// 3. Emit messages after compaction
+	// When there's a compaction, model context remains summary-first while the
+	// summary records where clients should present it among retained messages.
 	const messages: AgentMessage[] = [];
 
-	const appendMessage = (entry: SessionEntry) => {
+	const appendMessage = (entry: SessionEntry, target = messages) => {
 		if (entry.type === "message") {
-			messages.push(entry.message);
+			target.push(entry.message);
 		} else if (entry.type === "custom_message") {
-			messages.push(
+			target.push(
 				createCustomMessage(entry.customType, entry.content, entry.display, entry.details, entry.timestamp),
 			);
 		} else if (entry.type === "branch_summary" && entry.summary) {
-			messages.push(createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp));
+			target.push(createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp));
 		}
 	};
 
 	if (compaction) {
-		// Emit summary first
-		messages.push(
-			createCompactionSummaryMessage(
-				compaction.summary,
-				compaction.tokensBefore,
-				compaction.timestamp,
-				compaction.customInstructions,
-			),
-		);
-
 		// Find compaction index in path
 		const compactionIdx = path.findIndex((e) => e.type === "compaction" && e.id === compaction.id);
 
-		// Emit kept messages (before compaction, starting from firstKeptEntryId)
+		// Collect kept messages (before compaction, starting from firstKeptEntryId).
+		// The context remains summary-first for the model; retainedMessageCount records
+		// the exact chronological presentation boundary for clients.
+		const retainedMessages: AgentMessage[] = [];
 		let foundFirstKept = false;
 		for (let i = 0; i < compactionIdx; i++) {
 			const entry = path[i];
@@ -541,9 +532,20 @@ export function buildSessionContext(
 				foundFirstKept = true;
 			}
 			if (foundFirstKept) {
-				appendMessage(entry);
+				appendMessage(entry, retainedMessages);
 			}
 		}
+
+		messages.push(
+			createCompactionSummaryMessage(
+				compaction.summary,
+				compaction.tokensBefore,
+				compaction.timestamp,
+				compaction.customInstructions,
+				retainedMessages.length,
+			),
+			...retainedMessages,
+		);
 
 		// Emit messages after compaction
 		for (let i = compactionIdx + 1; i < path.length; i++) {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -3,16 +3,19 @@ import type { AssistantMessage, ImageContent, Message, ServiceTier, TextContent,
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
+	chmodSync,
 	createReadStream,
 	existsSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
+	rmSync,
 	statSync,
 	writeFileSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
-import { dirname, join, resolve } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { createInterface } from "readline";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -47,6 +50,15 @@ const CONTENT_ENTRY_TYPES = new Set([
 	"compaction",
 	"branch_summary",
 ]);
+
+function statModeIfPresent(path: string): number | undefined {
+	try {
+		return statSync(path).mode & 0o777;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}
 
 export interface SessionHeader {
 	type: "session";
@@ -1197,8 +1209,19 @@ export class SessionManager {
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
 		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-		mkdirSync(dirname(this.sessionFile), { recursive: true });
-		writeFileSync(this.sessionFile, content);
+		const directory = dirname(this.sessionFile);
+		mkdirSync(directory, { recursive: true });
+		const tempPath = join(directory, `.${basename(this.sessionFile)}.${process.pid}.${randomUUID()}.tmp`);
+		try {
+			const mode = statModeIfPresent(this.sessionFile);
+			writeFileSync(tempPath, content, mode === undefined ? undefined : { mode });
+			if (mode !== undefined) {
+				chmodSync(tempPath, mode);
+			}
+			renameSync(tempPath, this.sessionFile);
+		} finally {
+			rmSync(tempPath, { force: true });
+		}
 		this._notifyPersistListeners();
 	}
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1657,7 +1657,9 @@ export class SessionManager {
 	): string {
 		const previousLeafId = this.leafId;
 		try {
-			return this.appendCustomMessageEntry(customType, content, display, details);
+			const entryId = this.appendCustomMessageEntry(customType, content, display, details);
+			this.flushNow();
+			return entryId;
 		} catch (error) {
 			// The append indexes the entry before persisting it; undo exactly that.
 			if (this.leafId !== null && this.leafId !== previousLeafId) {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -9,6 +9,7 @@ import {
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	realpathSync,
 	renameSync,
 	rmSync,
 	statSync,
@@ -50,6 +51,15 @@ const CONTENT_ENTRY_TYPES = new Set([
 	"compaction",
 	"branch_summary",
 ]);
+
+function realpathIfPresent(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return path;
+		throw error;
+	}
+}
 
 function statModeIfPresent(path: string): number | undefined {
 	try {
@@ -1209,16 +1219,17 @@ export class SessionManager {
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
 		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-		const directory = dirname(this.sessionFile);
+		const targetPath = realpathIfPresent(this.sessionFile);
+		const directory = dirname(targetPath);
 		mkdirSync(directory, { recursive: true });
-		const tempPath = join(directory, `.${basename(this.sessionFile)}.${process.pid}.${randomUUID()}.tmp`);
+		const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
 		try {
-			const mode = statModeIfPresent(this.sessionFile);
+			const mode = statModeIfPresent(targetPath);
 			writeFileSync(tempPath, content, mode === undefined ? undefined : { mode });
 			if (mode !== undefined) {
 				chmodSync(tempPath, mode);
 			}
-			renameSync(tempPath, this.sessionFile);
+			renameSync(tempPath, targetPath);
 		} finally {
 			rmSync(tempPath, { force: true });
 		}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1627,9 +1627,15 @@ export class SessionManager {
 				this.byId.delete(this.leafId);
 				this.fileEntries.pop();
 				this.leafId = previousLeafId;
-				// The failed append may have partially changed the file. Force the next
-				// persisted entry to rewrite the restored state before it is appended.
+				// The failed append may have left a torn line on disk. Restore the file
+				// from the rolled-back entries now; if that also fails (e.g. the disk is
+				// still full), fall back to forcing the next persist to rewrite.
 				this.flushed = false;
+				try {
+					this.flushNow();
+				} catch {
+					this.flushed = false;
+				}
 			}
 			throw error;
 		}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1608,6 +1608,37 @@ export class SessionManager {
 		return entry.id;
 	}
 
+	/**
+	 * Append a custom message atomically with respect to in-memory session state.
+	 * Intended for best-effort records whose failed persistence must not leave an
+	 * unsaved leaf that later entries can attach to.
+	 */
+	appendCustomMessageEntryTransactional<T = unknown>(
+		customType: string,
+		content: string | (TextContent | ImageContent)[],
+		display: boolean,
+		details?: T,
+	): string {
+		const previousFileEntries = this.fileEntries;
+		const previousById = this.byId;
+		const previousLeafId = this.leafId;
+
+		// Isolate all append mutations so a failure can restore the exact prior objects.
+		this.fileEntries = [...previousFileEntries];
+		this.byId = new Map(previousById);
+		try {
+			return this.appendCustomMessageEntry(customType, content, display, details);
+		} catch (error) {
+			this.fileEntries = previousFileEntries;
+			this.byId = previousById;
+			this.leafId = previousLeafId;
+			// A failed append may have partially changed the file. Force the next
+			// persisted entry to rewrite the restored state before it is appended.
+			this.flushed = false;
+			throw error;
+		}
+	}
+
 	// =========================================================================
 	// Tree Traversal
 	// =========================================================================

--- a/packages/coding-agent/src/modes/headless-completion.ts
+++ b/packages/coding-agent/src/modes/headless-completion.ts
@@ -7,6 +7,7 @@ import {
 	buildAutonomousGateFailureContinuation,
 } from "../core/autonomous.js";
 import {
+	COMPACTION_OUTCOME_CUSTOM_TYPE,
 	type CompactionOutcomeMessage,
 	isCompactionOutcomeMessage,
 	isSessionSlashCommandResultMessage,
@@ -29,9 +30,18 @@ export function selectHeadlessTerminalResult(messages: readonly AgentMessage[]):
 	const compactionOutcomes: CompactionOutcomeMessage[] = [];
 	while (index >= 0) {
 		const message = messages[index];
-		if (!isCompactionOutcomeMessage(message)) break;
-		compactionOutcomes.unshift(message);
-		index--;
+		if (isCompactionOutcomeMessage(message)) {
+			compactionOutcomes.unshift(message);
+			index--;
+			continue;
+		}
+		// A corrupt outcome is still part of the terminal outcome suffix. Skip it
+		// without letting it hide earlier valid outcomes or their failure status.
+		if (message.role === "custom" && message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE) {
+			index--;
+			continue;
+		}
+		break;
 	}
 	const precedingMessage = messages[index];
 	const primary =

--- a/packages/coding-agent/src/modes/headless-completion.ts
+++ b/packages/coding-agent/src/modes/headless-completion.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { AgentSession } from "../core/agent-session.js";
 import {
@@ -5,9 +6,39 @@ import {
 	autonomousLimitReason,
 	buildAutonomousGateFailureContinuation,
 } from "../core/autonomous.js";
+import {
+	type CompactionOutcomeMessage,
+	isCompactionOutcomeMessage,
+	isSessionSlashCommandResultMessage,
+	type SessionSlashCommandResultMessage,
+} from "../core/messages.js";
 
 export function latestAutonomousGateAttempt(status: AgentAutonomousStatus): number {
 	return Math.max(status.lastGateFailure?.attempt ?? 0, 0, ...Object.values(status.gateAttempts));
+}
+
+export type HeadlessTerminalResultMessage = AssistantMessage | SessionSlashCommandResultMessage;
+
+export interface HeadlessTerminalResult {
+	primary?: HeadlessTerminalResultMessage;
+	compactionOutcomes: CompactionOutcomeMessage[];
+}
+
+export function selectHeadlessTerminalResult(messages: readonly AgentMessage[]): HeadlessTerminalResult {
+	let index = messages.length - 1;
+	const compactionOutcomes: CompactionOutcomeMessage[] = [];
+	while (index >= 0) {
+		const message = messages[index];
+		if (!isCompactionOutcomeMessage(message)) break;
+		compactionOutcomes.unshift(message);
+		index--;
+	}
+	const precedingMessage = messages[index];
+	const primary =
+		precedingMessage?.role === "assistant" || isSessionSlashCommandResultMessage(precedingMessage)
+			? precedingMessage
+			: undefined;
+	return { primary, compactionOutcomes };
 }
 
 function shouldContinueAutonomousGates(status: AgentAutonomousStatus): boolean {
@@ -63,10 +94,9 @@ export async function waitForHeadlessCompletion(session: AgentSession): Promise<
 		);
 		await session.agent.waitForIdle();
 		await session.refreshAutonomousGates();
-		const lastMessage = session.state.messages.at(-1);
-		if (lastMessage?.role === "assistant") {
-			const assistantMessage = lastMessage as AssistantMessage;
-			if (assistantMessage.stopReason === "error" || assistantMessage.stopReason === "aborted") {
+		const { primary } = selectHeadlessTerminalResult(session.state.messages);
+		if (primary?.role === "assistant") {
+			if (primary.stopReason === "error" || primary.stopReason === "aborted") {
 				const postErrorStatus = session.getAutonomousStatus();
 				if (shouldContinueAutonomousGates(postErrorStatus) && postErrorStatus.lastGateFailure) {
 					continue;

--- a/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-outcome-message.ts
@@ -1,0 +1,27 @@
+import { Box, Container, Text } from "@earendil-works/pi-tui";
+import type { CompactionOutcomeMessage } from "../../../core/messages.js";
+import { theme } from "../theme/theme.js";
+
+/** Renders a durable unsuccessful automatic-compaction outcome. */
+export class CompactionOutcomeMessageComponent extends Container {
+	constructor(message: CompactionOutcomeMessage) {
+		super();
+		const color = message.details.outcome === "skipped" ? "warning" : "error";
+		const contentBox = new Box(2, 1, (text: string) => theme.getUserMessageBackgroundColor()(text));
+		contentBox.addChild(new Text(theme.fg(color, message.content), 0, 0));
+		this.addChild(contentBox);
+	}
+
+	setExpanded(_expanded: boolean): void {}
+}
+
+export class MalformedCompactionOutcomeMessageComponent extends Container {
+	constructor() {
+		super();
+		const contentBox = new Box(2, 1, (text: string) => theme.getUserMessageBackgroundColor()(text));
+		contentBox.addChild(new Text(theme.fg("error", "[Malformed compaction outcome message]"), 0, 0));
+		this.addChild(contentBox);
+	}
+
+	setExpanded(_expanded: boolean): void {}
+}

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -2,6 +2,8 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Component, MarkdownTheme, TUI } from "@earendil-works/pi-tui";
 import { isAgentSessionMessage } from "../../../core/agent-messages.js";
 import {
+	COMPACTION_OUTCOME_CUSTOM_TYPE,
+	isCompactionOutcomeMessage,
 	isSessionSlashCommandMessage,
 	isSessionSlashCommandResultMessage,
 	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
@@ -9,6 +11,10 @@ import {
 } from "../../../core/messages.js";
 import { AgentMessageComponent } from "./agent-message.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
+import {
+	CompactionOutcomeMessageComponent,
+	MalformedCompactionOutcomeMessageComponent,
+} from "./compaction-outcome-message.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
 import { SlashCommandMessageComponent } from "./slash-command-message.js";
 import { SlashCommandResultMessageComponent } from "./slash-command-result-message.js";
@@ -106,6 +112,13 @@ export function buildConversationComponents(
 			} else {
 				components.push(new UserMessageComponent("[Malformed session command message]", options.markdownTheme));
 			}
+		} else if (message.role === "custom" && message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE) {
+			if (!message.display) continue;
+			components.push(
+				isCompactionOutcomeMessage(message)
+					? new CompactionOutcomeMessageComponent(message)
+					: new MalformedCompactionOutcomeMessageComponent(),
+			);
 		} else if (isAgentSessionMessage(message) && message.display) {
 			const component = new AgentMessageComponent(message, options.markdownTheme);
 			component.setExpanded(expanded);

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -12,6 +12,10 @@ export {
 	type ChildAgentStatus,
 	ChildAgentSummaryComponent,
 } from "./child-agent-inspector.js";
+export {
+	CompactionOutcomeMessageComponent,
+	MalformedCompactionOutcomeMessageComponent,
+} from "./compaction-outcome-message.js";
 export { CompactionSummaryMessageComponent } from "./compaction-summary-message.js";
 export {
 	ConfigurationMenuComponent,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -878,7 +878,8 @@ export class InteractiveMode {
 	// activityTracker token count already folded into the context snapshot; only output beyond
 	// this counts as live in-flight (keeps auto-retries from re-adding a failed attempt).
 	private contextUsageTokenBaseline = 0;
-	private contextUsageRefreshGeneration = 0;
+	private contextUsageRefreshRequestGeneration = 0;
+	private contextUsageRefreshResultGeneration = 0;
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
 
@@ -2588,19 +2589,20 @@ export class InteractiveMode {
 
 	/** Refresh the tray's context usage from the session after a turn or compaction completes. */
 	private async refreshConnectionContextUsage(): Promise<void> {
-		const generation = ++this.contextUsageRefreshGeneration;
+		const requestGeneration = ++this.contextUsageRefreshRequestGeneration;
 		const connection = this.agentConnection;
 		const sessionId = this.connectionState?.sessionId;
 		const stats = await connection?.getSessionStats?.().catch(() => undefined);
 		if (!stats) return;
-		// Drop results superseded by a newer refresh as well as results for a replaced session.
+		// Drop results superseded by a newer successful refresh as well as results for a replaced session.
 		if (
-			generation !== this.contextUsageRefreshGeneration ||
+			requestGeneration < this.contextUsageRefreshResultGeneration ||
 			this.agentConnection !== connection ||
 			this.connectionState?.sessionId !== sessionId
 		) {
 			return;
 		}
+		this.contextUsageRefreshResultGeneration = requestGeneration;
 		// Anything counted so far is now reflected in the snapshot; only later output is in-flight.
 		this.contextUsageTokenBaseline = this.activityTracker.getStatus().tokens;
 		this.patchConnectionState({ contextUsage: stats.contextUsage });

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -878,8 +878,8 @@ export class InteractiveMode {
 	// activityTracker token count already folded into the context snapshot; only output beyond
 	// this counts as live in-flight (keeps auto-retries from re-adding a failed attempt).
 	private contextUsageTokenBaseline = 0;
-	private contextUsageRefreshRequestGeneration = 0;
-	private contextUsageRefreshResultGeneration = 0;
+	// Refresh ordering: a stale failure must never clobber a newer success.
+	private contextUsageRefresh = { generation: 0, lastSuccessGeneration: 0 };
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
 
@@ -2589,20 +2589,20 @@ export class InteractiveMode {
 
 	/** Refresh the tray's context usage from the session after a turn or compaction completes. */
 	private async refreshConnectionContextUsage(): Promise<void> {
-		const requestGeneration = ++this.contextUsageRefreshRequestGeneration;
+		const generation = ++this.contextUsageRefresh.generation;
 		const connection = this.agentConnection;
 		const sessionId = this.connectionState?.sessionId;
 		const stats = await connection?.getSessionStats?.().catch(() => undefined);
 		if (!stats) return;
 		// Drop results superseded by a newer successful refresh as well as results for a replaced session.
 		if (
-			requestGeneration < this.contextUsageRefreshResultGeneration ||
+			generation < this.contextUsageRefresh.lastSuccessGeneration ||
 			this.agentConnection !== connection ||
 			this.connectionState?.sessionId !== sessionId
 		) {
 			return;
 		}
-		this.contextUsageRefreshResultGeneration = requestGeneration;
+		this.contextUsageRefresh.lastSuccessGeneration = generation;
 		// Anything counted so far is now reflected in the snapshot; only later output is in-flight.
 		this.contextUsageTokenBaseline = this.activityTracker.getStatus().tokens;
 		this.patchConnectionState({ contextUsage: stats.contextUsage });

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -99,10 +99,11 @@ import type { KernelSentAgentMessage } from "../../core/kernel/index.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import {
 	bashOutputToText,
-	createCompactionSummaryMessage,
+	COMPACTION_OUTCOME_CUSTOM_TYPE,
 	createHeartbeatPromptMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
+	isCompactionOutcomeMessage,
 	isSessionSlashCommandMessage,
 	isSessionSlashCommandResultMessage,
 } from "../../core/messages.js";
@@ -175,6 +176,10 @@ import {
 	type ChildAgentInspectorNode,
 	ChildAgentSummaryComponent,
 } from "./components/child-agent-inspector.js";
+import {
+	CompactionOutcomeMessageComponent,
+	MalformedCompactionOutcomeMessageComponent,
+} from "./components/compaction-outcome-message.js";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.js";
 import { ConfigurationMenuComponent, type ConfigurationMenuTab } from "./components/configuration-menu.js";
 import { formatContextTree } from "./components/context-tree-format.js";
@@ -873,6 +878,7 @@ export class InteractiveMode {
 	// activityTracker token count already folded into the context snapshot; only output beyond
 	// this counts as live in-flight (keeps auto-retries from re-adding a failed attempt).
 	private contextUsageTokenBaseline = 0;
+	private contextUsageRefreshGeneration = 0;
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
 
@@ -2582,13 +2588,19 @@ export class InteractiveMode {
 
 	/** Refresh the tray's context usage from the session after a turn or compaction completes. */
 	private async refreshConnectionContextUsage(): Promise<void> {
+		const generation = ++this.contextUsageRefreshGeneration;
 		const connection = this.agentConnection;
 		const sessionId = this.connectionState?.sessionId;
 		const stats = await connection?.getSessionStats?.().catch(() => undefined);
 		if (!stats) return;
-		// Drop the result if the user switched sessions or the connection was rebound while the
-		// async call was in flight — otherwise stale stats would overwrite the new session.
-		if (this.agentConnection !== connection || this.connectionState?.sessionId !== sessionId) return;
+		// Drop results superseded by a newer refresh as well as results for a replaced session.
+		if (
+			generation !== this.contextUsageRefreshGeneration ||
+			this.agentConnection !== connection ||
+			this.connectionState?.sessionId !== sessionId
+		) {
+			return;
+		}
 		// Anything counted so far is now reflected in the snapshot; only later output is in-flight.
 		this.contextUsageTokenBaseline = this.activityTracker.getStatus().tokens;
 		this.patchConnectionState({ contextUsage: stats.contextUsage });
@@ -5442,7 +5454,9 @@ export class InteractiveMode {
 				this.renderRecap();
 
 				this.applyOptimisticContextUsage();
-				await this.refreshConnectionContextUsage();
+				// Auto-compaction can start server-side while this event is being handled.
+				// Do not hold its start event behind a stats RPC; stale refreshes are discarded.
+				void this.refreshConnectionContextUsage();
 
 				await this.checkShutdownRequested();
 
@@ -5490,33 +5504,20 @@ export class InteractiveMode {
 				// Restore the working loader if streaming/subagents still warrant it.
 				this.syncWorkingLoader();
 				if (event.aborted) {
-					if (event.reason === "manual") {
-						this.showError("Compaction cancelled");
-					} else {
-						this.showStatus("Auto-compaction cancelled");
-					}
+					if (event.reason === "manual") this.showError("Compaction cancelled");
 				} else if (event.result) {
 					this.chatContainer.clear();
-					await this.rebuildChatFromMessages();
-					this.addMessageToChat(
-						createCompactionSummaryMessage(
-							event.result.summary,
-							event.result.tokensBefore,
-							new Date().toISOString(),
-							event.customInstructions,
-						),
-					);
+					try {
+						await this.rebuildChatFromMessages();
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						this.showError(`Compaction succeeded, but the transcript could not be refreshed: ${message}`);
+					}
 					await this.refreshConnectionContextUsage();
 					this.footer.invalidate();
-				} else if (event.errorMessage) {
-					if (event.errorSeverity === "warning") {
-						this.showWarning(event.errorMessage);
-					} else if (event.reason === "manual") {
-						this.showError(event.errorMessage);
-					} else {
-						this.chatContainer.addChild(new Spacer(1));
-						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
-					}
+				} else if (event.errorMessage && event.reason === "manual") {
+					if (event.errorSeverity === "warning") this.showWarning(event.errorMessage);
+					else this.showError(event.errorMessage);
 				}
 				this.ui.requestRender();
 				break;
@@ -6380,19 +6381,23 @@ export class InteractiveMode {
 						? new SlashCommandMessageComponent(message.content)
 						: isSessionSlashCommandResultMessage(message)
 							? new SlashCommandResultMessageComponent(message)
-							: isAgentSessionMessage(message)
-								? new AgentMessageComponent(message, this.getMarkdownThemeWithSettings())
-								: isInjectedPromptMessage(message)
-									? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
-									: new CustomMessageComponent(
-											message,
-											this.bindLocalSessionExtensions
-												? this.getLocalSessionHost()
-														.getExtensionRunner()
-														.getMessageRenderer(message.customType)
-												: undefined,
-											this.getMarkdownThemeWithSettings(),
-										);
+							: isCompactionOutcomeMessage(message)
+								? new CompactionOutcomeMessageComponent(message)
+								: message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE
+									? new MalformedCompactionOutcomeMessageComponent()
+									: isAgentSessionMessage(message)
+										? new AgentMessageComponent(message, this.getMarkdownThemeWithSettings())
+										: isInjectedPromptMessage(message)
+											? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
+											: new CustomMessageComponent(
+													message,
+													this.bindLocalSessionExtensions
+														? this.getLocalSessionHost()
+																.getExtensionRunner()
+																.getMessageRenderer(message.customType)
+														: undefined,
+													this.getMarkdownThemeWithSettings(),
+												);
 					component.setExpanded(this.toolOutputExpanded);
 					if (isSessionSlashCommandMessage(message) && this.chatContainer.children.length > 0) {
 						this.chatContainer.addChild(new Spacer(1));
@@ -6491,6 +6496,26 @@ export class InteractiveMode {
 	 * @param options.clearChat Clear the current transcript immediately before rendering
 	 * @param options.limitTranscript Limit transcript replay to the recent tail
 	 */
+	private orderMessagesForTranscript(messages: AgentMessage[]): AgentMessage[] {
+		const summaryIndex = messages.findIndex((message) => message.role === "compactionSummary");
+		if (summaryIndex === -1) return messages;
+		const summary = messages[summaryIndex];
+		if (summary.role !== "compactionSummary") return messages;
+		const remaining = messages.filter((_, index) => index !== summaryIndex);
+		if (Number.isSafeInteger(summary.retainedMessageCount) && summary.retainedMessageCount! >= 0) {
+			const boundary = Math.min(summary.retainedMessageCount!, remaining.length);
+			return [...remaining.slice(0, boundary), summary, ...remaining.slice(boundary)];
+		}
+
+		// Compatibility for summaries created before retainedMessageCount was added.
+		const retained: AgentMessage[] = [];
+		const later: AgentMessage[] = [];
+		for (const message of remaining) {
+			(message.timestamp <= summary.timestamp ? retained : later).push(message);
+		}
+		return [...retained, summary, ...later];
+	}
+
 	private async renderSessionContext(
 		sessionContext: AgentConnectionSessionContext,
 		options: {
@@ -6501,9 +6526,8 @@ export class InteractiveMode {
 		} = {},
 	): Promise<void> {
 		this.resetPendingToolState();
-		const messagesToRender = options.limitTranscript
-			? initialRenderMessages(sessionContext.messages)
-			: sessionContext.messages;
+		const transcriptMessages = this.orderMessagesForTranscript(sessionContext.messages);
+		const messagesToRender = options.limitTranscript ? initialRenderMessages(transcriptMessages) : transcriptMessages;
 		this.ipythonToolComponents.clear();
 		this.lateIpythonSentAgentMessages.clear();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5508,7 +5508,6 @@ export class InteractiveMode {
 				if (event.aborted) {
 					if (event.reason === "manual") this.showError("Compaction cancelled");
 				} else if (event.result) {
-					this.chatContainer.clear();
 					try {
 						await this.rebuildChatFromMessages();
 					} catch (error) {
@@ -7126,7 +7125,6 @@ export class InteractiveMode {
 
 		void (async () => {
 			// Rebuild chat from session messages
-			this.chatContainer.clear();
 			await this.rebuildChatFromMessages();
 
 			// If streaming, re-add the streaming component with updated visibility and re-render

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6512,7 +6512,7 @@ export class InteractiveMode {
 		const retained: AgentMessage[] = [];
 		const later: AgentMessage[] = [];
 		for (const message of remaining) {
-			(message.timestamp <= summary.timestamp ? retained : later).push(message);
+			(message.timestamp < summary.timestamp ? retained : later).push(message);
 		}
 		return [...retained, summary, ...later];
 	}

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -6,15 +6,14 @@
  * - `pi --mode json "prompt"` - JSON event stream
  */
 
-import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import type { ImageContent } from "@earendil-works/pi-ai";
 import type { AgentSessionRuntime } from "../core/agent-session-runtime.js";
 import { type AgentAutonomousStatus, type AutonomousLimitReason, autonomousLimitReason } from "../core/autonomous.js";
-import { isSessionSlashCommandResultMessage } from "../core/messages.js";
 import { flushRawStdout, writeRawStdout } from "../core/output-guard.js";
 import { killTrackedDetachedChildren } from "../utils/shell.js";
 import { InProcessAgentConnection } from "./agent-connection/in-process-agent-connection.js";
 import type { AgentConnection } from "./agent-connection/types.js";
-import { latestAutonomousGateAttempt } from "./headless-completion.js";
+import { latestAutonomousGateAttempt, selectHeadlessTerminalResult } from "./headless-completion.js";
 
 /**
  * Options for print mode.
@@ -116,22 +115,25 @@ async function runPrintModeWithConnectionInternal(
 
 		const autonomousStatus = await connection.waitForHeadlessCompletion();
 		if (mode === "text") {
-			const lastMessage = (await connection.getMessages()).at(-1);
-			if (lastMessage?.role === "assistant") {
-				const assistantMessage = lastMessage as AssistantMessage;
-				if (assistantMessage.stopReason === "error" || assistantMessage.stopReason === "aborted") {
-					console.error(assistantMessage.errorMessage || `Request ${assistantMessage.stopReason}`);
+			const { primary, compactionOutcomes } = selectHeadlessTerminalResult(await connection.getMessages());
+			if (primary?.role === "assistant") {
+				if (primary.stopReason === "error" || primary.stopReason === "aborted") {
+					console.error(primary.errorMessage || `Request ${primary.stopReason}`);
 					exitCode = 1;
 				} else {
-					for (const content of assistantMessage.content) {
+					for (const content of primary.content) {
 						if (content.type === "text") {
 							writeRawStdout(`${content.text}\n`);
 						}
 					}
 				}
-			} else if (lastMessage?.role === "custom" && isSessionSlashCommandResultMessage(lastMessage)) {
-				writeRawStdout(`${lastMessage.content}\n`);
-				if (!lastMessage.details.success || lastMessage.details.severity === "error") exitCode = 1;
+			} else if (primary) {
+				writeRawStdout(`${primary.content}\n`);
+				if (!primary.details.success || primary.details.severity === "error") exitCode = 1;
+			}
+			for (const outcome of compactionOutcomes) {
+				console.error(outcome.content);
+				if (outcome.details.outcome === "failed") exitCode = 1;
 			}
 		}
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -377,8 +377,11 @@ describe("buildSessionContext", () => {
 		const loaded = buildSessionContext(entries);
 		// summary + kept (u2, a2) + after (u3, a3) = 5
 		expect(loaded.messages.length).toBe(5);
-		expect(loaded.messages[0].role).toBe("compactionSummary");
-		expect((loaded.messages[0] as any).summary).toContain("Summary of 1,a,2,b");
+		expect(loaded.messages[0]).toMatchObject({
+			role: "compactionSummary",
+			summary: expect.stringContaining("Summary of 1,a,2,b"),
+			retainedMessageCount: 2,
+		});
 	});
 
 	it("should handle multiple compactions (only latest matters)", () => {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -1,8 +1,6 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { Container } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test, vi } from "vitest";
-import { createCompactionOutcomeMessage } from "../src/core/messages.js";
 import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -147,74 +145,6 @@ describe("InteractiveMode compaction events", () => {
 		);
 	});
 
-	test("renders valid and malformed compaction outcomes during live delivery", () => {
-		const chatContainer = new Container();
-		const fakeThis = {
-			chatContainer,
-			toolOutputExpanded: false,
-			bindLocalSessionExtensions: false,
-			getMarkdownThemeWithSettings: () => undefined,
-		};
-		Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
-		const addMessageToChat = Reflect.get(InteractiveMode.prototype, "addMessageToChat") as (
-			this: typeof fakeThis,
-			message: AgentMessage,
-		) => void;
 
-		addMessageToChat.call(
-			fakeThis,
-			createCompactionOutcomeMessage("Requested compaction failed", {
-				reason: "requested",
-				outcome: "failed",
-			}),
-		);
-		addMessageToChat.call(fakeThis, {
-			role: "custom",
-			customType: "compaction_outcome",
-			content: "untrusted malformed text",
-			display: true,
-			details: { reason: "manual", outcome: "failed" },
-			timestamp: 123,
-		});
 
-		const output = stripAnsi(chatContainer.render(100).join("\n"));
-		expect(output).toContain("Requested compaction failed");
-		expect(output).toContain("[Malformed compaction outcome message]");
-		expect(output).not.toContain("untrusted malformed text");
-	});
-
-	test("renders the persisted summary at its exact retained-message boundary", () => {
-		const retained = { role: "user", content: [], timestamp: 2 } as AgentMessage;
-		const summary = {
-			role: "compactionSummary",
-			summary: "summary",
-			tokensBefore: 123,
-			retainedMessageCount: 1,
-			timestamp: 2,
-		} as AgentMessage;
-		const later = { role: "user", content: [], timestamp: 2 } as AgentMessage;
-		const order = Reflect.get(InteractiveMode.prototype, "orderMessagesForTranscript") as (
-			this: InteractiveMode,
-			messages: AgentMessage[],
-		) => AgentMessage[];
-
-		expect(order.call({} as InteractiveMode, [summary, retained, later])).toEqual([retained, summary, later]);
-	});
-
-	test("falls back to timestamps for legacy compaction summaries", () => {
-		const retained = { role: "user", content: [], timestamp: 1 } as AgentMessage;
-		const summary = {
-			role: "compactionSummary",
-			summary: "summary",
-			tokensBefore: 123,
-			timestamp: 2,
-		} as AgentMessage;
-		const later = { role: "user", content: [], timestamp: 3 } as AgentMessage;
-		const order = Reflect.get(InteractiveMode.prototype, "orderMessagesForTranscript") as (
-			this: InteractiveMode,
-			messages: AgentMessage[],
-		) => AgentMessage[];
-
-		expect(order.call({} as InteractiveMode, [summary, retained, later])).toEqual([retained, summary, later]);
-	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -1,9 +1,60 @@
-import { describe, expect, test, vi } from "vitest";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { Container } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { createCompactionOutcomeMessage } from "../src/core/messages.js";
 import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
 describe("InteractiveMode compaction events", () => {
-	test("rebuilds chat and appends a synthetic compaction summary at the bottom", async () => {
+	beforeAll(() => initTheme("dark"));
+	test("shows an automatic compaction loader for the full operation", async () => {
+		const statusContainer = new Container();
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			updateConnectionStateFromEvent: vi.fn(),
+			activityTracker: new AgentActivityTracker(),
+			updateWorkingLoaderMessage: vi.fn(),
+			autoCompactionLoader: undefined,
+			retryLoader: undefined,
+			workingVisible: true,
+			stopWorkingLoader: vi.fn(),
+			syncWorkingLoader: vi.fn(),
+			statusContainer,
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event:
+				| { type: "compaction_start"; reason: "threshold"; customInstructions?: string }
+				| {
+						type: "compaction_end";
+						reason: "threshold";
+						result: undefined;
+						aborted: true;
+						willRetry: false;
+				  },
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "threshold" });
+
+		expect(stripAnsi(statusContainer.render(80).join("\n"))).toContain("Auto-compacting");
+		expect(fakeThis.ui.requestRender).toHaveBeenCalled();
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "threshold",
+			result: undefined,
+			aborted: true,
+			willRetry: false,
+		});
+		expect(statusContainer.children).toHaveLength(0);
+	});
+
+	test("rebuilds successful compaction from its single persisted summary", async () => {
 		const fakeThis = {
 			isInitialized: true,
 			footer: { invalidate: vi.fn() },
@@ -16,7 +67,7 @@ describe("InteractiveMode compaction events", () => {
 			defaultEditor: {},
 			statusContainer: { clear: vi.fn() },
 			chatContainer: { clear: vi.fn() },
-			rebuildChatFromMessages: vi.fn(),
+			rebuildChatFromMessages: vi.fn().mockResolvedValue(undefined),
 			addMessageToChat: vi.fn(),
 			refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
 			showError: vi.fn(),
@@ -25,74 +76,145 @@ describe("InteractiveMode compaction events", () => {
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
-
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
 			event: {
 				type: "compaction_end";
-				reason: "manual" | "threshold" | "overflow";
+				reason: "manual" | "requested" | "threshold" | "overflow";
 				result: { tokensBefore: number; summary: string } | undefined;
 				aborted: boolean;
 				willRetry: boolean;
 				errorMessage?: string;
 				errorSeverity?: "warning" | "error";
-				customInstructions?: string;
 			},
 		) => Promise<void>;
 
 		await handleEvent.call(fakeThis, {
 			type: "compaction_end",
-			reason: "manual",
-			result: {
-				tokensBefore: 123,
-				summary: "summary",
-			},
+			reason: "requested",
+			result: { tokensBefore: 123, summary: "summary" },
 			aborted: false,
 			willRetry: false,
 		});
 
-		expect(fakeThis.chatContainer.clear).toHaveBeenCalledTimes(1);
-		expect(fakeThis.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
-		expect(fakeThis.addMessageToChat).toHaveBeenCalledTimes(1);
-		expect(fakeThis.addMessageToChat).toHaveBeenCalledWith(
-			expect.objectContaining({
-				role: "compactionSummary",
-				tokensBefore: 123,
-				summary: "summary",
-			}),
-		);
+		expect(fakeThis.rebuildChatFromMessages).toHaveBeenCalledOnce();
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
+		expect(fakeThis.addMessageToChat).not.toHaveBeenCalled();
+	});
+
+	test("clears stale chat and reports a failed post-compaction refresh", async () => {
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			updateConnectionStateFromEvent: vi.fn(),
+			activityTracker: new AgentActivityTracker(),
+			updateWorkingLoaderMessage: vi.fn(),
+			autoCompactionLoader: undefined,
+			retryLoader: undefined,
+			syncWorkingLoader: vi.fn(),
+			defaultEditor: {},
+			statusContainer: { clear: vi.fn() },
+			chatContainer: { clear: vi.fn() },
+			rebuildChatFromMessages: vi.fn().mockRejectedValue(new Error("context unavailable")),
+			refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
+			showError: vi.fn(),
+			showWarning: vi.fn(),
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "requested";
+				result: { tokensBefore: number; summary: string };
+				aborted: false;
+				willRetry: false;
+			},
+		) => Promise<void>;
+
 		await handleEvent.call(fakeThis, {
 			type: "compaction_end",
-			reason: "manual",
-			result: {
-				tokensBefore: 456,
-				summary: "focused summary",
-			},
+			reason: "requested",
+			result: { tokensBefore: 123, summary: "summary" },
 			aborted: false,
 			willRetry: false,
-			customInstructions: "focus on xyz",
 		});
 
-		expect(fakeThis.addMessageToChat).toHaveBeenLastCalledWith(
-			expect.objectContaining({
-				role: "compactionSummary",
-				tokensBefore: 456,
-				summary: "focused summary",
-				customInstructions: "focus on xyz",
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
+		expect(fakeThis.showError).toHaveBeenCalledWith(
+			"Compaction succeeded, but the transcript could not be refreshed: context unavailable",
+		);
+	});
+
+	test("renders valid and malformed compaction outcomes during live delivery", () => {
+		const chatContainer = new Container();
+		const fakeThis = {
+			chatContainer,
+			toolOutputExpanded: false,
+			bindLocalSessionExtensions: false,
+			getMarkdownThemeWithSettings: () => undefined,
+		};
+		Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+		const addMessageToChat = Reflect.get(InteractiveMode.prototype, "addMessageToChat") as (
+			this: typeof fakeThis,
+			message: AgentMessage,
+		) => void;
+
+		addMessageToChat.call(
+			fakeThis,
+			createCompactionOutcomeMessage("Requested compaction failed", {
+				reason: "requested",
+				outcome: "failed",
 			}),
 		);
-
-		await handleEvent.call(fakeThis, {
-			type: "compaction_end",
-			reason: "manual",
-			result: undefined,
-			aborted: false,
-			willRetry: false,
-			errorMessage: "Session is too short to compact — try again once it grows",
-			errorSeverity: "warning",
+		addMessageToChat.call(fakeThis, {
+			role: "custom",
+			customType: "compaction_outcome",
+			content: "untrusted malformed text",
+			display: true,
+			details: { reason: "manual", outcome: "failed" },
+			timestamp: 123,
 		});
 
-		expect(fakeThis.showWarning).toHaveBeenCalledWith("Session is too short to compact — try again once it grows");
-		expect(fakeThis.showError).not.toHaveBeenCalled();
+		const output = stripAnsi(chatContainer.render(100).join("\n"));
+		expect(output).toContain("Requested compaction failed");
+		expect(output).toContain("[Malformed compaction outcome message]");
+		expect(output).not.toContain("untrusted malformed text");
+	});
+
+	test("renders the persisted summary at its exact retained-message boundary", () => {
+		const retained = { role: "user", content: [], timestamp: 2 } as AgentMessage;
+		const summary = {
+			role: "compactionSummary",
+			summary: "summary",
+			tokensBefore: 123,
+			retainedMessageCount: 1,
+			timestamp: 2,
+		} as AgentMessage;
+		const later = { role: "user", content: [], timestamp: 2 } as AgentMessage;
+		const order = Reflect.get(InteractiveMode.prototype, "orderMessagesForTranscript") as (
+			this: InteractiveMode,
+			messages: AgentMessage[],
+		) => AgentMessage[];
+
+		expect(order.call({} as InteractiveMode, [summary, retained, later])).toEqual([retained, summary, later]);
+	});
+
+	test("falls back to timestamps for legacy compaction summaries", () => {
+		const retained = { role: "user", content: [], timestamp: 1 } as AgentMessage;
+		const summary = {
+			role: "compactionSummary",
+			summary: "summary",
+			tokensBefore: 123,
+			timestamp: 2,
+		} as AgentMessage;
+		const later = { role: "user", content: [], timestamp: 3 } as AgentMessage;
+		const order = Reflect.get(InteractiveMode.prototype, "orderMessagesForTranscript") as (
+			this: InteractiveMode,
+			messages: AgentMessage[],
+		) => AgentMessage[];
+
+		expect(order.call({} as InteractiveMode, [summary, retained, later])).toEqual([retained, summary, later]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -25,7 +25,10 @@ function createFakeThis(overrides: Record<string, unknown> = {}) {
 		defaultEditor: {},
 		statusContainer: { clear: vi.fn() },
 		chatContainer: { clear: vi.fn() },
-		rebuildChatFromMessages: vi.fn().mockResolvedValue(undefined),
+		rebuildChatFromMessages: vi.fn(function (this: { chatContainer: { clear(): void } }) {
+			this.chatContainer.clear();
+			return Promise.resolve();
+		}),
 		addMessageToChat: vi.fn(),
 		refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
 		showError: vi.fn(),
@@ -61,7 +64,7 @@ describe("InteractiveMode compaction events", () => {
 
 	test.each([
 		{ name: "rebuilds successful compaction from its single persisted summary", refresh: "succeeds" },
-		{ name: "clears stale chat and reports a failed post-compaction refresh", refresh: "fails" },
+		{ name: "keeps stale chat and reports a failed post-compaction refresh", refresh: "fails" },
 	] as const)("$name", async ({ refresh }) => {
 		const fakeThis = createFakeThis(
 			refresh === "fails"
@@ -77,7 +80,7 @@ describe("InteractiveMode compaction events", () => {
 			willRetry: false,
 		});
 
-		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledTimes(refresh === "succeeds" ? 1 : 0);
 		expect(fakeThis.rebuildChatFromMessages).toHaveBeenCalledOnce();
 		expect(fakeThis.addMessageToChat).not.toHaveBeenCalled();
 		if (refresh === "fails") {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -5,37 +5,44 @@ import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
+const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+	this: unknown,
+	event: Record<string, unknown>,
+) => Promise<void>;
+
+function createFakeThis(overrides: Record<string, unknown> = {}) {
+	return {
+		isInitialized: true,
+		footer: { invalidate: vi.fn() },
+		updateConnectionStateFromEvent: vi.fn(),
+		activityTracker: new AgentActivityTracker(),
+		updateWorkingLoaderMessage: vi.fn(),
+		autoCompactionLoader: undefined,
+		retryLoader: undefined,
+		workingVisible: true,
+		stopWorkingLoader: vi.fn(),
+		syncWorkingLoader: vi.fn(),
+		defaultEditor: {},
+		statusContainer: { clear: vi.fn() },
+		chatContainer: { clear: vi.fn() },
+		rebuildChatFromMessages: vi.fn().mockResolvedValue(undefined),
+		addMessageToChat: vi.fn(),
+		refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
+		showError: vi.fn(),
+		showWarning: vi.fn(),
+		showStatus: vi.fn(),
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		...overrides,
+	};
+}
+
 describe("InteractiveMode compaction events", () => {
 	beforeAll(() => initTheme("dark"));
+
 	test("shows an automatic compaction loader for the full operation", async () => {
 		const statusContainer = new Container();
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			updateConnectionStateFromEvent: vi.fn(),
-			activityTracker: new AgentActivityTracker(),
-			updateWorkingLoaderMessage: vi.fn(),
-			autoCompactionLoader: undefined,
-			retryLoader: undefined,
-			workingVisible: true,
-			stopWorkingLoader: vi.fn(),
-			syncWorkingLoader: vi.fn(),
-			statusContainer,
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
-		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
-			this: typeof fakeThis,
-			event:
-				| { type: "compaction_start"; reason: "threshold"; customInstructions?: string }
-				| {
-						type: "compaction_end";
-						reason: "threshold";
-						result: undefined;
-						aborted: true;
-						willRetry: false;
-				  },
-		) => Promise<void>;
+		const fakeThis = createFakeThis({ statusContainer });
 
 		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "threshold" });
 
@@ -52,96 +59,33 @@ describe("InteractiveMode compaction events", () => {
 		expect(statusContainer.children).toHaveLength(0);
 	});
 
-	test("rebuilds successful compaction from its single persisted summary", async () => {
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			updateConnectionStateFromEvent: vi.fn(),
-			activityTracker: new AgentActivityTracker(),
-			updateWorkingLoaderMessage: vi.fn(),
-			autoCompactionLoader: undefined,
-			retryLoader: undefined,
-			syncWorkingLoader: vi.fn(),
-			defaultEditor: {},
-			statusContainer: { clear: vi.fn() },
-			chatContainer: { clear: vi.fn() },
-			rebuildChatFromMessages: vi.fn().mockResolvedValue(undefined),
-			addMessageToChat: vi.fn(),
-			refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
-			showError: vi.fn(),
-			showWarning: vi.fn(),
-			showStatus: vi.fn(),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
-		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
-			this: typeof fakeThis,
-			event: {
-				type: "compaction_end";
-				reason: "manual" | "requested" | "threshold" | "overflow";
-				result: { tokensBefore: number; summary: string } | undefined;
-				aborted: boolean;
-				willRetry: boolean;
-				errorMessage?: string;
-				errorSeverity?: "warning" | "error";
-			},
-		) => Promise<void>;
-
-		await handleEvent.call(fakeThis, {
-			type: "compaction_end",
-			reason: "requested",
-			result: { tokensBefore: 123, summary: "summary" },
-			aborted: false,
-			willRetry: false,
-		});
-
-		expect(fakeThis.rebuildChatFromMessages).toHaveBeenCalledOnce();
-		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
-		expect(fakeThis.addMessageToChat).not.toHaveBeenCalled();
-	});
-
-	test("clears stale chat and reports a failed post-compaction refresh", async () => {
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			updateConnectionStateFromEvent: vi.fn(),
-			activityTracker: new AgentActivityTracker(),
-			updateWorkingLoaderMessage: vi.fn(),
-			autoCompactionLoader: undefined,
-			retryLoader: undefined,
-			syncWorkingLoader: vi.fn(),
-			defaultEditor: {},
-			statusContainer: { clear: vi.fn() },
-			chatContainer: { clear: vi.fn() },
-			rebuildChatFromMessages: vi.fn().mockRejectedValue(new Error("context unavailable")),
-			refreshConnectionContextUsage: vi.fn().mockResolvedValue(undefined),
-			showError: vi.fn(),
-			showWarning: vi.fn(),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
-		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
-			this: typeof fakeThis,
-			event: {
-				type: "compaction_end";
-				reason: "requested";
-				result: { tokensBefore: number; summary: string };
-				aborted: false;
-				willRetry: false;
-			},
-		) => Promise<void>;
-
-		await handleEvent.call(fakeThis, {
-			type: "compaction_end",
-			reason: "requested",
-			result: { tokensBefore: 123, summary: "summary" },
-			aborted: false,
-			willRetry: false,
-		});
-
-		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
-		expect(fakeThis.showError).toHaveBeenCalledWith(
-			"Compaction succeeded, but the transcript could not be refreshed: context unavailable",
+	test.each([
+		{ name: "rebuilds successful compaction from its single persisted summary", refresh: "succeeds" },
+		{ name: "clears stale chat and reports a failed post-compaction refresh", refresh: "fails" },
+	] as const)("$name", async ({ refresh }) => {
+		const fakeThis = createFakeThis(
+			refresh === "fails"
+				? { rebuildChatFromMessages: vi.fn().mockRejectedValue(new Error("context unavailable")) }
+				: {},
 		);
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "requested",
+			result: { tokensBefore: 123, summary: "summary" },
+			aborted: false,
+			willRetry: false,
+		});
+
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledOnce();
+		expect(fakeThis.rebuildChatFromMessages).toHaveBeenCalledOnce();
+		expect(fakeThis.addMessageToChat).not.toHaveBeenCalled();
+		if (refresh === "fails") {
+			expect(fakeThis.showError).toHaveBeenCalledWith(
+				"Compaction succeeded, but the transcript could not be refreshed: context unavailable",
+			);
+		} else {
+			expect(fakeThis.showError).not.toHaveBeenCalled();
+		}
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -144,7 +144,4 @@ describe("InteractiveMode compaction events", () => {
 			"Compaction succeeded, but the transcript could not be refreshed: context unavailable",
 		);
 	});
-
-
-
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -485,6 +485,25 @@ describe("InteractiveMode.renderSessionContext", () => {
 		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
 	});
 
+	test("orders the compaction summary at its exact boundary before bounding the initial transcript", async () => {
+		const { harness, addMessageToChat } = createRenderSessionContextHarness();
+		const retained = Array.from({ length: 5 }, (_, index) => userMessage(`retained ${index}`, 5));
+		const summary = {
+			role: "compactionSummary",
+			summary: "summary",
+			tokensBefore: 123,
+			retainedMessageCount: retained.length,
+			timestamp: 5,
+		} as AgentMessage;
+		const later = Array.from({ length: 399 }, (_, index) => userMessage(`later ${index}`, 5));
+
+		await renderMessages(harness, [summary, ...retained, ...later], { limitTranscript: true });
+
+		expect(addMessageToChat).toHaveBeenCalledTimes(400);
+		expect(addMessageToChat.mock.calls[0]?.[0]).toBe(summary);
+		expect(addMessageToChat.mock.calls[1]?.[0]).toMatchObject({ content: "later 0" });
+	});
+
 	test("preserves the full transcript when rebuilding a cleared transcript", async () => {
 		const { harness, chatContainer, addMessageToChat } = createRenderSessionContextHarness();
 		chatContainer.addChild({ render: () => ["old transcript"], invalidate: () => {} });
@@ -3671,6 +3690,7 @@ describe("InteractiveMode live context usage", () => {
 			connectionState: { sessionId?: string; contextUsage?: unknown };
 			activityTracker: { getStatus(): { tokens: number } };
 			contextUsageTokenBaseline: number;
+			contextUsageRefreshGeneration: number;
 			patchConnectionState(patch: Record<string, unknown>): void;
 			refreshConnectionContextUsage(): Promise<void>;
 		};
@@ -3679,6 +3699,7 @@ describe("InteractiveMode live context usage", () => {
 		const patched: Record<string, unknown>[] = [];
 		fakeThis.activityTracker = { getStatus: () => ({ tokens: 0 }) };
 		fakeThis.contextUsageTokenBaseline = 0;
+		fakeThis.contextUsageRefreshGeneration = 0;
 		fakeThis.connectionState = { sessionId: "session-A", contextUsage: undefined };
 		fakeThis.patchConnectionState = (p) => patched.push(p);
 		fakeThis.agentConnection = {
@@ -3693,6 +3714,41 @@ describe("InteractiveMode live context usage", () => {
 
 		// Stats belonged to session-A; must not overwrite session-B.
 		expect(patched).toHaveLength(0);
+	});
+
+	test("refreshConnectionContextUsage drops an older same-session response", async () => {
+		type RefreshHarness = {
+			agentConnection: { getSessionStats(): Promise<{ contextUsage: unknown }> };
+			connectionState: { sessionId?: string; contextUsage?: unknown };
+			activityTracker: { getStatus(): { tokens: number } };
+			contextUsageTokenBaseline: number;
+			contextUsageRefreshGeneration: number;
+			patchConnectionState(patch: Record<string, unknown>): void;
+			refreshConnectionContextUsage(): Promise<void>;
+		};
+		const refresh = (InteractiveMode.prototype as unknown as RefreshHarness).refreshConnectionContextUsage;
+		const first = createDeferred<{ contextUsage: unknown }>();
+		const second = createDeferred<{ contextUsage: unknown }>();
+		const fakeThis = Object.create(InteractiveMode.prototype) as RefreshHarness;
+		const patched: Record<string, unknown>[] = [];
+		let request = 0;
+		fakeThis.activityTracker = { getStatus: () => ({ tokens: 0 }) };
+		fakeThis.contextUsageTokenBaseline = 0;
+		fakeThis.contextUsageRefreshGeneration = 0;
+		fakeThis.connectionState = { sessionId: "session-A", contextUsage: undefined };
+		fakeThis.patchConnectionState = (patch) => patched.push(patch);
+		fakeThis.agentConnection = {
+			getSessionStats: () => (++request === 1 ? first.promise : second.promise),
+		};
+
+		const olderRefresh = refresh.call(fakeThis);
+		const newerRefresh = refresh.call(fakeThis);
+		second.resolve({ contextUsage: { tokens: 10, contextWindow: 100, percent: 10 } });
+		await newerRefresh;
+		first.resolve({ contextUsage: { tokens: 90, contextWindow: 100, percent: 90 } });
+		await olderRefresh;
+
+		expect(patched).toEqual([{ contextUsage: { tokens: 10, contextWindow: 100, percent: 10 } }]);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1670,16 +1670,22 @@ describe("InteractiveMode tool event rendering", () => {
 });
 
 describe("InteractiveMode transcript rebuild", () => {
-	test("keeps existing chat visible when session context reload fails", async () => {
-		type RebuildHarness = {
-			chatContainer: Container;
-			agentConnection: { getSessionContext(): Promise<never> };
-			renderSessionContext(): Promise<void>;
-			rebuildChatFromMessages(): Promise<void>;
-		};
+	type RebuildHarness = {
+		chatContainer: Container;
+		agentConnection: { getSessionContext(): Promise<AgentConnectionSessionContext> };
+		renderSessionContext(context: AgentConnectionSessionContext, options: RenderSessionContextOptions): Promise<void>;
+		rebuildChatFromMessages(): Promise<void>;
+	};
+
+	function createRebuildHarness(): RebuildHarness {
 		const fakeThis = Object.create(InteractiveMode.prototype) as RebuildHarness;
 		fakeThis.chatContainer = new Container();
 		fakeThis.chatContainer.addChild(new Container());
+		return fakeThis;
+	}
+
+	test("keeps existing chat visible when session context reload fails", async () => {
+		const fakeThis = createRebuildHarness();
 		fakeThis.agentConnection = {
 			getSessionContext: vi.fn(async () => {
 				throw new Error("context unavailable");
@@ -1691,6 +1697,29 @@ describe("InteractiveMode transcript rebuild", () => {
 
 		expect(fakeThis.chatContainer.children).toHaveLength(1);
 		expect(fakeThis.renderSessionContext).not.toHaveBeenCalled();
+	});
+
+	test("replaces existing chat after session context reload succeeds", async () => {
+		const fakeThis = createRebuildHarness();
+		const staleChild = fakeThis.chatContainer.children[0];
+		const rebuiltChild = new Container();
+		const context: AgentConnectionSessionContext = {
+			messages: [],
+			thinkingLevel: "medium",
+			serviceTier: "default",
+			model: null,
+		};
+		fakeThis.agentConnection = { getSessionContext: vi.fn(async () => context) };
+		fakeThis.renderSessionContext = vi.fn(async (_context, options) => {
+			if (options.clearChat) fakeThis.chatContainer.clear();
+			fakeThis.chatContainer.addChild(rebuiltChild);
+		});
+
+		await fakeThis.rebuildChatFromMessages();
+
+		expect(fakeThis.renderSessionContext).toHaveBeenCalledWith(context, { clearChat: true });
+		expect(fakeThis.chatContainer.children).toEqual([rebuiltChild]);
+		expect(fakeThis.chatContainer.children).not.toContain(staleChild);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3689,8 +3689,7 @@ describe("InteractiveMode live context usage", () => {
 		connectionState: { sessionId?: string; contextUsage?: unknown };
 		activityTracker: { getStatus(): { tokens: number } };
 		contextUsageTokenBaseline: number;
-		contextUsageRefreshRequestGeneration: number;
-		contextUsageRefreshResultGeneration: number;
+		contextUsageRefresh: { generation: number; lastSuccessGeneration: number };
 		patchConnectionState(patch: Record<string, unknown>): void;
 		refreshConnectionContextUsage(): Promise<void>;
 	};
@@ -3705,8 +3704,7 @@ describe("InteractiveMode live context usage", () => {
 		fakeThis.patched = [];
 		fakeThis.activityTracker = { getStatus: () => ({ tokens: 0 }) };
 		fakeThis.contextUsageTokenBaseline = 0;
-		fakeThis.contextUsageRefreshRequestGeneration = 0;
-		fakeThis.contextUsageRefreshResultGeneration = 0;
+		fakeThis.contextUsageRefresh = { generation: 0, lastSuccessGeneration: 0 };
 		fakeThis.connectionState = { sessionId: "session-A", contextUsage: undefined };
 		fakeThis.patchConnectionState = (patch) => fakeThis.patched.push(patch);
 		fakeThis.agentConnection = { getSessionStats };

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3684,62 +3684,54 @@ describe("InteractiveMode live context usage", () => {
 		expect(prototype.getConnectionContextUsage.call(fakeThis)).toBeUndefined();
 	});
 
-	test("refreshConnectionContextUsage drops stale stats after a session switch", async () => {
-		type RefreshHarness = {
-			agentConnection: { getSessionStats(): Promise<{ contextUsage: unknown }> };
-			connectionState: { sessionId?: string; contextUsage?: unknown };
-			activityTracker: { getStatus(): { tokens: number } };
-			contextUsageTokenBaseline: number;
-			contextUsageRefreshGeneration: number;
-			patchConnectionState(patch: Record<string, unknown>): void;
-			refreshConnectionContextUsage(): Promise<void>;
+	type RefreshHarness = {
+		agentConnection: { getSessionStats(): Promise<{ contextUsage: unknown } | undefined> };
+		connectionState: { sessionId?: string; contextUsage?: unknown };
+		activityTracker: { getStatus(): { tokens: number } };
+		contextUsageTokenBaseline: number;
+		contextUsageRefreshRequestGeneration: number;
+		contextUsageRefreshResultGeneration: number;
+		patchConnectionState(patch: Record<string, unknown>): void;
+		refreshConnectionContextUsage(): Promise<void>;
+	};
+	const refresh = (InteractiveMode.prototype as unknown as RefreshHarness).refreshConnectionContextUsage;
+
+	function createRefreshHarness(
+		getSessionStats: RefreshHarness["agentConnection"]["getSessionStats"],
+	): RefreshHarness & { patched: Record<string, unknown>[] } {
+		const fakeThis = Object.create(InteractiveMode.prototype) as RefreshHarness & {
+			patched: Record<string, unknown>[];
 		};
-		const refresh = (InteractiveMode.prototype as unknown as RefreshHarness).refreshConnectionContextUsage;
-		const fakeThis = Object.create(InteractiveMode.prototype) as RefreshHarness;
-		const patched: Record<string, unknown>[] = [];
+		fakeThis.patched = [];
 		fakeThis.activityTracker = { getStatus: () => ({ tokens: 0 }) };
 		fakeThis.contextUsageTokenBaseline = 0;
-		fakeThis.contextUsageRefreshGeneration = 0;
+		fakeThis.contextUsageRefreshRequestGeneration = 0;
+		fakeThis.contextUsageRefreshResultGeneration = 0;
 		fakeThis.connectionState = { sessionId: "session-A", contextUsage: undefined };
-		fakeThis.patchConnectionState = (p) => patched.push(p);
-		fakeThis.agentConnection = {
-			getSessionStats: async () => {
-				// User switches sessions while the stats call is in flight.
-				fakeThis.connectionState = { sessionId: "session-B", contextUsage: undefined };
-				return { contextUsage: { contextWindow: 100_000, tokens: 50_000, percent: 50 } };
-			},
-		};
+		fakeThis.patchConnectionState = (patch) => fakeThis.patched.push(patch);
+		fakeThis.agentConnection = { getSessionStats };
+		return fakeThis;
+	}
+
+	test("refreshConnectionContextUsage drops stale stats after a session switch", async () => {
+		let fakeThis: ReturnType<typeof createRefreshHarness>;
+		fakeThis = createRefreshHarness(async () => {
+			// User switches sessions while the stats call is in flight.
+			fakeThis.connectionState = { sessionId: "session-B", contextUsage: undefined };
+			return { contextUsage: { contextWindow: 100_000, tokens: 50_000, percent: 50 } };
+		});
 
 		await refresh.call(fakeThis);
 
 		// Stats belonged to session-A; must not overwrite session-B.
-		expect(patched).toHaveLength(0);
+		expect(fakeThis.patched).toHaveLength(0);
 	});
 
-	test("refreshConnectionContextUsage drops an older same-session response", async () => {
-		type RefreshHarness = {
-			agentConnection: { getSessionStats(): Promise<{ contextUsage: unknown }> };
-			connectionState: { sessionId?: string; contextUsage?: unknown };
-			activityTracker: { getStatus(): { tokens: number } };
-			contextUsageTokenBaseline: number;
-			contextUsageRefreshGeneration: number;
-			patchConnectionState(patch: Record<string, unknown>): void;
-			refreshConnectionContextUsage(): Promise<void>;
-		};
-		const refresh = (InteractiveMode.prototype as unknown as RefreshHarness).refreshConnectionContextUsage;
+	test("refreshConnectionContextUsage keeps a newer successful same-session response", async () => {
 		const first = createDeferred<{ contextUsage: unknown }>();
 		const second = createDeferred<{ contextUsage: unknown }>();
-		const fakeThis = Object.create(InteractiveMode.prototype) as RefreshHarness;
-		const patched: Record<string, unknown>[] = [];
 		let request = 0;
-		fakeThis.activityTracker = { getStatus: () => ({ tokens: 0 }) };
-		fakeThis.contextUsageTokenBaseline = 0;
-		fakeThis.contextUsageRefreshGeneration = 0;
-		fakeThis.connectionState = { sessionId: "session-A", contextUsage: undefined };
-		fakeThis.patchConnectionState = (patch) => patched.push(patch);
-		fakeThis.agentConnection = {
-			getSessionStats: () => (++request === 1 ? first.promise : second.promise),
-		};
+		const fakeThis = createRefreshHarness(() => (++request === 1 ? first.promise : second.promise));
 
 		const olderRefresh = refresh.call(fakeThis);
 		const newerRefresh = refresh.call(fakeThis);
@@ -3748,8 +3740,29 @@ describe("InteractiveMode live context usage", () => {
 		first.resolve({ contextUsage: { tokens: 90, contextWindow: 100, percent: 90 } });
 		await olderRefresh;
 
-		expect(patched).toEqual([{ contextUsage: { tokens: 10, contextWindow: 100, percent: 10 } }]);
+		expect(fakeThis.patched).toEqual([{ contextUsage: { tokens: 10, contextWindow: 100, percent: 10 } }]);
 	});
+
+	test.each(["failure", "no stats"] as const)(
+		"refreshConnectionContextUsage lets an older successful response survive a newer %s",
+		async (newerResult) => {
+			const first = createDeferred<{ contextUsage: unknown }>();
+			let request = 0;
+			const fakeThis = createRefreshHarness(() => {
+				if (++request === 1) return first.promise;
+				return newerResult === "failure"
+					? Promise.reject(new Error("stats unavailable"))
+					: Promise.resolve(undefined);
+			});
+
+			const olderRefresh = refresh.call(fakeThis);
+			await refresh.call(fakeThis);
+			first.resolve({ contextUsage: { tokens: 90, contextWindow: 100, percent: 90 } });
+			await olderRefresh;
+
+			expect(fakeThis.patched).toEqual([{ contextUsage: { tokens: 90, contextWindow: 100, percent: 90 } }]);
+		},
+	);
 });
 
 describe("truncatePathMiddle", () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -485,6 +485,21 @@ describe("InteractiveMode.renderSessionContext", () => {
 		expect(renderAll(chatContainer)).toContain("Showing latest 400 of 405 messages for faster open.");
 	});
 
+	test("keeps equal-timestamp legacy messages after the compaction summary", async () => {
+		const { harness, addMessageToChat } = createRenderSessionContextHarness();
+		const earlier = userMessage("earlier", 4);
+		const summary = {
+			role: "compactionSummary",
+			summary: "legacy summary",
+			tokensBefore: 123,
+			timestamp: 5,
+		} as AgentMessage;
+		const equalLater = userMessage("equal later", 5);
+
+		await renderMessages(harness, [summary, earlier, equalLater]);
+		expect(addMessageToChat.mock.calls.map((call) => call[0])).toEqual([earlier, summary, equalLater]);
+	});
+
 	test("orders the compaction summary at its exact boundary before bounding the initial transcript", async () => {
 		const { harness, addMessageToChat } = createRenderSessionContextHarness();
 		const retained = Array.from({ length: 5 }, (_, index) => userMessage(`retained ${index}`, 5));
@@ -3109,9 +3124,8 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 			promptStashState: state,
 			retainedSubmissionGenerations: new WeakMap(),
 		};
-		const release = (
-			InteractiveMode.prototype as unknown as { releasePromptStashSession(this: unknown): void }
-		).releasePromptStashSession;
+		const release = (InteractiveMode.prototype as unknown as { releasePromptStashSession(this: unknown): void })
+			.releasePromptStashSession;
 		const retain = (
 			InteractiveMode.prototype as unknown as {
 				retainSubmittedDraft(this: unknown, stash: { text: string }, generation: number): void;

--- a/packages/coding-agent/test/interactive-mode-streaming.test.ts
+++ b/packages/coding-agent/test/interactive-mode-streaming.test.ts
@@ -50,6 +50,8 @@ type HandleEventThis = {
 	stopWorkingLoader(): void;
 	resetPendingToolState(): void;
 	checkShutdownRequested(): Promise<void>;
+	applyOptimisticContextUsage(): void;
+	refreshConnectionContextUsage(): Promise<void>;
 	setSessionHasMessages(hasMessages: boolean): void;
 	clearShortcutGuide(): void;
 	addMessageToChat(): void;
@@ -100,6 +102,8 @@ function createFakeInteractiveModeThis(): HandleEventThis {
 		stopWorkingLoader: vi.fn(),
 		resetPendingToolState: vi.fn(),
 		checkShutdownRequested: vi.fn(async () => {}),
+		applyOptimisticContextUsage: vi.fn(),
+		refreshConnectionContextUsage: vi.fn(async () => {}),
 		setSessionHasMessages: vi.fn(),
 		clearShortcutGuide: vi.fn(),
 		addMessageToChat: vi.fn(),
@@ -169,6 +173,22 @@ describe("InteractiveMode streaming events", () => {
 		expect(renderChat(fakeThis.chatContainer)).toContain("final response");
 		expect(fakeThis.streamingComponent).toBeUndefined();
 		expect(fakeThis.streamingMessage).toBeUndefined();
+	});
+
+	test("does not block later compaction events on the agent-end stats refresh", async () => {
+		const fakeThis = createFakeInteractiveModeThis();
+		let resolveRefresh!: () => void;
+		fakeThis.refreshConnectionContextUsage = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveRefresh = resolve;
+				}),
+		);
+		const handleEvent = (InteractiveMode.prototype as unknown as { handleEvent: HandleEvent }).handleEvent;
+
+		await expect(handleEvent.call(fakeThis, { type: "agent_end", messages: [] })).resolves.toBeUndefined();
+		expect(fakeThis.refreshConnectionContextUsage).toHaveBeenCalledOnce();
+		resolveRefresh();
 	});
 
 	test("keeps attached partial assistant text when agent_end arrives without message_end", async () => {

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -2,8 +2,13 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentAutonomousStatus } from "../src/core/autonomous.js";
-import { createSessionSlashCommandResultMessage } from "../src/core/messages.js";
+import {
+	createCompactionOutcomeMessage,
+	createCustomMessage,
+	createSessionSlashCommandResultMessage,
+} from "../src/core/messages.js";
 import type { SessionShutdownEvent } from "../src/index.js";
+import { selectHeadlessTerminalResult } from "../src/modes/headless-completion.js";
 import { runPrintMode } from "../src/modes/print-mode.js";
 
 const output = vi.hoisted(() => ({ write: vi.fn(), flush: vi.fn(async () => {}) }));
@@ -70,7 +75,7 @@ function createAssistantMessage(options?: {
 }
 
 function createRuntimeHost(
-	assistantMessage: AgentMessage,
+	assistantMessage: AgentMessage | AgentMessage[],
 	autonomousStatus: AgentAutonomousStatus = {
 		enabled: false,
 		continuationsUsed: 0,
@@ -86,7 +91,7 @@ function createRuntimeHost(
 		emit: vi.fn(async () => {}),
 	};
 
-	const state = { messages: [assistantMessage] };
+	const state = { messages: Array.isArray(assistantMessage) ? assistantMessage : [assistantMessage] };
 
 	const session: FakeSession = {
 		sessionManager: { getHeader: () => undefined },
@@ -155,6 +160,47 @@ describe("runPrintMode", () => {
 		expect(output.write).toHaveBeenCalledWith("No active goal.\n");
 	});
 
+	it("prints a session command result before a trailing compaction outcome", async () => {
+		const result = createSessionSlashCommandResultMessage("No active goal.", {
+			command: { name: "goal", args: "status", text: "/goal status" },
+			success: true,
+			severity: "info",
+		});
+		const outcome = createCompactionOutcomeMessage("Requested compaction skipped", {
+			reason: "requested",
+			outcome: "skipped",
+		});
+		const runtimeHost = createRuntimeHost([result, outcome]);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).toHaveBeenCalledWith("No active goal.\n");
+		expect(errorSpy).toHaveBeenCalledWith("Requested compaction skipped");
+	});
+
+	it("does not select a result across a message barrier", () => {
+		const outcome = createCompactionOutcomeMessage("Requested compaction skipped", {
+			reason: "requested",
+			outcome: "skipped",
+		});
+		const barriers: AgentMessage[] = [
+			{ role: "user", content: "next request", timestamp: Date.now() },
+			createCustomMessage("extension.notice", "unrelated", true, undefined, new Date().toISOString()),
+		];
+
+		for (const barrier of barriers) {
+			expect(selectHeadlessTerminalResult([createAssistantMessage({ text: "stale" }), barrier, outcome])).toEqual({
+				primary: undefined,
+				compactionOutcomes: [outcome],
+			});
+		}
+	});
+
 	it("returns non-zero for failed session command results in text mode", async () => {
 		const result = createSessionSlashCommandResultMessage("Command failed: bad arguments", {
 			command: { name: "refine", args: "rollback", text: "/refine rollback" },
@@ -203,6 +249,42 @@ describe("runPrintMode", () => {
 		expect(errorSpy).toHaveBeenCalledWith("provider failure");
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("prints assistant output and reports a trailing compaction outcome", async () => {
+		const outcome = createCompactionOutcomeMessage("Auto-compaction skipped: nothing to compact", {
+			reason: "threshold",
+			outcome: "skipped",
+		});
+		const runtimeHost = createRuntimeHost([createAssistantMessage({ text: "done" }), outcome]);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).toHaveBeenCalledWith("done\n");
+		expect(errorSpy).toHaveBeenCalledWith("Auto-compaction skipped: nothing to compact");
+	});
+
+	it("reports an outcome-only failure and exits non-zero", async () => {
+		const outcome = createCompactionOutcomeMessage("Context overflow recovery failed", {
+			reason: "overflow",
+			outcome: "failed",
+		});
+		const runtimeHost = createRuntimeHost(outcome);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(output.write).not.toHaveBeenCalled();
+		expect(errorSpy).toHaveBeenCalledWith("Context overflow recovery failed");
 	});
 
 	it("stops host-driven gate retries once gate maxRetries is exhausted", async () => {
@@ -348,7 +430,10 @@ describe("runPrintMode", () => {
 			() => statuses[Math.min(statusIndex++, statuses.length - 1)] as AgentAutonomousStatus,
 		);
 		session.prompt.mockImplementationOnce(async () => {
-			session.state.messages = [createAssistantMessage({ stopReason: "error", errorMessage: "provider down" })];
+			session.state.messages = [
+				createAssistantMessage({ stopReason: "error", errorMessage: "provider down" }),
+				createCompactionOutcomeMessage("Auto-compaction failed", { reason: "threshold", outcome: "failed" }),
+			];
 		});
 		session.prompt.mockImplementationOnce(async () => {
 			session.state.messages = [createAssistantMessage({ text: "still failing" })];

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -183,6 +183,20 @@ describe("runPrintMode", () => {
 		expect(errorSpy).toHaveBeenCalledWith("Requested compaction skipped");
 	});
 
+	it("skips malformed terminal outcomes without hiding earlier valid failures", () => {
+		const failed = createCompactionOutcomeMessage("Compaction failed", {
+			reason: "requested",
+			outcome: "failed",
+		});
+		const malformed = { ...failed, details: { reason: "unknown", outcome: "failed" } } as AgentMessage;
+		const assistant = createAssistantMessage({ text: "done" });
+
+		expect(selectHeadlessTerminalResult([assistant, failed, malformed])).toEqual({
+			primary: assistant,
+			compactionOutcomes: [failed],
+		});
+	});
+
 	it("does not select a result across a message barrier", () => {
 		const outcome = createCompactionOutcomeMessage("Requested compaction skipped", {
 			reason: "requested",

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -170,20 +170,6 @@ describe("session command messages", () => {
 		).toEqual([]);
 	});
 
-	test("renders valid and malformed compaction outcomes distinctly on replay", () => {
-		const valid = createCompactionOutcomeMessage("Auto-compaction skipped", {
-			reason: "threshold",
-			outcome: "skipped",
-		});
-		const malformed = customMessage(COMPACTION_OUTCOME_CUSTOM_TYPE, { reason: "manual", outcome: "skipped" });
-		const components = buildConversationComponents([valid, malformed], componentOptions);
-
-		expect(components[0]).toBeInstanceOf(CompactionOutcomeMessageComponent);
-		const output = stripAnsi(components.flatMap((component) => component.render(80)).join("\n"));
-		expect(output).toContain("Auto-compaction skipped");
-		expect(output).toContain("[Malformed compaction outcome message]");
-		expect(output).not.toContain("durable display text");
-	});
 
 	test("continues to include ordinary custom messages", () => {
 		expect(convertToLlm([customMessage("extension_notice")])).toMatchObject([
@@ -202,8 +188,13 @@ describe("session command messages", () => {
 					success: false,
 					severity: "warning",
 				}),
+				createCompactionOutcomeMessage("Auto-compaction skipped", {
+					reason: "threshold",
+					outcome: "skipped",
+				}),
 				customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE, { command: "not-a-command" }),
 				customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE, { severity: "fatal" }),
+				customMessage(COMPACTION_OUTCOME_CUSTOM_TYPE, { reason: "manual", outcome: "skipped" }),
 			],
 			componentOptions,
 		);
@@ -211,8 +202,11 @@ describe("session command messages", () => {
 
 		expect(components[0]).toBeInstanceOf(SlashCommandMessageComponent);
 		expect(components[1]).toBeInstanceOf(SlashCommandResultMessageComponent);
+		expect(components[2]).toBeInstanceOf(CompactionOutcomeMessageComponent);
 		expect(output).toContain("Compaction skipped");
+		expect(output).toContain("Auto-compaction skipped");
 		expect(output.match(/\[Malformed session command message\]/g)).toHaveLength(2);
+		expect(output).toContain("[Malformed compaction outcome message]");
 		expect(output).not.toContain("durable display text");
 	});
 });

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -170,7 +170,6 @@ describe("session command messages", () => {
 		).toEqual([]);
 	});
 
-
 	test("continues to include ordinary custom messages", () => {
 		expect(convertToLlm([customMessage("extension_notice")])).toMatchObject([
 			{ role: "user", content: [{ type: "text", text: "durable display text" }] },

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -2,16 +2,20 @@ import type { TUI } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import {
+	COMPACTION_OUTCOME_CUSTOM_TYPE,
 	type CustomMessage,
 	convertToLlm,
+	createCompactionOutcomeMessage,
 	createSessionSlashCommandMessage,
 	createSessionSlashCommandResultMessage,
+	isCompactionOutcomeMessage,
 	isSessionSlashCommandMessage,
 	isSessionSlashCommandResultMessage,
 	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
 	SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE,
 } from "../src/core/messages.js";
 import { parseSessionSlashCommand } from "../src/core/slash-commands.js";
+import { CompactionOutcomeMessageComponent } from "../src/modes/interactive/components/compaction-outcome-message.js";
 import { buildConversationComponents } from "../src/modes/interactive/components/conversation-components.js";
 import { SlashCommandMessageComponent } from "../src/modes/interactive/components/slash-command-message.js";
 import { SlashCommandResultMessageComponent } from "../src/modes/interactive/components/slash-command-result-message.js";
@@ -123,9 +127,34 @@ describe("session command messages", () => {
 		).toBe(false);
 	});
 
-	test("excludes valid and malformed reserved entries from LLM context", () => {
+	test("creates and validates typed compaction outcome messages", () => {
+		const outcome = createCompactionOutcomeMessage(
+			"Requested compaction skipped: too short",
+			{ reason: "requested", outcome: "skipped" },
+			true,
+			123,
+		);
+
+		expect(outcome).toEqual({
+			role: "custom",
+			customType: COMPACTION_OUTCOME_CUSTOM_TYPE,
+			content: "Requested compaction skipped: too short",
+			display: true,
+			details: { reason: "requested", outcome: "skipped" },
+			timestamp: 123,
+		});
+		expect(isCompactionOutcomeMessage(outcome)).toBe(true);
+		expect(isCompactionOutcomeMessage({ ...outcome, details: { reason: "manual", outcome: "skipped" } })).toBe(false);
+		expect(isCompactionOutcomeMessage({ ...outcome, details: { reason: "requested", outcome: "success" } })).toBe(
+			false,
+		);
+		expect(isCompactionOutcomeMessage({ ...outcome, timestamp: Number.NaN })).toBe(false);
+	});
+
+	test("excludes durable command, result, and compaction outcome entries from LLM context", () => {
 		const command = parseSessionSlashCommand("/compact");
 		expect(command).toBeDefined();
+
 		expect(
 			convertToLlm([
 				createSessionSlashCommandMessage(command!),
@@ -136,8 +165,24 @@ describe("session command messages", () => {
 				}),
 				customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE),
 				customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE),
+				customMessage(COMPACTION_OUTCOME_CUSTOM_TYPE),
 			]),
 		).toEqual([]);
+	});
+
+	test("renders valid and malformed compaction outcomes distinctly on replay", () => {
+		const valid = createCompactionOutcomeMessage("Auto-compaction skipped", {
+			reason: "threshold",
+			outcome: "skipped",
+		});
+		const malformed = customMessage(COMPACTION_OUTCOME_CUSTOM_TYPE, { reason: "manual", outcome: "skipped" });
+		const components = buildConversationComponents([valid, malformed], componentOptions);
+
+		expect(components[0]).toBeInstanceOf(CompactionOutcomeMessageComponent);
+		const output = stripAnsi(components.flatMap((component) => component.render(80)).join("\n"));
+		expect(output).toContain("Auto-compaction skipped");
+		expect(output).toContain("[Malformed compaction outcome message]");
+		expect(output).not.toContain("durable display text");
 	});
 
 	test("continues to include ordinary custom messages", () => {

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -1,12 +1,14 @@
 import {
 	appendFileSync,
 	chmodSync,
+	type chownSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	type renameSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -16,17 +18,32 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type ChmodSync = typeof chmodSync;
+type ChownSync = typeof chownSync;
+type RenameSync = typeof renameSync;
 type WriteFileSync = typeof writeFileSync;
 
 const fsMocks = vi.hoisted(() => ({
 	actualWriteFileSync: undefined as WriteFileSync | undefined,
+	chmodSync: vi.fn<ChmodSync>(),
+	chownSync: vi.fn<ChownSync>(),
+	renameSync: vi.fn<RenameSync>(),
 	writeFileSync: vi.fn<WriteFileSync>(),
 }));
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
 	fsMocks.actualWriteFileSync = actual.writeFileSync;
+	fsMocks.chmodSync.mockImplementation(actual.chmodSync);
+	fsMocks.chownSync.mockImplementation(actual.chownSync);
+	fsMocks.renameSync.mockImplementation(actual.renameSync);
 	fsMocks.writeFileSync.mockImplementation(actual.writeFileSync);
-	return { ...actual, writeFileSync: fsMocks.writeFileSync };
+	return {
+		...actual,
+		chmodSync: fsMocks.chmodSync,
+		chownSync: fsMocks.chownSync,
+		renameSync: fsMocks.renameSync,
+		writeFileSync: fsMocks.writeFileSync,
+	};
 });
 
 import { SessionManager } from "../src/core/session-manager.js";
@@ -98,18 +115,63 @@ describe("SessionManager.flushNow", () => {
 		);
 	});
 
-	it("preserves live-file permissions across rewrites", () => {
+	it("preserves live-file metadata before atomically replacing it", () => {
 		const dir = createTempDir();
 		const mgr = SessionManager.create(dir, join(dir, "sessions"));
-		mgr.appendCustomEntry("before_permission_check");
+		mgr.appendCustomEntry("before_metadata_check");
 		mgr.flushNow();
 		const file = mgr.getSessionFile()!;
 		chmodSync(file, 0o660);
+		const before = statSync(file);
+		fsMocks.chownSync.mockClear();
+		fsMocks.chownSync.mockImplementationOnce(() => undefined);
+		fsMocks.chmodSync.mockClear();
+		fsMocks.renameSync.mockClear();
 
 		mgr.appendMessage({ role: "user", content: "pending", timestamp: Date.now() });
 		mgr.flushNow();
 
-		expect(statSync(file).mode & 0o777).toBe(0o660);
+		const tempPath = fsMocks.chownSync.mock.calls[0]?.[0];
+		expect(tempPath).toEqual(expect.any(String));
+		expect(fsMocks.chownSync).toHaveBeenCalledWith(tempPath, before.uid, before.gid);
+		expect(fsMocks.chmodSync).toHaveBeenCalledWith(tempPath, before.mode & 0o777);
+		expect(fsMocks.renameSync).toHaveBeenCalledWith(tempPath, join(dirname(tempPath as string), basename(file)));
+		expect(fsMocks.chownSync.mock.invocationCallOrder[0]!).toBeLessThan(
+			fsMocks.chmodSync.mock.invocationCallOrder[0]!,
+		);
+		expect(fsMocks.chmodSync.mock.invocationCallOrder[0]!).toBeLessThan(
+			fsMocks.renameSync.mock.invocationCallOrder[0]!,
+		);
+		const after = statSync(file);
+		expect({ mode: after.mode & 0o777, uid: after.uid, gid: after.gid }).toEqual({
+			mode: before.mode & 0o777,
+			uid: before.uid,
+			gid: before.gid,
+		});
+	});
+
+	it("preserves live bytes and cleans the temp file when restoring ownership fails", () => {
+		const dir = createTempDir();
+		const mgr = SessionManager.create(dir, join(dir, "sessions"));
+		mgr.appendCustomEntry("before_ownership_failure");
+		mgr.flushNow();
+		const file = mgr.getSessionFile()!;
+		const before = readFileSync(file);
+		const tempPrefix = `.${basename(file)}.`;
+		const permissionError = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+		fsMocks.chownSync.mockImplementationOnce(() => {
+			throw permissionError;
+		});
+		fsMocks.renameSync.mockClear();
+
+		mgr.appendMessage({ role: "user", content: "pending", timestamp: Date.now() });
+
+		expect(() => mgr.flushNow()).toThrow(permissionError);
+		expect(fsMocks.renameSync).not.toHaveBeenCalled();
+		expect(readFileSync(file)).toEqual(before);
+		expect(readdirSync(dirname(file)).filter((name) => name.startsWith(tempPrefix) && name.endsWith(".tmp"))).toEqual(
+			[],
+		);
 	});
 
 	it("rewrites a cross-directory symlink target without replacing the alias", () => {

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -1,7 +1,31 @@
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+	appendFileSync,
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	type writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+type WriteFileSync = typeof writeFileSync;
+
+const fsMocks = vi.hoisted(() => ({
+	actualWriteFileSync: undefined as WriteFileSync | undefined,
+	writeFileSync: vi.fn<WriteFileSync>(),
+}));
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	fsMocks.actualWriteFileSync = actual.writeFileSync;
+	fsMocks.writeFileSync.mockImplementation(actual.writeFileSync);
+	return { ...actual, writeFileSync: fsMocks.writeFileSync };
+});
+
 import { SessionManager } from "../src/core/session-manager.js";
 
 const tempDirs: string[] = [];
@@ -47,6 +71,42 @@ describe("SessionManager.flushNow", () => {
 		expect(custom.type).toBe("custom");
 		expect(custom.customType).toBe("thread_goal_state");
 		expect(custom.data).toEqual({ active: true, status: "active" });
+	});
+
+	it("preserves live bytes and cleans up the temp file when a rewrite fails", () => {
+		const dir = createTempDir();
+		const mgr = SessionManager.create(dir, join(dir, "sessions"));
+		mgr.appendCustomEntry("before_failure");
+		mgr.flushNow();
+		const file = mgr.getSessionFile()!;
+		const before = readFileSync(file);
+		const tempPrefix = `.${basename(file)}.`;
+
+		mgr.appendMessage({ role: "user", content: "pending", timestamp: Date.now() });
+		fsMocks.writeFileSync.mockImplementationOnce((path, data, options) => {
+			fsMocks.actualWriteFileSync!(path, Buffer.from(String(data)).subarray(0, 12), options);
+			throw new Error("disk full");
+		});
+
+		expect(() => mgr.flushNow()).toThrow("disk full");
+		expect(readFileSync(file)).toEqual(before);
+		expect(readdirSync(dirname(file)).filter((name) => name.startsWith(tempPrefix) && name.endsWith(".tmp"))).toEqual(
+			[],
+		);
+	});
+
+	it("preserves live-file permissions across rewrites", () => {
+		const dir = createTempDir();
+		const mgr = SessionManager.create(dir, join(dir, "sessions"));
+		mgr.appendCustomEntry("before_permission_check");
+		mgr.flushNow();
+		const file = mgr.getSessionFile()!;
+		chmodSync(file, 0o660);
+
+		mgr.appendMessage({ role: "user", content: "pending", timestamp: Date.now() });
+		mgr.flushNow();
+
+		expect(statSync(file).mode & 0o777).toBe(0o660);
 	});
 
 	it("is a no-op for in-memory (non-persisted) sessions", () => {
@@ -163,8 +223,46 @@ describe("SessionManager.flushNow", () => {
 	});
 });
 
+function createPersistedSessionForRollbackTest(): { mgr: SessionManager; file: string; before: Buffer } {
+	const dir = createTempDir();
+	const mgr = SessionManager.create(dir, join(dir, "sessions"));
+	mgr.appendMessage({ role: "user", content: "hi", timestamp: Date.now() });
+	mgr.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "hello" }],
+		api: "openai-completions",
+		provider: "openai",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	});
+	const file = mgr.getSessionFile()!;
+	return { mgr, file, before: readFileSync(file) };
+}
+
+function failNextOutcomeAppend(mgr: SessionManager, file: string): void {
+	const internals = mgr as unknown as { _persist(entry: unknown): void };
+	internals._persist = () => {
+		appendFileSync(file, '{"type":"custom_message","truncat');
+		throw new Error("append failed");
+	};
+}
+
+const failAfterPartialTempWrite: WriteFileSync = (path, data, options) => {
+	fsMocks.actualWriteFileSync!(path, Buffer.from(String(data)).subarray(0, 12), options);
+	throw new Error("repair failed");
+};
+
 describe("SessionManager.appendCustomMessageEntryWithRollback", () => {
-	it("restores the session file after a torn append", () => {
+	it("repairs the session file immediately after a torn append", () => {
 		const dir = createTempDir();
 		const sessionDir = join(dir, "sessions");
 		const mgr = SessionManager.create(dir, sessionDir);
@@ -201,11 +299,25 @@ describe("SessionManager.appendCustomMessageEntryWithRollback", () => {
 
 		// The rollback rewrites the file from the restored in-memory entries, so the
 		// durable session has no torn tail even if the process exits right after.
-		const after = readFileSync(file, "utf8");
-		expect(after).toBe(before);
-		for (const line of after.trim().split("\n")) {
-			expect(() => JSON.parse(line)).not.toThrow();
-		}
-		expect(mgr.getLeafEntry()?.type).toBe("message");
+		expect(readFileSync(file, "utf8")).toBe(before);
+	});
+
+	it("preserves old history when rollback repair fails", () => {
+		const { mgr, file, before } = createPersistedSessionForRollbackTest();
+		failNextOutcomeAppend(mgr, file);
+		fsMocks.writeFileSync.mockImplementationOnce(failAfterPartialTempWrite);
+
+		expect(() => mgr.appendCustomMessageEntryWithRollback("test.outcome", "details", false)).toThrow("append failed");
+		expect(readFileSync(file).subarray(0, before.length)).toEqual(before);
+	});
+
+	it("repairs a torn tail on the next successful retry", () => {
+		const { mgr, file, before } = createPersistedSessionForRollbackTest();
+		failNextOutcomeAppend(mgr, file);
+		fsMocks.writeFileSync.mockImplementationOnce(failAfterPartialTempWrite);
+		expect(() => mgr.appendCustomMessageEntryWithRollback("test.outcome", "details", false)).toThrow();
+
+		mgr.flushNow();
+		expect(readFileSync(file)).toEqual(before);
 	});
 });

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -356,6 +356,17 @@ const failAfterPartialTempWrite: WriteFileSync = (path, data, options) => {
 };
 
 describe("SessionManager.appendCustomMessageEntryWithRollback", () => {
+	it("flushes rollback-aware custom messages before the first assistant response", () => {
+		const dir = createTempDir();
+		const sessionDir = join(dir, "sessions");
+		const mgr = SessionManager.create(dir, sessionDir);
+
+		mgr.appendCustomMessageEntryWithRollback("compaction_outcome", "failed early", true);
+
+		const persisted = readFileSync(mgr.getSessionFile()!, "utf8");
+		expect(persisted).toContain('"customType":"compaction_outcome"');
+	});
+
 	it("repairs the session file immediately after a torn append", () => {
 		const dir = createTempDir();
 		const sessionDir = join(dir, "sessions");

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -160,5 +160,52 @@ describe("SessionManager.flushNow", () => {
 			customType: "thread_goal_state",
 			data: { active: true, status: "active" },
 		});
+	});
+});
+
+describe("SessionManager.appendCustomMessageEntryWithRollback", () => {
+	it("restores the session file after a torn append", () => {
+		const dir = createTempDir();
+		const sessionDir = join(dir, "sessions");
+		const mgr = SessionManager.create(dir, sessionDir);
+		mgr.appendMessage({ role: "user", content: "hi", timestamp: Date.now() });
+		mgr.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hello" }],
+			api: "openai-completions",
+			provider: "openai",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+		const file = mgr.getSessionFile()!;
+		const before = readFileSync(file, "utf8");
+
+		// Simulate a partial append: the fs write tears the file, then throws.
+		const internals = mgr as unknown as { _persist(entry: unknown): void };
+		const originalPersist = internals._persist.bind(mgr);
+		internals._persist = () => {
+			appendFileSync(file, '{"type":"custom_message","truncat');
+			throw new Error("disk full");
+		};
+		expect(() => mgr.appendCustomMessageEntryWithRollback("test.outcome", "details", false)).toThrow("disk full");
+		internals._persist = originalPersist;
+
+		// The rollback rewrites the file from the restored in-memory entries, so the
+		// durable session has no torn tail even if the process exits right after.
+		const after = readFileSync(file, "utf8");
+		expect(after).toBe(before);
+		for (const line of after.trim().split("\n")) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+		expect(mgr.getLeafEntry()?.type).toBe("message");
 	});
 });

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -2,11 +2,14 @@ import {
 	appendFileSync,
 	chmodSync,
 	existsSync,
+	lstatSync,
+	mkdirSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	type writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -107,6 +110,35 @@ describe("SessionManager.flushNow", () => {
 		mgr.flushNow();
 
 		expect(statSync(file).mode & 0o777).toBe(0o660);
+	});
+
+	it("rewrites a cross-directory symlink target without replacing the alias", () => {
+		const dir = createTempDir();
+		const targetDir = join(dir, "targets");
+		const aliasDir = join(dir, "aliases");
+		mkdirSync(targetDir);
+		mkdirSync(aliasDir);
+		const target = join(targetDir, "session.jsonl");
+		const alias = join(aliasDir, "session.jsonl");
+		fsMocks.actualWriteFileSync!(
+			target,
+			`${JSON.stringify({
+				type: "session",
+				version: 2,
+				id: "symlink-session",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: dir,
+			})}\n`,
+		);
+		chmodSync(target, 0o640);
+		symlinkSync(target, alias);
+
+		const mgr = SessionManager.open(alias);
+
+		expect(mgr.getSessionFile()).toBe(alias);
+		expect(lstatSync(alias).isSymbolicLink()).toBe(true);
+		expect(JSON.parse(readFileSync(target, "utf8")).version).toBe(3);
+		expect(statSync(target).mode & 0o777).toBe(0o640);
 	});
 
 	it("is a no-op for in-memory (non-persisted) sessions", () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -11,6 +11,11 @@ type SessionWithCompactionInternals = {
 	) => Promise<void>;
 	_runAutoCompaction: (reason: "overflow" | "threshold" | "requested", willRetry: boolean) => Promise<void>;
 	_shouldStopAfterTurn: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+	_persistCompactionOutcome: (
+		reason: "overflow" | "threshold" | "requested",
+		outcome: "skipped" | "cancelled" | "failed",
+		message: string,
+	) => boolean;
 };
 
 function createUsage(totalTokens: number) {
@@ -386,11 +391,24 @@ describe("AgentSession compaction characterization", () => {
 
 		await sessionInternals._checkCompaction(overflowMessage);
 		await sessionInternals._checkCompaction({ ...overflowMessage, timestamp: Date.now() + 1 });
+		await sessionInternals._checkCompaction({ ...overflowMessage, timestamp: Date.now() + 2 });
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);
-		expect(compactionErrors).toContain(
-			"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
-		);
+		const message =
+			"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.";
+		expect(compactionErrors).toContain(message);
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "custom",
+			customType: "compaction_outcome",
+			content: message,
+			details: { reason: "overflow", outcome: "failed" },
+		});
+		expect(
+			harness.session.messages.filter(
+				(entry) =>
+					entry.role === "custom" && entry.customType === "compaction_outcome" && entry.content === message,
+			),
+		).toHaveLength(1);
 	});
 
 	it("ignores stale pre-compaction assistant usage on pre-prompt checks", async () => {
@@ -1041,5 +1059,42 @@ describe("AgentSession compaction characterization", () => {
 
 		expect(belowThresholdSpy).not.toHaveBeenCalled();
 		expect(disabledSpy).not.toHaveBeenCalled();
+	});
+
+	it("persists unsuccessful automatic compaction outcomes outside model context", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SessionWithCompactionInternals;
+
+		internals._persistCompactionOutcome("requested", "skipped", "Requested compaction skipped: too short");
+
+		const outcome = harness.session.messages.at(-1);
+		expect(outcome).toMatchObject({
+			role: "custom",
+			customType: "compaction_outcome",
+			content: "Requested compaction skipped: too short",
+			display: true,
+			details: { reason: "requested", outcome: "skipped" },
+		});
+		expect(harness.session.agent.convertToLlm([outcome!])).toEqual([]);
+	});
+
+	it("does not let outcome persistence failures replace compaction control flow", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SessionWithCompactionInternals;
+		vi.spyOn(harness.sessionManager, "appendCustomMessageEntry").mockImplementation(() => {
+			throw new Error("disk full");
+		});
+
+		expect(() =>
+			internals._persistCompactionOutcome("requested", "failed", "Requested compaction failed"),
+		).not.toThrow();
+		expect(harness.session.messages).toContainEqual(
+			expect.objectContaining({
+				customType: "compaction_outcome",
+				content: "Requested compaction failed",
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -3,7 +3,7 @@ import type { AgentMessage, ShouldStopAfterTurnContext } from "@earendil-works/p
 import { type AssistantMessage, fauxAssistantMessage, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../src/core/session-manager.js";
-import { createHarness, type Harness } from "./harness.js";
+import { createHarness, getMessageText, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (
@@ -1121,5 +1121,19 @@ describe("AgentSession compaction characterization", () => {
 			customType: "compaction_outcome",
 			content: expect.stringContaining("could not be saved to session history"),
 		});
+
+		// A turn persisted after the failure sorts below the disclosure on rebuild,
+		// matching where the notice appeared live.
+		harness.setResponses([fauxAssistantMessage("later response")]);
+		await harness.session.prompt("later turn");
+		const reordered = harness.session.buildSessionContext().messages;
+		const outcomeIndex = reordered.findIndex(
+			(message) => message.role === "custom" && message.customType === "compaction_outcome",
+		);
+		const laterTurnIndex = reordered.findIndex(
+			(message) => message.role === "user" && getMessageText(message).includes("later turn"),
+		);
+		expect(outcomeIndex).toBeGreaterThanOrEqual(0);
+		expect(laterTurnIndex).toBeGreaterThan(outcomeIndex);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -362,6 +362,7 @@ describe("AgentSession compaction characterization", () => {
 		const endEvents: Array<{ errorMessage?: string; errorSeverity?: string }> = [];
 		harness.session.subscribe((event) => {
 			if (event.type === "compaction_end") {
+				expect(harness.session.messages.at(-1)).toMatchObject({ customType: "compaction_outcome" });
 				endEvents.push({ errorMessage: event.errorMessage, errorSeverity: event.errorSeverity });
 			}
 		});

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -354,7 +354,7 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);
 	});
 
-	it("emits a warning when auto-compaction has nothing to summarize", async () => {
+	it("emits a warning and persists the outcome outside model context when auto-compaction has nothing to summarize", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		await harness.session.prompt("one");
@@ -372,6 +372,17 @@ describe("AgentSession compaction characterization", () => {
 		expect(endEvents).toHaveLength(1);
 		expect(endEvents[0].errorSeverity).toBe("warning");
 		expect(endEvents[0].errorMessage).toContain("Auto-compaction skipped");
+
+		// The unsuccessful outcome is disclosed as a durable custom message that stays out of model context.
+		const outcome = harness.session.messages.at(-1);
+		expect(outcome).toMatchObject({
+			role: "custom",
+			customType: "compaction_outcome",
+			content: endEvents[0].errorMessage,
+			display: true,
+			details: { reason: "threshold", outcome: "skipped" },
+		});
+		expect(harness.session.agent.convertToLlm([outcome!])).toEqual([]);
 	});
 
 	it("does not retry overflow recovery more than once", async () => {
@@ -1063,24 +1074,6 @@ describe("AgentSession compaction characterization", () => {
 		expect(disabledSpy).not.toHaveBeenCalled();
 	});
 
-	it("persists unsuccessful automatic compaction outcomes outside model context", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const internals = harness.session as unknown as SessionWithCompactionInternals;
-
-		internals._persistCompactionOutcome("requested", "skipped", "Requested compaction skipped: too short");
-
-		const outcome = harness.session.messages.at(-1);
-		expect(outcome).toMatchObject({
-			role: "custom",
-			customType: "compaction_outcome",
-			content: "Requested compaction skipped: too short",
-			display: true,
-			details: { reason: "requested", outcome: "skipped" },
-		});
-		expect(harness.session.agent.convertToLlm([outcome!])).toEqual([]);
-	});
-
 	it("rolls back failed outcome persistence without breaking the persisted branch", async () => {
 		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
@@ -1091,11 +1084,7 @@ describe("AgentSession compaction characterization", () => {
 		const sessionFile = harness.sessionManager.getSessionFile()!;
 		const persistedLeafId = harness.sessionManager.getLeafId();
 		const persistedEntries = harness.sessionManager.getEntries();
-		const persistedEntryObjects = new Map(persistedEntries.map((entry) => [entry.id, entry]));
-		vi.spyOn(harness.sessionManager, "_persist").mockImplementationOnce((entry) => {
-			// _appendEntry mutates all in-memory indexes before persistence is attempted.
-			expect(harness.sessionManager.getLeafId()).toBe(entry.id);
-			expect(harness.sessionManager.getEntry(entry.id)).toBe(entry);
+		vi.spyOn(harness.sessionManager, "_persist").mockImplementationOnce(() => {
 			appendFileSync(sessionFile, '{"type":"custom_message"');
 			throw new Error("disk full");
 		});
@@ -1103,22 +1092,18 @@ describe("AgentSession compaction characterization", () => {
 		expect(() =>
 			internals._persistCompactionOutcome("requested", "failed", "Requested compaction failed"),
 		).not.toThrow();
-		const outcome = harness.session.messages.at(-1);
-		expect(outcome).toMatchObject({
+		// The live outcome message discloses that it was not saved.
+		expect(harness.session.messages.at(-1)).toMatchObject({
 			role: "custom",
 			customType: "compaction_outcome",
 			content: expect.stringContaining("could not be saved to session history"),
 			details: { reason: "requested", outcome: "failed" },
 		});
+		// In-memory state is fully rolled back: no outcome entry, same leaf and entries.
 		expect(harness.sessionManager.getLeafId()).toBe(persistedLeafId);
 		expect(harness.sessionManager.getEntries()).toEqual(persistedEntries);
-		for (const [id, entry] of persistedEntryObjects) {
-			expect(harness.sessionManager.getEntry(id)).toBe(entry);
-		}
-		expect(harness.sessionManager.getEntries()).not.toContainEqual(
-			expect.objectContaining({ type: "custom_message", customType: "compaction_outcome" }),
-		);
 
+		// The next append attaches to the persisted leaf and rewrites a coherent file.
 		const nextId = harness.sessionManager.appendCustomEntry("after_failed_outcome");
 		const reloaded = SessionManager.open(sessionFile);
 		expect(reloaded.getEntry(nextId)?.parentId).toBe(persistedLeafId);

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,6 +1,8 @@
+import { appendFileSync } from "node:fs";
 import type { AgentMessage, ShouldStopAfterTurnContext } from "@earendil-works/pi-agent-core";
 import { type AssistantMessage, fauxAssistantMessage, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.js";
 import { createHarness, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
@@ -15,7 +17,7 @@ type SessionWithCompactionInternals = {
 		reason: "overflow" | "threshold" | "requested",
 		outcome: "skipped" | "cancelled" | "failed",
 		message: string,
-	) => boolean;
+	) => void;
 };
 
 function createUsage(totalTokens: number) {
@@ -1079,22 +1081,52 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.agent.convertToLlm([outcome!])).toEqual([]);
 	});
 
-	it("does not let outcome persistence failures replace compaction control flow", async () => {
-		const harness = await createHarness();
+	it("rolls back failed outcome persistence without breaking the persisted branch", async () => {
+		const harness = await createHarness({ persistSession: true });
 		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("persisted response")]);
+		await harness.session.prompt("persist this turn");
+
 		const internals = harness.session as unknown as SessionWithCompactionInternals;
-		vi.spyOn(harness.sessionManager, "appendCustomMessageEntry").mockImplementation(() => {
+		const sessionFile = harness.sessionManager.getSessionFile()!;
+		const persistedLeafId = harness.sessionManager.getLeafId();
+		const persistedEntries = harness.sessionManager.getEntries();
+		const persistedEntryObjects = new Map(persistedEntries.map((entry) => [entry.id, entry]));
+		vi.spyOn(harness.sessionManager, "_persist").mockImplementationOnce((entry) => {
+			// _appendEntry mutates all in-memory indexes before persistence is attempted.
+			expect(harness.sessionManager.getLeafId()).toBe(entry.id);
+			expect(harness.sessionManager.getEntry(entry.id)).toBe(entry);
+			appendFileSync(sessionFile, '{"type":"custom_message"');
 			throw new Error("disk full");
 		});
 
 		expect(() =>
 			internals._persistCompactionOutcome("requested", "failed", "Requested compaction failed"),
 		).not.toThrow();
-		expect(harness.session.messages).toContainEqual(
-			expect.objectContaining({
-				customType: "compaction_outcome",
-				content: "Requested compaction failed",
-			}),
+		const outcome = harness.session.messages.at(-1);
+		expect(outcome).toMatchObject({
+			role: "custom",
+			customType: "compaction_outcome",
+			content: expect.stringContaining("could not be saved to session history"),
+			details: { reason: "requested", outcome: "failed" },
+		});
+		expect(harness.sessionManager.getLeafId()).toBe(persistedLeafId);
+		expect(harness.sessionManager.getEntries()).toEqual(persistedEntries);
+		for (const [id, entry] of persistedEntryObjects) {
+			expect(harness.sessionManager.getEntry(id)).toBe(entry);
+		}
+		expect(harness.sessionManager.getEntries()).not.toContainEqual(
+			expect.objectContaining({ type: "custom_message", customType: "compaction_outcome" }),
+		);
+
+		const nextId = harness.sessionManager.appendCustomEntry("after_failed_outcome");
+		const reloaded = SessionManager.open(sessionFile);
+		expect(reloaded.getEntry(nextId)?.parentId).toBe(persistedLeafId);
+		expect(reloaded.getBranch().map((entry) => entry.id)).toEqual(
+			harness.sessionManager.getBranch().map((entry) => entry.id),
+		);
+		expect(reloaded.getEntries()).not.toContainEqual(
+			expect.objectContaining({ type: "custom_message", customType: "compaction_outcome" }),
 		);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1123,7 +1123,9 @@ describe("AgentSession compaction characterization", () => {
 		});
 
 		// A turn persisted after the failure sorts below the disclosure on rebuild,
-		// matching where the notice appeared live.
+		// matching where the notice appeared live. Cross a millisecond boundary so
+		// the later turn's timestamp is strictly newer.
+		await new Promise((resolve) => setTimeout(resolve, 5));
 		harness.setResponses([fauxAssistantMessage("later response")]);
 		await harness.session.prompt("later turn");
 		const reordered = harness.session.buildSessionContext().messages;
@@ -1135,5 +1137,46 @@ describe("AgentSession compaction characterization", () => {
 		);
 		expect(outcomeIndex).toBeGreaterThanOrEqual(0);
 		expect(laterTurnIndex).toBeGreaterThan(outcomeIndex);
+	});
+
+	it("keeps an unpersisted outcome in agent state after a successful compaction", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "post-failure summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: { source: "extension" },
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one response"), fauxAssistantMessage("two response")]);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		const internals = harness.session as unknown as SessionWithCompactionInternals;
+		vi.spyOn(harness.sessionManager, "_persist").mockImplementationOnce(() => {
+			throw new Error("disk full");
+		});
+		internals._persistCompactionOutcome("requested", "failed", "Requested compaction failed");
+
+		// A later successful compaction reloads agent.state.messages from the
+		// session file; the disclosure only exists in memory and must survive.
+		await harness.session.compact();
+
+		expect(harness.session.messages).toContainEqual(
+			expect.objectContaining({
+				role: "custom",
+				customType: "compaction_outcome",
+				content: expect.stringContaining("could not be saved to session history"),
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1114,5 +1114,12 @@ describe("AgentSession compaction characterization", () => {
 		expect(reloaded.getEntries()).not.toContainEqual(
 			expect.objectContaining({ type: "custom_message", customType: "compaction_outcome" }),
 		);
+		// The unpersisted disclosure survives context rebuilds (e.g. thinking toggle).
+		const rebuilt = harness.session.buildSessionContext();
+		expect(rebuilt.messages.at(-1)).toMatchObject({
+			role: "custom",
+			customType: "compaction_outcome",
+			content: expect.stringContaining("could not be saved to session history"),
+		});
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1122,9 +1122,7 @@ describe("AgentSession compaction characterization", () => {
 			content: expect.stringContaining("could not be saved to session history"),
 		});
 
-		// A turn persisted after the failure sorts below the disclosure on rebuild,
-		// matching where the notice appeared live. Cross a millisecond boundary so
-		// the later turn's timestamp is strictly newer.
+		// Cross a millisecond boundary so the later turn's timestamp is strictly newer.
 		await new Promise((resolve) => setTimeout(resolve, 5));
 		harness.setResponses([fauxAssistantMessage("later response")]);
 		await harness.session.prompt("later turn");
@@ -1167,8 +1165,8 @@ describe("AgentSession compaction characterization", () => {
 		});
 		internals._persistCompactionOutcome("requested", "failed", "Requested compaction failed");
 
-		// A later successful compaction reloads agent.state.messages from the
-		// session file; the disclosure only exists in memory and must survive.
+		// Compaction reloads agent.state.messages from the session file; the
+		// memory-only disclosure must survive.
 		await harness.session.compact();
 
 		expect(harness.session.messages).toContainEqual(

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -178,14 +178,14 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 	it("resets overflow recovery state when heartbeat prompt turns start", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const sessionInternals = harness.session as unknown as { _overflowRecoveryAttempted: boolean };
-		sessionInternals._overflowRecoveryAttempted = true;
+		const sessionInternals = harness.session as unknown as { _overflowRecovery: string };
+		sessionInternals._overflowRecovery = "attempted";
 		harness.setResponses([fauxAssistantMessage("heartbeat handled")]);
 
 		await harness.session.promptHeartbeat(createHeartbeat());
 		await harness.session.agent.waitForIdle();
 
-		expect(sessionInternals._overflowRecoveryAttempted).toBe(false);
+		expect(sessionInternals._overflowRecovery).toBe("idle");
 	});
 
 	it("keeps pending nextTurn context separate from queued heartbeat prompts", async () => {


### PR DESCRIPTION
## Summary

Unify durable compaction presentation on the session-owned input stack.

- one persisted compaction summary is the source of truth for live, reconnect, and resume
- exact retained-message boundary metadata places it chronologically before transcript limiting
- typed, validated failed/skipped/cancelled outcomes are durable, model-excluded, and rendered consistently live/replay
- malformed reserved outcomes are quarantined
- successful compaction clears stale transcript state before rebuilding
- context usage refreshes are generation-ordered

Stack base: #488. Validation: 197 focused tests passed; `npm run check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session file rewrite semantics and compaction/overflow recovery paths where data loss or wrong transcript ordering would be user-visible; changes are well-tested but span core persistence and agent loop behavior.
> 
> **Overview**
> Unifies how compaction is shown and recorded across the session stack, TUI, and headless print mode.
> 
> **Durable outcomes:** Failed, skipped, and cancelled compactions now emit typed `compaction_outcome` custom messages (persisted when possible, kept in memory if flush fails) instead of relying only on ephemeral `compaction_end` UI text. Overflow recovery uses a three-state `_overflowRecovery` flag so the post-retry failure notice is recorded once via `_endCompactionUnsuccessfully`.
> 
> **Transcript vs model context:** `buildSessionContext` still feeds the model summary-first but attaches `retainedMessageCount` on compaction summaries; the TUI reorders with `orderMessagesForTranscript` so the summary sits at the correct chronological boundary (including when limiting the initial transcript tail). Successful compaction no longer appends a synthetic summary—it rebuilds from the persisted session.
> 
> **Persistence:** Session file rewrites are atomic (temp file + rename, preserve mode/owner); `appendCustomMessageEntryWithRollback` rolls back in-memory leaf state on failed flush. Unpersisted outcomes are merged back into context on rebuilds.
> 
> **Headless / UX:** `selectHeadlessTerminalResult` walks trailing outcome suffixes for print mode (stderr + exit code on failure). Interactive mode renders outcome components, drops auto-compaction cancel toasts for non-manual reasons, and makes context-usage refresh generation-aware and non-blocking after turn end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb067cfe45af4ca053131707843c74d8075b8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify durable compaction outcome presentation across TUI, print mode, and session persistence
> - Adds `CompactionOutcomeMessage` (type `compaction_outcome`) to record failed, cancelled, or skipped compaction events durably in the session file, with in-memory fallback when persistence fails.
> - `AgentSession` now emits `compaction_end` with explicit outcome details and deduplicates overflow recovery failure notices after a single retry attempt.
> - The TUI renders compaction outcomes with new `CompactionOutcomeMessageComponent` / `MalformedCompactionOutcomeMessageComponent` components; on successful compaction the transcript is rebuilt from session messages rather than inserting a synthetic summary message.
> - Print mode reports trailing compaction outcome messages on stderr and exits non-zero if any outcome failed, using `selectHeadlessTerminalResult` to find the primary result regardless of trailing outcome messages.
> - `SessionManager` gains `appendCustomMessageEntryWithRollback` (rolls back in-memory state on flush failure) and an atomic, metadata-preserving `_rewriteFile`.
> - `buildSessionContext` places the compaction summary before retained messages and now includes `retainedMessageCount` so the TUI can position it at the correct transcript boundary.
> - Behavioral Change: non-manual compaction cancellations no longer display a cancellation message in the TUI; stats refresh after `turn_end` is now fire-and-forget to avoid blocking subsequent compaction events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbb067c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->