### PR TITLE
fix(websearch): constrain httpx below 1.0

### DIFF
--- a/packages/coding-agent/skills/websearch/pyproject.toml
+++ b/packages/coding-agent/skills/websearch/pyproject.toml
@@ -3,7 +3,7 @@ name = "prime-agent-skill-websearch"
 version = "0.1.0"
 description = "Web search skill for Prime Agent (Google search via Serper API)."
 requires-python = ">=3.10"
-dependencies = ["httpx", "prime-agent-runtime"]
+dependencies = ["httpx>=0.27,<1", "prime-agent-runtime"]
 
 [project.scripts]
 websearch = "rlm.skill:cli"


### PR DESCRIPTION
## Summary

- constrain the bundled websearch skill to `httpx>=0.27,<1`
- prevent resolution to the incompatible `httpx==1.0.dev3` prerelease

## Context

The websearch implementation uses the pre-1.0 APIs `httpx.AsyncClient` and `httpx.HTTPStatusError`. With the unconstrained `httpx` dependency, a fresh skill environment can resolve `1.0.dev3`, where those attributes are unavailable, causing every search to return an error.

## Validation

Installed `prime-agent-runtime` and the local websearch skill into a clean `uv` virtual environment and verified:

- resolution selects `httpx==0.28.1`
- `httpx.AsyncClient` is available
- `httpx.HTTPStatusError` is available
- installed skill metadata records `httpx<1,>=0.27`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency constraint in the websearch skill package; no application logic changes.
> 
> **Overview**
> Pins the websearch skill’s **`httpx`** dependency to **`>=0.27,<1`** so fresh installs no longer resolve **`httpx==1.0.dev3`**, which removed APIs the skill still uses (`AsyncClient`, `HTTPStatusError`) and caused searches to fail.
> 
> No runtime code changes—only **`packages/coding-agent/skills/websearch/pyproject.toml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd1d1856cb319e6d1464cee09b79d0ab0ad69c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Constrain `httpx` to `>=0.27,<1` in websearch package
> Updates [pyproject.toml](https://github.com/PrimeIntellect-ai/prime-agent/pull/505/files#diff-39935c051814a89580ec6430a6d45a758cab3c88d1229dcb5a3deac63bb2507d) to pin `httpx` below `1.0`, preventing installation of potentially breaking major-version releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd1d18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->