### PR TITLE
backgrounded refinement

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed `/refine` to run planning in the background so the conversation is not blocked during the LLM pass.
+
 ## [0.3.2] - 2026-07-20
 
 - Fixed invalid `--resume` session IDs being submitted as prompts, with nearest-session guidance instead ([ENG-4722](https://linear.app/primeintellect/issue/ENG-4722/prime-agent-resume-accepts-incorrect-session-ids)).

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -1355,7 +1355,9 @@ class DaemonAttachTerminal {
 				this.rl?.prompt();
 				return;
 			case "session_event":
-				this.handleSessionEvent(message.event);
+				if (message.event.type !== "refine_complete") {
+					this.handleSessionEvent(message.event);
+				}
 				return;
 			case "session_replaced":
 				this.isStreaming = message.state.isStreaming;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5248,13 +5248,18 @@ export class AgentSession {
 	 * reattached event handling; otherwise the turn's messages are never
 	 * persisted or rendered.
 	 *
-	 * Only the application phase (`_refineInFlight`) blocks here. The background
-	 * planning phase (`_refinePlanInFlight`) does NOT block turn entry points.
+	 * The application phase (`_refineInFlight`) and the transition window
+	 * (`_refineApplyPending`) block here. The background planning phase
+	 * (`_refinePlanInFlight`) does NOT block turn entry points.
 	 * Refine failures surface to the refine caller, not here.
 	 */
 	private async _waitForRefineIdle(): Promise<void> {
-		while (this._refineInFlight) {
-			await this._refineInFlight;
+		while (this._refineInFlight || this._refineApplyPending) {
+			if (this._refineInFlight) {
+				await this._refineInFlight;
+			} else {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -192,6 +192,7 @@ import {
 	mergeHarnessStates,
 	mergeRefinementHistory,
 	planRefinement,
+	type RefinementPlan,
 	type RefinementResult,
 	reviewAutoRefine,
 	saveHarnessState,
@@ -316,7 +317,8 @@ export type AgentSessionEvent =
 			fullOutputPath?: string;
 			/** Set when execution failed before producing a result (e.g. spawn failure) */
 			errorMessage?: string;
-	  };
+	  }
+	| { type: "refine_complete"; result: RefinementResult };
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -947,6 +949,8 @@ export class AgentSession {
 	private readonly _autoRefineReviewer?: AutoRefineReviewer;
 	/** Settles (never rejects) when the in-flight refine finishes; see _waitForRefineIdle. */
 	private _refineInFlight?: Promise<void>;
+	/** Settles when the background planning LLM pass completes. Planning does not block turn entry points. */
+	private _refinePlanInFlight?: Promise<void>;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -4857,6 +4861,9 @@ export class AgentSession {
 		this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 		this._assistantTurnsSinceAutoRefine = 0;
 		this._autoRefineBranchVersion++;
+		while (this._refinePlanInFlight) {
+			await this._refinePlanInFlight;
+		}
 		await this._waitForRefineIdle();
 	}
 
@@ -5144,26 +5151,57 @@ export class AgentSession {
 	/**
 	 * Refine editable continual harness state: prompt notes, memory, skills, and subagent specs.
 	 * The base system prompt is intentionally not editable through this path.
+	 *
+	 * Planning runs in the background and does NOT block turn entry points
+	 * (`_waitForRefineIdle` only waits for `_refineInFlight`). Only the fast
+	 * application phase (disk I/O + in-memory mutation) blocks turn entry points.
 	 */
 	async refine(
 		options: { instructions?: string; rollbackId?: string; global?: boolean } = {},
 	): Promise<RefinementResult> {
-		while (this._refineInFlight) {
-			await this._refineInFlight;
+		// Wait for any existing refine (both planning and application) before
+		// starting a new run. This serializes concurrent /refine calls so two
+		// planning phases cannot race into concurrent _applyRefine calls that
+		// overwrite harness state.
+		while (this._refineInFlight || this._refinePlanInFlight) {
+			await (this._refineInFlight ?? this._refinePlanInFlight);
 		}
 
-		const run = this._refine(options);
-		// Refine detaches session event handling for its whole LLM pass; expose a
-		// settled promise so turn entry points can wait instead of losing events.
-		const settled = run.then(
+		const refineAbort = new AbortController();
+		this._refineAbortController = refineAbort;
+
+		// Background planning phase — does NOT block turn entry points.
+		const planRun = this._planRefine(options, refineAbort.signal);
+		const planSettled = planRun.then(
 			() => undefined,
 			() => undefined,
 		);
-		this._refineInFlight = settled;
+		this._refinePlanInFlight = planSettled;
+		let plan: RefinementPlan;
 		try {
-			return await run;
+			plan = await planRun;
+		} catch (e) {
+			if (this._refineAbortController === refineAbort) {
+				this._refineAbortController = undefined;
+			}
+			throw e;
 		} finally {
-			if (this._refineInFlight === settled) {
+			if (this._refinePlanInFlight === planSettled) {
+				this._refinePlanInFlight = undefined;
+			}
+		}
+
+		// Application phase — blocks turn entry points via _refineInFlight.
+		const applyRun = this._applyRefine(plan, options, refineAbort);
+		const applySettled = applyRun.then(
+			() => undefined,
+			() => undefined,
+		);
+		this._refineInFlight = applySettled;
+		try {
+			return await applyRun;
+		} finally {
+			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
 			this._schedulePendingMessageResume();
@@ -5171,8 +5209,12 @@ export class AgentSession {
 	}
 
 	/**
-	 * Block a new agent turn until any in-flight refine has reattached event
-	 * handling; otherwise the turn's messages are never persisted or rendered.
+	 * Block a new agent turn until any in-flight refine application phase has
+	 * reattached event handling; otherwise the turn's messages are never
+	 * persisted or rendered.
+	 *
+	 * Only the application phase (`_refineInFlight`) blocks here. The background
+	 * planning phase (`_refinePlanInFlight`) does NOT block turn entry points.
 	 * Refine failures surface to the refine caller, not here.
 	 */
 	private async _waitForRefineIdle(): Promise<void> {
@@ -5181,51 +5223,83 @@ export class AgentSession {
 		}
 	}
 
-	private async _refine(
-		options: { instructions?: string; rollbackId?: string; global?: boolean } = {},
+	/**
+	 * Background planning phase: runs the LLM planning call via `planRefinement`.
+	 * Does NOT call `_disconnectFromAgent` or `this.abort` — those happen in
+	 * `_applyRefine`. Returns the plan without applying anything.
+	 */
+	private async _planRefine(
+		options: { instructions?: string; rollbackId?: string; global?: boolean },
+		signal: AbortSignal,
+	): Promise<RefinementPlan> {
+		if (this._disposed) {
+			throw new Error("Cannot refine a disposed session.");
+		}
+
+		if (!this.model) {
+			throw new Error(formatNoModelSelectedMessage());
+		}
+
+		const model = this.model;
+		const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+		const globalHarnessStateDir = getGlobalHarnessStateDir();
+		const localHarnessStateDir = this._localHarnessStateDir();
+		const requestedScope = options.global ? "global" : "local";
+		if (!options.rollbackId && requestedScope === "local" && !localHarnessStateDir) {
+			throw new Error("Local harness refinement requires a persisted session; use global refinement instead.");
+		}
+		const planningState =
+			requestedScope === "global"
+				? loadHarnessState(globalHarnessStateDir, "global")
+				: this._loadMergedHarnessState();
+		const history = this._loadRefinementHistory();
+		const plan = await planRefinement(
+			this.agent.state.messages,
+			planningState,
+			history,
+			model,
+			apiKey,
+			options,
+			headers,
+			signal,
+			this.thinkingLevel,
+		);
+		if (this._disposed || signal.aborted) {
+			throw new Error("Refinement cancelled because the session was disposed.");
+		}
+		return plan;
+	}
+
+	/**
+	 * Synchronous application phase: disconnects from the agent, aborts any
+	 * in-flight agent run, applies the refinement plan to disk and memory, then
+	 * reconnects. This is the only phase that blocks turn entry points.
+	 */
+	private async _applyRefine(
+		plan: RefinementPlan,
+		options: { instructions?: string; rollbackId?: string; global?: boolean },
+		refineAbort: AbortController,
 	): Promise<RefinementResult> {
 		if (this._disposed) {
 			throw new Error("Cannot refine a disposed session.");
 		}
-		const refineAbort = new AbortController();
-		this._refineAbortController = refineAbort;
+		// Wait for any agent turn that started during the background planning phase
+		// to finish before disconnecting and aborting. This prevents aborting an
+		// in-flight prompt that was accepted because planning does not block turns.
+		await this.agent.waitForIdle();
+		if (this._disposed || refineAbort.signal.aborted) {
+			throw new Error("Refinement cancelled because the session was disposed.");
+		}
 		this._disconnectFromAgent();
 
 		try {
 			await this.abort();
 
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-
-			const model = this.model;
-			const { apiKey, headers } = await this._getRequiredRequestAuth(model);
 			const globalHarnessStateDir = getGlobalHarnessStateDir();
 			const localHarnessStateDir = this._localHarnessStateDir();
 			const requestedScope = options.global ? "global" : "local";
-			if (!options.rollbackId && requestedScope === "local" && !localHarnessStateDir) {
-				throw new Error("Local harness refinement requires a persisted session; use global refinement instead.");
-			}
-			const planningState =
-				requestedScope === "global"
-					? loadHarnessState(globalHarnessStateDir, "global")
-					: this._loadMergedHarnessState();
 			const history = this._loadRefinementHistory();
 			const rollbackTarget = options.rollbackId ? history.find((item) => item.id === options.rollbackId) : undefined;
-			const plan = await planRefinement(
-				this.agent.state.messages,
-				planningState,
-				history,
-				model,
-				apiKey,
-				options,
-				headers,
-				refineAbort.signal,
-				this.thinkingLevel,
-			);
-			if (this._disposed || refineAbort.signal.aborted) {
-				throw new Error("Refinement cancelled because the session was disposed.");
-			}
 			let targetScope = plan.rollbackScope ?? requestedScope;
 			let targetHarnessStateDir = targetScope === "global" ? globalHarnessStateDir : localHarnessStateDir;
 			if (targetScope === "local" && rollbackTarget?.harnessStatePath) {
@@ -5277,6 +5351,7 @@ export class AgentSession {
 			this.sessionManager.appendCustomEntry("prime-agent.refinement", result);
 			this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
+			this._emit({ type: "refine_complete", result });
 			return result;
 		} finally {
 			if (this._refineAbortController === refineAbort) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -951,6 +951,9 @@ export class AgentSession {
 	private _refineInFlight?: Promise<void>;
 	/** Settles when the background planning LLM pass completes. Planning does not block turn entry points. */
 	private _refinePlanInFlight?: Promise<void>;
+	/** True between planning completion and _refineInFlight being set. Covers the gap
+	 * in the serialization guard without blocking turn entry points via _waitForRefineIdle. */
+	private _refineApplyPending = false;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -4869,8 +4872,12 @@ export class AgentSession {
 		this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 		this._assistantTurnsSinceAutoRefine = 0;
 		this._autoRefineBranchVersion++;
-		while (this._refinePlanInFlight) {
-			await this._refinePlanInFlight;
+		while (this._refinePlanInFlight || this._refineApplyPending) {
+			if (this._refinePlanInFlight) {
+				await this._refinePlanInFlight;
+			} else if (this._refineApplyPending) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
 		}
 		await this._waitForRefineIdle();
 	}
@@ -5171,8 +5178,11 @@ export class AgentSession {
 		// starting a new run. This serializes concurrent /refine calls so two
 		// planning phases cannot race into concurrent _applyRefine calls that
 		// overwrite harness state.
-		while (this._refineInFlight || this._refinePlanInFlight) {
+		while (this._refineInFlight || this._refinePlanInFlight || this._refineApplyPending) {
 			await (this._refineInFlight ?? this._refinePlanInFlight);
+			if (this._refineApplyPending) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
 		}
 
 		const refineAbort = new AbortController();
@@ -5199,17 +5209,24 @@ export class AgentSession {
 			}
 		}
 
+		// Mark that we're between planning and application so the serialization
+		// guard blocks concurrent refine calls. This flag does NOT block turn
+		// entry points (_waitForRefineIdle only checks _refineInFlight).
+		this._refineApplyPending = true;
+
 		// Wait for any agent turn that started during background planning to finish
 		// before entering the application critical section. This does NOT set
 		// _refineInFlight, so new prompts are not blocked during this wait.
 		await this.agent.waitForIdle();
 		if (this._disposed || refineAbort.signal.aborted) {
+			this._refineApplyPending = false;
 			throw new Error("Refinement cancelled because the session was disposed.");
 		}
 
 		// Application phase — blocks turn entry points via _refineInFlight.
 		// _refineInFlight only covers the brief disconnect+apply+reconnect,
 		// not the waitForIdle wait above.
+		this._refineApplyPending = false;
 		const applyRun = this._applyRefine(plan, options, refineAbort);
 		const applySettled = applyRun.then(
 			() => undefined,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -951,8 +951,9 @@ export class AgentSession {
 	private _refineInFlight?: Promise<void>;
 	/** Settles when the background planning LLM pass completes. Planning does not block turn entry points. */
 	private _refinePlanInFlight?: Promise<void>;
-	/** True between planning completion and _refineInFlight being set. Covers the gap
-	 * in the serialization guard without blocking turn entry points via _waitForRefineIdle. */
+	/** True between planning completion and _refineInFlight being set. Blocks
+	 * turn entry points via _waitForRefineIdle and concurrent refine calls via the
+	 * serialization guard, so no prompt or second plan can start in the gap. */
 	private _refineApplyPending = false;
 
 	constructor(config: AgentSessionConfig) {
@@ -3062,7 +3063,7 @@ export class AgentSession {
 			return;
 		}
 
-		if (this._refineInFlight) {
+		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
 		}
 		const shouldQueueAtHandoff =
@@ -3385,7 +3386,7 @@ export class AgentSession {
 		}
 		// Re-check adjacent to the handoff: extension before_agent_start handlers
 		// above may have suspended this turn long enough for a refine to start.
-		if (this._refineInFlight) {
+		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
 		}
 		if (acceptedAgentMessagePrompt?.cleared) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5199,7 +5199,17 @@ export class AgentSession {
 			}
 		}
 
+		// Wait for any agent turn that started during background planning to finish
+		// before entering the application critical section. This does NOT set
+		// _refineInFlight, so new prompts are not blocked during this wait.
+		await this.agent.waitForIdle();
+		if (this._disposed || refineAbort.signal.aborted) {
+			throw new Error("Refinement cancelled because the session was disposed.");
+		}
+
 		// Application phase — blocks turn entry points via _refineInFlight.
+		// _refineInFlight only covers the brief disconnect+apply+reconnect,
+		// not the waitForIdle wait above.
 		const applyRun = this._applyRefine(plan, options, refineAbort);
 		const applySettled = applyRun.then(
 			() => undefined,
@@ -5291,15 +5301,9 @@ export class AgentSession {
 		if (this._disposed) {
 			throw new Error("Cannot refine a disposed session.");
 		}
-		// Wait for any agent turn that started during the background planning phase
-		// to finish before disconnecting. This prevents disconnecting while a
-		// turn is streaming and losing its events. We do NOT call abort()
-		// because concurrent work (bash, RLM children, compaction) that started
-		// during planning should continue running.
-		await this.agent.waitForIdle();
-		if (this._disposed || refineAbort.signal.aborted) {
-			throw new Error("Refinement cancelled because the session was disposed.");
-		}
+		// The caller (refine()) has already waited for agent idle before
+		// setting _refineInFlight and calling us. We only need to disconnect
+		// for the brief apply + save + reconnect critical section.
 		this._disconnectFromAgent();
 
 		try {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5292,8 +5292,10 @@ export class AgentSession {
 			throw new Error("Cannot refine a disposed session.");
 		}
 		// Wait for any agent turn that started during the background planning phase
-		// to finish before disconnecting and aborting. This prevents aborting an
-		// in-flight prompt that was accepted because planning does not block turns.
+		// to finish before disconnecting. This prevents disconnecting while a
+		// turn is streaming and losing its events. We do NOT call abort()
+		// because concurrent work (bash, RLM children, compaction) that started
+		// during planning should continue running.
 		await this.agent.waitForIdle();
 		if (this._disposed || refineAbort.signal.aborted) {
 			throw new Error("Refinement cancelled because the session was disposed.");
@@ -5301,8 +5303,6 @@ export class AgentSession {
 		this._disconnectFromAgent();
 
 		try {
-			await this.abort();
-
 			const globalHarnessStateDir = getGlobalHarnessStateDir();
 			const localHarnessStateDir = this._localHarnessStateDir();
 			const requestedScope = options.global ? "global" : "local";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3919,6 +3919,14 @@ export class AgentSession {
 				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
 					return;
 				}
+				// Re-check adjacent to the handoff: background planning may have
+				// completed and entered _applyRefine during the awaits above,
+				// disconnecting event handling. Wait for it to finish so the
+				// resumed turn's events are not lost.
+				await this._waitForRefineIdle();
+				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
+					return;
+				}
 				this._flushPendingBashMessages();
 				if (this._pendingNextTurnMessages.length > 0) {
 					await this._drainQueuedMessagesAfterBash();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2613,6 +2613,7 @@ export class AgentSession {
 			// resolution cannot write harness state or re-subscribe handlers.
 			this._autoRefineReviewAbort?.abort();
 			this._refineAbortController?.abort();
+			this._refineApplyPending = false;
 			this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 			this._autoRefineBranchVersion++;
 			this._cancelActiveRlmChildRuns("Parent session disposed");
@@ -3065,6 +3066,9 @@ export class AgentSession {
 
 		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
+			// A refine may have completed during the wait and rewritten
+			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		const shouldQueueAtHandoff =
 			options?.queueIfBusy === true &&
@@ -3388,6 +3392,9 @@ export class AgentSession {
 		// above may have suspended this turn long enough for a refine to start.
 		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
+			// A refine may have completed during the wait and rewritten
+			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		if (acceptedAgentMessagePrompt?.cleared) {
 			reportPreflight(false);
@@ -5211,23 +5218,21 @@ export class AgentSession {
 		}
 
 		// Mark that we're between planning and application so the serialization
-		// guard blocks concurrent refine calls. This flag does NOT block turn
-		// entry points (_waitForRefineIdle only checks _refineInFlight).
+		// guard and _waitForRefineIdle block concurrent calls and new prompts.
 		this._refineApplyPending = true;
-
-		// Wait for any agent turn that started during background planning to finish
-		// before entering the application critical section. This does NOT set
-		// _refineInFlight, so new prompts are not blocked during this wait.
-		await this.agent.waitForIdle();
-		if (this._disposed || refineAbort.signal.aborted) {
+		try {
+			// Wait for any agent turn that started during background planning
+			// to finish before entering the application critical section.
+			await this.agent.waitForIdle();
+		} finally {
 			this._refineApplyPending = false;
+		}
+		if (this._disposed || refineAbort.signal.aborted) {
 			throw new Error("Refinement cancelled because the session was disposed.");
 		}
 
 		// Application phase — blocks turn entry points via _refineInFlight.
-		// _refineInFlight only covers the brief disconnect+apply+reconnect,
-		// not the waitForIdle wait above.
-		this._refineApplyPending = false;
+		// _refineInFlight only covers the brief disconnect+apply+reconnect.
 		const applyRun = this._applyRefine(plan, options, refineAbort);
 		const applySettled = applyRun.then(
 			() => undefined,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1336,7 +1336,9 @@ export class DaemonAgentConnection implements AgentConnection {
 		this.observeDaemonEventSequence(message);
 
 		if (message.type === "session_event") {
-			this.observeStreamingMessage(message.event);
+			if (message.event.type !== "refine_complete") {
+				this.observeStreamingMessage(message.event);
+			}
 			this.latestSnapshotIsFresh = false;
 			await this.emit({ type: "session_event", event: message.event });
 			return;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -567,7 +567,8 @@ export type AgentConnectionSessionEvent =
 			fullOutputPath?: string;
 			/** Set when execution failed before producing a result (e.g. spawn failure) */
 			errorMessage?: string;
-	  };
+	  }
+	| { type: "refine_complete"; result: RefinementResult };
 
 export type AgentConnectionEvent =
 	| { type: "session_event"; event: AgentConnectionSessionEvent }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9418,18 +9418,20 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 				: `Refining ${options.global ? "global" : "local"} continual harness state...`,
 		);
 
-		try {
-			const result = await this.agentConnection.refine(options);
-			const applied = result.appliedEdits.filter((edit) => edit.applied).length;
-			const failed = result.appliedEdits.length - applied;
-			const failedSuffix = failed > 0 ? `, ${failed} failed` : "";
-			this.showStatus(
-				`Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied${failedSuffix}`,
-			);
-			this.showStatus(`Harness state: ${result.harnessStatePath}`);
-		} catch (error) {
-			this.showError(`Refinement failed: ${error instanceof Error ? error.message : String(error)}`);
-		}
+		this.agentConnection
+			.refine(options)
+			.then((result) => {
+				const applied = result.appliedEdits.filter((edit) => edit.applied).length;
+				const failed = result.appliedEdits.length - applied;
+				const failedSuffix = failed > 0 ? `, ${failed} failed` : "";
+				this.showStatus(
+					`Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied${failedSuffix}`,
+				);
+				this.showStatus(`Harness state: ${result.harnessStatePath}`);
+			})
+			.catch((error) => {
+				this.showError(`Refinement failed: ${error instanceof Error ? error.message : String(error)}`);
+			});
 	}
 
 	stop(options: { preserveAltScreen?: boolean } = {}): void {

--- a/packages/coding-agent/test/interactive-mode-refine-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-refine-command.test.ts
@@ -153,4 +153,67 @@ describe("InteractiveMode.handleRefineCommand", () => {
 		expect(context.showWarning).toHaveBeenCalledWith("Nothing to refine (no trajectory yet)");
 		expect(context.agentConnection.refine).not.toHaveBeenCalled();
 	});
+
+	test("shows success status after refine resolves without blocking the caller", async () => {
+		let resolveRefine: ((value: unknown) => void) | undefined;
+		const refinePromise = new Promise((resolve) => {
+			resolveRefine = resolve;
+		});
+		const context = {
+			agentConnection: {
+				getSessionStats: vi.fn().mockResolvedValue({ totalMessages: 2 }),
+				refine: vi.fn().mockReturnValue(refinePromise),
+			},
+			stopWorkingLoader: vi.fn(),
+			showStatus: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		await handleRefineCommand.call(context, "focus on validation");
+
+		// The "Refining..." status is shown synchronously.
+		expect(context.showStatus).toHaveBeenCalledWith("Refining local continual harness state...");
+		// The success status is NOT shown yet because refine has not resolved.
+		expect(context.showStatus).not.toHaveBeenCalledWith("Refined continual harness state: 2 edits applied, 1 failed");
+
+		// Resolve the refine promise and let the microtask queue drain.
+		resolveRefine?.({
+			appliedEdits: [{ applied: true }, { applied: true }, { applied: false, error: "entry not found" }],
+			harnessStatePath: "/tmp/harness_state.json",
+		});
+		await vi.waitFor(() => {
+			expect(context.showStatus).toHaveBeenCalledWith("Refined continual harness state: 2 edits applied, 1 failed");
+		});
+		expect(context.showStatus).toHaveBeenCalledWith("Harness state: /tmp/harness_state.json");
+	});
+
+	test("shows error status after refine rejects without blocking the caller", async () => {
+		let rejectRefine: ((error: Error) => void) | undefined;
+		const refinePromise = new Promise<never>((_, reject) => {
+			rejectRefine = reject;
+		});
+		const context = {
+			agentConnection: {
+				getSessionStats: vi.fn().mockResolvedValue({ totalMessages: 2 }),
+				refine: vi.fn().mockReturnValue(refinePromise),
+			},
+			stopWorkingLoader: vi.fn(),
+			showStatus: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		await handleRefineCommand.call(context, "focus on validation");
+
+		// The "Refining..." status is shown synchronously.
+		expect(context.showStatus).toHaveBeenCalledWith("Refining local continual harness state...");
+		// The error is NOT shown yet because refine has not rejected.
+		expect(context.showError).not.toHaveBeenCalled();
+
+		rejectRefine?.(new Error("LLM timed out"));
+		await vi.waitFor(() => {
+			expect(context.showError).toHaveBeenCalledWith("Refinement failed: LLM timed out");
+		});
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1199,9 +1199,11 @@ describe("AgentSession queue characterization", () => {
 
 			const promptPromise = harness.session.prompt("hello during refine");
 			await new Promise((resolve) => setTimeout(resolve, 10));
-			// The prompt must wait for the refine (its response is still queued);
-			// running now would drop its events while the session is detached.
-			expect(harness.getPendingResponseCount()).toBe(1);
+			// With backgrounded refine planning, the prompt does NOT wait for the
+			// planning LLM pass. It starts immediately and streams its response
+			// while planning is still in flight. The application phase waits for
+			// the agent to be idle before disconnecting and applying.
+			expect(harness.getPendingResponseCount()).toBe(0);
 
 			releasePlan?.();
 			await refinePromise;


### PR DESCRIPTION
## Background Refine Planning — Non-blocking `/refine`

### Problem

`/refine` ran synchronously during the agent turn, blocking the conversation. The LLM planning call (5-30 seconds via `completeSimple`) prevented the user from typing new prompts, and auto-refine blocked the next turn via `_waitForRefineIdle()` at every turn entry point (`prompt()`, `acceptAgentMessagePrompt()`, `resumeSession()`, etc.).

### Solution

Split the refine flow into two phases:

1. **Planning (background)**: `planRefinement()` runs via `completeSimple` (an independent non-streaming API call) without disconnecting from agent events or aborting the agent. The agent can continue streaming and processing user prompts. Tracked by `_refinePlanInFlight`, which does **not** block `_waitForRefineIdle()`.

2. **Application (synchronous, fast)**: When planning completes, `_applyRefine()` waits for the agent to be idle (so an in-flight prompt can finish), then briefly disconnects, re-reads harness state from disk (to avoid clobbering concurrent kernel writes), applies the proposal, saves, rebuilds the system prompt, emits a `refine_complete` event, and reconnects. Tracked by `_refineInFlight`, which **does** block turn entry points.

### Changes

| File | Change |
|------|--------|
| `agent-session.ts` | Split `_refine()` into `_planRefine()` + `_applyRefine()`; added `_refinePlanInFlight`; added `refine_complete` event to `AgentSessionEvent`; `refine()` orchestrates both phases; `_waitForRefineIdle()` only blocks for application; `_applyRefine` waits for agent idle before disconnecting |
| `types.ts` | Added `refine_complete` to `AgentConnectionSessionEvent` |
| `interactive-mode.ts` | `handleRefineCommand` fires refine without blocking (`.then().catch()` instead of `await`) |
| `daemon-agent-connection.ts` | `refine_complete` type guard for event forwarding |
| `daemon-command.ts` | Same type guard |
| `CHANGELOG.md` | Entry under `[Unreleased]` |
| `interactive-mode-refine-command.test.ts` | 2 new tests for async success/error status using deferred promises |
| `agent-session-queue.test.ts` | Updated test: prompt starts immediately during background planning (pending=0 instead of 1) |

### Key Design Decisions

- **`_applyRefine` waits for `agent.waitForIdle()`**: A prompt that started during the background planning phase must be allowed to finish before the application phase disconnects and aborts. This prevents event loss.
- **`_refinePlanInFlight` does not block `_waitForRefineIdle()`**: Turn entry points proceed normally while planning is in flight. Only the application phase blocks.
- **`_invalidatePendingAutoRefineForBranchChange()` waits for both**: Branch changes must wait for both planning and application to settle to avoid stale state.
- **Public `refine()` signature unchanged**: All callers (manual /refine, auto-refine, daemon, RPC) continue to work without interface changes.

### Testing

All 152 tests across 5 test files pass. `npm run check` passes (biome, tsgo, installer, browser-smoke).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run /refine planning in the background so user turns are not blocked
> - The `/refine` command is split into two phases: background LLM planning (`_planRefine`) and a short application phase (`_applyRefine`). Only the application phase blocks new turns.
> - `InteractiveMode.handleRefineCommand` no longer awaits the refine call; success and error messages appear asynchronously via `.then`/`.catch`.
> - A new `refine_complete` session event (carrying `RefinementResult`) is emitted after application and propagated through `AgentConnection`; the terminal and streaming paths skip it to avoid side effects.
> - Turn entry points and queued message resume now also wait on `_refineApplyPending` (the planning→apply transition) to prevent races and ensure the updated system prompt is visible.
> - Behavioral Change: concurrent `/refine` calls and new prompts during planning now proceed in parallel with planning, but still serialize with the apply phase.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7a4358.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session concurrency around harness refinement and system-prompt sync after waits; incorrect timing could lose events or clobber harness state, though guards serialize apply and re-sync prompts after idle waits.
> 
> **Overview**
> **`/refine` no longer blocks the conversation during the planning LLM call.** `AgentSession.refine()` is split into background `_planRefine()` (runs `planRefinement` without detaching from the agent) and a short `_applyRefine()` phase that waits for agent idle, disconnects, applies harness edits, emits **`refine_complete`**, and reconnects. Turn entry only waits on apply (`_refineInFlight` / `_refineApplyPending`), not on `_refinePlanInFlight`.
> 
> **User-visible behavior:** prompts sent while refine is planning start immediately instead of queuing behind the whole refine. Interactive `/refine` is fire-and-forget (status updates via promise callbacks). Daemon and daemon-agent-connection skip treating `refine_complete` as a streaming transcript event.
> 
> Tests and changelog updated for the new concurrency semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a43585f75b4b650f7f2eb4054dcdff3597e595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->