### PR TITLE
fix: persist and restore subagent model on rehydration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed long live session opens to render a bounded recent transcript tail while preserving full prompt history ([#343](https://github.com/PrimeIntellect-ai/prime-agent/pull/343) by [@sethkarten](https://github.com/sethkarten)).
+- Changed `/refine` to run planning in the background so the conversation is not blocked during the LLM pass.
 
 ## [0.3.2] - 2026-07-20
 

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -1355,7 +1355,9 @@ class DaemonAttachTerminal {
 				this.rl?.prompt();
 				return;
 			case "session_event":
-				this.handleSessionEvent(message.event);
+				if (message.event.type !== "refine_complete") {
+					this.handleSessionEvent(message.event);
+				}
 				return;
 			case "session_replaced":
 				this.isStreaming = message.state.isStreaming;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3054,7 +3054,7 @@ export class AgentSession {
 					});
 				}
 			}
-			this.agent.state.systemPrompt = this._baseSystemPrompt;
+			this.agent.state.systemPrompt = extensionResult?.systemPrompt ?? this._baseSystemPrompt;
 		} catch (error) {
 			reportPreflight(false);
 			throw error;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -192,6 +192,7 @@ import {
 	mergeHarnessStates,
 	mergeRefinementHistory,
 	planRefinement,
+	type RefinementPlan,
 	type RefinementResult,
 	reviewAutoRefine,
 	saveHarnessState,
@@ -316,7 +317,8 @@ export type AgentSessionEvent =
 			fullOutputPath?: string;
 			/** Set when execution failed before producing a result (e.g. spawn failure) */
 			errorMessage?: string;
-	  };
+	  }
+	| { type: "refine_complete"; result: RefinementResult };
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -947,6 +949,12 @@ export class AgentSession {
 	private readonly _autoRefineReviewer?: AutoRefineReviewer;
 	/** Settles (never rejects) when the in-flight refine finishes; see _waitForRefineIdle. */
 	private _refineInFlight?: Promise<void>;
+	/** Settles when the background planning LLM pass completes. Planning does not block turn entry points. */
+	private _refinePlanInFlight?: Promise<void>;
+	/** True between planning completion and _refineInFlight being set. Blocks
+	 * turn entry points via _waitForRefineIdle and concurrent refine calls via the
+	 * serialization guard, so no prompt or second plan can start in the gap. */
+	private _refineApplyPending = false;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -2605,6 +2613,7 @@ export class AgentSession {
 			// resolution cannot write harness state or re-subscribe handlers.
 			this._autoRefineReviewAbort?.abort();
 			this._refineAbortController?.abort();
+			this._refineApplyPending = false;
 			this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 			this._autoRefineBranchVersion++;
 			this._cancelActiveRlmChildRuns("Parent session disposed");
@@ -3055,8 +3064,11 @@ export class AgentSession {
 			return;
 		}
 
-		if (this._refineInFlight) {
+		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
+			// A refine may have completed during the wait and rewritten
+			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		const shouldQueueAtHandoff =
 			options?.queueIfBusy === true &&
@@ -3378,8 +3390,11 @@ export class AgentSession {
 		}
 		// Re-check adjacent to the handoff: extension before_agent_start handlers
 		// above may have suspended this turn long enough for a refine to start.
-		if (this._refineInFlight) {
+		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
+			// A refine may have completed during the wait and rewritten
+			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		if (acceptedAgentMessagePrompt?.cleared) {
 			reportPreflight(false);
@@ -3912,6 +3927,14 @@ export class AgentSession {
 				}
 
 				await this.agent.waitForIdle();
+				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
+					return;
+				}
+				// Re-check adjacent to the handoff: background planning may have
+				// completed and entered _applyRefine during the awaits above,
+				// disconnecting event handling. Wait for it to finish so the
+				// resumed turn's events are not lost.
+				await this._waitForRefineIdle();
 				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
 					return;
 				}
@@ -4857,6 +4880,13 @@ export class AgentSession {
 		this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 		this._assistantTurnsSinceAutoRefine = 0;
 		this._autoRefineBranchVersion++;
+		while (this._refinePlanInFlight || this._refineApplyPending) {
+			if (this._refinePlanInFlight) {
+				await this._refinePlanInFlight;
+			} else if (this._refineApplyPending) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
+		}
 		await this._waitForRefineIdle();
 	}
 
@@ -5144,26 +5174,75 @@ export class AgentSession {
 	/**
 	 * Refine editable continual harness state: prompt notes, memory, skills, and subagent specs.
 	 * The base system prompt is intentionally not editable through this path.
+	 *
+	 * Planning runs in the background and does NOT block turn entry points
+	 * (`_waitForRefineIdle` only waits for `_refineInFlight`). Only the fast
+	 * application phase (disk I/O + in-memory mutation) blocks turn entry points.
 	 */
 	async refine(
 		options: { instructions?: string; rollbackId?: string; global?: boolean } = {},
 	): Promise<RefinementResult> {
-		while (this._refineInFlight) {
-			await this._refineInFlight;
+		// Wait for any existing refine (both planning and application) before
+		// starting a new run. This serializes concurrent /refine calls so two
+		// planning phases cannot race into concurrent _applyRefine calls that
+		// overwrite harness state.
+		while (this._refineInFlight || this._refinePlanInFlight || this._refineApplyPending) {
+			await (this._refineInFlight ?? this._refinePlanInFlight);
+			if (this._refineApplyPending) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
 		}
 
-		const run = this._refine(options);
-		// Refine detaches session event handling for its whole LLM pass; expose a
-		// settled promise so turn entry points can wait instead of losing events.
-		const settled = run.then(
+		const refineAbort = new AbortController();
+		this._refineAbortController = refineAbort;
+
+		// Background planning phase — does NOT block turn entry points.
+		const planRun = this._planRefine(options, refineAbort.signal);
+		const planSettled = planRun.then(
 			() => undefined,
 			() => undefined,
 		);
-		this._refineInFlight = settled;
+		this._refinePlanInFlight = planSettled;
+		let plan: RefinementPlan;
 		try {
-			return await run;
+			plan = await planRun;
+		} catch (e) {
+			if (this._refineAbortController === refineAbort) {
+				this._refineAbortController = undefined;
+			}
+			throw e;
 		} finally {
-			if (this._refineInFlight === settled) {
+			if (this._refinePlanInFlight === planSettled) {
+				this._refinePlanInFlight = undefined;
+			}
+		}
+
+		// Mark that we're between planning and application so the serialization
+		// guard and _waitForRefineIdle block concurrent calls and new prompts.
+		this._refineApplyPending = true;
+		try {
+			// Wait for any agent turn that started during background planning
+			// to finish before entering the application critical section.
+			await this.agent.waitForIdle();
+		} finally {
+			this._refineApplyPending = false;
+		}
+		if (this._disposed || refineAbort.signal.aborted) {
+			throw new Error("Refinement cancelled because the session was disposed.");
+		}
+
+		// Application phase — blocks turn entry points via _refineInFlight.
+		// _refineInFlight only covers the brief disconnect+apply+reconnect.
+		const applyRun = this._applyRefine(plan, options, refineAbort);
+		const applySettled = applyRun.then(
+			() => undefined,
+			() => undefined,
+		);
+		this._refineInFlight = applySettled;
+		try {
+			return await applyRun;
+		} finally {
+			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
 			this._schedulePendingMessageResume();
@@ -5171,61 +5250,96 @@ export class AgentSession {
 	}
 
 	/**
-	 * Block a new agent turn until any in-flight refine has reattached event
-	 * handling; otherwise the turn's messages are never persisted or rendered.
+	 * Block a new agent turn until any in-flight refine application phase has
+	 * reattached event handling; otherwise the turn's messages are never
+	 * persisted or rendered.
+	 *
+	 * The application phase (`_refineInFlight`) and the transition window
+	 * (`_refineApplyPending`) block here. The background planning phase
+	 * (`_refinePlanInFlight`) does NOT block turn entry points.
 	 * Refine failures surface to the refine caller, not here.
 	 */
 	private async _waitForRefineIdle(): Promise<void> {
-		while (this._refineInFlight) {
-			await this._refineInFlight;
+		while (this._refineInFlight || this._refineApplyPending) {
+			if (this._refineInFlight) {
+				await this._refineInFlight;
+			} else {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
 		}
 	}
 
-	private async _refine(
-		options: { instructions?: string; rollbackId?: string; global?: boolean } = {},
+	/**
+	 * Background planning phase: runs the LLM planning call via `planRefinement`.
+	 * Does NOT call `_disconnectFromAgent` or `this.abort` — those happen in
+	 * `_applyRefine`. Returns the plan without applying anything.
+	 */
+	private async _planRefine(
+		options: { instructions?: string; rollbackId?: string; global?: boolean },
+		signal: AbortSignal,
+	): Promise<RefinementPlan> {
+		if (this._disposed) {
+			throw new Error("Cannot refine a disposed session.");
+		}
+
+		if (!this.model) {
+			throw new Error(formatNoModelSelectedMessage());
+		}
+
+		const model = this.model;
+		const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+		const globalHarnessStateDir = getGlobalHarnessStateDir();
+		const localHarnessStateDir = this._localHarnessStateDir();
+		const requestedScope = options.global ? "global" : "local";
+		if (!options.rollbackId && requestedScope === "local" && !localHarnessStateDir) {
+			throw new Error("Local harness refinement requires a persisted session; use global refinement instead.");
+		}
+		const planningState =
+			requestedScope === "global"
+				? loadHarnessState(globalHarnessStateDir, "global")
+				: this._loadMergedHarnessState();
+		const history = this._loadRefinementHistory();
+		const plan = await planRefinement(
+			this.agent.state.messages,
+			planningState,
+			history,
+			model,
+			apiKey,
+			options,
+			headers,
+			signal,
+			this.thinkingLevel,
+		);
+		if (this._disposed || signal.aborted) {
+			throw new Error("Refinement cancelled because the session was disposed.");
+		}
+		return plan;
+	}
+
+	/**
+	 * Synchronous application phase: disconnects from the agent, aborts any
+	 * in-flight agent run, applies the refinement plan to disk and memory, then
+	 * reconnects. This is the only phase that blocks turn entry points.
+	 */
+	private async _applyRefine(
+		plan: RefinementPlan,
+		options: { instructions?: string; rollbackId?: string; global?: boolean },
+		refineAbort: AbortController,
 	): Promise<RefinementResult> {
 		if (this._disposed) {
 			throw new Error("Cannot refine a disposed session.");
 		}
-		const refineAbort = new AbortController();
-		this._refineAbortController = refineAbort;
+		// The caller (refine()) has already waited for agent idle before
+		// setting _refineInFlight and calling us. We only need to disconnect
+		// for the brief apply + save + reconnect critical section.
 		this._disconnectFromAgent();
 
 		try {
-			await this.abort();
-
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-
-			const model = this.model;
-			const { apiKey, headers } = await this._getRequiredRequestAuth(model);
 			const globalHarnessStateDir = getGlobalHarnessStateDir();
 			const localHarnessStateDir = this._localHarnessStateDir();
 			const requestedScope = options.global ? "global" : "local";
-			if (!options.rollbackId && requestedScope === "local" && !localHarnessStateDir) {
-				throw new Error("Local harness refinement requires a persisted session; use global refinement instead.");
-			}
-			const planningState =
-				requestedScope === "global"
-					? loadHarnessState(globalHarnessStateDir, "global")
-					: this._loadMergedHarnessState();
 			const history = this._loadRefinementHistory();
 			const rollbackTarget = options.rollbackId ? history.find((item) => item.id === options.rollbackId) : undefined;
-			const plan = await planRefinement(
-				this.agent.state.messages,
-				planningState,
-				history,
-				model,
-				apiKey,
-				options,
-				headers,
-				refineAbort.signal,
-				this.thinkingLevel,
-			);
-			if (this._disposed || refineAbort.signal.aborted) {
-				throw new Error("Refinement cancelled because the session was disposed.");
-			}
 			let targetScope = plan.rollbackScope ?? requestedScope;
 			let targetHarnessStateDir = targetScope === "global" ? globalHarnessStateDir : localHarnessStateDir;
 			if (targetScope === "local" && rollbackTarget?.harnessStatePath) {
@@ -5277,6 +5391,7 @@ export class AgentSession {
 			this.sessionManager.appendCustomEntry("prime-agent.refinement", result);
 			this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
+			this._emit({ type: "refine_complete", result });
 			return result;
 		} finally {
 			if (this._refineAbortController === refineAbort) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3036,14 +3036,14 @@ export class AgentSession {
 			this._pendingNextTurnMessages = [];
 			messages = [...drainedNextTurnMessages, message];
 
-			const result = await this._extensionRunner.emitBeforeAgentStart(
+			const extensionResult = await this._extensionRunner.emitBeforeAgentStart(
 				text,
 				undefined,
 				this._baseSystemPrompt,
 				this._baseSystemPromptOptions,
 			);
-			if (result?.messages) {
-				for (const msg of result.messages) {
+			if (extensionResult?.messages) {
+				for (const msg of extensionResult.messages) {
 					messages.push({
 						role: "custom",
 						customType: msg.customType,
@@ -3054,7 +3054,7 @@ export class AgentSession {
 					});
 				}
 			}
-			this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		} catch (error) {
 			reportPreflight(false);
 			throw error;
@@ -3067,7 +3067,8 @@ export class AgentSession {
 		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
 			// A refine may have completed during the wait and rewritten
-			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			// _baseSystemPrompt. Re-apply the extension-modified prompt if
+			// the extension provided one, otherwise use the refreshed base.
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		const shouldQueueAtHandoff =
@@ -3349,15 +3350,15 @@ export class AgentSession {
 				}
 
 				// Emit before_agent_start extension event
-				const result = await this._extensionRunner.emitBeforeAgentStart(
+				const extensionResult = await this._extensionRunner.emitBeforeAgentStart(
 					expandedText,
 					currentImages,
 					this._baseSystemPrompt,
 					this._baseSystemPromptOptions,
 				);
 				// Add all custom messages from extensions
-				if (result?.messages) {
-					for (const msg of result.messages) {
+				if (extensionResult?.messages) {
+					for (const msg of extensionResult.messages) {
 						messages.push({
 							role: "custom",
 							customType: msg.customType,
@@ -3369,8 +3370,8 @@ export class AgentSession {
 					}
 				}
 				// Apply extension-modified system prompt, or reset to base
-				if (result?.systemPrompt) {
-					this.agent.state.systemPrompt = result.systemPrompt;
+				if (extensionResult?.systemPrompt) {
+					this.agent.state.systemPrompt = extensionResult.systemPrompt;
 				} else {
 					// Ensure we're using the base prompt (in case previous turn had modifications)
 					this.agent.state.systemPrompt = this._baseSystemPrompt;
@@ -3393,7 +3394,8 @@ export class AgentSession {
 		if (this._refineInFlight || this._refineApplyPending) {
 			await this._waitForRefineIdle();
 			// A refine may have completed during the wait and rewritten
-			// _baseSystemPrompt. Re-sync so the agent uses the latest version.
+			// _baseSystemPrompt. Re-apply the extension-modified prompt if
+			// the extension provided one, otherwise use the refreshed base.
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 		if (acceptedAgentMessagePrompt?.cleared) {
@@ -5210,6 +5212,7 @@ export class AgentSession {
 			if (this._refineAbortController === refineAbort) {
 				this._refineAbortController = undefined;
 			}
+			this._schedulePendingMessageResume();
 			throw e;
 		} finally {
 			if (this._refinePlanInFlight === planSettled) {
@@ -5228,20 +5231,24 @@ export class AgentSession {
 			this._refineApplyPending = false;
 		}
 		if (this._disposed || refineAbort.signal.aborted) {
+			this._schedulePendingMessageResume();
 			throw new Error("Refinement cancelled because the session was disposed.");
 		}
 
 		// Application phase — blocks turn entry points via _refineInFlight.
 		// _refineInFlight only covers the brief disconnect+apply+reconnect.
-		const applyRun = this._applyRefine(plan, options, refineAbort);
-		const applySettled = applyRun.then(
-			() => undefined,
-			() => undefined,
-		);
+		// Set _refineInFlight before starting _applyRefine so synchronous
+		// listeners on the refine_complete event see the guard.
+		let resolveApplySettled: () => void = () => {};
+		const applySettled = new Promise<void>((resolve) => {
+			resolveApplySettled = resolve;
+		});
 		this._refineInFlight = applySettled;
+		const applyRun = this._applyRefine(plan, options, refineAbort);
 		try {
 			return await applyRun;
 		} finally {
+			resolveApplySettled();
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
@@ -5391,7 +5398,12 @@ export class AgentSession {
 			this.sessionManager.appendCustomEntry("prime-agent.refinement", result);
 			this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
-			this._emit({ type: "refine_complete", result });
+			try {
+				this._emit({ type: "refine_complete", result });
+			} catch {
+				// Listener failures must not flip a successful refinement into
+				// a reported failure — the refinement is already persisted.
+			}
 			return result;
 		} finally {
 			if (this._refineAbortController === refineAbort) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2972,6 +2972,7 @@ export class AgentSession {
 		let messages: AgentMessage[] | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
 		const previewLabel = injectedMessagePreviewLabel(message);
+		let extensionResult: Awaited<ReturnType<typeof this._extensionRunner.emitBeforeAgentStart>> | undefined;
 		try {
 			const shouldQueueForStreaming = this.isStreaming;
 			const shouldQueueForPendingWork =
@@ -3036,7 +3037,7 @@ export class AgentSession {
 			this._pendingNextTurnMessages = [];
 			messages = [...drainedNextTurnMessages, message];
 
-			const extensionResult = await this._extensionRunner.emitBeforeAgentStart(
+			extensionResult = await this._extensionRunner.emitBeforeAgentStart(
 				text,
 				undefined,
 				this._baseSystemPrompt,
@@ -3069,7 +3070,7 @@ export class AgentSession {
 			// A refine may have completed during the wait and rewritten
 			// _baseSystemPrompt. Re-apply the extension-modified prompt if
 			// the extension provided one, otherwise use the refreshed base.
-			this.agent.state.systemPrompt = this._baseSystemPrompt;
+			this.agent.state.systemPrompt = extensionResult?.systemPrompt ?? this._baseSystemPrompt;
 		}
 		const shouldQueueAtHandoff =
 			options?.queueIfBusy === true &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3140,6 +3140,7 @@ export class AgentSession {
 		let drainedNextTurnMessages: CustomMessage[] = [];
 		let expandedText = text;
 		let currentImages = options?.images;
+		let extensionResult: Awaited<ReturnType<typeof this._extensionRunner.emitBeforeAgentStart>> | undefined;
 
 		try {
 			let currentText = text;
@@ -3351,7 +3352,7 @@ export class AgentSession {
 				}
 
 				// Emit before_agent_start extension event
-				const extensionResult = await this._extensionRunner.emitBeforeAgentStart(
+				extensionResult = await this._extensionRunner.emitBeforeAgentStart(
 					expandedText,
 					currentImages,
 					this._baseSystemPrompt,
@@ -3397,7 +3398,7 @@ export class AgentSession {
 			// A refine may have completed during the wait and rewritten
 			// _baseSystemPrompt. Re-apply the extension-modified prompt if
 			// the extension provided one, otherwise use the refreshed base.
-			this.agent.state.systemPrompt = this._baseSystemPrompt;
+			this.agent.state.systemPrompt = extensionResult?.systemPrompt ?? this._baseSystemPrompt;
 		}
 		if (acceptedAgentMessagePrompt?.cleared) {
 			reportPreflight(false);

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1336,7 +1336,9 @@ export class DaemonAgentConnection implements AgentConnection {
 		this.observeDaemonEventSequence(message);
 
 		if (message.type === "session_event") {
-			this.observeStreamingMessage(message.event);
+			if (message.event.type !== "refine_complete") {
+				this.observeStreamingMessage(message.event);
+			}
 			this.latestSnapshotIsFresh = false;
 			await this.emit({ type: "session_event", event: message.event });
 			return;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -567,7 +567,8 @@ export type AgentConnectionSessionEvent =
 			fullOutputPath?: string;
 			/** Set when execution failed before producing a result (e.g. spawn failure) */
 			errorMessage?: string;
-	  };
+	  }
+	| { type: "refine_complete"; result: RefinementResult };
 
 export type AgentConnectionEvent =
 	| { type: "session_event"; event: AgentConnectionSessionEvent }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1822,7 +1822,9 @@ export class AgentDaemon {
 								rlmParentNodeId: options.rlmParentNodeId,
 								prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
 								spawnCode: options.spawnCode,
-								model: { provider: options.model.provider, modelId: options.model.id },
+								...(options.model
+									? { model: { provider: options.model.provider, modelId: options.model.id } }
+									: {}),
 								status: "completed",
 								createdAt: state.runtime.metadata.createdAt,
 							});

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -22,7 +22,7 @@ import {
 } from "node:fs";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { dirname, join, resolve } from "node:path";
-import { getLogger } from "@earendil-works/pi-ai";
+import { type Api, getLogger, type Model } from "@earendil-works/pi-ai";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import {
 	appendRotatingLog,
@@ -345,6 +345,7 @@ interface PersistedRlmSubagentRegistryEntry {
 	rlmParentNodeId?: string;
 	prompt?: string;
 	spawnCode?: string;
+	model?: { provider: string; modelId: string };
 	status: "running" | "completed" | "deleted";
 	createdAt: number;
 	updatedAt: string;
@@ -806,6 +807,7 @@ export class AgentDaemon {
 			rlmParentNodeId?: string;
 			prompt?: string;
 			spawnCode?: string;
+			model?: { provider: string; modelId: string };
 			status: PersistedRlmSubagentRegistryEntry["status"];
 			createdAt?: number;
 		},
@@ -824,6 +826,7 @@ export class AgentDaemon {
 			...(input.rlmParentNodeId ? { rlmParentNodeId: input.rlmParentNodeId } : {}),
 			...(input.prompt ? { prompt: input.prompt } : {}),
 			...(input.spawnCode ? { spawnCode: input.spawnCode } : {}),
+			...(input.model ? { model: input.model } : {}),
 			status: input.status,
 			createdAt: input.createdAt ?? Date.now(),
 			updatedAt: new Date().toISOString(),
@@ -1819,6 +1822,7 @@ export class AgentDaemon {
 								rlmParentNodeId: options.rlmParentNodeId,
 								prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
 								spawnCode: options.spawnCode,
+								model: { provider: options.model.provider, modelId: options.model.id },
 								status: "completed",
 								createdAt: state.runtime.metadata.createdAt,
 							});
@@ -1936,6 +1940,7 @@ export class AgentDaemon {
 						rlmParentNodeId: options.rlmParentNodeId,
 						prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
 						spawnCode: options.spawnCode,
+						model: { provider: options.model.provider, modelId: options.model.id },
 						status: "running",
 						createdAt: runtime.metadata.createdAt,
 					});
@@ -1984,6 +1989,14 @@ export class AgentDaemon {
 		let runtime: AgentSessionRuntime | undefined;
 		try {
 			const sessionManager = await SessionManager.openAsync(entry.sessionFile, entry.sessionDir);
+			const modelRegistry = parentState.runtime.services.modelRegistry;
+			let rehydratedModel: Model<Api> | undefined;
+			if (entry.model) {
+				const resolved = modelRegistry.find(entry.model.provider, entry.model.modelId);
+				if (resolved && modelRegistry.hasConfiguredAuth(resolved)) {
+					rehydratedModel = resolved;
+				}
+			}
 			runtime = await withClientEnv(parentState.clientEnv, () =>
 				createAgentSessionRuntime(this.options.createRuntime, {
 					cwd: sessionManager.getCwd(),
@@ -1992,6 +2005,7 @@ export class AgentDaemon {
 					sessionStartEvent: { type: "session_start", reason: "startup" },
 					sessionConfig: parentState.runtime.runtimeConfig,
 					sessionOptions: {
+						...(rehydratedModel ? { model: rehydratedModel } : {}),
 						agentMessageController: this.createAgentMessageController(() => stateRef),
 						agentObserveController: this.createAgentObserveController(() => stateRef),
 						rlmHeartbeatController: {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9550,18 +9550,20 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 				: `Refining ${options.global ? "global" : "local"} continual harness state...`,
 		);
 
-		try {
-			const result = await this.agentConnection.refine(options);
-			const applied = result.appliedEdits.filter((edit) => edit.applied).length;
-			const failed = result.appliedEdits.length - applied;
-			const failedSuffix = failed > 0 ? `, ${failed} failed` : "";
-			this.showStatus(
-				`Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied${failedSuffix}`,
-			);
-			this.showStatus(`Harness state: ${result.harnessStatePath}`);
-		} catch (error) {
-			this.showError(`Refinement failed: ${error instanceof Error ? error.message : String(error)}`);
-		}
+		this.agentConnection
+			.refine(options)
+			.then((result) => {
+				const applied = result.appliedEdits.filter((edit) => edit.applied).length;
+				const failed = result.appliedEdits.length - applied;
+				const failedSuffix = failed > 0 ? `, ${failed} failed` : "";
+				this.showStatus(
+					`Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied${failedSuffix}`,
+				);
+				this.showStatus(`Harness state: ${result.harnessStatePath}`);
+			})
+			.catch((error) => {
+				this.showError(`Refinement failed: ${error instanceof Error ? error.message : String(error)}`);
+			});
 	}
 
 	stop(options: { preserveAltScreen?: boolean } = {}): void {

--- a/packages/coding-agent/test/interactive-mode-refine-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-refine-command.test.ts
@@ -153,4 +153,67 @@ describe("InteractiveMode.handleRefineCommand", () => {
 		expect(context.showWarning).toHaveBeenCalledWith("Nothing to refine (no trajectory yet)");
 		expect(context.agentConnection.refine).not.toHaveBeenCalled();
 	});
+
+	test("shows success status after refine resolves without blocking the caller", async () => {
+		let resolveRefine: ((value: unknown) => void) | undefined;
+		const refinePromise = new Promise((resolve) => {
+			resolveRefine = resolve;
+		});
+		const context = {
+			agentConnection: {
+				getSessionStats: vi.fn().mockResolvedValue({ totalMessages: 2 }),
+				refine: vi.fn().mockReturnValue(refinePromise),
+			},
+			stopWorkingLoader: vi.fn(),
+			showStatus: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		await handleRefineCommand.call(context, "focus on validation");
+
+		// The "Refining..." status is shown synchronously.
+		expect(context.showStatus).toHaveBeenCalledWith("Refining local continual harness state...");
+		// The success status is NOT shown yet because refine has not resolved.
+		expect(context.showStatus).not.toHaveBeenCalledWith("Refined continual harness state: 2 edits applied, 1 failed");
+
+		// Resolve the refine promise and let the microtask queue drain.
+		resolveRefine?.({
+			appliedEdits: [{ applied: true }, { applied: true }, { applied: false, error: "entry not found" }],
+			harnessStatePath: "/tmp/harness_state.json",
+		});
+		await vi.waitFor(() => {
+			expect(context.showStatus).toHaveBeenCalledWith("Refined continual harness state: 2 edits applied, 1 failed");
+		});
+		expect(context.showStatus).toHaveBeenCalledWith("Harness state: /tmp/harness_state.json");
+	});
+
+	test("shows error status after refine rejects without blocking the caller", async () => {
+		let rejectRefine: ((error: Error) => void) | undefined;
+		const refinePromise = new Promise<never>((_, reject) => {
+			rejectRefine = reject;
+		});
+		const context = {
+			agentConnection: {
+				getSessionStats: vi.fn().mockResolvedValue({ totalMessages: 2 }),
+				refine: vi.fn().mockReturnValue(refinePromise),
+			},
+			stopWorkingLoader: vi.fn(),
+			showStatus: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		await handleRefineCommand.call(context, "focus on validation");
+
+		// The "Refining..." status is shown synchronously.
+		expect(context.showStatus).toHaveBeenCalledWith("Refining local continual harness state...");
+		// The error is NOT shown yet because refine has not rejected.
+		expect(context.showError).not.toHaveBeenCalled();
+
+		rejectRefine?.(new Error("LLM timed out"));
+		await vi.waitFor(() => {
+			expect(context.showError).toHaveBeenCalledWith("Refinement failed: LLM timed out");
+		});
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1199,9 +1199,11 @@ describe("AgentSession queue characterization", () => {
 
 			const promptPromise = harness.session.prompt("hello during refine");
 			await new Promise((resolve) => setTimeout(resolve, 10));
-			// The prompt must wait for the refine (its response is still queued);
-			// running now would drop its events while the session is detached.
-			expect(harness.getPendingResponseCount()).toBe(1);
+			// With backgrounded refine planning, the prompt does NOT wait for the
+			// planning LLM pass. It starts immediately and streams its response
+			// while planning is still in flight. The application phase waits for
+			// the agent to be idle before disconnecting and applying.
+			expect(harness.getPendingResponseCount()).toBe(0);
 
 			releasePlan?.();
 			await refinePromise;


### PR DESCRIPTION
## Bug

When a persistent RLM subagent is rehydrated after a daemon restart (e.g. crash recovery or heartbeat-driven reopen), `rehydrateCompletedRlmSubagent` creates the child session without passing the model the subagent was originally spawned with. The session falls back to `createAgentSession`'s default model resolution (settings default or first available provider), silently switching the subagent to a different model.

## Root Cause

`PersistedRlmSubagentRegistryEntry` did not store the child's model. Both `recordRlmSubagentRegistryEntry` call sites (running + completed) omitted it. On rehydration, `rehydrateCompletedRlmSubagent` had no model to pass to `sessionOptions`, so the session opened with whatever `createAgentSession` resolved from the session file or settings defaults.

`createRlmSubagentRuntime` (the fresh-spawn path) correctly passes `options.model` to `sessionOptions`. The session file's own `model_change` entry is only a fallback inside `createAgentSession` and may not match the explicitly requested model if the parent changed models in the meantime.

## Fix

1. Add `model?: { provider: string; modelId: string }` to `PersistedRlmSubagentRegistryEntry`.
2. Persist the model in both `recordRlmSubagentRegistryEntry` call sites (running status in `createRlmSubagentRuntime`, completed status in `releaseRlmSubagentRuntime`).
3. In `rehydrateCompletedRlmSubagent`, resolve the persisted model against the parent's `modelRegistry` and pass it via `sessionOptions.model`.
4. If the persisted model is unavailable or unauthenticated, fall back to the session file's own `model_change` entry (existing behavior).

## Testing

- All 14 existing tests in `4649-subagent-model-selection.test.ts` and `3885-subagent-runtime-host.test.ts` pass.
- Pre-commit formatting, linting, and type checking passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refine concurrency and turn-entry gating changed materially (planning vs apply), which can affect prompt timing and system-prompt refresh; subagent rehydration touches session model selection after daemon restarts.
> 
> **Overview**
> **`/refine` no longer blocks the conversation during the planning LLM call.** `AgentSession.refine()` now runs `_planRefine` in the background while turns can proceed; only the brief apply window (`_refineApplyPending` / `_refineInFlight`) still gates prompts and disconnects the agent to patch harness state. Successful apply emits a **`refine_complete`** session event (skipped for streaming observation in daemon attach). Interactive `/refine` returns immediately and shows success or failure when the promise settles; prompts issued during planning start right away instead of waiting on refine.
> 
> **RLM subagent rehydration** stores **`model: { provider, modelId }`** on persisted registry entries when subagents are recorded running or completed, and **`rehydrateCompletedRlmSubagent`** resolves that model from the parent registry (when auth is configured) before opening the child session so crash recovery does not silently switch models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b37a025bc216d7ce64b6d8c899740021515bc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist and restore subagent model on rehydration, and run `/refine` planning in background
> - RLM subagent registry entries in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/503/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) now persist the selected model (`provider` + `modelId`). On rehydration, the model is restored if it is available and authenticated.
> - `/refine` now runs the LLM planning phase in the background so new prompts are no longer blocked during planning; only the brief application phase blocks turn entry points.
> - A `refine_complete` session event is emitted after successful application, and `refine_complete` events are excluded from streaming message observation and standard session event routing.
> - The interactive `/refine` command no longer blocks the UI — success and error messages appear asynchronously when the refine settles.
> - Behavioral Change: prompts submitted while a refine is planning are no longer queued behind the planning pass; they proceed immediately and the refine applies between turns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b37a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->