### PR TITLE
test(coding-agent): promote routing and notice coverage

### DIFF
--- a/packages/coding-agent/test/fixtures/owned-session-worker-fixture.ts
+++ b/packages/coding-agent/test/fixtures/owned-session-worker-fixture.ts
@@ -7,6 +7,9 @@ import {
 import { attachJsonlLineReader, serializeJsonLine } from "../../src/modes/rpc/jsonl.js";
 
 const args = process.argv.slice(2);
+if (process.env.PRIME_AGENT_TEST_STDIN_TTY) {
+	Object.defineProperty(process.stdin, "isTTY", { value: process.env.PRIME_AGENT_TEST_STDIN_TTY === "1" });
+}
 const pidPath = process.env.PRIME_AGENT_TEST_OWNED_PID_PATH;
 installOwnedSessionWorkerOwnerWatch();
 
@@ -14,6 +17,7 @@ if (process.env.PRIME_AGENT_INTERNAL_OWNED_WORKER === "1") {
 	if (pidPath) {
 		writeFileSync(pidPath, `${process.pid}\n`);
 		writeFileSync(`${pidPath}.ppid`, `${process.ppid}\n`);
+		writeFileSync(`${pidPath}.profile`, `${process.env.PRIME_AGENT_INTERNAL_OWNED_PROFILE ?? ""}\n`);
 		process.once("SIGTERM", () => {
 			writeFileSync(`${pidPath}.terminated`, "terminated\n");
 			process.exit(0);

--- a/packages/coding-agent/test/fixtures/owned-session-worker-fixture.ts
+++ b/packages/coding-agent/test/fixtures/owned-session-worker-fixture.ts
@@ -15,9 +15,9 @@ installOwnedSessionWorkerOwnerWatch();
 
 if (process.env.PRIME_AGENT_INTERNAL_OWNED_WORKER === "1") {
 	if (pidPath) {
-		writeFileSync(pidPath, `${process.pid}\n`);
 		writeFileSync(`${pidPath}.ppid`, `${process.ppid}\n`);
 		writeFileSync(`${pidPath}.profile`, `${process.env.PRIME_AGENT_INTERNAL_OWNED_PROFILE ?? ""}\n`);
+		writeFileSync(pidPath, `${process.pid}\n`);
 		process.once("SIGTERM", () => {
 			writeFileSync(`${pidPath}.terminated`, "terminated\n");
 			process.exit(0);

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -183,13 +183,7 @@ describe("InteractiveMode update notifications", () => {
 
 		const output = normalizeRenderedOutput(chatContainer);
 		expect(chatContainer.children).toHaveLength(1);
-		expect(output.split("\n")).toHaveLength(1);
-		expect(output).toContain("Update available:");
-		expect(output).toContain("v1.2.3");
-		expect(output).toContain("/update");
-		expect(output).not.toContain("prime-agent update");
-		expect(output).not.toContain("pi update");
-		expect(output).not.toContain("Changelog:");
+		expect(output).toBe("Update available: v1.2.3. Run /update");
 	});
 
 	test("shows package updates in one compact line", () => {
@@ -203,11 +197,7 @@ describe("InteractiveMode update notifications", () => {
 
 		const output = normalizeRenderedOutput(chatContainer);
 		expect(chatContainer.children).toHaveLength(1);
-		expect(output.split("\n")).toHaveLength(1);
-		expect(output).toContain("Package updates available:");
-		expect(output).toContain("npm:@foo/bar");
-		expect(output).toContain("/update --extensions");
-		expect(output).not.toContain("prime-agent update");
+		expect(output).toBe("Package updates available: npm:@foo/bar. Run /update --extensions");
 		expect(output).not.toContain("pi update");
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -193,12 +193,11 @@ describe("InteractiveMode update notifications", () => {
 			ui: { requestRender: vi.fn() },
 		} as unknown as InteractiveMode;
 
-		InteractiveMode.prototype.showPackageUpdateNotification.call(fakeThis, ["npm:@foo/bar"]);
+		InteractiveMode.prototype.showPackageUpdateNotification.call(fakeThis, ["npm:@foo/bar", "npm:@baz/qux"]);
 
 		const output = normalizeRenderedOutput(chatContainer);
 		expect(chatContainer.children).toHaveLength(1);
-		expect(output).toBe("Package updates available: npm:@foo/bar. Run /update --extensions");
-		expect(output).not.toContain("pi update");
+		expect(output).toBe("Package updates available: npm:@foo/bar, npm:@baz/qux. Run /update --extensions");
 	});
 });
 

--- a/packages/coding-agent/test/owned-session-worker-process.test.ts
+++ b/packages/coding-agent/test/owned-session-worker-process.test.ts
@@ -120,6 +120,35 @@ async function waitForProcessGone(pid: number): Promise<void> {
 }
 
 describe("owned session worker processes", () => {
+	it("routes every headless surface through its real worker profile", async () => {
+		const cases: Array<[string[], string | undefined, string, boolean?]> = [
+			[["-p", "hello"], undefined, "print"],
+			[[], "hello", "print", false],
+			[["--mode", "json"], "", "json"],
+			[["--mode", "rpc"], `${JSON.stringify({ id: "state", type: "get_state" })}\n`, "rpc"],
+			[["--no-session"], undefined, "interactive-ephemeral", true],
+		];
+		for (const [args, stdin, profile, tty] of cases) {
+			const root = mkdtempSync(join(tmpdir(), "prime-owned-worker-routing-"));
+			tempDirs.push(root);
+			const pidPath = join(root, "worker.pid");
+			const frontend = spawnFrontend(
+				args,
+				pidPath,
+				tty === false,
+				tty === undefined ? {} : { PRIME_AGENT_TEST_STDIN_TTY: tty ? "1" : "0" },
+			);
+			if (stdin !== undefined) frontend.stdin?.write(stdin);
+			const workerPid = await waitForWorkerPid(pidPath);
+			expect(readFileSync(`${pidPath}.profile`, "utf8").trim()).toBe(profile);
+			frontend.stdin?.end();
+			if (tty === false) process.kill(workerPid, "SIGKILL");
+			await waitForExit(frontend);
+			children.delete(frontend);
+			await waitForProcessGone(workerPid);
+		}
+	});
+
 	it("keeps RPC framing in the frontend and exits its worker on stdin EOF", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-owned-worker-test-"));
 		tempDirs.push(root);

--- a/packages/coding-agent/test/owned-session-worker.test.ts
+++ b/packages/coding-agent/test/owned-session-worker.test.ts
@@ -8,14 +8,6 @@ import {
 } from "../src/cli/owned-session-worker.js";
 
 describe("owned session worker CLI routing", () => {
-	it("routes every headless surface to an owned worker", () => {
-		expect(classifyOwnedSessionWorkerInvocation(["-p", "hello"], true, {})).toBe("print");
-		expect(classifyOwnedSessionWorkerInvocation([], false, {})).toBe("print");
-		expect(classifyOwnedSessionWorkerInvocation(["--mode", "json", "hello"], true, {})).toBe("json");
-		expect(classifyOwnedSessionWorkerInvocation(["--mode", "rpc"], true, {})).toBe("rpc");
-		expect(classifyOwnedSessionWorkerInvocation(["--no-session"], true, {})).toBe("interactive-ephemeral");
-	});
-
 	it("leaves resident interactive and non-session operations in the frontend", () => {
 		expect(classifyOwnedSessionWorkerInvocation([], true, {})).toBeUndefined();
 		expect(classifyOwnedSessionWorkerInvocation(["--mode", "daemon"], false, {})).toBeUndefined();

--- a/packages/coding-agent/test/startup-notices.test.ts
+++ b/packages/coding-agent/test/startup-notices.test.ts
@@ -1,10 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
-import {
-	formatPackageUpdateNotice,
-	formatTmuxWarningNotice,
-	formatUpdateAvailableNotice,
-} from "../src/modes/shared/startup-notices.js";
+import { formatTmuxWarningNotice } from "../src/modes/shared/startup-notices.js";
 
 const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
@@ -15,19 +11,6 @@ function stripAnsi(text: string): string {
 describe("startup notice formatters", () => {
 	beforeAll(() => {
 		initTheme("dark");
-	});
-
-	test("update notice mentions the version and slash update command", () => {
-		const output = stripAnsi(formatUpdateAvailableNotice("1.2.3"));
-		expect(output).toBe("Update available: v1.2.3. Run /update");
-		expect(output).not.toContain("prime-agent update");
-		expect(output).not.toContain("pi update");
-	});
-
-	test("package update notice lists packages and the extensions command", () => {
-		const output = stripAnsi(formatPackageUpdateNotice(["npm:@foo/bar", "npm:@baz/qux"]));
-		expect(output).toBe("Package updates available: npm:@foo/bar, npm:@baz/qux. Run /update --extensions");
-		expect(output).not.toContain("prime-agent update");
 	});
 
 	test("tmux warning notice is prefixed with the warning glyph", () => {


### PR DESCRIPTION
## Why

A pure routing-table assertion duplicated behavior that can be proven through real local frontend/worker processes, while update notices were asserted both at formatter level and after insertion into the interactive transcript.

## What changes

- expands the existing owned-worker process fixture to record the actual selected worker profile
- verifies short print, piped stdin, JSON, RPC, and ephemeral interactive surfaces through real local processes
- removes the superseded headless-routing classifier assertion while retaining exclusion, recursion, launch-spec, and recovery unit tests
- strengthens InteractiveMode update/package notice tests to exact rendered output
- removes the two superseded formatter assertions while retaining unique tmux notice coverage

## Boundaries and cost

The routing test uses local Node child processes and IPC only: no provider, network, API key, or token cost.

- real worker-profile matrix: 1.02 s
- affected focused set: 8 passed in 1.04 s test time
- `npm run check`

Net diff: 2 lines removed while moving assertions to stronger boundaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and the owned-worker test fixture; no production routing or notice logic is modified in this diff.
> 
> **Overview**
> **Test-only refactor** that moves owned-session-worker routing and startup notice assertions to stronger boundaries without changing production behavior.
> 
> The owned-session-worker **fixture** now simulates stdin TTY via `PRIME_AGENT_TEST_STDIN_TTY` and writes a **`.profile`** file from `PRIME_AGENT_INTERNAL_OWNED_PROFILE` so integration tests can see which worker profile was selected. A new **process integration test** exercises print (`-p`), piped stdin, JSON, RPC, and ephemeral interactive (`--no-session`) through real child processes and asserts each profile. The old **unit-level** `classifyOwnedSessionWorkerInvocation` matrix for headless surfaces is removed; exclusion, recursion, launch-spec, and recovery tests remain.
> 
> **Update/package notice** coverage is consolidated: `InteractiveMode` tests now use **exact string** expectations for rendered transcript output (including a second package in the package-update case), and duplicate **`formatUpdateAvailableNotice` / `formatPackageUpdateNotice`** tests are dropped from `startup-notices.test.ts` (tmux warning formatter coverage stays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3beee4506f92cafdd943b392d7004d2dac90fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote routing and notice coverage in coding-agent tests
> - Adds a new test in [`owned-session-worker-process.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/500/files#diff-17be2e894e9a203c92a66ffbafe0a1a6d15b13dfb9e89c475fd71e00cabe1923) that iterates over headless surface cases and asserts each spawns a worker with the correct profile file (`<pidPath>.profile`).
> - Updates [`owned-session-worker-fixture.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/500/files#diff-4ccd0dc6301fb0d5d3b6974909f65c4341cd903005c8aa8f494684d65d9b3087) to write `.ppid` and `.profile` files before the main pid file, and to set `stdin.isTTY` from `PRIME_AGENT_TEST_STDIN_TTY`.
> - Moves update notice assertions from [`startup-notices.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/500/files#diff-f8d7e79cd595f85e1a26a3b820a5f0c5f1253c9fe5e89af475d9a7eb7b158e1c) into [`interactive-mode-status.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/500/files#diff-437901e4bcf3ed59fe6e211eac1c38b57637ff69b35a384dc4d1b8dfcfcb15d3), tightening expectations to exact rendered strings.
> - Removes the 'routes every headless surface to an owned worker' test from [`owned-session-worker.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/500/files#diff-7e71cad690c89be729345b06c72a5ee6db52f2ae182c7ac7057fb8dec19e74d4), superseded by the new process-level routing test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3beee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->