### PR TITLE
feat(agent): stop before scheduling another turn

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -412,6 +412,10 @@ async function runLoop(
 				return;
 			}
 			pendingMessages = steeringMessagesResult.value;
+			if (shouldStopBeforeTurn()) {
+				await emit({ type: "agent_end", messages: newMessages });
+				return;
+			}
 		}
 
 		// Agent would stop here. Check for follow-up messages.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -317,6 +317,8 @@ async function runLoop(
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = await pollMessagesUnlessAborted(config.getSteeringMessages, signal);
 
+	const shouldStopBeforeTurn = (): boolean => !firstTurn && (config.shouldStopBeforeTurn?.() ?? false);
+
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
 		throwIfAborted(signal);
@@ -396,7 +398,7 @@ async function runLoop(
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
 			}
-			if (shouldStopResult.value) {
+			if (shouldStopResult.value || shouldStopBeforeTurn()) {
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
 			}
@@ -413,6 +415,7 @@ async function runLoop(
 		}
 
 		// Agent would stop here. Check for follow-up messages.
+		if (shouldStopBeforeTurn()) break;
 		const followUpMessagesResult = await settlePostTurn(
 			pollMessagesUnlessAborted(config.getFollowUpMessages, signal),
 			signal,
@@ -428,6 +431,7 @@ async function runLoop(
 			continue;
 		}
 
+		if (shouldStopBeforeTurn()) break;
 		const continuationMessagesResult = lastTurn
 			? await settlePostTurn(
 					maybePromiseWithAbort(config.getContinuationMessages?.(lastTurn, signal) ?? [], signal),

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -412,7 +412,10 @@ async function runLoop(
 				return;
 			}
 			pendingMessages = steeringMessagesResult.value;
-			if (shouldStopBeforeTurn()) {
+			// Steering returned by the poll owns the turn boundary; a stop may only
+			// end the loop when the poll came back empty, or the drained messages
+			// would be dropped without ever being injected.
+			if (pendingMessages.length === 0 && shouldStopBeforeTurn()) {
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
 			}

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -412,9 +412,7 @@ async function runLoop(
 				return;
 			}
 			pendingMessages = steeringMessagesResult.value;
-			// Steering returned by the poll owns the turn boundary; a stop may only
-			// end the loop when the poll came back empty, or the drained messages
-			// would be dropped without ever being injected.
+			// Steering drained by this poll owns the turn boundary; stop only when it was empty.
 			if (pendingMessages.length === 0 && shouldStopBeforeTurn()) {
 				await emit({ type: "agent_end", messages: newMessages });
 				return;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -106,6 +106,7 @@ export interface AgentOptions {
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
 	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+	shouldStopBeforeTurn?: () => boolean;
 	getContinuationMessages?: (context: GetContinuationMessagesContext, signal?: AbortSignal) => Promise<AgentMessage[]>;
 	steeringMode?: QueueMode;
 	followUpMode?: QueueMode;
@@ -199,6 +200,7 @@ export class Agent {
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
 	public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
+	public shouldStopBeforeTurn?: () => boolean;
 	public getContinuationMessages?: (
 		context: GetContinuationMessagesContext,
 		signal?: AbortSignal,
@@ -226,6 +228,7 @@ export class Agent {
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
 		this.shouldStopAfterTurn = options.shouldStopAfterTurn;
+		this.shouldStopBeforeTurn = options.shouldStopBeforeTurn;
 		this.getContinuationMessages = options.getContinuationMessages;
 		this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
 		this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
@@ -481,6 +484,7 @@ export class Agent {
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			shouldStopAfterTurn: async (context) => this.shouldStopAfterTurn?.(context) ?? false,
+			shouldStopBeforeTurn: () => this.shouldStopBeforeTurn?.() ?? false,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -192,6 +192,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 
 	/**
+	 * Called synchronously after a completed turn and before polling work for another turn.
+	 * Return true to emit `agent_end` without starting another provider call. Work returned by
+	 * an asynchronous poll owns that boundary; queue owners must suppress stale continuation
+	 * results if their higher-level stop condition changes while generating them.
+	 * The hook is never checked before the initial assistant turn.
+	 */
+	shouldStopBeforeTurn?: () => boolean;
+
+	/**
 	 * Returns steering messages to inject into the conversation mid-run.
 	 *
 	 * Called after the current assistant turn finishes executing its tool calls, unless `shouldStopAfterTurn` exits first.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1487,8 +1487,7 @@ describe("agentLoop with AgentMessage", () => {
 				convertToLlm: identityConverter,
 				shouldStopBeforeTurn: () => stopRequested,
 				getSteeringMessages: async () => {
-					// Only the post-tool-batch poll returns steering; the stop flips
-					// during that same poll.
+					// Only the post-tool-batch poll returns steering; the stop flips during it.
 					if (llmCalls !== 1 || stopRequested) return [];
 					stopRequested = true;
 					return [createUserMessage("late steer")];
@@ -1522,7 +1521,6 @@ describe("agentLoop with AgentMessage", () => {
 				injected.push(text);
 			}
 		}
-		// The drained steering message must reach the conversation, not vanish.
 		expect(injected).toContain("late steer");
 		expect(llmCalls).toBe(2);
 	});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1443,7 +1443,9 @@ describe("agentLoop with AgentMessage", () => {
 				convertToLlm: identityConverter,
 				shouldStopBeforeTurn: () => stopRequested,
 				getSteeringMessages: async () => {
-					stopRequested = true;
+					// Only the post-tool-batch poll flips the stop; flipping on the
+					// pre-loop poll would stop before the recheck under test runs.
+					if (llmCalls > 0) stopRequested = true;
 					return [];
 				},
 			},

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1427,6 +1427,49 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("rechecks a tool-cycle stop after polling steering", async () => {
+		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "done" }], details: {} }));
+		let stopRequested = false;
+		let llmCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{
+				systemPrompt: "",
+				messages: [],
+				tools: [{ name: "work", label: "Work", description: "Work", parameters: Type.Object({}), execute }],
+			},
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				shouldStopBeforeTurn: () => stopRequested,
+				getSteeringMessages: async () => {
+					stopRequested = true;
+					return [];
+				},
+			},
+			undefined,
+			() => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "work", arguments: {} }],
+							"toolUse",
+						),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+		expect(llmCalls).toBe(1);
+	});
+
 	it("checks shouldStopBeforeTurn after a tool batch and before another model call", async () => {
 		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "done" }], details: {} }));
 		const context: AgentContext = {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1470,6 +1470,63 @@ describe("agentLoop with AgentMessage", () => {
 		expect(llmCalls).toBe(1);
 	});
 
+	it("injects steering drained by the poll even when a stop flips during it", async () => {
+		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "done" }], details: {} }));
+		let stopRequested = false;
+		const injected: string[] = [];
+		let llmCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{
+				systemPrompt: "",
+				messages: [],
+				tools: [{ name: "work", label: "Work", description: "Work", parameters: Type.Object({}), execute }],
+			},
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				shouldStopBeforeTurn: () => stopRequested,
+				getSteeringMessages: async () => {
+					// Only the post-tool-batch poll returns steering; the stop flips
+					// during that same poll.
+					if (llmCalls !== 1 || stopRequested) return [];
+					stopRequested = true;
+					return [createUserMessage("late steer")];
+				},
+			},
+			undefined,
+			() => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				const calls = llmCalls;
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: calls === 1 ? "toolUse" : "stop",
+						message:
+							calls === 1
+								? createAssistantMessage(
+										[{ type: "toolCall", id: "tool-1", name: "work", arguments: {} }],
+										"toolUse",
+									)
+								: createAssistantMessage([{ type: "text", text: "steered reply" }], "stop"),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const event of stream) {
+			if (event.type === "message_end" && event.message.role === "user") {
+				const text = event.message.content;
+				if (typeof text !== "string") continue;
+				injected.push(text);
+			}
+		}
+		// The drained steering message must reach the conversation, not vanish.
+		expect(injected).toContain("late steer");
+		expect(llmCalls).toBe(2);
+	});
+
 	it("checks shouldStopBeforeTurn after a tool batch and before another model call", async () => {
 		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "done" }], details: {} }));
 		const context: AgentContext = {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1336,13 +1336,69 @@ describe("agentLoop with AgentMessage", () => {
 		expect(parallelObserved).toBe(true);
 	});
 
-	it("does not check shouldStopBeforeTurn before the initial turn", async () => {
-		const shouldStopBeforeTurn = vi.fn(() => true);
+	const naturalCompletionCases: Array<{
+		name: string;
+		stopBefore: "always" | "afterTurn" | "never";
+		steerOnce?: boolean;
+		naturalWork?: boolean;
+		expected: { llmCalls: number; stopChecks?: number; steeringPolls?: number; naturalPolls?: number };
+	}> = [
+		{
+			name: "stops only after completing the initial turn",
+			stopBefore: "always",
+			expected: { llmCalls: 1, stopChecks: 1 },
+		},
+		{
+			name: "observes a stop requested after the turn before polling steering",
+			stopBefore: "afterTurn",
+			expected: { llmCalls: 1, steeringPolls: 1 },
+		},
+		{
+			name: "stops before polling natural-completion work",
+			stopBefore: "always",
+			naturalWork: true,
+			expected: { llmCalls: 1, naturalPolls: 0 },
+		},
+		{
+			name: "continues with steering when no stop is requested",
+			stopBefore: "never",
+			steerOnce: true,
+			expected: { llmCalls: 2 },
+		},
+	];
+
+	it.each(naturalCompletionCases)("$name", async ({ stopBefore, steerOnce, naturalWork, expected }) => {
 		let llmCalls = 0;
+		let stopRequested = false;
+		let steeringDelivered = false;
+		const shouldStopBeforeTurn = vi.fn(() => stopBefore === "always" || stopRequested);
+		const getSteeringMessages = vi.fn(async () => {
+			if (steerOnce && llmCalls === 1 && !steeringDelivered) {
+				steeringDelivered = true;
+				return [createUserMessage("steer")];
+			}
+			return [];
+		});
+		const getFollowUpMessages = vi.fn(async () => (naturalWork ? [createUserMessage("follow up")] : []));
+		const getContinuationMessages = vi.fn(async () => (naturalWork ? [createUserMessage("continue")] : []));
 		const stream = agentLoop(
 			[createUserMessage("start")],
 			{ systemPrompt: "", messages: [], tools: [] },
-			{ model: createModel(), convertToLlm: identityConverter, shouldStopBeforeTurn },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				shouldStopBeforeTurn,
+				getSteeringMessages,
+				getFollowUpMessages,
+				getContinuationMessages,
+				...(stopBefore === "afterTurn" && {
+					shouldStopAfterTurn: async () => {
+						await Promise.resolve();
+						stopRequested = true;
+						return false;
+					},
+				}),
+			},
 			undefined,
 			() => {
 				llmCalls++;
@@ -1361,8 +1417,14 @@ describe("agentLoop with AgentMessage", () => {
 			// Drain the stream.
 		}
 
-		expect(llmCalls).toBe(1);
-		expect(shouldStopBeforeTurn).toHaveBeenCalledOnce();
+		expect(llmCalls).toBe(expected.llmCalls);
+		if (expected.stopChecks !== undefined) expect(shouldStopBeforeTurn).toHaveBeenCalledTimes(expected.stopChecks);
+		if (expected.steeringPolls !== undefined)
+			expect(getSteeringMessages).toHaveBeenCalledTimes(expected.steeringPolls);
+		if (expected.naturalPolls !== undefined) {
+			expect(getFollowUpMessages).toHaveBeenCalledTimes(expected.naturalPolls);
+			expect(getContinuationMessages).toHaveBeenCalledTimes(expected.naturalPolls);
+		}
 	});
 
 	it("checks shouldStopBeforeTurn after a tool batch and before another model call", async () => {
@@ -1408,117 +1470,6 @@ describe("agentLoop with AgentMessage", () => {
 
 		expect(execute).toHaveBeenCalledOnce();
 		expect(llmCalls).toBe(1);
-	});
-
-	it("observes a stop flag changed during shouldStopAfterTurn before polling steering", async () => {
-		let shouldStop = false;
-		const getSteeringMessages = vi.fn(async () => []);
-		const stream = agentLoop(
-			[createUserMessage("start")],
-			{ systemPrompt: "", messages: [], tools: [] },
-			{
-				model: createModel(),
-				convertToLlm: identityConverter,
-				getSteeringMessages,
-				shouldStopAfterTurn: async () => {
-					await Promise.resolve();
-					shouldStop = true;
-					return false;
-				},
-				shouldStopBeforeTurn: () => shouldStop,
-			},
-			undefined,
-			() => {
-				const mockStream = new MockAssistantStream();
-				queueMicrotask(() =>
-					mockStream.push({
-						type: "done",
-						reason: "stop",
-						message: createAssistantMessage([{ type: "text", text: "done" }]),
-					}),
-				);
-				return mockStream;
-			},
-		);
-		for await (const _event of stream) {
-			// Drain the stream.
-		}
-
-		// The only poll is the non-destructive initial-turn poll.
-		expect(getSteeringMessages).toHaveBeenCalledOnce();
-	});
-
-	it("checks shouldStopBeforeTurn before natural-completion polls", async () => {
-		const getFollowUpMessages = vi.fn(async () => [createUserMessage("follow up")]);
-		const getContinuationMessages = vi.fn(async () => [createUserMessage("continue")]);
-		const stream = agentLoop(
-			[createUserMessage("start")],
-			{ systemPrompt: "", messages: [], tools: [] },
-			{
-				model: createModel(),
-				convertToLlm: identityConverter,
-				shouldStopBeforeTurn: () => true,
-				getFollowUpMessages,
-				getContinuationMessages,
-			},
-			undefined,
-			() => {
-				const mockStream = new MockAssistantStream();
-				queueMicrotask(() =>
-					mockStream.push({
-						type: "done",
-						reason: "stop",
-						message: createAssistantMessage([{ type: "text", text: "done" }]),
-					}),
-				);
-				return mockStream;
-			},
-		);
-		for await (const _event of stream) {
-			// Drain the stream.
-		}
-
-		expect(getFollowUpMessages).not.toHaveBeenCalled();
-		expect(getContinuationMessages).not.toHaveBeenCalled();
-	});
-
-	it("preserves steering behavior when shouldStopBeforeTurn returns false", async () => {
-		let delivered = false;
-		let llmCalls = 0;
-		const stream = agentLoop(
-			[createUserMessage("start")],
-			{ systemPrompt: "", messages: [], tools: [] },
-			{
-				model: createModel(),
-				convertToLlm: identityConverter,
-				shouldStopBeforeTurn: () => false,
-				getSteeringMessages: async () => {
-					if (llmCalls === 1 && !delivered) {
-						delivered = true;
-						return [createUserMessage("steer")];
-					}
-					return [];
-				},
-			},
-			undefined,
-			() => {
-				llmCalls++;
-				const mockStream = new MockAssistantStream();
-				queueMicrotask(() =>
-					mockStream.push({
-						type: "done",
-						reason: "stop",
-						message: createAssistantMessage([{ type: "text", text: "done" }]),
-					}),
-				);
-				return mockStream;
-			},
-		);
-		for await (const _event of stream) {
-			// Drain the stream.
-		}
-
-		expect(llmCalls).toBe(2);
 	});
 
 	it("should stop after the current turn when shouldStopAfterTurn returns true", async () => {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1443,8 +1443,7 @@ describe("agentLoop with AgentMessage", () => {
 				convertToLlm: identityConverter,
 				shouldStopBeforeTurn: () => stopRequested,
 				getSteeringMessages: async () => {
-					// Only the post-tool-batch poll flips the stop; flipping on the
-					// pre-loop poll would stop before the recheck under test runs.
+					// Flip only on the post-tool-batch poll; the pre-loop poll would stop before the recheck runs.
 					if (llmCalls > 0) stopRequested = true;
 					return [];
 				},

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1336,6 +1336,191 @@ describe("agentLoop with AgentMessage", () => {
 		expect(parallelObserved).toBe(true);
 	});
 
+	it("does not check shouldStopBeforeTurn before the initial turn", async () => {
+		const shouldStopBeforeTurn = vi.fn(() => true);
+		let llmCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{ systemPrompt: "", messages: [], tools: [] },
+			{ model: createModel(), convertToLlm: identityConverter, shouldStopBeforeTurn },
+			undefined,
+			() => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+
+		expect(llmCalls).toBe(1);
+		expect(shouldStopBeforeTurn).toHaveBeenCalledOnce();
+	});
+
+	it("checks shouldStopBeforeTurn after a tool batch and before another model call", async () => {
+		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "done" }], details: {} }));
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [
+				{
+					name: "work",
+					label: "Work",
+					description: "Work",
+					parameters: Type.Object({}),
+					execute,
+				},
+			],
+		};
+		let llmCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			context,
+			{ model: createModel(), convertToLlm: identityConverter, shouldStopBeforeTurn: () => true },
+			undefined,
+			() => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "work", arguments: {} }],
+							"toolUse",
+						),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+
+		expect(execute).toHaveBeenCalledOnce();
+		expect(llmCalls).toBe(1);
+	});
+
+	it("observes a stop flag changed during shouldStopAfterTurn before polling steering", async () => {
+		let shouldStop = false;
+		const getSteeringMessages = vi.fn(async () => []);
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{ systemPrompt: "", messages: [], tools: [] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				getSteeringMessages,
+				shouldStopAfterTurn: async () => {
+					await Promise.resolve();
+					shouldStop = true;
+					return false;
+				},
+				shouldStopBeforeTurn: () => shouldStop,
+			},
+			undefined,
+			() => {
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+
+		// The only poll is the non-destructive initial-turn poll.
+		expect(getSteeringMessages).toHaveBeenCalledOnce();
+	});
+
+	it("checks shouldStopBeforeTurn before natural-completion polls", async () => {
+		const getFollowUpMessages = vi.fn(async () => [createUserMessage("follow up")]);
+		const getContinuationMessages = vi.fn(async () => [createUserMessage("continue")]);
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{ systemPrompt: "", messages: [], tools: [] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				shouldStopBeforeTurn: () => true,
+				getFollowUpMessages,
+				getContinuationMessages,
+			},
+			undefined,
+			() => {
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+
+		expect(getFollowUpMessages).not.toHaveBeenCalled();
+		expect(getContinuationMessages).not.toHaveBeenCalled();
+	});
+
+	it("preserves steering behavior when shouldStopBeforeTurn returns false", async () => {
+		let delivered = false;
+		let llmCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			{ systemPrompt: "", messages: [], tools: [] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				shouldStopBeforeTurn: () => false,
+				getSteeringMessages: async () => {
+					if (llmCalls === 1 && !delivered) {
+						delivered = true;
+						return [createUserMessage("steer")];
+					}
+					return [];
+				},
+			},
+			undefined,
+			() => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() =>
+					mockStream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					}),
+				);
+				return mockStream;
+			},
+		);
+		for await (const _event of stream) {
+			// Drain the stream.
+		}
+
+		expect(llmCalls).toBe(2);
+	});
+
 	it("should stop after the current turn when shouldStopAfterTurn returns true", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: string[] = [];

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -540,6 +540,40 @@ describe("Agent", () => {
 		await firstPrompt.catch(() => {});
 	});
 
+	it("forwards shouldStopBeforeTurn from Agent options", async () => {
+		const shouldStopBeforeTurn = vi.fn(() => true);
+		let responseCount = 0;
+		const agent = new Agent({
+			shouldStopBeforeTurn,
+			streamFn: () => {
+				responseCount++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createToolUseMessage("work"),
+					});
+				});
+				return stream;
+			},
+		});
+		agent.state.tools = [
+			{
+				name: "work",
+				label: "Work",
+				description: "Work",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "done" }], details: {} }),
+			},
+		];
+
+		await agent.prompt("start");
+
+		expect(responseCount).toBe(1);
+		expect(shouldStopBeforeTurn).toHaveBeenCalledOnce();
+	});
+
 	it("continue() should process queued follow-up messages after an assistant turn", async () => {
 		const agent = new Agent({
 			streamFn: () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -540,40 +540,6 @@ describe("Agent", () => {
 		await firstPrompt.catch(() => {});
 	});
 
-	it("forwards shouldStopBeforeTurn from Agent options", async () => {
-		const shouldStopBeforeTurn = vi.fn(() => true);
-		let responseCount = 0;
-		const agent = new Agent({
-			shouldStopBeforeTurn,
-			streamFn: () => {
-				responseCount++;
-				const stream = new MockAssistantStream();
-				queueMicrotask(() => {
-					stream.push({
-						type: "done",
-						reason: "toolUse",
-						message: createToolUseMessage("work"),
-					});
-				});
-				return stream;
-			},
-		});
-		agent.state.tools = [
-			{
-				name: "work",
-				label: "Work",
-				description: "Work",
-				parameters: Type.Object({}),
-				execute: async () => ({ content: [{ type: "text", text: "done" }], details: {} }),
-			},
-		];
-
-		await agent.prompt("start");
-
-		expect(responseCount).toBe(1);
-		expect(shouldStopBeforeTurn).toHaveBeenCalledOnce();
-	});
-
 	it("continue() should process queued follow-up messages after an assistant turn", async () => {
 		const agent = new Agent({
 			streamFn: () => {

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -222,7 +222,9 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 			session.dispose();
 			fauxProvider.unregister();
 			if (existsSync(tempDir)) {
-				rmSync(tempDir, { recursive: true });
+				// Spawned fixture processes may still be flushing their final registry
+				// writes; retry briefly instead of failing the suite on ENOTEMPTY.
+				rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 			}
 		},
 	};

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -90,6 +90,16 @@ afterEach(async () => {
 			await waitForExit(handle).catch(() => undefined);
 		}
 	}
+	// A worker or fixture can publish a replacement owner while the first cleanup
+	// sweep is stopping processes. Discover and stop that exact identity only after
+	// every tracked fixture handle has exited, before removing harness directories.
+	for (const registryDir of cleanupRegistryDirs) {
+		registerOwnerRecordsForCleanup(registryDir);
+	}
+	await cleanupRegisteredProcesses();
+	for (const registryDir of cleanupRegistryDirs) {
+		await removeDeadFixtureOwnerRecords(registryDir);
+	}
 	handles.clear();
 	cleanupProcesses.clear();
 	cleanupRegistryDirs.clear();

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -719,7 +719,10 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 			client.close();
 			await waitForExit(legacyCleanup);
 			await waitForCleanupProcessExit(workerCleanupIdentity);
-			await waitForCleanupProcessExit(successorCleanupIdentity);
+			// Under a fully loaded CI shard, the replacement supervisor can remain
+			// observable after shutdown longer than the helper's general cleanup bound.
+			// Extend only this exact generation/pid/process-start identity's polled wait.
+			await waitForCleanupProcessExit(successorCleanupIdentity, 60_000);
 			registerOwnerRecordsForCleanup(paths.registryDir);
 			await cleanupRegisteredProcesses(client);
 			await removeDeadFixtureOwnerRecords(paths.registryDir);

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -414,7 +414,7 @@ function cleanupProcessState(identity: CleanupProcessIdentity): "exited" | "matc
 	return observedStartId === identity.processStartId ? "matching" : "exited";
 }
 
-function removeDeadFixtureOwnerRecords(registryDir: string): void {
+async function removeDeadFixtureOwnerRecords(registryDir: string): Promise<void> {
 	for (const owner of listOwnerRecords(registryDir)) {
 		if (!owner.processStartId) {
 			throw new Error(`Cannot clean owner ${owner.generation} without an exact process-start identity`);
@@ -424,11 +424,11 @@ function removeDeadFixtureOwnerRecords(registryDir: string): void {
 			processStartId: owner.processStartId,
 			label: `supervisor ${owner.generation}`,
 		};
-		const state = cleanupProcessState(identity);
-		if (state !== "exited") {
-			throw new Error(
-				`Refusing to clean ${identity.label} owner for ${identity.pid} (${identity.processStartId}): ${state}`,
-			);
+		// A supervisor that just acknowledged shutdown can stay observable for a
+		// moment; wait for the exact identity to exit instead of refusing outright.
+		if (cleanupProcessState(identity) !== "exited") {
+			await forceShutdownReachableSupervisor(owner.socketPath);
+			await waitForCleanupProcessExit(identity);
 		}
 
 		const current = readOwnerRecord(registryDir, owner.generation);
@@ -722,7 +722,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 			await waitForCleanupProcessExit(successorCleanupIdentity);
 			registerOwnerRecordsForCleanup(paths.registryDir);
 			await cleanupRegisteredProcesses(client);
-			removeDeadFixtureOwnerRecords(paths.registryDir);
+			await removeDeadFixtureOwnerRecords(paths.registryDir);
 			expect(listOwnerRecords(paths.registryDir)).toEqual([]);
 		} finally {
 			await connection?.dispose().catch(() => undefined);

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -437,8 +437,9 @@ async function removeDeadFixtureOwnerRecords(registryDir: string): Promise<void>
 		// A supervisor that just acknowledged shutdown can stay observable for a
 		// moment; wait for the exact identity to exit instead of refusing outright.
 		if (cleanupProcessState(identity) !== "exited") {
-			await forceShutdownReachableSupervisor(owner.socketPath);
-			await waitForCleanupProcessExit(identity);
+			registerCleanupProcess(identity);
+			cleanupSupervisorSockets.add(owner.socketPath);
+			await cleanupRegisteredProcesses();
 		}
 
 		const current = readOwnerRecord(registryDir, owner.generation);

--- a/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
@@ -129,7 +129,9 @@ async function waitForTerminalStatus(agentDir: string, timeoutMs = 120_000) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (existsSync(directory)) {
-			for (const name of readdirSync(directory)) {
+			// The writer stages "<name>.json.<pid>.<uuid>.tmp" files in this directory
+			// before its atomic rename; parsing one mid-write reads torn JSON.
+			for (const name of readdirSync(directory).filter((entry) => entry.endsWith(".json"))) {
 				const path = join(directory, name);
 				const status = readDaemonUpdateRestartStatus(path);
 				if (status && (status.phase === "complete" || status.phase === "failed" || status.phase === "skipped")) {


### PR DESCRIPTION
## Summary

Add a synchronous Agent-loop boundary that can stop after a completed turn but before polling work for another provider turn.

This is the first layer of the session-input scheduling stack. It intentionally does not introduce transactional Agent queues: higher-level session input remains session-owned, and asynchronous continuation generation must suppress stale results in the scheduler layer.

## Invariants

- never suppress the initial assistant turn
- check after `shouldStopAfterTurn` settles and before steering polling
- check at natural completion before follow-up and continuation polling
- finish the current assistant/tool batch normally
- emit `agent_end` without another provider call
- false preserves existing queue behavior

## Validation

- focused Agent tests: 56 passed
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the agent loop exits relative to queue polling, which session schedulers must align with; test harness edits are low risk.
> 
> **Overview**
> Adds an optional **`shouldStopBeforeTurn`** hook on `Agent` / `AgentLoopConfig` so hosts can end a run after a finished assistant/tool turn **without** polling steering, follow-up, or continuation work or starting another model call. The loop never evaluates it before the first turn; it runs after `shouldStopAfterTurn`, again when steering returns empty, and before follow-up/continuation polls. Non-empty steering from an async poll still runs even if stop flips during the poll.
> 
> **Test-only:** coding-agent suite teardown is more tolerant of flaky CI (retried temp dir removal, extra supervisor owner cleanup passes, longer wait for replacement supervisor exit, and ignoring staged `*.tmp` update-restart status files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604714a1dabb327102bf11ed8e99248f1015d534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `shouldStopBeforeTurn` hook to agent loop to halt before scheduling another turn
> - Adds an optional synchronous `shouldStopBeforeTurn?: () => boolean` hook to `AgentLoopConfig` and `AgentOptions`/`Agent` that is consulted after each completed turn but never before the initial turn.
> - When the hook returns true, the loop emits `agent_end` and exits without issuing another provider call; steering messages drained by the post-turn poll are still injected before stopping.
> - New tests in [agent-loop.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/507/files#diff-fd0e125e70b3ceeba9f3f47a1beb9380f40b97d91d825e7fa67e2ad9b7d979ec) cover interactions with steering, follow-up, continuation messages, and tool-call cycles.
> - Flakiness fixes to the coding-agent test harness: retry `rmSync` on cleanup, filter temp files before JSON parsing, and perform a late owner-record sweep in teardown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 604714a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->