### PR TITLE
fix: /btw now shows full answer instead of truncating

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.
 - Changed `/context` tree connectors from `├ `/`└ ` to `├─ `/`└─ ` to match the tree selector and session picker.

--- a/packages/coding-agent/src/modes/interactive/components/side-question.ts
+++ b/packages/coding-agent/src/modes/interactive/components/side-question.ts
@@ -7,11 +7,7 @@ export class SideQuestionComponent implements Component {
 	private readonly answer: Markdown;
 	private event: AgentConnectionSideQuestionEvent;
 
-	constructor(
-		event: AgentConnectionSideQuestionEvent,
-		private readonly getMaxLines: () => number,
-		paddingX = 2,
-	) {
+	constructor(event: AgentConnectionSideQuestionEvent, paddingX = 2) {
 		this.event = event;
 		this.paddingX = Math.max(2, paddingX);
 		this.answer = new Markdown("", this.paddingX, 0, getMarkdownTheme(), {
@@ -37,12 +33,7 @@ export class SideQuestionComponent implements Component {
 			0,
 		).render(width);
 		const lines = [blank, ...question, blank, ...this.renderAnswer(width), blank];
-		const maxLines = Math.max(6, this.getMaxLines());
-		if (lines.length <= maxLines) {
-			return lines.map((line) => this.applySurface(line, width));
-		}
-		const ellipsis = new Text(theme.fg("dim", "…"), this.paddingX, 0).render(width)[0] ?? blank;
-		return [...lines.slice(0, maxLines - 1), ellipsis].map((line) => this.applySurface(line, width));
+		return lines.map((line) => this.applySurface(line, width));
 	}
 
 	private renderAnswer(width: number): string[] {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1353,7 +1353,6 @@ export class InteractiveMode {
 		this.mainContainer.addChild(this.widgetContainerBelow);
 		this.footerSlot.addChild(this.footer);
 		this.mainContainer.addChild(this.footerSlot);
-		this.promptDock.addChild(this.sideQuestionContainer);
 		this.promptDock.addChild(this.featureHintContainer);
 		this.promptDock.addChild(this.editorContainer);
 		this.promptDock.addChild(this.childAgentSummary);
@@ -4142,11 +4141,7 @@ export class InteractiveMode {
 		};
 		this.activeSideQuestionId = event.id;
 		this.sideQuestionEvent = event;
-		this.sideQuestionComponent = new SideQuestionComponent(
-			event,
-			() => this.getSideQuestionMaxLines(),
-			this.settingsManager.getEditorPaddingX(),
-		);
+		this.sideQuestionComponent = new SideQuestionComponent(event, this.settingsManager.getEditorPaddingX());
 		this.sideQuestionContainer.addChild(new Spacer(1));
 		this.sideQuestionContainer.addChild(this.sideQuestionComponent);
 		this.ui.requestRender();
@@ -4216,10 +4211,6 @@ export class InteractiveMode {
 		}
 		this.showStatus("Navigated to selected point");
 		void this.flushCompactionQueue({ willRetry: false });
-	}
-
-	private getSideQuestionMaxLines(): number {
-		return Math.max(6, Math.min(12, Math.floor(this.ui.terminal.rows * 0.3)));
 	}
 
 	private setupEditorSubmitHandler(): void {
@@ -6615,6 +6606,7 @@ export class InteractiveMode {
 					this.widgetContainerAbove,
 					this.recapContainer,
 					this.queuedMessagesContainer,
+					this.sideQuestionContainer,
 					this.widgetContainerBelow,
 				],
 				dock: this.promptDock,

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -214,39 +214,34 @@ describe("ENG-4509 side questions", () => {
 		expect(hasActiveSideQuestionFor.call(fakeThis, otherClient, "session-1")).toBe(false);
 	});
 
-	it("renders a bounded one-turn panel above the prompt", () => {
-		const component = new SideQuestionComponent(
-			{
-				id: "question-4",
-				question: "What changed?",
-				answer: "First line\n\nSecond line\n\nThird line\n\nFourth line",
-				status: "complete",
-			},
-			() => 8,
-		);
+	it("renders the complete side-question answer", () => {
+		const component = new SideQuestionComponent({
+			id: "question-4",
+			question: "What changed?",
+			answer: "First line\n\nSecond line\n\nThird line\n\nFourth line",
+			status: "complete",
+		});
 		const lines = component.render(40);
 		const rendered = stripAnsi(lines.join("\n"));
 		const blankPopupLine = theme.getPopupBackgroundColor()(" ".repeat(40));
 
-		expect(lines).toHaveLength(8);
 		expect(lines.every((line) => line.includes("\x1b[48"))).toBe(true);
 		expect(lines[0]).toBe(blankPopupLine);
 		expect(getEditorTheme().autocompleteBackgroundColor?.(" ".repeat(40))).toBe(blankPopupLine);
 		expect(rendered).toContain("  /btw  What changed?");
 		expect(rendered).not.toContain("  answer");
 		expect(rendered).toContain("First line");
-		expect(rendered).toContain("…");
+		expect(rendered).toContain("Fourth line");
+		expect(rendered).not.toContain("…");
 	});
 
 	it("aligns the thinking placeholder with the streamed response", () => {
 		const running = new SideQuestionComponent(
 			{ id: "question-5", question: "Still running?", answer: "", status: "running" },
-			() => 8,
 			4,
 		);
 		const complete = new SideQuestionComponent(
 			{ id: "question-5", question: "Still running?", answer: "Aligned response", status: "complete" },
-			() => 8,
 			4,
 		);
 		const runningLines = running.render(40).map(stripAnsi);
@@ -260,10 +255,12 @@ describe("ENG-4509 side questions", () => {
 	});
 
 	it("uses the user-message foreground for pane content", () => {
-		const component = new SideQuestionComponent(
-			{ id: "question-5", question: "Readable question", answer: "Readable response", status: "complete" },
-			() => 8,
-		);
+		const component = new SideQuestionComponent({
+			id: "question-5",
+			question: "Readable question",
+			answer: "Readable response",
+			status: "complete",
+		});
 		const rendered = component.render(40).join("\n");
 
 		expect(rendered).toContain("\x1b[39mReadable question\x1b[39m");
@@ -271,10 +268,12 @@ describe("ENG-4509 side questions", () => {
 	});
 
 	it("keeps streamed text when a side question is cancelled", () => {
-		const component = new SideQuestionComponent(
-			{ id: "question-5", question: "Partial?", answer: "Useful partial response", status: "cancelled" },
-			() => 8,
-		);
+		const component = new SideQuestionComponent({
+			id: "question-5",
+			question: "Partial?",
+			answer: "Useful partial response",
+			status: "cancelled",
+		});
 		const rendered = stripAnsi(component.render(40).join("\n"));
 
 		expect(rendered).toContain("Useful partial response");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Interactive TUI layout and rendering only; no auth, daemon protocol, or session persistence changes.
> 
> **Overview**
> **`/btw` and `/side` answers are no longer capped** with a terminal-height ellipsis. `SideQuestionComponent` always renders the full markdown answer instead of slicing to ~30% of the screen.
> 
> **Placement changes in fullscreen:** the side-question panel stays in the main layout above the prompt, but it is **removed from the pinned prompt dock** and **added to the fullscreen scroll region** (with recap and queued messages), so long replies can be read by scrolling the transcript rather than being clipped in a fixed panel above the input.
> 
> Regression tests now assert the fourth line of a multi-line answer is visible and that `…` truncation is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655679a2216e054d0e02ea4253eaf7137b9df772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/btw` side questions to show full answers without truncation
> - Removes the `getMaxLines` callback from `SideQuestionComponent` and the truncation/ellipsis logic in its `render` method, so the full answer is always displayed.
> - Moves `sideQuestionContainer` from the pinned prompt dock into the main scrollable transcript, so long answers scroll naturally rather than being clipped.
> - In fullscreen mode, `sideQuestionContainer` is added to the scroll list so it participates in the scrollable region.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 655679a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->