### PR TITLE
fix(coding-agent): open resumed sessions with right arrow

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -654,8 +654,12 @@ class SessionList implements Component, Focusable {
 		else if (kb.matches(keyData, "tui.select.pageDown")) {
 			this.selectedIndex = Math.min(this.filteredSessions.length - 1, this.selectedIndex + this.maxVisible);
 		}
-		// Enter
-		else if (kb.matches(keyData, "tui.select.confirm")) {
+		// Enter, or right arrow when it is not needed to move within the search field
+		else if (
+			kb.matches(keyData, "tui.select.confirm") ||
+			(kb.matches(keyData, "tui.editor.cursorRight") &&
+				this.searchInput.getCursor() === this.searchInput.getValue().length)
+		) {
 			const selected = this.filteredSessions[this.selectedIndex];
 			if (selected && this.onSelect) {
 				this.onSelect(selected.session.path);

--- a/packages/coding-agent/test/selector-search-reset.test.ts
+++ b/packages/coding-agent/test/selector-search-reset.test.ts
@@ -160,7 +160,7 @@ describe("searchable selector navigation", () => {
 		expect(enabledModelIds).toEqual([`${harness.models[0]?.provider}/faux-1`]);
 	});
 
-	it("selects the first session after the search query changes", async () => {
+	it("selects the first session with right arrow after the search query changes", async () => {
 		const sessions = Array.from({ length: 12 }, (_, index) => makeSession(index + 1));
 		let selectedPath: string | undefined;
 		const selector = new SessionSelectorComponent(
@@ -178,8 +178,11 @@ describe("searchable selector navigation", () => {
 		const list = selector.getSessionList();
 		moveDown(list, 8);
 		list.handleInput("c");
-		list.handleInput("\r");
+		list.handleInput("\x1b[D");
+		list.handleInput("\x1b[C");
+		expect(selectedPath).toBeUndefined();
 
+		list.handleInput("\x1b[C");
 		expect(selectedPath).toBe(sessions.at(-1)?.path);
 	});
 });


### PR DESCRIPTION
## Why

The resume-session picker supports left arrow as back, but right arrow does not open the highlighted session. This makes horizontal navigation inconsistent with the rest of the session-management UI.

## What changes

- treats right arrow at the end of the search field as selection, equivalent to Enter
- preserves ordinary right-arrow cursor movement while editing within a search query
- extends the existing searchable-selector navigation scenario rather than adding a duplicate selector fixture

## Validation

- `npx vitest --run test/selector-search-reset.test.ts` — 5 passed
- `npm run check`
