### PR TITLE
feat(runtime): support anonymous MCP integrations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added anonymous endpoints and configurable HTTP timeouts to Python-backed MCP integrations.
+
 ## [0.3.2] - 2026-07-20
 
 - Fixed invalid `--resume` session IDs being submitted as prompts, with nearest-session guidance instead ([ENG-4722](https://linear.app/primeintellect/issue/ENG-4722/prime-agent-resume-accepts-incorrect-session-ids)).

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -12,9 +12,9 @@ import linear
 issues = await linear.list_issues(team="Engineering")
 ```
 
-The MCP connection runs inside the kernel via the official `mcp` Python SDK. The
-host's only jobs are interactive login (browser OAuth) and minting/refreshing
-credentials in `auth.json`.
+The MCP connection runs inside the kernel via the official `mcp` Python SDK. For
+authenticated integrations, the host handles interactive login (browser OAuth)
+and minting/refreshing credentials in `auth.json`.
 
 ## Table of Contents
 
@@ -175,6 +175,20 @@ is a few lines — the package above is the whole integration.
 - **Static bearer token** (`"bearerTokenEnvVar": "ACME_TOKEN"`): no login needed;
   the integration is "connected" whenever that env var is set. Set the matching
   `bearer_token_env = "ACME_TOKEN"` on the subclass.
+- **No authentication**: for an endpoint that intentionally accepts anonymous
+  requests, set `requires_auth = False` on the subclass. The integration skips
+  `auth.json` and does not inject an `Authorization` header.
+
+Long-running MCP tools can also override the transport timeouts on the subclass:
+
+```python
+class Acme(McpIntegration):
+    server = "acme"
+    url = "https://mcp.acme.com/mcp"
+    requires_auth = False
+    request_timeout = 120       # regular HTTP operations, seconds
+    sse_read_timeout = 15_000   # silent streaming response, seconds
+```
 
 ## The `McpIntegration` API
 
@@ -186,6 +200,11 @@ Class attributes to set on your subclass:
 - `url: str | None` — the remote endpoint (required unless you override
   `_open_session` for a non-HTTP transport).
 - `bearer_token_env: str | None` — optional env var holding a static bearer token.
+- `requires_auth: bool` — whether to require and inject a bearer token; defaults
+  to `True`.
+- `request_timeout: float | None` — optional regular HTTP timeout in seconds.
+- `sse_read_timeout: float | None` — optional streaming read timeout in seconds
+  for long-running tools.
 
 Methods:
 

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -8,10 +8,12 @@ methods, so the agent writes ordinary Python:
     import linear
     issues = await linear.list_issues(team="Engineering")
 
-Credentials live in the host's ``auth.json`` (single store, survives kernel
-rebuilds). This module reads that file directly for the common case; on token
-expiry it asks the host to refresh via ``rlm.host_request("mcp.refresh", ...)``
-and re-reads. Interactive login runs host-side, never here.
+Authenticated integrations keep credentials in the host's ``auth.json`` (single
+store, survives kernel rebuilds). This module reads that file directly for the
+common case; on token expiry it asks the host to refresh via
+``rlm.host_request("mcp.refresh", ...)`` and re-reads. Interactive login runs
+host-side, never here. Integrations whose endpoint intentionally accepts no
+authentication can set ``requires_auth = False``.
 """
 
 from __future__ import annotations
@@ -127,9 +129,25 @@ class McpIntegration:
     #: Optional env var holding a static bearer token (used instead of auth.json OAuth).
     bearer_token_env: str | None = None
 
+    #: Require and inject a bearer token. Set false only for endpoints that
+    #: intentionally accept unauthenticated requests.
+    requires_auth: bool = True
+
+    #: Optional regular HTTP request timeout, in seconds. ``None`` preserves the
+    #: transport SDK's default.
+    request_timeout: float | None = None
+
+    #: Optional streaming-response read timeout, in seconds. Use this for MCP
+    #: tools that may remain silent while performing long-running work.
+    sse_read_timeout: float | None = None
+
     def __init__(self) -> None:
         if not self.server:
             raise ValueError(f"{type(self).__name__} must set a non-empty `server`")
+        for attribute in ("request_timeout", "sse_read_timeout"):
+            value = getattr(self, attribute)
+            if value is not None and value <= 0:
+                raise ValueError(f"{type(self).__name__}.{attribute} must be positive")
         self._tools: dict[str, Any] | None = None
         self._lock = asyncio.Lock()
 
@@ -219,19 +237,46 @@ class McpIntegration:
             raise ValueError(
                 f"{type(self).__name__} must set `url` or override `_open_session`"
             )
-        token = await self._resolve_token()
         transport = _resolve_streamable_http()
-        # Extra configured headers first, Authorization last so it always wins.
-        auth_header = {**extra_headers, "Authorization": f"Bearer {token}"}
+        headers = dict(extra_headers)
+        if self.requires_auth:
+            token = await self._resolve_token()
+            # Extra configured headers first, Authorization last so it always wins.
+            headers["Authorization"] = f"Bearer {token}"
 
         # SDK signatures vary: some take headers=, others only http_client=.
         params = inspect.signature(transport).parameters
         if "headers" in params:
-            cm = transport(url, headers=auth_header)
+            kwargs: dict[str, Any] = {"headers": headers}
+            unsupported: list[str] = []
+            if self.request_timeout is not None:
+                if "timeout" in params:
+                    kwargs["timeout"] = self.request_timeout
+                else:
+                    unsupported.append("request_timeout")
+            if self.sse_read_timeout is not None:
+                if "sse_read_timeout" in params:
+                    kwargs["sse_read_timeout"] = self.sse_read_timeout
+                else:
+                    unsupported.append("sse_read_timeout")
+            if unsupported:
+                raise RuntimeError(
+                    "mcp streamable-HTTP client does not support configured "
+                    + ", ".join(unsupported)
+                )
+            cm = transport(url, **kwargs)
         elif "http_client" in params:
             import httpx  # noqa: PLC0415
 
-            client = await stack.enter_async_context(httpx.AsyncClient(headers=auth_header))
+            client_kwargs: dict[str, Any] = {"headers": headers}
+            if self.sse_read_timeout is not None:
+                default_timeout = self.request_timeout or 5.0
+                client_kwargs["timeout"] = httpx.Timeout(
+                    default_timeout, read=self.sse_read_timeout
+                )
+            elif self.request_timeout is not None:
+                client_kwargs["timeout"] = self.request_timeout
+            client = await stack.enter_async_context(httpx.AsyncClient(**client_kwargs))
             cm = transport(url, http_client=client)
         else:
             raise RuntimeError(

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -192,15 +192,30 @@ class McpIntegrationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             Bad()
 
-    def _run_open_session_with_transport(self, transport):
+    def test_rejects_non_positive_transport_timeout(self):
+        class Bad(_Integration):
+            sse_read_timeout = 0
+
+        with self.assertRaisesRegex(ValueError, "sse_read_timeout must be positive"):
+            Bad()
+
+    def _run_open_session_with_transport(
+        self, transport, integration_cls=_Integration, *, with_auth=True
+    ):
         """Drive the real _open_session against a fake transport callable.
 
         `transport` must declare its real parameters (headers= or http_client=)
         so the signature inspection in _open_session is exercised faithfully.
         """
-        self._write_auth(
-            {"type": "oauth", "access": "tok-xyz", "refresh": "r", "expires": (time.time() + 3600) * 1000}
-        )
+        if with_auth:
+            self._write_auth(
+                {
+                    "type": "oauth",
+                    "access": "tok-xyz",
+                    "refresh": "r",
+                    "expires": (time.time() + 3600) * 1000,
+                }
+            )
 
         async def fake_host_request(req_type, payload):
             return {}  # no host URL override; _resolve_url falls back to self.url
@@ -215,7 +230,7 @@ class McpIntegrationTest(unittest.TestCase):
             )
             session_cls.return_value.__aenter__ = mock.AsyncMock(return_value=session)
             session_cls.return_value.__aexit__ = mock.AsyncMock(return_value=False)
-            _run(_Integration().call_tool("noop", {}))
+            _run(integration_cls().call_tool("noop", {}))
 
     def test_open_session_uses_headers_signature(self):
         # streamablehttp_client(url, headers=...)
@@ -235,6 +250,68 @@ class McpIntegrationTest(unittest.TestCase):
         self._run_open_session_with_transport(transport)
         self.assertEqual(captured["headers"], {"Authorization": "Bearer tok-xyz"})
 
+    def test_open_session_supports_anonymous_servers(self):
+        captured = {}
+
+        class AnonymousIntegration(_Integration):
+            requires_auth = False
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, headers=None):
+            captured["headers"] = headers
+            return _CM()
+
+        self._run_open_session_with_transport(
+            transport, AnonymousIntegration, with_auth=False
+        )
+        self.assertEqual(captured["headers"], {})
+
+    def test_open_session_passes_configured_transport_timeouts(self):
+        captured = {}
+
+        class LongRunningIntegration(_Integration):
+            request_timeout = 120
+            sse_read_timeout = 15_000
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, headers=None, timeout=30, sse_read_timeout=300):
+            captured["timeout"] = timeout
+            captured["sse_read_timeout"] = sse_read_timeout
+            return _CM()
+
+        self._run_open_session_with_transport(transport, LongRunningIntegration)
+        self.assertEqual(captured["timeout"], 120)
+        self.assertEqual(captured["sse_read_timeout"], 15_000)
+
+    def test_open_session_rejects_unsupported_configured_timeout(self):
+        class LongRunningIntegration(_Integration):
+            sse_read_timeout = 15_000
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, headers=None):
+            return _CM()
+
+        with self.assertRaisesRegex(RuntimeError, "sse_read_timeout"):
+            self._run_open_session_with_transport(transport, LongRunningIntegration)
+
     def test_open_session_uses_http_client_signature(self):
         # streamable_http_client(url, *, http_client=...) — must NOT pass headers=
         captured = {}
@@ -252,6 +329,32 @@ class McpIntegrationTest(unittest.TestCase):
 
         self._run_open_session_with_transport(transport)
         self.assertIsNotNone(captured["http_client"])
+
+    def test_http_client_signature_uses_streaming_read_timeout(self):
+        captured = {}
+
+        class LongRunningIntegration(_Integration):
+            requires_auth = False
+            request_timeout = 120
+            sse_read_timeout = 15_000
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, *, http_client=None):
+            captured["http_client"] = http_client
+            return _CM()
+
+        self._run_open_session_with_transport(
+            transport, LongRunningIntegration, with_auth=False
+        )
+        timeout = captured["http_client"].timeout
+        self.assertEqual(timeout.connect, 120)
+        self.assertEqual(timeout.read, 15_000)
 
     def test_resolve_config_prefers_host_override_and_headers(self):
         async def host_with_override(req_type, payload):


### PR DESCRIPTION
## Summary

- allow Python-backed `McpIntegration` subclasses to opt out of bearer authentication
- add per-integration request and SSE read timeouts across both supported MCP SDK transport signatures
- preserve Prime Agent's single-tool design: integrations remain Python skills invoked through IPython
- document the new subclass configuration

## Testing

- `PYTHONPATH=src /data/hillclimb-src/.venv/bin/python -m unittest test/test_mcp_base.py` (22 tests)
- `npm run check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add anonymous MCP integration support and configurable HTTP timeouts to `McpIntegration`
> - Subclasses can set `requires_auth = False` to skip reading `auth.json` and omit the `Authorization` header when connecting to anonymous MCP endpoints.
> - Adds `request_timeout` and `sse_read_timeout` class attributes; when set, these are passed to streamable-HTTP transports that accept them or applied via an `httpx.Timeout` when the transport uses an `http_client` parameter.
> - Non-positive timeout values raise `ValueError` at construction; configured timeouts that the selected transport does not support raise `RuntimeError` when opening a session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d029d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->