### PR TITLE
refactor(coding-agent): centralize session input scheduling

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5290,6 +5290,25 @@ export class AgentSession {
 		await this._sessionInputPump;
 	}
 
+	async waitForIdle(): Promise<void> {
+		while (true) {
+			const pump = this._sessionInputPump;
+			const acceptedPrompts = [...this._acceptedPromptCompletions];
+			await Promise.all([pump, ...acceptedPrompts]);
+			await this.agent.waitForIdle();
+			if (
+				pump === this._sessionInputPump &&
+				acceptedPrompts.length === this._acceptedPromptCompletions.size &&
+				acceptedPrompts.every((completion) => this._acceptedPromptCompletions.has(completion)) &&
+				!this._sessionInputPumpRequested &&
+				!this._pumpingSessionInput &&
+				this._acceptedAgentMessagePrompt === undefined
+			) {
+				return;
+			}
+		}
+	}
+
 	getPendingNextTurnMessageSnapshots(): readonly CustomMessage[] {
 		const messages = this._pendingNextTurnMessages.map((message) => cloneCustomMessage(message));
 		const accepted = this._acceptedAgentMessagePrompt;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6308,7 +6308,14 @@ export class AgentSession {
 			this._scheduleAutoRefineAfterAgentEnd();
 			return;
 		}
-		if (this.pendingMessageCount > 0) {
+		// The pump owns items it moved into _activeSessionInput before handoff, so
+		// an empty queue alone does not mean idle.
+		if (
+			this.pendingMessageCount > 0 ||
+			this._activeSessionInput !== undefined ||
+			this._pumpingSessionInput ||
+			this._sessionInputPumpRequested
+		) {
 			this._scheduleSessionInputPump();
 			await this._sessionInputPump;
 			if (this._postCompactionContinuationScheduled) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5205,6 +5205,14 @@ export class AgentSession {
 		return { steering, followUp };
 	}
 
+	private _invalidateQueuedPromptPreparation(): void {
+		for (const queue of [this._steeringMessages, this._followUpMessages]) {
+			for (const input of queue) {
+				if (input.kind === "prompt") input.preparation = undefined;
+			}
+		}
+	}
+
 	private _removeActivePreparingPrompts(predicate: (message: PreparedPromptInput) => boolean): {
 		steering: PreparedPromptInput[];
 		followUp: PreparedPromptInput[];
@@ -9503,6 +9511,9 @@ export class AgentSession {
 			this.agent.state.messages = sessionContext.messages;
 			this._restoreLateIpythonSentAgentMessages();
 			this._reloadGoalStateFromBranch();
+			// Queued prompts prepared against the old branch must re-run
+			// before_agent_start against the new context.
+			this._invalidateQueuedPromptPreparation();
 
 			// Emit session_tree event
 			await this._extensionRunner.emit({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6302,11 +6302,13 @@ export class AgentSession {
 				const sessionOwnedContinuationsStillRemain = continuationMessages.some((message) =>
 					this._postCompactionContinuationMessages.includes(message),
 				);
-				if (continuationMessages.length > 0 && !sessionOwnedContinuationsStillRemain) {
+				const shouldReschedule =
+					continuationMessages.length === 0 ? this.pendingMessageCount > 0 : sessionOwnedContinuationsStillRemain;
+				if (shouldReschedule) {
+					this._schedulePostCompactionContinue();
+				} else {
 					this._scheduledPostCompactionContinuationMessages = [];
 					this._scheduleAutoRefineAfterAgentEnd();
-				} else {
-					this._schedulePostCompactionContinue();
 				}
 			}
 			return;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3066,12 +3066,8 @@ export class AgentSession {
 			this._resolveRetry();
 		}
 
-		// Remove queued messages before emitting so the UI sees the updated queue.
-		if (event.type === "message_start") {
-			if (this._isPromptTurnStartMessage(event.message)) {
-				this._overflowRecoveryAttempted = false;
-			}
-			this._removeDeliveredSessionInput(event.message);
+		if (event.type === "message_start" && this._isPromptTurnStartMessage(event.message)) {
+			this._overflowRecoveryAttempted = false;
 		}
 
 		// Emit to extensions first
@@ -3391,6 +3387,7 @@ export class AgentSession {
 				return;
 			}
 			this._disposing = true;
+			this._wakeQueuedWorkAdmissionWaiters();
 			await this._disposeAsyncOnce();
 		})();
 		return this._disposeAsyncPromise;
@@ -3558,6 +3555,7 @@ export class AgentSession {
 			return;
 		}
 		this._disposed = true;
+		this._wakeQueuedWorkAdmissionWaiters();
 		try {
 			// Invalidate scheduled timers and abort any in-flight review so a late
 			// resolution cannot write harness state or re-subscribe handlers.
@@ -4718,19 +4716,6 @@ export class AgentSession {
 		return true;
 	}
 
-	/** Remove a delivered queued input from whichever lane holds it (steering first, then follow-up). */
-	private _removeDeliveredSessionInput(message: AgentMessage): void {
-		for (const queue of [this._steeringMessages, this._followUpMessages]) {
-			const index = queue.findIndex((item) => item.message === message);
-			if (index !== -1) {
-				const [removed] = queue.splice(index, 1);
-				this._resolveAgentMessageDelivery(removed?.agentMessageId);
-				this._emitQueueUpdate();
-				return;
-			}
-		}
-	}
-
 	private async _queueSteer(
 		text: string,
 		images?: ImageContent[],
@@ -5299,13 +5284,24 @@ export class AgentSession {
 				if (released) return;
 				released = true;
 				this._queuedWorkPauses.delete(token);
-				if (this._queuedWorkPauses.size === 0) {
-					for (const resolve of this._queuedWorkAdmissionWaiters) resolve();
-					this._queuedWorkAdmissionWaiters.clear();
-				}
+				if (this._queuedWorkPauses.size === 0) this._wakeQueuedWorkAdmissionWaiters();
 				this._scheduleSessionInputPump();
 			},
 		};
+	}
+
+	private _wakeQueuedWorkAdmissionWaiters(): void {
+		for (const resolve of this._queuedWorkAdmissionWaiters) resolve();
+		this._queuedWorkAdmissionWaiters.clear();
+	}
+
+	private _assertDirectTurnAdmissionAvailable(): void {
+		if (this._disposed || this._disposing) {
+			throw new Error("Cannot start a direct turn because the session is disposing or disposed.");
+		}
+		if (this.pendingMessageCount > 0 && this._sessionInputPumpSuspended) {
+			throw new Error("Cannot start a direct turn while queued session input is suspended.");
+		}
 	}
 
 	private async _acquireTurnAdmission(): Promise<{ owner: symbol; release(): void }> {
@@ -5337,26 +5333,37 @@ export class AgentSession {
 		options: { allowStreaming?: boolean } = {},
 	): Promise<{ owner: symbol; release(): void }> {
 		while (true) {
+			this._assertDirectTurnAdmissionAvailable();
 			await this._waitForQueuedWorkAdmission();
+			this._assertDirectTurnAdmissionAvailable();
 			if (this.pendingMessageCount > 0) this._scheduleSessionInputPump();
 			const admission = await this._acquireTurnAdmission();
-			if (
-				(options.allowStreaming === true && this.isStreaming) ||
-				(this.pendingMessageCount === 0 &&
-					this._activeSessionInput === undefined &&
-					!this._pumpingSessionInput &&
-					!this._sessionInputPumpRequested)
-			) {
-				return admission;
+			try {
+				this._assertDirectTurnAdmissionAvailable();
+				if (
+					(options.allowStreaming === true && this.isStreaming) ||
+					(this.pendingMessageCount === 0 &&
+						this._activeSessionInput === undefined &&
+						!this._pumpingSessionInput &&
+						!this._sessionInputPumpRequested)
+				) {
+					return admission;
+				}
+			} catch (error) {
+				admission.release();
+				throw error;
 			}
 			admission.release();
 			await this.waitForSessionInputIdle();
+			this._assertDirectTurnAdmissionAvailable();
 		}
 	}
 
 	private async _waitForQueuedWorkAdmission(): Promise<void> {
 		while (this._queuedWorkPauses.size > 0) {
+			this._assertDirectTurnAdmissionAvailable();
 			await new Promise<void>((resolve) => this._queuedWorkAdmissionWaiters.add(resolve));
+			this._assertDirectTurnAdmissionAvailable();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1539,11 +1539,10 @@ export class AgentSession {
 	}
 
 	private _parseGoalSlashCommand(text: string): GoalSlashCommand | undefined {
-		if (text !== "/goal" && !text.startsWith("/goal ")) {
-			return undefined;
-		}
+		const command = parseSessionSlashCommand(text);
+		if (command?.name !== "goal") return undefined;
 
-		const rest = text.slice("/goal".length).trim();
+		const rest = command.args;
 		const normalized = rest.toLowerCase();
 		if (!rest || normalized === "status") {
 			return { kind: "status" };
@@ -1588,10 +1587,9 @@ export class AgentSession {
 	}
 
 	private _parseAutonomousSlashCommand(text: string): AutonomousSlashCommand | undefined {
-		if (text !== "/autonomous" && !text.startsWith("/autonomous ")) {
-			return undefined;
-		}
-		const rest = text.slice("/autonomous".length).trim().toLowerCase();
+		const command = parseSessionSlashCommand(text);
+		if (command?.name !== "autonomous") return undefined;
+		const rest = command.args.toLowerCase();
 		if (!rest || rest === "status") {
 			return { kind: "status" };
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1042,6 +1042,7 @@ export class AgentSession {
 	private _postCompactionContinuationScheduled = false;
 	private _postCompactionContinuationTimer: ReturnType<typeof setTimeout> | undefined;
 	private _postCompactionContinuationMessages: AgentMessage[] = [];
+	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
 	private _queuedAutonomousThresholdContinuations = new WeakMap<AssistantMessage, AgentMessage>();
 	private _queuedAutonomousContinuationSnapshots = new WeakMap<AgentMessage, AutonomousRuntimeSnapshot>();
 	private _pendingThresholdCompactionAutonomousMessages: AgentMessage[] = [];
@@ -1693,10 +1694,11 @@ export class AgentSession {
 		this._ensureGoalRuntimeActive();
 		const message = createGoalContextMessage(this._goalState, kind, images);
 		if (this._pumpingSessionInput) {
+			const normalized = normalizeMessageContent(message.content);
 			if (kind === "budget_limit") {
-				await this._queueSteer(String(message.content), undefined, { message, resumeIfIdle: true });
+				await this._queueSteer(normalized.text, normalized.images, { message, resumeIfIdle: true });
 			} else {
-				const input = this._createPreparedPromptInput(String(message.content), undefined, {
+				const input = this._createPreparedPromptInput(normalized.text, normalized.images, {
 					message,
 					resumeIfIdle: true,
 				});
@@ -3896,7 +3898,7 @@ export class AgentSession {
 		options?: InternalPromptOptions,
 	): Promise<void> {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
-		const releaseAdmission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : () => {};
+		const releaseAdmission = await this._acquireDirectTurnAdmission({ allowStreaming: true });
 		try {
 			await this._promptInjectedMessageUnserialized(text, message, options, releaseAdmission);
 		} finally {
@@ -5387,16 +5389,17 @@ export class AgentSession {
 		};
 	}
 
-	private async _acquireDirectTurnAdmission(): Promise<() => void> {
+	private async _acquireDirectTurnAdmission(options: { allowStreaming?: boolean } = {}): Promise<() => void> {
 		while (true) {
 			await this._waitForQueuedWorkAdmission();
 			if (this.pendingMessageCount > 0) this._scheduleSessionInputPump();
 			const release = await this._acquireTurnAdmission();
 			if (
-				this.pendingMessageCount === 0 &&
-				this._activeSessionInput === undefined &&
-				!this._pumpingSessionInput &&
-				!this._sessionInputPumpRequested
+				(options.allowStreaming === true && this.isStreaming) ||
+				(this.pendingMessageCount === 0 &&
+					this._activeSessionInput === undefined &&
+					!this._pumpingSessionInput &&
+					!this._sessionInputPumpRequested)
 			) {
 				return release;
 			}
@@ -6165,6 +6168,7 @@ export class AgentSession {
 			this._postCompactionContinuationTimer = undefined;
 		}
 		this._postCompactionContinuationScheduled = false;
+		this._scheduledPostCompactionContinuationMessages = [];
 	}
 
 	private _discardPendingAutoRefine(options: { cancelPostCompactionContinue?: boolean } = {}): void {
@@ -6263,6 +6267,7 @@ export class AgentSession {
 			return;
 		}
 		this._postCompactionContinuationScheduled = true;
+		this._scheduledPostCompactionContinuationMessages = [...this._postCompactionContinuationMessages];
 		this._postCompactionContinuationTimer = setTimeout(() => {
 			this._postCompactionContinuationTimer = undefined;
 			void this._runScheduledPostCompactionContinue();
@@ -6280,18 +6285,34 @@ export class AgentSession {
 			return;
 		}
 
+		const continuationMessages = [...this._scheduledPostCompactionContinuationMessages];
+		const sessionOwnedContinuationsRemain = continuationMessages.some((message) =>
+			this._postCompactionContinuationMessages.includes(message),
+		);
+		if (continuationMessages.length > 0 && !sessionOwnedContinuationsRemain) {
+			this._cancelPostCompactionContinue();
+			this._scheduleAutoRefineAfterAgentEnd();
+			return;
+		}
 		if (this.pendingMessageCount > 0) {
 			this._scheduleSessionInputPump();
 			await this._sessionInputPump;
 			if (this._postCompactionContinuationScheduled) {
 				this._postCompactionContinuationScheduled = false;
-				this._schedulePostCompactionContinue();
+				const sessionOwnedContinuationsStillRemain = continuationMessages.some((message) =>
+					this._postCompactionContinuationMessages.includes(message),
+				);
+				if (continuationMessages.length > 0 && !sessionOwnedContinuationsStillRemain) {
+					this._scheduledPostCompactionContinuationMessages = [];
+					this._scheduleAutoRefineAfterAgentEnd();
+				} else {
+					this._schedulePostCompactionContinue();
+				}
 			}
 			return;
 		}
 
 		this._postCompactionContinuationScheduled = false;
-		const continuationMessages = [...this._postCompactionContinuationMessages];
 		try {
 			await this.agent.continue();
 			this._forgetConsumedPostCompactionContinuations(continuationMessages);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5049,6 +5049,8 @@ export class AgentSession {
 			}
 			if (resultText) this._appendDurableSessionCommandMessage(resultText, input.command, true, false);
 		} catch (error) {
+			// A skipped compaction is benign and already surfaced by compaction_end.
+			if (error instanceof CompactionSkippedError) return;
 			const message = error instanceof Error ? error.message : String(error);
 			this._appendDurableSessionCommandMessage(`Command failed: ${message}`, input.command, true, true);
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5473,6 +5473,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._cancelPostCompactionContinue();
 		this.abortRetry();
 		this.abortCompaction();
 		this.abortBranchSummary();
@@ -5511,6 +5512,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._cancelPostCompactionContinue();
 		this.abortRetry();
 		this._cancelActiveRlmChildRuns("Parent session aborted for update restart");
 		this._goalAbortInProgress = this._goalState.status === "active";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3946,7 +3946,10 @@ export class AgentSession {
 		options?: InternalPromptOptions,
 	): Promise<void> {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
-		const admission = await this._acquireDirectTurnAdmission({ allowStreaming: true });
+		const admission = await this._acquireDirectTurnAdmission({
+			allowStreaming: true,
+			allowPendingQueue: options?.queueIfBusy === true,
+		});
 		try {
 			await this._turnAdmissionContext.run(admission.owner, () =>
 				this._promptInjectedMessageUnserialized(text, message, options, admission.release),
@@ -4078,7 +4081,9 @@ export class AgentSession {
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
 		if (!this.isStreaming) this._sessionInputPumpSuspended = false;
-		const admission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : undefined;
+		const admission = !this.isStreaming
+			? await this._acquireDirectTurnAdmission({ allowPendingQueue: options?.queueIfBusy === true })
+			: undefined;
 		const releaseAdmission = admission?.release ?? (() => {});
 		try {
 			if (admission) {
@@ -5369,7 +5374,7 @@ export class AgentSession {
 	}
 
 	private async _acquireDirectTurnAdmission(
-		options: { allowStreaming?: boolean } = {},
+		options: { allowStreaming?: boolean; allowPendingQueue?: boolean } = {},
 	): Promise<{ owner: symbol; release(): void }> {
 		while (true) {
 			this._assertDirectTurnAdmissionAvailable();
@@ -5384,8 +5389,11 @@ export class AgentSession {
 					await this._waitForQueuedWorkAdmission();
 					continue;
 				}
+				// allowPendingQueue: queueIfBusy callers only need admission ownership,
+				// not a drained queue - they enqueue behind pending work at preflight.
 				if (
 					(options.allowStreaming === true && this.isStreaming) ||
+					options.allowPendingQueue === true ||
 					(this.pendingMessageCount === 0 &&
 						this._activeSessionInput === undefined &&
 						!this._pumpingSessionInput &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5506,6 +5506,11 @@ export class AgentSession {
 	}
 
 	abortForUpdateRestart(): void {
+		// Cancel scheduled pumps and suspend new ones: queued inputs must survive
+		// into the restart manifest instead of starting a turn during teardown.
+		this._sessionInputPumpRequested = false;
+		this._sessionInputPumpEpoch++;
+		this._sessionInputPumpSuspended = true;
 		this.abortRetry();
 		this._cancelActiveRlmChildRuns("Parent session aborted for update restart");
 		this._goalAbortInProgress = this._goalState.status === "active";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3942,6 +3942,7 @@ export class AgentSession {
 			);
 		} finally {
 			admission.release();
+			this._scheduleSessionInputPump();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -546,6 +546,19 @@ interface PreparedPromptPreparation {
 
 class DeferredSessionInputError extends Error {}
 
+/** Wrap a preflight callback so only the first report wins. */
+function oncePreflight(
+	preflightResult: ((success: boolean, queued?: boolean) => void) | undefined,
+): (success: boolean, queued?: boolean) => void {
+	let settled = false;
+	return (success, queued = false) => {
+		if (!settled) {
+			settled = true;
+			preflightResult?.(success, queued);
+		}
+	};
+}
+
 interface PreparedCommandInput {
 	kind: "command";
 	text: string;
@@ -1652,6 +1665,24 @@ export class AgentSession {
 		return true;
 	}
 
+	/** Append custom messages returned by before_agent_start extension handlers. */
+	private _appendBeforeAgentStartMessages(
+		messages: AgentMessage[],
+		result: Awaited<ReturnType<ExtensionRunner["emitBeforeAgentStart"]>>,
+	): void {
+		if (!result?.messages) return;
+		for (const message of result.messages) {
+			messages.push({
+				role: "custom",
+				customType: message.customType,
+				content: message.content,
+				display: message.display,
+				details: message.details,
+				timestamp: Date.now(),
+			});
+		}
+	}
+
 	private async _validateCanStartAgentRun(): Promise<void> {
 		if (!this.model) {
 			throw new Error(formatNoModelSelectedMessage());
@@ -2114,7 +2145,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 		}
 	}
 
@@ -2275,7 +2306,7 @@ export class AgentSession {
 			if (this._refineAbortController === refineAbort) {
 				this._refineAbortController = undefined;
 			}
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 			throw error;
 		} finally {
 			if (this._refinePlanInFlight === planSettled) {
@@ -2287,7 +2318,7 @@ export class AgentSession {
 			if (this._refineAbortController === refineAbort) {
 				this._refineAbortController = undefined;
 			}
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 			return;
 		}
 
@@ -2305,7 +2336,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 		}
 	}
 
@@ -3038,19 +3069,7 @@ export class AgentSession {
 			if (this._isPromptTurnStartMessage(event.message)) {
 				this._overflowRecoveryAttempted = false;
 			}
-			const steeringIndex = this._steeringMessages.findIndex((message) => message.message === event.message);
-			if (steeringIndex !== -1) {
-				const [removed] = this._steeringMessages.splice(steeringIndex, 1);
-				this._resolveAgentMessageDelivery(removed?.agentMessageId);
-				this._emitQueueUpdate();
-			} else {
-				const followUpIndex = this._followUpMessages.findIndex((message) => message.message === event.message);
-				if (followUpIndex !== -1) {
-					const [removed] = this._followUpMessages.splice(followUpIndex, 1);
-					this._resolveAgentMessageDelivery(removed?.agentMessageId);
-					this._emitQueueUpdate();
-				}
-			}
+			this._removeDeliveredSessionInput(event.message);
 		}
 
 		// Emit to extensions first
@@ -3197,7 +3216,7 @@ export class AgentSession {
 			this._retryResolve();
 			this._retryResolve = undefined;
 			this._retryPromise = undefined;
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 		}
 	}
 
@@ -3922,14 +3941,7 @@ export class AgentSession {
 		options: InternalPromptOptions | undefined,
 		releaseAdmission: () => void,
 	): Promise<void> {
-		const preflightResult = options?.preflightResult;
-		let preflightSettled = false;
-		const reportPreflight = (success: boolean, queued = false) => {
-			if (!preflightSettled) {
-				preflightSettled = true;
-				preflightResult?.(success, queued);
-			}
-		};
+		const reportPreflight = oncePreflight(options?.preflightResult);
 
 		let messages: AgentMessage[] | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
@@ -3938,13 +3950,7 @@ export class AgentSession {
 		let basePromptSnapshot: string | undefined;
 		try {
 			const shouldQueueForStreaming = this.isStreaming;
-			const shouldQueueForPendingWork =
-				options?.queueIfBusy === true &&
-				(this.pendingMessageCount > 0 ||
-					this.isCompacting ||
-					this.isRetrying ||
-					this.isBashRunning ||
-					this.hasAcceptedPromptInFlight);
+			const shouldQueueForPendingWork = options?.queueIfBusy === true && this._isBusyForSessionInput("preflight");
 			if (shouldQueueForStreaming || shouldQueueForPendingWork) {
 				if (!options?.streamingBehavior) {
 					const stateDescription = shouldQueueForStreaming
@@ -3954,37 +3960,19 @@ export class AgentSession {
 						`${stateDescription}. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`,
 					);
 				}
-				const queued = await this._queueInjectedMessageWithPendingNextTurnMessages(
-					text,
+				await this._queueWithPendingNextTurnMessages(text, options.streamingBehavior, reportPreflight, {
 					message,
-					options.streamingBehavior,
-					{
-						queueKey: options.followUpQueueKey,
-						previewLabel,
-						suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-						resumeIfIdle: options.resumeIfIdle,
-					},
-				);
-				if (!queued) {
-					reportPreflight(false);
-					return;
-				}
-				reportPreflight(true, true);
+					queueKey: options.followUpQueueKey,
+					previewLabel,
+					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+					resumeIfIdle: options.resumeIfIdle,
+				});
 				return;
 			}
 
 			await this._waitForRefineIdle();
 			this._flushPendingBashMessages();
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-			if (!this._modelRegistry.hasConfiguredAuth(this.model)) {
-				const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
-				if (isOAuth) {
-					throw new Error(formatAuthenticationFailedMessage(this.model.provider));
-				}
-				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
-			}
+			await this._validateCanStartAgentRun();
 
 			const lastAssistant = this._findLastAssistantMessage();
 			if (lastAssistant) {
@@ -4007,18 +3995,7 @@ export class AgentSession {
 				basePromptSnapshot,
 				this._baseSystemPromptOptions,
 			);
-			if (extensionResult?.messages) {
-				for (const msg of extensionResult.messages) {
-					messages.push({
-						role: "custom",
-						customType: msg.customType,
-						content: msg.content,
-						display: msg.display,
-						details: msg.details,
-						timestamp: Date.now(),
-					});
-				}
-			}
+			this._appendBeforeAgentStartMessages(messages, extensionResult);
 			this.agent.state.systemPrompt =
 				extensionResult?.systemPrompt !== undefined
 					? this._refreshExtensionSystemPrompt(extensionResult.systemPrompt, basePromptSnapshot)
@@ -4043,40 +4020,22 @@ export class AgentSession {
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 			}
 		}
-		const shouldQueueAtHandoff =
-			options?.queueIfBusy === true &&
-			(this.isStreaming ||
-				this.pendingMessageCount > 0 ||
-				this.isCompacting ||
-				this.isRetrying ||
-				this.isBashRunning ||
-				this._acceptedPromptCompletions.size > 0 ||
-				this._acceptedAgentMessagePrompt !== undefined);
+		const shouldQueueAtHandoff = options?.queueIfBusy === true && this._isBusyForSessionInput("handoff");
 		if (shouldQueueAtHandoff) {
+			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
 			if (!options?.streamingBehavior) {
-				this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
 				reportPreflight(false);
 				throw new Error(
 					"Agent became busy before prompt delivery. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
 				);
 			}
-			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
-			const queued = await this._queueInjectedMessageWithPendingNextTurnMessages(
-				text,
+			await this._queueWithPendingNextTurnMessages(text, options.streamingBehavior, reportPreflight, {
 				message,
-				options.streamingBehavior,
-				{
-					queueKey: options.followUpQueueKey,
-					previewLabel,
-					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-					resumeIfIdle: options.resumeIfIdle,
-				},
-			);
-			if (!queued) {
-				reportPreflight(false);
-				return;
-			}
-			reportPreflight(true, true);
+				queueKey: options.followUpQueueKey,
+				previewLabel,
+				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+				resumeIfIdle: options.resumeIfIdle,
+			});
 			return;
 		}
 
@@ -4123,14 +4082,7 @@ export class AgentSession {
 	): Promise<void> {
 		const isInternalPrompt = options?.internalPrompt === true;
 		const expandPromptTemplates = isInternalPrompt ? false : (options?.expandPromptTemplates ?? true);
-		const preflightResult = options?.preflightResult;
-		let preflightSettled = false;
-		const reportPreflight = (success: boolean, queued = false) => {
-			if (!preflightSettled) {
-				preflightSettled = true;
-				preflightResult?.(success, queued);
-			}
-		};
+		const reportPreflight = oncePreflight(options?.preflightResult);
 		let messages: AgentMessage[] | undefined;
 		let acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined;
 		let drainedNextTurnMessages: CustomMessage[] = [];
@@ -4141,14 +4093,6 @@ export class AgentSession {
 
 		try {
 			let currentText = text;
-			const hasQueueIfBusyBackpressure = () =>
-				options?.queueIfBusy === true &&
-				(this.pendingMessageCount > 0 ||
-					this.isCompacting ||
-					this.isRetrying ||
-					this.isBashRunning ||
-					this.hasAcceptedPromptInFlight);
-
 			const shouldHandleBuiltInSlashCommands = !isInternalPrompt && !options?.skipPrePromptWork;
 			const sessionCommand = shouldHandleBuiltInSlashCommands ? parseSessionSlashCommand(currentText) : undefined;
 			if (sessionCommand) {
@@ -4213,7 +4157,7 @@ export class AgentSession {
 			// If streaming, or a caller explicitly asked to respect existing queued work,
 			// enqueue according to the requested behavior.
 			const shouldQueueForStreaming = this.isStreaming;
-			const shouldQueueForPendingWork = hasQueueIfBusyBackpressure();
+			const shouldQueueForPendingWork = options?.queueIfBusy === true && this._isBusyForSessionInput("preflight");
 			if (shouldQueueForStreaming || shouldQueueForPendingWork) {
 				if (!options?.streamingBehavior) {
 					const stateDescription = shouldQueueForStreaming
@@ -4223,23 +4167,14 @@ export class AgentSession {
 						`${stateDescription}. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`,
 					);
 				}
-				const queued = await this._queuePromptWithPendingNextTurnMessages(
-					expandedText,
-					currentImages,
-					options.streamingBehavior,
-					{
-						queueKey: options.followUpQueueKey,
-						agentMessageId: options.agentMessageId,
-						suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-						customMessage: options.customMessage,
-						resumeIfIdle: options.resumeIfIdle,
-					},
-				);
-				if (!queued) {
-					reportPreflight(false);
-					return;
-				}
-				reportPreflight(true, true);
+				await this._queueWithPendingNextTurnMessages(expandedText, options.streamingBehavior, reportPreflight, {
+					images: currentImages,
+					queueKey: options.followUpQueueKey,
+					agentMessageId: options.agentMessageId,
+					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+					message: options.customMessage,
+					resumeIfIdle: options.resumeIfIdle,
+				});
 				return;
 			}
 
@@ -4249,24 +4184,21 @@ export class AgentSession {
 
 			// Flush any pending bash messages before the new prompt, including accepted agent messages.
 			this._flushPendingBashMessages();
-
-			// Validate model
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-
-			if (!this._modelRegistry.hasConfiguredAuth(this.model)) {
-				const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
-				if (isOAuth) {
-					throw new Error(formatAuthenticationFailedMessage(this.model.provider));
-				}
-				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
-			}
+			await this._validateCanStartAgentRun();
 
 			const pendingModelSelectEmit = this._pendingModelSelectEmit();
 			if (pendingModelSelectEmit) {
 				await pendingModelSelectEmit;
 			}
+			const buildUserContent = (): (TextContent | ImageContent)[] => {
+				const userContent: (TextContent | ImageContent)[] = options?.content
+					? options.content.map((block) => ({ ...block }))
+					: [{ type: "text", text: expandedText }];
+				if (!options?.content && currentImages) {
+					userContent.push(...currentImages);
+				}
+				return userContent;
+			};
 			if (options?.skipPrePromptWork) {
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 				messages = [];
@@ -4275,17 +4207,11 @@ export class AgentSession {
 					messages.push(msg);
 				}
 				this._pendingNextTurnMessages = [];
-				const userContent: (TextContent | ImageContent)[] = options?.content
-					? options.content.map((block) => ({ ...block }))
-					: [{ type: "text", text: expandedText }];
-				if (!options?.content && currentImages) {
-					userContent.push(...currentImages);
-				}
 				const promptMessage: QueuedAgentMessage = options.customMessage
 					? cloneCustomMessage(options.customMessage)
 					: {
 							role: "user",
-							content: userContent,
+							content: buildUserContent(),
 							timestamp: Date.now(),
 						};
 				messages.push(promptMessage);
@@ -4330,15 +4256,9 @@ export class AgentSession {
 				if (options?.customMessage) {
 					messages.push(cloneCustomMessage(options.customMessage));
 				} else {
-					const userContent: (TextContent | ImageContent)[] = options?.content
-						? options.content.map((block) => ({ ...block }))
-						: [{ type: "text", text: expandedText }];
-					if (!options?.content && currentImages) {
-						userContent.push(...currentImages);
-					}
 					messages.push({
 						role: "user",
-						content: userContent,
+						content: buildUserContent(),
 						timestamp: Date.now(),
 					});
 				}
@@ -4352,18 +4272,8 @@ export class AgentSession {
 					this._baseSystemPromptOptions,
 				);
 				// Add all custom messages from extensions
-				if (extensionResult?.messages) {
-					for (const msg of extensionResult.messages) {
-						messages.push({
-							role: "custom",
-							customType: msg.customType,
-							content: msg.content,
-							display: msg.display,
-							details: msg.details,
-							timestamp: Date.now(),
-						});
-					}
-				}
+				this._appendBeforeAgentStartMessages(messages, extensionResult);
+				// Apply extension-modified system prompt, or reset to base
 				this.agent.state.systemPrompt = extensionResult?.systemPrompt
 					? this._refreshExtensionSystemPrompt(extensionResult.systemPrompt, basePromptSnapshot)
 					: this._baseSystemPrompt;
@@ -4398,47 +4308,26 @@ export class AgentSession {
 			throw new Error("Accepted agent message was cleared before delivery.");
 		}
 		const shouldQueueAtHandoff =
-			options?.queueIfBusy === true &&
-			(this.isStreaming ||
-				this.pendingMessageCount > 0 ||
-				this.isCompacting ||
-				this.isRetrying ||
-				this.isBashRunning ||
-				this._acceptedPromptCompletions.size > 0 ||
-				(this._acceptedAgentMessagePrompt !== undefined &&
-					this._acceptedAgentMessagePrompt !== acceptedAgentMessagePrompt));
+			options?.queueIfBusy === true && this._isBusyForSessionInput("handoff", acceptedAgentMessagePrompt);
 		if (shouldQueueAtHandoff) {
+			if (acceptedAgentMessagePrompt && this._acceptedAgentMessagePrompt === acceptedAgentMessagePrompt) {
+				this._acceptedAgentMessagePrompt = undefined;
+			}
+			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((message) => ({ ...message })));
 			if (!options?.streamingBehavior) {
-				if (acceptedAgentMessagePrompt && this._acceptedAgentMessagePrompt === acceptedAgentMessagePrompt) {
-					this._acceptedAgentMessagePrompt = undefined;
-				}
-				this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((message) => ({ ...message })));
 				reportPreflight(false);
 				throw new Error(
 					"Agent became busy before prompt delivery. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
 				);
 			}
-			if (acceptedAgentMessagePrompt && this._acceptedAgentMessagePrompt === acceptedAgentMessagePrompt) {
-				this._acceptedAgentMessagePrompt = undefined;
-			}
-			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((message) => ({ ...message })));
-			const queued = await this._queuePromptWithPendingNextTurnMessages(
-				expandedText,
-				currentImages,
-				options.streamingBehavior,
-				{
-					queueKey: options.followUpQueueKey,
-					agentMessageId: options.agentMessageId,
-					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-					customMessage: options.customMessage,
-					resumeIfIdle: options.resumeIfIdle,
-				},
-			);
-			if (!queued) {
-				reportPreflight(false);
-				return;
-			}
-			reportPreflight(true, true);
+			await this._queueWithPendingNextTurnMessages(expandedText, options.streamingBehavior, reportPreflight, {
+				images: currentImages,
+				queueKey: options.followUpQueueKey,
+				agentMessageId: options.agentMessageId,
+				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+				message: options.customMessage,
+				resumeIfIdle: options.resumeIfIdle,
+			});
 			return;
 		}
 		if (options?.suppressAutonomousContinuation) {
@@ -4499,20 +4388,14 @@ export class AgentSession {
 				) {
 					this._acceptedAgentMessagePrompt = undefined;
 				}
-				this._schedulePendingMessageResume();
+				this._scheduleSessionInputPump();
 			})
 			.catch(() => undefined);
 		if (options?.returnAfterAccepted) {
 			this._acceptedPromptCompletions.add(promptCompletion);
-			void promptCompletion.then(
-				() => {
-					this._acceptedPromptCompletions.delete(promptCompletion);
-				},
-				() => {
-					this._acceptedPromptCompletions.delete(promptCompletion);
-				},
-			);
-			void promptCompletion.catch(() => undefined);
+			void promptCompletion
+				.finally(() => this._acceptedPromptCompletions.delete(promptCompletion))
+				.catch(() => undefined);
 			return;
 		}
 		await promptCompletion;
@@ -4708,87 +4591,43 @@ export class AgentSession {
 		return content;
 	}
 
-	private async _queuePromptWithPendingNextTurnMessages(
+	/** Queue via the requested lane, restoring drained next-turn context on failure, and report preflight. */
+	private async _queueWithPendingNextTurnMessages(
 		text: string,
-		images: ImageContent[] | undefined,
 		streamingBehavior: "steer" | "followUp",
+		reportPreflight: (success: boolean, queued?: boolean) => void,
 		options: {
+			images?: ImageContent[];
 			queueKey?: string;
 			agentMessageId?: string;
-			customMessage?: CustomMessage;
-			suppressAutonomousContinuation?: boolean;
-			resumeIfIdle?: boolean;
-		} = {},
-	): Promise<boolean> {
-		const pendingNextTurnMessages = this._pendingNextTurnMessages;
-		this._pendingNextTurnMessages = [];
-		try {
-			if (streamingBehavior === "followUp") {
-				const queued = await this._queueFollowUp(text, images, {
-					queueKey: options.queueKey,
-					agentMessageId: options.agentMessageId,
-					message: options.customMessage,
-					prefixMessages: pendingNextTurnMessages,
-					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-					resumeIfIdle: options.resumeIfIdle,
-				});
-				if (!queued) {
-					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
-				}
-				return queued;
-			}
-			await this._queueSteer(text, images, {
-				agentMessageId: options.agentMessageId,
-				queueKey: options.queueKey,
-				message: options.customMessage,
-				prefixMessages: pendingNextTurnMessages,
-				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-				resumeIfIdle: options.resumeIfIdle,
-			});
-			return true;
-		} catch (error) {
-			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
-			throw error;
-		}
-	}
-
-	private async _queueInjectedMessageWithPendingNextTurnMessages(
-		text: string,
-		message: CustomMessage,
-		streamingBehavior: "steer" | "followUp",
-		options: {
-			queueKey?: string;
+			message?: QueuedAgentMessage;
 			previewLabel?: string;
 			suppressAutonomousContinuation?: boolean;
 			resumeIfIdle?: boolean;
 		} = {},
-	): Promise<boolean> {
+	): Promise<void> {
 		const pendingNextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
+		const queueOptions = {
+			queueKey: options.queueKey,
+			agentMessageId: options.agentMessageId,
+			message: options.message,
+			prefixMessages: pendingNextTurnMessages,
+			previewLabel: options.previewLabel,
+			suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+			resumeIfIdle: options.resumeIfIdle,
+		};
 		try {
 			if (streamingBehavior === "followUp") {
-				const queued = await this._queueFollowUp(text, undefined, {
-					queueKey: options.queueKey,
-					message,
-					prefixMessages: pendingNextTurnMessages,
-					previewLabel: options.previewLabel,
-					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-					resumeIfIdle: options.resumeIfIdle,
-				});
+				const queued = await this._queueFollowUp(text, options.images, queueOptions);
 				if (!queued) {
 					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 				}
-				return queued;
+				reportPreflight(queued, queued);
+				return;
 			}
-			await this._queueSteer(text, undefined, {
-				message,
-				prefixMessages: pendingNextTurnMessages,
-				previewLabel: options.previewLabel,
-				queueKey: options.queueKey,
-				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-				resumeIfIdle: options.resumeIfIdle,
-			});
-			return true;
+			await this._queueSteer(text, options.images, queueOptions);
+			reportPreflight(true, true);
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 			throw error;
@@ -4868,6 +4707,19 @@ export class AgentSession {
 		return true;
 	}
 
+	/** Remove a delivered queued input from whichever lane holds it (steering first, then follow-up). */
+	private _removeDeliveredSessionInput(message: AgentMessage): void {
+		for (const queue of [this._steeringMessages, this._followUpMessages]) {
+			const index = queue.findIndex((item) => item.message === message);
+			if (index !== -1) {
+				const [removed] = queue.splice(index, 1);
+				this._resolveAgentMessageDelivery(removed?.agentMessageId);
+				this._emitQueueUpdate();
+				return;
+			}
+		}
+	}
+
 	private async _queueSteer(
 		text: string,
 		images?: ImageContent[],
@@ -4925,12 +4777,7 @@ export class AgentSession {
 		this._sessionInputPump.catch(() => {});
 	}
 
-	private _schedulePendingMessageResume(_request = false): void {
-		this._scheduleSessionInputPump();
-	}
-
 	private async _pumpSessionInputs(epoch: number): Promise<void> {
-		if (this._pumpingSessionInput) return;
 		this._pumpingSessionInput = true;
 		let blocked = false;
 		try {
@@ -5011,19 +4858,37 @@ export class AgentSession {
 		}
 	}
 
-	private _isSessionInputHandoffDeferred(epoch: number): boolean {
-		return (
-			this._disposed ||
-			this._disposing ||
-			epoch !== this._sessionInputPumpEpoch ||
-			this._sessionInputPumpSuspended ||
-			this._queuedWorkPauses.size > 0 ||
-			this.isBashRunning ||
+	/**
+	 * Single busy truth table for turn-admission decision points:
+	 * "preflight" is queueIfBusy backpressure before pre-prompt work (streaming checked separately),
+	 * "handoff" re-checks adjacent to the agent.prompt() handoff (includes streaming),
+	 * "pump" is session-input pump deferral (adds lifecycle and pause state).
+	 */
+	private _isBusyForSessionInput(
+		point: "preflight" | "handoff" | "pump",
+		ignoreAcceptedPrompt?: AcceptedAgentMessagePrompt,
+	): boolean {
+		const busy =
 			this.isCompacting ||
-			this._branchSummaryOperation !== undefined ||
 			this.isRetrying ||
-			this.hasAcceptedPromptInFlight
-		);
+			this.isBashRunning ||
+			this._acceptedPromptCompletions.size > 0 ||
+			(this._acceptedAgentMessagePrompt !== undefined && this._acceptedAgentMessagePrompt !== ignoreAcceptedPrompt);
+		if (point === "pump") {
+			return (
+				busy ||
+				this._disposed ||
+				this._disposing ||
+				this._sessionInputPumpSuspended ||
+				this._queuedWorkPauses.size > 0 ||
+				this._branchSummaryOperation !== undefined
+			);
+		}
+		return busy || this.pendingMessageCount > 0 || (point === "handoff" && this.isStreaming);
+	}
+
+	private _isSessionInputHandoffDeferred(epoch: number): boolean {
+		return epoch !== this._sessionInputPumpEpoch || this._isBusyForSessionInput("pump");
 	}
 
 	private _asError(error: unknown): Error {
@@ -5031,11 +4896,7 @@ export class AgentSession {
 	}
 
 	private _isDeferredSessionInputError(error: unknown, epoch: number): boolean {
-		return (
-			error instanceof DeferredSessionInputError ||
-			this._isSessionInputHandoffDeferred(epoch) ||
-			(error instanceof Error && error.message.startsWith("Agent is already processing"))
-		);
+		return error instanceof DeferredSessionInputError || this._isSessionInputHandoffDeferred(epoch);
 	}
 
 	private _surfaceSessionInputError(error: unknown): void {
@@ -5090,18 +4951,7 @@ export class AgentSession {
 			if (prompt.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(prompt.message);
 		}
 		const result = prompts[0]?.preparation?.result;
-		if (result?.messages) {
-			for (const message of result.messages) {
-				messages.push({
-					role: "custom",
-					customType: message.customType,
-					content: message.content,
-					display: message.display,
-					details: message.details,
-					timestamp: Date.now(),
-				});
-			}
-		}
+		this._appendBeforeAgentStartMessages(messages, result);
 		// Re-check adjacent to the handoff: background refine planning may have
 		// completed and entered _applyRefine during the awaits above,
 		// disconnecting event handling. Wait for it to finish so the new
@@ -5113,6 +4963,10 @@ export class AgentSession {
 		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
 		try {
 			if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
+			if (this.isStreaming) {
+				// agent.prompt() would reject with its already-processing error; defer instead.
+				throw new DeferredSessionInputError("Agent became active before session input handoff");
+			}
 			const promptPromise = this.agent.prompt(messages);
 			releaseAdmission();
 			await promptPromise;
@@ -6123,7 +5977,7 @@ export class AgentSession {
 				this._compactionOperation = undefined;
 			}
 			resolveCompactionOperation();
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 			if (didCompact) {
 				this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 				if (hadPostCompactionContinue) {
@@ -6348,6 +6202,11 @@ export class AgentSession {
 		}, 100);
 	}
 
+	/** Whether any snapshot of scheduled continuation messages is still session-owned. */
+	private _sessionOwnsScheduledContinuations(continuationMessages: AgentMessage[]): boolean {
+		return continuationMessages.some((message) => this._postCompactionContinuationMessages.includes(message));
+	}
+
 	private async _runScheduledPostCompactionContinue(): Promise<void> {
 		await this._waitForRefineIdle();
 		if (!this._postCompactionContinuationScheduled) {
@@ -6360,10 +6219,7 @@ export class AgentSession {
 		}
 
 		const continuationMessages = [...this._scheduledPostCompactionContinuationMessages];
-		const sessionOwnedContinuationsRemain = continuationMessages.some((message) =>
-			this._postCompactionContinuationMessages.includes(message),
-		);
-		if (continuationMessages.length > 0 && !sessionOwnedContinuationsRemain) {
+		if (continuationMessages.length > 0 && !this._sessionOwnsScheduledContinuations(continuationMessages)) {
 			this._cancelPostCompactionContinue();
 			this._scheduleAutoRefineAfterAgentEnd();
 			return;
@@ -6373,11 +6229,10 @@ export class AgentSession {
 			await this._sessionInputPump;
 			if (this._postCompactionContinuationScheduled) {
 				this._postCompactionContinuationScheduled = false;
-				const sessionOwnedContinuationsStillRemain = continuationMessages.some((message) =>
-					this._postCompactionContinuationMessages.includes(message),
-				);
 				const shouldReschedule =
-					continuationMessages.length === 0 ? this.pendingMessageCount > 0 : sessionOwnedContinuationsStillRemain;
+					continuationMessages.length === 0
+						? this.pendingMessageCount > 0
+						: this._sessionOwnsScheduledContinuations(continuationMessages);
 				if (shouldReschedule) {
 					this._schedulePostCompactionContinue();
 				} else {
@@ -6683,7 +6538,7 @@ export class AgentSession {
 			if (this._refineAbortController === refineAbort) {
 				this._refineAbortController = undefined;
 			}
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 			throw e;
 		} finally {
 			if (this._refinePlanInFlight === planSettled) {
@@ -6729,7 +6584,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
-			this._schedulePendingMessageResume(true);
+			this._scheduleSessionInputPump();
 		}
 	}
 
@@ -7211,7 +7066,7 @@ export class AgentSession {
 			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
-			this._schedulePendingMessageResume();
+			this._scheduleSessionInputPump();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -542,6 +542,8 @@ interface PreparedPromptInput {
 
 interface PreparedPromptPreparation {
 	result: Awaited<ReturnType<ExtensionRunner["emitBeforeAgentStart"]>>;
+	/** Base system prompt captured at emitBeforeAgentStart, for stale-base refresh at handoff. */
+	basePromptSnapshot: string;
 }
 
 class DeferredSessionInputError extends Error {}
@@ -4617,21 +4619,30 @@ export class AgentSession {
 			suppressAutonomousContinuation: options.suppressAutonomousContinuation,
 			resumeIfIdle: options.resumeIfIdle,
 		};
-		try {
-			if (streamingBehavior === "followUp") {
-				const queued = await this._queueFollowUp(text, options.images, queueOptions);
+		// Preflight callbacks run outside the try: a throwing callback must not roll
+		// back queue state for an input that was in fact enqueued (its prefixMessages
+		// would be delivered twice).
+		if (streamingBehavior === "followUp") {
+			let queued: boolean;
+			try {
+				queued = await this._queueFollowUp(text, options.images, queueOptions);
 				if (!queued) {
 					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 				}
-				reportPreflight(queued, queued);
-				return;
+			} catch (error) {
+				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
+				throw error;
 			}
+			reportPreflight(queued, queued);
+			return;
+		}
+		try {
 			await this._queueSteer(text, options.images, queueOptions);
-			reportPreflight(true, true);
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 			throw error;
 		}
+		reportPreflight(true, true);
 	}
 
 	/**
@@ -4915,6 +4926,9 @@ export class AgentSession {
 		releaseAdmission: () => void,
 	): Promise<void> {
 		await this._validateCanStartAgentRun();
+		if (this._isSessionInputHandoffDeferred(epoch)) {
+			throw new DeferredSessionInputError("Session input paused before preflight");
+		}
 		this._flushPendingBashMessages();
 		const lastAssistant = this._findLastAssistantMessage();
 		if (lastAssistant) await this._checkCompaction(lastAssistant, false, false);
@@ -4927,14 +4941,15 @@ export class AgentSession {
 			}
 			const preparationPrompt = prompts.at(-1);
 			if (!preparationPrompt) return;
+			const basePromptSnapshot = this._baseSystemPrompt;
 			const result = await this._extensionRunner.emitBeforeAgentStart(
 				preparationPrompt.text,
 				preparationPrompt.images,
-				this._baseSystemPrompt,
+				basePromptSnapshot,
 				this._baseSystemPromptOptions,
 			);
 			if (prompts.at(-1) !== preparationPrompt) continue;
-			const preparation = { result };
+			const preparation = { result, basePromptSnapshot };
 			for (const prompt of prompts) prompt.preparation = preparation;
 		}
 		if (this._isSessionInputHandoffDeferred(epoch)) {
@@ -4950,7 +4965,8 @@ export class AgentSession {
 			messages.push(...prompt.prefixMessages, prompt.message);
 			if (prompt.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(prompt.message);
 		}
-		const result = prompts[0]?.preparation?.result;
+		const preparation = prompts[0]?.preparation;
+		const result = preparation?.result;
 		this._appendBeforeAgentStartMessages(messages, result);
 		// Re-check adjacent to the handoff: background refine planning may have
 		// completed and entered _applyRefine during the awaits above,
@@ -4960,7 +4976,12 @@ export class AgentSession {
 		if (this._isSessionInputHandoffDeferred(epoch)) {
 			throw new DeferredSessionInputError("Session input paused before handoff");
 		}
-		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
+		// The base prompt may have changed (e.g. refine) since preparation; splice the
+		// current base into an extension-modified prompt exactly like the direct path.
+		this.agent.state.systemPrompt =
+			result?.systemPrompt !== undefined && preparation !== undefined
+				? this._refreshExtensionSystemPrompt(result.systemPrompt, preparation.basePromptSnapshot)
+				: this._baseSystemPrompt;
 		try {
 			if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 			if (this.isStreaming) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1857,9 +1857,6 @@ export class AgentSession {
 		if (this._stopGoalContinuationForTerminalMessage(context.message)) {
 			return true;
 		}
-		if (this._steeringStopPending) {
-			return true;
-		}
 		try {
 			if (this._accountGoalUsageForAssistantMessage(context.message)) {
 				this.agent.steer(createGoalContextMessage(this._goalState, "budget_limit"));
@@ -1882,7 +1879,9 @@ export class AgentSession {
 		if (await this._shouldStopForThresholdCompaction(context)) {
 			return true;
 		}
-		return false;
+		// Steering stops continuation only after mandatory serialized checkpoints.
+		// Returning true here still prevents the agent loop from starting another turn.
+		return this._steeringStopPending;
 	}
 
 	private async _shouldStopForThresholdCompaction(context: ShouldStopAfterTurnContext): Promise<boolean> {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -530,8 +530,15 @@ interface PreparedPromptInput {
 	prefixMessages: CustomMessage[];
 	suppressAutonomousContinuation?: boolean;
 	autoPump: boolean;
+	preparation?: PreparedPromptPreparation;
 	message: QueuedAgentMessage;
 }
+
+interface PreparedPromptPreparation {
+	result: Awaited<ReturnType<ExtensionRunner["emitBeforeAgentStart"]>>;
+}
+
+class DeferredSessionInputError extends Error {}
 
 interface PreparedCommandInput {
 	kind: "command";
@@ -605,6 +612,19 @@ function createQueuedAgentInputSnapshot(message: QueuedSessionInput): QueuedAgen
 
 function queuedMessagePreview(message: { text: string; previewLabel?: string }): string {
 	return message.previewLabel ? `${message.previewLabel}: ${message.text}` : message.text;
+}
+
+function normalizeMessageContent(content: string | (TextContent | ImageContent)[]): {
+	text: string;
+	images?: ImageContent[];
+} {
+	if (typeof content === "string") return { text: content };
+	const text = content
+		.filter((part): part is TextContent => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+	const images = content.filter((part): part is ImageContent => part.type === "image");
+	return { text, ...(images.length > 0 ? { images } : {}) };
 }
 
 function queuedAgentMessagePreview(message: QueuedSessionInput): string {
@@ -885,6 +905,8 @@ export class AgentSession {
 	private _sessionInputArrivalEpoch = 0;
 	private _sessionInputPumpSuspended = false;
 	private readonly _queuedWorkPauses = new Set<symbol>();
+	private readonly _queuedWorkAdmissionWaiters = new Set<() => void>();
+	private _turnAdmissionTail: Promise<void> = Promise.resolve();
 	private _legacyQueuedWorkPause: { release(): void } | undefined;
 	private _pumpingSessionInput = false;
 	private _activeSessionInput:
@@ -1401,6 +1423,7 @@ export class AgentSession {
 			input.kind === "prompt" && input.customMessage?.customType === GOAL_CONTEXT_CUSTOM_TYPE;
 		this._steeringMessages = this._steeringMessages.filter((input) => !isGoalContext(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isGoalContext(input));
+		this._steeringStopPending = this._steeringMessages.length > 0 && this.isStreaming;
 		this._emitQueueUpdate();
 	}
 
@@ -1680,6 +1703,7 @@ export class AgentSession {
 					resumeIfIdle: true,
 				});
 				this._followUpMessages.unshift(input);
+				this._sessionInputArrivalEpoch++;
 				this._emitQueueUpdate();
 			}
 			return;
@@ -2883,10 +2907,17 @@ export class AgentSession {
 		// and waitForRetry() can miss the in-flight retry.
 		this._createRetryPromiseForAgentEnd(event);
 		const acceptedPrompt = this._acceptedAgentMessagePrompt;
-		if (event.type === "message_start" && acceptedPrompt?.message === event.message && !acceptedPrompt.cleared) {
-			acceptedPrompt.turnStarted = true;
-			this._resolveAgentMessageDelivery(acceptedPrompt.agentMessageId);
-			acceptedPrompt.resolveAccepted();
+		if (event.type === "message_start") {
+			if (acceptedPrompt?.message === event.message && !acceptedPrompt.cleared) {
+				acceptedPrompt.turnStarted = true;
+				this._resolveAgentMessageDelivery(acceptedPrompt.agentMessageId);
+				acceptedPrompt.resolveAccepted();
+			}
+			const activeInput =
+				this._activeSessionInput?.kind === "prompt"
+					? this._activeSessionInput.items.find((input) => input.message === event.message)
+					: undefined;
+			this._resolveAgentMessageDelivery(activeInput?.agentMessageId);
 		}
 		this._agentEventQueue = this._agentEventQueue.then(
 			() => this._processAgentEvent(event),
@@ -2996,13 +3027,6 @@ export class AgentSession {
 
 		// Remove queued messages before emitting so the UI sees the updated queue.
 		if (event.type === "message_start") {
-			const activeInput =
-				this._activeSessionInput?.kind === "prompt"
-					? this._activeSessionInput.items.find((input) => input.message === event.message)
-					: undefined;
-			if (activeInput) {
-				this._resolveAgentMessageDelivery(activeInput.agentMessageId);
-			}
 			if (this._isPromptTurnStartMessage(event.message)) {
 				this._overflowRecoveryAttempted = false;
 			}
@@ -3873,6 +3897,21 @@ export class AgentSession {
 		message: CustomMessage,
 		options?: InternalPromptOptions,
 	): Promise<void> {
+		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
+		const releaseAdmission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : () => {};
+		try {
+			await this._promptInjectedMessageUnserialized(text, message, options, releaseAdmission);
+		} finally {
+			releaseAdmission();
+		}
+	}
+
+	private async _promptInjectedMessageUnserialized(
+		text: string,
+		message: CustomMessage,
+		options: InternalPromptOptions | undefined,
+		releaseAdmission: () => void,
+	): Promise<void> {
 		const preflightResult = options?.preflightResult;
 		let preflightSettled = false;
 		const reportPreflight = (success: boolean, queued = false) => {
@@ -4032,12 +4071,12 @@ export class AgentSession {
 		}
 
 		try {
-			if (options?.suppressAutonomousContinuation) {
-				this._markAutonomousContinuationSuppressed(message);
-				await this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages));
-			} else {
-				await this.agent.prompt(messages);
-			}
+			if (options?.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(message);
+			const promptPromise = options?.suppressAutonomousContinuation
+				? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
+				: this.agent.prompt(messages);
+			releaseAdmission();
+			await promptPromise;
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...drainedNextTurnMessages.map((pending) => ({ ...pending })));
 			throw error;
@@ -4047,11 +4086,31 @@ export class AgentSession {
 	}
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
+		if (!this.isStreaming) this._sessionInputPumpSuspended = false;
+		const releaseAdmission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : () => {};
+		try {
+			await this._promptUnserialized(text, options, releaseAdmission);
+		} finally {
+			releaseAdmission();
+		}
+	}
+
+	private async _promptUnserialized(
+		text: string,
+		options: InternalPromptOptions | undefined,
+		releaseAdmission: () => void,
+	): Promise<void> {
 		if (!this.isStreaming) {
+			await this._waitForQueuedWorkAdmission();
 			this._sessionInputPumpSuspended = false;
-			if (this.pendingMessageCount > 0) {
+			if (
+				this.pendingMessageCount > 0 ||
+				this._activeSessionInput !== undefined ||
+				this._pumpingSessionInput ||
+				this._sessionInputPumpRequested
+			) {
 				this._scheduleSessionInputPump();
-				await this._sessionInputPump;
+				await this.waitForSessionInputIdle();
 			}
 		}
 		const isInternalPrompt = options?.internalPrompt === true;
@@ -4381,6 +4440,7 @@ export class AgentSession {
 		const promptPromise = options?.suppressAutonomousContinuation
 			? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(messages))
 			: this.agent.prompt(messages);
+		releaseAdmission();
 		const promptAccepted = Symbol("promptAccepted");
 		const acceptance = acceptedAgentMessagePrompt
 			? acceptedAgentMessagePrompt.accepted.then(
@@ -4447,6 +4507,7 @@ export class AgentSession {
 			return;
 		}
 		await promptCompletion;
+		releaseAdmission?.();
 		this._scheduleSessionInputPump();
 		await this._sessionInputPump;
 	}
@@ -4751,7 +4812,9 @@ export class AgentSession {
 			schedule === "followUp" &&
 			input.kind === "prompt" &&
 			input.queueKey &&
-			queue.some((item) => item.queueKey === input.queueKey)
+			(queue.some((item) => item.queueKey === input.queueKey) ||
+				(this._activeSessionInput?.kind === "prompt" &&
+					this._activeSessionInput.items.some((item) => item.queueKey === input.queueKey)))
 		) {
 			return false;
 		}
@@ -4762,6 +4825,7 @@ export class AgentSession {
 		}
 		this._emitQueueUpdate();
 		if ((schedule === "steer" && this.isStreaming) || input.kind === "command" || input.autoPump) {
+			if (input.kind === "prompt" && input.autoPump) this._sessionInputPumpSuspended = false;
 			this._scheduleSessionInputPump();
 		}
 		return true;
@@ -4838,15 +4902,7 @@ export class AgentSession {
 				if (epoch !== this._sessionInputPumpEpoch) return;
 				await this._agentEventQueue;
 				await this._waitForRefineIdle();
-				if (
-					this._sessionInputPumpSuspended ||
-					this._queuedWorkPauses.size > 0 ||
-					this.isBashRunning ||
-					this.isCompacting ||
-					this._branchSummaryOperation !== undefined ||
-					this.isRetrying ||
-					this.hasAcceptedPromptInFlight
-				) {
+				if (this._isSessionInputHandoffDeferred(epoch)) {
 					blocked = true;
 					return;
 				}
@@ -4872,7 +4928,7 @@ export class AgentSession {
 				while (queue[0]?.kind === "prompt" && (mode === "all" || prompts.length === 0)) {
 					prompts.push(queue.shift() as PreparedPromptInput);
 				}
-				this._steeringStopPending = this._steeringMessages.length > 0 && this.isStreaming;
+				this._steeringStopPending = this._steeringMessages.length > 0;
 				if (epoch !== this._sessionInputPumpEpoch) {
 					queue.unshift(...prompts);
 					return;
@@ -4882,19 +4938,25 @@ export class AgentSession {
 				try {
 					await this._startPreparedPromptItems(prompts, epoch);
 					if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
-				} catch {
+				} catch (error) {
 					const delivered = new Set(this.agent.state.messages);
 					const undelivered: PreparedPromptInput[] = [];
 					for (const prompt of prompts) {
 						prompt.prefixMessages = prompt.prefixMessages.filter((message) => !delivered.has(message));
 						if (!delivered.has(prompt.message)) undelivered.push(prompt);
 					}
-					if (undelivered.length > 0) {
-						queue.unshift(...undelivered);
-						this._emitQueueUpdate();
+					if (this._isDeferredSessionInputError(error, epoch)) {
+						if (undelivered.length > 0) {
+							queue.unshift(...undelivered);
+							this._emitQueueUpdate();
+						}
 						blocked = true;
 						return;
 					}
+					for (const prompt of undelivered) {
+						this._rejectAgentMessageDelivery(prompt.agentMessageId, this._asError(error));
+					}
+					this._surfaceSessionInputError(error);
 				} finally {
 					this._activeSessionInput = undefined;
 				}
@@ -4908,7 +4970,67 @@ export class AgentSession {
 		}
 	}
 
+	private _isSessionInputHandoffDeferred(epoch: number): boolean {
+		return (
+			epoch !== this._sessionInputPumpEpoch ||
+			this._sessionInputPumpSuspended ||
+			this._queuedWorkPauses.size > 0 ||
+			this.isBashRunning ||
+			this.isCompacting ||
+			this._branchSummaryOperation !== undefined ||
+			this.isRetrying ||
+			this.hasAcceptedPromptInFlight
+		);
+	}
+
+	private _asError(error: unknown): Error {
+		return error instanceof Error ? error : new Error(String(error));
+	}
+
+	private _isDeferredSessionInputError(error: unknown, epoch: number): boolean {
+		return (
+			error instanceof DeferredSessionInputError ||
+			this._isSessionInputHandoffDeferred(epoch) ||
+			(error instanceof Error && error.message.startsWith("Agent is already processing"))
+		);
+	}
+
+	private _surfaceSessionInputError(error: unknown): void {
+		const normalized = this._asError(error);
+		this._extensionRunner.emitError({
+			extensionPath: "<session-input>",
+			event: "session_input",
+			error: normalized.message,
+			stack: normalized.stack,
+		});
+	}
+
 	private async _startPreparedPromptItems(prompts: PreparedPromptInput[], epoch: number): Promise<void> {
+		await this._validateCanStartAgentRun();
+		this._flushPendingBashMessages();
+		const lastAssistant = this._findLastAssistantMessage();
+		if (lastAssistant) await this._checkCompaction(lastAssistant, false, false);
+		const pendingModelSelectEmit = this._pendingModelSelectEmit();
+		if (pendingModelSelectEmit) await pendingModelSelectEmit;
+
+		const preparationPrompt = prompts.at(-1);
+		if (!prompts.every((prompt) => prompt.preparation !== undefined)) {
+			if (this._isSessionInputHandoffDeferred(epoch)) {
+				throw new DeferredSessionInputError("Session input paused before preparation");
+			}
+			const result = await this._extensionRunner.emitBeforeAgentStart(
+				preparationPrompt?.text ?? "",
+				preparationPrompt?.images,
+				this._baseSystemPrompt,
+				this._baseSystemPromptOptions,
+			);
+			const preparation = { result };
+			for (const prompt of prompts) prompt.preparation = preparation;
+		}
+		if (this._isSessionInputHandoffDeferred(epoch)) {
+			throw new DeferredSessionInputError("Session input paused before handoff");
+		}
+
 		const messages: AgentMessage[] = [];
 		const nextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
@@ -4917,34 +5039,7 @@ export class AgentSession {
 			messages.push(...prompt.prefixMessages, prompt.message);
 			if (prompt.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(prompt.message);
 		}
-		try {
-			await this._startPreparedAgentPrompt(prompts.at(-1)?.text ?? "", prompts.at(-1)?.images, messages, epoch);
-			this._forgetConsumedPostCompactionContinuations(prompts.map((prompt) => prompt.message));
-		} catch (error) {
-			const delivered = new Set(this.agent.state.messages);
-			this._pendingNextTurnMessages.unshift(...nextTurnMessages.filter((message) => !delivered.has(message)));
-			throw error;
-		}
-	}
-
-	private async _startPreparedAgentPrompt(
-		text: string,
-		images: ImageContent[] | undefined,
-		messages: AgentMessage[],
-		epoch: number,
-	): Promise<void> {
-		await this._validateCanStartAgentRun();
-		this._flushPendingBashMessages();
-		const lastAssistant = this._findLastAssistantMessage();
-		if (lastAssistant) await this._checkCompaction(lastAssistant, false, false);
-		const pendingModelSelectEmit = this._pendingModelSelectEmit();
-		if (pendingModelSelectEmit) await pendingModelSelectEmit;
-		const result = await this._extensionRunner.emitBeforeAgentStart(
-			text,
-			images,
-			this._baseSystemPrompt,
-			this._baseSystemPromptOptions,
-		);
+		const result = prompts[0]?.preparation?.result;
 		if (result?.messages) {
 			for (const message of result.messages) {
 				messages.push({
@@ -4962,21 +5057,19 @@ export class AgentSession {
 		// disconnecting event handling. Wait for it to finish so the new
 		// turn's events are not lost.
 		await this._waitForRefineIdle();
-		if (
-			epoch !== this._sessionInputPumpEpoch ||
-			this._sessionInputPumpSuspended ||
-			this._queuedWorkPauses.size > 0 ||
-			this.isBashRunning ||
-			this.isCompacting ||
-			this._branchSummaryOperation !== undefined ||
-			this.isRetrying ||
-			this.hasAcceptedPromptInFlight
-		) {
-			throw new Error("Session input paused before handoff");
+		if (this._isSessionInputHandoffDeferred(epoch)) {
+			throw new DeferredSessionInputError("Session input paused before handoff");
 		}
 		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
-		await this.agent.prompt(messages);
-		await this.waitForRetry();
+		try {
+			await this.agent.prompt(messages);
+			await this.waitForRetry();
+			this._forgetConsumedPostCompactionContinuations(prompts.map((prompt) => prompt.message));
+		} catch (error) {
+			const delivered = new Set(this.agent.state.messages);
+			this._pendingNextTurnMessages.unshift(...nextTurnMessages.filter((message) => !delivered.has(message)));
+			throw error;
+		}
 	}
 
 	private async _executeQueuedSessionCommand(input: PreparedCommandInput): Promise<void> {
@@ -5097,14 +5190,23 @@ export class AgentSession {
 		if (options?.deliverAs === "nextTurn") {
 			this._pendingNextTurnMessages.push(appMessage);
 		} else if (this.isStreaming) {
+			const normalized = normalizeMessageContent(message.content);
 			if (options?.deliverAs === "followUp") {
-				await this._queueFollowUp(String(message.content), undefined, { message: appMessage, resumeIfIdle: true });
+				await this._queueFollowUp(normalized.text, normalized.images, { message: appMessage, resumeIfIdle: true });
 			} else {
-				await this._queueSteer(String(message.content), undefined, { message: appMessage, resumeIfIdle: true });
+				await this._queueSteer(normalized.text, normalized.images, { message: appMessage, resumeIfIdle: true });
 			}
 		} else if (options?.triggerTurn) {
-			await this._waitForRefineIdle();
-			await this.agent.prompt(appMessage);
+			const releaseAdmission = await this._acquireDirectTurnAdmission();
+			try {
+				if (this.isStreaming) await this.agent.waitForIdle();
+				await this._waitForRefineIdle();
+				const promptPromise = this.agent.prompt(appMessage);
+				releaseAdmission();
+				await promptPromise;
+			} finally {
+				releaseAdmission();
+			}
 		} else {
 			this.agent.state.messages.push(appMessage);
 			this.sessionManager.appendCustomMessageEntry(
@@ -5262,9 +5364,52 @@ export class AgentSession {
 				if (released) return;
 				released = true;
 				this._queuedWorkPauses.delete(token);
+				if (this._queuedWorkPauses.size === 0) {
+					for (const resolve of this._queuedWorkAdmissionWaiters) resolve();
+					this._queuedWorkAdmissionWaiters.clear();
+				}
 				this._scheduleSessionInputPump();
 			},
 		};
+	}
+
+	private async _acquireTurnAdmission(): Promise<() => void> {
+		const previous = this._turnAdmissionTail;
+		let resolve = () => {};
+		this._turnAdmissionTail = new Promise<void>((release) => {
+			resolve = release;
+		});
+		await previous;
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			resolve();
+		};
+	}
+
+	private async _acquireDirectTurnAdmission(): Promise<() => void> {
+		while (true) {
+			await this._waitForQueuedWorkAdmission();
+			if (this.pendingMessageCount > 0) this._scheduleSessionInputPump();
+			const release = await this._acquireTurnAdmission();
+			if (
+				this.pendingMessageCount === 0 &&
+				this._activeSessionInput === undefined &&
+				!this._pumpingSessionInput &&
+				!this._sessionInputPumpRequested
+			) {
+				return release;
+			}
+			release();
+			await this.waitForSessionInputIdle();
+		}
+	}
+
+	private async _waitForQueuedWorkAdmission(): Promise<void> {
+		while (this._queuedWorkPauses.size > 0) {
+			await new Promise<void>((resolve) => this._queuedWorkAdmissionWaiters.add(resolve));
+		}
 	}
 
 	/** Compatibility wrapper for callers migrating to owned pause leases. */
@@ -5276,6 +5421,7 @@ export class AgentSession {
 
 	/** Compatibility wrapper that releases only the pause acquired by pauseQueuedWork(). */
 	resumeQueuedWork(): boolean {
+		this._sessionInputPumpSuspended = false;
 		const pause = this._legacyQueuedWorkPause;
 		if (pause) {
 			this._legacyQueuedWorkPause = undefined;
@@ -5287,7 +5433,11 @@ export class AgentSession {
 	}
 
 	async waitForSessionInputIdle(): Promise<void> {
-		await this._sessionInputPump;
+		while (true) {
+			const pump = this._sessionInputPump;
+			await pump;
+			if (pump === this._sessionInputPump && !this._sessionInputPumpRequested && !this._pumpingSessionInput) return;
+		}
 	}
 
 	async waitForIdle(): Promise<void> {
@@ -5335,7 +5485,11 @@ export class AgentSession {
 	}
 
 	hasQueuedFollowUp(queueKey: string): boolean {
-		return this._followUpMessages.some((message) => message.queueKey === queueKey);
+		return (
+			this._followUpMessages.some((message) => message.queueKey === queueKey) ||
+			(this._activeSessionInput?.kind === "prompt" &&
+				this._activeSessionInput.items.some((message) => message.queueKey === queueKey))
+		);
 	}
 
 	removeQueuedFollowUp(queueKey: string): boolean {
@@ -9127,13 +9281,6 @@ export class AgentSession {
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
-		const oldLeafId = this.sessionManager.getLeafId();
-
-		// No-op if already at target
-		if (targetId === oldLeafId) {
-			return { cancelled: false };
-		}
-
 		// Model required for summarization
 		if (options.summarize && !this.model) {
 			throw new Error("No model available for summarization");
@@ -9145,16 +9292,34 @@ export class AgentSession {
 		}
 
 		const queuedWorkPause = this.acquireQueuedWorkPause();
-		await this.waitForSessionInputIdle();
+		let releaseAdmission: (() => void) | undefined;
+		try {
+			releaseAdmission = await this._acquireTurnAdmission();
+			await this.agent.waitForIdle();
+			await this._agentEventQueue;
+			await this.waitForSessionInputIdle();
+			return await this._navigateTreeUnderPause(targetId, targetEntry, options);
+		} finally {
+			queuedWorkPause.release();
+			releaseAdmission?.();
+		}
+	}
+
+	private async _navigateTreeUnderPause(
+		targetId: string,
+		targetEntry: NonNullable<ReturnType<SessionManager["getEntry"]>>,
+		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string },
+	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
+		const oldLeafId = this.sessionManager.getLeafId();
+
+		// No-op if already at target after admitted work has settled.
+		if (targetId === oldLeafId) {
+			return { cancelled: false };
+		}
 
 		// Do not switch branches while /refine has detached event handling and is
 		// about to persist harness/session entries for the current branch.
-		try {
-			await this._invalidatePendingAutoRefineForBranchChange();
-		} catch (error) {
-			queuedWorkPause.release();
-			throw error;
-		}
+		await this._invalidatePendingAutoRefineForBranchChange();
 
 		// Collect entries to summarize (from old leaf to common ancestor)
 		const { entries: entriesToSummarize, commonAncestorId } = collectEntriesForBranchSummary(
@@ -9329,7 +9494,6 @@ export class AgentSession {
 				this._branchSummaryOperation = undefined;
 			}
 			resolveBranchSummaryOperation();
-			queuedWorkPause.release();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1447,7 +1447,7 @@ export class AgentSession {
 			input.kind === "prompt" && input.customMessage?.customType === GOAL_CONTEXT_CUSTOM_TYPE;
 		this._steeringMessages = this._steeringMessages.filter((input) => !isGoalContext(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isGoalContext(input));
-		this._steeringStopPending = this._steeringMessages.length > 0 && this.isStreaming;
+		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 	}
 
@@ -1838,6 +1838,15 @@ export class AgentSession {
 			lastError: undefined,
 		});
 		return true;
+	}
+
+	private _syncSteeringStopPending(): void {
+		const activeSteeringHandoff =
+			this._activeSessionInput?.kind === "prompt" &&
+			this._activeSessionInput.lane === "steer" &&
+			this._activeSessionInput.phase === "preparing" &&
+			this._activeSessionInput.items.length > 0;
+		this._steeringStopPending = this._steeringMessages.length > 0 || activeSteeringHandoff;
 	}
 
 	private _shouldStopBeforeTurn(): boolean {
@@ -2441,6 +2450,7 @@ export class AgentSession {
 			input.kind === "prompt" && queuedMessageSet.has(input.message);
 		this._steeringMessages = this._steeringMessages.filter((input) => !isQueuedContinuation(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isQueuedContinuation(input));
+		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 		if (options.restoreAutonomousState) {
 			for (const queuedMessage of queuedMessages) {
@@ -3585,6 +3595,7 @@ export class AgentSession {
 			this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 			this._steeringMessages = [];
 			this._followUpMessages = [];
+			this._syncSteeringStopPending();
 			this.agent.clearAllQueues();
 			this._extensionRunner.invalidate(
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
@@ -4702,9 +4713,7 @@ export class AgentSession {
 		}
 		queue.push(input);
 		this._sessionInputArrivalEpoch++;
-		if (schedule === "steer" && this.isStreaming) {
-			this._steeringStopPending = true;
-		}
+		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 		if (
 			!options.restore &&
@@ -4797,11 +4806,13 @@ export class AgentSession {
 					if (first.kind === "command") {
 						queue.shift();
 						this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
+						this._syncSteeringStopPending();
 						this._emitQueueUpdate();
 						try {
 							await this._executeQueuedSessionCommand(first);
 						} finally {
 							this._activeSessionInput = undefined;
+							this._syncSteeringStopPending();
 						}
 						continue;
 					}
@@ -4810,12 +4821,13 @@ export class AgentSession {
 					while (queue[0]?.kind === "prompt" && (mode === "all" || prompts.length === 0)) {
 						prompts.push(queue.shift() as PreparedPromptInput);
 					}
-					this._steeringStopPending = this._steeringMessages.length > 0;
 					if (epoch !== this._sessionInputPumpEpoch) {
 						queue.unshift(...prompts);
+						this._syncSteeringStopPending();
 						return;
 					}
 					this._activeSessionInput = { kind: "prompt", lane, items: prompts, phase: "preparing" };
+					this._syncSteeringStopPending();
 					this._emitQueueUpdate();
 					try {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
@@ -4829,6 +4841,7 @@ export class AgentSession {
 						if (this._isDeferredSessionInputError(error, epoch)) {
 							if (undelivered.length > 0) {
 								queue.unshift(...undelivered);
+								this._syncSteeringStopPending();
 								this._emitQueueUpdate();
 							}
 							blocked = true;
@@ -4840,6 +4853,7 @@ export class AgentSession {
 						this._surfaceSessionInputError(error);
 					} finally {
 						this._activeSessionInput = undefined;
+						this._syncSteeringStopPending();
 					}
 				} finally {
 					admission.release();
@@ -4847,7 +4861,7 @@ export class AgentSession {
 			}
 		} finally {
 			this._pumpingSessionInput = false;
-			this._steeringStopPending = false;
+			this._syncSteeringStopPending();
 			if (!blocked && epoch === this._sessionInputPumpEpoch && this.pendingMessageCount > 0) {
 				this._scheduleSessionInputPump();
 			}
@@ -4972,10 +4986,13 @@ export class AgentSession {
 				? this._refreshExtensionSystemPrompt(result.systemPrompt, preparation.basePromptSnapshot)
 				: this._baseSystemPrompt;
 		try {
-			if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 			if (this.isStreaming) {
 				// agent.prompt() would reject with its already-processing error; defer instead.
 				throw new DeferredSessionInputError("Agent became active before session input handoff");
+			}
+			if (this._activeSessionInput?.kind === "prompt") {
+				this._activeSessionInput.phase = "handedOff";
+				this._syncSteeringStopPending();
 			}
 			const promptPromise = this.agent.prompt(messages);
 			releaseAdmission();
@@ -5170,6 +5187,7 @@ export class AgentSession {
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 		this._steeringMessages = [];
 		this._followUpMessages = [];
+		this._syncSteeringStopPending();
 		this.agent.clearAllQueues();
 		this._emitQueueUpdate();
 		return { steering, followUp };
@@ -5218,6 +5236,7 @@ export class AgentSession {
 		this._followUpMessages = this._followUpMessages.filter(
 			(message) => !followUpSet.has(message as PreparedPromptInput),
 		);
+		this._syncSteeringStopPending();
 		for (const message of [...steering, ...followUp]) {
 			this._rejectAgentMessageDelivery(
 				message.agentMessageId,
@@ -5462,6 +5481,7 @@ export class AgentSession {
 		const removed = new Set<QueuedSessionInput>([...removedSteering, ...removedFollowUp]);
 		this._steeringMessages = this._steeringMessages.filter((message) => !removed.has(message));
 		this._followUpMessages = this._followUpMessages.filter((message) => !removed.has(message));
+		this._syncSteeringStopPending();
 		for (const message of removed) {
 			this._rejectAgentMessageDelivery(
 				message.agentMessageId,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5389,8 +5389,7 @@ export class AgentSession {
 					await this._waitForQueuedWorkAdmission();
 					continue;
 				}
-				// allowPendingQueue: queueIfBusy callers only need admission ownership,
-				// not a drained queue - they enqueue behind pending work at preflight.
+				// queueIfBusy callers enqueue behind pending work at preflight; they need ownership, not a drained queue.
 				if (
 					(options.allowStreaming === true && this.isStreaming) ||
 					options.allowPendingQueue === true ||
@@ -6316,8 +6315,7 @@ export class AgentSession {
 			this._scheduleAutoRefineAfterAgentEnd();
 			return;
 		}
-		// The pump owns items it moved into _activeSessionInput before handoff, so
-		// an empty queue alone does not mean idle.
+		// An empty queue is not idle: the pump owns items moved into _activeSessionInput before handoff.
 		if (
 			this.pendingMessageCount > 0 ||
 			this._activeSessionInput !== undefined ||

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5371,6 +5371,11 @@ export class AgentSession {
 			const admission = await this._acquireTurnAdmission();
 			try {
 				this._assertDirectTurnAdmissionAvailable();
+				if (this._queuedWorkPauses.size > 0) {
+					admission.release();
+					await this._waitForQueuedWorkAdmission();
+					continue;
+				}
 				if (
 					(options.allowStreaming === true && this.isStreaming) ||
 					(this.pendingMessageCount === 0 &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -907,6 +907,8 @@ export class AgentSession {
 	private readonly _queuedWorkPauses = new Set<symbol>();
 	private readonly _queuedWorkAdmissionWaiters = new Set<() => void>();
 	private _turnAdmissionTail: Promise<void> = Promise.resolve();
+	private _turnAdmissionOwner: symbol | undefined;
+	private readonly _turnAdmissionContext = new AsyncLocalStorage<symbol>();
 	private _legacyQueuedWorkPause: { release(): void } | undefined;
 	private _pumpingSessionInput = false;
 	private _activeSessionInput:
@@ -3898,11 +3900,11 @@ export class AgentSession {
 		options?: InternalPromptOptions,
 	): Promise<void> {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
-		const releaseAdmission = await this._acquireDirectTurnAdmission({ allowStreaming: true });
+		const admission = await this._acquireDirectTurnAdmission({ allowStreaming: true });
 		try {
-			await this._promptInjectedMessageUnserialized(text, message, options, releaseAdmission);
+			await this._promptInjectedMessageUnserialized(text, message, options, admission.release);
 		} finally {
-			releaseAdmission();
+			admission.release();
 		}
 	}
 
@@ -4087,7 +4089,8 @@ export class AgentSession {
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
 		if (!this.isStreaming) this._sessionInputPumpSuspended = false;
-		const releaseAdmission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : () => {};
+		const admission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : undefined;
+		const releaseAdmission = admission?.release ?? (() => {});
 		try {
 			await this._promptUnserialized(text, options, releaseAdmission);
 		} finally {
@@ -4529,7 +4532,12 @@ export class AgentSession {
 		const ctx = this._extensionRunner.createCommandContext();
 
 		try {
-			await command.handler(args, ctx);
+			const owner = this._turnAdmissionOwner;
+			if (owner) {
+				await this._turnAdmissionContext.run(owner, () => command.handler(args, ctx));
+			} else {
+				await command.handler(args, ctx);
+			}
 			return true;
 		} catch (err) {
 			// Emit error via extension runner
@@ -4899,67 +4907,72 @@ export class AgentSession {
 		let blocked = false;
 		try {
 			while (!this._disposed && !this._disposing && this.pendingMessageCount > 0) {
-				await this.agent.waitForIdle();
-				if (epoch !== this._sessionInputPumpEpoch) return;
-				await this._agentEventQueue;
-				await this._waitForRefineIdle();
-				if (this._isSessionInputHandoffDeferred(epoch)) {
-					blocked = true;
-					return;
-				}
-
-				const queue = this._steeringMessages.length > 0 ? this._steeringMessages : this._followUpMessages;
-				const mode = queue === this._steeringMessages ? this.steeringMode : this.followUpMode;
-				const first = queue[0];
-				if (!first) continue;
-				const lane: SessionInputSchedule = queue === this._steeringMessages ? "steer" : "followUp";
-				if (first.kind === "command") {
-					queue.shift();
-					this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
-					this._emitQueueUpdate();
-					try {
-						await this._executeQueuedSessionCommand(first);
-					} finally {
-						this._activeSessionInput = undefined;
-					}
-					continue;
-				}
-
-				const prompts: PreparedPromptInput[] = [];
-				while (queue[0]?.kind === "prompt" && (mode === "all" || prompts.length === 0)) {
-					prompts.push(queue.shift() as PreparedPromptInput);
-				}
-				this._steeringStopPending = this._steeringMessages.length > 0;
-				if (epoch !== this._sessionInputPumpEpoch) {
-					queue.unshift(...prompts);
-					return;
-				}
-				this._activeSessionInput = { kind: "prompt", lane, items: prompts, phase: "preparing" };
-				this._emitQueueUpdate();
+				const admission = await this._acquireTurnAdmission();
 				try {
-					await this._startPreparedPromptItems(prompts, epoch);
-					if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
-				} catch (error) {
-					const delivered = new Set(this.agent.state.messages);
-					const undelivered: PreparedPromptInput[] = [];
-					for (const prompt of prompts) {
-						prompt.prefixMessages = prompt.prefixMessages.filter((message) => !delivered.has(message));
-						if (!delivered.has(prompt.message)) undelivered.push(prompt);
-					}
-					if (this._isDeferredSessionInputError(error, epoch)) {
-						if (undelivered.length > 0) {
-							queue.unshift(...undelivered);
-							this._emitQueueUpdate();
-						}
+					await this.agent.waitForIdle();
+					if (epoch !== this._sessionInputPumpEpoch) return;
+					await this._agentEventQueue;
+					await this._waitForRefineIdle();
+					if (this._isSessionInputHandoffDeferred(epoch)) {
 						blocked = true;
 						return;
 					}
-					for (const prompt of undelivered) {
-						this._rejectAgentMessageDelivery(prompt.agentMessageId, this._asError(error));
+
+					const queue = this._steeringMessages.length > 0 ? this._steeringMessages : this._followUpMessages;
+					const mode = queue === this._steeringMessages ? this.steeringMode : this.followUpMode;
+					const first = queue[0];
+					if (!first) continue;
+					const lane: SessionInputSchedule = queue === this._steeringMessages ? "steer" : "followUp";
+					if (first.kind === "command") {
+						queue.shift();
+						this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
+						this._emitQueueUpdate();
+						try {
+							await this._executeQueuedSessionCommand(first);
+						} finally {
+							this._activeSessionInput = undefined;
+						}
+						continue;
 					}
-					this._surfaceSessionInputError(error);
+
+					const prompts: PreparedPromptInput[] = [];
+					while (queue[0]?.kind === "prompt" && (mode === "all" || prompts.length === 0)) {
+						prompts.push(queue.shift() as PreparedPromptInput);
+					}
+					this._steeringStopPending = this._steeringMessages.length > 0;
+					if (epoch !== this._sessionInputPumpEpoch) {
+						queue.unshift(...prompts);
+						return;
+					}
+					this._activeSessionInput = { kind: "prompt", lane, items: prompts, phase: "preparing" };
+					this._emitQueueUpdate();
+					try {
+						await this._startPreparedPromptItems(prompts, epoch, admission.release);
+						if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
+					} catch (error) {
+						const delivered = new Set(this.agent.state.messages);
+						const undelivered: PreparedPromptInput[] = [];
+						for (const prompt of prompts) {
+							prompt.prefixMessages = prompt.prefixMessages.filter((message) => !delivered.has(message));
+							if (!delivered.has(prompt.message)) undelivered.push(prompt);
+						}
+						if (this._isDeferredSessionInputError(error, epoch)) {
+							if (undelivered.length > 0) {
+								queue.unshift(...undelivered);
+								this._emitQueueUpdate();
+							}
+							blocked = true;
+							return;
+						}
+						for (const prompt of undelivered) {
+							this._rejectAgentMessageDelivery(prompt.agentMessageId, this._asError(error));
+						}
+						this._surfaceSessionInputError(error);
+					} finally {
+						this._activeSessionInput = undefined;
+					}
 				} finally {
-					this._activeSessionInput = undefined;
+					admission.release();
 				}
 			}
 		} finally {
@@ -4973,6 +4986,8 @@ export class AgentSession {
 
 	private _isSessionInputHandoffDeferred(epoch: number): boolean {
 		return (
+			this._disposed ||
+			this._disposing ||
 			epoch !== this._sessionInputPumpEpoch ||
 			this._sessionInputPumpSuspended ||
 			this._queuedWorkPauses.size > 0 ||
@@ -5006,7 +5021,11 @@ export class AgentSession {
 		});
 	}
 
-	private async _startPreparedPromptItems(prompts: PreparedPromptInput[], epoch: number): Promise<void> {
+	private async _startPreparedPromptItems(
+		prompts: PreparedPromptInput[],
+		epoch: number,
+		releaseAdmission: () => void,
+	): Promise<void> {
 		await this._validateCanStartAgentRun();
 		this._flushPendingBashMessages();
 		const lastAssistant = this._findLastAssistantMessage();
@@ -5063,7 +5082,9 @@ export class AgentSession {
 		}
 		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
 		try {
-			await this.agent.prompt(messages);
+			const promptPromise = this.agent.prompt(messages);
+			releaseAdmission();
+			await promptPromise;
 			await this.waitForRetry();
 			this._forgetConsumedPostCompactionContinuations(prompts.map((prompt) => prompt.message));
 		} catch (error) {
@@ -5198,15 +5219,15 @@ export class AgentSession {
 				await this._queueSteer(normalized.text, normalized.images, { message: appMessage, resumeIfIdle: true });
 			}
 		} else if (options?.triggerTurn) {
-			const releaseAdmission = await this._acquireDirectTurnAdmission();
+			const admission = await this._acquireDirectTurnAdmission();
 			try {
 				if (this.isStreaming) await this.agent.waitForIdle();
 				await this._waitForRefineIdle();
 				const promptPromise = this.agent.prompt(appMessage);
-				releaseAdmission();
+				admission.release();
 				await promptPromise;
 			} finally {
-				releaseAdmission();
+				admission.release();
 			}
 		} else {
 			this.agent.state.messages.push(appMessage);
@@ -5374,26 +5395,38 @@ export class AgentSession {
 		};
 	}
 
-	private async _acquireTurnAdmission(): Promise<() => void> {
+	private async _acquireTurnAdmission(): Promise<{ owner: symbol; release(): void }> {
+		const inheritedOwner = this._turnAdmissionContext.getStore();
+		if (inheritedOwner !== undefined && inheritedOwner === this._turnAdmissionOwner) {
+			return { owner: inheritedOwner, release: () => {} };
+		}
 		const previous = this._turnAdmissionTail;
 		let resolve = () => {};
 		this._turnAdmissionTail = new Promise<void>((release) => {
 			resolve = release;
 		});
 		await previous;
+		const owner = Symbol("turn-admission");
+		this._turnAdmissionOwner = owner;
 		let released = false;
-		return () => {
-			if (released) return;
-			released = true;
-			resolve();
+		return {
+			owner,
+			release: () => {
+				if (released) return;
+				released = true;
+				if (this._turnAdmissionOwner === owner) this._turnAdmissionOwner = undefined;
+				resolve();
+			},
 		};
 	}
 
-	private async _acquireDirectTurnAdmission(options: { allowStreaming?: boolean } = {}): Promise<() => void> {
+	private async _acquireDirectTurnAdmission(
+		options: { allowStreaming?: boolean } = {},
+	): Promise<{ owner: symbol; release(): void }> {
 		while (true) {
 			await this._waitForQueuedWorkAdmission();
 			if (this.pendingMessageCount > 0) this._scheduleSessionInputPump();
-			const release = await this._acquireTurnAdmission();
+			const admission = await this._acquireTurnAdmission();
 			if (
 				(options.allowStreaming === true && this.isStreaming) ||
 				(this.pendingMessageCount === 0 &&
@@ -5401,9 +5434,9 @@ export class AgentSession {
 					!this._pumpingSessionInput &&
 					!this._sessionInputPumpRequested)
 			) {
-				return release;
+				return admission;
 			}
-			release();
+			admission.release();
 			await this.waitForSessionInputIdle();
 		}
 	}
@@ -5454,6 +5487,7 @@ export class AgentSession {
 				acceptedPrompts.every((completion) => this._acceptedPromptCompletions.has(completion)) &&
 				!this._sessionInputPumpRequested &&
 				!this._pumpingSessionInput &&
+				!this.agent.state.isStreaming &&
 				this._acceptedAgentMessagePrompt === undefined
 			) {
 				return;
@@ -5988,6 +6022,9 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string, options: { skipAbort?: boolean } = {}): Promise<CompactionResult> {
+		if (options.skipAbort && this.isStreaming) {
+			throw new Error("Cannot compact without aborting while the agent is running.");
+		}
 		const hadPostCompactionContinue = this._postCompactionContinuationScheduled;
 		this._disconnectFromAgent();
 		if (!options.skipAbort) await this.abort();
@@ -9314,16 +9351,17 @@ export class AgentSession {
 		}
 
 		const queuedWorkPause = this.acquireQueuedWorkPause();
-		let releaseAdmission: (() => void) | undefined;
+		let admission: { owner: symbol; release(): void } | undefined;
 		try {
-			releaseAdmission = await this._acquireTurnAdmission();
-			await this.agent.waitForIdle();
-			await this._agentEventQueue;
-			await this.waitForSessionInputIdle();
-			return await this._navigateTreeUnderPause(targetId, targetEntry, options);
+			admission = await this._acquireTurnAdmission();
+			return await this._turnAdmissionContext.run(admission.owner, async () => {
+				await this.agent.waitForIdle();
+				await this._agentEventQueue;
+				return this._navigateTreeUnderPause(targetId, targetEntry, options);
+			});
 		} finally {
 			queuedWorkPause.release();
-			releaseAdmission?.();
+			admission?.release();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1445,6 +1445,7 @@ export class AgentSession {
 		);
 		const isGoalContext = (input: QueuedSessionInput) =>
 			input.kind === "prompt" && input.customMessage?.customType === GOAL_CONTEXT_CUSTOM_TYPE;
+		this._removeActivePreparingPrompts(isGoalContext);
 		this._steeringMessages = this._steeringMessages.filter((input) => !isGoalContext(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isGoalContext(input));
 		this._syncSteeringStopPending();
@@ -1859,7 +1860,12 @@ export class AgentSession {
 		}
 		try {
 			if (this._accountGoalUsageForAssistantMessage(context.message)) {
-				this.agent.steer(createGoalContextMessage(this._goalState, "budget_limit"));
+				const message = createGoalContextMessage(this._goalState, "budget_limit");
+				const normalized = normalizeMessageContent(message.content);
+				await this._queueSteer(normalized.text, normalized.images, {
+					message,
+					resumeIfIdle: true,
+				});
 			}
 		} catch {
 			// Goal accounting must not interrupt the core agent loop.
@@ -3154,7 +3160,12 @@ export class AgentSession {
 					this._retryAuthFailureSources = [];
 				}
 				if (this._accountGoalUsageForAssistantMessage(assistantMsg)) {
-					this.agent.steer(createGoalContextMessage(this._goalState, "budget_limit"));
+					const message = createGoalContextMessage(this._goalState, "budget_limit");
+					const normalized = normalizeMessageContent(message.content);
+					await this._queueSteer(normalized.text, normalized.images, {
+						message,
+						resumeIfIdle: true,
+					});
 				}
 			}
 		}
@@ -5121,6 +5132,7 @@ export class AgentSession {
 				await promptPromise;
 			} finally {
 				admission.release();
+				this._scheduleSessionInputPump();
 			}
 		} else {
 			this.agent.state.messages.push(appMessage);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -172,6 +172,8 @@ import {
 	type BashExecutionMessage,
 	type CustomMessage,
 	createHeartbeatPromptMessage,
+	createSessionSlashCommandMessage,
+	createSessionSlashCommandResultMessage,
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
@@ -232,7 +234,7 @@ import {
 import type { SessionStats } from "./session-stats.js";
 import type { SettingsManager } from "./settings-manager.js";
 import { getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
-import { parseSessionSlashCommand, type SlashCommandInfo } from "./slash-commands.js";
+import { parseSessionSlashCommand, type SessionSlashCommand, type SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
@@ -500,6 +502,8 @@ export interface PromptOptions {
 	suppressAutonomousContinuation?: boolean;
 	/** Skip extension input handlers for replaying already-accepted input. */
 	skipInputHandlers?: boolean;
+	/** Start queued work when this input is admitted to an otherwise idle session. */
+	resumeIfIdle?: boolean;
 	agentMessageId?: string;
 	content?: (TextContent | ImageContent)[];
 	customMessage?: CustomMessage;
@@ -509,28 +513,37 @@ interface InternalPromptOptions extends PromptOptions {
 	skipPrePromptWork?: boolean;
 	returnAfterAccepted?: boolean;
 	agentMessageId?: string;
-	resumeIfIdle?: boolean;
 }
 
 type QueuedAgentMessage = UserMessage | CustomMessage;
+type SessionInputSchedule = "steer" | "followUp";
 
-interface QueuedSteeringMessage {
+interface PreparedPromptInput {
+	kind: "prompt";
 	text: string;
+	images?: ImageContent[];
+	content?: (TextContent | ImageContent)[];
+	customMessage?: CustomMessage;
 	previewLabel?: string;
 	queueKey?: string;
 	agentMessageId?: string;
 	prefixMessages: CustomMessage[];
+	suppressAutonomousContinuation?: boolean;
+	autoPump: boolean;
 	message: QueuedAgentMessage;
 }
 
-interface QueuedFollowUpMessage {
+interface PreparedCommandInput {
+	kind: "command";
 	text: string;
-	previewLabel?: string;
-	queueKey?: string;
-	agentMessageId?: string;
-	prefixMessages: CustomMessage[];
-	message: QueuedAgentMessage;
+	command: SessionSlashCommand;
+	images?: ImageContent[];
+	queueKey?: undefined;
+	agentMessageId?: undefined;
+	message?: undefined;
 }
+
+type QueuedSessionInput = PreparedPromptInput | PreparedCommandInput;
 
 export interface QueuedAgentInputSnapshot {
 	text: string;
@@ -569,17 +582,24 @@ function createQueuedAgentInputSnapshotFromUserMessage(
 	return { text, content, ...(images.length > 0 ? { images } : {}) };
 }
 
-function createQueuedAgentInputSnapshot(
-	message: QueuedSteeringMessage | QueuedFollowUpMessage,
-): QueuedAgentInputSnapshot {
-	const snapshot = createQueuedAgentInputSnapshotFromUserMessage(message.text, message.message);
+function createQueuedAgentInputSnapshot(message: QueuedSessionInput): QueuedAgentInputSnapshot {
+	if (message.kind === "command") {
+		return {
+			text: message.text,
+			...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
+			customMessage: createSessionSlashCommandMessage(message.command),
+		};
+	}
 	return {
-		...snapshot,
+		text: message.text,
+		...(message.content ? { content: message.content.map((block) => ({ ...block })) } : {}),
+		...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
+		...(message.customMessage ? { customMessage: cloneCustomMessage(message.customMessage) } : {}),
 		...(message.prefixMessages.length > 0
 			? { prefixMessages: message.prefixMessages.map((prefix) => cloneCustomMessage(prefix)) }
 			: {}),
 		...(message.agentMessageId ? { agentMessageId: message.agentMessageId } : {}),
-		...("queueKey" in message && message.queueKey ? { queueKey: message.queueKey } : {}),
+		...(message.queueKey ? { queueKey: message.queueKey } : {}),
 	};
 }
 
@@ -587,9 +607,12 @@ function queuedMessagePreview(message: { text: string; previewLabel?: string }):
 	return message.previewLabel ? `${message.previewLabel}: ${message.text}` : message.text;
 }
 
-function queuedAgentMessagePreview(message: QueuedSteeringMessage | QueuedFollowUpMessage): string {
-	if (isAgentSessionMessage(message.message)) {
-		return `${AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL}: ${message.message.details.message}`;
+function queuedAgentMessagePreview(message: QueuedSessionInput): string {
+	if (message.kind === "command") {
+		return message.text;
+	}
+	if (message.customMessage && isAgentSessionMessage(message.customMessage)) {
+		return `${AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL}: ${message.customMessage.details.message}`;
 	}
 	return queuedMessagePreview(message);
 }
@@ -852,14 +875,23 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _agentEventQueue: Promise<void> = Promise.resolve();
-	private _pendingMessageResumeQueue: Promise<void> = Promise.resolve();
-	private _pendingMessageResumeEpoch = 0;
-	private _pendingMessageResumeRequested = false;
 
-	/** Tracks pending steering messages for UI display. Removed when delivered. */
-	private _steeringMessages: QueuedSteeringMessage[] = [];
-	/** Tracks pending follow-up messages for UI display. Removed when delivered. */
-	private _followUpMessages: QueuedFollowUpMessage[] = [];
+	/** Session-owned typed queues. Items are never fed into Agent.steer/followUp. */
+	private _steeringMessages: QueuedSessionInput[] = [];
+	private _followUpMessages: QueuedSessionInput[] = [];
+	private _sessionInputPump: Promise<void> = Promise.resolve();
+	private _sessionInputPumpRequested = false;
+	private _sessionInputPumpEpoch = 0;
+	private _sessionInputArrivalEpoch = 0;
+	private _sessionInputPumpSuspended = false;
+	private readonly _queuedWorkPauses = new Set<symbol>();
+	private _legacyQueuedWorkPause: { release(): void } | undefined;
+	private _pumpingSessionInput = false;
+	private _activeSessionInput:
+		| { kind: "prompt"; lane: SessionInputSchedule; items: PreparedPromptInput[]; phase: "preparing" | "handedOff" }
+		| { kind: "command"; lane: SessionInputSchedule; item: PreparedCommandInput; phase: "executing" }
+		| undefined;
+	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 
@@ -1183,6 +1215,7 @@ export class AgentSession {
 	}
 
 	private _installAgentTurnHook(): void {
+		this.agent.shouldStopBeforeTurn = () => this._shouldStopBeforeTurn();
 		this.agent.shouldStopAfterTurn = (context) => this._shouldStopAfterTurn(context);
 	}
 
@@ -1203,9 +1236,6 @@ export class AgentSession {
 	}
 
 	private _emitQueueUpdate(): void {
-		if (this.pendingMessageCount === 0) {
-			this._pendingMessageResumeRequested = false;
-		}
 		this._emit({
 			type: "queue_update",
 			steering: this._steeringMessages.map(queuedAgentMessagePreview),
@@ -1367,6 +1397,11 @@ export class AgentSession {
 		this.agent.removeQueuedMessages(
 			(message) => message.role === "custom" && message.customType === GOAL_CONTEXT_CUSTOM_TYPE,
 		);
+		const isGoalContext = (input: QueuedSessionInput) =>
+			input.kind === "prompt" && input.customMessage?.customType === GOAL_CONTEXT_CUSTOM_TYPE;
+		this._steeringMessages = this._steeringMessages.filter((input) => !isGoalContext(input));
+		this._followUpMessages = this._followUpMessages.filter((input) => !isGoalContext(input));
+		this._emitQueueUpdate();
 	}
 
 	private _startGoal(objectiveText: string, tokenBudget: number | undefined): GoalState {
@@ -1481,10 +1516,11 @@ export class AgentSession {
 	}
 
 	private _parseGoalSlashCommand(text: string): GoalSlashCommand | undefined {
-		const command = parseSessionSlashCommand(text);
-		if (command?.name !== "goal") return undefined;
+		if (text !== "/goal" && !text.startsWith("/goal ")) {
+			return undefined;
+		}
 
-		const rest = command.args;
+		const rest = text.slice("/goal".length).trim();
 		const normalized = rest.toLowerCase();
 		if (!rest || normalized === "status") {
 			return { kind: "status" };
@@ -1529,9 +1565,10 @@ export class AgentSession {
 	}
 
 	private _parseAutonomousSlashCommand(text: string): AutonomousSlashCommand | undefined {
-		const command = parseSessionSlashCommand(text);
-		if (command?.name !== "autonomous") return undefined;
-		const rest = command.args.toLowerCase();
+		if (text !== "/autonomous" && !text.startsWith("/autonomous ")) {
+			return undefined;
+		}
+		const rest = text.slice("/autonomous".length).trim().toLowerCase();
 		if (!rest || rest === "status") {
 			return { kind: "status" };
 		}
@@ -1634,12 +1671,22 @@ export class AgentSession {
 		}
 		this._ensureGoalRuntimeActive();
 		const message = createGoalContextMessage(this._goalState, kind, images);
-		if (this.isStreaming) {
+		if (this._pumpingSessionInput) {
 			if (kind === "budget_limit") {
-				this.agent.steer(message);
+				await this._queueSteer(String(message.content), undefined, { message, resumeIfIdle: true });
 			} else {
-				this.agent.followUp(message);
+				const input = this._createPreparedPromptInput(String(message.content), undefined, {
+					message,
+					resumeIfIdle: true,
+				});
+				this._followUpMessages.unshift(input);
+				this._emitQueueUpdate();
 			}
+			return;
+		}
+		if (this.isStreaming) {
+			if (kind === "budget_limit") this.agent.steer(message);
+			else this.agent.followUp(message);
 			return;
 		}
 
@@ -1728,8 +1775,15 @@ export class AgentSession {
 		return true;
 	}
 
+	private _shouldStopBeforeTurn(): boolean {
+		return this._steeringStopPending;
+	}
+
 	private async _shouldStopAfterTurn(context: ShouldStopAfterTurnContext): Promise<boolean> {
 		if (this._stopGoalContinuationForTerminalMessage(context.message)) {
+			return true;
+		}
+		if (this._steeringStopPending) {
 			return true;
 		}
 		try {
@@ -2275,6 +2329,7 @@ export class AgentSession {
 			return queuedMessage;
 		}
 		const snapshot = this._snapshotAutonomousRuntimeState();
+		const arrivalEpoch = this._sessionInputArrivalEpoch;
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, message, {
 			cwd: this._cwd,
 			signal: this.agent.signal,
@@ -2282,11 +2337,22 @@ export class AgentSession {
 		if (!autonomousMessage) {
 			return undefined;
 		}
+		if (this._sessionInputArrivalEpoch !== arrivalEpoch) {
+			this._restoreAutonomousRuntimeSnapshot(snapshot);
+			return undefined;
+		}
 		this._queuedAutonomousThresholdContinuations.set(message, autonomousMessage);
 		this._queuedAutonomousContinuationSnapshots.set(autonomousMessage, snapshot);
 		this._postCompactionContinuationMessages.push(autonomousMessage);
 		this._pendingThresholdCompactionAutonomousMessages.push(autonomousMessage);
-		this.agent.followUp(autonomousMessage);
+		const text =
+			typeof autonomousMessage.content === "string"
+				? autonomousMessage.content
+				: autonomousMessage.content.map((block) => (block.type === "text" ? block.text : "")).join("\n");
+		this._enqueueSessionInput(
+			this._createPreparedPromptInput(text, undefined, { message: autonomousMessage }),
+			"followUp",
+		);
 		return autonomousMessage;
 	}
 
@@ -2306,6 +2372,11 @@ export class AgentSession {
 			(message) => !queuedMessageSet.has(message),
 		);
 		this.agent.removeQueuedMessages((message) => queuedMessageSet.has(message));
+		const isQueuedContinuation = (input: QueuedSessionInput) =>
+			input.kind === "prompt" && queuedMessageSet.has(input.message);
+		this._steeringMessages = this._steeringMessages.filter((input) => !isQueuedContinuation(input));
+		this._followUpMessages = this._followUpMessages.filter((input) => !isQueuedContinuation(input));
+		this._emitQueueUpdate();
 		if (options.restoreAutonomousState) {
 			for (const queuedMessage of queuedMessages) {
 				const snapshot = this._queuedAutonomousContinuationSnapshots.get(queuedMessage);
@@ -2324,7 +2395,7 @@ export class AgentSession {
 		if (options.messages === undefined) {
 			this._continueAfterThresholdCompaction = false;
 		}
-		if (!this.agent.hasQueuedMessages()) {
+		if (!this.agent.hasQueuedMessages() && this.pendingMessageCount === 0) {
 			this._cancelPostCompactionContinue();
 		}
 	}
@@ -2711,8 +2782,19 @@ export class AgentSession {
 		context: GetContinuationMessagesContext,
 		signal?: AbortSignal,
 	): Promise<AgentMessage[]> {
+		if (this.pendingMessageCount > 0) {
+			return [];
+		}
+		const arrivalEpoch = this._sessionInputArrivalEpoch;
+		const goalSnapshot = this._goalState;
+		const goalAccountingStartedAt = this._goalAccountingStartedAt;
 		const goalMessages = await this._getGoalContinuationMessages(context, signal);
 		if (goalMessages.length > 0 || signal?.aborted) {
+			if (goalMessages.length > 0 && this._sessionInputArrivalEpoch !== arrivalEpoch) {
+				this._setGoalState(goalSnapshot);
+				this._goalAccountingStartedAt = goalAccountingStartedAt;
+				return [];
+			}
 			return goalMessages;
 		}
 		if (
@@ -2721,10 +2803,15 @@ export class AgentSession {
 		) {
 			return [];
 		}
+		const autonomousSnapshot = this._snapshotAutonomousRuntimeState();
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, context.message, {
 			cwd: this._cwd,
 			signal,
 		});
+		if (autonomousMessage && this._sessionInputArrivalEpoch !== arrivalEpoch) {
+			this._restoreAutonomousRuntimeSnapshot(autonomousSnapshot);
+			return [];
+		}
 		return autonomousMessage ? [autonomousMessage] : [];
 	}
 
@@ -2909,6 +2996,13 @@ export class AgentSession {
 
 		// Remove queued messages before emitting so the UI sees the updated queue.
 		if (event.type === "message_start") {
+			const activeInput =
+				this._activeSessionInput?.kind === "prompt"
+					? this._activeSessionInput.items.find((input) => input.message === event.message)
+					: undefined;
+			if (activeInput) {
+				this._resolveAgentMessageDelivery(activeInput.agentMessageId);
+			}
 			if (this._isPromptTurnStartMessage(event.message)) {
 				this._overflowRecoveryAttempted = false;
 			}
@@ -3953,6 +4047,13 @@ export class AgentSession {
 	}
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
+		if (!this.isStreaming) {
+			this._sessionInputPumpSuspended = false;
+			if (this.pendingMessageCount > 0) {
+				this._scheduleSessionInputPump();
+				await this._sessionInputPump;
+			}
+		}
 		const isInternalPrompt = options?.internalPrompt === true;
 		const expandPromptTemplates = isInternalPrompt ? false : (options?.expandPromptTemplates ?? true);
 		const preflightResult = options?.preflightResult;
@@ -3982,28 +4083,26 @@ export class AgentSession {
 					this.hasAcceptedPromptInFlight);
 
 			const shouldHandleBuiltInSlashCommands = !isInternalPrompt && !options?.skipPrePromptWork;
-			const sessionSlashCommand = shouldHandleBuiltInSlashCommands
-				? parseSessionSlashCommand(currentText)
-				: undefined;
-			const isBuiltInSlashCommand =
-				sessionSlashCommand?.name === "autonomous" || sessionSlashCommand?.name === "goal";
-			if (!this.isStreaming && isBuiltInSlashCommand && hasQueueIfBusyBackpressure()) {
-				reportPreflight(false);
-				throw new Error("Agent has queued work. Retry the slash command after pending work finishes.");
-			}
-			if (sessionSlashCommand?.name === "autonomous") {
-				const handledAutonomousCommand = await this._handleAutonomousSlashCommand(currentText);
-				if (handledAutonomousCommand) {
-					reportPreflight(true);
-					return;
-				}
-			}
-			if (sessionSlashCommand?.name === "goal") {
-				const handledGoalCommand = await this._handleGoalSlashCommand(currentText, currentImages);
-				if (handledGoalCommand) {
-					reportPreflight(true);
-					return;
-				}
+			const sessionCommand = shouldHandleBuiltInSlashCommands ? parseSessionSlashCommand(currentText) : undefined;
+			if (sessionCommand) {
+				const wasBusy =
+					this.isStreaming ||
+					this.isCompacting ||
+					this.isRetrying ||
+					this.isBashRunning ||
+					this.hasAcceptedPromptInFlight ||
+					this._sessionInputPumpSuspended ||
+					this._queuedWorkPauses.size > 0 ||
+					this._activeSessionInput !== undefined ||
+					this.pendingMessageCount > 0;
+				const schedule = options?.streamingBehavior ?? (this.isStreaming ? "steer" : "followUp");
+				const queued = this._enqueueSessionInput(
+					{ kind: "command", text: currentText, command: sessionCommand, images: currentImages },
+					schedule,
+				);
+				reportPreflight(queued, wasBusy);
+				if (!wasBusy) await this._sessionInputPump;
+				return;
 			}
 
 			// Handle extension commands first (execute immediately, even during streaming)
@@ -4348,6 +4447,8 @@ export class AgentSession {
 			return;
 		}
 		await promptCompletion;
+		this._scheduleSessionInputPump();
+		await this._sessionInputPump;
 	}
 
 	/**
@@ -4537,6 +4638,7 @@ export class AgentSession {
 					agentMessageId: options.agentMessageId,
 					message: options.customMessage,
 					prefixMessages: pendingNextTurnMessages,
+					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
 					resumeIfIdle: options.resumeIfIdle,
 				});
 				if (!queued) {
@@ -4605,6 +4707,66 @@ export class AgentSession {
 	/**
 	 * Internal: Queue a steering message (already expanded, no extension command check).
 	 */
+	private _createPreparedPromptInput(
+		text: string,
+		images: ImageContent[] | undefined,
+		options: {
+			agentMessageId?: string;
+			queueKey?: string;
+			content?: (TextContent | ImageContent)[];
+			message?: QueuedAgentMessage;
+			prefixMessages?: CustomMessage[];
+			previewLabel?: string;
+			suppressAutonomousContinuation?: boolean;
+			resumeIfIdle?: boolean;
+		},
+	): PreparedPromptInput {
+		const content = options.content ?? this._buildPromptContent(text, images);
+		const message =
+			options.message ??
+			({
+				role: "user",
+				content: content.map((block) => ({ ...block })),
+				timestamp: Date.now(),
+			} satisfies UserMessage);
+		return {
+			kind: "prompt",
+			text,
+			images: images?.map((image) => ({ ...image })),
+			content: content.map((block) => ({ ...block })),
+			customMessage: options.message?.role === "custom" ? cloneCustomMessage(options.message) : undefined,
+			previewLabel: options.previewLabel,
+			queueKey: options.queueKey,
+			agentMessageId: options.agentMessageId,
+			prefixMessages: options.prefixMessages?.map((message) => cloneCustomMessage(message)) ?? [],
+			suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+			autoPump: options.resumeIfIdle === true,
+			message,
+		};
+	}
+
+	private _enqueueSessionInput(input: QueuedSessionInput, schedule: SessionInputSchedule): boolean {
+		const queue = schedule === "steer" ? this._steeringMessages : this._followUpMessages;
+		if (
+			schedule === "followUp" &&
+			input.kind === "prompt" &&
+			input.queueKey &&
+			queue.some((item) => item.queueKey === input.queueKey)
+		) {
+			return false;
+		}
+		queue.push(input);
+		this._sessionInputArrivalEpoch++;
+		if (schedule === "steer" && this.isStreaming) {
+			this._steeringStopPending = true;
+		}
+		this._emitQueueUpdate();
+		if ((schedule === "steer" && this.isStreaming) || input.kind === "command" || input.autoPump) {
+			this._scheduleSessionInputPump();
+		}
+		return true;
+	}
+
 	private async _queueSteer(
 		text: string,
 		images?: ImageContent[],
@@ -4619,35 +4781,13 @@ export class AgentSession {
 			resumeIfIdle?: boolean;
 		} = {},
 	): Promise<void> {
-		const content = options.content ?? this._buildPromptContent(text, images);
-		const message: QueuedAgentMessage =
-			options.message ??
-			({
-				role: "user",
-				content,
-				timestamp: Date.now(),
-			} satisfies UserMessage);
+		const input = this._createPreparedPromptInput(text, images, options);
 		if (options.suppressAutonomousContinuation) {
-			this._markAutonomousContinuationSuppressed(message);
+			this._markAutonomousContinuationSuppressed(input.message);
 		}
-		this._steeringMessages.push({
-			text,
-			previewLabel: options.previewLabel,
-			queueKey: options.queueKey,
-			agentMessageId: options.agentMessageId,
-			prefixMessages: options.prefixMessages ?? [],
-			message,
-		});
-		this.agent.steer(options.prefixMessages?.length ? [...options.prefixMessages, message] : message);
-		this._emitQueueUpdate();
-		if (options.resumeIfIdle) {
-			this._schedulePendingMessageResume(true);
-		}
+		this._enqueueSessionInput(input, "steer");
 	}
 
-	/**
-	 * Internal: Queue a follow-up message (already expanded, no extension command check).
-	 */
 	private async _queueFollowUp(
 		text: string,
 		images?: ImageContent[],
@@ -4662,124 +4802,257 @@ export class AgentSession {
 			resumeIfIdle?: boolean;
 		} = {},
 	): Promise<boolean> {
-		if (options.queueKey && this._followUpMessages.some((message) => message.queueKey === options.queueKey)) {
-			return false;
-		}
-		const content = options.content ?? this._buildPromptContent(text, images);
-		const message: QueuedAgentMessage =
-			options.message ??
-			({
-				role: "user",
-				content,
-				timestamp: Date.now(),
-			} satisfies UserMessage);
+		const input = this._createPreparedPromptInput(text, images, options);
 		if (options.suppressAutonomousContinuation) {
-			this._markAutonomousContinuationSuppressed(message);
+			this._markAutonomousContinuationSuppressed(input.message);
 		}
-		this._followUpMessages.push({
-			text,
-			previewLabel: options.previewLabel,
-			queueKey: options.queueKey,
-			agentMessageId: options.agentMessageId,
-			prefixMessages: options.prefixMessages ?? [],
-			message,
-		});
-		this.agent.followUp(options.prefixMessages?.length ? [...options.prefixMessages, message] : message);
-		this._emitQueueUpdate();
-		if (options.resumeIfIdle) {
-			this._schedulePendingMessageResume(true);
-		}
-		return true;
+		return this._enqueueSessionInput(input, "followUp");
 	}
 
-	private _schedulePendingMessageResume(request = false): void {
-		if (request) {
-			this._pendingMessageResumeRequested = true;
-		}
-		if (this._disposed || this._disposing || this.pendingMessageCount === 0) {
-			if (this.pendingMessageCount === 0) {
-				this._pendingMessageResumeRequested = false;
-			}
+	private _scheduleSessionInputPump(): void {
+		if (this._sessionInputPumpSuspended || this._queuedWorkPauses.size > 0) return;
+		if (this._disposed || this._disposing || this._sessionInputPumpRequested || this.pendingMessageCount === 0) {
 			return;
 		}
-		if (!this._pendingMessageResumeRequested) {
-			return;
-		}
-		const epoch = this._pendingMessageResumeEpoch;
-		const resume = () => this._resumePendingMessages(epoch);
-		this._pendingMessageResumeQueue = this._pendingMessageResumeQueue.then(resume, resume);
-		this._pendingMessageResumeQueue.catch(() => {});
+		this._sessionInputPumpRequested = true;
+		const epoch = this._sessionInputPumpEpoch;
+		const pump = async () => {
+			this._sessionInputPumpRequested = false;
+			await this._pumpSessionInputs(epoch);
+		};
+		this._sessionInputPump = this._sessionInputPump.then(pump, pump);
+		this._sessionInputPump.catch(() => {});
 	}
 
-	private async _resumePendingMessages(epoch: number): Promise<void> {
+	private _schedulePendingMessageResume(_request = false): void {
+		this._scheduleSessionInputPump();
+	}
+
+	private async _pumpSessionInputs(epoch: number): Promise<void> {
+		if (this._pumpingSessionInput) return;
+		this._pumpingSessionInput = true;
+		let blocked = false;
 		try {
-			while (
-				!this._disposed &&
-				!this._disposing &&
-				this._pendingMessageResumeRequested &&
-				epoch === this._pendingMessageResumeEpoch &&
-				this.pendingMessageCount > 0
-			) {
+			while (!this._disposed && !this._disposing && this.pendingMessageCount > 0) {
 				await this.agent.waitForIdle();
+				if (epoch !== this._sessionInputPumpEpoch) return;
 				await this._agentEventQueue;
 				await this._waitForRefineIdle();
-				if (epoch !== this._pendingMessageResumeEpoch) {
-					return;
-				}
-
-				const blockingOperations = [this._compactionOperation, this._branchSummaryOperation].filter(
-					(operation): operation is Promise<void> => operation !== undefined,
-				);
-				if (blockingOperations.length > 0) {
-					await Promise.allSettled(blockingOperations);
-					continue;
-				}
-				if (this.isRetrying) {
-					await this.waitForRetry();
-					continue;
-				}
-				const acceptedPrompts = [...this._acceptedPromptCompletions];
-				if (acceptedPrompts.length > 0) {
-					await Promise.allSettled(acceptedPrompts);
-					continue;
-				}
-
 				if (
-					this._disposed ||
-					this._disposing ||
-					epoch !== this._pendingMessageResumeEpoch ||
-					this.pendingMessageCount === 0
+					this._sessionInputPumpSuspended ||
+					this._queuedWorkPauses.size > 0 ||
+					this.isBashRunning ||
+					this.isCompacting ||
+					this._branchSummaryOperation !== undefined ||
+					this.isRetrying ||
+					this.hasAcceptedPromptInFlight
 				) {
-					return;
-				}
-				if (this.isBashRunning || this.isCompacting || this.isRetrying || this.hasAcceptedPromptInFlight) {
+					blocked = true;
 					return;
 				}
 
-				await this.agent.waitForIdle();
-				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
+				const queue = this._steeringMessages.length > 0 ? this._steeringMessages : this._followUpMessages;
+				const mode = queue === this._steeringMessages ? this.steeringMode : this.followUpMode;
+				const first = queue[0];
+				if (!first) continue;
+				const lane: SessionInputSchedule = queue === this._steeringMessages ? "steer" : "followUp";
+				if (first.kind === "command") {
+					queue.shift();
+					this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
+					this._emitQueueUpdate();
+					try {
+						await this._executeQueuedSessionCommand(first);
+					} finally {
+						this._activeSessionInput = undefined;
+					}
+					continue;
+				}
+
+				const prompts: PreparedPromptInput[] = [];
+				while (queue[0]?.kind === "prompt" && (mode === "all" || prompts.length === 0)) {
+					prompts.push(queue.shift() as PreparedPromptInput);
+				}
+				this._steeringStopPending = this._steeringMessages.length > 0 && this.isStreaming;
+				if (epoch !== this._sessionInputPumpEpoch) {
+					queue.unshift(...prompts);
 					return;
 				}
-				// Re-check adjacent to the handoff: background planning may have
-				// completed and entered _applyRefine during the awaits above,
-				// disconnecting event handling. Wait for it to finish so the
-				// resumed turn's events are not lost.
-				await this._waitForRefineIdle();
-				if (epoch !== this._pendingMessageResumeEpoch || this.pendingMessageCount === 0) {
-					return;
-				}
-				this._flushPendingBashMessages();
-				if (this._pendingNextTurnMessages.length > 0) {
-					await this._drainQueuedMessagesAfterBash();
-				} else {
-					await this.agent.continue();
+				this._activeSessionInput = { kind: "prompt", lane, items: prompts, phase: "preparing" };
+				this._emitQueueUpdate();
+				try {
+					await this._startPreparedPromptItems(prompts, epoch);
+					if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
+				} catch {
+					const delivered = new Set(this.agent.state.messages);
+					const undelivered: PreparedPromptInput[] = [];
+					for (const prompt of prompts) {
+						prompt.prefixMessages = prompt.prefixMessages.filter((message) => !delivered.has(message));
+						if (!delivered.has(prompt.message)) undelivered.push(prompt);
+					}
+					if (undelivered.length > 0) {
+						queue.unshift(...undelivered);
+						this._emitQueueUpdate();
+						blocked = true;
+						return;
+					}
+				} finally {
+					this._activeSessionInput = undefined;
 				}
 			}
 		} finally {
-			if (epoch === this._pendingMessageResumeEpoch && this.pendingMessageCount === 0) {
-				this._pendingMessageResumeRequested = false;
+			this._pumpingSessionInput = false;
+			this._steeringStopPending = false;
+			if (!blocked && epoch === this._sessionInputPumpEpoch && this.pendingMessageCount > 0) {
+				this._scheduleSessionInputPump();
 			}
 		}
+	}
+
+	private async _startPreparedPromptItems(prompts: PreparedPromptInput[], epoch: number): Promise<void> {
+		const messages: AgentMessage[] = [];
+		const nextTurnMessages = this._pendingNextTurnMessages;
+		this._pendingNextTurnMessages = [];
+		messages.push(...nextTurnMessages);
+		for (const prompt of prompts) {
+			messages.push(...prompt.prefixMessages, prompt.message);
+			if (prompt.suppressAutonomousContinuation) this._markAutonomousContinuationSuppressed(prompt.message);
+		}
+		try {
+			await this._startPreparedAgentPrompt(prompts.at(-1)?.text ?? "", prompts.at(-1)?.images, messages, epoch);
+			this._forgetConsumedPostCompactionContinuations(prompts.map((prompt) => prompt.message));
+		} catch (error) {
+			const delivered = new Set(this.agent.state.messages);
+			this._pendingNextTurnMessages.unshift(...nextTurnMessages.filter((message) => !delivered.has(message)));
+			throw error;
+		}
+	}
+
+	private async _startPreparedAgentPrompt(
+		text: string,
+		images: ImageContent[] | undefined,
+		messages: AgentMessage[],
+		epoch: number,
+	): Promise<void> {
+		await this._validateCanStartAgentRun();
+		this._flushPendingBashMessages();
+		const lastAssistant = this._findLastAssistantMessage();
+		if (lastAssistant) await this._checkCompaction(lastAssistant, false, false);
+		const pendingModelSelectEmit = this._pendingModelSelectEmit();
+		if (pendingModelSelectEmit) await pendingModelSelectEmit;
+		const result = await this._extensionRunner.emitBeforeAgentStart(
+			text,
+			images,
+			this._baseSystemPrompt,
+			this._baseSystemPromptOptions,
+		);
+		if (result?.messages) {
+			for (const message of result.messages) {
+				messages.push({
+					role: "custom",
+					customType: message.customType,
+					content: message.content,
+					display: message.display,
+					details: message.details,
+					timestamp: Date.now(),
+				});
+			}
+		}
+		// Re-check adjacent to the handoff: background refine planning may have
+		// completed and entered _applyRefine during the awaits above,
+		// disconnecting event handling. Wait for it to finish so the new
+		// turn's events are not lost.
+		await this._waitForRefineIdle();
+		if (
+			epoch !== this._sessionInputPumpEpoch ||
+			this._sessionInputPumpSuspended ||
+			this._queuedWorkPauses.size > 0 ||
+			this.isBashRunning ||
+			this.isCompacting ||
+			this._branchSummaryOperation !== undefined ||
+			this.isRetrying ||
+			this.hasAcceptedPromptInFlight
+		) {
+			throw new Error("Session input paused before handoff");
+		}
+		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
+		await this.agent.prompt(messages);
+		await this.waitForRetry();
+	}
+
+	private async _executeQueuedSessionCommand(input: PreparedCommandInput): Promise<void> {
+		this._appendDurableSessionCommandMessage(input.text, input.command, false);
+		try {
+			let resultText: string | undefined;
+			switch (input.command.name) {
+				case "compact":
+					await this.compact(input.command.args || undefined, { skipAbort: true });
+					break;
+				case "refine": {
+					const options = this._parseRefineCommandOptions(input.command.args);
+					const result = await this.refine(options, { skipAbort: true });
+					const applied = result.appliedEdits.filter((edit) => edit.applied).length;
+					resultText = `Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied.`;
+					break;
+				}
+				case "goal":
+					await this._handleGoalSlashCommand(input.text, input.images);
+					resultText = this._goalState.objective
+						? `Goal ${this._goalState.status}: ${this._goalState.objective}`
+						: "No active goal.";
+					break;
+				case "autonomous":
+					await this._handleAutonomousSlashCommand(input.text);
+					break;
+			}
+			if (resultText) this._appendDurableSessionCommandMessage(resultText, input.command, true, false);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this._appendDurableSessionCommandMessage(`Command failed: ${message}`, input.command, true, true);
+		}
+	}
+
+	private _appendDurableSessionCommandMessage(
+		content: string,
+		command: SessionSlashCommand,
+		isResult: boolean,
+		isError = false,
+	): void {
+		const message: CustomMessage = isResult
+			? createSessionSlashCommandResultMessage(content, {
+					command,
+					success: !isError,
+					severity: isError ? "error" : "info",
+					...(isError ? { error: content.replace(/^Command failed:\s*/, "") } : {}),
+				})
+			: createSessionSlashCommandMessage(command);
+		this.agent.state.messages.push(message);
+		this.sessionManager.appendCustomMessageEntry(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+		);
+		this._emit({ type: "message_start", message });
+		this._emit({ type: "message_end", message });
+	}
+
+	private _parseRefineCommandOptions(args: string): { instructions?: string; rollbackId?: string; global?: boolean } {
+		let rest = args.trim();
+		let global = false;
+		if (/^--global(?=\s|$)/.test(rest)) {
+			global = true;
+			rest = rest.replace(/^--global(?=\s|$)/, "").trim();
+		}
+		if (rest === "rollback") throw new Error("Usage: /refine rollback <refinement-id>");
+		if (rest.startsWith("rollback ")) {
+			let rollbackId = rest.slice("rollback ".length).trim();
+			if (/\s--global$/.test(rollbackId)) {
+				global = true;
+				rollbackId = rollbackId.replace(/\s--global$/, "").trim();
+			}
+			return { rollbackId, global };
+		}
+		return { instructions: rest || undefined, global };
 	}
 
 	/**
@@ -4825,9 +5098,9 @@ export class AgentSession {
 			this._pendingNextTurnMessages.push(appMessage);
 		} else if (this.isStreaming) {
 			if (options?.deliverAs === "followUp") {
-				this.agent.followUp(appMessage);
+				await this._queueFollowUp(String(message.content), undefined, { message: appMessage, resumeIfIdle: true });
 			} else {
-				this.agent.steer(appMessage);
+				await this._queueSteer(String(message.content), undefined, { message: appMessage, resumeIfIdle: true });
 			}
 		} else if (options?.triggerTurn) {
 			await this._waitForRefineIdle();
@@ -4904,50 +5177,36 @@ export class AgentSession {
 
 	clearQueuedUserMessagesMatching(predicate: (text: string) => boolean): { steering: string[]; followUp: string[] } {
 		const steering = this._steeringMessages.filter(
-			(message) => message.agentMessageId !== undefined && predicate(message.text),
+			(message): message is PreparedPromptInput =>
+				message.kind === "prompt" && message.agentMessageId !== undefined && predicate(message.text),
 		);
 		const followUp = this._followUpMessages.filter(
-			(message) => message.agentMessageId !== undefined && predicate(message.text),
+			(message): message is PreparedPromptInput =>
+				message.kind === "prompt" && message.agentMessageId !== undefined && predicate(message.text),
 		);
 		const accepted = this._acceptedAgentMessagePrompt;
 		const acceptedMatches =
 			accepted !== undefined && !accepted.turnStarted && !accepted.cleared && predicate(accepted.text);
-		if (steering.length === 0 && followUp.length === 0 && !acceptedMatches) {
-			return { steering: [], followUp: [] };
-		}
-		const steeringToRemove = new Set<AgentMessage>(steering.map((message) => message.message));
-		const followUpToRemove = new Set<AgentMessage>(followUp.map((message) => message.message));
-		const removedQueuedMessages = new Set(
-			this.agent.removeQueuedMessages((message) => steeringToRemove.has(message) || followUpToRemove.has(message)),
+		if (steering.length === 0 && followUp.length === 0 && !acceptedMatches) return { steering: [], followUp: [] };
+		const steeringSet = new Set(steering);
+		const followUpSet = new Set(followUp);
+		this._steeringMessages = this._steeringMessages.filter(
+			(message) => !steeringSet.has(message as PreparedPromptInput),
 		);
-		const removedSteeringMessages = steering.filter((message) => removedQueuedMessages.has(message.message));
-		const removedFollowUpMessages = followUp.filter((message) => removedQueuedMessages.has(message.message));
-		if (removedSteeringMessages.length === 0 && removedFollowUpMessages.length === 0 && !acceptedMatches) {
-			return { steering: [], followUp: [] };
-		}
-		const removedSteeringSet = new Set(removedSteeringMessages.map((message) => message.message));
-		const removedFollowUpSet = new Set(removedFollowUpMessages.map((message) => message.message));
-		this._steeringMessages = this._steeringMessages.filter((message) => !removedSteeringSet.has(message.message));
-		this._followUpMessages = this._followUpMessages.filter((message) => !removedFollowUpSet.has(message.message));
-		const removedSteering = removedSteeringMessages.map((message) => message.text);
-		const removedFollowUp = removedFollowUpMessages.map((message) => message.text);
-		for (const message of removedSteeringMessages) {
+		this._followUpMessages = this._followUpMessages.filter(
+			(message) => !followUpSet.has(message as PreparedPromptInput),
+		);
+		for (const message of [...steering, ...followUp]) {
 			this._rejectAgentMessageDelivery(
 				message.agentMessageId,
 				new Error("Queued agent message was cleared before delivery."),
 			);
 		}
-		for (const message of removedFollowUpMessages) {
-			this._rejectAgentMessageDelivery(
-				message.agentMessageId,
-				new Error("Queued agent message was cleared before delivery."),
-			);
-		}
+		const removedSteering = steering.map((message) => message.text);
+		const removedFollowUp = followUp.map((message) => message.text);
 		if (acceptedMatches) {
 			accepted.cleared = true;
 			this.agent.state.messages = this.agent.state.messages.filter((message) => !accepted.messages.has(message));
-			// Restore drained nextTurn messages the model never saw. Clones, so the cleared
-			// run's late-event cleanup cannot strip the restored copies from a newer run.
 			this._pendingNextTurnMessages.unshift(
 				...undeliveredPendingNextTurnMessages(accepted).map((message) => ({ ...message })),
 			);
@@ -4992,6 +5251,45 @@ export class AgentSession {
 		return this._followUpMessages.map((message) => createQueuedAgentInputSnapshot(message));
 	}
 
+	acquireQueuedWorkPause(): { release(): void } {
+		const token = Symbol("queued-work-pause");
+		this._queuedWorkPauses.add(token);
+		this._sessionInputPumpRequested = false;
+		this._sessionInputPumpEpoch++;
+		let released = false;
+		return {
+			release: () => {
+				if (released) return;
+				released = true;
+				this._queuedWorkPauses.delete(token);
+				this._scheduleSessionInputPump();
+			},
+		};
+	}
+
+	/** Compatibility wrapper for callers migrating to owned pause leases. */
+	pauseQueuedWork(): boolean {
+		if (this._legacyQueuedWorkPause) return false;
+		this._legacyQueuedWorkPause = this.acquireQueuedWorkPause();
+		return true;
+	}
+
+	/** Compatibility wrapper that releases only the pause acquired by pauseQueuedWork(). */
+	resumeQueuedWork(): boolean {
+		const pause = this._legacyQueuedWorkPause;
+		if (pause) {
+			this._legacyQueuedWorkPause = undefined;
+			pause.release();
+		} else {
+			this._scheduleSessionInputPump();
+		}
+		return this.pendingMessageCount > 0;
+	}
+
+	async waitForSessionInputIdle(): Promise<void> {
+		await this._sessionInputPump;
+	}
+
 	getPendingNextTurnMessageSnapshots(): readonly CustomMessage[] {
 		const messages = this._pendingNextTurnMessages.map((message) => cloneCustomMessage(message));
 		const accepted = this._acceptedAgentMessagePrompt;
@@ -5022,24 +5320,22 @@ export class AgentSession {
 	}
 
 	removeQueuedFollowUp(queueKey: string): boolean {
-		const removedSteering = this._steeringMessages.filter((message) => message.queueKey === queueKey);
-		const removedFollowUp = this._followUpMessages.filter((message) => message.queueKey === queueKey);
-		if (removedSteering.length === 0 && removedFollowUp.length === 0) {
-			return false;
-		}
-		this._steeringMessages = this._steeringMessages.filter((message) => message.queueKey !== queueKey);
-		this._followUpMessages = this._followUpMessages.filter((message) => message.queueKey !== queueKey);
-		const removedMessages = new Set<AgentMessage>([
-			...removedSteering.map((message) => message.message),
-			...removedFollowUp.map((message) => message.message),
-		]);
-		for (const message of [...removedSteering, ...removedFollowUp]) {
+		const removedSteering = this._steeringMessages.filter(
+			(message): message is PreparedPromptInput => message.kind === "prompt" && message.queueKey === queueKey,
+		);
+		const removedFollowUp = this._followUpMessages.filter(
+			(message): message is PreparedPromptInput => message.kind === "prompt" && message.queueKey === queueKey,
+		);
+		if (removedSteering.length === 0 && removedFollowUp.length === 0) return false;
+		const removed = new Set<QueuedSessionInput>([...removedSteering, ...removedFollowUp]);
+		this._steeringMessages = this._steeringMessages.filter((message) => !removed.has(message));
+		this._followUpMessages = this._followUpMessages.filter((message) => !removed.has(message));
+		for (const message of removed) {
 			this._rejectAgentMessageDelivery(
 				message.agentMessageId,
 				new Error("Queued agent message was cleared before delivery."),
 			);
 		}
-		this.agent.removeQueuedMessages((message) => removedMessages.has(message));
 		this._emitQueueUpdate();
 		return true;
 	}
@@ -5049,6 +5345,9 @@ export class AgentSession {
 	}
 
 	requestAbort(): void {
+		this._sessionInputPumpRequested = false;
+		this._sessionInputPumpEpoch++;
+		this._sessionInputPumpSuspended = true;
 		this.abortRetry();
 		this.abortCompaction();
 		this.abortBranchSummary();
@@ -5057,8 +5356,6 @@ export class AgentSession {
 		this._autoRefineBranchVersion++;
 		this._autoRefineReviewAbort?.abort();
 		this._refineAbortController?.abort();
-		this._pendingMessageResumeRequested = false;
-		this._pendingMessageResumeEpoch++;
 		this.agent.abort();
 	}
 
@@ -5085,8 +5382,6 @@ export class AgentSession {
 
 	abortForUpdateRestart(): void {
 		this.abortRetry();
-		this._pendingMessageResumeRequested = false;
-		this._pendingMessageResumeEpoch++;
 		this._cancelActiveRlmChildRuns("Parent session aborted for update restart");
 		this._goalAbortInProgress = this._goalState.status === "active";
 		this.agent.abort();
@@ -5517,10 +5812,10 @@ export class AgentSession {
 	 * Aborts current agent operation first.
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
-	async compact(customInstructions?: string): Promise<CompactionResult> {
+	async compact(customInstructions?: string, options: { skipAbort?: boolean } = {}): Promise<CompactionResult> {
 		const hadPostCompactionContinue = this._postCompactionContinuationScheduled;
 		this._disconnectFromAgent();
-		await this.abort();
+		if (!options.skipAbort) await this.abort();
 		let didCompact = false;
 		this._compactionAbortController = new AbortController();
 		let resolveCompactionOperation: () => void = () => {};
@@ -5807,9 +6102,19 @@ export class AgentSession {
 		if (!this._postCompactionContinuationScheduled) {
 			return;
 		}
-		if (this.isStreaming || this.isCompacting) {
+		if (this.isStreaming || this.isCompacting || this.isRetrying || this._queuedWorkPauses.size > 0) {
 			this._postCompactionContinuationScheduled = false;
 			this._schedulePostCompactionContinue();
+			return;
+		}
+
+		if (this.pendingMessageCount > 0) {
+			this._scheduleSessionInputPump();
+			await this._sessionInputPump;
+			if (this._postCompactionContinuationScheduled) {
+				this._postCompactionContinuationScheduled = false;
+				this._schedulePostCompactionContinue();
+			}
 			return;
 		}
 
@@ -6055,7 +6360,15 @@ export class AgentSession {
 	 */
 	async refine(
 		options: { instructions?: string; rollbackId?: string; global?: boolean } = {},
+		internal: { skipAbort?: boolean } = {},
 	): Promise<RefinementResult> {
+		// Queued /refine executes from the session-input pump between turns;
+		// refine never aborts the agent (planning is backgrounded and the apply
+		// phase waits for quiescence), so skipAbort only asserts the pump's
+		// idle invariant instead of changing abort behavior.
+		if (internal.skipAbort && this.isStreaming) {
+			throw new Error("Cannot refine without aborting while the agent is running.");
+		}
 		// Wait for any existing refine (both planning and application) before
 		// starting a new run. This serializes concurrent /refine calls so two
 		// planning phases cannot race into concurrent _applyRefine calls that
@@ -8604,59 +8917,7 @@ export class AgentSession {
 
 	private async _drainQueuedMessagesAfterBash(): Promise<void> {
 		await this.agent.waitForIdle();
-		if (
-			this.isStreaming ||
-			this.isCompacting ||
-			this.isRetrying ||
-			this.hasAcceptedPromptInFlight ||
-			this.pendingMessageCount === 0
-		) {
-			return;
-		}
-		await this._promptPendingMessagesWithNextTurnContext();
-	}
-
-	private async _promptPendingMessagesWithNextTurnContext(): Promise<void> {
-		const steeringMessages = [...this._steeringMessages];
-		const followUpMessages = [...this._followUpMessages];
-		const drainedSteeringMessages = steeringMessages.length > 0 ? steeringMessages : [];
-		const drainedFollowUpMessages = steeringMessages.length > 0 ? [] : followUpMessages;
-		const queuedMessages = [...drainedSteeringMessages, ...drainedFollowUpMessages].flatMap((message) => [
-			...message.prefixMessages,
-			message.message,
-		]);
-		if (queuedMessages.length === 0) {
-			return;
-		}
-
-		const queuedMessageSet = new Set<AgentMessage>(queuedMessages);
-		this.agent.removeQueuedMessages((message) => queuedMessageSet.has(message));
-		this._flushPendingBashMessages();
-		const nextTurnMessages = this._pendingNextTurnMessages;
-		this._pendingNextTurnMessages = [];
-		try {
-			await this.agent.prompt([...nextTurnMessages, ...queuedMessages]);
-			await this.waitForRetry();
-		} catch {
-			const deliveredMessages = new Set(this.agent.state.messages);
-			this._pendingNextTurnMessages.unshift(
-				...nextTurnMessages.filter((message) => !deliveredMessages.has(message)).map((message) => ({ ...message })),
-			);
-			const queuedSteering = new Set(this._steeringMessages.map((message) => message.message));
-			const queuedFollowUps = new Set(this._followUpMessages.map((message) => message.message));
-			for (const queued of drainedSteeringMessages) {
-				queued.prefixMessages = queued.prefixMessages.filter((message) => !deliveredMessages.has(message));
-				if (queuedSteering.has(queued.message) && !deliveredMessages.has(queued.message)) {
-					this.agent.steer([...queued.prefixMessages, queued.message]);
-				}
-			}
-			for (const queued of drainedFollowUpMessages) {
-				queued.prefixMessages = queued.prefixMessages.filter((message) => !deliveredMessages.has(message));
-				if (queuedFollowUps.has(queued.message) && !deliveredMessages.has(queued.message)) {
-					this.agent.followUp([...queued.prefixMessages, queued.message]);
-				}
-			}
-		}
+		this._scheduleSessionInputPump();
 	}
 
 	private async runUserBashLocked(
@@ -8824,7 +9085,26 @@ export class AgentSession {
 	 * @param options.label Label to attach to the branch summary entry
 	 * @returns Result with editorText (if user message) and cancelled status
 	 */
+	private _branchNavigationQueue: Promise<void> = Promise.resolve();
+
 	async navigateTree(
+		targetId: string,
+		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
+	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
+		const previous = this._branchNavigationQueue;
+		let release = () => {};
+		this._branchNavigationQueue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await this._navigateTree(targetId, options);
+		} finally {
+			release();
+		}
+	}
+
+	private async _navigateTree(
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
@@ -8845,9 +9125,17 @@ export class AgentSession {
 			throw new Error(`Entry ${targetId} not found`);
 		}
 
+		const queuedWorkPause = this.acquireQueuedWorkPause();
+		await this.waitForSessionInputIdle();
+
 		// Do not switch branches while /refine has detached event handling and is
 		// about to persist harness/session entries for the current branch.
-		await this._invalidatePendingAutoRefineForBranchChange();
+		try {
+			await this._invalidatePendingAutoRefineForBranchChange();
+		} catch (error) {
+			queuedWorkPause.release();
+			throw error;
+		}
 
 		// Collect entries to summarize (from old leaf to common ancestor)
 		const { entries: entriesToSummarize, commonAncestorId } = collectEntriesForBranchSummary(
@@ -9022,7 +9310,7 @@ export class AgentSession {
 				this._branchSummaryOperation = undefined;
 			}
 			resolveBranchSummaryOperation();
-			this._schedulePendingMessageResume();
+			queuedWorkPause.release();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9511,8 +9511,6 @@ export class AgentSession {
 			this.agent.state.messages = sessionContext.messages;
 			this._restoreLateIpythonSentAgentMessages();
 			this._reloadGoalStateFromBranch();
-			// Queued prompts prepared against the old branch must re-run
-			// before_agent_start against the new context.
 			this._invalidateQueuedPromptPreparation();
 
 			// Emit session_tree event

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -177,6 +177,7 @@ import {
 	HEARTBEAT_PROMPT_CUSTOM_TYPE,
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+	isSessionSlashCommandMessage,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -234,7 +235,12 @@ import {
 import type { SessionStats } from "./session-stats.js";
 import type { SettingsManager } from "./settings-manager.js";
 import { getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
-import { parseSessionSlashCommand, type SessionSlashCommand, type SlashCommandInfo } from "./slash-commands.js";
+import {
+	parseRefineCommandOptions,
+	parseSessionSlashCommand,
+	type SessionSlashCommand,
+	type SlashCommandInfo,
+} from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
@@ -3902,7 +3908,9 @@ export class AgentSession {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
 		const admission = await this._acquireDirectTurnAdmission({ allowStreaming: true });
 		try {
-			await this._promptInjectedMessageUnserialized(text, message, options, admission.release);
+			await this._turnAdmissionContext.run(admission.owner, () =>
+				this._promptInjectedMessageUnserialized(text, message, options, admission.release),
+			);
 		} finally {
 			admission.release();
 		}
@@ -4092,9 +4100,19 @@ export class AgentSession {
 		const admission = !this.isStreaming ? await this._acquireDirectTurnAdmission() : undefined;
 		const releaseAdmission = admission?.release ?? (() => {});
 		try {
-			await this._promptUnserialized(text, options, releaseAdmission);
+			if (admission) {
+				await this._turnAdmissionContext.run(admission.owner, () =>
+					this._promptUnserialized(text, options, releaseAdmission),
+				);
+			} else {
+				await this._promptUnserialized(text, options, releaseAdmission);
+			}
 		} finally {
 			releaseAdmission();
+		}
+		if (admission) {
+			this._scheduleSessionInputPump();
+			await this._sessionInputPump;
 		}
 	}
 
@@ -4103,19 +4121,6 @@ export class AgentSession {
 		options: InternalPromptOptions | undefined,
 		releaseAdmission: () => void,
 	): Promise<void> {
-		if (!this.isStreaming) {
-			await this._waitForQueuedWorkAdmission();
-			this._sessionInputPumpSuspended = false;
-			if (
-				this.pendingMessageCount > 0 ||
-				this._activeSessionInput !== undefined ||
-				this._pumpingSessionInput ||
-				this._sessionInputPumpRequested
-			) {
-				this._scheduleSessionInputPump();
-				await this.waitForSessionInputIdle();
-			}
-		}
 		const isInternalPrompt = options?.internalPrompt === true;
 		const expandPromptTemplates = isInternalPrompt ? false : (options?.expandPromptTemplates ?? true);
 		const preflightResult = options?.preflightResult;
@@ -4511,9 +4516,6 @@ export class AgentSession {
 			return;
 		}
 		await promptCompletion;
-		releaseAdmission?.();
-		this._scheduleSessionInputPump();
-		await this._sessionInputPump;
 	}
 
 	/**
@@ -4532,12 +4534,7 @@ export class AgentSession {
 		const ctx = this._extensionRunner.createCommandContext();
 
 		try {
-			const owner = this._turnAdmissionOwner;
-			if (owner) {
-				await this._turnAdmissionContext.run(owner, () => command.handler(args, ctx));
-			} else {
-				await command.handler(args, ctx);
-			}
+			await command.handler(args, ctx);
 			return true;
 		} catch (err) {
 			// Emit error via extension runner
@@ -4638,6 +4635,27 @@ export class AgentSession {
 		});
 	}
 
+	private _restoreSessionCommand(
+		text: string,
+		customMessage: CustomMessage | undefined,
+		images: ImageContent[] | undefined,
+		schedule: SessionInputSchedule,
+	): boolean | undefined {
+		if (!isSessionSlashCommandMessage(customMessage) || text !== customMessage.details.command.text) {
+			return undefined;
+		}
+		return this._enqueueSessionInput(
+			{
+				kind: "command",
+				text,
+				command: customMessage.details.command,
+				images,
+			},
+			schedule,
+			{ restore: true },
+		);
+	}
+
 	async restoreSteeringMessage(
 		text: string,
 		images?: ImageContent[],
@@ -4649,6 +4667,7 @@ export class AgentSession {
 			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<void> {
+		if (this._restoreSessionCommand(text, options.customMessage, images, "steer") !== undefined) return;
 		await this._queueSteer(text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -4669,6 +4688,8 @@ export class AgentSession {
 			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<boolean> {
+		const restoredCommand = this._restoreSessionCommand(text, options.customMessage, images, "followUp");
+		if (restoredCommand !== undefined) return restoredCommand;
 		return this._queueFollowUp(text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -4815,7 +4836,11 @@ export class AgentSession {
 		};
 	}
 
-	private _enqueueSessionInput(input: QueuedSessionInput, schedule: SessionInputSchedule): boolean {
+	private _enqueueSessionInput(
+		input: QueuedSessionInput,
+		schedule: SessionInputSchedule,
+		options: { restore?: boolean } = {},
+	): boolean {
 		const queue = schedule === "steer" ? this._steeringMessages : this._followUpMessages;
 		if (
 			schedule === "followUp" &&
@@ -4833,7 +4858,10 @@ export class AgentSession {
 			this._steeringStopPending = true;
 		}
 		this._emitQueueUpdate();
-		if ((schedule === "steer" && this.isStreaming) || input.kind === "command" || input.autoPump) {
+		if (
+			!options.restore &&
+			((schedule === "steer" && this.isStreaming) || input.kind === "command" || input.autoPump)
+		) {
 			if (input.kind === "prompt" && input.autoPump) this._sessionInputPumpSuspended = false;
 			this._scheduleSessionInputPump();
 		}
@@ -4948,7 +4976,6 @@ export class AgentSession {
 					this._emitQueueUpdate();
 					try {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
-						if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 					} catch (error) {
 						const delivered = new Set(this.agent.state.messages);
 						const undelivered: PreparedPromptInput[] = [];
@@ -5033,23 +5060,26 @@ export class AgentSession {
 		const pendingModelSelectEmit = this._pendingModelSelectEmit();
 		if (pendingModelSelectEmit) await pendingModelSelectEmit;
 
-		const preparationPrompt = prompts.at(-1);
-		if (!prompts.every((prompt) => prompt.preparation !== undefined)) {
+		while (!prompts.every((prompt) => prompt.preparation !== undefined)) {
 			if (this._isSessionInputHandoffDeferred(epoch)) {
 				throw new DeferredSessionInputError("Session input paused before preparation");
 			}
+			const preparationPrompt = prompts.at(-1);
+			if (!preparationPrompt) return;
 			const result = await this._extensionRunner.emitBeforeAgentStart(
-				preparationPrompt?.text ?? "",
-				preparationPrompt?.images,
+				preparationPrompt.text,
+				preparationPrompt.images,
 				this._baseSystemPrompt,
 				this._baseSystemPromptOptions,
 			);
+			if (prompts.at(-1) !== preparationPrompt) continue;
 			const preparation = { result };
 			for (const prompt of prompts) prompt.preparation = preparation;
 		}
 		if (this._isSessionInputHandoffDeferred(epoch)) {
 			throw new DeferredSessionInputError("Session input paused before handoff");
 		}
+		if (prompts.length === 0) return;
 
 		const messages: AgentMessage[] = [];
 		const nextTurnMessages = this._pendingNextTurnMessages;
@@ -5082,6 +5112,7 @@ export class AgentSession {
 		}
 		this.agent.state.systemPrompt = result?.systemPrompt ?? this._baseSystemPrompt;
 		try {
+			if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 			const promptPromise = this.agent.prompt(messages);
 			releaseAdmission();
 			await promptPromise;
@@ -5103,7 +5134,7 @@ export class AgentSession {
 					await this.compact(input.command.args || undefined, { skipAbort: true });
 					break;
 				case "refine": {
-					const options = this._parseRefineCommandOptions(input.command.args);
+					const options = parseRefineCommandOptions(input.command.args);
 					const result = await this.refine(options, { skipAbort: true });
 					const applied = result.appliedEdits.filter((edit) => edit.applied).length;
 					resultText = `Refined continual harness state: ${applied} edit${applied === 1 ? "" : "s"} applied.`;
@@ -5149,25 +5180,6 @@ export class AgentSession {
 		);
 		this._emit({ type: "message_start", message });
 		this._emit({ type: "message_end", message });
-	}
-
-	private _parseRefineCommandOptions(args: string): { instructions?: string; rollbackId?: string; global?: boolean } {
-		let rest = args.trim();
-		let global = false;
-		if (/^--global(?=\s|$)/.test(rest)) {
-			global = true;
-			rest = rest.replace(/^--global(?=\s|$)/, "").trim();
-		}
-		if (rest === "rollback") throw new Error("Usage: /refine rollback <refinement-id>");
-		if (rest.startsWith("rollback ")) {
-			let rollbackId = rest.slice("rollback ".length).trim();
-			if (/\s--global$/.test(rollbackId)) {
-				global = true;
-				rollbackId = rollbackId.replace(/\s--global$/, "").trim();
-			}
-			return { rollbackId, global };
-		}
-		return { instructions: rest || undefined, global };
 	}
 
 	/**
@@ -5299,6 +5311,23 @@ export class AgentSession {
 		return { steering, followUp };
 	}
 
+	private _removeActivePreparingPrompts(predicate: (message: PreparedPromptInput) => boolean): {
+		steering: PreparedPromptInput[];
+		followUp: PreparedPromptInput[];
+	} {
+		const active = this._activeSessionInput;
+		if (active?.kind !== "prompt" || active.phase !== "preparing") return { steering: [], followUp: [] };
+		const removed = active.items.filter(predicate);
+		if (removed.length === 0) return { steering: [], followUp: [] };
+		const previousAnchor = active.items.at(-1);
+		const removedSet = new Set(removed);
+		active.items.splice(0, active.items.length, ...active.items.filter((message) => !removedSet.has(message)));
+		if (active.items.at(-1) !== previousAnchor) {
+			for (const message of active.items) message.preparation = undefined;
+		}
+		return active.lane === "steer" ? { steering: removed, followUp: [] } : { steering: [], followUp: removed };
+	}
+
 	clearQueuedUserMessagesMatching(predicate: (text: string) => boolean): { steering: string[]; followUp: string[] } {
 		const steering = this._steeringMessages.filter(
 			(message): message is PreparedPromptInput =>
@@ -5308,6 +5337,11 @@ export class AgentSession {
 			(message): message is PreparedPromptInput =>
 				message.kind === "prompt" && message.agentMessageId !== undefined && predicate(message.text),
 		);
+		const active = this._removeActivePreparingPrompts(
+			(message) => message.agentMessageId !== undefined && predicate(message.text),
+		);
+		steering.push(...active.steering);
+		followUp.push(...active.followUp);
 		const accepted = this._acceptedAgentMessagePrompt;
 		const acceptedMatches =
 			accepted !== undefined && !accepted.turnStarted && !accepted.cleared && predicate(accepted.text);
@@ -5535,6 +5569,9 @@ export class AgentSession {
 		const removedFollowUp = this._followUpMessages.filter(
 			(message): message is PreparedPromptInput => message.kind === "prompt" && message.queueKey === queueKey,
 		);
+		const active = this._removeActivePreparingPrompts((message) => message.queueKey === queueKey);
+		removedSteering.push(...active.steering);
+		removedFollowUp.push(...active.followUp);
 		if (removedSteering.length === 0 && removedFollowUp.length === 0) return false;
 		const removed = new Set<QueuedSessionInput>([...removedSteering, ...removedFollowUp]);
 		this._steeringMessages = this._steeringMessages.filter((message) => !removed.has(message));

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4957,6 +4957,18 @@ export class AgentSession {
 		}
 		if (prompts.length === 0) return;
 
+		// Re-check adjacent to the handoff: background refine planning may have
+		// completed and entered _applyRefine during the awaits above,
+		// disconnecting event handling. Wait for it to finish so the new
+		// turn's events are not lost.
+		await this._waitForRefineIdle();
+		if (this._isSessionInputHandoffDeferred(epoch)) {
+			throw new DeferredSessionInputError("Session input paused before handoff");
+		}
+		// Assemble the handoff snapshot only after the last await: a clear that runs
+		// during the waits above must still be able to remove prompts from
+		// active.items before they are captured for agent.prompt().
+		if (prompts.length === 0) return;
 		const messages: AgentMessage[] = [];
 		const nextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
@@ -4968,14 +4980,6 @@ export class AgentSession {
 		const preparation = prompts[0]?.preparation;
 		const result = preparation?.result;
 		this._appendBeforeAgentStartMessages(messages, result);
-		// Re-check adjacent to the handoff: background refine planning may have
-		// completed and entered _applyRefine during the awaits above,
-		// disconnecting event handling. Wait for it to finish so the new
-		// turn's events are not lost.
-		await this._waitForRefineIdle();
-		if (this._isSessionInputHandoffDeferred(epoch)) {
-			throw new DeferredSessionInputError("Session input paused before handoff");
-		}
 		// The base prompt may have changed (e.g. refine) since preparation; splice the
 		// current base into an extension-modified prompt exactly like the direct path.
 		this.agent.state.systemPrompt =

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4158,6 +4158,7 @@ export class AgentSession {
 					schedule,
 				);
 				reportPreflight(queued, wasBusy);
+				releaseAdmission();
 				if (!wasBusy) await this._sessionInputPump;
 				return;
 			}

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -26,6 +26,35 @@ export interface SessionSlashCommand {
 	text: string;
 }
 
+export interface RefineCommandOptions {
+	instructions?: string;
+	rollbackId?: string;
+	global?: boolean;
+}
+
+export function parseRefineCommandOptions(args: string): RefineCommandOptions {
+	let rest = args.trim();
+	let global = false;
+	if (/^--global(?=\s|$)/.test(rest)) {
+		global = true;
+		rest = rest.replace(/^--global(?=\s|$)/, "").trim();
+	}
+	if (rest === "rollback") throw new Error("Usage: /refine rollback <refinement-id>");
+	if (rest.startsWith("rollback ")) {
+		let rollbackId = rest.slice("rollback ".length).trim();
+		if (rollbackId === "--global") {
+			throw new Error("Usage: /refine rollback <refinement-id>");
+		}
+		if (/\s--global$/.test(rollbackId)) {
+			global = true;
+			rollbackId = rollbackId.replace(/\s--global$/, "").trim();
+		}
+		if (!rollbackId) throw new Error("Usage: /refine rollback <refinement-id>");
+		return { rollbackId, global };
+	}
+	return { instructions: rest || undefined, global };
+}
+
 export interface BuiltinSlashCommand {
 	name: string;
 	description: string;

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -40,8 +40,11 @@ export function parseRefineCommandOptions(args: string): RefineCommandOptions {
 		rest = rest.replace(/^--global(?=\s|$)/, "").trim();
 	}
 	if (rest === "rollback") throw new Error("Usage: /refine rollback <refinement-id>");
-	if (rest.startsWith("rollback ")) {
-		let rollbackId = rest.slice("rollback ".length).trim();
+	// Slash-command args keep their original separators (tabs, Unicode spaces);
+	// match the subcommand with the same class parseSlashCommand splits on.
+	const rollbackMatch = /^rollback[\t\p{Zs}]/u.exec(rest);
+	if (rollbackMatch) {
+		let rollbackId = rest.slice(rollbackMatch[0].length).trim();
 		if (rollbackId === "--global") {
 			throw new Error("Usage: /refine rollback <refinement-id>");
 		}

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -376,7 +376,7 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async waitForIdle(): Promise<void> {
-		await this.session.agent.waitForIdle();
+		await this.session.waitForIdle();
 	}
 
 	async waitForHeadlessCompletion(): Promise<AgentAutonomousStatus> {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2943,23 +2943,9 @@ export class AgentDaemon {
 
 			case "resume_queue": {
 				const state = this.getSessionState(command.activeSessionId);
-				let checkedStart = false;
-				let startError: unknown;
-				void state.runtime.session.agent.continue().then(undefined, (error: unknown) => {
-					if (checkedStart) {
-						this.broadcastToSession(
-							state,
-							failure(undefined, "resume_queue", error, serializeDaemonError(error)),
-						);
-					} else {
-						startError = error;
-					}
-				});
-				// Self-update restore must acknowledge that queued work restarted without waiting for it to finish.
-				await Promise.resolve();
-				checkedStart = true;
-				if (startError !== undefined) {
-					return failure(command.id, "resume_queue", startError, serializeDaemonError(startError));
+				if (!state.runtime.session.resumeQueuedWork()) {
+					const error = new Error("No queued work to resume");
+					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
 				}
 				return success(command.id, "resume_queue");
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -115,6 +115,7 @@ import {
 	BUILTIN_SLASH_COMMANDS,
 	builtinSlashCommandTakesArgument,
 	isBuiltinSlashCommandName,
+	parseRefineCommandOptions,
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
 } from "../../core/slash-commands.js";
@@ -9744,30 +9745,15 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 	}
 
 	private async handleRefineCommand(args?: string): Promise<void> {
-		let trimmedArgs = args?.trim() ?? "";
-		const globalOption: { global: boolean } = { global: false };
-		if (/^--global(?=\s|$)/.test(trimmedArgs)) {
-			globalOption.global = true;
-			trimmedArgs = trimmedArgs.replace(/^--global(?=\s|$)/, "").trim();
-		}
-		const rollbackPrefix = "rollback ";
 		let options: { instructions?: string; rollbackId?: string; global?: boolean };
-
-		if (trimmedArgs === "rollback") {
-			this.showWarning("Usage: /refine rollback <refinement-id>");
+		try {
+			options = parseRefineCommandOptions(args ?? "");
+		} catch (error) {
+			this.showWarning(error instanceof Error ? error.message : String(error));
 			return;
 		}
 
-		if (trimmedArgs?.startsWith(rollbackPrefix) && trimmedArgs.slice(rollbackPrefix.length).trim()) {
-			// Rollback uses the global refinement history, not the current trajectory,
-			// so it must work even in a fresh session with no messages yet.
-			let rollbackId = trimmedArgs.slice(rollbackPrefix.length).trim();
-			if (/\s--global$/.test(rollbackId)) {
-				globalOption.global = true;
-				rollbackId = rollbackId.replace(/\s--global$/, "").trim();
-			}
-			options = { rollbackId, ...globalOption };
-		} else {
+		if (!options.rollbackId) {
 			let messageCount: number;
 			try {
 				const stats = await this.agentConnection.getSessionStats();
@@ -9781,7 +9767,6 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 				this.showWarning("Nothing to refine (no trajectory yet)");
 				return;
 			}
-			options = { instructions: trimmedArgs || undefined, ...globalOption };
 		}
 
 		this.stopWorkingLoader();

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -43,7 +43,11 @@ import {
 } from "./config.js";
 import { parseAgentSessionMessagePromptId } from "./core/agent-messages.js";
 import type { AgentSessionRuntimeMetadata } from "./core/agent-session-runtime.js";
-import type { CustomMessage } from "./core/messages.js";
+import {
+	type CustomMessage,
+	isSessionSlashCommandMessage,
+	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
+} from "./core/messages.js";
 import { DefaultPackageManager } from "./core/package-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { DaemonClient, type DaemonHello } from "./modes/daemon/daemon-client.js";
@@ -622,7 +626,12 @@ function parseDaemonUpdateRestartQueuedMessage(value: unknown): DaemonUpdateRest
 			: isCustomMessage(value.customMessage)
 				? value.customMessage
 				: undefined;
-	if (value.customMessage !== undefined && !customMessage) {
+	if (
+		value.customMessage !== undefined &&
+		(!customMessage ||
+			(customMessage.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE &&
+				(!isSessionSlashCommandMessage(customMessage) || message !== customMessage.details.command.text)))
+	) {
 		throw new Error("Daemon update restart response contains an invalid custom queued message");
 	}
 	const agentMessageId =

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -45,6 +45,7 @@ interface MockCustomMessage {
 	content: string;
 	display: boolean;
 	timestamp: number;
+	details?: unknown;
 }
 
 interface MockQueuedMessage {
@@ -1217,6 +1218,16 @@ describe("self-update daemon restart", () => {
 			display: true,
 			timestamp: Date.now(),
 		};
+		const commandMessage: MockCustomMessage = {
+			role: "custom",
+			customType: "session_slash_command",
+			content: "/autonomous on",
+			display: true,
+			timestamp: Date.now(),
+			details: {
+				command: { name: "autonomous", args: "on", text: "/autonomous on" },
+			},
+		};
 		const prefixMessage: MockCustomMessage = {
 			role: "custom",
 			customType: "ipython_state_restored",
@@ -1242,6 +1253,10 @@ describe("self-update daemon restart", () => {
 								agentMessageId: "agentmsg_followup",
 								customMessage,
 								prefixMessages: [prefixMessage],
+							},
+							{
+								message: "/autonomous on",
+								customMessage: commandMessage,
 							},
 						],
 						nextTurn: [],
@@ -1272,6 +1287,30 @@ describe("self-update daemon restart", () => {
 					customMessage,
 					prefixMessages: [prefixMessage],
 				}),
+			);
+			expect(mockState.requestPayloads).toContainEqual(
+				expect.objectContaining({
+					type: "follow_up",
+					activeSessionId: "restored-active",
+					message: "/autonomous on",
+					customMessage: commandMessage,
+				}),
+			);
+			mockState.prepareResponse = {
+				success: true,
+				data: {
+					...mockState.prepareManifest,
+					sessions: mockState.prepareManifest.sessions.map((session) => ({
+						...session,
+						queue: {
+							...session.queue,
+							followUp: [{ message: "/autonomous off", customMessage: commandMessage }],
+						},
+					})),
+				},
+			};
+			await expect(prepareDaemonUpdateRestart(mockState.socketPath, agentDir)).rejects.toThrow(
+				"invalid custom queued message",
 			);
 		} finally {
 			errorSpy.mockRestore();

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -4,6 +4,7 @@ import {
 	builtinSlashCommandTakesArgument,
 	isBuiltinSlashCommandName,
 	isSessionSlashCommandName,
+	parseRefineCommandOptions,
 	parseSessionSlashCommand,
 	parseSlashCommand,
 	resolveBuiltinSlashCommandName,
@@ -180,6 +181,10 @@ describe("session slash commands", () => {
 			expect(parseSessionSlashCommand(`/goal\t${lineTerminator}ship it`)).toBeUndefined();
 			expect(parseSessionSlashCommand(`/autonomous\t${lineTerminator}on`)).toBeUndefined();
 		}
+	});
+
+	test("requires a rollback id after removing --global", () => {
+		expect(() => parseRefineCommandOptions("rollback --global")).toThrow("Usage: /refine rollback <refinement-id>");
 	});
 
 	test("classifies only exact leading session-owned commands", () => {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -183,8 +183,27 @@ describe("session slash commands", () => {
 		}
 	});
 
-	test("requires a rollback id after removing --global", () => {
-		expect(() => parseRefineCommandOptions("rollback --global")).toThrow("Usage: /refine rollback <refinement-id>");
+	test("parses refine rollback ids and --global placement without consuming instruction text", () => {
+		expect(parseRefineCommandOptions("rollback refine_123")).toEqual({ rollbackId: "refine_123", global: false });
+		expect(parseRefineCommandOptions("rollback refine_456 --global")).toEqual({
+			rollbackId: "refine_456",
+			global: true,
+		});
+		expect(parseRefineCommandOptions("--global rollback refine_789")).toEqual({
+			rollbackId: "refine_789",
+			global: true,
+		});
+		expect(parseRefineCommandOptions("--global focus on validation")).toEqual({
+			instructions: "focus on validation",
+			global: true,
+		});
+		expect(parseRefineCommandOptions("update docs to explain --global")).toEqual({
+			instructions: "update docs to explain --global",
+			global: false,
+		});
+		for (const args of ["rollback", "rollback --global"]) {
+			expect(() => parseRefineCommandOptions(args)).toThrow("Usage: /refine rollback <refinement-id>");
+		}
 	});
 
 	test("classifies only exact leading session-owned commands", () => {

--- a/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	addAutonomousUsage,
 	createAutonomousRuntimeState,
@@ -326,7 +326,9 @@ describe("AgentSession autonomous mode", () => {
 			suppressAutonomousContinuation: true,
 		});
 		sessionInternals._compactionAbortController = undefined;
-		await harness.session.agent.continue();
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await vi.waitFor(() => expect(harness.session.pendingMessageCount).toBe(0));
+		await harness.session.waitForSessionInputIdle();
 
 		expect(getAssistantTexts(harness)).toEqual(["Still failing."]);
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -421,6 +421,7 @@ describe("AgentSession bash and persistence characterization", () => {
 		await bashRun;
 		await steerDelivery;
 		await followUpDelivery;
+		await harness.session.waitForIdle();
 
 		const userTexts = harness.session.messages.filter((message) => message.role === "user").map(getMessageText);
 		expect(userTexts.findIndex((text) => text.includes("steer after bash"))).toBeLessThan(
@@ -430,26 +431,52 @@ describe("AgentSession bash and persistence characterization", () => {
 	});
 
 	it("flushes pending bash output before draining queued prompts", async () => {
-		const harness = await createHarness();
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("after bash")]);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("turn complete"),
+			fauxAssistantMessage("after bash"),
+		]);
+		const toolStarted = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start" && event.toolName === "wait") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
 		const agentPrompt =
 			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_flush_bash\n\nqueued after bash";
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_flush_bash");
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+
+		const turn = harness.session.prompt("start");
+		await toolStarted;
 		harness.session.recordBashResult("echo flushed", {
 			output: "flushed output",
 			exitCode: 0,
 			cancelled: false,
 			truncated: false,
 		});
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
 		await harness.session.queueAgentMessagePrompt(agentPrompt, "followUp");
-
-		await (
-			harness.session as unknown as { _drainQueuedMessagesAfterBash(): Promise<void> }
-		)._drainQueuedMessagesAfterBash();
+		releaseToolExecution?.();
+		await turn;
 		await delivery;
+		await harness.session.waitForIdle();
 
 		const bashIndex = harness.session.messages.findIndex((message) => message.role === "bashExecution");
 		const userIndex = harness.session.messages.findIndex(

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage, ShouldStopAfterTurnContext } from "@earendil-works/pi-agent-core";
 import { type AssistantMessage, fauxAssistantMessage, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createHarness, getMessageText, type Harness } from "./harness.js";
+import { createHarness, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (
@@ -293,9 +293,7 @@ describe("AgentSession compaction characterization", () => {
 
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(1);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([firstQueued]);
-		expect(
-			harness.session.agent.removeQueuedMessages((message) => message === firstQueued || message === secondQueued),
-		).toEqual([firstQueued]);
+		expect(harness.session.getFollowUpMessages()).toHaveLength(1);
 	});
 
 	it("clears queued autonomous continuations when threshold compaction is skipped", async () => {
@@ -340,7 +338,7 @@ describe("AgentSession compaction characterization", () => {
 			newMessages: [successfulAssistant, toolResult],
 		});
 		expect(shouldStop).toBe(true);
-		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.session.getFollowUpMessages()).toHaveLength(1);
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(1);
 
 		await sessionInternals._runAutoCompaction("threshold", false);
@@ -605,8 +603,8 @@ describe("AgentSession compaction characterization", () => {
 			continuationsUsed: 1,
 			gates: expect.objectContaining({ maxRetries: 5 }),
 		});
-		expect(followUpSpy).toHaveBeenCalledTimes(1);
-		const queuedText = getMessageText(followUpSpy.mock.calls[0]?.[0]);
+		expect(followUpSpy).not.toHaveBeenCalled();
+		const queuedText = harness.session.getFollowUpMessages()[0] ?? "";
 		expect(queuedText).toContain("Autonomous quality gate failed (attempt 1/5)");
 		expect(queuedText).toContain("gate failed");
 
@@ -755,7 +753,6 @@ describe("AgentSession compaction characterization", () => {
 			harness.sessionManager.appendMessage(message);
 		}
 		harness.session.agent.state.messages = [oldUser, oldAssistant, currentUser, successfulAssistant, toolResult];
-		const continueSpy = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
 
 		await sessionInternals._shouldStopAfterTurn({
 			message: successfulAssistant,
@@ -767,16 +764,16 @@ describe("AgentSession compaction characterization", () => {
 			},
 			newMessages: [successfulAssistant, toolResult],
 		});
-		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.session.getFollowUpMessages()).toHaveLength(1);
 
 		await harness.session.prompt("/autonomous off");
 		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
-		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
 
 		await sessionInternals._runAutoCompaction("threshold", false);
 		await vi.advanceTimersByTimeAsync(100);
 
-		expect(continueSpy).not.toHaveBeenCalled();
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
 	it("queues a failing autonomous gate continuation before post-turn threshold compaction", async () => {
@@ -818,9 +815,9 @@ describe("AgentSession compaction characterization", () => {
 		await sessionInternals._checkCompaction(successfulAssistant, false);
 
 		expect(runCompactionSpy).toHaveBeenCalledWith("threshold", false);
-		expect(followUpSpy).toHaveBeenCalledTimes(1);
+		expect(followUpSpy).not.toHaveBeenCalled();
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(1);
-		const queuedText = getMessageText(followUpSpy.mock.calls[0]?.[0]);
+		const queuedText = harness.session.getFollowUpMessages()[0] ?? "";
 		expect(queuedText).toContain("Autonomous quality gate failed (attempt 1/5)");
 		expect(queuedText).toContain("gate failed");
 	});

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -611,7 +611,8 @@ describe("AgentSession compaction characterization", () => {
 		await sessionInternals._runAutoCompaction("threshold", false);
 		await vi.advanceTimersByTimeAsync(100);
 
-		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
 	it("keeps autonomous continuation bookkeeping when only steering queue is drained", async () => {
@@ -654,6 +655,43 @@ describe("AgentSession compaction characterization", () => {
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([autonomousMessage]);
 		expect(followUpSpy).toHaveBeenCalledWith(autonomousMessage);
+	});
+
+	it("does not continue again after the session pump consumes post-compaction continuations", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_postCompactionContinuationMessages: AgentMessage[];
+			_createPreparedPromptInput(
+				text: string,
+				images: undefined,
+				options: { message: AgentMessage; resumeIfIdle: boolean },
+			): unknown;
+			_enqueueSessionInput(input: unknown, schedule: "followUp"): boolean;
+		};
+		const continuation = {
+			role: "user",
+			content: [{ type: "text", text: "session-owned continuation" }],
+			timestamp: Date.now(),
+		} satisfies AgentMessage;
+		sessionInternals._postCompactionContinuationMessages = [continuation];
+		harness.setResponses([fauxAssistantMessage("continuation handled")]);
+		sessionInternals._enqueueSessionInput(
+			sessionInternals._createPreparedPromptInput("session-owned continuation", undefined, {
+				message: continuation,
+				resumeIfIdle: true,
+			}),
+			"followUp",
+		);
+		const continueSpy = vi.spyOn(harness.session.agent, "continue");
+
+		sessionInternals._schedulePostCompactionContinue();
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(sessionInternals._postCompactionContinuationMessages).toEqual([]);
 	});
 
 	it("keeps autonomous threshold continuations when post-compaction continue must retry", async () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -657,6 +657,35 @@ describe("AgentSession compaction characterization", () => {
 		expect(followUpSpy).toHaveBeenCalledWith(autonomousMessage);
 	});
 
+	it("does not continue after the session pump handles an untracked queued input", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_postCompactionContinuationScheduled: boolean;
+			_createPreparedPromptInput(text: string, images: undefined, options: { resumeIfIdle: boolean }): unknown;
+			_enqueueSessionInput(input: unknown, schedule: "followUp"): boolean;
+		};
+		harness.setResponses([fauxAssistantMessage("queued input handled")]);
+		sessionInternals._enqueueSessionInput(
+			sessionInternals._createPreparedPromptInput("queued input", undefined, { resumeIfIdle: false }),
+			"followUp",
+		);
+		const continueSpy = vi.spyOn(harness.session.agent, "continue");
+
+		sessionInternals._schedulePostCompactionContinue();
+		await vi.advanceTimersByTimeAsync(200);
+		vi.useRealTimers();
+
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(sessionInternals._postCompactionContinuationScheduled).toBe(false);
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "queued input handled" }],
+		});
+	});
+
 	it("does not continue again after the session pump consumes post-compaction continuations", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness();

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -657,70 +657,60 @@ describe("AgentSession compaction characterization", () => {
 		expect(followUpSpy).toHaveBeenCalledWith(autonomousMessage);
 	});
 
-	it("does not continue after the session pump handles an untracked queued input", async () => {
-		vi.useFakeTimers();
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const sessionInternals = harness.session as unknown as {
-			_schedulePostCompactionContinue(): void;
-			_postCompactionContinuationScheduled: boolean;
-			_createPreparedPromptInput(text: string, images: undefined, options: { resumeIfIdle: boolean }): unknown;
-			_enqueueSessionInput(input: unknown, schedule: "followUp"): boolean;
-		};
-		harness.setResponses([fauxAssistantMessage("queued input handled")]);
-		sessionInternals._enqueueSessionInput(
-			sessionInternals._createPreparedPromptInput("queued input", undefined, { resumeIfIdle: false }),
-			"followUp",
-		);
-		const continueSpy = vi.spyOn(harness.session.agent, "continue");
-
-		sessionInternals._schedulePostCompactionContinue();
-		await vi.advanceTimersByTimeAsync(200);
-		vi.useRealTimers();
-
-		expect(continueSpy).not.toHaveBeenCalled();
-		expect(sessionInternals._postCompactionContinuationScheduled).toBe(false);
-		expect(harness.session.messages.at(-1)).toMatchObject({
-			role: "assistant",
-			content: [{ type: "text", text: "queued input handled" }],
-		});
-	});
-
-	it("does not continue again after the session pump consumes post-compaction continuations", async () => {
+	it.each([
+		{
+			name: "untracked queued input",
+			text: "queued input",
+			response: "queued input handled",
+			tracked: false,
+		},
+		{
+			name: "post-compaction continuation",
+			text: "session-owned continuation",
+			response: "continuation handled",
+			tracked: true,
+		},
+	])("does not continue again after the session pump handles $name", async ({ text, response, tracked }) => {
 		vi.useFakeTimers();
 		const harness = await createHarness();
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as {
 			_schedulePostCompactionContinue(): void;
 			_postCompactionContinuationMessages: AgentMessage[];
+			_postCompactionContinuationScheduled: boolean;
 			_createPreparedPromptInput(
 				text: string,
 				images: undefined,
-				options: { message: AgentMessage; resumeIfIdle: boolean },
+				options: { message?: AgentMessage; resumeIfIdle: boolean },
 			): unknown;
 			_enqueueSessionInput(input: unknown, schedule: "followUp"): boolean;
 		};
 		const continuation = {
 			role: "user",
-			content: [{ type: "text", text: "session-owned continuation" }],
+			content: [{ type: "text", text }],
 			timestamp: Date.now(),
 		} satisfies AgentMessage;
-		sessionInternals._postCompactionContinuationMessages = [continuation];
-		harness.setResponses([fauxAssistantMessage("continuation handled")]);
+		if (tracked) sessionInternals._postCompactionContinuationMessages = [continuation];
+		harness.setResponses([fauxAssistantMessage(response)]);
 		sessionInternals._enqueueSessionInput(
-			sessionInternals._createPreparedPromptInput("session-owned continuation", undefined, {
-				message: continuation,
-				resumeIfIdle: true,
+			sessionInternals._createPreparedPromptInput(text, undefined, {
+				...(tracked && { message: continuation }),
+				resumeIfIdle: tracked,
 			}),
 			"followUp",
 		);
 		const continueSpy = vi.spyOn(harness.session.agent, "continue");
 
 		sessionInternals._schedulePostCompactionContinue();
-		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(200);
 
 		expect(continueSpy).not.toHaveBeenCalled();
+		expect(sessionInternals._postCompactionContinuationScheduled).toBe(false);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([]);
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: response }],
+		});
 	});
 
 	it("keeps autonomous threshold continuations when post-compaction continue must retry", async () => {

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -625,7 +625,9 @@ describe("AgentSession goals", () => {
 
 		await harness.session.prompt("/goal clear");
 
-		expect(harness.session.messages).toEqual([]);
+		expect(
+			harness.session.messages.map((message) => (message.role === "custom" ? message.customType : message.role)),
+		).toEqual(["session_slash_command", "session_slash_command_result"]);
 		expect(harness.eventsOfType("goal_update").at(-1)?.goal.status).toBe("idle");
 		expect(harness.getPendingResponseCount()).toBe(1);
 	});
@@ -634,13 +636,17 @@ describe("AgentSession goals", () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 
-		await expect(harness.session.prompt("/goal do task")).rejects.toThrow();
+		await harness.session.prompt("/goal do task");
 
 		expect(harness.session.goalState).toMatchObject({
 			active: false,
 			status: "idle",
 		});
-		expect(harness.session.messages).toEqual([]);
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "custom",
+			customType: "session_slash_command_result",
+			details: { success: false },
+		});
 	});
 
 	it("completes a goal whose completing turn crosses the budget without a stale budget-limit steer", async () => {
@@ -737,7 +743,12 @@ describe("AgentSession goals", () => {
 			harnesses.push(harness);
 			harness.setResponses([fauxAssistantMessage("unused")]);
 
-			await expect(harness.session.prompt(command)).rejects.toThrow("Goal token budget must be a positive integer.");
+			await harness.session.prompt(command);
+			expect(harness.session.messages.at(-1)).toMatchObject({
+				role: "custom",
+				customType: "session_slash_command_result",
+				details: { success: false, error: "Goal token budget must be a positive integer." },
+			});
 
 			expect(harness.session.goalState).toMatchObject({
 				active: false,
@@ -834,7 +845,9 @@ describe("AgentSession goals", () => {
 
 		await harness.session.prompt("/goal status");
 
-		expect(harness.session.messages).toEqual([]);
+		expect(
+			harness.session.messages.map((message) => (message.role === "custom" ? message.customType : message.role)),
+		).toEqual(["session_slash_command", "session_slash_command_result"]);
 		expect(harness.eventsOfType("goal_update").at(-1)?.goal.status).toBe("idle");
 		expect(harness.getPendingResponseCount()).toBe(1);
 	});

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -739,11 +739,13 @@ describe("AgentSession goals", () => {
 
 		const promptPromise = harness.session.prompt("/goal --budget 10 do work");
 		try {
-			await waitForCondition(() => harness.getPendingResponseCount() === 1);
+			await waitForCondition(() => harness.session.goalState.status === "budget_limited");
 		} finally {
 			releaseMessageEnd?.();
 		}
 		await promptPromise;
+		await harness.session.waitForIdle();
+		await vi.waitFor(() => expect(visibleAssistantTexts(harness)).toHaveLength(2));
 
 		expect(visibleAssistantTexts(harness)).toEqual(["Spent the budget.", "Wrapping up."]);
 		expect(harness.getPendingResponseCount()).toBe(1);

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -459,6 +459,25 @@ describe("AgentSession goals", () => {
 		});
 	});
 
+	it("normalizes queued goal context text and images", async () => {
+		const harness = await createGoalHarness();
+		const image = { type: "image" as const, data: "image-data", mimeType: "image/png" };
+		let preparedText: string | undefined;
+		let preparedImages: unknown;
+		harness.setResponses([fauxAssistantMessage("goal handled")]);
+		vi.spyOn(harness.session.extensionRunner, "emitBeforeAgentStart").mockImplementationOnce(async (text, images) => {
+			preparedText = text;
+			preparedImages = images;
+			return undefined;
+		});
+
+		await harness.session.prompt("/goal inspect the image", { images: [image] });
+
+		expect(preparedText).toContain("<goal_context>");
+		expect(preparedText).not.toContain("[object Object]");
+		expect(preparedImages).toEqual([image]);
+	});
+
 	it("keeps active goals sticky across normal user prompts", async () => {
 		const waiting = createWaitingTool();
 		const harness = await createGoalHarness([waiting.tool]);

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -368,26 +368,36 @@ describe("AgentSession model and extension characterization", () => {
 	});
 
 	it("keeps streaming injected prompts under turn admission when the turn becomes idle", async () => {
-		const harness = await createHarness();
+		const toolStarted = createDeferred();
+		const finishTool = createDeferred();
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				toolStarted.resolve();
+				await finishTool.promise;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("heartbeat")]);
-		const internals = harness.session as unknown as { _acquireTurnAdmission(): Promise<() => void> };
-		const releaseBlocker = await internals._acquireTurnAdmission();
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
-		let settled = false;
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("turn complete"),
+			fauxAssistantMessage("heartbeat"),
+		]);
 
-		const heartbeat = harness.session
-			.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" })
-			.finally(() => {
-				settled = true;
-			});
-		await flushAsyncWork();
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		const turn = harness.session.prompt("start");
+		await toolStarted.promise;
+		await harness.session.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" });
 
-		expect(settled).toBe(false);
-		releaseBlocker();
-		await heartbeat;
-		expect(getAssistantTexts(harness)).toEqual(["heartbeat"]);
+		finishTool.resolve();
+		await turn;
+		await harness.session.waitForIdle();
+
+		expect(getAssistantTexts(harness)).toEqual(["", "turn complete", "heartbeat"]);
 	});
 
 	it("includes nextTurn messages queued by pending model_select handlers in injected prompts", async () => {

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -367,6 +367,29 @@ describe("AgentSession model and extension characterization", () => {
 		expect(getAssistantTexts(harness)).toContain("accepted");
 	});
 
+	it("keeps streaming injected prompts under turn admission when the turn becomes idle", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("heartbeat")]);
+		const internals = harness.session as unknown as { _acquireTurnAdmission(): Promise<() => void> };
+		const releaseBlocker = await internals._acquireTurnAdmission();
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		let settled = false;
+
+		const heartbeat = harness.session
+			.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" })
+			.finally(() => {
+				settled = true;
+			});
+		await flushAsyncWork();
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+
+		expect(settled).toBe(false);
+		releaseBlocker();
+		await heartbeat;
+		expect(getAssistantTexts(harness)).toEqual(["heartbeat"]);
+	});
+
 	it("includes nextTurn messages queued by pending model_select handlers in injected prompts", async () => {
 		const handlerStarted = createDeferred();
 		const finishHandler = createDeferred();

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1212,16 +1212,17 @@ stale post-hook extension instructions`,
 		};
 		sessionInternals._compactionAbortController = new AbortController();
 
-		await expect(
-			harness.session.prompt("/autonomous on", {
-				queueIfBusy: true,
-				streamingBehavior: "followUp",
-			}),
-		).rejects.toThrow("Agent has queued work");
-		sessionInternals._compactionAbortController = undefined;
+		await harness.session.prompt("/autonomous on", {
+			queueIfBusy: true,
+			streamingBehavior: "followUp",
+		});
 
 		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
-		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["/autonomous on"]);
+		sessionInternals._compactionAbortController = undefined;
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await harness.session.waitForSessionInputIdle();
+		expect(harness.session.getAutonomousStatus().enabled).toBe(true);
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -10,7 +10,7 @@ import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
 import { createTestResourceLoader } from "../utilities.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
-import { createWaitingHarness } from "./scheduling.js";
+import { createWaitingHarness, gatedHook } from "./scheduling.js";
 
 // acceptAgentMessagePrompt admission is asynchronous. Pause after agent.prompt has
 // synchronously claimed the run, but before its prompt messages become delivered.
@@ -560,6 +560,45 @@ stale injected extension instructions`,
 		expect(providerSystemPrompt).toContain("refined injected base");
 		expect(providerSystemPrompt).toContain("stale injected extension instructions");
 		expect(providerMessages).toContain("injected extension message preserved");
+	});
+
+	it("pumps a follow-up queued while an injected prompt owns the active turn", async () => {
+		const hook = gatedHook({ prompt: "injected prompt" });
+		const harness = await createHarness({ extensionFactories: [hook.factory] });
+		harnesses.push(harness);
+		const internals = harness.session as unknown as {
+			_promptInjectedMessage(
+				text: string,
+				message: {
+					role: "custom";
+					customType: string;
+					content: string;
+					display: boolean;
+					details: Record<string, never>;
+					timestamp: number;
+				},
+			): Promise<void>;
+		};
+		harness.setResponses([fauxAssistantMessage("injected done"), fauxAssistantMessage("follow-up done")]);
+
+		const injectedPrompt = internals._promptInjectedMessage("injected prompt", {
+			role: "custom",
+			customType: "injected-test",
+			content: "injected prompt",
+			display: true,
+			details: {},
+			timestamp: Date.now(),
+		});
+		await hook.reached;
+		await harness.session.followUp("queued follow-up");
+		hook.release();
+
+		await injectedPrompt;
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["queued follow-up"]);
+		expect(getAssistantTexts(harness)).toEqual(["injected done", "follow-up done"]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
 	it("preserves an empty extension system prompt across an injected refine handoff wait", async () => {

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -11,6 +11,27 @@ import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
 import { createTestResourceLoader } from "../utilities.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
 
+// acceptAgentMessagePrompt admission is asynchronous. Pause after agent.prompt has
+// synchronously claimed the run, but before its prompt messages become delivered.
+function gateNextAgentStart(harness: Harness): { reached: Promise<void>; release(): void } {
+	let markReached = () => {};
+	const reached = new Promise<void>((resolve) => {
+		markReached = resolve;
+	});
+	let release = () => {};
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let unsubscribe = () => {};
+	unsubscribe = harness.session.agent.subscribe(async (event) => {
+		if (event.type !== "agent_start") return;
+		unsubscribe();
+		markReached();
+		await gate;
+	});
+	return { reached, release };
+}
+
 describe("AgentSession prompt characterization", () => {
 	const harnesses: Harness[] = [];
 	const tempDirs: string[] = [];
@@ -852,7 +873,7 @@ stale post-hook extension instructions`,
 			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_handoff_reject\n\nagent text",
 			{ expandPromptTemplates: false, queueIfBusy: true },
 		);
-		await Promise.resolve();
+		await vi.waitFor(() => expect(harness.session.getPendingNextTurnMessageSnapshots()).toEqual([]));
 		sessionInternals._userBashRunning = true;
 		sessionInternals._refineInFlight = undefined;
 		releaseRefine?.();
@@ -1035,11 +1056,14 @@ stale post-hook extension instructions`,
 
 		harness.setResponses([fauxAssistantMessage("never delivered"), fauxAssistantMessage("after clear response")]);
 		gateAgentStart = true;
+		const admission = gateNextAgentStart(harness);
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
+		await admission.reached;
 		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});
+		admission.release();
 		await expect(accepted).rejects.toThrow("cleared before delivery");
 		await harness.session.agent.waitForIdle();
 
@@ -1066,11 +1090,14 @@ stale post-hook extension instructions`,
 		);
 		harness.setResponses([fauxAssistantMessage("never delivered")]);
 
+		const admission = gateNextAgentStart(harness);
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
+		await admission.reached;
 		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});
+		admission.release();
 		await expect(accepted).rejects.toThrow("cleared before delivery");
 		await harness.session.agent.waitForIdle();
 		await (harness.session as unknown as { _agentEventQueue: Promise<void> })._agentEventQueue;
@@ -1141,11 +1168,14 @@ stale post-hook extension instructions`,
 		harness.setResponses([fauxAssistantMessage("never delivered")]);
 
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_late_events");
+		const admission = gateNextAgentStart(harness);
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
+		await admission.reached;
 		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});
+		admission.release();
 		await expect(accepted).rejects.toThrow("cleared before delivery");
 		await expect(delivery).rejects.toThrow("cleared before delivery");
 		await harness.session.agent.waitForIdle();

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -10,6 +10,7 @@ import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
 import { createTestResourceLoader } from "../utilities.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
+import { createWaitingHarness } from "./scheduling.js";
 
 // acceptAgentMessagePrompt admission is asynchronous. Pause after agent.prompt has
 // synchronously claimed the run, but before its prompt messages become delivered.
@@ -283,47 +284,19 @@ describe("AgentSession prompt characterization", () => {
 	});
 
 	it("throws when prompted during streaming without a streamingBehavior", async () => {
-		let releaseToolExecution: (() => void) | undefined;
-		const toolRelease = new Promise<void>((resolve) => {
-			releaseToolExecution = resolve;
-		});
-		const waitTool: AgentTool = {
-			name: "wait",
-			label: "Wait",
-			description: "Wait for release",
-			parameters: Type.Object({}),
-			execute: async () => {
-				await toolRelease;
-				return {
-					content: [{ type: "text", text: "released" }],
-					details: {},
-				};
-			},
-		};
-		const harness = await createHarness({ tools: [waitTool] });
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = await createWaitingHarness();
 		harnesses.push(harness);
 		harness.setResponses([
 			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("done"),
 		]);
-
-		const sawToolStart = new Promise<void>((resolve) => {
-			const unsubscribe = harness.session.subscribe((event) => {
-				if (event.type === "tool_execution_start") {
-					unsubscribe();
-					resolve();
-				}
-			});
-		});
-
-		const promptPromise = harness.session.prompt("start");
-		await sawToolStart;
+		await waitForToolStart;
 
 		await expect(harness.session.prompt("second")).rejects.toThrow(
 			"Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
 		);
 
-		releaseToolExecution?.();
+		releaseToolExecution();
 		await promptPromise;
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -773,7 +773,6 @@ describe("AgentSession queue characterization", () => {
 		const target = harness.sessionManager.getEntries().find((entry) => entry.type === "message");
 		expect(target).toBeDefined();
 
-		// Preparation completes, then the pause defers the handoff and requeues.
 		withStreaming(harness, true);
 		await harness.session.followUp("queued", undefined, { resumeIfIdle: true });
 		withStreaming(harness, false);
@@ -783,8 +782,6 @@ describe("AgentSession queue characterization", () => {
 			._followUpMessages;
 		await vi.waitFor(() => expect(queued[0]?.preparation).toBeDefined());
 
-		// The branch switch must clear the cached preparation so
-		// before_agent_start re-runs against the new context on the next pump.
 		const navigation = harness.session.navigateTree(target!.id, { summarize: false });
 		pause?.release();
 		pause = undefined;

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2277,65 +2277,7 @@ describe("AgentSession queue characterization", () => {
 		);
 	});
 
-	it("reports whether a queue pause was newly acquired", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
 
-		expect(harness.session.pauseQueuedWork()).toBe(true);
-		expect(harness.session.pauseQueuedWork()).toBe(false);
-	});
 
-	it("reports session commands as queued while compaction blocks delivery", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const internals = harness.session as unknown as { _compactionAbortController?: AbortController };
-		internals._compactionAbortController = new AbortController();
-		const preflight = vi.fn();
 
-		await harness.session.prompt("/autonomous on", {
-			streamingBehavior: "followUp",
-			queueIfBusy: true,
-			preflightResult: preflight,
-		});
-
-		expect(preflight).toHaveBeenCalledWith(true, true);
-		expect(harness.session.getFollowUpMessages()).toEqual(["/autonomous on"]);
-		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
-	});
-
-	it("reschedules session-owned inputs when compaction finishes", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("after compaction")]);
-		const internals = harness.session as unknown as {
-			_compactionAbortController?: AbortController;
-			_schedulePendingMessageResume(): void;
-		};
-		internals._compactionAbortController = new AbortController();
-		await harness.session.followUp("queued during compaction", undefined, { resumeIfIdle: true });
-		await harness.session.waitForSessionInputIdle();
-		expect(harness.session.getFollowUpMessages()).toEqual(["queued during compaction"]);
-
-		internals._compactionAbortController = undefined;
-		internals._schedulePendingMessageResume();
-		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["queued during compaction"]));
-	});
-
-	it("uses the compaction card as the only successful compact result", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		vi.spyOn(harness.session, "compact").mockResolvedValue({
-			summary: "summary",
-			firstKeptEntryId: "kept",
-			tokensBefore: 128_144,
-		});
-
-		await harness.session.prompt("/compact focus");
-
-		expect(
-			harness.session.messages.filter(
-				(message) => message.role === "custom" && message.customType === "session_slash_command_result",
-			),
-		).toEqual([]);
-	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/core/refinement/index.js";
 import { parseSessionSlashCommand } from "../../src/core/slash-commands.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
+import { createDeferred, createWaitingHarness, gatedHook, withStreaming } from "./scheduling.js";
 
 type AutoRefineReason = "turn_interval" | "compact";
 
@@ -51,65 +52,20 @@ function emptyRefinementResult(): RefinementResult {
 	};
 }
 
+function refinePlanJson(summary: string, edits: unknown[] = []): string {
+	return JSON.stringify({
+		summary,
+		rationale: `${summary} rationale`,
+		expectedOutcome: `${summary} outcome`,
+		edits,
+	});
+}
+
 function createAutoRefineHarness(options: Parameters<typeof createHarness>[0] = {}): Promise<Harness> {
 	return createHarness({ ...options, persistSession: true });
 }
 
-function setAgentStreaming(harness: Harness, isStreaming: boolean): void {
-	(harness.session.agent.state as { isStreaming: boolean }).isStreaming = isStreaming;
-}
-
-async function createWaitingHarness(
-	options: {
-		tools?: AgentTool[];
-		extensionFactories?: Harness["session"]["extensionRunner"] extends never
-			? never
-			: Array<(pi: ExtensionAPI) => void>;
-	} = {},
-): Promise<{
-	harness: Harness;
-	releaseToolExecution: () => void;
-	promptPromise: Promise<void>;
-	waitForToolStart: Promise<void>;
-}> {
-	let releaseToolExecution: (() => void) | undefined;
-	const toolRelease = new Promise<void>((resolve) => {
-		releaseToolExecution = resolve;
-	});
-	const waitTool: AgentTool = {
-		name: "wait",
-		label: "Wait",
-		description: "Wait for release",
-		parameters: Type.Object({}),
-		execute: async () => {
-			await toolRelease;
-			return {
-				content: [{ type: "text", text: "released" }],
-				details: {},
-			};
-		},
-	};
-	const harness = await createHarness({
-		tools: [waitTool, ...(options.tools ?? [])],
-		extensionFactories: options.extensionFactories,
-	});
-
-	const waitForToolStart = new Promise<void>((resolve) => {
-		const unsubscribe = harness.session.subscribe((event) => {
-			if (event.type === "tool_execution_start" && event.toolName === "wait") {
-				unsubscribe();
-				resolve();
-			}
-		});
-	});
-
-	return {
-		harness,
-		releaseToolExecution: () => releaseToolExecution?.(),
-		promptPromise: harness.session.prompt("start"),
-		waitForToolStart,
-	};
-}
+const skipReviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
 
 describe("AgentSession queue characterization", () => {
 	const harnesses: Harness[] = [];
@@ -133,93 +89,154 @@ describe("AgentSession queue characterization", () => {
 		expect(internals._assistantTurnsSinceAutoRefine).toBe(0);
 	});
 
-	it("auto-refine review runs after the configured turn interval", async () => {
-		const reviewer = vi.fn(async () => ({
-			shouldRefine: true,
-			rationale: "durable lesson found",
-			instructions: "capture the durable lesson",
-		}));
-		const harness = await createAutoRefineHarness({
+	it.each([
+		{
+			name: "review runs after the configured turn interval",
 			settings: { autoRefine: { enabled: true, turnInterval: 2, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 2;
-
-		await internals._maybeAutoRefine("turn_interval");
-
-		expect(reviewer).toHaveBeenCalledWith(
-			{ reason: "turn_interval", turnsSinceLastReview: 2 },
-			expect.any(AbortSignal),
-		);
-		expect(refine).toHaveBeenCalledWith(
-			expect.objectContaining({ instructions: expect.stringContaining("capture the durable lesson") }),
-		);
-		expect(refine).toHaveBeenCalledWith(
-			expect.objectContaining({ instructions: expect.stringContaining("local harness entries") }),
-		);
-		expect(refine).toHaveBeenCalledWith(
-			expect.objectContaining({ instructions: expect.stringContaining("Do not promote anything global") }),
-		);
-		expect(internals._assistantTurnsSinceAutoRefine).toBe(0);
-	});
-
-	it("auto-refine compact hook does not require the turn interval", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: false, rationale: "nothing durable" }));
-		const harness = await createAutoRefineHarness({
+			turns: 2,
+			reason: "turn_interval" as AutoRefineReason,
+			review: {
+				shouldRefine: true,
+				rationale: "durable lesson found",
+				instructions: "capture the durable lesson",
+			},
+			expectedReviewContext: { reason: "turn_interval", turnsSinceLastReview: 2 },
+			refineFragments: ["capture the durable lesson", "local harness entries", "Do not promote anything global"],
+			turnsAfter: 0,
+			compactPendingAfter: undefined as boolean | undefined,
+			scheduleCalledWith: undefined as AutoRefineReason | undefined,
+			queuedMessages: false,
+		},
+		{
+			name: "compact hook does not require the turn interval",
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 0;
-
-		await internals._maybeAutoRefine("compact");
-
-		expect(reviewer).toHaveBeenCalledWith({ reason: "compact", turnsSinceLastReview: 0 }, expect.any(AbortSignal));
-		expect(refine).not.toHaveBeenCalled();
-	});
-
-	it("falls back to turn-interval review when compact auto-refine is disabled", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: false, rationale: "nothing durable" }));
-		const harness = await createAutoRefineHarness({
+			turns: 0,
+			reason: "compact" as AutoRefineReason,
+			review: { shouldRefine: false, rationale: "nothing durable" },
+			expectedReviewContext: { reason: "compact", turnsSinceLastReview: 0 },
+			refineFragments: undefined as string[] | undefined,
+			turnsAfter: undefined as number | undefined,
+			compactPendingAfter: undefined,
+			scheduleCalledWith: undefined,
+			queuedMessages: false,
+		},
+		{
+			name: "falls back to turn-interval review when compact auto-refine is disabled",
 			settings: { autoRefine: { enabled: true, compact: false, turnInterval: 2, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 2;
-
-		await internals._maybeAutoRefine("compact");
-
-		expect(reviewer).toHaveBeenCalledWith(
-			{ reason: "turn_interval", turnsSinceLastReview: 2 },
-			expect.any(AbortSignal),
-		);
-		expect(internals._compactAutoRefinePending).toBe(false);
-	});
-
-	it("declined compact review preserves an already-due turn interval", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: false, rationale: "nothing compact-specific" }));
-		const harness = await createAutoRefineHarness({
+			turns: 2,
+			reason: "compact" as AutoRefineReason,
+			review: { shouldRefine: false, rationale: "nothing durable" },
+			expectedReviewContext: { reason: "turn_interval", turnsSinceLastReview: 2 },
+			refineFragments: undefined,
+			turnsAfter: undefined,
+			compactPendingAfter: false as boolean | undefined,
+			scheduleCalledWith: undefined,
+			queuedMessages: false,
+		},
+		{
+			name: "declined compact review preserves an already-due turn interval",
 			settings: { autoRefine: { enabled: true, turnInterval: 2, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 2;
-		const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
+			turns: 2,
+			reason: "compact" as AutoRefineReason,
+			review: { shouldRefine: false, rationale: "nothing compact-specific" },
+			expectedReviewContext: undefined as { reason: string; turnsSinceLastReview: number } | undefined,
+			refineFragments: undefined,
+			turnsAfter: 2,
+			compactPendingAfter: undefined,
+			scheduleCalledWith: "turn_interval" as AutoRefineReason | undefined,
+			queuedMessages: false,
+		},
+		{
+			name: "queued follow-up messages do not make an idle agent active",
+			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
+			turns: 1,
+			reason: "turn_interval" as AutoRefineReason,
+			review: {
+				shouldRefine: true,
+				rationale: "durable lesson found",
+				instructions: "capture the durable lesson",
+			},
+			expectedReviewContext: { reason: "turn_interval", turnsSinceLastReview: 1 },
+			refineFragments: [],
+			turnsAfter: undefined,
+			compactPendingAfter: undefined,
+			scheduleCalledWith: undefined,
+			queuedMessages: true,
+		},
+	])(
+		"auto-refine $name",
+		async ({
+			settings,
+			turns,
+			reason,
+			review,
+			expectedReviewContext,
+			refineFragments,
+			turnsAfter,
+			compactPendingAfter,
+			scheduleCalledWith,
+			queuedMessages,
+		}) => {
+			const reviewer = vi.fn(async () => review);
+			const harness = await createAutoRefineHarness({ settings, autoRefineReviewer: reviewer });
+			harnesses.push(harness);
+			const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
+			const internals = harness.session as unknown as AutoRefineInternals;
+			internals._assistantTurnsSinceAutoRefine = turns;
+			const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
+			if (queuedMessages) vi.spyOn(harness.session.agent, "hasQueuedMessages").mockReturnValue(true);
 
-		await internals._maybeAutoRefine("compact");
+			await internals._maybeAutoRefine(reason);
 
-		expect(internals._assistantTurnsSinceAutoRefine).toBe(2);
-		expect(scheduleAutoRefine).toHaveBeenCalledWith("turn_interval");
-	});
+			if (expectedReviewContext !== undefined) {
+				expect(reviewer).toHaveBeenCalledWith(expectedReviewContext, expect.any(AbortSignal));
+			}
+			if (refineFragments === undefined) {
+				expect(refine).not.toHaveBeenCalled();
+			} else {
+				expect(refine).toHaveBeenCalled();
+				for (const fragment of refineFragments) {
+					expect(refine).toHaveBeenCalledWith(
+						expect.objectContaining({ instructions: expect.stringContaining(fragment) }),
+					);
+				}
+			}
+			if (turnsAfter !== undefined) expect(internals._assistantTurnsSinceAutoRefine).toBe(turnsAfter);
+			if (compactPendingAfter !== undefined) expect(internals._compactAutoRefinePending).toBe(compactPendingAfter);
+			if (scheduleCalledWith !== undefined) expect(scheduleAutoRefine).toHaveBeenCalledWith(scheduleCalledWith);
+		},
+	);
 
-	it("auto-refine compact hook waits for planned post-compaction continuation", async () => {
+	it.each([
+		{
+			name: "waits for planned post-compaction continuation",
+			act: (internals: AutoRefineInternals, expectSchedule: (called: boolean) => void) => {
+				internals._scheduleAutoRefineAfterCompaction(true);
+				expect(internals._compactAutoRefinePending).toBe(true);
+				expectSchedule(false);
+				internals._scheduleAutoRefineAfterAgentEnd();
+				expect(internals._compactAutoRefinePending).toBe(true);
+			},
+		},
+		{
+			name: "waits until the scheduled post-compaction continuation starts",
+			act: (internals: AutoRefineInternals, expectSchedule: (called: boolean) => void) => {
+				internals._compactAutoRefinePending = true;
+				internals._postCompactionContinuationScheduled = true;
+				internals._scheduleAutoRefineAfterAgentEnd();
+				expectSchedule(false);
+				internals._postCompactionContinuationScheduled = false;
+				internals._scheduleAutoRefineAfterAgentEnd();
+			},
+		},
+		{
+			name: "runs immediately when no post-compaction continuation is planned",
+			act: (internals: AutoRefineInternals) => {
+				internals._scheduleAutoRefineAfterCompaction(false);
+				expect(internals._compactAutoRefinePending).toBe(false);
+			},
+		},
+	])("auto-refine compact hook $name", async ({ act }) => {
 		const harness = await createAutoRefineHarness({
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
 		});
@@ -227,62 +244,20 @@ describe("AgentSession queue characterization", () => {
 		const internals = harness.session as unknown as AutoRefineInternals;
 		const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
 
-		internals._scheduleAutoRefineAfterCompaction(true);
+		act(internals, (called) =>
+			called ? expect(scheduleAutoRefine).toHaveBeenCalled() : expect(scheduleAutoRefine).not.toHaveBeenCalled(),
+		);
 
-		expect(internals._compactAutoRefinePending).toBe(true);
-		expect(scheduleAutoRefine).not.toHaveBeenCalled();
-
-		internals._scheduleAutoRefineAfterAgentEnd();
-
-		expect(internals._compactAutoRefinePending).toBe(true);
 		expect(scheduleAutoRefine).toHaveBeenCalledWith("compact");
 		expect(scheduleAutoRefine).toHaveBeenCalledTimes(1);
-	});
-
-	it("auto-refine compact hook waits until the scheduled post-compaction continuation starts", async () => {
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
-		internals._compactAutoRefinePending = true;
-		internals._postCompactionContinuationScheduled = true;
-
-		internals._scheduleAutoRefineAfterAgentEnd();
-
-		expect(scheduleAutoRefine).not.toHaveBeenCalled();
-
-		internals._postCompactionContinuationScheduled = false;
-		internals._scheduleAutoRefineAfterAgentEnd();
-
-		expect(scheduleAutoRefine).toHaveBeenCalledWith("compact");
-		expect(scheduleAutoRefine).toHaveBeenCalledTimes(1);
-	});
-
-	it("auto-refine compact hook runs immediately when no post-compaction continuation is planned", async () => {
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
-
-		internals._scheduleAutoRefineAfterCompaction(false);
-
-		expect(internals._compactAutoRefinePending).toBe(false);
-		expect(scheduleAutoRefine).toHaveBeenCalledWith("compact");
 	});
 
 	it("runs a turn-interval review after a concurrent compact review declines", async () => {
 		vi.useFakeTimers();
-		let releaseCompactReview: (() => void) | undefined;
-		const compactReviewGate = new Promise<void>((resolve) => {
-			releaseCompactReview = resolve;
-		});
+		const compactReviewGate = createDeferred();
 		const reviewer = vi.fn(async ({ reason }: { reason: AutoRefineReason }) => {
 			if (reason === "compact") {
-				await compactReviewGate;
+				await compactReviewGate.promise;
 			}
 			return { shouldRefine: false, rationale: `${reason} found nothing durable` };
 		});
@@ -301,7 +276,7 @@ describe("AgentSession queue characterization", () => {
 
 			expect(internals._turnIntervalAutoRefinePending).toBe(true);
 
-			releaseCompactReview?.();
+			compactReviewGate.resolve();
 			await compactReview;
 			await vi.runOnlyPendingTimersAsync();
 
@@ -400,73 +375,57 @@ describe("AgentSession queue characterization", () => {
 		}
 	});
 
-	it("auto-refine compact hook defers an approved refine if the agent becomes active during review", async () => {
-		let finishReview: (() => void) | undefined;
-		const reviewStarted = new Promise<void>((resolve) => {
-			finishReview = resolve;
-		});
-		const reviewer = vi.fn(async () => {
-			await reviewStarted;
-			setAgentStreaming(harness, true);
-			return { shouldRefine: true, rationale: "durable lesson" };
-		});
-		const harness = await createAutoRefineHarness({
+	it.each([
+		{
+			trigger: "compact" as AutoRefineReason,
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
-
-		const autoRefinePromise = internals._maybeAutoRefine("compact");
-		expect(reviewer).toHaveBeenCalledWith({ reason: "compact", turnsSinceLastReview: 0 }, expect.any(AbortSignal));
-		finishReview?.();
-		await autoRefinePromise;
-
-		expect(refine).not.toHaveBeenCalled();
-		expect(internals._pendingAutoRefineReview).toBeDefined();
-		expect(internals._compactAutoRefinePending).toBe(false);
-	});
-
-	it("auto-refine turn interval defers an approved refine if the agent becomes active during review", async () => {
-		let finishReview: (() => void) | undefined;
-		const reviewStarted = new Promise<void>((resolve) => {
-			finishReview = resolve;
-		});
-		const reviewer = vi.fn(async () => {
-			await reviewStarted;
-			setAgentStreaming(harness, true);
-			return { shouldRefine: true, rationale: "durable lesson" };
-		});
-		const harness = await createAutoRefineHarness({
+			turns: 0,
+			expectedContext: { reason: "compact", turnsSinceLastReview: 0 },
+			resumeWhenIdle: false,
+		},
+		{
+			trigger: "turn_interval" as AutoRefineReason,
 			settings: { autoRefine: { enabled: true, turnInterval: 2, cooldownMs: 60_000 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 2;
-		const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
+			turns: 2,
+			expectedContext: { reason: "turn_interval", turnsSinceLastReview: 2 },
+			resumeWhenIdle: true,
+		},
+	])(
+		"auto-refine $trigger defers an approved refine if the agent becomes active during review",
+		async ({ trigger, settings, turns, expectedContext, resumeWhenIdle }) => {
+			const reviewStarted = createDeferred();
+			const reviewer = vi.fn(async () => {
+				await reviewStarted.promise;
+				withStreaming(harness, true);
+				return { shouldRefine: true, rationale: "durable lesson" };
+			});
+			const harness = await createAutoRefineHarness({ settings, autoRefineReviewer: reviewer });
+			harnesses.push(harness);
+			const internals = harness.session as unknown as AutoRefineInternals;
+			internals._assistantTurnsSinceAutoRefine = turns;
+			const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
 
-		const autoRefinePromise = internals._maybeAutoRefine("turn_interval");
-		expect(reviewer).toHaveBeenCalledWith(
-			{ reason: "turn_interval", turnsSinceLastReview: 2 },
-			expect.any(AbortSignal),
-		);
-		finishReview?.();
-		await autoRefinePromise;
+			const autoRefinePromise = internals._maybeAutoRefine(trigger);
+			expect(reviewer).toHaveBeenCalledWith(expectedContext, expect.any(AbortSignal));
+			reviewStarted.resolve();
+			await autoRefinePromise;
 
-		expect(refine).not.toHaveBeenCalled();
-		expect(internals._pendingAutoRefineReview).toBeDefined();
+			expect(refine).not.toHaveBeenCalled();
+			expect(internals._pendingAutoRefineReview).toBeDefined();
+			if (trigger === "compact") expect(internals._compactAutoRefinePending).toBe(false);
 
-		setAgentStreaming(harness, false);
-		await internals._maybeAutoRefine("turn_interval");
+			if (resumeWhenIdle) {
+				withStreaming(harness, false);
+				await internals._maybeAutoRefine(trigger);
 
-		expect(reviewer).toHaveBeenCalledTimes(1);
-		expect(refine).toHaveBeenCalledWith(
-			expect.objectContaining({ instructions: expect.stringContaining("durable lesson") }),
-		);
-		expect(internals._pendingAutoRefineReview).toBeUndefined();
-	});
+				expect(reviewer).toHaveBeenCalledTimes(1);
+				expect(refine).toHaveBeenCalledWith(
+					expect.objectContaining({ instructions: expect.stringContaining("durable lesson") }),
+				);
+				expect(internals._pendingAutoRefineReview).toBeUndefined();
+			}
+		},
+	);
 
 	it("auto-refine pending review uses the in-progress guard and catches refine failures", async () => {
 		const harness = await createAutoRefineHarness({
@@ -530,15 +489,12 @@ describe("AgentSession queue characterization", () => {
 	});
 
 	it("does not refine when a review resolves after the session is disposed", async () => {
-		let finishReview: (() => void) | undefined;
-		const reviewGate = new Promise<void>((resolve) => {
-			finishReview = resolve;
-		});
+		const reviewGate = createDeferred();
 		const signals: Array<AbortSignal | undefined> = [];
 		const reviewer = vi.fn(
 			async (_context: { reason: AutoRefineReason; turnsSinceLastReview: number }, signal?: AbortSignal) => {
 				signals.push(signal);
-				await reviewGate;
+				await reviewGate.promise;
 				return { shouldRefine: true, rationale: "durable lesson" };
 			},
 		);
@@ -556,7 +512,7 @@ describe("AgentSession queue characterization", () => {
 		const entriesBeforeDispose = harness.sessionManager.getEntries().length;
 		harness.session.dispose();
 		expect(signals[0]?.aborted).toBe(true);
-		finishReview?.();
+		reviewGate.resolve();
 		await autoRefinePromise;
 
 		expect(refine).not.toHaveBeenCalled();
@@ -612,45 +568,25 @@ describe("AgentSession queue characterization", () => {
 	it("serializes concurrent refine calls", async () => {
 		const harness = await createAutoRefineHarness();
 		harnesses.push(harness);
-		let releaseFirstPlan: (() => void) | undefined;
-		const firstPlanGate = new Promise<void>((resolve) => {
-			releaseFirstPlan = resolve;
-		});
-		let firstPlanStarted: (() => void) | undefined;
-		const firstPlanStartedPromise = new Promise<void>((resolve) => {
-			firstPlanStarted = resolve;
-		});
+		const firstPlanGate = createDeferred();
+		const firstPlanStartedPromise = createDeferred();
 		harness.setResponses([
 			async () => {
-				firstPlanStarted?.();
-				await firstPlanGate;
-				return fauxAssistantMessage(
-					JSON.stringify({
-						summary: "first",
-						rationale: "first refine",
-						expectedOutcome: "first finished",
-						edits: [],
-					}),
-				);
+				firstPlanStartedPromise.resolve();
+				await firstPlanGate.promise;
+				return fauxAssistantMessage(refinePlanJson("first"));
 			},
-			fauxAssistantMessage(
-				JSON.stringify({
-					summary: "second",
-					rationale: "second refine",
-					expectedOutcome: "second finished",
-					edits: [],
-				}),
-			),
+			fauxAssistantMessage(refinePlanJson("second")),
 		]);
 
 		const firstRefine = harness.session.refine({ instructions: "first refine" });
-		await firstPlanStartedPromise;
+		await firstPlanStartedPromise.promise;
 		const secondRefine = harness.session.refine({ instructions: "second refine" });
 		await Promise.resolve();
 
 		expect(harness.getPendingResponseCount()).toBe(1);
 
-		releaseFirstPlan?.();
+		firstPlanGate.resolve();
 		await firstRefine;
 		await secondRefine;
 
@@ -660,33 +596,22 @@ describe("AgentSession queue characterization", () => {
 	it("does not persist or reconnect an in-flight refine after dispose", async () => {
 		const harness = await createAutoRefineHarness();
 		harnesses.push(harness);
-		let releasePlan: (() => void) | undefined;
-		const planGate = new Promise<void>((resolve) => {
-			releasePlan = resolve;
-		});
-		let planStarted: (() => void) | undefined;
-		const planStartedPromise = new Promise<void>((resolve) => {
-			planStarted = resolve;
-		});
+		const planGate = createDeferred();
+		const planStartedPromise = createDeferred();
 		harness.setResponses([
 			async () => {
-				planStarted?.();
-				await planGate;
+				planStartedPromise.resolve();
+				await planGate.promise;
 				return fauxAssistantMessage(
-					JSON.stringify({
-						summary: "stale refine",
-						rationale: "the session was disposed before apply",
-						expectedOutcome: "nothing is persisted",
-						edits: [
-							{
-								action: "create",
-								kind: "memory",
-								id: "stale_after_dispose",
-								title: "Stale after dispose",
-								content: "This must not be saved.",
-							},
-						],
-					}),
+					refinePlanJson("stale refine", [
+						{
+							action: "create",
+							kind: "memory",
+							id: "stale_after_dispose",
+							title: "Stale after dispose",
+							content: "This must not be saved.",
+						},
+					]),
 				);
 			},
 		]);
@@ -695,9 +620,9 @@ describe("AgentSession queue characterization", () => {
 		const entriesBeforeDispose = harness.sessionManager.getEntries().length;
 
 		const refine = harness.session.refine({ instructions: "write stale state" });
-		await planStartedPromise;
+		await planStartedPromise.promise;
 		harness.session.dispose();
-		releasePlan?.();
+		planGate.resolve();
 
 		await expect(refine).rejects.toThrow();
 		expect(reconnect).not.toHaveBeenCalled();
@@ -756,14 +681,11 @@ describe("AgentSession queue characterization", () => {
 	});
 
 	it("keeps queued work paused until tree navigation events settle", async () => {
-		let releaseTreeEvent: (() => void) | undefined;
-		const treeEvent = new Promise<void>((resolve) => {
-			releaseTreeEvent = resolve;
-		});
+		const treeEvent = createDeferred();
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_tree", async () => treeEvent);
+					pi.on("session_tree", async () => treeEvent.promise);
 				},
 			],
 		});
@@ -778,18 +700,15 @@ describe("AgentSession queue characterization", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(getUserTexts(harness)).not.toContain("after navigation");
 
-		releaseTreeEvent?.();
+		treeEvent.resolve();
 		await navigation;
 		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("after navigation"));
 	});
 
 	it("does not apply stale auto-refine cooldown when a review completes after branch navigation", async () => {
-		let finishReview: (() => void) | undefined;
-		const reviewStarted = new Promise<void>((resolve) => {
-			finishReview = resolve;
-		});
+		const reviewStarted = createDeferred();
 		const reviewer = vi.fn(async () => {
-			await reviewStarted;
+			await reviewStarted.promise;
 			return { shouldRefine: true, rationale: "old branch" };
 		});
 		const harness = await createAutoRefineHarness({
@@ -808,7 +727,7 @@ describe("AgentSession queue characterization", () => {
 			expect.any(AbortSignal),
 		);
 		await internals._invalidatePendingAutoRefineForBranchChange();
-		finishReview?.();
+		reviewStarted.resolve();
 		await autoRefinePromise;
 
 		expect(refine).not.toHaveBeenCalled();
@@ -817,12 +736,29 @@ describe("AgentSession queue characterization", () => {
 		expect(internals._pendingAutoRefineReview).toBeUndefined();
 	});
 
-	it("auto-refine is skipped for sessions without a local harness directory", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
-		const harness = await createHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
+	it.each([
+		{
+			name: "sessions without a local harness directory",
+			makeHarness: () =>
+				createHarness({
+					settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
+					autoRefineReviewer: skipReviewer,
+				}),
+			expectRefineChecked: true,
+		},
+		{
+			name: "subagent sessions",
+			makeHarness: () =>
+				createAutoRefineHarness({
+					settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
+					rlmDepth: 1,
+					autoRefineReviewer: skipReviewer,
+				}),
+			expectRefineChecked: false,
+		},
+	])("auto-refine is skipped for $name", async ({ makeHarness, expectRefineChecked }) => {
+		skipReviewer.mockClear();
+		const harness = await makeHarness();
 		harnesses.push(harness);
 		const internals = harness.session as unknown as AutoRefineInternals;
 		internals._assistantTurnsSinceAutoRefine = 1;
@@ -833,28 +769,8 @@ describe("AgentSession queue characterization", () => {
 		internals._scheduleAutoRefineAfterCompaction(false);
 		internals._scheduleAutoRefineAfterAgentEnd();
 
-		expect(reviewer).not.toHaveBeenCalled();
-		expect(refine).not.toHaveBeenCalled();
-		expect(scheduleAutoRefine).not.toHaveBeenCalled();
-	});
-
-	it("auto-refine is skipped for subagent sessions", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
-			rlmDepth: 1,
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 1;
-		const scheduleAutoRefine = vi.spyOn(internals, "_scheduleAutoRefine").mockImplementation(() => {});
-
-		await internals._maybeAutoRefine("turn_interval");
-		internals._scheduleAutoRefineAfterCompaction(false);
-		internals._scheduleAutoRefineAfterAgentEnd();
-
-		expect(reviewer).not.toHaveBeenCalled();
+		expect(skipReviewer).not.toHaveBeenCalled();
+		if (expectRefineChecked) expect(refine).not.toHaveBeenCalled();
 		expect(scheduleAutoRefine).not.toHaveBeenCalled();
 	});
 
@@ -872,282 +788,126 @@ describe("AgentSession queue characterization", () => {
 		expect(internals._compactAutoRefinePending).toBe(true);
 	});
 
-	it("auto-refine review obeys the cooldown", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 60_000 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 1;
-		internals._lastAutoRefineReviewAt = Date.now();
-
-		await internals._maybeAutoRefine("turn_interval");
-
-		expect(reviewer).not.toHaveBeenCalled();
-	});
-
-	it("auto-refine preserves a turn-interval checkpoint when cooldown is active", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 60_000 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 1;
-		internals._lastAutoRefineReviewAt = Date.now();
-
-		await internals._maybeAutoRefine("turn_interval");
-
-		expect(reviewer).not.toHaveBeenCalled();
-		expect(internals._turnIntervalAutoRefinePending).toBe(true);
-	});
-
-	it("auto-refine preserves a compact checkpoint when cooldown is active", async () => {
-		const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 60_000 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._lastAutoRefineReviewAt = Date.now();
-
-		await internals._maybeAutoRefine("compact");
-
-		expect(reviewer).not.toHaveBeenCalled();
-		expect(internals._compactAutoRefinePending).toBe(true);
-	});
-
-	it("queued follow-up messages do not make an idle agent active for auto-refine", async () => {
-		const reviewer = vi.fn(async () => ({
-			shouldRefine: true,
-			rationale: "durable lesson found",
-			instructions: "capture the durable lesson",
-		}));
-		const harness = await createAutoRefineHarness({
-			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
-			autoRefineReviewer: reviewer,
-		});
-		harnesses.push(harness);
-		const internals = harness.session as unknown as AutoRefineInternals;
-		internals._assistantTurnsSinceAutoRefine = 1;
-		vi.spyOn(harness.session.agent, "hasQueuedMessages").mockReturnValue(true);
-		const refine = vi.spyOn(harness.session, "refine").mockResolvedValue(emptyRefinementResult());
-
-		await internals._maybeAutoRefine("turn_interval");
-
-		expect(reviewer).toHaveBeenCalledWith(
-			{ reason: "turn_interval", turnsSinceLastReview: 1 },
-			expect.any(AbortSignal),
-		);
-		expect(refine).toHaveBeenCalled();
-	});
-
-	it("strips local display prefixes before applying local refine edits", async () => {
-		const harness = await createAutoRefineHarness();
-		harnesses.push(harness);
-		const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
-		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
-		try {
-			const globalDir = getGlobalHarnessStateDir();
-			const localDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir())!;
-			const globalState = loadHarnessState(globalDir, "global");
-			const localState = loadHarnessState(localDir, "local");
-			applyRefinementProposal(
-				globalState,
-				{
-					summary: "Global shared memory",
-					rationale: "seed",
-					expectedOutcome: "seeded",
-					edits: [
-						{
-							action: "create",
-							kind: "memory",
-							id: "shared",
-							title: "Shared",
-							content: "Global content",
-						},
-					],
-				},
-				{ id: "seed_global", scope: "global" },
-			);
-			applyRefinementProposal(
-				localState,
-				{
-					summary: "Local shared memory",
-					rationale: "seed",
-					expectedOutcome: "seeded",
-					edits: [
-						{
-							action: "create",
-							kind: "memory",
-							id: "shared",
-							title: "Shared",
-							content: "Local content",
-						},
-					],
-				},
-				{ id: "seed_local", scope: "local" },
-			);
-			saveHarnessState(globalDir, globalState);
-			saveHarnessState(localDir, localState);
-			harness.setResponses([
-				fauxAssistantMessage(
-					JSON.stringify({
-						summary: "Update local shared memory",
-						rationale: "The local display id was selected from merged state.",
-						expectedOutcome: "Only the local entry changes.",
-						edits: [
-							{
-								action: "update",
-								kind: "memory",
-								id: "local:shared",
-								title: "Shared",
-								content: "Updated local content",
-							},
-						],
-					}),
-				),
-			]);
-
-			const result = await harness.session.refine({ instructions: "update the local shared memory" });
-
-			expect(result.appliedEdits[0]).toMatchObject({ id: "shared", applied: true });
-			expect(loadHarnessState(localDir, "local").entries.memory.shared.content).toBe("Updated local content");
-			expect(loadHarnessState(globalDir, "global").entries.memory.shared.content).toBe("Global content");
-		} finally {
-			if (previousAgentDir === undefined) {
-				delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
-			} else {
-				process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
-			}
-		}
-	});
-
-	it("strips global display prefixes before applying local refine edits", async () => {
-		const harness = await createAutoRefineHarness();
-		harnesses.push(harness);
-		const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
-		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
-		try {
-			const localDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir())!;
-			const localState = loadHarnessState(localDir, "local");
-			applyRefinementProposal(
-				localState,
-				{
-					summary: "Local memory",
-					rationale: "seed",
-					expectedOutcome: "seeded",
-					edits: [
-						{
-							action: "create",
-							kind: "memory",
-							id: "shared",
-							title: "Shared",
-							content: "Local content",
-						},
-					],
-				},
-				{ id: "seed_local", scope: "local" },
-			);
-			saveHarnessState(localDir, localState);
-			harness.setResponses([
-				fauxAssistantMessage(
-					JSON.stringify({
-						summary: "Update local memory",
-						rationale: "The display id came from merged state.",
-						expectedOutcome: "The local entry changes without a prefixed id.",
-						edits: [
-							{
-								action: "update",
-								kind: "memory",
-								id: "global:shared",
-								title: "Shared",
-								content: "Updated local content",
-							},
-						],
-					}),
-				),
-			]);
-
-			const result = await harness.session.refine({ instructions: "update local memory" });
-
-			expect(result.appliedEdits[0]).toMatchObject({ id: "shared", applied: true });
-			expect(loadHarnessState(localDir, "local").entries.memory.shared.content).toBe("Updated local content");
-			expect(loadHarnessState(localDir, "local").entries.memory["global:shared"]).toBeUndefined();
-		} finally {
-			if (previousAgentDir === undefined) {
-				delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
-			} else {
-				process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
-			}
-		}
-	});
-
-	it("strips global display prefixes before applying global refine edits", async () => {
-		const harness = await createAutoRefineHarness();
-		harnesses.push(harness);
-		const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
-		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
-		try {
-			const globalDir = getGlobalHarnessStateDir();
-			const globalState = loadHarnessState(globalDir, "global");
-			applyRefinementProposal(
-				globalState,
-				{
-					summary: "Global shared memory",
-					rationale: "seed",
-					expectedOutcome: "seeded",
-					edits: [
-						{
-							action: "create",
-							kind: "memory",
-							id: "shared",
-							title: "Shared",
-							content: "Global content",
-						},
-					],
-				},
-				{ id: "seed_global", scope: "global" },
-			);
-			saveHarnessState(globalDir, globalState);
-			harness.setResponses([
-				fauxAssistantMessage(
-					JSON.stringify({
-						summary: "Update global shared memory",
-						rationale: "The global display id was selected from the overview.",
-						expectedOutcome: "Only the global entry changes.",
-						edits: [
-							{
-								action: "update",
-								kind: "memory",
-								id: "global:shared",
-								title: "Shared",
-								content: "Updated global content",
-							},
-						],
-					}),
-				),
-			]);
-
-			const result = await harness.session.refine({
-				instructions: "update the global shared memory",
-				global: true,
+	it.each([
+		{ reason: "turn_interval" as AutoRefineReason, turns: 1, pendingFlag: "_turnIntervalAutoRefinePending" as const },
+		{ reason: "compact" as AutoRefineReason, turns: 0, pendingFlag: "_compactAutoRefinePending" as const },
+	])(
+		"auto-refine review obeys the cooldown and preserves a $reason checkpoint",
+		async ({ reason, turns, pendingFlag }) => {
+			const reviewer = vi.fn(async () => ({ shouldRefine: true, rationale: "durable lesson" }));
+			const harness = await createAutoRefineHarness({
+				settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 60_000 } },
+				autoRefineReviewer: reviewer,
 			});
+			harnesses.push(harness);
+			const internals = harness.session as unknown as AutoRefineInternals;
+			internals._assistantTurnsSinceAutoRefine = turns;
+			internals._lastAutoRefineReviewAt = Date.now();
 
-			expect(result.appliedEdits[0]).toMatchObject({ id: "shared", applied: true });
-			expect(loadHarnessState(globalDir, "global").entries.memory.shared.content).toBe("Updated global content");
-		} finally {
-			if (previousAgentDir === undefined) {
-				delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
-			} else {
-				process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
+			await internals._maybeAutoRefine(reason);
+
+			expect(reviewer).not.toHaveBeenCalled();
+			expect(internals[pendingFlag]).toBe(true);
+		},
+	);
+
+	it.each([
+		{
+			name: "local display prefixes before applying local refine edits",
+			seedGlobal: true,
+			seedLocal: true,
+			editId: "local:shared",
+			refineOptions: { instructions: "update the local shared memory" },
+			updatedContent: "Updated local content",
+			expectLocalContent: "Updated local content" as string | undefined,
+			expectGlobalContent: "Global content" as string | undefined,
+		},
+		{
+			name: "global display prefixes before applying local refine edits",
+			seedGlobal: false,
+			seedLocal: true,
+			editId: "global:shared",
+			refineOptions: { instructions: "update local memory" },
+			updatedContent: "Updated local content",
+			expectLocalContent: "Updated local content" as string | undefined,
+			expectGlobalContent: undefined as string | undefined,
+		},
+		{
+			name: "global display prefixes before applying global refine edits",
+			seedGlobal: true,
+			seedLocal: false,
+			editId: "global:shared",
+			refineOptions: { instructions: "update the global shared memory", global: true },
+			updatedContent: "Updated global content",
+			expectLocalContent: undefined as string | undefined,
+			expectGlobalContent: "Updated global content" as string | undefined,
+		},
+	])(
+		"strips $name",
+		async ({
+			seedGlobal,
+			seedLocal,
+			editId,
+			refineOptions,
+			updatedContent,
+			expectLocalContent,
+			expectGlobalContent,
+		}) => {
+			const harness = await createAutoRefineHarness();
+			harnesses.push(harness);
+			const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
+			process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
+			try {
+				const globalDir = getGlobalHarnessStateDir();
+				const localDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir())!;
+				const seedMemory = (scope: "global" | "local", dir: string, content: string) => {
+					const state = loadHarnessState(dir, scope);
+					applyRefinementProposal(
+						state,
+						{
+							summary: `${scope} shared memory`,
+							rationale: "seed",
+							expectedOutcome: "seeded",
+							edits: [{ action: "create", kind: "memory", id: "shared", title: "Shared", content }],
+						},
+						{ id: `seed_${scope}`, scope },
+					);
+					saveHarnessState(dir, state);
+				};
+				if (seedGlobal) seedMemory("global", globalDir, "Global content");
+				if (seedLocal) seedMemory("local", localDir, "Local content");
+				harness.setResponses([
+					fauxAssistantMessage(
+						JSON.stringify({
+							summary: "Update shared memory",
+							rationale: "The display id was selected from merged state.",
+							expectedOutcome: "Only the targeted entry changes.",
+							edits: [
+								{ action: "update", kind: "memory", id: editId, title: "Shared", content: updatedContent },
+							],
+						}),
+					),
+				]);
+
+				const result = await harness.session.refine(refineOptions);
+
+				expect(result.appliedEdits[0]).toMatchObject({ id: "shared", applied: true });
+				if (expectLocalContent !== undefined) {
+					expect(loadHarnessState(localDir, "local").entries.memory.shared.content).toBe(expectLocalContent);
+					expect(loadHarnessState(localDir, "local").entries.memory["global:shared"]).toBeUndefined();
+				}
+				if (expectGlobalContent !== undefined) {
+					expect(loadHarnessState(globalDir, "global").entries.memory.shared.content).toBe(expectGlobalContent);
+				}
+			} finally {
+				if (previousAgentDir === undefined) {
+					delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
+				} else {
+					process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
+				}
 			}
-		}
-	});
+		},
+	);
 
 	it("rolls back copied local refinement history against the original local harness state", async () => {
 		const original = await createAutoRefineHarness();
@@ -1180,20 +940,15 @@ describe("AgentSession queue characterization", () => {
 			saveHarnessState(branchedLocalDir, branchedState);
 			original.setResponses([
 				fauxAssistantMessage(
-					JSON.stringify({
-						summary: "Create original local memory",
-						rationale: "seed",
-						expectedOutcome: "Original local entry exists.",
-						edits: [
-							{
-								action: "create",
-								kind: "memory",
-								id: "remember_me",
-								title: "Original memory",
-								content: "Original content should be rolled back.",
-							},
-						],
-					}),
+					refinePlanJson("Create original local memory", [
+						{
+							action: "create",
+							kind: "memory",
+							id: "remember_me",
+							title: "Original memory",
+							content: "Original content should be rolled back.",
+						},
+					]),
 				),
 			]);
 
@@ -1224,56 +979,37 @@ describe("AgentSession queue characterization", () => {
 		const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
 		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
 		try {
-			let releasePlan: (() => void) | undefined;
-			const planGate = new Promise<void>((resolve) => {
-				releasePlan = resolve;
-			});
-			let planStarted: (() => void) | undefined;
-			const planStartedPromise = new Promise<void>((resolve) => {
-				planStarted = resolve;
-			});
-			let releasePrompt: (() => void) | undefined;
-			const promptGate = new Promise<void>((resolve) => {
-				releasePrompt = resolve;
-			});
-			let promptStarted: (() => void) | undefined;
-			const promptStartedPromise = new Promise<void>((resolve) => {
-				promptStarted = resolve;
-			});
+			const planGate = createDeferred();
+			const planStartedPromise = createDeferred();
+			const promptGate = createDeferred();
+			const promptStartedPromise = createDeferred();
 			let promptSignal: AbortSignal | undefined;
 			harness.setResponses([
 				async () => {
-					planStarted?.();
-					await planGate;
-					return fauxAssistantMessage(
-						JSON.stringify({
-							summary: "no-op",
-							rationale: "nothing to change",
-							expectedOutcome: "unchanged",
-							edits: [],
-						}),
-					);
+					planStartedPromise.resolve();
+					await planGate.promise;
+					return fauxAssistantMessage(refinePlanJson("no-op"));
 				},
 				async (_context, options) => {
 					promptSignal = options?.signal;
-					promptStarted?.();
-					await promptGate;
+					promptStartedPromise.resolve();
+					await promptGate.promise;
 					return fauxAssistantMessage("prompt reply");
 				},
 			]);
 
 			const refinePromise = harness.session.refine({ instructions: "background refine" });
-			await planStartedPromise;
+			await planStartedPromise.promise;
 
 			const promptPromise = harness.session.prompt("hello during refine");
-			await promptStartedPromise;
+			await promptStartedPromise.promise;
 			// With backgrounded refine planning, the prompt does NOT wait for the
 			// planning LLM pass. It starts immediately and streams its response
 			// while planning is still in flight. The application phase waits for
 			// the agent to be idle before disconnecting and applying.
 			expect(harness.getPendingResponseCount()).toBe(0);
 
-			releasePlan?.();
+			planGate.resolve();
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 			expect(promptSignal?.aborted).toBe(false);
 
@@ -1284,7 +1020,7 @@ describe("AgentSession queue characterization", () => {
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 			expect(refineSettled).toBe(false);
 
-			releasePrompt?.();
+			promptGate.resolve();
 			await refinePromise;
 			await promptPromise;
 
@@ -1563,123 +1299,108 @@ describe("AgentSession queue characterization", () => {
 		expect(getAssistantTexts(harness)).toContain("saw steer");
 	});
 
-	it("coalesces follow-up messages with the same queue key", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
+	it.each([
+		{
+			name: "coalesces follow-up messages with the same queue key",
+			prompts: [
+				{ text: "heartbeat", key: "heartbeat:one" },
+				{ text: "heartbeat", key: "heartbeat:one" },
+			],
+			capturePreflightOnLast: false,
+			expectedPreflights: undefined as boolean[] | undefined,
+			removeKey: undefined as string | undefined,
+			expectedQueue: ["heartbeat"],
+			expectedFinalUsers: undefined as string[] | undefined,
+		},
+		{
+			name: "reports failed preflight when a duplicate follow-up queue key is not queued",
+			prompts: [
+				{ text: "heartbeat", key: "heartbeat:one" },
+				{ text: "heartbeat", key: "heartbeat:one" },
+			],
+			capturePreflightOnLast: true,
+			expectedPreflights: [false],
+			removeKey: undefined,
+			expectedQueue: ["heartbeat"],
+			expectedFinalUsers: undefined,
+		},
+		{
+			name: "keeps separate follow-up messages for different queue keys",
+			prompts: [
+				{ text: "heartbeat one", key: "heartbeat:one" },
+				{ text: "heartbeat two", key: "heartbeat:two" },
+			],
+			capturePreflightOnLast: false,
+			expectedPreflights: undefined,
+			removeKey: undefined,
+			expectedQueue: ["heartbeat one", "heartbeat two"],
+			expectedFinalUsers: undefined,
+		},
+		{
+			name: "removes only the matching coalesced follow-up when texts match",
+			prompts: [
+				{ text: "same heartbeat", key: "heartbeat:one" },
+				{ text: "same heartbeat", key: "heartbeat:two" },
+			],
+			capturePreflightOnLast: false,
+			expectedPreflights: undefined,
+			removeKey: "heartbeat:one",
+			expectedQueue: ["same heartbeat"],
+			expectedFinalUsers: ["start", "same heartbeat"],
+		},
+		{
+			name: "removes coalesced follow-up messages by queue key",
+			prompts: [{ text: "heartbeat", key: "heartbeat:one" }],
+			capturePreflightOnLast: false,
+			expectedPreflights: undefined,
+			removeKey: "heartbeat:one",
+			expectedQueue: [],
+			expectedFinalUsers: ["start"],
+		},
+	])(
+		"$name",
+		async ({ prompts, capturePreflightOnLast, expectedPreflights, removeKey, expectedQueue, expectedFinalUsers }) => {
+			const waiting = await createWaitingHarness();
+			const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+			harnesses.push(harness);
+			const preflightResults: boolean[] = [];
 
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("done"),
-		]);
-		await waitForToolStart;
-		await harness.session.prompt("heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
-		await harness.session.prompt("heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+				...prompts.map((_, index) => fauxAssistantMessage(`done ${index}`)),
+			]);
+			await waitForToolStart;
+			for (const [index, prompt] of prompts.entries()) {
+				await harness.session.prompt(prompt.text, {
+					streamingBehavior: "followUp",
+					followUpQueueKey: prompt.key,
+					...(capturePreflightOnLast && index === prompts.length - 1
+						? { preflightResult: (didSucceed: boolean) => preflightResults.push(didSucceed) }
+						: {}),
+				});
+			}
+			if (removeKey !== undefined) {
+				expect(harness.session.removeQueuedFollowUp(removeKey)).toBe(true);
+			}
 
-		expect(harness.session.getFollowUpMessages()).toEqual(["heartbeat"]);
+			if (expectedPreflights !== undefined) expect(preflightResults).toEqual(expectedPreflights);
+			expect(harness.session.getFollowUpMessages()).toEqual(expectedQueue);
 
-		releaseToolExecution();
-		await promptPromise;
-	});
-
-	it("reports failed preflight when a duplicate follow-up queue key is not queued", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-		const preflightResults: boolean[] = [];
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("done"),
-		]);
-		await waitForToolStart;
-		await harness.session.prompt("heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
-		await harness.session.prompt("heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-			preflightResult: (didSucceed) => preflightResults.push(didSucceed),
-		});
-
-		expect(preflightResults).toEqual([false]);
-		expect(harness.session.getFollowUpMessages()).toEqual(["heartbeat"]);
-		releaseToolExecution();
-		await promptPromise;
-	});
-
-	it("keeps separate follow-up messages for different queue keys", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("first done"),
-			fauxAssistantMessage("second done"),
-		]);
-		await waitForToolStart;
-		await harness.session.prompt("heartbeat one", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
-		await harness.session.prompt("heartbeat two", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:two",
-		});
-
-		expect(harness.session.getFollowUpMessages()).toEqual(["heartbeat one", "heartbeat two"]);
-
-		releaseToolExecution();
-		await promptPromise;
-	});
-
-	it("removes only the matching coalesced follow-up when texts match", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("done"),
-		]);
-		await waitForToolStart;
-		await harness.session.prompt("same heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
-		await harness.session.prompt("same heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:two",
-		});
-
-		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(true);
-		expect(harness.session.getFollowUpMessages()).toEqual(["same heartbeat"]);
-
-		releaseToolExecution();
-		await promptPromise;
-		expect(getUserTexts(harness)).toEqual(["start", "same heartbeat"]);
-	});
+			releaseToolExecution();
+			await promptPromise;
+			if (expectedFinalUsers !== undefined) expect(getUserTexts(harness)).toEqual(expectedFinalUsers);
+		},
+	);
 
 	it("removes preparing inputs and re-prepares when the last batch anchor changes", async () => {
-		let releaseFirstPreparation = () => {};
-		const firstPreparation = new Promise<void>((resolve) => {
-			releaseFirstPreparation = resolve;
-		});
+		const firstPreparation = createDeferred();
 		const prepared: string[] = [];
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
 					pi.on("before_agent_start", async (event) => {
 						prepared.push(event.prompt);
-						if (prepared.length === 1) await firstPreparation;
+						if (prepared.length === 1) await firstPreparation.promise;
 						return {
 							systemPrompt: `${event.systemPrompt}
 prepared:${event.prompt}`,
@@ -1690,22 +1411,17 @@ prepared:${event.prompt}`,
 		});
 		harnesses.push(harness);
 		harness.session.setFollowUpMode("all");
-		let releaseResponse = () => {};
-		const responseGate = new Promise<void>((resolve) => {
-			releaseResponse = resolve;
-		});
+		const responseGate = createDeferred();
 		let providerSystemPrompt = "";
 		harness.setResponses([
 			async (context) => {
 				providerSystemPrompt = context.systemPrompt ?? "";
-				await responseGate;
+				await responseGate.promise;
 				return fauxAssistantMessage("remaining response");
 			},
 		]);
-		const removedAgentMessage =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_remove\n\nremove";
-		const keptAgentMessage =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_keep\n\nkeep";
+		const removedAgentMessage = agentPromptText("agentmsg_remove", "remove");
+		const keptAgentMessage = agentPromptText("agentmsg_keep", "keep");
 		const pause = harness.session.acquireQueuedWorkPause();
 		await harness.session.followUp("ordinary");
 		await harness.session.queueAgentMessagePrompt(removedAgentMessage, "followUp", undefined);
@@ -1719,39 +1435,16 @@ prepared:${event.prompt}`,
 			followUp: [removedAgentMessage],
 		});
 		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(true);
-		releaseFirstPreparation();
+		firstPreparation.resolve();
 		await vi.waitFor(() => expect(providerSystemPrompt).not.toBe(""));
 		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(false);
-		releaseResponse();
+		responseGate.resolve();
 		await harness.session.waitForIdle();
 
 		expect(prepared).toEqual(["last anchor", keptAgentMessage]);
 		expect(providerSystemPrompt).toContain(`prepared:${keptAgentMessage}`);
 		expect(providerSystemPrompt).not.toContain("prepared:last anchor");
 		expect(getUserTexts(harness)).toEqual(["ordinary", keptAgentMessage]);
-	});
-
-	it("removes coalesced follow-up messages by queue key", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("done"),
-		]);
-		await waitForToolStart;
-		await harness.session.prompt("heartbeat", {
-			streamingBehavior: "followUp",
-			followUpQueueKey: "heartbeat:one",
-		});
-
-		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(true);
-		expect(harness.session.getFollowUpMessages()).toEqual([]);
-
-		releaseToolExecution();
-		await promptPromise;
-		expect(getUserTexts(harness)).toEqual(["start"]);
 	});
 
 	it("delivers follow-up messages only after the current run finishes", async () => {
@@ -1787,189 +1480,159 @@ prepared:${event.prompt}`,
 		expect(getAssistantTexts(harness)).toContain("follow-up response");
 	});
 
-	it("delivers multiple steering messages in order in one-at-a-time mode", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
+	it.each([
+		{
+			lane: "steering",
+			mode: "one-at-a-time" as const,
+			responses: [fauxAssistantMessage("handled steer 1"), fauxAssistantMessage("handled steer 2")],
+			queue: (harness: Harness) => [harness.session.steer("steer 1"), harness.session.steer("steer 2")],
+			expectedUsers: ["start", "steer 1", "steer 2"],
+			expectedAssistants: ["", "handled steer 1", "handled steer 2"],
+			expectedBatch: undefined as string[] | undefined,
+		},
+		{
+			lane: "follow-up",
+			mode: "one-at-a-time" as const,
+			responses: [
+				fauxAssistantMessage("original turn complete"),
+				fauxAssistantMessage("handled follow-up 1"),
+				fauxAssistantMessage("handled follow-up 2"),
+			],
+			queue: (harness: Harness) => [
+				harness.session.followUp("follow-up 1"),
+				harness.session.followUp("follow-up 2"),
+			],
+			expectedUsers: ["start", "follow-up 1", "follow-up 2"],
+			expectedAssistants: ["", "original turn complete", "handled follow-up 1", "handled follow-up 2"],
+			expectedBatch: undefined as string[] | undefined,
+		},
+		{
+			lane: "steering",
+			mode: "all" as const,
+			responses: [fauxAssistantMessage("batched steer response")],
+			queue: (harness: Harness) => [harness.session.steer("steer 1"), harness.session.steer("steer 2")],
+			expectedUsers: undefined,
+			expectedAssistants: ["", "batched steer response"],
+			expectedBatch: ["start", "steer 1", "steer 2"] as string[] | undefined,
+		},
+		{
+			lane: "follow-up",
+			mode: "all" as const,
+			responses: [
+				fauxAssistantMessage("original turn complete"),
+				fauxAssistantMessage("batched follow-up response"),
+			],
+			queue: (harness: Harness) => [
+				harness.session.followUp("follow-up 1"),
+				harness.session.followUp("follow-up 2"),
+			],
+			expectedUsers: undefined,
+			expectedAssistants: ["", "original turn complete", "batched follow-up response"],
+			expectedBatch: ["start", "follow-up 1", "follow-up 2"] as string[] | undefined,
+		},
+	])(
+		"delivers $lane messages in order in $mode mode",
+		async ({ lane, mode, responses, queue, expectedUsers, expectedAssistants, expectedBatch }) => {
+			const waiting = await createWaitingHarness();
+			const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+			harnesses.push(harness);
+			if (mode === "all") {
+				if (lane === "steering") harness.session.setSteeringMode("all");
+				else harness.session.setFollowUpMode("all");
+			}
+			let batchedUserMessages: string[] | undefined;
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+				...responses.slice(0, -1),
+				(context) => {
+					batchedUserMessages = context.messages
+						.filter((message) => message.role === "user")
+						.map((message) => getMessageText(message));
+					return responses[responses.length - 1]!;
+				},
+			]);
 
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("handled steer 1"),
-			fauxAssistantMessage("handled steer 2"),
-		]);
+			await waitForToolStart;
+			await Promise.all(queue(harness));
+			releaseToolExecution();
+			await promptPromise;
 
-		await waitForToolStart;
-		await harness.session.steer("steer 1");
-		await harness.session.steer("steer 2");
-		releaseToolExecution();
-		await promptPromise;
+			if (expectedUsers !== undefined) expect(getUserTexts(harness)).toEqual(expectedUsers);
+			if (expectedBatch !== undefined) expect(batchedUserMessages).toEqual(expectedBatch);
+			expect(getAssistantTexts(harness)).toEqual(expectedAssistants);
+		},
+	);
 
-		expect(getUserTexts(harness)).toEqual(["start", "steer 1", "steer 2"]);
-		expect(getAssistantTexts(harness)).toEqual(["", "handled steer 1", "handled steer 2"]);
-	});
+	it.each([
+		{
+			deliverAs: "steer" as const,
+			content: "steer custom" as string | ({ type: "text"; text: string } | ImageContent)[],
+			expectedText: "steer custom",
+			interimResponses: [] as ReturnType<typeof fauxAssistantMessage>[],
+			capturedPreparation: false,
+		},
+		{
+			deliverAs: "followUp" as const,
+			content: [
+				{ type: "text" as const, text: "follow-up custom" },
+				{ type: "image" as const, data: "image-data", mimeType: "image/png" },
+			] as string | ({ type: "text"; text: string } | ImageContent)[],
+			expectedText: "follow-up custom",
+			interimResponses: [fauxAssistantMessage("original turn complete")],
+			capturedPreparation: true,
+		},
+	])(
+		"queues custom messages with deliverAs $deliverAs while streaming",
+		async ({ deliverAs, content, expectedText, interimResponses, capturedPreparation }) => {
+			const waiting = await createWaitingHarness();
+			const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+			harnesses.push(harness);
+			let sawCustomMessage = false;
+			let preparedText: string | undefined;
+			let preparedImages: ImageContent[] | undefined;
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+				...interimResponses,
+				(context) => {
+					sawCustomMessage = context.messages.some(
+						(message) =>
+							message.role === "user" &&
+							typeof message.content !== "string" &&
+							message.content.some((part) => part.type === "text" && part.text === expectedText),
+					);
+					return fauxAssistantMessage("done");
+				},
+			]);
 
-	it("delivers multiple follow-up messages in order in one-at-a-time mode", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("original turn complete"),
-			fauxAssistantMessage("handled follow-up 1"),
-			fauxAssistantMessage("handled follow-up 2"),
-		]);
-
-		await waitForToolStart;
-		await harness.session.followUp("follow-up 1");
-		await harness.session.followUp("follow-up 2");
-		releaseToolExecution();
-		await promptPromise;
-
-		expect(getUserTexts(harness)).toEqual(["start", "follow-up 1", "follow-up 2"]);
-		expect(getAssistantTexts(harness)).toEqual([
-			"",
-			"original turn complete",
-			"handled follow-up 1",
-			"handled follow-up 2",
-		]);
-	});
-
-	it("delivers all steering messages in one batch in all mode", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-		harness.session.setSteeringMode("all");
-		let batchedUserMessages: string[] = [];
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			(context) => {
-				batchedUserMessages = context.messages
-					.filter((message) => message.role === "user")
-					.map((message) => getMessageText(message));
-				return fauxAssistantMessage("batched steer response");
-			},
-		]);
-
-		await waitForToolStart;
-		await harness.session.steer("steer 1");
-		await harness.session.steer("steer 2");
-		releaseToolExecution();
-		await promptPromise;
-
-		expect(batchedUserMessages).toEqual(["start", "steer 1", "steer 2"]);
-		expect(getAssistantTexts(harness)).toEqual(["", "batched steer response"]);
-	});
-
-	it("delivers all follow-up messages in one batch in all mode", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-		harness.session.setFollowUpMode("all");
-		let batchedUserMessages: string[] = [];
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("original turn complete"),
-			(context) => {
-				batchedUserMessages = context.messages
-					.filter((message) => message.role === "user")
-					.map((message) => getMessageText(message));
-				return fauxAssistantMessage("batched follow-up response");
-			},
-		]);
-
-		await waitForToolStart;
-		await harness.session.followUp("follow-up 1");
-		await harness.session.followUp("follow-up 2");
-		releaseToolExecution();
-		await promptPromise;
-
-		expect(batchedUserMessages).toEqual(["start", "follow-up 1", "follow-up 2"]);
-		expect(getAssistantTexts(harness)).toEqual(["", "original turn complete", "batched follow-up response"]);
-	});
-
-	it("queues custom messages with deliverAs steer while streaming", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-		let sawCustomMessage = false;
-
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			(context) => {
-				sawCustomMessage = context.messages.some(
-					(message) =>
-						message.role === "user" &&
-						typeof message.content !== "string" &&
-						message.content.some((part) => part.type === "text" && part.text === "steer custom"),
+			await waitForToolStart;
+			if (capturedPreparation) {
+				vi.spyOn(harness.session.extensionRunner, "emitBeforeAgentStart").mockImplementationOnce(
+					async (text, images) => {
+						preparedText = text;
+						preparedImages = images;
+						return undefined;
+					},
 				);
-				return fauxAssistantMessage("done");
-			},
-		]);
+			}
+			await harness.session.sendCustomMessage(
+				{ customType: "queue-test", content, display: true, details: { value: 1 } },
+				{ deliverAs },
+			);
+			releaseToolExecution();
+			await promptPromise;
 
-		await waitForToolStart;
-		await harness.session.sendCustomMessage(
-			{ customType: "queue-test", content: "steer custom", display: true, details: { value: 1 } },
-			{ deliverAs: "steer" },
-		);
-		releaseToolExecution();
-		await promptPromise;
-
-		expect(sawCustomMessage).toBe(true);
-		expect(
-			harness.session.messages.some((message) => message.role === "custom" && message.customType === "queue-test"),
-		).toBe(true);
-	});
-
-	it("queues custom messages with deliverAs followUp while streaming", async () => {
-		const waiting = await createWaitingHarness();
-		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
-		harnesses.push(harness);
-		let sawCustomMessage = false;
-		let preparedText: string | undefined;
-		let preparedImages: ImageContent[] | undefined;
-		const image = { type: "image" as const, data: "image-data", mimeType: "image/png" };
-		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
-			fauxAssistantMessage("original turn complete"),
-			(context) => {
-				sawCustomMessage = context.messages.some(
-					(message) =>
-						message.role === "user" &&
-						typeof message.content !== "string" &&
-						message.content.some((part) => part.type === "text" && part.text === "follow-up custom"),
-				);
-				return fauxAssistantMessage("done");
-			},
-		]);
-
-		await waitForToolStart;
-		vi.spyOn(harness.session.extensionRunner, "emitBeforeAgentStart").mockImplementationOnce(async (text, images) => {
-			preparedText = text;
-			preparedImages = images;
-			return undefined;
-		});
-		await harness.session.sendCustomMessage(
-			{
-				customType: "queue-test",
-				content: [{ type: "text", text: "follow-up custom" }, image],
-				display: true,
-				details: { value: 1 },
-			},
-			{ deliverAs: "followUp" },
-		);
-		releaseToolExecution();
-		await promptPromise;
-
-		expect(sawCustomMessage).toBe(true);
-		expect(preparedText).toBe("follow-up custom");
-		expect(preparedImages).toEqual([image]);
-		expect(
-			harness.session.messages.some((message) => message.role === "custom" && message.customType === "queue-test"),
-		).toBe(true);
-	});
+			expect(sawCustomMessage).toBe(true);
+			if (capturedPreparation) {
+				expect(preparedText).toBe(expectedText);
+				expect(preparedImages).toEqual([{ type: "image", data: "image-data", mimeType: "image/png" }]);
+			}
+			expect(
+				harness.session.messages.some(
+					(message) => message.role === "custom" && message.customType === "queue-test",
+				),
+			).toBe(true);
+		},
+	);
 
 	it("injects nextTurn custom messages into the next prompt", async () => {
 		const harness = await createHarness();
@@ -2044,45 +1707,44 @@ prepared:${event.prompt}`,
 		expect(harness.session.pendingMessageCount).toBe(0);
 	});
 
-	it("clears only internally queued agent-message prompts", async () => {
+	function agentPromptText(id: string, body: string): string {
+		return `Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: ${id}\n\n${body}`;
+	}
+
+	it.each([
+		{
+			name: "only internally queued agent-message prompts",
+			lane: "followUp" as const,
+			plain: agentPromptText("agentmsg_spoof", "ordinary user text"),
+			internal: agentPromptText("agentmsg_real", "real agent text"),
+		},
+		{
+			name: "internally queued agent-message steering prompts by message identity",
+			lane: "steer" as const,
+			plain: agentPromptText("agentmsg_shared", "shared text"),
+			internal: agentPromptText("agentmsg_shared", "shared text"),
+		},
+	])("clears $name", async ({ lane, plain, internal }) => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const spoofed =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_spoof\n\nordinary user text";
-		const real =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_real\n\nreal agent text";
 
-		await harness.session.followUp(spoofed);
-		await harness.session.queueAgentMessagePrompt(real, "followUp");
+		if (lane === "followUp") await harness.session.followUp(plain);
+		else await harness.session.steer(plain);
+		await harness.session.queueAgentMessagePrompt(internal, lane);
 
 		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
-			steering: [],
-			followUp: [real],
+			steering: lane === "steer" ? [internal] : [],
+			followUp: lane === "followUp" ? [internal] : [],
 		});
-		expect(harness.session.getFollowUpMessages()).toEqual([spoofed]);
-	});
-
-	it("clears internally queued agent-message steering prompts by message identity", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const sharedText =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_shared\n\nshared text";
-
-		await harness.session.steer(sharedText);
-		await harness.session.queueAgentMessagePrompt(sharedText, "steer");
-
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
-			steering: [sharedText],
-			followUp: [],
-		});
-		expect(harness.session.getSteeringMessages()).toEqual([sharedText]);
+		const remaining =
+			lane === "followUp" ? harness.session.getFollowUpMessages() : harness.session.getSteeringMessages();
+		expect(remaining).toEqual([plain]);
 	});
 
 	it("clears the agent queue when a queue update listener clears a newly queued steering prompt", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const agentPrompt =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_queue_update_clear\n\nclear during update";
+		const agentPrompt = agentPromptText("agentmsg_queue_update_clear", "clear during update");
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_queue_update_clear");
 		let cleared = false;
 		const unsubscribe = harness.session.subscribe((event) => {
@@ -2133,8 +1795,7 @@ prepared:${event.prompt}`,
 	it("keeps queued agent-message delivery waiters pending on abort until the message is delivered", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const agentPrompt =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_abort\n\nsurvive the abort";
+		const agentPrompt = agentPromptText("agentmsg_abort", "survive the abort");
 		harness.setResponses([fauxAssistantMessage("x".repeat(20_000))]);
 
 		const sawMessageUpdate = new Promise<void>((resolve) => {
@@ -2179,36 +1840,32 @@ prepared:${event.prompt}`,
 	});
 
 	it("resolves queued delivery when message_start is received", async () => {
-		let releaseTurnStart = () => {};
-		const blocked = new Promise<void>((resolve) => {
-			releaseTurnStart = resolve;
-		});
+		const blocked = createDeferred();
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
-					pi.on("turn_start", async () => blocked);
+					pi.on("turn_start", async () => blocked.promise);
 				},
 			],
 		});
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("done")]);
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 		await harness.session.followUp("agent message", undefined, {
 			agentMessageId: "agentmsg_sync",
 			resumeIfIdle: true,
 		});
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		withStreaming(harness, false);
 
 		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
-		releaseTurnStart();
+		blocked.resolve();
 		await harness.session.waitForIdle();
 	});
 
 	it("resolves direct agent-message delivery waiters when the accepted prompt starts", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const agentPrompt =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_direct\n\ndirect delivery";
+		const agentPrompt = agentPromptText("agentmsg_direct", "direct delivery");
 		harness.setResponses([fauxAssistantMessage("direct reply")]);
 
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_direct");
@@ -2220,8 +1877,7 @@ prepared:${event.prompt}`,
 	it("rejects queued agent-message delivery waiters on dispose", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		const agentPrompt =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_dispose\n\ndispose me";
+		const agentPrompt = agentPromptText("agentmsg_dispose", "dispose me");
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_dispose");
 
 		await harness.session.queueAgentMessagePrompt(agentPrompt, "followUp");
@@ -2230,7 +1886,10 @@ prepared:${event.prompt}`,
 		await expect(delivery).rejects.toThrow("cleared before delivery");
 	});
 
-	it("throws when queueing an extension command with steer", async () => {
+	it.each([
+		{ behavior: "steer", queue: (harness: Harness) => harness.session.steer("/testcmd queued") },
+		{ behavior: "followUp", queue: (harness: Harness) => harness.session.followUp("/testcmd queued") },
+	])("throws when queueing an extension command with $behavior", async ({ queue }) => {
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
@@ -2243,25 +1902,7 @@ prepared:${event.prompt}`,
 		});
 		harnesses.push(harness);
 
-		await expect(harness.session.steer("/testcmd queued")).rejects.toThrow(
-			'Extension command "/testcmd" cannot be queued. Use prompt() or execute the command when not streaming.',
-		);
-	});
-
-	it("throws when queueing an extension command with followUp", async () => {
-		const harness = await createHarness({
-			extensionFactories: [
-				(pi) => {
-					pi.registerCommand("testcmd", {
-						description: "Test command",
-						handler: async () => {},
-					});
-				},
-			],
-		});
-		harnesses.push(harness);
-
-		await expect(harness.session.followUp("/testcmd queued")).rejects.toThrow(
+		await expect(queue(harness)).rejects.toThrow(
 			'Extension command "/testcmd" cannot be queued. Use prompt() or execute the command when not streaming.',
 		);
 	});
@@ -2430,7 +2071,7 @@ prepared:${event.prompt}`,
 	it("preserves queued command images in restart snapshots", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 		const image = { type: "image" as const, mimeType: "image/png", data: "image-data" };
 
 		await harness.session.prompt("/goal inspect image", { streamingBehavior: "followUp", images: [image] });
@@ -2444,7 +2085,7 @@ prepared:${event.prompt}`,
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.session.pauseQueuedWork();
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 
 		await harness.session.steer("first", undefined, { queueKey: "same" });
 		await harness.session.steer("second", undefined, { queueKey: "same" });
@@ -2469,9 +2110,9 @@ prepared:${event.prompt}`,
 		});
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("queued done"), fauxAssistantMessage("direct done")]);
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 		await harness.session.followUp("queued", undefined, { queueKey: "same", resumeIfIdle: true });
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		withStreaming(harness, false);
 		await vi.waitFor(() => expect(pause).toBeDefined());
 
 		expect(await harness.session.followUp("duplicate", undefined, { queueKey: "same" })).toBe(false);
@@ -2490,13 +2131,13 @@ prepared:${event.prompt}`,
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 		await harness.session.bindExtensions({ onError: (error) => errors.push(error.error) });
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 		await harness.session.followUp("cannot start", undefined, {
 			agentMessageId: "agentmsg_terminal",
 			resumeIfIdle: true,
 		});
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		withStreaming(harness, false);
 		await harness.session.waitForSessionInputIdle();
 
 		await expect(delivery).rejects.toThrow("No API key");
@@ -2540,39 +2181,24 @@ prepared:${event.prompt}`,
 	])("rejects skip-abort $action while a turn is active", async ({ action, run }) => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		setAgentStreaming(harness, true);
+		withStreaming(harness, true);
 
 		await expect(run(harness)).rejects.toThrow(`Cannot ${action} without aborting while the agent is running.`);
 	});
 
 	it("serializes queued prompt preparation with a direct prompt handoff", async () => {
-		let releaseDirectPreparation = () => {};
-		const directPreparation = new Promise<void>((resolve) => {
-			releaseDirectPreparation = resolve;
-		});
-		let directPreparing = false;
-		const harness = await createHarness({
-			extensionFactories: [
-				(pi) => {
-					pi.on("before_agent_start", async (event) => {
-						if (event.prompt === "direct") {
-							directPreparing = true;
-							await directPreparation;
-						}
-					});
-				},
-			],
-		});
+		const gate = gatedHook({ prompt: "direct" });
+		const harness = await createHarness({ extensionFactories: [gate.factory] });
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("direct done"), fauxAssistantMessage("queued done")]);
 
 		const direct = harness.session.prompt("direct");
-		await vi.waitFor(() => expect(directPreparing).toBe(true));
+		await gate.reached;
 		await harness.session.followUp("queued", undefined, { resumeIfIdle: true });
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		expect(getUserTexts(harness)).toEqual([]);
 
-		releaseDirectPreparation();
+		gate.release();
 		await direct;
 		await harness.session.waitForIdle();
 		expect(getUserTexts(harness)).toEqual(["direct", "queued"]);
@@ -2607,17 +2233,14 @@ prepared:${event.prompt}`,
 
 	it("serializes an extension command behind an unrelated navigation owner", async () => {
 		let targetId: string | undefined;
-		let releaseNavigation = () => {};
-		const navigationGate = new Promise<void>((resolve) => {
-			releaseNavigation = resolve;
-		});
+		const navigationGate = createDeferred();
 		let navigationStarts = 0;
 		let commandNavigated = false;
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
 					pi.on("session_before_tree", async () => {
-						if (navigationStarts++ === 0) await navigationGate;
+						if (navigationStarts++ === 0) await navigationGate.promise;
 					});
 					pi.registerCommand("back", {
 						description: "Navigate back",
@@ -2653,7 +2276,7 @@ prepared:${event.prompt}`,
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		expect(commandNavigated).toBe(false);
 
-		releaseNavigation();
+		navigationGate.resolve();
 		await unrelatedNavigation;
 		await extensionCommand;
 		expect(commandNavigated).toBe(true);
@@ -2662,20 +2285,14 @@ prepared:${event.prompt}`,
 	});
 
 	it("waitForIdle observes a run that starts at its final idle boundary", async () => {
-		let releaseResponse = () => {};
-		const responseGate = new Promise<void>((resolve) => {
-			releaseResponse = resolve;
-		});
-		let responseStarted = () => {};
-		const waitForResponseStart = new Promise<void>((resolve) => {
-			responseStarted = resolve;
-		});
+		const responseGate = createDeferred();
+		const waitForResponseStart = createDeferred();
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([
 			async () => {
-				responseStarted();
-				await responseGate;
+				waitForResponseStart.resolve();
+				await responseGate.promise;
 				return fauxAssistantMessage("late done");
 			},
 		]);
@@ -2690,11 +2307,11 @@ prepared:${event.prompt}`,
 		const waiting = harness.session.waitForIdle().then(() => {
 			idle = true;
 		});
-		await waitForResponseStart;
+		await waitForResponseStart.promise;
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		expect(idle).toBe(false);
 
-		releaseResponse();
+		responseGate.resolve();
 		await waiting;
 		expect(idle).toBe(true);
 	});

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -756,6 +756,30 @@ describe("AgentSession queue characterization", () => {
 		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("after navigation"));
 	});
 
+	it("queueIfBusy enqueues behind pending work instead of draining it first", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first done"), fauxAssistantMessage("second done")]);
+		withStreaming(harness, true);
+		await harness.session.followUp("already queued", undefined, { queueKey: "existing" });
+		withStreaming(harness, false);
+
+		let queuedAtPreflight: boolean | undefined;
+		await harness.session.prompt("respects the queue", {
+			queueIfBusy: true,
+			streamingBehavior: "followUp",
+			preflightResult: (_success, queued) => {
+				queuedAtPreflight ??= queued;
+			},
+		});
+		await harness.session.waitForIdle();
+
+		// The prompt joined the queue rather than waiting for it to drain and
+		// starting a direct turn; delivery order proves queue membership.
+		expect(queuedAtPreflight).toBe(true);
+		expect(getUserTexts(harness)).toEqual(["already queued", "respects the queue"]);
+	});
+
 	it("invalidates queued prompt preparation on branch navigation", async () => {
 		let pause: { release(): void } | undefined;
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1491,6 +1491,40 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["kept"]);
 	});
 
+	it("does not start a queued turn after abortForUpdateRestart", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let providerCalls = 0;
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		harness.setResponses([
+			async () => {
+				await firstGate;
+				return fauxAssistantMessage("first done");
+			},
+			() => {
+				providerCalls++;
+				return fauxAssistantMessage("must not run");
+			},
+		]);
+
+		const first = harness.session.prompt("first");
+		await vi.waitFor(() => expect(harness.session.isStreaming).toBe(true));
+		await harness.session.followUp("queued for restart");
+		harness.session.abortForUpdateRestart();
+		releaseFirst?.();
+		await first.catch(() => undefined);
+		await harness.session.agent.waitForIdle();
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		// The queued input must survive into the restart manifest instead of
+		// starting a fresh turn during teardown.
+		expect(providerCalls).toBe(0);
+		expect(harness.session.getFollowUpMessages()).toEqual(["queued for restart"]);
+	});
+
 	it("delivers follow-up messages only after the current run finishes", async () => {
 		const waiting = await createWaitingHarness();
 		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -5,6 +5,12 @@ import { fauxAssistantMessage, fauxToolCall, type ImageContent } from "@earendil
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	AGENT_MESSAGE_SOURCE,
+	type AgentSessionMessagePayload,
+	createAgentSessionMessage,
+	createAgentSessionMessagePrompt,
+} from "../../src/core/agent-messages.js";
 import { createSessionSlashCommandMessage } from "../../src/core/messages.js";
 import {
 	applyRefinementProposal,
@@ -1947,6 +1953,46 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toContain(agentPrompt);
 	});
 
+	it("keeps a second one-at-a-time input queued when both use the same message object", async () => {
+		const firstResponse = createDeferred();
+		const firstProviderStarted = createDeferred();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.session.setFollowUpMode("one-at-a-time");
+		harness.setResponses([
+			async () => {
+				firstProviderStarted.resolve();
+				await firstResponse.promise;
+				return fauxAssistantMessage("first done");
+			},
+			fauxAssistantMessage("second done"),
+		]);
+		const payload: AgentSessionMessagePayload = {
+			id: "agentmsg_same_object",
+			source: AGENT_MESSAGE_SOURCE,
+			message: "same object",
+			deliveryMode: "follow_up" as const,
+			target: { activeSessionId: "worker-active", sessionId: "worker-session" },
+		};
+		const message = createAgentSessionMessage(payload);
+		const prompt = createAgentSessionMessagePrompt(payload);
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.queueAgentMessagePrompt(prompt, "followUp", message);
+		await harness.session.queueAgentMessagePrompt(prompt, "followUp", message);
+		pause.release();
+
+		await firstProviderStarted.promise;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(harness.session.pendingMessageCount).toBe(1);
+		expect(harness.session.getFollowUpMessages()).toEqual([prompt]);
+		firstResponse.resolve();
+		await harness.session.waitForIdle();
+
+		expect(harness.session.pendingMessageCount).toBe(0);
+		expect(harness.session.messages.filter((item) => item === message)).toHaveLength(2);
+		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
+	});
+
 	it("resolves queued delivery when message_start is received", async () => {
 		const blocked = createDeferred();
 		const harness = await createHarness({
@@ -2143,6 +2189,58 @@ prepared:${event.prompt}`,
 		expect(
 			harness.session.messages.filter((message) => message.role === "custom").map((message) => message.content),
 		).toEqual(["first", "second"]);
+	});
+
+	it("rejects triggerTurn promptly when pending input is suspended", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await harness.session.restoreFollowUpMessage("suspended");
+		harness.session.abortForUpdateRestart();
+		const prompt = vi.spyOn(harness.session.agent, "prompt");
+
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "trigger", content: "trigger", display: false },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("queued session input is suspended");
+
+		expect(prompt).not.toHaveBeenCalled();
+		expect(harness.session.getFollowUpMessages()).toEqual(["suspended"]);
+	});
+
+	it("rejects disposal while direct admission waits behind a pause", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const pause = harness.session.acquireQueuedWorkPause();
+		const release = vi.spyOn(pause, "release");
+		const prompt = vi.spyOn(harness.session.agent, "prompt");
+		const trigger = harness.session.sendCustomMessage(
+			{ customType: "trigger", content: "trigger", display: false },
+			{ triggerTurn: true },
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		harness.session.dispose();
+		await expect(trigger).rejects.toThrow("session is disposing or disposed");
+
+		expect(prompt).not.toHaveBeenCalled();
+		expect(release).not.toHaveBeenCalled();
+	});
+
+	it("rejects a post-disposal direct call without prompting the agent", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const prompt = vi.spyOn(harness.session.agent, "prompt");
+		harness.session.dispose();
+
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "trigger", content: "trigger", display: false },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("session is disposing or disposed");
+		expect(prompt).not.toHaveBeenCalled();
 	});
 
 	it("resumes explicitly admitted and restored work after abort", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -756,6 +756,43 @@ describe("AgentSession queue characterization", () => {
 		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("after navigation"));
 	});
 
+	it("invalidates queued prompt preparation on branch navigation", async () => {
+		let pause: { release(): void } | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => {
+						if (event.prompt === "queued" && !pause) pause = harness.session.acquireQueuedWorkPause();
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one")]);
+		await harness.session.prompt("first");
+		const target = harness.sessionManager.getEntries().find((entry) => entry.type === "message");
+		expect(target).toBeDefined();
+
+		// Preparation completes, then the pause defers the handoff and requeues.
+		withStreaming(harness, true);
+		await harness.session.followUp("queued", undefined, { resumeIfIdle: true });
+		withStreaming(harness, false);
+		await vi.waitFor(() => expect(pause).toBeDefined());
+		await harness.session.waitForSessionInputIdle();
+		const queued = (harness.session as unknown as { _followUpMessages: { preparation?: unknown }[] })
+			._followUpMessages;
+		await vi.waitFor(() => expect(queued[0]?.preparation).toBeDefined());
+
+		// The branch switch must clear the cached preparation so
+		// before_agent_start re-runs against the new context on the next pump.
+		const navigation = harness.session.navigateTree(target!.id, { summarize: false });
+		pause?.release();
+		pause = undefined;
+		await navigation;
+
+		expect(queued[0]?.preparation).toBeUndefined();
+	});
+
 	it("does not apply stale auto-refine cooldown when a review completes after branch navigation", async () => {
 		const reviewStarted = createDeferred();
 		const reviewer = vi.fn(async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2442,4 +2442,44 @@ describe("AgentSession queue characterization", () => {
 			"Cannot refine without aborting while the agent is running.",
 		);
 	});
+	it("waits for an earlier direct handoff before executing a session command", async () => {
+		let releaseBeforeAgentStart: (() => void) | undefined;
+		const beforeAgentStartGate = new Promise<void>((resolve) => {
+			releaseBeforeAgentStart = resolve;
+		});
+		let directHandoffStarted: (() => void) | undefined;
+		const waitForDirectHandoff = new Promise<void>((resolve) => {
+			directHandoffStarted = resolve;
+		});
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => {
+						if (event.prompt === "earlier direct prompt") await beforeAgentStartGate;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			async () => {
+				directHandoffStarted?.();
+				return fauxAssistantMessage("direct done");
+			},
+		]);
+
+		const direct = harness.session.prompt("earlier direct prompt");
+		await vi.waitFor(() => expect(releaseBeforeAgentStart).toBeDefined());
+		const command = harness.session.prompt("/autonomous on");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
+
+		releaseBeforeAgentStart?.();
+		await waitForDirectHandoff;
+		await direct;
+		await command;
+
+		expect(harness.session.getAutonomousStatus().enabled).toBe(true);
+		expect(getUserTexts(harness)).toEqual(["earlier direct prompt"]);
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2433,15 +2433,23 @@ describe("AgentSession queue characterization", () => {
 		expect(getAssistantTexts(harness)).toEqual(["", "second handled"]);
 	});
 
-	it("rejects skip-abort refinement while a turn is active", async () => {
+	it.each([
+		{
+			action: "refine",
+			run: (harness: Harness) => harness.session.refine({}, { skipAbort: true }),
+		},
+		{
+			action: "compact",
+			run: (harness: Harness) => harness.session.compact(undefined, { skipAbort: true }),
+		},
+	])("rejects skip-abort $action while a turn is active", async ({ action, run }) => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		setAgentStreaming(harness, true);
 
-		await expect(harness.session.refine({}, { skipAbort: true })).rejects.toThrow(
-			"Cannot refine without aborting while the agent is running.",
-		);
+		await expect(run(harness)).rejects.toThrow(`Cannot ${action} without aborting while the agent is running.`);
 	});
+
 	it("serializes queued prompt preparation with a direct prompt handoff", async () => {
 		let releaseDirectPreparation = () => {};
 		const directPreparation = new Promise<void>((resolve) => {
@@ -2538,56 +2546,5 @@ describe("AgentSession queue characterization", () => {
 		releaseResponse();
 		await waiting;
 		expect(idle).toBe(true);
-	});
-
-	it("rejects skip-abort compaction while a turn is active", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		setAgentStreaming(harness, true);
-
-		await expect(harness.session.compact(undefined, { skipAbort: true })).rejects.toThrow(
-			"Cannot compact without aborting while the agent is running.",
-		);
-	});
-
-	it("waits for an earlier direct handoff before executing a session command", async () => {
-		let releaseBeforeAgentStart: (() => void) | undefined;
-		const beforeAgentStartGate = new Promise<void>((resolve) => {
-			releaseBeforeAgentStart = resolve;
-		});
-		let directHandoffStarted: (() => void) | undefined;
-		const waitForDirectHandoff = new Promise<void>((resolve) => {
-			directHandoffStarted = resolve;
-		});
-		const harness = await createHarness({
-			extensionFactories: [
-				(pi) => {
-					pi.on("before_agent_start", async (event) => {
-						if (event.prompt === "earlier direct prompt") await beforeAgentStartGate;
-					});
-				},
-			],
-		});
-		harnesses.push(harness);
-		harness.setResponses([
-			async () => {
-				directHandoffStarted?.();
-				return fauxAssistantMessage("direct done");
-			},
-		]);
-
-		const direct = harness.session.prompt("earlier direct prompt");
-		await vi.waitFor(() => expect(releaseBeforeAgentStart).toBeDefined());
-		const command = harness.session.prompt("/autonomous on");
-		await new Promise<void>((resolve) => setImmediate(resolve));
-		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
-
-		releaseBeforeAgentStart?.();
-		await waitForDirectHandoff;
-		await direct;
-		await command;
-
-		expect(harness.session.getAutonomousStatus().enabled).toBe(true);
-		expect(getUserTexts(harness)).toEqual(["earlier direct prompt"]);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -729,6 +729,34 @@ describe("AgentSession queue characterization", () => {
 		expect(internals._assistantTurnsSinceAutoRefine).toBe(0);
 	});
 
+	it("keeps queued work paused until tree navigation events settle", async () => {
+		let releaseTreeEvent: (() => void) | undefined;
+		const treeEvent = new Promise<void>((resolve) => {
+			releaseTreeEvent = resolve;
+		});
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_tree", async () => treeEvent);
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("queued")]);
+		await harness.session.prompt("first");
+		const target = harness.sessionManager.getEntries().find((entry) => entry.type === "message");
+		expect(target).toBeDefined();
+
+		const navigation = harness.session.navigateTree(target!.id, { summarize: false });
+		await harness.session.followUp("after navigation", undefined, { resumeIfIdle: true });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(getUserTexts(harness)).not.toContain("after navigation");
+
+		releaseTreeEvent?.();
+		await navigation;
+		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("after navigation"));
+	});
+
 	it("does not apply stale auto-refine cooldown when a review completes after branch navigation", async () => {
 		let finishReview: (() => void) | undefined;
 		const reviewStarted = new Promise<void>((resolve) => {
@@ -2093,5 +2121,206 @@ describe("AgentSession queue characterization", () => {
 		await expect(harness.session.followUp("/testcmd queued")).rejects.toThrow(
 			'Extension command "/testcmd" cannot be queued. Use prompt() or execute the command when not streaming.',
 		);
+	});
+
+	it("keeps admitted prompts in session queues instead of Agent queues", async () => {
+		const waiting = await createWaitingHarness();
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("handled queued prompt"),
+		]);
+		await waitForToolStart;
+		await harness.session.followUp("session owned", undefined, { resumeIfIdle: true });
+
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+		expect(harness.session.getFollowUpMessages()).toEqual(["session owned"]);
+
+		releaseToolExecution();
+		await promptPromise;
+		expect(getUserTexts(harness)).toEqual(["start", "session owned"]);
+	});
+
+	it("treats queued session commands as hard boundaries with durable outcomes", async () => {
+		const waiting = await createWaitingHarness();
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		harness.session.setFollowUpMode("all");
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("before command"),
+			fauxAssistantMessage("after command"),
+		]);
+		await waitForToolStart;
+		await harness.session.followUp("first");
+		await harness.session.prompt("/autonomous status", { streamingBehavior: "followUp" });
+		await harness.session.followUp("second");
+
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(getUserTexts(harness)).toEqual(["start", "first", "second"]);
+		const commandMessages = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "custom" }> =>
+				message.role === "custom" && message.customType.startsWith("session_slash_command"),
+		);
+		expect(commandMessages.map((message) => message.customType)).toEqual(["session_slash_command"]);
+		expect(commandMessages.map((message) => message.content)).toEqual(["/autonomous status"]);
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "autonomous_status",
+			),
+		).toBe(true);
+	});
+
+	it("restores slash-prefixed snapshots as literal prompts by custom marker", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("literal handled")]);
+		await harness.session.restoreFollowUpMessage("/autonomous off", undefined, {
+			customMessage: {
+				role: "custom",
+				customType: "restored-literal",
+				content: "/autonomous off",
+				display: true,
+				timestamp: Date.now(),
+			},
+		});
+		await harness.session.prompt("trigger");
+
+		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "restored-literal",
+			),
+		).toBe(true);
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "session_slash_command",
+			),
+		).toBe(false);
+	});
+
+	it("resumes queued work after an empty update pause", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("resumed")]);
+
+		harness.session.pauseQueuedWork();
+		expect(harness.session.resumeQueuedWork()).toBe(false);
+		await harness.session.followUp("after pause", undefined, { resumeIfIdle: true });
+		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["after pause"]));
+	});
+
+	it("preserves queued command images in restart snapshots", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const image = { type: "image" as const, mimeType: "image/png", data: "image-data" };
+
+		await harness.session.prompt("/goal inspect image", { streamingBehavior: "followUp", images: [image] });
+
+		expect(harness.session.getFollowUpQueueSnapshots()).toEqual([
+			expect.objectContaining({ text: "/goal inspect image", images: [image] }),
+		]);
+	});
+
+	it("does not coalesce steering inputs that share a follow-up queue key", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.session.pauseQueuedWork();
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+
+		await harness.session.steer("first", undefined, { queueKey: "same" });
+		await harness.session.steer("second", undefined, { queueKey: "same" });
+
+		expect(harness.session.getSteeringMessages()).toEqual(["first", "second"]);
+	});
+
+	it("requeues prepared prompts after a pre-start failure", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		await harness.session.followUp("retry me");
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		vi.spyOn(harness.session.agent, "prompt").mockRejectedValueOnce(new Error("transient pre-start failure"));
+
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await harness.session.waitForSessionInputIdle();
+
+		expect(harness.session.getFollowUpMessages()).toEqual(["retry me"]);
+	});
+
+	it("rejects skip-abort refinement while a turn is active", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+
+		await expect(harness.session.refine({}, { skipAbort: true })).rejects.toThrow(
+			"Cannot refine without aborting while the agent is running.",
+		);
+	});
+
+	it("reports whether a queue pause was newly acquired", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		expect(harness.session.pauseQueuedWork()).toBe(true);
+		expect(harness.session.pauseQueuedWork()).toBe(false);
+	});
+
+	it("reports session commands as queued while compaction blocks delivery", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as { _compactionAbortController?: AbortController };
+		internals._compactionAbortController = new AbortController();
+		const preflight = vi.fn();
+
+		await harness.session.prompt("/autonomous on", {
+			streamingBehavior: "followUp",
+			queueIfBusy: true,
+			preflightResult: preflight,
+		});
+
+		expect(preflight).toHaveBeenCalledWith(true, true);
+		expect(harness.session.getFollowUpMessages()).toEqual(["/autonomous on"]);
+		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
+	});
+
+	it("reschedules session-owned inputs when compaction finishes", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("after compaction")]);
+		const internals = harness.session as unknown as {
+			_compactionAbortController?: AbortController;
+			_schedulePendingMessageResume(): void;
+		};
+		internals._compactionAbortController = new AbortController();
+		await harness.session.followUp("queued during compaction", undefined, { resumeIfIdle: true });
+		await harness.session.waitForSessionInputIdle();
+		expect(harness.session.getFollowUpMessages()).toEqual(["queued during compaction"]);
+
+		internals._compactionAbortController = undefined;
+		internals._schedulePendingMessageResume();
+		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["queued during compaction"]));
+	});
+
+	it("uses the compaction card as the only successful compact result", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		vi.spyOn(harness.session, "compact").mockResolvedValue({
+			summary: "summary",
+			firstKeptEntryId: "kept",
+			tokensBefore: 128_144,
+		});
+
+		await harness.session.prompt("/compact focus");
+
+		expect(
+			harness.session.messages.filter(
+				(message) => message.role === "custom" && message.customType === "session_slash_command_result",
+			),
+		).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2213,6 +2213,21 @@ describe("AgentSession queue characterization", () => {
 		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["after pause"]));
 	});
 
+	it("waits for all admitted session inputs to finish", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first response"), fauxAssistantMessage("second response")]);
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.followUp("first", undefined, { resumeIfIdle: true });
+		await harness.session.followUp("second", undefined, { resumeIfIdle: true });
+		pause.release();
+
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["first", "second"]);
+		expect(getAssistantTexts(harness)).toEqual(["first response", "second response"]);
+	});
+
 	it("preserves queued command images in restart snapshots", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -5,6 +5,7 @@ import { fauxAssistantMessage, fauxToolCall, type ImageContent } from "@earendil
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSessionSlashCommandMessage } from "../../src/core/messages.js";
 import {
 	applyRefinementProposal,
 	getGlobalHarnessStateDir,
@@ -16,6 +17,7 @@ import {
 	type RefinementResult,
 	saveHarnessState,
 } from "../../src/core/refinement/index.js";
+import { parseSessionSlashCommand } from "../../src/core/slash-commands.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
 
 type AutoRefineReason = "turn_interval" | "compact";
@@ -1666,6 +1668,69 @@ describe("AgentSession queue characterization", () => {
 		expect(getUserTexts(harness)).toEqual(["start", "same heartbeat"]);
 	});
 
+	it("removes preparing inputs and re-prepares when the last batch anchor changes", async () => {
+		let releaseFirstPreparation = () => {};
+		const firstPreparation = new Promise<void>((resolve) => {
+			releaseFirstPreparation = resolve;
+		});
+		const prepared: string[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => {
+						prepared.push(event.prompt);
+						if (prepared.length === 1) await firstPreparation;
+						return {
+							systemPrompt: `${event.systemPrompt}
+prepared:${event.prompt}`,
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.session.setFollowUpMode("all");
+		let releaseResponse = () => {};
+		const responseGate = new Promise<void>((resolve) => {
+			releaseResponse = resolve;
+		});
+		let providerSystemPrompt = "";
+		harness.setResponses([
+			async (context) => {
+				providerSystemPrompt = context.systemPrompt ?? "";
+				await responseGate;
+				return fauxAssistantMessage("remaining response");
+			},
+		]);
+		const removedAgentMessage =
+			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_remove\n\nremove";
+		const keptAgentMessage =
+			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_keep\n\nkeep";
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.followUp("ordinary");
+		await harness.session.queueAgentMessagePrompt(removedAgentMessage, "followUp", undefined);
+		await harness.session.queueAgentMessagePrompt(keptAgentMessage, "followUp", undefined);
+		await harness.session.followUp("last anchor", undefined, { queueKey: "heartbeat:one" });
+		pause.release();
+		await vi.waitFor(() => expect(prepared).toEqual(["last anchor"]));
+
+		expect(harness.session.clearQueuedUserMessagesMatching((text) => text === removedAgentMessage)).toEqual({
+			steering: [],
+			followUp: [removedAgentMessage],
+		});
+		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(true);
+		releaseFirstPreparation();
+		await vi.waitFor(() => expect(providerSystemPrompt).not.toBe(""));
+		expect(harness.session.removeQueuedFollowUp("heartbeat:one")).toBe(false);
+		releaseResponse();
+		await harness.session.waitForIdle();
+
+		expect(prepared).toEqual(["last anchor", keptAgentMessage]);
+		expect(providerSystemPrompt).toContain(`prepared:${keptAgentMessage}`);
+		expect(providerSystemPrompt).not.toContain("prepared:last anchor");
+		expect(getUserTexts(harness)).toEqual(["ordinary", keptAgentMessage]);
+	});
+
 	it("removes coalesced follow-up messages by queue key", async () => {
 		const waiting = await createWaitingHarness();
 		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
@@ -2252,10 +2317,21 @@ describe("AgentSession queue characterization", () => {
 		).toBe(true);
 	});
 
-	it("restores slash-prefixed snapshots as literal prompts by custom marker", async () => {
+	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("literal handled")]);
+		const command = parseSessionSlashCommand("/autonomous status");
+		expect(command).toBeDefined();
+
+		await harness.session.restoreFollowUpMessage(command!.text, undefined, {
+			customMessage: createSessionSlashCommandMessage(command!),
+		});
+		const mismatchedCommand = parseSessionSlashCommand("/autonomous on");
+		expect(mismatchedCommand).toBeDefined();
+		await harness.session.restoreFollowUpMessage(command!.text, undefined, {
+			customMessage: createSessionSlashCommandMessage(mismatchedCommand!),
+		});
 		await harness.session.restoreFollowUpMessage("/autonomous off", undefined, {
 			customMessage: {
 				role: "custom",
@@ -2265,19 +2341,38 @@ describe("AgentSession queue characterization", () => {
 				timestamp: Date.now(),
 			},
 		});
-		await harness.session.prompt("trigger");
+		expect(harness.session.getFollowUpQueueSnapshots()).toEqual([
+			expect.objectContaining({
+				text: command!.text,
+				customMessage: expect.objectContaining({ customType: "session_slash_command" }),
+			}),
+			expect.objectContaining({
+				text: command!.text,
+				customMessage: expect.objectContaining({ customType: "session_slash_command" }),
+			}),
+			expect.objectContaining({
+				text: "/autonomous off",
+				customMessage: expect.objectContaining({ customType: "restored-literal" }),
+			}),
+		]);
+		harness.session.resumeQueuedWork();
+		await harness.session.waitForIdle();
 
 		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
+		expect(getUserTexts(harness)).toEqual([]);
 		expect(
 			harness.session.messages.some(
 				(message) => message.role === "custom" && message.customType === "restored-literal",
 			),
 		).toBe(true);
 		expect(
-			harness.session.messages.some(
-				(message) => message.role === "custom" && message.customType === "session_slash_command",
+			harness.session.messages.filter(
+				(message) =>
+					message.role === "custom" &&
+					message.customType === "session_slash_command" &&
+					(message.details as { command?: { text?: string } } | undefined)?.command?.text === command!.text,
 			),
-		).toBe(false);
+		).toHaveLength(1);
 	});
 
 	it("serializes concurrent trigger-turn custom messages", async () => {
@@ -2483,31 +2578,87 @@ describe("AgentSession queue characterization", () => {
 		expect(getUserTexts(harness)).toEqual(["direct", "queued"]);
 	});
 
-	it("allows an admitted extension command to navigate the session tree", async () => {
+	it("defers work queued after direct admission until the direct handoff", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("direct done"), fauxAssistantMessage("queued done")]);
+		const internals = harness.session as unknown as {
+			_acquireDirectTurnAdmission(options?: { allowStreaming?: boolean }): Promise<{
+				owner: symbol;
+				release(): void;
+			}>;
+		};
+		const acquireDirectTurnAdmission = internals._acquireDirectTurnAdmission.bind(internals);
+		let queuedAtBoundary = false;
+		internals._acquireDirectTurnAdmission = async (options = {}) => {
+			const admission = await acquireDirectTurnAdmission(options);
+			if (!queuedAtBoundary) {
+				queuedAtBoundary = true;
+				await harness.session.followUp("queued", undefined, { resumeIfIdle: true });
+			}
+			return admission;
+		};
+
+		await harness.session.prompt("direct");
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["direct", "queued"]);
+	});
+
+	it("serializes an extension command behind an unrelated navigation owner", async () => {
 		let targetId: string | undefined;
-		let navigated = false;
+		let releaseNavigation = () => {};
+		const navigationGate = new Promise<void>((resolve) => {
+			releaseNavigation = resolve;
+		});
+		let navigationStarts = 0;
+		let commandNavigated = false;
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
+					pi.on("session_before_tree", async () => {
+						if (navigationStarts++ === 0) await navigationGate;
+					});
 					pi.registerCommand("back", {
 						description: "Navigate back",
 						handler: async (_args, ctx) => {
-							if (targetId) await ctx.navigateTree(targetId, { summarize: false });
-							navigated = true;
+							await ctx.navigateTree(targetId!, { summarize: false });
+							commandNavigated = true;
 						},
 					});
 				},
 			],
 		});
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("one")]);
+		await harness.session.bindExtensions({
+			commandContextActions: {
+				waitForIdle: () => harness.session.waitForIdle(),
+				newSession: async () => ({ cancelled: false }),
+				fork: async () => ({ cancelled: false }),
+				navigateTree: async (target, options) => harness.session.navigateTree(target, options),
+				switchSession: async () => ({ cancelled: false }),
+				reload: async () => {},
+			},
+		});
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
 		await harness.session.prompt("one");
 		targetId = harness.sessionManager.getEntries().find((entry) => entry.type === "message")?.id;
 		expect(targetId).toBeDefined();
+		await harness.session.prompt("two");
+		const secondId = harness.sessionManager.getLeafId();
 
-		await harness.session.prompt("/back");
+		const unrelatedNavigation = harness.session.navigateTree(targetId!, { summarize: false });
+		await vi.waitFor(() => expect(navigationStarts).toBe(1));
+		const extensionCommand = harness.session.prompt("/back");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(commandNavigated).toBe(false);
 
-		expect(navigated).toBe(true);
+		releaseNavigation();
+		await unrelatedNavigation;
+		await extensionCommand;
+		expect(commandNavigated).toBe(true);
+		expect(navigationStarts).toBe(2);
+		expect(harness.sessionManager.getLeafId()).not.toBe(secondId);
 	});
 
 	it("waitForIdle observes a run that starts at its final idle boundary", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall, type ImageContent } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -727,6 +727,30 @@ describe("AgentSession queue characterization", () => {
 		expect(internals._compactAutoRefinePending).toBe(false);
 		expect(internals._pendingAutoRefineReview).toBeUndefined();
 		expect(internals._assistantTurnsSinceAutoRefine).toBe(0);
+	});
+
+	it("waits for an active direct prompt before navigating", async () => {
+		const waiting = await createWaitingHarness();
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		await waitForToolStart;
+		const target = harness.sessionManager.getEntries().find((entry) => entry.type === "message");
+		expect(target).toBeDefined();
+		let navigated = false;
+		const navigation = harness.session.navigateTree(target!.id).then(() => {
+			navigated = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(navigated).toBe(false);
+
+		releaseToolExecution();
+		await promptPromise;
+		await navigation;
+		expect(navigated).toBe(true);
 	});
 
 	it("keeps queued work paused until tree navigation events settle", async () => {
@@ -1839,7 +1863,9 @@ describe("AgentSession queue characterization", () => {
 		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
 		harnesses.push(harness);
 		let sawCustomMessage = false;
-
+		let preparedText: string | undefined;
+		let preparedImages: ImageContent[] | undefined;
+		const image = { type: "image" as const, data: "image-data", mimeType: "image/png" };
 		harness.setResponses([
 			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("original turn complete"),
@@ -1855,14 +1881,26 @@ describe("AgentSession queue characterization", () => {
 		]);
 
 		await waitForToolStart;
+		vi.spyOn(harness.session.extensionRunner, "emitBeforeAgentStart").mockImplementationOnce(async (text, images) => {
+			preparedText = text;
+			preparedImages = images;
+			return undefined;
+		});
 		await harness.session.sendCustomMessage(
-			{ customType: "queue-test", content: "follow-up custom", display: true, details: { value: 1 } },
+			{
+				customType: "queue-test",
+				content: [{ type: "text", text: "follow-up custom" }, image],
+				display: true,
+				details: { value: 1 },
+			},
 			{ deliverAs: "followUp" },
 		);
 		releaseToolExecution();
 		await promptPromise;
 
 		expect(sawCustomMessage).toBe(true);
+		expect(preparedText).toBe("follow-up custom");
+		expect(preparedImages).toEqual([image]);
 		expect(
 			harness.session.messages.some((message) => message.role === "custom" && message.customType === "queue-test"),
 		).toBe(true);
@@ -1873,10 +1911,18 @@ describe("AgentSession queue characterization", () => {
 		harnesses.push(harness);
 		let sawCustomMessage = false;
 
-		await harness.session.sendCustomMessage(
-			{ customType: "next-turn", content: "carry this", display: true, details: {} },
-			{ deliverAs: "nextTurn" },
-		);
+		harness.setResponses([fauxAssistantMessage("seed")]);
+		await harness.session.prompt("seed");
+		vi.spyOn(
+			harness.session as unknown as { _checkCompaction(): Promise<boolean> },
+			"_checkCompaction",
+		).mockImplementationOnce(async () => {
+			await harness.session.sendCustomMessage(
+				{ customType: "next-turn", content: "carry this", display: true, details: {} },
+				{ deliverAs: "nextTurn" },
+			);
+			return false;
+		});
 
 		harness.setResponses([
 			(context) => {
@@ -1893,7 +1939,13 @@ describe("AgentSession queue characterization", () => {
 		await harness.session.prompt("normal prompt");
 
 		expect(sawCustomMessage).toBe(true);
-		expect(harness.session.messages.map((message) => message.role)).toEqual(["custom", "user", "assistant"]);
+		expect(harness.session.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"custom",
+			"user",
+			"assistant",
+		]);
 	});
 
 	it("updates pendingMessageCount and removes queued text before message_start is emitted", async () => {
@@ -2061,6 +2113,32 @@ describe("AgentSession queue characterization", () => {
 		expect(getUserTexts(harness)).toContain(agentPrompt);
 	});
 
+	it("resolves queued delivery when message_start is received", async () => {
+		let releaseTurnStart = () => {};
+		const blocked = new Promise<void>((resolve) => {
+			releaseTurnStart = resolve;
+		});
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("turn_start", async () => blocked);
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		await harness.session.followUp("agent message", undefined, {
+			agentMessageId: "agentmsg_sync",
+			resumeIfIdle: true,
+		});
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+
+		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
+		releaseTurnStart();
+		await harness.session.waitForIdle();
+	});
+
 	it("resolves direct agent-message delivery waiters when the accepted prompt starts", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -2202,15 +2280,41 @@ describe("AgentSession queue characterization", () => {
 		).toBe(false);
 	});
 
-	it("resumes queued work after an empty update pause", async () => {
+	it("serializes concurrent trigger-turn custom messages", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("resumed")]);
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("second")]);
 
-		harness.session.pauseQueuedWork();
-		expect(harness.session.resumeQueuedWork()).toBe(false);
-		await harness.session.followUp("after pause", undefined, { resumeIfIdle: true });
-		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["after pause"]));
+		await Promise.all([
+			harness.session.sendCustomMessage(
+				{ customType: "first", content: "first", display: false },
+				{ triggerTurn: true },
+			),
+			harness.session.sendCustomMessage(
+				{ customType: "second", content: "second", display: false },
+				{ triggerTurn: true },
+			),
+		]);
+
+		expect(
+			harness.session.messages.filter((message) => message.role === "custom").map((message) => message.content),
+		).toEqual(["first", "second"]);
+	});
+
+	it("resumes explicitly admitted and restored work after abort", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("second")]);
+
+		await harness.session.abort();
+		await harness.session.followUp("resume if idle", undefined, { resumeIfIdle: true });
+		await harness.session.waitForIdle();
+		await harness.session.abort();
+		await harness.session.restoreFollowUpMessage("explicit resume");
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["resume if idle", "explicit resume"]);
 	});
 
 	it("waits for all admitted session inputs to finish", async () => {
@@ -2253,18 +2357,80 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.session.getSteeringMessages()).toEqual(["first", "second"]);
 	});
 
-	it("requeues prepared prompts after a pre-start failure", async () => {
-		const harness = await createHarness();
+	it("retains active preparation while blocking duplicate and direct admission", async () => {
+		let hookRuns = 0;
+		let pause: { release(): void } | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => {
+						if (event.prompt === "queued") {
+							hookRuns++;
+							pause = harness.session.acquireQueuedWorkPause();
+						}
+					});
+				},
+			],
+		});
 		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("queued done"), fauxAssistantMessage("direct done")]);
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
-		await harness.session.followUp("retry me");
+		await harness.session.followUp("queued", undefined, { queueKey: "same", resumeIfIdle: true });
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
-		vi.spyOn(harness.session.agent, "prompt").mockRejectedValueOnce(new Error("transient pre-start failure"));
+		await vi.waitFor(() => expect(pause).toBeDefined());
 
-		expect(harness.session.resumeQueuedWork()).toBe(true);
+		expect(await harness.session.followUp("duplicate", undefined, { queueKey: "same" })).toBe(false);
+		const direct = harness.session.prompt("direct");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(getUserTexts(harness)).toEqual([]);
+		pause?.release();
+		await direct;
+
+		expect(hookRuns).toBe(1);
+		expect(getUserTexts(harness)).toEqual(["queued", "direct"]);
+	});
+
+	it("rejects and surfaces terminal queued-prompt preparation errors", async () => {
+		const errors: string[] = [];
+		const harness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ onError: (error) => errors.push(error.error) });
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		await harness.session.followUp("cannot start", undefined, {
+			agentMessageId: "agentmsg_terminal",
+			resumeIfIdle: true,
+		});
+		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
 		await harness.session.waitForSessionInputIdle();
 
-		expect(harness.session.getFollowUpMessages()).toEqual(["retry me"]);
+		await expect(delivery).rejects.toThrow("No API key");
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(errors).toEqual([expect.stringContaining("No API key")]);
+	});
+
+	it("stops before another turn when more steering remains", async () => {
+		const tool: AgentTool = {
+			name: "instant",
+			label: "Instant",
+			description: "Returns immediately",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "done" }], details: {} }),
+		};
+		const harness = await createHarness({ tools: [tool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("instant", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("second handled"),
+		]);
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.steer("first", undefined, { resumeIfIdle: true });
+		await harness.session.steer("second", undefined, { resumeIfIdle: true });
+		pause.release();
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["first", "second"]);
+		expect(getAssistantTexts(harness)).toEqual(["", "second handled"]);
 	});
 
 	it("rejects skip-abort refinement while a turn is active", async () => {
@@ -2276,8 +2442,4 @@ describe("AgentSession queue characterization", () => {
 			"Cannot refine without aborting while the agent is running.",
 		);
 	});
-
-
-
-
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1503,6 +1503,31 @@ describe("AgentSession queue characterization", () => {
 		expect(providerCalls).toBe(1);
 	});
 
+	it("removes goal context while its steering handoff is still preparing", async () => {
+		const hook = gatedHook({ prompt: "stale goal context" });
+		const harness = await createHarness({ extensionFactories: [hook.factory] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not run")]);
+		const pause = harness.session.acquireQueuedWorkPause();
+		withStreaming(harness, true);
+		await harness.session.sendCustomMessage(
+			{ customType: "goal_context", content: "stale goal context", display: true },
+			{ triggerTurn: true, deliverAs: "steer" },
+		);
+		withStreaming(harness, false);
+		pause.release();
+		await hook.reached;
+
+		(harness.session as unknown as SteeringStopInternals)._clearQueuedGoalContexts();
+		hook.release();
+		await harness.session.waitForIdle();
+
+		expect(
+			harness.session.messages.some((message) => message.role === "custom" && message.customType === "goal_context"),
+		).toBe(false);
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
 	it("keeps steering stop pending while a steering handoff is still preparing", async () => {
 		const hook = gatedHook({ prompt: "active steering" });
 		const harness = await createHarness({ extensionFactories: [hook.factory] });
@@ -2329,6 +2354,29 @@ prepared:${event.prompt}`,
 		expect(
 			harness.session.messages.filter((message) => message.role === "custom").map((message) => message.content),
 		).toEqual(["first", "second"]);
+	});
+
+	it("pumps follow-up work admitted during a trigger-turn custom message", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let queued = false;
+		harness.setResponses([
+			async () => {
+				queued = await harness.session.restoreFollowUpMessage("queued during custom turn");
+				return fauxAssistantMessage("custom done");
+			},
+			fauxAssistantMessage("follow-up done"),
+		]);
+
+		await harness.session.sendCustomMessage(
+			{ customType: "trigger", content: "trigger", display: false },
+			{ triggerTurn: true },
+		);
+		await harness.session.waitForIdle();
+
+		expect(queued).toBe(true);
+		expect(getUserTexts(harness)).toEqual(["queued during custom turn"]);
+		expect(getAssistantTexts(harness)).toEqual(["custom done", "follow-up done"]);
 	});
 
 	it("rejects triggerTurn promptly when pending input is suspended", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2442,6 +2442,114 @@ describe("AgentSession queue characterization", () => {
 			"Cannot refine without aborting while the agent is running.",
 		);
 	});
+	it("serializes queued prompt preparation with a direct prompt handoff", async () => {
+		let releaseDirectPreparation = () => {};
+		const directPreparation = new Promise<void>((resolve) => {
+			releaseDirectPreparation = resolve;
+		});
+		let directPreparing = false;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async (event) => {
+						if (event.prompt === "direct") {
+							directPreparing = true;
+							await directPreparation;
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("direct done"), fauxAssistantMessage("queued done")]);
+
+		const direct = harness.session.prompt("direct");
+		await vi.waitFor(() => expect(directPreparing).toBe(true));
+		await harness.session.followUp("queued", undefined, { resumeIfIdle: true });
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(getUserTexts(harness)).toEqual([]);
+
+		releaseDirectPreparation();
+		await direct;
+		await harness.session.waitForIdle();
+		expect(getUserTexts(harness)).toEqual(["direct", "queued"]);
+	});
+
+	it("allows an admitted extension command to navigate the session tree", async () => {
+		let targetId: string | undefined;
+		let navigated = false;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("back", {
+						description: "Navigate back",
+						handler: async (_args, ctx) => {
+							if (targetId) await ctx.navigateTree(targetId, { summarize: false });
+							navigated = true;
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one")]);
+		await harness.session.prompt("one");
+		targetId = harness.sessionManager.getEntries().find((entry) => entry.type === "message")?.id;
+		expect(targetId).toBeDefined();
+
+		await harness.session.prompt("/back");
+
+		expect(navigated).toBe(true);
+	});
+
+	it("waitForIdle observes a run that starts at its final idle boundary", async () => {
+		let releaseResponse = () => {};
+		const responseGate = new Promise<void>((resolve) => {
+			releaseResponse = resolve;
+		});
+		let responseStarted = () => {};
+		const waitForResponseStart = new Promise<void>((resolve) => {
+			responseStarted = resolve;
+		});
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			async () => {
+				responseStarted();
+				await responseGate;
+				return fauxAssistantMessage("late done");
+			},
+		]);
+		const agentWaitForIdle = harness.session.agent.waitForIdle.bind(harness.session.agent);
+		let waitCalls = 0;
+		vi.spyOn(harness.session.agent, "waitForIdle").mockImplementation(async () => {
+			await agentWaitForIdle();
+			if (waitCalls++ === 0) void harness.session.agent.prompt("late run");
+		});
+
+		let idle = false;
+		const waiting = harness.session.waitForIdle().then(() => {
+			idle = true;
+		});
+		await waitForResponseStart;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(idle).toBe(false);
+
+		releaseResponse();
+		await waiting;
+		expect(idle).toBe(true);
+	});
+
+	it("rejects skip-abort compaction while a turn is active", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		setAgentStreaming(harness, true);
+
+		await expect(harness.session.compact(undefined, { skipAbort: true })).rejects.toThrow(
+			"Cannot compact without aborting while the agent is running.",
+		);
+	});
+
 	it("waits for an earlier direct handoff before executing a session command", async () => {
 		let releaseBeforeAgentStart: (() => void) | undefined;
 		const beforeAgentStartGate = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -47,6 +47,21 @@ type AutoRefineInternals = {
 	_autoRefineBranchVersion: number;
 };
 
+type SteeringStopInternals = {
+	_steeringStopPending: boolean;
+	_clearQueuedGoalContexts(): void;
+};
+
+function testAgentMessage(id: string, message: string) {
+	return createAgentSessionMessage({
+		id,
+		source: AGENT_MESSAGE_SOURCE,
+		message,
+		target: { activeSessionId: "target-active", sessionId: "target-session" },
+		deliveryMode: "steer",
+	});
+}
+
 function emptyRefinementResult(): RefinementResult {
 	return {
 		id: "refine_test",
@@ -1425,6 +1440,131 @@ describe("AgentSession queue characterization", () => {
 			releaseToolExecution();
 			await promptPromise;
 			if (expectedFinalUsers !== undefined) expect(getUserTexts(harness)).toEqual(expectedFinalUsers);
+		},
+	);
+
+	it.each([
+		{
+			name: "clearQueue",
+			queue: async (harness: Harness, text: string, _id: string) => {
+				await harness.session.steer(text);
+			},
+			remove: (harness: Harness, _text: string) => harness.session.clearQueue(),
+		},
+		{
+			name: "clearQueuedUserMessagesMatching",
+			queue: async (harness: Harness, text: string, id: string) => {
+				await harness.session.queueAgentMessagePrompt(text, "steer", testAgentMessage(id, text));
+			},
+			remove: (harness: Harness, text: string) =>
+				harness.session.clearQueuedUserMessagesMatching((candidate) => candidate === text),
+		},
+		{
+			name: "removeQueuedFollowUp",
+			queue: async (harness: Harness, text: string, id: string) => {
+				await harness.session.steer(text, undefined, { queueKey: id });
+			},
+			remove: (harness: Harness, _text: string, id: string) => harness.session.removeQueuedFollowUp(id),
+		},
+		{
+			name: "goal-context cleanup",
+			queue: async (harness: Harness, text: string, _id: string) => {
+				await harness.session.sendCustomMessage(
+					{ customType: "goal_context", content: text, display: true },
+					{ triggerTurn: true, deliverAs: "steer" },
+				);
+			},
+			remove: (harness: Harness, _text: string) =>
+				(harness.session as unknown as SteeringStopInternals)._clearQueuedGoalContexts(),
+		},
+	])("reconciles steering stop state after $name removes queued steering", async ({ queue, remove }) => {
+		const waiting = await createWaitingHarness();
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SteeringStopInternals;
+		let providerCalls = 0;
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			() => {
+				providerCalls++;
+				return fauxAssistantMessage("continued without a stale stop");
+			},
+		]);
+		await waitForToolStart;
+		await queue(harness, "remove me", "remove-key");
+		expect(internals._steeringStopPending).toBe(true);
+
+		remove(harness, "remove me", "remove-key");
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(internals._steeringStopPending).toBe(false);
+
+		releaseToolExecution();
+		await promptPromise;
+		expect(providerCalls).toBe(1);
+	});
+
+	it("keeps steering stop pending while a steering handoff is still preparing", async () => {
+		const hook = gatedHook({ prompt: "active steering" });
+		const harness = await createHarness({ extensionFactories: [hook.factory] });
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SteeringStopInternals;
+		harness.setResponses([fauxAssistantMessage("delivered")]);
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.steer("active steering", undefined, { resumeIfIdle: true });
+		pause.release();
+		await hook.reached;
+
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(internals._steeringStopPending).toBe(true);
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [] });
+		expect(internals._steeringStopPending).toBe(true);
+
+		hook.release();
+		await harness.session.waitForIdle();
+		expect(internals._steeringStopPending).toBe(false);
+		expect(getUserTexts(harness)).toEqual(["active steering"]);
+	});
+
+	it.each([
+		{
+			name: "clearQueuedUserMessagesMatching",
+			queueRemoved: (harness: Harness) =>
+				harness.session.queueAgentMessagePrompt(
+					"remove me",
+					"steer",
+					testAgentMessage("remove-message", "remove me"),
+				),
+			remove: (harness: Harness) =>
+				harness.session.clearQueuedUserMessagesMatching((candidate) => candidate === "remove me"),
+		},
+		{
+			name: "removeQueuedFollowUp",
+			queueRemoved: (harness: Harness) => harness.session.steer("remove me", undefined, { queueKey: "remove-key" }),
+			remove: (harness: Harness) => harness.session.removeQueuedFollowUp("remove-key"),
+		},
+		{
+			name: "goal-context cleanup",
+			queueRemoved: (harness: Harness) =>
+				harness.session.sendCustomMessage(
+					{ customType: "goal_context", content: "remove me", display: true },
+					{ triggerTurn: true, deliverAs: "steer" },
+				),
+			remove: (harness: Harness) => (harness.session as unknown as SteeringStopInternals)._clearQueuedGoalContexts(),
+		},
+	])(
+		"preserves steering stop state after $name when another steering input remains",
+		async ({ queueRemoved, remove }) => {
+			const harness = await createHarness();
+			harnesses.push(harness);
+			const internals = harness.session as unknown as SteeringStopInternals;
+			withStreaming(harness, true);
+			await queueRemoved(harness);
+			await harness.session.steer("keep me");
+
+			remove(harness);
+
+			expect(harness.session.getSteeringMessages()).toEqual(["keep me"]);
+			expect(internals._steeringStopPending).toBe(true);
 		},
 	);
 

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -774,8 +774,6 @@ describe("AgentSession queue characterization", () => {
 		});
 		await harness.session.waitForIdle();
 
-		// The prompt joined the queue rather than waiting for it to drain and
-		// starting a direct turn; delivery order proves queue membership.
 		expect(queuedAtPreflight).toBe(true);
 		expect(getUserTexts(harness)).toEqual(["already queued", "respects the queue"]);
 	});

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2333,6 +2333,25 @@ prepared:${event.prompt}`,
 		).toBe(true);
 	});
 
+	it("does not record a benign compaction skip as a command failure", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let compactionEndErrorSeverity: string | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end") compactionEndErrorSeverity = event.errorSeverity;
+		});
+
+		// Too-short session: compact() throws CompactionSkippedError.
+		await harness.session.prompt("/compact");
+
+		const commandMessages = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "custom" }> =>
+				message.role === "custom" && message.customType.startsWith("session_slash_command"),
+		);
+		expect(commandMessages.map((message) => message.customType)).toEqual(["session_slash_command"]);
+		expect(compactionEndErrorSeverity).toBe("warning");
+	});
+
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2397,6 +2397,32 @@ prepared:${event.prompt}`,
 		expect(harness.session.getFollowUpMessages()).toEqual(["suspended"]);
 	});
 
+	it("rechecks queued-work pauses acquired at the direct-admission boundary", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("direct done")]);
+		const internals = harness.session as unknown as {
+			_acquireTurnAdmission(): Promise<{ owner: symbol; release(): void }>;
+		};
+		const acquireTurnAdmission = internals._acquireTurnAdmission.bind(internals);
+		let pause: { release(): void } | undefined;
+		let first = true;
+		internals._acquireTurnAdmission = async () => {
+			const admission = await acquireTurnAdmission();
+			if (first) {
+				first = false;
+				pause = harness.session.acquireQueuedWorkPause();
+			}
+			return admission;
+		};
+		const prompt = harness.session.prompt("direct");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(getUserTexts(harness)).toEqual([]);
+		pause?.release();
+		await prompt;
+		expect(getUserTexts(harness)).toEqual(["direct"]);
+	});
+
 	it("rejects disposal while direct admission waits behind a pause", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1447,6 +1447,50 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["ordinary", keptAgentMessage]);
 	});
 
+	it("keeps cleared prompts out of the handoff snapshot during the refine wait", async () => {
+		let sessionInternals: { _refineInFlight?: Promise<void> };
+		let clearDuringRefineWait: (() => void) | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async () => {
+						// Stall the pre-handoff refine wait and clear the queued agent
+						// message inside that window; the handoff snapshot must not
+						// deliver it.
+						let releaseRefine: (() => void) | undefined;
+						sessionInternals._refineInFlight = new Promise<void>((resolve) => {
+							releaseRefine = resolve;
+						});
+						setTimeout(() => {
+							clearDuringRefineWait?.();
+							sessionInternals._refineInFlight = undefined;
+							releaseRefine?.();
+						}, 0);
+						return {};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		sessionInternals = harness.session as unknown as { _refineInFlight?: Promise<void> };
+		harness.setResponses([fauxAssistantMessage("kept response")]);
+
+		const clearedAgentMessage = agentPromptText("agentmsg_cleared", "cleared");
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.followUp("kept");
+		await harness.session.queueAgentMessagePrompt(clearedAgentMessage, "followUp", undefined);
+		harness.session.setFollowUpMode("all");
+		let cleared: { steering: string[]; followUp: string[] } | undefined;
+		clearDuringRefineWait = () => {
+			cleared = harness.session.clearQueuedUserMessagesMatching((text) => text === clearedAgentMessage);
+		};
+		pause.release();
+		await harness.session.waitForIdle();
+
+		expect(cleared).toEqual({ steering: [], followUp: [clearedAgentMessage] });
+		expect(getUserTexts(harness)).toEqual(["kept"]);
+	});
+
 	it("delivers follow-up messages only after the current run finishes", async () => {
 		const waiting = await createWaitingHarness();
 		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -337,7 +337,35 @@ describe("AgentSession queue characterization", () => {
 		}
 	});
 
-	it("keeps scheduled post-compaction continuation when manual compaction is skipped", async () => {
+	it.each([
+		{ name: "requestAbort", abort: (harness: Harness) => harness.session.requestAbort() },
+		{
+			name: "abortForUpdateRestart",
+			abort: (harness: Harness) => harness.session.abortForUpdateRestart(),
+		},
+	])("cancels scheduled post-compaction continuation at $name without dropping queued input", async ({ abort }) => {
+		vi.useFakeTimers();
+		const harness = await createAutoRefineHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as AutoRefineInternals;
+		const continueAgent = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
+
+		try {
+			internals._schedulePostCompactionContinue();
+			await harness.session.followUp("queued across abort");
+
+			abort(harness);
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(continueAgent).not.toHaveBeenCalled();
+			expect(internals._postCompactionContinuationScheduled).toBe(false);
+			expect(harness.session.getFollowUpMessages()).toEqual(["queued across abort"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps scheduled post-compaction continuation when session-input pump compaction skips without aborting", async () => {
 		vi.useFakeTimers();
 		const harness = await createAutoRefineHarness({
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
@@ -347,7 +375,9 @@ describe("AgentSession queue characterization", () => {
 		try {
 			internals._schedulePostCompactionContinue();
 
-			await expect(harness.session.compact()).rejects.toThrow("Session is too short to compact");
+			await expect(harness.session.compact(undefined, { skipAbort: true })).rejects.toThrow(
+				"Session is too short to compact",
+			);
 
 			expect(internals._postCompactionContinuationScheduled).toBe(true);
 		} finally {

--- a/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
@@ -25,6 +25,7 @@ type SerializedInternals = {
 		abort: AbortController,
 	): Promise<unknown>;
 	_serializedRefine: boolean;
+	_steeringStopPending: boolean;
 	_pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
 	_assistantTurnsSinceAutoRefine: number;
 	_lastAutoRefineReviewAt: number;
@@ -297,6 +298,31 @@ describe("Serialized agent-callable refine", () => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
+	});
+
+	it("services a pending refine.run before stopping for steering", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			serializedRefine: true,
+			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SerializedInternals;
+		const { applyRefine } = mockSerializedRefine(harness);
+		internals._pendingRequestedRefine = { instructions: "capture a lesson" };
+		internals._steeringStopPending = true;
+		const compactionSpy = vi
+			.spyOn(
+				internals as unknown as { _shouldStopForThresholdCompaction: (ctx: unknown) => Promise<boolean> },
+				"_shouldStopForThresholdCompaction",
+			)
+			.mockResolvedValue(false);
+
+		const shouldStop = await internals._shouldStopAfterTurn(makeCtx("turn"));
+
+		expect(applyRefine).toHaveBeenCalledTimes(1);
+		expect(compactionSpy).toHaveBeenCalledTimes(1);
+		expect(shouldStop).toBe(true);
 	});
 
 	it("agent-callable refine.run starts background planning immediately in serialized mode", async () => {
@@ -1662,7 +1688,7 @@ describe("P0 concurrency regressions", () => {
 		}
 	});
 
-	it("serialized threshold compaction: background plan applied before compaction fires", async () => {
+	it("steering waits for interval refine and threshold compaction boundaries", async () => {
 		// Verify that when threshold compaction would fire, the serialized
 		// checkpoint runs FIRST, draining the background plan, so the
 		// compaction model call cannot overlap an in-flight refine.
@@ -1679,6 +1705,7 @@ describe("P0 concurrency regressions", () => {
 		});
 		harnesses.push(harness);
 		const internals = harness.session as unknown as SerializedInternals;
+		internals._steeringStopPending = true;
 
 		let planResolved = false;
 		let applyFinished = false;

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -5,7 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getDaemonUpdateRestartManifestPath } from "../../../src/config.js";
 import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.js";
 import type { AgentCronJobStore, AgentCronScheduler } from "../../../src/core/cron-jobs.js";
-import type { CustomMessage } from "../../../src/core/messages.js";
+import { type CustomMessage, createSessionSlashCommandMessage } from "../../../src/core/messages.js";
+import { parseSessionSlashCommand } from "../../../src/core/slash-commands.js";
 import type { BashOperations } from "../../../src/core/tools/bash.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
 import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
@@ -323,6 +324,11 @@ describe("issue #4257 update restart resume", () => {
 			agentMessageId: "agentmsg_custom",
 			customMessage: customFollowUp,
 		});
+		const command = parseSessionSlashCommand("/autonomous on");
+		const commandMessage = createSessionSlashCommandMessage(command!);
+		await parentHarness.session.restoreFollowUpMessage("/autonomous on", undefined, {
+			customMessage: commandMessage,
+		});
 		childHarness.session.recordBashResult("echo child", {
 			output: "child",
 			exitCode: 0,
@@ -390,6 +396,13 @@ describe("issue #4257 update restart resume", () => {
 						queueKey: "heartbeat:custom",
 						agentMessageId: "agentmsg_custom",
 						customMessage: customFollowUp,
+					},
+					{
+						message: "/autonomous on",
+						customMessage: expect.objectContaining({
+							customType: "session_slash_command",
+							details: { command },
+						}),
 					},
 				],
 			},

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -52,12 +52,6 @@ type QueueInternals = {
 	};
 };
 
-type AgentInternals = {
-	_state: {
-		isStreaming: boolean;
-	};
-};
-
 function createState(
 	harness: Harness,
 	activeSessionId: string,
@@ -309,41 +303,26 @@ describe("issue #4257 update restart resume", () => {
 		const image: ImageContent = { type: "image", data: "ZmFrZQ==", mimeType: "image/png" };
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text: "queued work" }, image];
 		const queuedContext = createCustomMessage("queued context");
-		const message: UserMessage = { role: "user", content, timestamp: Date.now() };
 		const followUpContent: TextContent[] = [{ type: "text", text: "heartbeat" }];
 		const followUpContext = createCustomMessage("follow-up context");
-		const followUpMessage: UserMessage = {
-			role: "user",
-			content: followUpContent,
-			timestamp: Date.now(),
-		};
 		const customFollowUp = createCustomMessage("custom heartbeat");
-		const queueInternals = parentHarness.session as unknown as QueueInternals;
-		queueInternals._steeringMessages = [
-			{
-				text: "queued work",
-				queueKey: "heartbeat:steer",
-				agentMessageId: "agentmsg_steer",
-				prefixMessages: [queuedContext],
-				message,
-			},
-		];
-		queueInternals._followUpMessages = [
-			{
-				text: "heartbeat",
-				queueKey: "heartbeat:job-1",
-				agentMessageId: "agentmsg_followup",
-				prefixMessages: [followUpContext],
-				message: followUpMessage,
-			},
-			{
-				text: "custom heartbeat",
-				queueKey: "heartbeat:custom",
-				agentMessageId: "agentmsg_custom",
-				prefixMessages: [],
-				message: customFollowUp,
-			},
-		];
+		await parentHarness.session.restoreSteeringMessage("queued work", [image], {
+			queueKey: "heartbeat:steer",
+			agentMessageId: "agentmsg_steer",
+			content,
+			prefixMessages: [queuedContext],
+		});
+		await parentHarness.session.restoreFollowUpMessage("heartbeat", undefined, {
+			queueKey: "heartbeat:job-1",
+			agentMessageId: "agentmsg_followup",
+			content: followUpContent,
+			prefixMessages: [followUpContext],
+		});
+		await parentHarness.session.restoreFollowUpMessage("custom heartbeat", undefined, {
+			queueKey: "heartbeat:custom",
+			agentMessageId: "agentmsg_custom",
+			customMessage: customFollowUp,
+		});
 		childHarness.session.recordBashResult("echo child", {
 			output: "child",
 			exitCode: 0,
@@ -450,7 +429,7 @@ describe("issue #4257 update restart resume", () => {
 			timestamp: Date.now(),
 		};
 		const queueInternals = harness.session as unknown as QueueInternals;
-		queueInternals._pendingNextTurnMessages = [pendingNextTurn];
+		harness.session.restorePendingNextTurnMessages([pendingNextTurn]);
 		queueInternals._acceptedAgentMessagePrompt = {
 			text: "accepted work",
 			agentMessageId: "agentmsg_accepted",
@@ -502,16 +481,11 @@ describe("issue #4257 update restart resume", () => {
 			{ type: "text", text: "queued context" },
 			{ type: "text", text: "queued follow-up" },
 		];
-		const queueInternals = harness.session as unknown as QueueInternals;
-		queueInternals._followUpMessages = [
-			{
-				text: "queued follow-up",
-				queueKey: "heartbeat:job-1",
-				agentMessageId: "agentmsg_followup",
-				prefixMessages: [],
-				message: { role: "user", content: followUpContent, timestamp: Date.now() },
-			},
-		];
+		await harness.session.restoreFollowUpMessage("queued follow-up", undefined, {
+			queueKey: "heartbeat:job-1",
+			agentMessageId: "agentmsg_followup",
+			content: followUpContent,
+		});
 
 		const sessionDir = `${harness.tempDir}/sessions`;
 		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
@@ -547,7 +521,7 @@ describe("issue #4257 update restart resume", () => {
 	it("materializes busy in-memory drafts before update restart", async () => {
 		const harness = await createHarness({ persistSession: false });
 		harnesses.push(harness);
-		(harness.session.agent as unknown as AgentInternals)._state.isStreaming = true;
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
 
 		const sessionDir = `${harness.tempDir}/sessions`;
 		const daemon = new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
@@ -588,7 +562,7 @@ describe("issue #4257 update restart resume", () => {
 			timestamp: Date.now(),
 		};
 		const queueInternals = harness.session as unknown as QueueInternals;
-		queueInternals._pendingNextTurnMessages = [pendingNextTurn];
+		harness.session.restorePendingNextTurnMessages([pendingNextTurn]);
 		queueInternals._acceptedAgentMessagePrompt = {
 			text: "accepted work",
 			agentMessageId: "agentmsg_accepted",
@@ -757,7 +731,6 @@ describe("issue #4257 update restart resume", () => {
 			createState(harness, "active-1", { kind: "top-level", createdAt: Date.now() }),
 		);
 
-		const queueInternals = harness.session as unknown as QueueInternals;
 		const restoredSteerContent: TextContent[] = [
 			{ type: "text", text: "restored steer context" },
 			{ type: "text", text: "restored steer" },
@@ -767,15 +740,10 @@ describe("issue #4257 update restart resume", () => {
 			{ type: "text", text: "restored follow-up" },
 		];
 		const restoredPrefix = createCustomMessage("restored custom prefix");
-		queueInternals._followUpMessages = [
-			{
-				text: "existing",
-				queueKey: "heartbeat:job-1",
-				agentMessageId: "agentmsg_existing",
-				prefixMessages: [],
-				message: { role: "user", content: [{ type: "text", text: "existing" }], timestamp: Date.now() },
-			},
-		];
+		await harness.session.restoreFollowUpMessage("existing", undefined, {
+			queueKey: "heartbeat:job-1",
+			agentMessageId: "agentmsg_existing",
+		});
 		const writes: string[] = [];
 		const client: DaemonSocketClient = {
 			id: "client-1",
@@ -1034,7 +1002,7 @@ describe("issue #4257 update restart resume", () => {
 			expect.objectContaining({ id: "follow-up-1", command: "follow_up", success: true }),
 			expect.objectContaining({ id: "prompt-1", command: "prompt", success: true }),
 		]);
-		expect(getUserTexts(harness)).toEqual(["continue interrupted work", "restored steer", "restored follow-up"]);
+		expect(getUserTexts(harness)).toEqual(["restored steer", "restored follow-up", "continue interrupted work"]);
 		expect(harness.session.getSteeringQueueSnapshots()).toEqual([]);
 		expect(harness.session.getFollowUpQueueSnapshots()).toEqual([]);
 	});
@@ -1150,6 +1118,6 @@ describe("issue #4257 update restart resume", () => {
 
 		const response = JSON.parse(writes.join("").trim());
 		expect(response).toMatchObject({ id: "resume-1", command: "resume_queue", success: false });
-		expect(JSON.stringify(response)).toContain("No messages to continue from");
+		expect(JSON.stringify(response)).toContain("No queued work to resume");
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -17,11 +17,6 @@ import { createHarness, getMessageText, getUserTexts, type Harness } from "../ha
 
 type StateRestoreHost = {
 	_onIpythonStateRestored(result: RestoreResult): void;
-};
-
-type QueueDrainHost = {
-	_followUpMessages: Array<{ prefixMessages: CustomMessage[]; message: AgentMessage }>;
-	_drainQueuedMessagesAfterBash(): Promise<void>;
 };
 
 function stripAnsi(text: string): string {
@@ -123,23 +118,7 @@ describe("ENG-4530 IPython state restore message", () => {
 		expect(render(component)).not.toContain("alpha");
 	});
 
-	it("shows an accurate fixed label when restoration starts a fresh kernel", () => {
-		const message: CustomMessage<IpythonStateRestoredDetails> = {
-			role: "custom",
-			customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
-			content: "restore details",
-			display: true,
-			details: { restored: false },
-			timestamp: Date.now(),
-		};
-		const component = new InjectedPromptMessageComponent(message);
-
-		expect(render(component)).toContain("◆ Started fresh IPython kernel");
-		component.setExpanded(true);
-		expect(render(component)).not.toContain("restore details");
-	});
-
-	it("does not requeue prefixes already delivered before a drain failure", async () => {
+	it("retries only undelivered input after partial scheduler delivery", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		await harness.session.sendCustomMessage(
@@ -154,22 +133,37 @@ describe("ENG-4530 IPython state restore message", () => {
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
 		await harness.session.prompt("queued prompt", { streamingBehavior: "followUp" });
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
-
-		const queueHost = harness.session as unknown as QueueDrainHost;
-		const queued = queueHost._followUpMessages[0];
-		const deliveredPrefix = queued?.prefixMessages[0];
-		if (!queued || !deliveredPrefix) {
-			throw new Error("Expected queued restore context");
-		}
-		vi.spyOn(harness.session.agent, "prompt").mockImplementation(async () => {
-			harness.session.agent.state.messages.push(deliveredPrefix);
+		vi.spyOn(harness.session.agent, "prompt").mockImplementationOnce(async (messages) => {
+			const batch = Array.isArray(messages) ? messages : [messages];
+			harness.session.agent.state.messages.push(batch[0]);
+			harness.session.acquireQueuedWorkPause();
 			throw new Error("partial delivery failed");
 		});
-		const followUp = vi.spyOn(harness.session.agent, "followUp");
 
-		await queueHost._drainQueuedMessagesAfterBash();
+		harness.session.resumeQueuedWork();
+		await harness.session.waitForSessionInputIdle();
 
-		expect(queued.prefixMessages).toEqual([]);
-		expect(followUp).toHaveBeenCalledWith([queued.message]);
+		const [queued] = harness.session.getFollowUpQueueSnapshots();
+		expect(queued).toMatchObject({ text: "queued prompt" });
+		expect(queued?.prefixMessages).toBeUndefined();
+		expect(harness.session.messages).toEqual([
+			expect.objectContaining({ customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE }),
+		]);
+	});
+
+	it("shows an accurate fixed label when restoration starts a fresh kernel", () => {
+		const message: CustomMessage<IpythonStateRestoredDetails> = {
+			role: "custom",
+			customType: IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
+			content: "restore details",
+			display: true,
+			details: { restored: false },
+			timestamp: Date.now(),
+		};
+		const component = new InjectedPromptMessageComponent(message);
+
+		expect(render(component)).toContain("◆ Started fresh IPython kernel");
+		component.setExpanded(true);
+		expect(render(component)).not.toContain("restore details");
 	});
 });

--- a/packages/coding-agent/test/suite/scheduling.ts
+++ b/packages/coding-agent/test/suite/scheduling.ts
@@ -1,0 +1,100 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { createHarness, type Harness } from "./harness.js";
+
+/** A promise with its resolve/reject functions exposed. */
+export interface Deferred<T = void> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error: Error) => void;
+}
+
+export function createDeferred<T = void>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (error: Error) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+/**
+ * A before_agent_start gate as an extension factory: `reached` resolves when the
+ * hook first runs (optionally filtered by prompt), `release()` lets gated runs
+ * proceed, and `runs` records the prompts the hook observed.
+ */
+export function gatedHook(options: { prompt?: string } = {}): {
+	factory: (pi: ExtensionAPI) => void;
+	reached: Promise<void>;
+	release: () => void;
+	runs: string[];
+} {
+	const reached = createDeferred();
+	const gate = createDeferred();
+	const runs: string[] = [];
+	return {
+		factory: (pi) => {
+			pi.on("before_agent_start", async (event) => {
+				if (options.prompt !== undefined && event.prompt !== options.prompt) return;
+				runs.push(event.prompt);
+				reached.resolve();
+				await gate.promise;
+			});
+		},
+		reached: reached.promise,
+		release: gate.resolve,
+		runs,
+	};
+}
+
+/** Force the harness agent's streaming flag, replacing the `as { isStreaming: boolean }` cast idiom. */
+export function withStreaming(harness: Harness, on: boolean): void {
+	(harness.session.agent.state as { isStreaming: boolean }).isStreaming = on;
+}
+
+export interface WaitingHarness {
+	harness: Harness;
+	releaseToolExecution: () => void;
+	promptPromise: Promise<void>;
+	waitForToolStart: Promise<void>;
+}
+
+/**
+ * Harness whose first turn calls a gated "wait" tool: the run stays streaming
+ * until `releaseToolExecution()` is called, so tests can queue inputs mid-run.
+ */
+export async function createWaitingHarness(
+	options: { tools?: AgentTool[]; extensionFactories?: Array<(pi: ExtensionAPI) => void> } = {},
+): Promise<WaitingHarness> {
+	const toolRelease = createDeferred();
+	const waitTool: AgentTool = {
+		name: "wait",
+		label: "Wait",
+		description: "Wait for release",
+		parameters: Type.Object({}),
+		execute: async () => {
+			await toolRelease.promise;
+			return { content: [{ type: "text", text: "released" }], details: {} };
+		},
+	};
+	const harness = await createHarness({
+		tools: [waitTool, ...(options.tools ?? [])],
+		extensionFactories: options.extensionFactories,
+	});
+	const waitForToolStart = new Promise<void>((resolve) => {
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "tool_execution_start" && event.toolName === "wait") {
+				unsubscribe();
+				resolve();
+			}
+		});
+	});
+	return {
+		harness,
+		releaseToolExecution: toolRelease.resolve,
+		promptPromise: harness.session.prompt("start"),
+		waitForToolStart,
+	};
+}


### PR DESCRIPTION
## Summary

Move prompt, steering, follow-up, and typed session-command scheduling into `AgentSession` as the single high-level queue owner.

- prepare prompt inputs once and preserve images, content, prefixes, queue keys, and agent-message IDs
- model steering/follow-up as delivery schedules, with steering stopping before another parent turn
- execute typed commands as hard queue boundaries with durable outcomes
- preserve goal/autonomous ordering, compaction/refine/branch-navigation blockers, and session-owned post-compaction continuations
- add owned pause leases and explicit active prompt/command lifecycle for later daemon checkpointing
- requeue undelivered pre-handoff inputs without replaying delivered prefixes

This is the core-only third layer. It intentionally does not change the TUI, daemon protocol, or coordinated restart transport yet.

## Validation

- focused scheduler/goal/prompt/autonomous/compaction/message tests: 192 passed
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor of when and how queued user input, steering, autonomous continuations, and slash commands reach the agent loop; ordering and timing changed across compaction, refine, bash drain, and restart restore paths.
> 
> **Overview**
> **AgentSession** becomes the sole owner of steering, follow-up, and built-in slash-command work. Queued items are no longer passed through `agent.steer` / `followUp`; a **`_pumpSessionInputs`** loop admits turns, prepares prompts (`before_agent_start`), hands off to `agent.prompt`, and runs typed commands (`/compact`, `/refine`, `/goal`, `/autonomous`) as queue boundaries with durable `session_slash_command` messages.
> 
> Steering now **stops the parent loop before the next turn** via `shouldStopBeforeTurn` and `_steeringStopPending`, after serialized refine/compaction checkpoints. **Turn admission**, **pause leases** (`acquireQueuedWorkPause`), and **`waitForIdle` / `waitForSessionInputIdle`** on the session subsume the old pending-message resume path.
> 
> Goal budget steers, autonomous threshold continuations, streaming custom messages, and post-compaction follow-ups are routed through the same queues; continuation hooks bail when pending session input exists. **`parseRefineCommandOptions`** is shared with interactive mode; daemon **`resume_queue`** calls **`resumeQueuedWork()`** instead of `agent.continue()`. Branch navigation serializes behind a pause + admission gate and invalidates stale queued prompt preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a39331550c36f007f92b61a16b16d28c764831d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize session input scheduling in `AgentSession` with an admission-controlled pump
> - Replaces the legacy `_resumePendingMessages` mechanism with a new `_pumpSessionInputs` loop that serializes delivery of steering and follow-up inputs through an admission-controlled queue, preventing races between concurrent prompt, navigation, and compaction operations.
> - Slash commands (`/refine`, etc.) are now enqueued as `PreparedCommandInput` items and executed by the pump rather than being handled synchronously during preflight.
> - `navigateTo` acquires a queued-work pause and turn admission before performing branch navigation, invalidating stale queued prompt preparation when the branch changes.
> - `resumeQueuedWork` in daemon mode returns an immediate failure when no queued work is present instead of calling `agent.continue()` and broadcasting async errors.
> - `/refine` argument parsing is extracted into a shared `parseRefineCommandOptions` utility used by both interactive mode and the session layer.
> - Risk: `waitForIdle` now awaits the session input pump and accepted prompts in addition to agent idle, which changes the timing semantics for callers relying on idle detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a39331.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->