### PR TITLE
feat(coding-agent): add durable session command primitives

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -232,7 +232,7 @@ import {
 import type { SessionStats } from "./session-stats.js";
 import type { SettingsManager } from "./settings-manager.js";
 import { getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
-import type { SlashCommandInfo } from "./slash-commands.js";
+import { parseSessionSlashCommand, type SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
@@ -1481,11 +1481,10 @@ export class AgentSession {
 	}
 
 	private _parseGoalSlashCommand(text: string): GoalSlashCommand | undefined {
-		if (text !== "/goal" && !text.startsWith("/goal ")) {
-			return undefined;
-		}
+		const command = parseSessionSlashCommand(text);
+		if (command?.name !== "goal") return undefined;
 
-		const rest = text.slice("/goal".length).trim();
+		const rest = command.args;
 		const normalized = rest.toLowerCase();
 		if (!rest || normalized === "status") {
 			return { kind: "status" };
@@ -1530,10 +1529,9 @@ export class AgentSession {
 	}
 
 	private _parseAutonomousSlashCommand(text: string): AutonomousSlashCommand | undefined {
-		if (text !== "/autonomous" && !text.startsWith("/autonomous ")) {
-			return undefined;
-		}
-		const rest = text.slice("/autonomous".length).trim().toLowerCase();
+		const command = parseSessionSlashCommand(text);
+		if (command?.name !== "autonomous") return undefined;
+		const rest = command.args.toLowerCase();
 		if (!rest || rest === "status") {
 			return { kind: "status" };
 		}
@@ -3984,27 +3982,23 @@ export class AgentSession {
 					this.hasAcceptedPromptInFlight);
 
 			const shouldHandleBuiltInSlashCommands = !isInternalPrompt && !options?.skipPrePromptWork;
+			const sessionSlashCommand = shouldHandleBuiltInSlashCommands
+				? parseSessionSlashCommand(currentText)
+				: undefined;
 			const isBuiltInSlashCommand =
-				shouldHandleBuiltInSlashCommands &&
-				(currentText === "/autonomous" ||
-					currentText.startsWith("/autonomous ") ||
-					currentText === "/goal" ||
-					currentText.startsWith("/goal "));
+				sessionSlashCommand?.name === "autonomous" || sessionSlashCommand?.name === "goal";
 			if (!this.isStreaming && isBuiltInSlashCommand && hasQueueIfBusyBackpressure()) {
 				reportPreflight(false);
 				throw new Error("Agent has queued work. Retry the slash command after pending work finishes.");
 			}
-			if (
-				shouldHandleBuiltInSlashCommands &&
-				(currentText === "/autonomous" || currentText.startsWith("/autonomous "))
-			) {
+			if (sessionSlashCommand?.name === "autonomous") {
 				const handledAutonomousCommand = await this._handleAutonomousSlashCommand(currentText);
 				if (handledAutonomousCommand) {
 					reportPreflight(true);
 					return;
 				}
 			}
-			if (shouldHandleBuiltInSlashCommands && (currentText === "/goal" || currentText.startsWith("/goal "))) {
+			if (sessionSlashCommand?.name === "goal") {
 				const handledGoalCommand = await this._handleGoalSlashCommand(currentText, currentImages);
 				if (handledGoalCommand) {
 					reportPreflight(true);

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -252,11 +252,17 @@ function hasValidCustomMessageEnvelope(message: Record<string, unknown>, customT
 }
 
 function isSessionSlashCommand(value: unknown): value is SessionSlashCommand {
+	if (
+		!isRecord(value) ||
+		!isSessionSlashCommandName(value.name) ||
+		typeof value.args !== "string" ||
+		typeof value.text !== "string"
+	) {
+		return false;
+	}
+	const parsed = parseSessionSlashCommand(value.text);
 	return (
-		isRecord(value) &&
-		isSessionSlashCommandName(value.name) &&
-		typeof value.args === "string" &&
-		typeof value.text === "string"
+		parsed !== undefined && parsed.name === value.name && parsed.args === value.args && parsed.text === value.text
 	);
 }
 
@@ -273,14 +279,7 @@ export function isSessionSlashCommandMessage(message: unknown): message is Sessi
 		return false;
 	}
 	if (!isRecord(message.details) || !isSessionSlashCommand(message.details.command)) return false;
-	const parsed = parseSessionSlashCommand(message.content);
-	return (
-		parsed !== undefined &&
-		parsed.name === message.details.command.name &&
-		parsed.args === message.details.command.args &&
-		parsed.text === message.details.command.text &&
-		isValidCommandEntryId(message.details.commandEntryId)
-	);
+	return message.content === message.details.command.text && isValidCommandEntryId(message.details.commandEntryId);
 }
 
 export function isSessionSlashCommandResultMessage(message: unknown): message is SessionSlashCommandResultMessage {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -8,6 +8,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
 import type { AgentCronJob } from "./cron-jobs.js";
+import { isSessionSlashCommandName, parseSessionSlashCommand, type SessionSlashCommand } from "./slash-commands.js";
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
 
@@ -27,6 +28,33 @@ export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
 export const HEARTBEAT_PROMPT_CUSTOM_TYPE = "heartbeat_prompt";
 export const HEARTBEAT_PROMPT_PREVIEW_LABEL = "Heartbeat prompt";
 export const IPYTHON_STATE_RESTORED_CUSTOM_TYPE = "ipython_state_restored";
+export const SESSION_SLASH_COMMAND_CUSTOM_TYPE = "session_slash_command";
+export const SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE = "session_slash_command_result";
+
+export interface SessionSlashCommandDetails {
+	command: SessionSlashCommand;
+	commandEntryId?: string;
+}
+
+export interface SessionSlashCommandResultDetails {
+	command: SessionSlashCommand;
+	success: boolean;
+	severity: "info" | "warning" | "error";
+	error?: string;
+	commandEntryId?: string;
+}
+
+export interface SessionSlashCommandMessage extends CustomMessage<SessionSlashCommandDetails> {
+	customType: typeof SESSION_SLASH_COMMAND_CUSTOM_TYPE;
+	content: string;
+	details: SessionSlashCommandDetails;
+}
+
+export interface SessionSlashCommandResultMessage extends CustomMessage<SessionSlashCommandResultDetails> {
+	customType: typeof SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE;
+	content: string;
+	details: SessionSlashCommandResultDetails;
+}
 
 /**
  * Message type for bash executions via the ! command.
@@ -176,6 +204,99 @@ export function createCustomMessage(
 	};
 }
 
+export function createSessionSlashCommandMessage(
+	command: SessionSlashCommand,
+	details: Omit<SessionSlashCommandDetails, "command"> = {},
+	display = true,
+	timestamp = Date.now(),
+): SessionSlashCommandMessage {
+	return {
+		role: "custom",
+		customType: SESSION_SLASH_COMMAND_CUSTOM_TYPE,
+		content: command.text,
+		display,
+		details: { ...details, command: { ...command } },
+		timestamp,
+	};
+}
+
+export function createSessionSlashCommandResultMessage(
+	content: string,
+	details: SessionSlashCommandResultDetails,
+	display = true,
+	timestamp = Date.now(),
+): SessionSlashCommandResultMessage {
+	return {
+		role: "custom",
+		customType: SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE,
+		content,
+		display,
+		details: { ...details, command: { ...details.command } },
+		timestamp,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function hasValidCustomMessageEnvelope(message: Record<string, unknown>, customType: string): boolean {
+	return (
+		message.role === "custom" &&
+		message.customType === customType &&
+		typeof message.content === "string" &&
+		typeof message.display === "boolean" &&
+		typeof message.timestamp === "number" &&
+		Number.isFinite(message.timestamp)
+	);
+}
+
+function isSessionSlashCommand(value: unknown): value is SessionSlashCommand {
+	return (
+		isRecord(value) &&
+		isSessionSlashCommandName(value.name) &&
+		typeof value.args === "string" &&
+		typeof value.text === "string"
+	);
+}
+
+function isValidCommandEntryId(value: unknown): value is string | undefined {
+	return value === undefined || (typeof value === "string" && value.length > 0);
+}
+
+export function isSessionSlashCommandMessage(message: unknown): message is SessionSlashCommandMessage {
+	if (
+		!isRecord(message) ||
+		!hasValidCustomMessageEnvelope(message, SESSION_SLASH_COMMAND_CUSTOM_TYPE) ||
+		typeof message.content !== "string"
+	) {
+		return false;
+	}
+	if (!isRecord(message.details) || !isSessionSlashCommand(message.details.command)) return false;
+	const parsed = parseSessionSlashCommand(message.content);
+	return (
+		parsed !== undefined &&
+		parsed.name === message.details.command.name &&
+		parsed.args === message.details.command.args &&
+		parsed.text === message.details.command.text &&
+		isValidCommandEntryId(message.details.commandEntryId)
+	);
+}
+
+export function isSessionSlashCommandResultMessage(message: unknown): message is SessionSlashCommandResultMessage {
+	if (!isRecord(message) || !hasValidCustomMessageEnvelope(message, SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE))
+		return false;
+	if (!isRecord(message.details) || !isSessionSlashCommand(message.details.command)) return false;
+	return (
+		typeof message.details.success === "boolean" &&
+		(message.details.severity === "info" ||
+			message.details.severity === "warning" ||
+			message.details.severity === "error") &&
+		(message.details.error === undefined || typeof message.details.error === "string") &&
+		isValidCommandEntryId(message.details.commandEntryId)
+	);
+}
+
 export function createHeartbeatPromptMessage(
 	job: AgentCronJob,
 	timestamp = Date.now(),
@@ -220,6 +341,12 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						timestamp: m.timestamp,
 					};
 				case "custom": {
+					if (
+						m.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE ||
+						m.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE
+					) {
+						return undefined;
+					}
 					const content = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
 					return {
 						role: "user",

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -10,9 +10,26 @@ export interface SlashCommandInfo {
 	sourceInfo: SourceInfo;
 }
 
+export const SESSION_SLASH_COMMAND_NAMES = ["compact", "refine", "goal", "autonomous"] as const;
+
+export type SessionSlashCommandName = (typeof SESSION_SLASH_COMMAND_NAMES)[number];
+
+const SESSION_SLASH_COMMAND_NAME_SET: ReadonlySet<string> = new Set(SESSION_SLASH_COMMAND_NAMES);
+
+export function isSessionSlashCommandName(value: unknown): value is SessionSlashCommandName {
+	return typeof value === "string" && SESSION_SLASH_COMMAND_NAME_SET.has(value);
+}
+
+export interface SessionSlashCommand {
+	name: SessionSlashCommandName;
+	args: string;
+	text: string;
+}
+
 export interface BuiltinSlashCommand {
 	name: string;
 	description: string;
+	execution?: "client" | "session";
 	/** Shown in autocomplete before the description, e.g. "[instructions]" */
 	argumentHint?: string;
 	/** Hidden names that resolve to this command without being shown as commands. */
@@ -86,11 +103,20 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 		description: "Compact the session context; optional instructions focus the summary",
 		argumentHint: "[instructions]",
 	},
-	{ name: "refine", description: "Refine continual harness prompt notes, skills, subagents, and memory" },
+	{
+		name: "refine",
+		description: "Refine continual harness prompt notes, skills, subagents, and memory",
+	},
 	{
 		name: "goal",
 		description: "Set or view a persistent goal; supports pause, resume, and clear",
 		argumentHint: "[objective]",
+		takesArgument: true,
+	},
+	{
+		name: "autonomous",
+		description: "Set or view autonomous mode",
+		argumentHint: "[status|on|off]",
 		takesArgument: true,
 	},
 	{
@@ -137,6 +163,7 @@ function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {
 	}
 	return CANONICAL_BUILTIN_SLASH_COMMANDS.map((command) => ({
 		...command,
+		...(isSessionSlashCommandName(command.name) ? { execution: "session" as const } : {}),
 		...(aliasesByTarget.has(command.name) ? { aliases: aliasesByTarget.get(command.name) } : {}),
 	}));
 }
@@ -152,12 +179,12 @@ export function parseSlashCommand(text: string): ParsedSlashCommand | undefined 
 	if (!text.startsWith("/")) {
 		return undefined;
 	}
-	const spaceIndex = text.indexOf(" ");
-	const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const whitespaceIndex = text.search(/[\t\p{Zs}]/u);
+	const name = whitespaceIndex === -1 ? text.slice(1) : text.slice(1, whitespaceIndex);
 	if (!name) {
 		return undefined;
 	}
-	return { name, args: spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim() };
+	return { name, args: whitespaceIndex === -1 ? "" : text.slice(whitespaceIndex).trim() };
 }
 
 export function resolveBuiltinSlashCommandName(name: string): string {
@@ -180,4 +207,13 @@ export function resolveSlashCommand(command: ParsedSlashCommand): ResolvedSlashC
 		originalName: command.name,
 		isAlias: name !== command.name,
 	};
+}
+
+export function parseSessionSlashCommand(text: string): SessionSlashCommand | undefined {
+	const parsed = parseSlashCommand(text);
+	if (!parsed) return undefined;
+	const name = resolveBuiltinSlashCommandName(parsed.name);
+	const command = BUILTIN_SLASH_COMMAND_BY_NAME.get(name);
+	if (command?.execution !== "session" || !isSessionSlashCommandName(name)) return undefined;
+	return { name, args: parsed.args, text };
 }

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -210,6 +210,7 @@ export function resolveSlashCommand(command: ParsedSlashCommand): ResolvedSlashC
 }
 
 export function parseSessionSlashCommand(text: string): SessionSlashCommand | undefined {
+	if (/[\r\n\u2028\u2029]/u.test(text)) return undefined;
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return undefined;
 	const name = resolveBuiltinSlashCommandName(parsed.name);

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -1,9 +1,17 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Component, MarkdownTheme, TUI } from "@earendil-works/pi-tui";
 import { isAgentSessionMessage } from "../../../core/agent-messages.js";
+import {
+	isSessionSlashCommandMessage,
+	isSessionSlashCommandResultMessage,
+	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
+	SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE,
+} from "../../../core/messages.js";
 import { AgentMessageComponent } from "./agent-message.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
+import { SlashCommandMessageComponent } from "./slash-command-message.js";
+import { SlashCommandResultMessageComponent } from "./slash-command-result-message.js";
 import {
 	selectLatestToolExpandHint,
 	ToolExecutionComponent,
@@ -85,6 +93,19 @@ export function buildConversationComponents(
 		} else if (message.role === "toolResult") {
 			pendingTools.get(message.toolCallId)?.updateResult(message);
 			pendingTools.delete(message.toolCallId);
+		} else if (
+			message.role === "custom" &&
+			(message.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE ||
+				message.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE)
+		) {
+			if (!message.display) continue;
+			if (isSessionSlashCommandMessage(message)) {
+				components.push(new SlashCommandMessageComponent(message.content));
+			} else if (isSessionSlashCommandResultMessage(message)) {
+				components.push(new SlashCommandResultMessageComponent(message));
+			} else {
+				components.push(new UserMessageComponent("[Malformed session command message]", options.markdownTheme));
+			}
 		} else if (isAgentSessionMessage(message) && message.display) {
 			const component = new AgentMessageComponent(message, options.markdownTheme);
 			component.setExpanded(expanded);

--- a/packages/coding-agent/src/modes/interactive/components/slash-command-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/slash-command-message.ts
@@ -1,0 +1,35 @@
+import { Box, Container, Text } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.js";
+
+const OSC133_ZONE_START = "\x1b]133;A\x07";
+const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+
+export function styleSlashCommandText(text: string): string {
+	const space = text.search(/\s/);
+	const command = space === -1 ? text : text.slice(0, space);
+	const rest = space === -1 ? "" : text.slice(space);
+	return `${theme.fg("accent", command)}${rest}`;
+}
+
+/** Renders a durable session command with the same layout as a user message. */
+export class SlashCommandMessageComponent extends Container {
+	private readonly contentBox: Box;
+
+	constructor(text: string) {
+		super();
+		this.contentBox = new Box(2, 1, (content: string) => theme.getUserMessageBackgroundColor()(content));
+		this.contentBox.addChild(new Text(styleSlashCommandText(text), 0, 0));
+		this.addChild(this.contentBox);
+	}
+
+	setExpanded(_expanded: boolean): void {}
+
+	override render(width: number): string[] {
+		const lines = super.render(width);
+		if (lines.length === 0) return lines;
+		lines[0] = OSC133_ZONE_START + lines[0];
+		lines[lines.length - 1] = OSC133_ZONE_END + OSC133_ZONE_FINAL + lines[lines.length - 1];
+		return lines;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/slash-command-result-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/slash-command-result-message.ts
@@ -1,0 +1,15 @@
+import { Box, Container, Text } from "@earendil-works/pi-tui";
+import type { SessionSlashCommandResultMessage } from "../../../core/messages.js";
+import { theme } from "../theme/theme.js";
+
+/** Renders a durable session-command outcome with user-message spacing. */
+export class SlashCommandResultMessageComponent extends Container {
+	constructor(message: SessionSlashCommandResultMessage) {
+		super();
+		const contentBox = new Box(2, 1, (text: string) => theme.getUserMessageBackgroundColor()(text));
+		contentBox.addChild(new Text(message.content, 0, 0));
+		this.addChild(contentBox);
+	}
+
+	setExpanded(_expanded: boolean): void {}
+}

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -1,4 +1,3 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { TUI } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test, vi } from "vitest";
@@ -141,7 +140,7 @@ describe("session command messages", () => {
 		]);
 	});
 
-	test("renders validated durable command and result components", () => {
+	test("dispatches valid messages and safely diagnoses malformed reserved entries", () => {
 		const command = parseSessionSlashCommand("/compact focus");
 		expect(command).toBeDefined();
 		const components = buildConversationComponents(
@@ -152,30 +151,18 @@ describe("session command messages", () => {
 					success: false,
 					severity: "warning",
 				}),
+				customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE, { command: "not-a-command" }),
+				customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE, { severity: "fatal" }),
 			],
 			componentOptions,
 		);
+		const output = stripAnsi(components.flatMap((component) => component.render(80)).join("\n"));
 
 		expect(components[0]).toBeInstanceOf(SlashCommandMessageComponent);
 		expect(components[1]).toBeInstanceOf(SlashCommandResultMessageComponent);
-		expect(stripAnsi(components.map((component) => component.render(80).join("\n")).join("\n"))).toContain(
-			"Compaction skipped",
-		);
-	});
-
-	test("uses an explicit diagnostic for malformed reserved messages without inventing failure text", () => {
-		const malformed: AgentMessage[] = [
-			customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE, { command: "not-a-command" }),
-			customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE, { severity: "fatal" }),
-		];
-		const output = stripAnsi(
-			buildConversationComponents(malformed, componentOptions)
-				.flatMap((component) => component.render(80))
-				.join("\n"),
-		);
-
+		expect(output).toContain("Compaction skipped");
 		expect(output.match(/\[Malformed session command message\]/g)).toHaveLength(2);
-		expect(output).not.toContain("Command failed");
 		expect(output).not.toContain("durable display text");
 	});
+
 });

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -78,6 +78,12 @@ describe("session command messages", () => {
 		expect(
 			isSessionSlashCommandResultMessage({
 				...resultMessage,
+				details: { ...resultMessage.details, command: { ...command!, text: "/compact" } },
+			}),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandResultMessage({
+				...resultMessage,
 				details: { ...resultMessage.details, severity: "fatal" },
 			}),
 		).toBe(false);
@@ -164,5 +170,4 @@ describe("session command messages", () => {
 		expect(output.match(/\[Malformed session command message\]/g)).toHaveLength(2);
 		expect(output).not.toContain("durable display text");
 	});
-
 });

--- a/packages/coding-agent/test/session-command-messages.test.ts
+++ b/packages/coding-agent/test/session-command-messages.test.ts
@@ -1,0 +1,181 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { TUI } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import {
+	type CustomMessage,
+	convertToLlm,
+	createSessionSlashCommandMessage,
+	createSessionSlashCommandResultMessage,
+	isSessionSlashCommandMessage,
+	isSessionSlashCommandResultMessage,
+	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
+	SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE,
+} from "../src/core/messages.js";
+import { parseSessionSlashCommand } from "../src/core/slash-commands.js";
+import { buildConversationComponents } from "../src/modes/interactive/components/conversation-components.js";
+import { SlashCommandMessageComponent } from "../src/modes/interactive/components/slash-command-message.js";
+import { SlashCommandResultMessageComponent } from "../src/modes/interactive/components/slash-command-result-message.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+const componentOptions = {
+	ui: { requestRender: vi.fn() } as unknown as TUI,
+	cwd: "/tmp",
+	toolOptions: {},
+	getToolDefinition: () => undefined,
+};
+
+function customMessage(customType: string, details?: unknown): CustomMessage {
+	return {
+		role: "custom",
+		customType,
+		content: "durable display text",
+		display: true,
+		details,
+		timestamp: 123,
+	};
+}
+
+describe("session command messages", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("creates and recognizes typed command and result messages", () => {
+		const command = parseSessionSlashCommand("/goal\tship it");
+		expect(command).toBeDefined();
+		const commandMessage = createSessionSlashCommandMessage(command!, { commandEntryId: "entry-1" }, true, 123);
+		const attemptedOverwrite = Reflect.apply(createSessionSlashCommandMessage, undefined, [
+			command!,
+			{ command: { name: "compact", args: "", text: "/compact" } },
+		]);
+		const resultMessage = createSessionSlashCommandResultMessage(
+			"Goal unavailable",
+			{
+				command: command!,
+				success: false,
+				severity: "warning",
+				error: "Goal unavailable",
+				commandEntryId: "entry-1",
+			},
+			true,
+			124,
+		);
+
+		expect(commandMessage).toEqual({
+			role: "custom",
+			customType: SESSION_SLASH_COMMAND_CUSTOM_TYPE,
+			content: "/goal\tship it",
+			display: true,
+			details: {
+				command: { name: "goal", args: "ship it", text: "/goal\tship it" },
+				commandEntryId: "entry-1",
+			},
+			timestamp: 123,
+		});
+		expect(isSessionSlashCommandMessage(commandMessage)).toBe(true);
+		expect(attemptedOverwrite.details.command).toEqual(command);
+		expect(isSessionSlashCommandResultMessage(resultMessage)).toBe(true);
+		expect(
+			isSessionSlashCommandResultMessage({
+				...resultMessage,
+				details: { ...resultMessage.details, severity: "fatal" },
+			}),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandResultMessage({ ...resultMessage, details: { ...resultMessage.details, success: "no" } }),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandResultMessage({
+				...resultMessage,
+				details: { ...resultMessage.details, commandEntryId: "" },
+			}),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandMessage({
+				...commandMessage,
+				details: { command: { ...commandMessage.details.command, name: "compact" } },
+			}),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandMessage({
+				...commandMessage,
+				details: { command: { ...commandMessage.details.command, args: "other" } },
+			}),
+		).toBe(false);
+		expect(
+			isSessionSlashCommandMessage({
+				...commandMessage,
+				details: { command: { ...commandMessage.details.command, text: "/goal other" } },
+			}),
+		).toBe(false);
+		expect(isSessionSlashCommandMessage({ ...commandMessage, timestamp: Number.NaN })).toBe(false);
+		expect(
+			isSessionSlashCommandMessage({
+				...commandMessage,
+				details: { ...commandMessage.details, commandEntryId: "" },
+			}),
+		).toBe(false);
+	});
+
+	test("excludes valid and malformed reserved entries from LLM context", () => {
+		const command = parseSessionSlashCommand("/compact");
+		expect(command).toBeDefined();
+		expect(
+			convertToLlm([
+				createSessionSlashCommandMessage(command!),
+				createSessionSlashCommandResultMessage("Skipped", {
+					command: command!,
+					success: false,
+					severity: "warning",
+				}),
+				customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE),
+				customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE),
+			]),
+		).toEqual([]);
+	});
+
+	test("continues to include ordinary custom messages", () => {
+		expect(convertToLlm([customMessage("extension_notice")])).toMatchObject([
+			{ role: "user", content: [{ type: "text", text: "durable display text" }] },
+		]);
+	});
+
+	test("renders validated durable command and result components", () => {
+		const command = parseSessionSlashCommand("/compact focus");
+		expect(command).toBeDefined();
+		const components = buildConversationComponents(
+			[
+				createSessionSlashCommandMessage(command!),
+				createSessionSlashCommandResultMessage("Compaction skipped", {
+					command: command!,
+					success: false,
+					severity: "warning",
+				}),
+			],
+			componentOptions,
+		);
+
+		expect(components[0]).toBeInstanceOf(SlashCommandMessageComponent);
+		expect(components[1]).toBeInstanceOf(SlashCommandResultMessageComponent);
+		expect(stripAnsi(components.map((component) => component.render(80).join("\n")).join("\n"))).toContain(
+			"Compaction skipped",
+		);
+	});
+
+	test("uses an explicit diagnostic for malformed reserved messages without inventing failure text", () => {
+		const malformed: AgentMessage[] = [
+			customMessage(SESSION_SLASH_COMMAND_CUSTOM_TYPE, { command: "not-a-command" }),
+			customMessage(SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE, { severity: "fatal" }),
+		];
+		const output = stripAnsi(
+			buildConversationComponents(malformed, componentOptions)
+				.flatMap((component) => component.render(80))
+				.join("\n"),
+		);
+
+		expect(output.match(/\[Malformed session command message\]/g)).toHaveLength(2);
+		expect(output).not.toContain("Command failed");
+		expect(output).not.toContain("durable display text");
+	});
+});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -175,8 +175,11 @@ describe("session slash commands", () => {
 			expect(parseSessionSlashCommand(text)).toEqual({ name: "goal", args: "ship it", text });
 		}
 		expect(parseSlashCommand("/goal\t  ship it  ")).toEqual({ name: "goal", args: "ship it" });
-		expect(parseSessionSlashCommand("/goal\nship it")).toBeUndefined();
-		expect(parseSessionSlashCommand("/goal\rship it")).toBeUndefined();
+		for (const lineTerminator of ["\n", "\r", "\r\n", "\u2028", "\u2029"]) {
+			expect(parseSessionSlashCommand(`/goal${lineTerminator}ship it`)).toBeUndefined();
+			expect(parseSessionSlashCommand(`/goal\t${lineTerminator}ship it`)).toBeUndefined();
+			expect(parseSessionSlashCommand(`/autonomous\t${lineTerminator}on`)).toBeUndefined();
+		}
 	});
 
 	test("classifies only exact leading session-owned commands", () => {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -3,9 +3,12 @@ import {
 	BUILTIN_SLASH_COMMANDS,
 	builtinSlashCommandTakesArgument,
 	isBuiltinSlashCommandName,
+	isSessionSlashCommandName,
+	parseSessionSlashCommand,
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
 	resolveSlashCommand,
+	SESSION_SLASH_COMMAND_NAMES,
 } from "../src/core/slash-commands.js";
 
 describe("built-in slash commands", () => {
@@ -154,5 +157,48 @@ describe("slash command aliases", () => {
 			originalName: "side",
 			isAlias: true,
 		});
+	});
+});
+
+describe("session slash commands", () => {
+	test("keeps the authoritative names and built-in execution metadata in sync", () => {
+		expect(
+			BUILTIN_SLASH_COMMANDS.filter((command) => command.execution === "session").map((command) => command.name),
+		).toEqual([...SESSION_SLASH_COMMAND_NAMES]);
+		for (const name of SESSION_SLASH_COMMAND_NAMES) expect(isSessionSlashCommandName(name)).toBe(true);
+		expect(isSessionSlashCommandName("settings")).toBe(false);
+	});
+
+	test("splits at the first horizontal Unicode whitespace and preserves the raw text", () => {
+		for (const text of ["/goal ship it", "/goal\tship it", "/goal\u00a0ship it", "/goal\u2003ship it"]) {
+			expect(parseSlashCommand(text)).toEqual({ name: "goal", args: "ship it" });
+			expect(parseSessionSlashCommand(text)).toEqual({ name: "goal", args: "ship it", text });
+		}
+		expect(parseSlashCommand("/goal\t  ship it  ")).toEqual({ name: "goal", args: "ship it" });
+		expect(parseSessionSlashCommand("/goal\nship it")).toBeUndefined();
+		expect(parseSessionSlashCommand("/goal\rship it")).toBeUndefined();
+	});
+
+	test("classifies only exact leading session-owned commands", () => {
+		expect(parseSessionSlashCommand("/compact focus on tests")).toEqual({
+			name: "compact",
+			args: "focus on tests",
+			text: "/compact focus on tests",
+		});
+		expect(parseSessionSlashCommand("/refine")).toEqual({ name: "refine", args: "", text: "/refine" });
+		expect(parseSessionSlashCommand("/goal ship it")).toEqual({
+			name: "goal",
+			args: "ship it",
+			text: "/goal ship it",
+		});
+		expect(parseSessionSlashCommand("/autonomous status")).toEqual({
+			name: "autonomous",
+			args: "status",
+			text: "/autonomous status",
+		});
+		expect(parseSessionSlashCommand("Explain /compact")).toBeUndefined();
+		expect(parseSessionSlashCommand(" /compact")).toBeUndefined();
+		expect(parseSessionSlashCommand("/compaction")).toBeUndefined();
+		expect(parseSessionSlashCommand("/settings")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1190,6 +1190,20 @@ stale post-hook extension instructions`,
 		expect(getAssistantTexts(harness)).toEqual([]);
 	});
 
+	it("sends multiline goal and autonomous variants to the model", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("second")]);
+
+		await harness.session.prompt("/goal\t\nship it", { expandPromptTemplates: false });
+		await harness.session.prompt("/autonomous\t\non", { expandPromptTemplates: false });
+
+		expect(harness.session.goalState.status).toBe("idle");
+		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
+		expect(getUserTexts(harness)).toEqual(["/goal\t\nship it", "/autonomous\t\non"]);
+		expect(getAssistantTexts(harness)).toEqual(["first", "second"]);
+	});
+
 	it("does not run built-in slash commands immediately while queueIfBusy backpressure is active", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1168,22 +1168,22 @@ stale post-hook extension instructions`,
 		).toBeUndefined();
 	});
 
-	it("handles autonomous slash commands when template expansion is disabled", async () => {
+	it("handles tab-separated autonomous slash commands when template expansion is disabled", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 
-		await harness.session.prompt("/autonomous on", { expandPromptTemplates: false });
+		await harness.session.prompt("/autonomous	on", { expandPromptTemplates: false });
 
 		expect(harness.session.getAutonomousStatus().enabled).toBe(true);
 		expect(harness.getPendingResponseCount()).toBe(0);
 		expect(harness.session.messages.some((message) => message.role === "custom")).toBe(true);
 	});
 
-	it("handles goal slash commands when template expansion is disabled", async () => {
+	it("handles Unicode-space-separated goal slash commands when template expansion is disabled", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 
-		await harness.session.prompt("/goal status", { expandPromptTemplates: false });
+		await harness.session.prompt("/goal status", { expandPromptTemplates: false });
 
 		expect(harness.eventsOfType("goal_update")).toHaveLength(1);
 		expect(harness.getPendingResponseCount()).toBe(0);


### PR DESCRIPTION
## Summary

Introduce typed, durable primitives for session-owned slash commands without changing scheduling yet.

- one authoritative command-name set for `/compact`, `/refine`, `/goal`, and `/autonomous`
- robust horizontal-whitespace parsing while preserving multiline prompt behavior
- typed command/result message factories, metadata, correlation IDs, and runtime guards
- durable rows remain excluded from model context
- validated replay rendering with an explicit malformed-record diagnostic

This is stacked on the Agent pre-turn boundary PR and is the second layer of the input-scheduling stack.

## Validation

- focused command/message tests: 21 passed
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user input is classified before the agent loop (goal/autonomous vs model), which can alter session behavior; new message types affect persistence and LLM context filtering but scheduling is unchanged in this layer.
> 
> **Overview**
> Adds a shared **`parseSessionSlashCommand`** path for session-owned builtins (`/compact`, `/refine`, `/goal`, `/autonomous`), marks them with **`execution: "session"`**, and tightens slash parsing to split on horizontal Unicode whitespace while **rejecting line terminators** so multiline `/goal` / `/autonomous` input is no longer treated as built-ins.
> 
> Introduces durable **`session_slash_command`** and **`session_slash_command_result`** custom message types (factories, validation guards, optional `commandEntryId`), **drops them from `convertToLlm`**, and wires the interactive transcript to dedicated slash-command UI components (with a malformed-record placeholder).
> 
> **`AgentSession`** pre-prompt handling now keys off the shared parser instead of `startsWith` checks; behavior change: multiline variants fall through to the model, while tab/Unicode-space separators still run `/goal` and `/autonomous` handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af38965bb75239604721c6c67e0a9c4ef3224298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add durable session slash command primitives to the coding agent
> - Introduces `parseSessionSlashCommand` in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/508/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051) to classify `/goal`, `/autonomous`, `/compact`, and `/refine` as session-owned commands, rejecting multiline input and supporting tab/Unicode horizontal whitespace as separators.
> - Adds `SESSION_SLASH_COMMAND_CUSTOM_TYPE` and `SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE` message types with factories, type guards, and LLM-conversion exclusion so session command entries and their results are stored durably but never sent to the model.
> - Updates `AgentSession` prompt handling to use the new parser instead of string `.startsWith` checks, preventing false positives on multiline inputs that now fall through to the model.
> - Adds `SlashCommandMessageComponent` and `SlashCommandResultMessageComponent` to render session command entries in the conversation UI; malformed reserved messages render as a diagnostic placeholder.
> - Behavioral Change: multiline text beginning with `/goal` or `/autonomous` no longer triggers built-in command handling and is sent to the model instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af38965.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->