### PR TITLE
feat(daemon): unify session input admission

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4996,7 +4996,7 @@ export class AgentSession {
 							if (!delivered.has(prompt.message)) undelivered.push(prompt);
 						}
 						if (this._isDeferredSessionInputError(error, epoch)) {
-							if (undelivered.length > 0) {
+							if (!this._activeSessionInput?.cancelled && undelivered.length > 0) {
 								queue.unshift(...undelivered);
 								this._syncSteeringStopPending();
 								this._emitQueueUpdate();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3005,10 +3005,16 @@ export class AgentSession {
 		else deferred?.resolve();
 	}
 
-	/** Reject both delivery and completion with one error unless the message already delivered. */
+	/**
+	 * Reject both legs of an agent message outcome. Delivery stays sticky once it
+	 * succeeded, but a re-armed completion (a reused id queued again after its first
+	 * turn finished) must still reject or its waiter hangs forever.
+	 */
 	private _rejectAgentMessage(agentMessageId: string | undefined, error: Error): void {
-		if (agentMessageId === undefined || this._agentMessageOutcomes.get(agentMessageId)?.delivered) return;
-		this._settleAgentMessage(agentMessageId, "delivery", error);
+		if (agentMessageId === undefined) return;
+		if (!this._agentMessageOutcomes.get(agentMessageId)?.delivered) {
+			this._settleAgentMessage(agentMessageId, "delivery", error);
+		}
 		this._settleAgentMessage(agentMessageId, "completion", error);
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -786,14 +786,11 @@ interface AgentMessageDeferred {
 
 /**
  * Per-agent-message settlement record: `delivery` settles when the prompt reaches agent state,
- * `completion` when its turn (or command) finishes. `delivered`/`deliveryError` keep the
- * delivery outcome sticky for late waiters; completion deferreds are detached once settled.
+ * `completion` when its turn (or command) finishes. Settled deferreds are removed immediately.
  */
 interface AgentMessageOutcome {
 	delivery?: AgentMessageDeferred;
 	completion?: AgentMessageDeferred;
-	delivered?: boolean;
-	deliveryError?: Error;
 }
 
 function createAgentMessageDeferred(): AgentMessageDeferred {
@@ -2968,53 +2965,39 @@ export class AgentSession {
 		return outcome;
 	}
 
+	/**
+	 * Register a delivery waiter before submitting the prompt. Delivery outcomes are not retained
+	 * for late lookup, so callers that register after admission may wait for a future use of the id.
+	 */
 	waitForAgentMessagePromptDelivery(agentMessageId: string): Promise<void> {
 		const outcome = this._agentMessageOutcome(agentMessageId);
-		if (outcome.delivered) return Promise.resolve();
-		if (outcome.deliveryError) return Promise.reject(outcome.deliveryError);
 		outcome.delivery ??= createAgentMessageDeferred();
 		return outcome.delivery.promise;
 	}
 
-	/**
-	 * Resolve (no error) or reject one leg of an agent message outcome. The first delivery
-	 * settlement is sticky for late waiters; settled completion deferreds free the id for reuse.
-	 */
+	/** Resolve (no error) or reject an existing leg of an agent message outcome. */
 	private _settleAgentMessage(
 		agentMessageId: string | undefined,
 		leg: "delivery" | "completion",
 		error?: Error,
 	): void {
 		if (agentMessageId === undefined) return;
-		const outcome =
-			leg === "delivery"
-				? this._agentMessageOutcome(agentMessageId)
-				: this._agentMessageOutcomes.get(agentMessageId);
+		const outcome = this._agentMessageOutcomes.get(agentMessageId);
 		if (!outcome) return;
-		if (leg === "delivery") {
-			if (outcome.delivered || outcome.deliveryError) return;
-			outcome.delivered = !error;
-			outcome.deliveryError = error;
-		}
 		const deferred = outcome[leg];
+		if (!deferred) return;
 		outcome[leg] = undefined;
-		if (!outcome.delivery && !outcome.completion && !outcome.delivered && !outcome.deliveryError) {
+		if (!outcome.delivery && !outcome.completion) {
 			this._agentMessageOutcomes.delete(agentMessageId);
 		}
-		if (error) deferred?.reject(error);
-		else deferred?.resolve();
+		if (error) deferred.reject(error);
+		else deferred.resolve();
 	}
 
-	/**
-	 * Reject both legs of an agent message outcome. Delivery stays sticky once it
-	 * succeeded, but a re-armed completion (a reused id queued again after its first
-	 * turn finished) must still reject or its waiter hangs forever.
-	 */
+	/** Reject both currently registered legs of an agent message outcome. */
 	private _rejectAgentMessage(agentMessageId: string | undefined, error: Error): void {
 		if (agentMessageId === undefined) return;
-		if (!this._agentMessageOutcomes.get(agentMessageId)?.delivered) {
-			this._settleAgentMessage(agentMessageId, "delivery", error);
-		}
+		this._settleAgentMessage(agentMessageId, "delivery", error);
 		this._settleAgentMessage(agentMessageId, "completion", error);
 	}
 
@@ -3987,7 +3970,6 @@ export class AgentSession {
 	}
 
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
-		const internalId = options?.agentMessageId === undefined;
 		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
 		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
 			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
@@ -4001,10 +3983,6 @@ export class AgentSession {
 		} catch (error) {
 			this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
 			throw error;
-		} finally {
-			// A generated id has no late waiters; drop its sticky delivery record so
-			// long-lived sessions do not grow one outcome entry per prompt.
-			if (internalId) this._agentMessageOutcomes.delete(agentMessageId);
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -623,24 +623,6 @@ function cloneCustomMessage(message: CustomMessage): CustomMessage {
 	};
 }
 
-function restoredSessionSlashCommand(message: CustomMessage | undefined): SessionSlashCommand | undefined {
-	if (!isSessionSlashCommandMessage(message)) return undefined;
-	const command = message.details.command;
-	if (!command || typeof command !== "object") return undefined;
-	const candidate = command as Partial<SessionSlashCommand>;
-	if (
-		(candidate.name !== "compact" &&
-			candidate.name !== "refine" &&
-			candidate.name !== "goal" &&
-			candidate.name !== "autonomous") ||
-		typeof candidate.args !== "string" ||
-		typeof candidate.text !== "string"
-	) {
-		return undefined;
-	}
-	return candidate as SessionSlashCommand;
-}
-
 function createQueuedAgentInputSnapshotFromUserMessage(
 	text: string,
 	message: QueuedAgentMessage,
@@ -796,10 +778,32 @@ function undeliveredPendingNextTurnMessages(accepted: AcceptedAgentMessagePrompt
 	return accepted.pendingNextTurnMessages.filter((message) => !accepted.deliveredPendingNextTurnMessages.has(message));
 }
 
-interface AgentMessageDeliveryWaiter {
+interface AgentMessageDeferred {
 	promise: Promise<void>;
 	resolve: () => void;
 	reject: (error: Error) => void;
+}
+
+/**
+ * Per-agent-message settlement record: `delivery` settles when the prompt reaches agent state,
+ * `completion` when its turn (or command) finishes. `delivered`/`deliveryError` keep the
+ * delivery outcome sticky for late waiters; completion deferreds are detached once settled.
+ */
+interface AgentMessageOutcome {
+	delivery?: AgentMessageDeferred;
+	completion?: AgentMessageDeferred;
+	delivered?: boolean;
+	deliveryError?: Error;
+}
+
+function createAgentMessageDeferred(): AgentMessageDeferred {
+	const deferred = {} as AgentMessageDeferred;
+	deferred.promise = new Promise<void>((resolve, reject) => {
+		deferred.resolve = resolve;
+		deferred.reject = reject;
+	});
+	deferred.promise.catch(() => undefined);
+	return deferred;
 }
 
 /** Result from cycleModel() */
@@ -1025,10 +1029,7 @@ export class AgentSession {
 	private _retryAuthFailureSources: AuthSourceToken[] = [];
 	private _acceptedPromptCompletions = new Set<Promise<void>>();
 	private _acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined = undefined;
-	private _agentMessageDeliveryWaiters = new Map<string, AgentMessageDeliveryWaiter>();
-	private _agentMessageCompletionWaiters = new Map<string, AgentMessageDeliveryWaiter>();
-	private _deliveredAgentMessageIds = new Set<string>();
-	private _failedAgentMessageDeliveries = new Map<string, Error>();
+	private _agentMessageOutcomes = new Map<string, AgentMessageOutcome>();
 	private _lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
 
 	// Bash execution state
@@ -1795,7 +1796,10 @@ export class AgentSession {
 		if (this._pumpingSessionInput) {
 			const normalized = normalizeMessageContent(message.content);
 			if (kind === "budget_limit") {
-				await this._queueSteer(normalized.text, normalized.images, { message, resumeIfIdle: true });
+				await this._queuePreparedPrompt("steer", normalized.text, normalized.images, {
+					message,
+					resumeIfIdle: true,
+				});
 			} else {
 				const input = this._createPreparedPromptInput(normalized.text, normalized.images, {
 					message,
@@ -2955,85 +2959,63 @@ export class AgentSession {
 	// Track last assistant message for auto-compaction check
 	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
 
+	private _agentMessageOutcome(agentMessageId: string): AgentMessageOutcome {
+		let outcome = this._agentMessageOutcomes.get(agentMessageId);
+		if (!outcome) {
+			outcome = {};
+			this._agentMessageOutcomes.set(agentMessageId, outcome);
+		}
+		return outcome;
+	}
+
 	waitForAgentMessagePromptDelivery(agentMessageId: string): Promise<void> {
-		if (this._deliveredAgentMessageIds.has(agentMessageId)) {
-			return Promise.resolve();
-		}
-		const failedDelivery = this._failedAgentMessageDeliveries.get(agentMessageId);
-		if (failedDelivery) {
-			return Promise.reject(failedDelivery);
-		}
-		let waiter = this._agentMessageDeliveryWaiters.get(agentMessageId);
-		if (waiter) {
-			return waiter.promise;
-		}
-		let resolveDelivery = () => {};
-		let rejectDelivery = (_error: Error) => {};
-		const promise = new Promise<void>((resolve, reject) => {
-			resolveDelivery = resolve;
-			rejectDelivery = reject;
-		});
-		waiter = { promise, resolve: resolveDelivery, reject: rejectDelivery };
-		this._agentMessageDeliveryWaiters.set(agentMessageId, waiter);
-		void promise
-			.finally(() => {
-				if (this._agentMessageDeliveryWaiters.get(agentMessageId) === waiter) {
-					this._agentMessageDeliveryWaiters.delete(agentMessageId);
-				}
-			})
-			.catch(() => undefined);
-		return promise;
+		const outcome = this._agentMessageOutcome(agentMessageId);
+		if (outcome.delivered) return Promise.resolve();
+		if (outcome.deliveryError) return Promise.reject(outcome.deliveryError);
+		outcome.delivery ??= createAgentMessageDeferred();
+		return outcome.delivery.promise;
 	}
 
-	private waitForAgentMessagePromptCompletion(agentMessageId: string): Promise<void> {
-		let waiter = this._agentMessageCompletionWaiters.get(agentMessageId);
-		if (waiter) return waiter.promise;
-		let resolve = () => {};
-		let reject = (_error: Error) => {};
-		const promise = new Promise<void>((resolvePromise, rejectPromise) => {
-			resolve = resolvePromise;
-			reject = rejectPromise;
-		});
-		waiter = { promise, resolve, reject };
-		this._agentMessageCompletionWaiters.set(agentMessageId, waiter);
-		void promise.finally(() => this._agentMessageCompletionWaiters.delete(agentMessageId)).catch(() => undefined);
-		return promise;
-	}
-
-	private _resolveAgentMessageCompletion(agentMessageId: string | undefined): void {
-		if (agentMessageId) this._agentMessageCompletionWaiters.get(agentMessageId)?.resolve();
-	}
-
-	private _rejectAgentMessageCompletion(agentMessageId: string | undefined, error: Error): void {
-		if (agentMessageId) this._agentMessageCompletionWaiters.get(agentMessageId)?.reject(error);
-	}
-
-	private _resolveAgentMessageDelivery(agentMessageId: string | undefined): void {
-		if (agentMessageId === undefined) {
-			return;
-		}
-		this._failedAgentMessageDeliveries.delete(agentMessageId);
-		this._deliveredAgentMessageIds.add(agentMessageId);
-		this._agentMessageDeliveryWaiters.get(agentMessageId)?.resolve();
-	}
-
-	private _rejectAgentMessageDelivery(
+	/**
+	 * Resolve (no error) or reject one leg of an agent message outcome. The first delivery
+	 * settlement is sticky for late waiters; settled completion deferreds free the id for reuse.
+	 */
+	private _settleAgentMessage(
 		agentMessageId: string | undefined,
-		error: Error,
-		rejectCompletion = true,
+		leg: "delivery" | "completion",
+		error?: Error,
 	): void {
-		if (agentMessageId === undefined || this._deliveredAgentMessageIds.has(agentMessageId)) {
-			return;
+		if (agentMessageId === undefined) return;
+		const outcome =
+			leg === "delivery"
+				? this._agentMessageOutcome(agentMessageId)
+				: this._agentMessageOutcomes.get(agentMessageId);
+		if (!outcome) return;
+		if (leg === "delivery") {
+			if (outcome.delivered) return;
+			outcome.delivered = !error;
+			outcome.deliveryError = error;
 		}
-		this._failedAgentMessageDeliveries.set(agentMessageId, error);
-		this._agentMessageDeliveryWaiters.get(agentMessageId)?.reject(error);
-		if (rejectCompletion) this._rejectAgentMessageCompletion(agentMessageId, error);
+		const deferred = outcome[leg];
+		outcome[leg] = undefined;
+		if (!outcome.delivery && !outcome.completion && !outcome.delivered && !outcome.deliveryError) {
+			this._agentMessageOutcomes.delete(agentMessageId);
+		}
+		if (error) deferred?.reject(error);
+		else deferred?.resolve();
+	}
+
+	/** Reject both delivery and completion with one error unless the message already delivered. */
+	private _rejectAgentMessage(agentMessageId: string | undefined, error: Error): void {
+		if (agentMessageId === undefined || this._agentMessageOutcomes.get(agentMessageId)?.delivered) return;
+		this._settleAgentMessage(agentMessageId, "delivery", error);
+		this._settleAgentMessage(agentMessageId, "completion", error);
 	}
 
 	private _rejectQueuedAgentMessageDeliveries(deliveryError: Error, completionError = deliveryError): void {
 		for (const message of [...this._steeringMessages, ...this._followUpMessages]) {
-			this._rejectAgentMessageDelivery(message.agentMessageId, deliveryError, false);
-			this._rejectAgentMessageCompletion(message.agentMessageId, completionError);
+			this._settleAgentMessage(message.agentMessageId, "delivery", deliveryError);
+			this._settleAgentMessage(message.agentMessageId, "completion", completionError);
 		}
 	}
 
@@ -3049,14 +3031,14 @@ export class AgentSession {
 		if (event.type === "message_start") {
 			if (acceptedPrompt?.message === event.message && !acceptedPrompt.cleared) {
 				acceptedPrompt.turnStarted = true;
-				this._resolveAgentMessageDelivery(acceptedPrompt.agentMessageId);
+				this._settleAgentMessage(acceptedPrompt.agentMessageId, "delivery");
 				acceptedPrompt.resolveAccepted();
 			}
 			const activeInput =
 				this._activeSessionInput?.kind === "prompt"
 					? this._activeSessionInput.items.find((input) => input.message === event.message)
 					: undefined;
-			this._resolveAgentMessageDelivery(activeInput?.agentMessageId);
+			this._settleAgentMessage(activeInput?.agentMessageId, "delivery");
 		}
 		this._agentEventQueue = this._agentEventQueue.then(
 			() => this._processAgentEvent(event),
@@ -3688,10 +3670,10 @@ export class AgentSession {
 			const deliveryError = new Error("Session disposed before prompt delivery.");
 			const completionError = new Error("Session disposed before prompt completion.");
 			this._rejectQueuedAgentMessageDeliveries(deliveryError, completionError);
-			for (const agentMessageId of this._agentMessageDeliveryWaiters.keys()) {
-				this._rejectAgentMessageDelivery(agentMessageId, deliveryError, false);
+			for (const [agentMessageId, outcome] of this._agentMessageOutcomes) {
+				if (outcome.delivery) this._settleAgentMessage(agentMessageId, "delivery", deliveryError);
+				if (outcome.completion) this._settleAgentMessage(agentMessageId, "completion", completionError);
 			}
-			for (const waiter of this._agentMessageCompletionWaiters.values()) waiter.reject(completionError);
 			this._steeringMessages = [];
 			this._followUpMessages = [];
 			this._syncSteeringStopPending();
@@ -4000,15 +3982,17 @@ export class AgentSession {
 
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
 		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
-		if (this._agentMessageCompletionWaiters.has(agentMessageId)) {
+		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
 			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
 		}
-		const completion = this.waitForAgentMessagePromptCompletion(agentMessageId);
+		const outcome = this._agentMessageOutcome(agentMessageId);
+		outcome.completion = createAgentMessageDeferred();
+		const completion = outcome.completion.promise;
 		try {
 			await this.promptUntilAccepted(text, { ...options, agentMessageId });
 			await completion;
 		} catch (error) {
-			this._rejectAgentMessageCompletion(agentMessageId, error instanceof Error ? error : new Error(String(error)));
+			this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
 			throw error;
 		}
 	}
@@ -4034,10 +4018,10 @@ export class AgentSession {
 	): Promise<boolean> {
 		const agentMessageId = customMessage?.details.id ?? parseAgentSessionMessagePromptId(text);
 		if (streamingBehavior === "steer") {
-			await this._queueSteer(text, undefined, { agentMessageId, message: customMessage });
+			await this._queuePreparedPrompt("steer", text, undefined, { agentMessageId, message: customMessage });
 			return true;
 		}
-		return this._queueFollowUp(text, undefined, { agentMessageId, message: customMessage });
+		return this._queuePreparedPrompt("followUp", text, undefined, { agentMessageId, message: customMessage });
 	}
 
 	async promptHeartbeat(job: AgentCronJob, options?: PromptOptions): Promise<void> {
@@ -4265,8 +4249,8 @@ export class AgentSession {
 				if (commandCompletion) {
 					reportPreflight(true);
 					void commandCompletion.then(
-						() => this._resolveAgentMessageCompletion(options?.agentMessageId),
-						(error) => this._rejectAgentMessageCompletion(options?.agentMessageId, error),
+						() => this._settleAgentMessage(options?.agentMessageId, "completion"),
+						(error) => this._settleAgentMessage(options?.agentMessageId, "completion", error),
 					);
 					void commandCompletion.catch(() => undefined);
 					if (!options?.returnAfterAccepted) await commandCompletion.catch(() => undefined);
@@ -4285,7 +4269,7 @@ export class AgentSession {
 				);
 				if (inputResult.action === "handled") {
 					reportPreflight(true);
-					this._resolveAgentMessageCompletion(options?.agentMessageId);
+					this._settleAgentMessage(options?.agentMessageId, "completion");
 					return;
 				}
 				if (inputResult.action === "transform") {
@@ -4531,12 +4515,8 @@ export class AgentSession {
 		});
 		if (options?.agentMessageId) {
 			void promptCompletion.then(
-				() => this._resolveAgentMessageCompletion(options.agentMessageId),
-				(error) =>
-					this._rejectAgentMessageCompletion(
-						options.agentMessageId,
-						error instanceof Error ? error : new Error(String(error)),
-					),
+				() => this._settleAgentMessage(options.agentMessageId, "completion"),
+				(error) => this._settleAgentMessage(options.agentMessageId, "completion", this._asError(error)),
 			);
 		}
 		void promptCompletion
@@ -4634,7 +4614,7 @@ export class AgentSession {
 		let expandedText = this._expandSkillCommand(text);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
-		await this._queueSteer(expandedText, images, {
+		await this._queuePreparedPrompt("steer", expandedText, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
 			resumeIfIdle: options.resumeIfIdle,
@@ -4662,7 +4642,7 @@ export class AgentSession {
 		let expandedText = this._expandSkillCommand(text);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
-		return this._queueFollowUp(expandedText, images, {
+		return this._queuePreparedPrompt("followUp", expandedText, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
 			resumeIfIdle: options.resumeIfIdle,
@@ -4703,8 +4683,7 @@ export class AgentSession {
 	): Promise<void> {
 		if (this._restoreSessionCommand(text, options.customMessage, images, "steer") !== undefined) return;
 
-
-		await this._queueSteer(text, images, {
+		await this._queuePreparedPrompt("steer", text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
 			content: options.content,
@@ -4727,8 +4706,7 @@ export class AgentSession {
 		const restoredCommand = this._restoreSessionCommand(text, options.customMessage, images, "followUp");
 		if (restoredCommand !== undefined) return restoredCommand;
 
-
-		return this._queueFollowUp(text, images, {
+		return this._queuePreparedPrompt("followUp", text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
 			content: options.content,
@@ -4763,43 +4741,33 @@ export class AgentSession {
 	): Promise<void> {
 		const pendingNextTurnMessages = this._pendingNextTurnMessages;
 		this._pendingNextTurnMessages = [];
-		const queueOptions = {
-			queueKey: options.queueKey,
-			agentMessageId: options.agentMessageId,
-			message: options.message,
-			prefixMessages: pendingNextTurnMessages,
-			previewLabel: options.previewLabel,
-			suppressAutonomousContinuation: options.suppressAutonomousContinuation,
-			resumeIfIdle: options.resumeIfIdle,
-		};
 		// Preflight callbacks run outside the try: a throwing callback must not roll
 		// back queue state for an input that was in fact enqueued (its prefixMessages
 		// would be delivered twice).
-		if (streamingBehavior === "followUp") {
-			let queued: boolean;
-			try {
-				queued = await this._queueFollowUp(text, options.images, queueOptions);
-				if (!queued) {
-					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
-					this._rejectAgentMessageCompletion(
-						options.agentMessageId,
-						new Error("Prompt was not queued because an equivalent follow-up is already pending."),
-					);
-				}
-			} catch (error) {
-				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
-				throw error;
-			}
-			reportPreflight(queued, queued);
-			return;
-		}
+		let queued: boolean;
 		try {
-			await this._queueSteer(text, options.images, queueOptions);
+			queued = await this._queuePreparedPrompt(streamingBehavior, text, options.images, {
+				queueKey: options.queueKey,
+				agentMessageId: options.agentMessageId,
+				message: options.message,
+				prefixMessages: pendingNextTurnMessages,
+				previewLabel: options.previewLabel,
+				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
+				resumeIfIdle: options.resumeIfIdle,
+			});
+			if (!queued) {
+				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
+				this._settleAgentMessage(
+					options.agentMessageId,
+					"completion",
+					new Error("Prompt was not queued because an equivalent follow-up is already pending."),
+				);
+			}
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
 			throw error;
 		}
-		reportPreflight(true, true);
+		reportPreflight(queued, queued);
 	}
 
 	/**
@@ -4873,33 +4841,14 @@ export class AgentSession {
 		return true;
 	}
 
-	private async _queueSteer(
+	/** Queue a prepared prompt on one lane; steering always queues, follow-up may coalesce by queue key. */
+	private async _queuePreparedPrompt(
+		schedule: SessionInputSchedule,
 		text: string,
 		images?: ImageContent[],
 		options: {
 			agentMessageId?: string;
 			queueKey?: string;
-			content?: (TextContent | ImageContent)[];
-			message?: QueuedAgentMessage;
-			prefixMessages?: CustomMessage[];
-			previewLabel?: string;
-			suppressAutonomousContinuation?: boolean;
-			resumeIfIdle?: boolean;
-		} = {},
-	): Promise<void> {
-		const input = this._createPreparedPromptInput(text, images, options);
-		if (options.suppressAutonomousContinuation) {
-			this._markAutonomousContinuationSuppressed(input.message);
-		}
-		this._enqueueSessionInput(input, "steer");
-	}
-
-	private async _queueFollowUp(
-		text: string,
-		images?: ImageContent[],
-		options: {
-			queueKey?: string;
-			agentMessageId?: string;
 			content?: (TextContent | ImageContent)[];
 			message?: QueuedAgentMessage;
 			prefixMessages?: CustomMessage[];
@@ -4912,7 +4861,7 @@ export class AgentSession {
 		if (options.suppressAutonomousContinuation) {
 			this._markAutonomousContinuationSuppressed(input.message);
 		}
-		return this._enqueueSessionInput(input, "followUp");
+		return this._enqueueSessionInput(input, schedule);
 	}
 
 	private _scheduleSessionInputPump(): void {
@@ -4958,12 +4907,9 @@ export class AgentSession {
 						this._emitQueueUpdate();
 						try {
 							await this._executeQueuedSessionCommand(first);
-							this._resolveAgentMessageCompletion(first.agentMessageId);
+							this._settleAgentMessage(first.agentMessageId, "completion");
 						} catch (error) {
-							this._rejectAgentMessageCompletion(
-								first.agentMessageId,
-								error instanceof Error ? error : new Error(String(error)),
-							);
+							this._settleAgentMessage(first.agentMessageId, "completion", this._asError(error));
 						} finally {
 							this._activeSessionInput = undefined;
 							this._syncSteeringStopPending();
@@ -4986,7 +4932,7 @@ export class AgentSession {
 					try {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
 						for (const prompt of prompts) {
-							this._resolveAgentMessageCompletion(prompt.agentMessageId);
+							this._settleAgentMessage(prompt.agentMessageId, "completion");
 						}
 					} catch (error) {
 						const delivered = new Set(this.agent.state.messages);
@@ -5006,10 +4952,10 @@ export class AgentSession {
 						}
 						const terminalError = this._asError(error);
 						for (const prompt of undelivered) {
-							this._rejectAgentMessageDelivery(prompt.agentMessageId, terminalError, false);
+							this._settleAgentMessage(prompt.agentMessageId, "delivery", terminalError);
 						}
 						for (const prompt of prompts) {
-							this._rejectAgentMessageCompletion(prompt.agentMessageId, terminalError);
+							this._settleAgentMessage(prompt.agentMessageId, "completion", terminalError);
 						}
 						this._surfaceSessionInputError(error);
 					} finally {
@@ -5270,9 +5216,15 @@ export class AgentSession {
 		} else if (this.isStreaming) {
 			const normalized = normalizeMessageContent(message.content);
 			if (options?.deliverAs === "followUp") {
-				await this._queueFollowUp(normalized.text, normalized.images, { message: appMessage, resumeIfIdle: true });
+				await this._queuePreparedPrompt("followUp", normalized.text, normalized.images, {
+					message: appMessage,
+					resumeIfIdle: true,
+				});
 			} else {
-				await this._queueSteer(normalized.text, normalized.images, { message: appMessage, resumeIfIdle: true });
+				await this._queuePreparedPrompt("steer", normalized.text, normalized.images, {
+					message: appMessage,
+					resumeIfIdle: true,
+				});
 			}
 		} else if (options?.triggerTurn) {
 			const admission = await this._acquireDirectTurnAdmission();
@@ -5355,8 +5307,8 @@ export class AgentSession {
 			this._sessionInputPumpEpoch++;
 			const error = new Error("Queued prompt was cleared before delivery.");
 			for (const input of active.items) {
-				this._rejectAgentMessageDelivery(input.agentMessageId, error, false);
-				this._rejectAgentMessageCompletion(input.agentMessageId, error);
+				this._settleAgentMessage(input.agentMessageId, "delivery", error);
+				this._settleAgentMessage(input.agentMessageId, "completion", error);
 			}
 		}
 		const activeTexts = active?.items.map((message) => message.text) ?? [];
@@ -5422,7 +5374,7 @@ export class AgentSession {
 		);
 		this._syncSteeringStopPending();
 		for (const message of [...steering, ...followUp]) {
-			this._rejectAgentMessageDelivery(
+			this._rejectAgentMessage(
 				message.agentMessageId,
 				new Error("Queued agent message was cleared before delivery."),
 			);
@@ -5436,7 +5388,7 @@ export class AgentSession {
 				...undeliveredPendingNextTurnMessages(accepted).map((message) => ({ ...message })),
 			);
 			const error = new Error("Accepted agent message was cleared before delivery.");
-			this._rejectAgentMessageDelivery(accepted.agentMessageId, error);
+			this._rejectAgentMessage(accepted.agentMessageId, error);
 			accepted.rejectAccepted(error);
 			this.agent.abort();
 			removedFollowUp.push(accepted.text);
@@ -5692,7 +5644,7 @@ export class AgentSession {
 		this._followUpMessages = this._followUpMessages.filter((message) => !removed.has(message));
 		this._syncSteeringStopPending();
 		for (const message of removed) {
-			this._rejectAgentMessageDelivery(
+			this._rejectAgentMessage(
 				message.agentMessageId,
 				new Error("Queued agent message was cleared before delivery."),
 			);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -662,6 +662,7 @@ function createQueuedAgentInputSnapshot(message: QueuedSessionInput): QueuedAgen
 		return {
 			text: message.text,
 			...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
+			...(message.agentMessageId ? { agentMessageId: message.agentMessageId } : {}),
 			customMessage: createSessionSlashCommandMessage(message.command),
 		};
 	}
@@ -3016,21 +3017,23 @@ export class AgentSession {
 		this._agentMessageDeliveryWaiters.get(agentMessageId)?.resolve();
 	}
 
-	private _rejectAgentMessageDelivery(agentMessageId: string | undefined, error: Error): void {
+	private _rejectAgentMessageDelivery(
+		agentMessageId: string | undefined,
+		error: Error,
+		rejectCompletion = true,
+	): void {
 		if (agentMessageId === undefined || this._deliveredAgentMessageIds.has(agentMessageId)) {
 			return;
 		}
 		this._failedAgentMessageDeliveries.set(agentMessageId, error);
 		this._agentMessageDeliveryWaiters.get(agentMessageId)?.reject(error);
-		this._rejectAgentMessageCompletion(agentMessageId, error);
+		if (rejectCompletion) this._rejectAgentMessageCompletion(agentMessageId, error);
 	}
 
-	private _rejectQueuedAgentMessageDeliveries(error: Error): void {
-		for (const message of this._steeringMessages) {
-			this._rejectAgentMessageDelivery(message.agentMessageId, error);
-		}
-		for (const message of this._followUpMessages) {
-			this._rejectAgentMessageDelivery(message.agentMessageId, error);
+	private _rejectQueuedAgentMessageDeliveries(deliveryError: Error, completionError = deliveryError): void {
+		for (const message of [...this._steeringMessages, ...this._followUpMessages]) {
+			this._rejectAgentMessageDelivery(message.agentMessageId, deliveryError, false);
+			this._rejectAgentMessageCompletion(message.agentMessageId, completionError);
 		}
 	}
 
@@ -3682,9 +3685,13 @@ export class AgentSession {
 			this._deletedRlmChildIds.clear();
 			this._retryableRlmSubagentDeletions.clear();
 			this._pendingNextTurnMessages = [];
-			const disposeError = new Error("Session disposed before prompt completion.");
-			this._rejectQueuedAgentMessageDeliveries(disposeError);
-			for (const waiter of this._agentMessageCompletionWaiters.values()) waiter.reject(disposeError);
+			const deliveryError = new Error("Session disposed before prompt delivery.");
+			const completionError = new Error("Session disposed before prompt completion.");
+			this._rejectQueuedAgentMessageDeliveries(deliveryError, completionError);
+			for (const agentMessageId of this._agentMessageDeliveryWaiters.keys()) {
+				this._rejectAgentMessageDelivery(agentMessageId, deliveryError, false);
+			}
+			for (const waiter of this._agentMessageCompletionWaiters.values()) waiter.reject(completionError);
 			this._steeringMessages = [];
 			this._followUpMessages = [];
 			this._syncSteeringStopPending();
@@ -4247,18 +4254,22 @@ export class AgentSession {
 				);
 				reportPreflight(queued, wasBusy);
 				releaseAdmission();
-				if (!wasBusy) await this._sessionInputPump;
+				if (!wasBusy && !options?.returnAfterAccepted) await this._sessionInputPump;
 				return;
 			}
 
 			// Handle extension commands first (execute immediately, even during streaming)
 			// Extension commands manage their own LLM interaction via pi.sendMessage()
 			if (expandPromptTemplates && currentText.startsWith("/")) {
-				const handled = await this._tryExecuteExtensionCommand(currentText);
-				if (handled) {
-					// Extension command executed, no prompt to send
+				const commandCompletion = this._executeExtensionCommand(currentText);
+				if (commandCompletion) {
 					reportPreflight(true);
-					this._resolveAgentMessageCompletion(options?.agentMessageId);
+					void commandCompletion.then(
+						() => this._resolveAgentMessageCompletion(options?.agentMessageId),
+						(error) => this._rejectAgentMessageCompletion(options?.agentMessageId, error),
+					);
+					void commandCompletion.catch(() => undefined);
+					if (!options?.returnAfterAccepted) await commandCompletion.catch(() => undefined);
 					return;
 				}
 			}
@@ -4549,33 +4560,25 @@ export class AgentSession {
 		await promptCompletion;
 	}
 
-	/**
-	 * Try to execute an extension command. Returns true if command was found and executed.
-	 */
-	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
-		// Parse command name and args
+	private _executeExtensionCommand(text: string): Promise<void> | undefined {
 		const spaceIndex = text.indexOf(" ");
 		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
-
 		const command = this._extensionRunner.getCommand(commandName);
-		if (!command) return false;
-
-		// Get command context from extension runner (includes session control methods)
-		const ctx = this._extensionRunner.createCommandContext();
-
-		try {
-			await command.handler(args, ctx);
-			return true;
-		} catch (err) {
-			// Emit error via extension runner
-			this._extensionRunner.emitError({
-				extensionPath: `command:${commandName}`,
-				event: "command",
-				error: err instanceof Error ? err.message : String(err),
+		if (!command) return undefined;
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		const context = this._extensionRunner.createCommandContext();
+		return Promise.resolve()
+			.then(() => command.handler(args, context))
+			.catch((error: unknown) => {
+				const commandError = error instanceof Error ? error : new Error(String(error));
+				this._extensionRunner.emitError({
+					extensionPath: `command:${commandName}`,
+					event: "command",
+					error: commandError.message,
+				});
+				throw commandError;
 			});
-			return true;
-		}
+			});
 	}
 
 	/**
@@ -4700,6 +4703,7 @@ export class AgentSession {
 	): Promise<void> {
 		if (this._restoreSessionCommand(text, options.customMessage, images, "steer") !== undefined) return;
 
+
 		await this._queueSteer(text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -4722,6 +4726,7 @@ export class AgentSession {
 	): Promise<boolean> {
 		const restoredCommand = this._restoreSessionCommand(text, options.customMessage, images, "followUp");
 		if (restoredCommand !== undefined) return restoredCommand;
+
 
 		return this._queueFollowUp(text, images, {
 			queueKey: options.queueKey,
@@ -5004,6 +5009,7 @@ export class AgentSession {
 						this._activeSessionInput = undefined;
 						this._syncSteeringStopPending();
 					}
+
 				} finally {
 					admission.release();
 				}
@@ -5334,15 +5340,25 @@ export class AgentSession {
 	 * @returns Object with steering and followUp arrays
 	 */
 	clearQueue(): { steering: string[]; followUp: string[] } {
-		if (this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing") {
-			this._activeSessionInput.cancelled = true;
+		const active =
+			this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing"
+				? this._activeSessionInput
+				: undefined;
+		if (active) {
+			active.cancelled = true;
 			this._sessionInputPumpEpoch++;
 			const error = new Error("Queued prompt was cleared before delivery.");
-			for (const input of this._activeSessionInput.items)
-				this._rejectAgentMessageDelivery(input.agentMessageId, error);
+			for (const input of active.items) this._rejectAgentMessageDelivery(input.agentMessageId, error);
 		}
-		const steering = this._steeringMessages.map((message) => message.text);
-		const followUp = this._followUpMessages.map((message) => message.text);
+		const activeTexts = active?.items.map((message) => message.text) ?? [];
+		const steering = [
+			...(active?.lane === "steer" ? activeTexts : []),
+			...this._steeringMessages.map((message) => message.text),
+		];
+		const followUp = [
+			...(active?.lane === "followUp" ? activeTexts : []),
+			...this._followUpMessages.map((message) => message.text),
+		];
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 		this._steeringMessages = [];
 		this._followUpMessages = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5315,7 +5315,9 @@ export class AgentSession {
 	 */
 	clearQueue(): { steering: string[]; followUp: string[] } {
 		const active =
-			this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing"
+			this._activeSessionInput?.kind === "prompt" &&
+			this._activeSessionInput.phase === "preparing" &&
+			!this._activeSessionInput.cancelled
 				? this._activeSessionInput
 				: undefined;
 		if (active) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -512,6 +512,8 @@ export interface PromptOptions {
 	skipInputHandlers?: boolean;
 	/** Cancel this prompt while it is waiting for direct-turn admission. */
 	signal?: AbortSignal;
+	/** Internal host hook fired at the direct-turn ownership commit point. */
+	admissionCommitted?: () => void;
 	agentMessageId?: string;
 	content?: (TextContent | ImageContent)[];
 	customMessage?: CustomMessage;
@@ -577,6 +579,8 @@ function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | un
 		};
 		const cleanup = () => signal.removeEventListener("abort", onAbort);
 		signal.addEventListener("abort", onAbort, { once: true });
+		// Close the listener-registration race before observing the awaited work.
+		if (signal.aborted) return onAbort();
 		promise.then(
 			(value) => {
 				cleanup();
@@ -4029,6 +4033,8 @@ export class AgentSession {
 	): Promise<void> {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
 		const admission = await this._acquireDirectTurnAdmission({ allowStreaming: true, signal: options?.signal });
+		throwIfPromptAdmissionCancelled(options?.signal);
+		options?.admissionCommitted?.();
 		try {
 			await this._turnAdmissionContext.run(admission.owner, () =>
 				this._promptInjectedMessageUnserialized(text, message, options, admission.release),
@@ -4166,6 +4172,10 @@ export class AgentSession {
 			? await this._acquireDirectTurnAdmission({ signal: options?.signal })
 			: undefined;
 		const releaseAdmission = admission?.release ?? (() => {});
+		// Streaming prompts skip direct-turn admission but still transfer ownership
+		// before any queue/interception work begins.
+		throwIfPromptAdmissionCancelled(options?.signal);
+		options?.admissionCommitted?.();
 		try {
 			if (admission) {
 				await this._turnAdmissionContext.run(admission.owner, () =>

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4768,11 +4768,6 @@ export class AgentSession {
 			});
 			if (!queued) {
 				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
-				this._settleAgentMessage(
-					options.agentMessageId,
-					"completion",
-					new Error("Prompt was not queued because an equivalent follow-up is already pending."),
-				);
 			}
 		} catch (error) {
 			this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
@@ -4828,14 +4823,20 @@ export class AgentSession {
 		options: { restore?: boolean } = {},
 	): boolean {
 		const queue = schedule === "steer" ? this._steeringMessages : this._followUpMessages;
-		if (
-			schedule === "followUp" &&
-			input.kind === "prompt" &&
-			input.queueKey &&
-			(queue.some((item) => item.queueKey === input.queueKey) ||
-				(this._activeSessionInput?.kind === "prompt" &&
-					this._activeSessionInput.items.some((item) => item.queueKey === input.queueKey)))
-		) {
+		const coalescedOwner =
+			schedule === "followUp" && input.kind === "prompt" && input.queueKey
+				? (queue.find((item) => item.queueKey === input.queueKey) ??
+					(this._activeSessionInput?.kind === "prompt"
+						? this._activeSessionInput.items.find((item) => item.queueKey === input.queueKey)
+						: undefined))
+				: undefined;
+		if (coalescedOwner) {
+			if (input.agentMessageId !== coalescedOwner.agentMessageId) {
+				this._rejectAgentMessage(
+					input.agentMessageId,
+					new Error("Prompt was not queued because an equivalent follow-up is already pending."),
+				);
+			}
 			return false;
 		}
 		queue.push(input);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -502,14 +502,14 @@ export interface PromptOptions {
 	preflightResult?: (success: boolean, queued?: boolean) => void;
 	/** Queue instead of starting immediately when the session is idle but already has queued work. */
 	queueIfBusy?: boolean;
+	/** Start queued work when no agent turn is currently running. */
+	resumeIfIdle?: boolean;
 	/** Host-generated prompt that must bypass extension/slash/template input interception. */
 	internalPrompt?: boolean;
 	/** Prevent host-driven prompts from causing autonomous continuation injection. */
 	suppressAutonomousContinuation?: boolean;
 	/** Skip extension input handlers for replaying already-accepted input. */
 	skipInputHandlers?: boolean;
-	/** Start queued work when this input is admitted to an otherwise idle session. */
-	resumeIfIdle?: boolean;
 	/** Cancel this prompt while it is waiting for direct-turn admission. */
 	signal?: AbortSignal;
 	agentMessageId?: string;
@@ -596,7 +596,7 @@ interface PreparedCommandInput {
 	command: SessionSlashCommand;
 	images?: ImageContent[];
 	queueKey?: undefined;
-	agentMessageId?: undefined;
+	agentMessageId?: string;
 	message?: undefined;
 }
 
@@ -623,6 +623,24 @@ function cloneCustomMessage(message: CustomMessage): CustomMessage {
 	};
 }
 
+function restoredSessionSlashCommand(message: CustomMessage | undefined): SessionSlashCommand | undefined {
+	if (!isSessionSlashCommandMessage(message)) return undefined;
+	const command = message.details.command;
+	if (!command || typeof command !== "object") return undefined;
+	const candidate = command as Partial<SessionSlashCommand>;
+	if (
+		(candidate.name !== "compact" &&
+			candidate.name !== "refine" &&
+			candidate.name !== "goal" &&
+			candidate.name !== "autonomous") ||
+		typeof candidate.args !== "string" ||
+		typeof candidate.text !== "string"
+	) {
+		return undefined;
+	}
+	return candidate as SessionSlashCommand;
+}
+
 function createQueuedAgentInputSnapshotFromUserMessage(
 	text: string,
 	message: QueuedAgentMessage,
@@ -647,7 +665,9 @@ function createQueuedAgentInputSnapshot(message: QueuedSessionInput): QueuedAgen
 			customMessage: createSessionSlashCommandMessage(message.command),
 		};
 	}
+	const legacySnapshot = createQueuedAgentInputSnapshotFromUserMessage(message.text, message.message);
 	return {
+		...legacySnapshot,
 		text: message.text,
 		...(message.content ? { content: message.content.map((block) => ({ ...block })) } : {}),
 		...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
@@ -962,7 +982,13 @@ export class AgentSession {
 	private _legacyQueuedWorkPause: { release(): void } | undefined;
 	private _pumpingSessionInput = false;
 	private _activeSessionInput:
-		| { kind: "prompt"; lane: SessionInputSchedule; items: PreparedPromptInput[]; phase: "preparing" | "handedOff" }
+		| {
+				kind: "prompt";
+				lane: SessionInputSchedule;
+				items: PreparedPromptInput[];
+				phase: "preparing" | "handedOff";
+				cancelled?: boolean;
+		  }
 		| { kind: "command"; lane: SessionInputSchedule; item: PreparedCommandInput; phase: "executing" }
 		| undefined;
 	private _steeringStopPending = false;
@@ -999,6 +1025,7 @@ export class AgentSession {
 	private _acceptedPromptCompletions = new Set<Promise<void>>();
 	private _acceptedAgentMessagePrompt: AcceptedAgentMessagePrompt | undefined = undefined;
 	private _agentMessageDeliveryWaiters = new Map<string, AgentMessageDeliveryWaiter>();
+	private _agentMessageCompletionWaiters = new Map<string, AgentMessageDeliveryWaiter>();
 	private _deliveredAgentMessageIds = new Set<string>();
 	private _failedAgentMessageDeliveries = new Map<string, Error>();
 	private _lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
@@ -2957,6 +2984,29 @@ export class AgentSession {
 		return promise;
 	}
 
+	private waitForAgentMessagePromptCompletion(agentMessageId: string): Promise<void> {
+		let waiter = this._agentMessageCompletionWaiters.get(agentMessageId);
+		if (waiter) return waiter.promise;
+		let resolve = () => {};
+		let reject = (_error: Error) => {};
+		const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+			resolve = resolvePromise;
+			reject = rejectPromise;
+		});
+		waiter = { promise, resolve, reject };
+		this._agentMessageCompletionWaiters.set(agentMessageId, waiter);
+		void promise.finally(() => this._agentMessageCompletionWaiters.delete(agentMessageId)).catch(() => undefined);
+		return promise;
+	}
+
+	private _resolveAgentMessageCompletion(agentMessageId: string | undefined): void {
+		if (agentMessageId) this._agentMessageCompletionWaiters.get(agentMessageId)?.resolve();
+	}
+
+	private _rejectAgentMessageCompletion(agentMessageId: string | undefined, error: Error): void {
+		if (agentMessageId) this._agentMessageCompletionWaiters.get(agentMessageId)?.reject(error);
+	}
+
 	private _resolveAgentMessageDelivery(agentMessageId: string | undefined): void {
 		if (agentMessageId === undefined) {
 			return;
@@ -2972,6 +3022,7 @@ export class AgentSession {
 		}
 		this._failedAgentMessageDeliveries.set(agentMessageId, error);
 		this._agentMessageDeliveryWaiters.get(agentMessageId)?.reject(error);
+		this._rejectAgentMessageCompletion(agentMessageId, error);
 	}
 
 	private _rejectQueuedAgentMessageDeliveries(error: Error): void {
@@ -3631,7 +3682,9 @@ export class AgentSession {
 			this._deletedRlmChildIds.clear();
 			this._retryableRlmSubagentDeletions.clear();
 			this._pendingNextTurnMessages = [];
-			this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
+			const disposeError = new Error("Session disposed before prompt completion.");
+			this._rejectQueuedAgentMessageDeliveries(disposeError);
+			for (const waiter of this._agentMessageCompletionWaiters.values()) waiter.reject(disposeError);
 			this._steeringMessages = [];
 			this._followUpMessages = [];
 			this._syncSteeringStopPending();
@@ -3933,6 +3986,26 @@ export class AgentSession {
 		return this._prompt(text, options);
 	}
 
+	/** Resolve once the session has accepted ownership, before queued or active execution completes. */
+	async promptUntilAccepted(text: string, options?: PromptOptions): Promise<void> {
+		return this._prompt(text, { ...options, returnAfterAccepted: true });
+	}
+
+	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
+		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
+		if (this._agentMessageCompletionWaiters.has(agentMessageId)) {
+			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
+		}
+		const completion = this.waitForAgentMessagePromptCompletion(agentMessageId);
+		try {
+			await this.promptUntilAccepted(text, { ...options, agentMessageId });
+			await completion;
+		} catch (error) {
+			this._rejectAgentMessageCompletion(agentMessageId, error instanceof Error ? error : new Error(String(error)));
+			throw error;
+		}
+	}
+
 	async acceptAgentMessagePrompt(text: string, options?: PromptOptions): Promise<void> {
 		const customMessage =
 			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
@@ -4018,6 +4091,7 @@ export class AgentSession {
 					suppressAutonomousContinuation: options.suppressAutonomousContinuation,
 					resumeIfIdle: options.resumeIfIdle,
 				});
+
 				return;
 			}
 
@@ -4087,6 +4161,7 @@ export class AgentSession {
 				suppressAutonomousContinuation: options.suppressAutonomousContinuation,
 				resumeIfIdle: options.resumeIfIdle,
 			});
+
 			return;
 		}
 
@@ -4161,7 +4236,13 @@ export class AgentSession {
 					this.pendingMessageCount > 0;
 				const schedule = options?.streamingBehavior ?? (this.isStreaming ? "steer" : "followUp");
 				const queued = this._enqueueSessionInput(
-					{ kind: "command", text: currentText, command: sessionCommand, images: currentImages },
+					{
+						kind: "command",
+						text: currentText,
+						command: sessionCommand,
+						images: currentImages,
+						agentMessageId: options?.agentMessageId,
+					},
 					schedule,
 				);
 				reportPreflight(queued, wasBusy);
@@ -4177,6 +4258,7 @@ export class AgentSession {
 				if (handled) {
 					// Extension command executed, no prompt to send
 					reportPreflight(true);
+					this._resolveAgentMessageCompletion(options?.agentMessageId);
 					return;
 				}
 			}
@@ -4192,6 +4274,7 @@ export class AgentSession {
 				);
 				if (inputResult.action === "handled") {
 					reportPreflight(true);
+					this._resolveAgentMessageCompletion(options?.agentMessageId);
 					return;
 				}
 				if (inputResult.action === "transform") {
@@ -4228,6 +4311,7 @@ export class AgentSession {
 					message: options.customMessage,
 					resumeIfIdle: options.resumeIfIdle,
 				});
+
 				return;
 			}
 
@@ -4381,6 +4465,7 @@ export class AgentSession {
 				message: options.customMessage,
 				resumeIfIdle: options.resumeIfIdle,
 			});
+
 			return;
 		}
 		if (options?.suppressAutonomousContinuation) {
@@ -4433,6 +4518,16 @@ export class AgentSession {
 		const promptCompletion = promptPromise.then(async () => {
 			await this.waitForRetry();
 		});
+		if (options?.agentMessageId) {
+			void promptCompletion.then(
+				() => this._resolveAgentMessageCompletion(options.agentMessageId),
+				(error) =>
+					this._rejectAgentMessageCompletion(
+						options.agentMessageId,
+						error instanceof Error ? error : new Error(String(error)),
+					),
+			);
+		}
 		void promptCompletion
 			.finally(() => {
 				if (
@@ -4604,6 +4699,7 @@ export class AgentSession {
 		} = {},
 	): Promise<void> {
 		if (this._restoreSessionCommand(text, options.customMessage, images, "steer") !== undefined) return;
+
 		await this._queueSteer(text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -4626,6 +4722,7 @@ export class AgentSession {
 	): Promise<boolean> {
 		const restoredCommand = this._restoreSessionCommand(text, options.customMessage, images, "followUp");
 		if (restoredCommand !== undefined) return restoredCommand;
+
 		return this._queueFollowUp(text, images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -4679,6 +4776,10 @@ export class AgentSession {
 				queued = await this._queueFollowUp(text, options.images, queueOptions);
 				if (!queued) {
 					this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
+					this._rejectAgentMessageCompletion(
+						options.agentMessageId,
+						new Error("Prompt was not queued because an equivalent follow-up is already pending."),
+					);
 				}
 			} catch (error) {
 				this._pendingNextTurnMessages.unshift(...pendingNextTurnMessages);
@@ -5027,6 +5128,7 @@ export class AgentSession {
 			result?.systemPrompt !== undefined && preparation !== undefined
 				? this._refreshExtensionSystemPrompt(result.systemPrompt, preparation.basePromptSnapshot)
 				: this._baseSystemPrompt;
+		if (this._activeSessionInput?.kind === "prompt") this._activeSessionInput.phase = "handedOff";
 		try {
 			if (this.isStreaming) {
 				// agent.prompt() would reject with its already-processing error; defer instead.
@@ -5225,6 +5327,13 @@ export class AgentSession {
 	 * @returns Object with steering and followUp arrays
 	 */
 	clearQueue(): { steering: string[]; followUp: string[] } {
+		if (this._activeSessionInput?.kind === "prompt" && this._activeSessionInput.phase === "preparing") {
+			this._activeSessionInput.cancelled = true;
+			this._sessionInputPumpEpoch++;
+			const error = new Error("Queued prompt was cleared before delivery.");
+			for (const input of this._activeSessionInput.items)
+				this._rejectAgentMessageDelivery(input.agentMessageId, error);
+		}
 		const steering = this._steeringMessages.map((message) => message.text);
 		const followUp = this._followUpMessages.map((message) => message.text);
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4033,9 +4033,11 @@ export class AgentSession {
 	): Promise<void> {
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
 		const admission = await this._acquireDirectTurnAdmission({ allowStreaming: true, signal: options?.signal });
-		throwIfPromptAdmissionCancelled(options?.signal);
-		options?.admissionCommitted?.();
 		try {
+			// Ownership commits before destructive preflight, but cancellation and the
+			// commit callback are covered by release if either throws.
+			throwIfPromptAdmissionCancelled(options?.signal);
+			options?.admissionCommitted?.();
 			await this._turnAdmissionContext.run(admission.owner, () =>
 				this._promptInjectedMessageUnserialized(text, message, options, admission.release),
 			);
@@ -4172,11 +4174,12 @@ export class AgentSession {
 			? await this._acquireDirectTurnAdmission({ signal: options?.signal })
 			: undefined;
 		const releaseAdmission = admission?.release ?? (() => {});
-		// Streaming prompts skip direct-turn admission but still transfer ownership
-		// before any queue/interception work begins.
-		throwIfPromptAdmissionCancelled(options?.signal);
-		options?.admissionCommitted?.();
 		try {
+			// Streaming prompts skip direct-turn admission but still transfer ownership
+			// before any queue/interception work begins. Keep this before destructive
+			// preflight while ensuring a directly acquired admission is always released.
+			throwIfPromptAdmissionCancelled(options?.signal);
+			options?.admissionCommitted?.();
 			if (admission) {
 				await this._turnAdmissionContext.run(admission.owner, () =>
 					this._promptUnserialized(text, options, releaseAdmission),

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4252,7 +4252,7 @@ export class AgentSession {
 					},
 					schedule,
 				);
-				reportPreflight(queued, wasBusy);
+				reportPreflight(queued, queued);
 				releaseAdmission();
 				if (!wasBusy && !options?.returnAfterAccepted) await this._sessionInputPump;
 				return;
@@ -5010,6 +5010,7 @@ export class AgentSession {
 						this._syncSteeringStopPending();
 					}
 
+
 				} finally {
 					admission.release();
 				}
@@ -5348,7 +5349,10 @@ export class AgentSession {
 			active.cancelled = true;
 			this._sessionInputPumpEpoch++;
 			const error = new Error("Queued prompt was cleared before delivery.");
-			for (const input of active.items) this._rejectAgentMessageDelivery(input.agentMessageId, error);
+			for (const input of active.items) {
+				this._rejectAgentMessageDelivery(input.agentMessageId, error, false);
+				this._rejectAgentMessageCompletion(input.agentMessageId, error);
+			}
 		}
 		const activeTexts = active?.items.map((message) => message.text) ?? [];
 		const steering = [

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2992,7 +2992,7 @@ export class AgentSession {
 				: this._agentMessageOutcomes.get(agentMessageId);
 		if (!outcome) return;
 		if (leg === "delivery") {
-			if (outcome.delivered) return;
+			if (outcome.delivered || outcome.deliveryError) return;
 			outcome.delivered = !error;
 			outcome.deliveryError = error;
 		}
@@ -4665,6 +4665,7 @@ export class AgentSession {
 		customMessage: CustomMessage | undefined,
 		images: ImageContent[] | undefined,
 		schedule: SessionInputSchedule,
+		agentMessageId: string | undefined,
 	): boolean | undefined {
 		if (!isSessionSlashCommandMessage(customMessage) || text !== customMessage.details.command.text) {
 			return undefined;
@@ -4675,6 +4676,7 @@ export class AgentSession {
 				text,
 				command: customMessage.details.command,
 				images,
+				agentMessageId,
 			},
 			schedule,
 			{ restore: true },
@@ -4692,7 +4694,10 @@ export class AgentSession {
 			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<void> {
-		if (this._restoreSessionCommand(text, options.customMessage, images, "steer") !== undefined) return;
+		if (
+			this._restoreSessionCommand(text, options.customMessage, images, "steer", options.agentMessageId) !== undefined
+		)
+			return;
 
 		await this._queuePreparedPrompt("steer", text, images, {
 			queueKey: options.queueKey,
@@ -4714,7 +4719,13 @@ export class AgentSession {
 			prefixMessages?: CustomMessage[];
 		} = {},
 	): Promise<boolean> {
-		const restoredCommand = this._restoreSessionCommand(text, options.customMessage, images, "followUp");
+		const restoredCommand = this._restoreSessionCommand(
+			text,
+			options.customMessage,
+			images,
+			"followUp",
+			options.agentMessageId,
+		);
 		if (restoredCommand !== undefined) return restoredCommand;
 
 		return this._queuePreparedPrompt("followUp", text, images, {
@@ -4921,7 +4932,7 @@ export class AgentSession {
 							await this._executeQueuedSessionCommand(first);
 							this._settleAgentMessage(first.agentMessageId, "completion");
 						} catch (error) {
-							this._settleAgentMessage(first.agentMessageId, "completion", this._asError(error));
+							this._rejectAgentMessage(first.agentMessageId, this._asError(error));
 						} finally {
 							this._activeSessionInput = undefined;
 							this._syncSteeringStopPending();
@@ -5128,6 +5139,7 @@ export class AgentSession {
 
 	private async _executeQueuedSessionCommand(input: PreparedCommandInput): Promise<void> {
 		this._appendDurableSessionCommandMessage(input.text, input.command, false);
+		this._settleAgentMessage(input.agentMessageId, "delivery");
 		try {
 			let resultText: string | undefined;
 			switch (input.command.name) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -569,9 +569,12 @@ function throwIfPromptAdmissionCancelled(signal: AbortSignal | undefined): void 
 	if (signal?.aborted) throw new Error("Prompt admission was cancelled.");
 }
 
-function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+export function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
 	if (!signal) return promise;
-	throwIfPromptAdmissionCancelled(signal);
+	if (signal.aborted) {
+		void promise.catch(() => {});
+		throwIfPromptAdmissionCancelled(signal);
+	}
 	return new Promise<T>((resolve, reject) => {
 		const onAbort = () => {
 			cleanup();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1908,6 +1908,7 @@ export class AgentSession {
 			this._activeSessionInput?.kind === "prompt" &&
 			this._activeSessionInput.lane === "steer" &&
 			this._activeSessionInput.phase === "preparing" &&
+			!this._activeSessionInput.cancelled &&
 			this._activeSessionInput.items.length > 0;
 		this._steeringStopPending = this._steeringMessages.length > 0 || activeSteeringHandoff;
 	}
@@ -1924,7 +1925,7 @@ export class AgentSession {
 			if (this._accountGoalUsageForAssistantMessage(context.message)) {
 				const message = createGoalContextMessage(this._goalState, "budget_limit");
 				const normalized = normalizeMessageContent(message.content);
-				await this._queueSteer(normalized.text, normalized.images, {
+				await this._queuePreparedPrompt("steer", normalized.text, normalized.images, {
 					message,
 					resumeIfIdle: true,
 				});
@@ -3220,7 +3221,7 @@ export class AgentSession {
 				if (this._accountGoalUsageForAssistantMessage(assistantMsg)) {
 					const message = createGoalContextMessage(this._goalState, "budget_limit");
 					const normalized = normalizeMessageContent(message.content);
-					await this._queueSteer(normalized.text, normalized.images, {
+					await this._queuePreparedPrompt("steer", normalized.text, normalized.images, {
 						message,
 						resumeIfIdle: true,
 					});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4569,6 +4569,7 @@ export class AgentSession {
 		const context = this._extensionRunner.createCommandContext();
 		return Promise.resolve()
 			.then(() => command.handler(args, context))
+
 			.catch((error: unknown) => {
 				const commandError = error instanceof Error ? error : new Error(String(error));
 				this._extensionRunner.emitError({
@@ -4577,7 +4578,6 @@ export class AgentSession {
 					error: commandError.message,
 				});
 				throw commandError;
-			});
 			});
 	}
 
@@ -5009,8 +5009,6 @@ export class AgentSession {
 						this._activeSessionInput = undefined;
 						this._syncSteeringStopPending();
 					}
-
-
 				} finally {
 					admission.release();
 				}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4985,6 +4985,9 @@ export class AgentSession {
 					this._emitQueueUpdate();
 					try {
 						await this._startPreparedPromptItems(prompts, epoch, admission.release);
+						for (const prompt of prompts) {
+							this._resolveAgentMessageCompletion(prompt.agentMessageId);
+						}
 					} catch (error) {
 						const delivered = new Set(this.agent.state.messages);
 						const undelivered: PreparedPromptInput[] = [];
@@ -5001,8 +5004,12 @@ export class AgentSession {
 							blocked = true;
 							return;
 						}
+						const terminalError = this._asError(error);
 						for (const prompt of undelivered) {
-							this._rejectAgentMessageDelivery(prompt.agentMessageId, this._asError(error));
+							this._rejectAgentMessageDelivery(prompt.agentMessageId, terminalError, false);
+						}
+						for (const prompt of prompts) {
+							this._rejectAgentMessageCompletion(prompt.agentMessageId, terminalError);
 						}
 						this._surfaceSessionInputError(error);
 					} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3987,6 +3987,7 @@ export class AgentSession {
 	}
 
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
+		const internalId = options?.agentMessageId === undefined;
 		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
 		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
 			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
@@ -4000,6 +4001,10 @@ export class AgentSession {
 		} catch (error) {
 			this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
 			throw error;
+		} finally {
+			// A generated id has no late waiters; drop its sticky delivery record so
+			// long-lived sessions do not grow one outcome entry per prompt.
+			if (internalId) this._agentMessageOutcomes.delete(agentMessageId);
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4953,6 +4953,12 @@ export class AgentSession {
 						this._emitQueueUpdate();
 						try {
 							await this._executeQueuedSessionCommand(first);
+							this._resolveAgentMessageCompletion(first.agentMessageId);
+						} catch (error) {
+							this._rejectAgentMessageCompletion(
+								first.agentMessageId,
+								error instanceof Error ? error : new Error(String(error)),
+							);
 						} finally {
 							this._activeSessionInput = undefined;
 							this._syncSteeringStopPending();
@@ -5177,8 +5183,9 @@ export class AgentSession {
 			}
 			if (resultText) this._appendDurableSessionCommandMessage(resultText, input.command, true, false);
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			this._appendDurableSessionCommandMessage(`Command failed: ${message}`, input.command, true, true);
+			const commandError = error instanceof Error ? error : new Error(String(error));
+			this._appendDurableSessionCommandMessage(`Command failed: ${commandError.message}`, input.command, true, true);
+			throw commandError;
 		}
 	}
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -316,6 +316,7 @@ export {
 	type DaemonResumeCursor,
 	type DaemonSessionSnapshot,
 	defaultDaemonSocketPath,
+	type InteractiveInitialPrompt,
 	InteractiveMode,
 	type InteractiveModeLocalSessionHost,
 	type InteractiveModeOptions,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -200,6 +200,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
+	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
 
@@ -805,6 +806,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		try {
 			const first = await Promise.race([promptRequest.then(() => "settled" as const), aborted]);
 			if (first === "settled" && promptError === undefined) return;
+			if (
+				first === "settled" &&
+				!signal.aborted &&
+				promptError instanceof Error &&
+				this.definitiveRequestErrors.has(promptError)
+			) {
+				throw promptError;
+			}
 			let status: "cancelled" | "owned" | "unknown" = "unknown";
 			try {
 				const result = await this.requestData<{ status: "cancelled" | "owned" | "unknown" }>({
@@ -818,7 +827,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			}
 			if (status === "owned") {
 				await promptRequest;
-				if (promptError === undefined) return;
+				if (promptError === undefined || type === "prompt") return;
 			}
 			throw new AgentConnectionPromptAdmissionError(
 				promptError instanceof Error ? promptError.message : "Prompt admission did not complete.",
@@ -1382,7 +1391,9 @@ export class DaemonAgentConnection implements AgentConnection {
 	): Promise<T> {
 		const response = await this.client.request(command, timeoutMs, options);
 		if (!response.success) {
-			throw deserializeDaemonError(response);
+			const error = deserializeDaemonError(response);
+			this.definitiveRequestErrors.add(error);
+			throw error;
 		}
 		if (invalidatesCachedSnapshot(command.type)) {
 			this.latestSnapshotIsFresh = false;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -826,7 +826,8 @@ export class DaemonAgentConnection implements AgentConnection {
 				// Timeout/transport is indistinguishable from accepted ownership.
 			}
 			await promptRequest;
-			if (promptError === undefined || (status === "owned" && type === "prompt")) return;
+			const definitiveFailure = promptError instanceof Error && this.definitiveRequestErrors.has(promptError);
+			if (promptError === undefined || (status === "owned" && type === "prompt" && !definitiveFailure)) return;
 			throw new AgentConnectionPromptAdmissionError(
 				promptError instanceof Error ? promptError.message : "Prompt admission did not complete.",
 				status,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -27,6 +27,8 @@ import { deserializeDaemonError } from "../daemon/daemon-errors.js";
 import {
 	collectDaemonClientEnv,
 	collectDaemonLaunchEnv,
+	DAEMON_PROTOCOL_VERSION,
+	DAEMON_SCHEMA_REVISION,
 	type DaemonAttachResult,
 	type DaemonCommand,
 	type DaemonEventCursor,
@@ -78,6 +80,7 @@ import type {
 	AgentConnectionToolDefinition,
 	AgentConnectionUserMessage,
 } from "./types.js";
+import { AgentConnectionPromptAdmissionError } from "./types.js";
 
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
@@ -723,33 +726,108 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async prompt(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		await this.requestData<unknown>(
-			{
-				type: "prompt",
-				activeSessionId: this.activeSessionId,
-				message,
-				images: options?.images,
-				streamingBehavior: options?.streamingBehavior,
-				queueIfBusy: options?.queueIfBusy,
-				source: options?.source,
-			},
-			DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
-		);
+		await this.promptWithAdmissionCancellation("prompt", message, options);
 	}
 
 	async promptAndWait(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		await this.requestData<unknown>(
-			{
-				type: "prompt_and_wait",
-				activeSessionId: this.activeSessionId,
-				message,
-				images: options?.images,
-				streamingBehavior: options?.streamingBehavior,
-				queueIfBusy: options?.queueIfBusy,
-				source: options?.source,
+		await this.promptWithAdmissionCancellation("prompt_and_wait", message, options);
+	}
+
+	private async promptWithAdmissionCancellation(
+		type: "prompt" | "prompt_and_wait",
+		message: string,
+		options?: AgentConnectionPromptOptions,
+	): Promise<void> {
+		const signal = options?.signal;
+		if (signal?.aborted) {
+			throw new AgentConnectionPromptAdmissionError("Prompt admission was cancelled.", "cancelled");
+		}
+		if (!signal) {
+			await this.requestData<unknown>(
+				{
+					type,
+					activeSessionId: this.activeSessionId,
+					message,
+					images: options?.images,
+					streamingBehavior: options?.streamingBehavior,
+					queueIfBusy: options?.queueIfBusy,
+					source: options?.source,
+				},
+				DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
+			);
+			return;
+		}
+		const hello = this.client.hello ?? (await this.client.waitForHello());
+		if (
+			hello.protocol.version < DAEMON_PROTOCOL_VERSION ||
+			hello.schemaRevision !== DAEMON_SCHEMA_REVISION ||
+			!this.client.supportsServerCapability("prompt_admission_cancellation")
+		) {
+			throw new AgentConnectionPromptAdmissionError(
+				"Startup prompt cancellation requires daemon protocol 5, schema 4, and prompt_admission_cancellation.",
+				"unsupported",
+			);
+		}
+
+		const admissionId = `prompt-admission:${randomUUID()}`;
+		let resolveAbort = () => {};
+		const aborted = new Promise<"abort">((resolve) => {
+			resolveAbort = () => resolve("abort");
+		});
+		const onAbort = () => resolveAbort();
+		signal.addEventListener("abort", onAbort, { once: true });
+		// Close the listener-registration race before issuing the first request.
+		if (signal.aborted) {
+			signal.removeEventListener("abort", onAbort);
+			throw new AgentConnectionPromptAdmissionError("Prompt admission was cancelled.", "cancelled");
+		}
+		const command = {
+			type,
+			activeSessionId: this.activeSessionId,
+			message,
+			images: options.images,
+			streamingBehavior: options.streamingBehavior,
+			queueIfBusy: options.queueIfBusy,
+			source: options.source,
+			admissionId,
+		} as Extract<DaemonCommandBody, { type: typeof type }>;
+		let promptError: unknown;
+		const promptRequest = this.requestData<unknown>(command, DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS, {
+			requiredSchema: {
+				protocol: DAEMON_PROTOCOL_VERSION,
+				revision: DAEMON_SCHEMA_REVISION,
+				capability: "prompt_admission_cancellation",
 			},
-			DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
-		);
+		}).catch((error: unknown) => {
+			promptError = error;
+			return "failed" as const;
+		});
+		try {
+			const first = await Promise.race([promptRequest.then(() => "settled" as const), aborted]);
+			if (first === "settled" && promptError === undefined) return;
+			let status: "cancelled" | "owned" | "unknown" = "unknown";
+			try {
+				const result = await this.requestData<{ status: "cancelled" | "owned" | "unknown" }>({
+					type: "cancel_prompt_admission",
+					activeSessionId: this.activeSessionId,
+					admissionId,
+				});
+				status = result.status;
+			} catch {
+				// Timeout/transport is indistinguishable from accepted ownership.
+			}
+			if (status === "owned") {
+				await promptRequest;
+				if (promptError === undefined) return;
+			}
+			throw new AgentConnectionPromptAdmissionError(
+				promptError instanceof Error ? promptError.message : "Prompt admission did not complete.",
+				status,
+				promptError === undefined ? undefined : { cause: promptError },
+			);
+		} finally {
+			signal.removeEventListener("abort", onAbort);
+		}
 	}
 
 	async startSideQuestion(
@@ -1297,8 +1375,12 @@ export class DaemonAgentConnection implements AgentConnection {
 		return response.data as T;
 	}
 
-	private async requestData<T>(command: DaemonCommandBody, timeoutMs?: number): Promise<T> {
-		const response = await this.client.request(command, timeoutMs);
+	private async requestData<T>(
+		command: DaemonCommandBody,
+		timeoutMs?: number,
+		options?: Parameters<DaemonClient["request"]>[2],
+	): Promise<T> {
+		const response = await this.client.request(command, timeoutMs, options);
 		if (!response.success) {
 			throw deserializeDaemonError(response);
 		}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -765,7 +765,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			!this.client.supportsServerCapability("prompt_admission_cancellation")
 		) {
 			throw new AgentConnectionPromptAdmissionError(
-				"Startup prompt cancellation requires daemon protocol 5, schema 4, and prompt_admission_cancellation.",
+				`Startup prompt cancellation requires daemon protocol ${DAEMON_PROTOCOL_VERSION}, schema ${DAEMON_SCHEMA_REVISION}, and prompt_admission_cancellation.`,
 				"unsupported",
 			);
 		}
@@ -825,10 +825,8 @@ export class DaemonAgentConnection implements AgentConnection {
 			} catch {
 				// Timeout/transport is indistinguishable from accepted ownership.
 			}
-			if (status === "owned") {
-				await promptRequest;
-				if (promptError === undefined || type === "prompt") return;
-			}
+			await promptRequest;
+			if (promptError === undefined || (status === "owned" && type === "prompt")) return;
 			throw new AgentConnectionPromptAdmissionError(
 				promptError instanceof Error ? promptError.message : "Prompt admission did not complete.",
 				status,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -761,7 +761,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		const hello = this.client.hello ?? (await this.client.waitForHello());
 		if (
 			hello.protocol.version < DAEMON_PROTOCOL_VERSION ||
-			hello.schemaRevision !== DAEMON_SCHEMA_REVISION ||
+			(hello.schemaRevision ?? 0) < DAEMON_SCHEMA_REVISION ||
 			!this.client.supportsServerCapability("prompt_admission_cancellation")
 		) {
 			throw new AgentConnectionPromptAdmissionError(

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -723,14 +723,18 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async prompt(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		await this.requestOk({
-			type: "prompt",
-			activeSessionId: this.activeSessionId,
-			message,
-			images: options?.images,
-			streamingBehavior: options?.streamingBehavior,
-			source: options?.source,
-		});
+		await this.requestData<unknown>(
+			{
+				type: "prompt",
+				activeSessionId: this.activeSessionId,
+				message,
+				images: options?.images,
+				streamingBehavior: options?.streamingBehavior,
+				queueIfBusy: options?.queueIfBusy,
+				source: options?.source,
+			},
+			DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
+		);
 	}
 
 	async promptAndWait(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
@@ -741,6 +745,7 @@ export class DaemonAgentConnection implements AgentConnection {
 				message,
 				images: options?.images,
 				streamingBehavior: options?.streamingBehavior,
+				queueIfBusy: options?.queueIfBusy,
 				source: options?.source,
 			},
 			DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -328,16 +328,12 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async promptAndWait(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		if (!options) {
-			await this.session.prompt(message);
-			return;
-		}
-		await this.session.prompt(message, {
-			...(options.images ? { images: options.images } : {}),
-			...(options.streamingBehavior ? { streamingBehavior: options.streamingBehavior, resumeIfIdle: true } : {}),
-			...(options.queueIfBusy !== undefined ? { queueIfBusy: options.queueIfBusy } : {}),
-			...(options.source ? { source: options.source } : {}),
-			...(options.signal ? { signal: options.signal } : {}),
+		await this.session.promptAndWait(message, {
+			...(options?.images ? { images: options.images } : {}),
+			...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior, resumeIfIdle: true } : {}),
+			...(options?.queueIfBusy !== undefined ? { queueIfBusy: options.queueIfBusy } : {}),
+			...(options?.source ? { source: options.source } : {}),
+			...(options?.signal ? { signal: options.signal } : {}),
 		});
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -73,3 +73,4 @@ export type {
 	AgentConnectionToolDefinition,
 	AgentConnectionUserMessage,
 } from "./types.js";
+export { AgentConnectionPromptAdmissionError } from "./types.js";

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -425,6 +425,21 @@ export interface AgentConnectionToolDefinition {
 	replayBuiltInToolName?: ReplayBuiltInToolName;
 }
 
+/** Prompt admission failure; only a confirmed cancellation is retry-safe. */
+export class AgentConnectionPromptAdmissionError extends Error {
+	readonly cancelled: boolean;
+
+	constructor(
+		message: string,
+		readonly status: "cancelled" | "owned" | "unknown" | "unsupported",
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.cancelled = status === "cancelled";
+		this.name = "AgentConnectionPromptAdmissionError";
+	}
+}
+
 export interface AgentConnectionPromptOptions {
 	images?: ImageContent[];
 	streamingBehavior?: "steer" | "followUp";

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -314,7 +314,6 @@ export class DaemonClient {
 			("capability" in compatibility && !this.supportsServerCapability(compatibility.capability)) ||
 			(requiredSchema !== undefined &&
 				(hello.protocol.version < requiredSchema.protocol ||
-					// schemaRevision is monotonic; a newer daemon must stay compatible.
 					(hello.schemaRevision ?? 0) < requiredSchema.revision ||
 					!this.supportsServerCapability(requiredSchema.capability)))
 		) {

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -7,6 +7,7 @@ import {
 	DAEMON_COMMAND_COMPATIBILITY,
 	DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION,
 	DAEMON_PROTOCOL_VERSION,
+	DAEMON_SCHEMA_REVISION,
 	type DaemonClosingReason,
 	type DaemonCommand,
 	type DaemonCommandEnvelope,
@@ -33,6 +34,8 @@ export type DaemonClientProgressListener = (message: DaemonRequestProgress) => v
 
 export interface DaemonClientRequestOptions {
 	onProgress?: DaemonClientProgressListener;
+	/** Fields that require an exact protocol/schema/capability handshake. */
+	requiredSchema?: { protocol: number; revision: number; capability: DaemonServerCapability };
 }
 
 interface PendingDaemonRequest {
@@ -298,13 +301,25 @@ export class DaemonClient {
 		}
 		const hello = this.helloMessage ?? (await this.waitForHello());
 		const compatibility = DAEMON_COMMAND_COMPATIBILITY[command.type];
+		const requiredSchema =
+			(command.type === "prompt" || command.type === "prompt_and_wait") && command.admissionId !== undefined
+				? {
+						protocol: DAEMON_PROTOCOL_VERSION,
+						revision: DAEMON_SCHEMA_REVISION,
+						capability: "prompt_admission_cancellation" as const,
+					}
+				: options.requiredSchema;
 		if (
 			hello.protocol.version < compatibility.minProtocol ||
-			("capability" in compatibility && !this.supportsServerCapability(compatibility.capability))
+			("capability" in compatibility && !this.supportsServerCapability(compatibility.capability)) ||
+			(requiredSchema !== undefined &&
+				(hello.protocol.version < requiredSchema.protocol ||
+					hello.schemaRevision !== requiredSchema.revision ||
+					!this.supportsServerCapability(requiredSchema.capability)))
 		) {
 			throw new DaemonCapabilityUnavailableError(
 				command.type,
-				"capability" in compatibility ? compatibility.capability : undefined,
+				requiredSchema?.capability ?? ("capability" in compatibility ? compatibility.capability : undefined),
 			);
 		}
 		const envelopeProtocolVersion = Math.min(hello.protocol.version, DAEMON_PROTOCOL_VERSION);

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -34,8 +34,14 @@ export type DaemonClientProgressListener = (message: DaemonRequestProgress) => v
 
 export interface DaemonClientRequestOptions {
 	onProgress?: DaemonClientProgressListener;
-	/** Fields that require an exact protocol/schema/capability handshake. */
-	requiredSchema?: { protocol: number; revision: number; capability: DaemonServerCapability };
+	/** Fields that require a minimum protocol/schema plus a capability handshake. */
+	requiredSchema?: DaemonRequiredSchema;
+}
+
+export interface DaemonRequiredSchema {
+	protocol: number;
+	revision: number;
+	capability: DaemonServerCapability;
 }
 
 interface PendingDaemonRequest {
@@ -48,6 +54,8 @@ interface PendingDaemonRequest {
 	wireData: string;
 	awaitingReconnect: boolean;
 	acknowledgeResult: boolean;
+	/** Re-checked against the new hello before a reconnect replay. */
+	requiredSchema?: DaemonRequiredSchema;
 }
 
 function daemonEndpointDetails(socketPath: string): string {
@@ -312,10 +320,7 @@ export class DaemonClient {
 		if (
 			hello.protocol.version < compatibility.minProtocol ||
 			("capability" in compatibility && !this.supportsServerCapability(compatibility.capability)) ||
-			(requiredSchema !== undefined &&
-				(hello.protocol.version < requiredSchema.protocol ||
-					(hello.schemaRevision ?? 0) < requiredSchema.revision ||
-					!this.supportsServerCapability(requiredSchema.capability)))
+			(requiredSchema !== undefined && !this.meetsRequiredSchema(hello, requiredSchema))
 		) {
 			throw new DaemonCapabilityUnavailableError(
 				command.type,
@@ -328,6 +333,15 @@ export class DaemonClient {
 			timeoutMs,
 			options,
 			envelopeProtocolVersion >= DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION ? envelopeProtocolVersion : undefined,
+			requiredSchema,
+		);
+	}
+
+	private meetsRequiredSchema(hello: DaemonHello, required: DaemonRequiredSchema): boolean {
+		return (
+			hello.protocol.version >= required.protocol &&
+			(hello.schemaRevision ?? 0) >= required.revision &&
+			hello.serverCapabilities?.includes(required.capability) === true
 		);
 	}
 
@@ -357,6 +371,7 @@ export class DaemonClient {
 		timeoutMs: number,
 		options: DaemonClientRequestOptions = {},
 		publicEnvelopeProtocolVersion?: DaemonProtocolVersion,
+		requiredSchema?: DaemonRequiredSchema,
 	): Promise<DaemonResponse> {
 		if (!this.socket || this.socket.destroyed) {
 			throw new Error(
@@ -388,6 +403,7 @@ export class DaemonClient {
 				wireData,
 				awaitingReconnect: false,
 				acknowledgeResult,
+				requiredSchema,
 			};
 			this.pendingRequests.set(id, pending);
 			this.armPendingRequestTimeout(id, pending);
@@ -451,6 +467,18 @@ export class DaemonClient {
 						continue;
 					}
 					pending.awaitingReconnect = false;
+					// A replaced daemon may no longer satisfy a field-gated request;
+					// replaying it would silently drop the gated field (e.g. admissionId).
+					if (pending.requiredSchema && !this.meetsRequiredSchema(message, pending.requiredSchema)) {
+						this.pendingRequests.delete(id);
+						pending.reject(
+							new DaemonCapabilityUnavailableError(
+								pending.commandType as DaemonCommand["type"],
+								pending.requiredSchema.capability,
+							),
+						);
+						continue;
+					}
 					this.armPendingRequestTimeout(id, pending);
 					this.socket.write(pending.wireData);
 				}

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -314,7 +314,8 @@ export class DaemonClient {
 			("capability" in compatibility && !this.supportsServerCapability(compatibility.capability)) ||
 			(requiredSchema !== undefined &&
 				(hello.protocol.version < requiredSchema.protocol ||
-					hello.schemaRevision !== requiredSchema.revision ||
+					// schemaRevision is monotonic; a newer daemon must stay compatible.
+					(hello.schemaRevision ?? 0) < requiredSchema.revision ||
 					!this.supportsServerCapability(requiredSchema.capability)))
 		) {
 			throw new DaemonCapabilityUnavailableError(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2461,6 +2461,8 @@ export class AgentDaemon {
 
 	private async handleLine(client: DaemonSocketClient, line: string): Promise<void> {
 		let command: DaemonCommand;
+		let clearParsedAdmission = () => {};
+		let promptHandlerOwnsAdmission = false;
 		try {
 			const parsed = this.parseCommandAndRegisterPromptAdmission(line) as {
 				id?: unknown;
@@ -2484,7 +2486,7 @@ export class AgentDaemon {
 							this.promptAdmissionKey(parsed.activeSessionId, (parsed as { admissionId: string }).admissionId),
 						)
 					: undefined;
-			const clearParsedAdmission = () => {
+			clearParsedAdmission = () => {
 				if (!parsedAdmission) return;
 				const key = this.promptAdmissionKey(parsedAdmission.activeSessionId, parsedAdmission.admissionId);
 				if (this.promptAdmissions.get(key) === parsedAdmission) {
@@ -2540,6 +2542,7 @@ export class AgentDaemon {
 			if (this.options.worker) {
 				const boundClaim = this.supervisorClaims.get(client);
 				if (!boundClaim) {
+					clearParsedAdmission();
 					this.write(
 						client,
 						failure(
@@ -2578,7 +2581,7 @@ export class AgentDaemon {
 						failure(
 							typeof parsed.id === "string" ? parsed.id : undefined,
 							typeof parsed.type === "string" ? parsed.type : "worker_auth",
-							error,
+							admissionCancelled ? error : "supervisor_generation_stale",
 						),
 					);
 					// Cancelling this prompt only abandons its admission wait. A genuine
@@ -2605,7 +2608,9 @@ export class AgentDaemon {
 		}
 
 		try {
-			const response = await this.handleCommand(client, command);
+			const response = await this.handleCommand(client, command, () => {
+				promptHandlerOwnsAdmission = true;
+			});
 			if (response) {
 				this.write(client, response);
 			}
@@ -2617,6 +2622,8 @@ export class AgentDaemon {
 				`daemon command "${command.type}" failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
 			);
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));
+		} finally {
+			if (!promptHandlerOwnsAdmission) clearParsedAdmission();
 		}
 	}
 
@@ -2727,6 +2734,7 @@ export class AgentDaemon {
 	private async handleCommand(
 		client: DaemonSocketClient,
 		command: DaemonCommand,
+		onPromptHandlerOwnsAdmission: () => void = () => {},
 	): Promise<DaemonResponse | undefined> {
 		if (this.updateRestartPreparing && command.type !== "shutdown" && command.type !== "ack_result") {
 			throw new Error("Daemon is preparing an update restart");
@@ -2990,6 +2998,7 @@ export class AgentDaemon {
 
 			case "prompt":
 			case "prompt_and_wait": {
+				onPromptHandlerOwnsAdmission();
 				const admissionKey = command.admissionId
 					? this.promptAdmissionKey(command.activeSessionId, command.admissionId)
 					: undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1260,21 +1260,24 @@ export class AgentDaemon {
 		message: string,
 		options?: PromptOptions,
 		canPrompt?: () => boolean,
+		waitForCompletion = true,
 	): Promise<boolean> {
 		return this.withAgentMessagePreparingGuard(
 			state,
 			(session, clearPreparing) => {
 				const prompt =
-					options?.agentMessageId === undefined
-						? session.prompt.bind(session)
-						: session.acceptAgentMessagePrompt.bind(session);
+					options?.agentMessageId !== undefined
+						? session.acceptAgentMessagePrompt.bind(session)
+						: waitForCompletion
+							? (session.promptAndWait ?? session.prompt).bind(session)
+							: (session.promptUntilAccepted ?? session.prompt).bind(session);
 				return prompt(message, {
 					...options,
-					preflightResult: (didSucceed) => {
+					preflightResult: (didSucceed, queued) => {
 						if (didSucceed && session.isStreaming) {
 							clearPreparing();
 						}
-						options?.preflightResult?.(didSucceed);
+						options?.preflightResult?.(didSucceed, queued);
 					},
 				});
 			},
@@ -2464,6 +2467,7 @@ export class AgentDaemon {
 				await this.handleWorkerCommand(client, parsed as DaemonWorkerCommand);
 				return;
 			}
+
 			if (typeof parsed.type !== "string" || !DAEMON_COMMAND_TYPES.has(parsed.type)) {
 				const commandName = typeof parsed.type === "string" ? parsed.type : "unknown";
 				const commandId = typeof parsed.id === "string" ? parsed.id : undefined;
@@ -2837,22 +2841,30 @@ export class AgentDaemon {
 					responseSent = true;
 					this.write(client, success(command.id, "prompt"));
 				};
-				void this.promptWithAgentMessagePreparingGuard(state, command.message, {
-					content: command.content,
-					images: command.images,
-					streamingBehavior: command.streamingBehavior,
-					expandPromptTemplates: command.expandPromptTemplates,
-					agentMessageId: command.agentMessageId,
-					customMessage: command.customMessage,
-					skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
-					source: command.source,
-					preflightResult: (didSucceed) => {
-						if (didSucceed) {
-							this.recordWorkerRecoveryState(state, "prompt_accepted", true);
-							sendSuccessResponse();
-						}
+				void this.promptWithAgentMessagePreparingGuard(
+					state,
+					command.message,
+					{
+						content: command.content,
+						images: command.images,
+						streamingBehavior: command.streamingBehavior,
+						queueIfBusy: command.queueIfBusy ?? command.streamingBehavior !== undefined,
+						resumeIfIdle: command.streamingBehavior !== undefined,
+						expandPromptTemplates: command.expandPromptTemplates,
+						agentMessageId: command.agentMessageId,
+						customMessage: command.customMessage,
+						skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
+						source: command.source,
+						preflightResult: (didSucceed) => {
+							if (didSucceed) {
+								this.recordWorkerRecoveryState(state, "prompt_accepted", true);
+								sendSuccessResponse();
+							}
+						},
 					},
-				})
+					undefined,
+					false,
+				)
 					.then(() => {
 						sendSuccessResponse();
 					})
@@ -2872,6 +2884,8 @@ export class AgentDaemon {
 					content: command.content,
 					images: command.images,
 					streamingBehavior: command.streamingBehavior,
+					queueIfBusy: command.queueIfBusy ?? command.streamingBehavior !== undefined,
+					resumeIfIdle: command.streamingBehavior !== undefined,
 					expandPromptTemplates: command.expandPromptTemplates,
 					skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
 					source: command.source,
@@ -2895,11 +2909,20 @@ export class AgentDaemon {
 						prefixMessages: command.prefixMessages,
 					});
 				} else {
-					await state.runtime.session.steer(command.message, command.images, {
-						queueKey: command.queueKey,
-						agentMessageId: command.agentMessageId,
-						resumeIfIdle: true,
-					});
+					await this.promptWithAgentMessagePreparingGuard(
+						state,
+						command.message,
+						{
+							images: command.images,
+							streamingBehavior: "steer",
+							queueIfBusy: true,
+							resumeIfIdle: true,
+							followUpQueueKey: command.queueKey,
+							agentMessageId: command.agentMessageId,
+						},
+						undefined,
+						false,
+					);
 				}
 				this.recordWorkerRecoveryState(state, "steer_queued", true);
 				return success(command.id, "steer");
@@ -2907,7 +2930,7 @@ export class AgentDaemon {
 
 			case "follow_up": {
 				const state = this.getBoundSessionState(command.activeSessionId);
-				let queued: boolean;
+				let queued = true;
 				if (command.expandPromptTemplates === false) {
 					queued = await state.runtime.session.restoreFollowUpMessage(command.message, command.images, {
 						queueKey: command.queueKey,
@@ -2917,11 +2940,23 @@ export class AgentDaemon {
 						prefixMessages: command.prefixMessages,
 					});
 				} else {
-					queued = await state.runtime.session.followUp(command.message, command.images, {
-						queueKey: command.queueKey,
-						agentMessageId: command.agentMessageId,
-						resumeIfIdle: true,
-					});
+					await this.promptWithAgentMessagePreparingGuard(
+						state,
+						command.message,
+						{
+							images: command.images,
+							streamingBehavior: "followUp",
+							queueIfBusy: true,
+							resumeIfIdle: true,
+							followUpQueueKey: command.queueKey,
+							agentMessageId: command.agentMessageId,
+							preflightResult: (didSucceed, didQueue) => {
+								queued = didSucceed && didQueue === true;
+							},
+						},
+						undefined,
+						false,
+					);
 				}
 				if (queued) {
 					this.recordWorkerRecoveryState(state, "follow_up_queued", true);
@@ -2946,6 +2981,7 @@ export class AgentDaemon {
 				if (!state.runtime.session.resumeQueuedWork()) {
 					const error = new Error("No queued work to resume");
 					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
+
 				}
 				return success(command.id, "resume_queue");
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -324,14 +324,26 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
-function waitForDaemonPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+class DaemonPromptAdmissionCancelledError extends Error {
+	constructor() {
+		super("Prompt admission was cancelled.");
+		this.name = "DaemonPromptAdmissionCancelledError";
+	}
+}
+
+export function waitForDaemonPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 	if (!signal) return promise;
-	if (signal.aborted) return Promise.reject(new Error("Prompt admission was cancelled."));
+	if (signal.aborted) {
+		// The caller supplied already-running work. Observe its eventual rejection
+		// even though admission cancellation wins immediately.
+		void promise.catch(() => {});
+		return Promise.reject(new DaemonPromptAdmissionCancelledError());
+	}
 	return new Promise<T>((resolve, reject) => {
 		const cleanup = () => signal.removeEventListener("abort", onAbort);
 		const onAbort = () => {
 			cleanup();
-			reject(new Error("Prompt admission was cancelled."));
+			reject(new DaemonPromptAdmissionCancelledError());
 		};
 		signal.addEventListener("abort", onAbort, { once: true });
 		// Close the registration-to-check race before observing the awaited work.
@@ -2473,10 +2485,10 @@ export class AgentDaemon {
 						)
 					: undefined;
 			const clearParsedAdmission = () => {
-				if (parsedAdmission) {
-					this.promptAdmissions.delete(
-						this.promptAdmissionKey(parsedAdmission.activeSessionId, parsedAdmission.admissionId),
-					);
+				if (!parsedAdmission) return;
+				const key = this.promptAdmissionKey(parsedAdmission.activeSessionId, parsedAdmission.admissionId);
+				if (this.promptAdmissions.get(key) === parsedAdmission) {
+					this.promptAdmissions.delete(key);
 				}
 			};
 			// Envelope client identity is irrelevant to worker-local prompt admission.
@@ -2492,6 +2504,7 @@ export class AgentDaemon {
 					(parsed.supervisorProcessStartId !== undefined && typeof parsed.supervisorProcessStartId !== "string") ||
 					typeof parsed.supervisorSocketPath !== "string"
 				) {
+					clearParsedAdmission();
 					this.write(client, failure(commandId, "worker_auth", "Worker authentication failed"));
 					client.socket.end();
 					return;
@@ -2538,12 +2551,27 @@ export class AgentDaemon {
 					client.socket.end();
 					return;
 				}
+				const claimCheck = this.assertSupervisorClaimCurrent(boundClaim.claim, boundClaim.ownerFingerprint);
+				// Observe the already-running fence check even if admission cancellation
+				// wins the command wait below.
+				void claimCheck.catch(() => {});
 				try {
-					boundClaim.ownerFingerprint = await waitForDaemonPromptAdmission(
-						this.assertSupervisorClaimCurrent(boundClaim.claim, boundClaim.ownerFingerprint),
+					const ownerFingerprint = await waitForDaemonPromptAdmission(
+						claimCheck,
 						parsedAdmission?.controller?.signal,
 					);
+					if (this.supervisorClaims.get(client) === boundClaim) {
+						boundClaim.ownerFingerprint = ownerFingerprint;
+					}
 				} catch (error) {
+					const admissionCancelled = error instanceof DaemonPromptAdmissionCancelledError;
+					if (admissionCancelled) {
+						// The fence check remains authoritative after cancellation. Its rejection
+						// revokes only the exact binding that initiated it; replacements survive.
+						void claimCheck.catch(() => {
+							if (this.supervisorClaims.get(client) === boundClaim) client.socket.end();
+						});
+					}
 					clearParsedAdmission();
 					this.write(
 						client,
@@ -2553,7 +2581,9 @@ export class AgentDaemon {
 							error,
 						),
 					);
-					client.socket.end();
+					// Cancelling this prompt only abandons its admission wait. A genuine
+					// stale supervisor claim fences only the binding that it checked.
+					if (!admissionCancelled && this.supervisorClaims.get(client) === boundClaim) client.socket.end();
 					return;
 				}
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -130,6 +130,7 @@ import {
 	DAEMON_DEFAULT_SERVER_CAPABILITIES,
 	DAEMON_PROTOCOL_INFO,
 	DAEMON_SCHEMA_ID,
+	DAEMON_SCHEMA_REVISION,
 	DAEMON_SUPPORTED_CLIENT_CAPABILITIES,
 	type DaemonAttachResult,
 	type DaemonClientCapability,
@@ -210,6 +211,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"kill",
 	"rename",
 	"prompt",
+	"cancel_prompt_admission",
 	"prompt_and_wait",
 	"steer",
 	"follow_up",
@@ -322,6 +324,31 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
+function waitForDaemonPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(new Error("Prompt admission was cancelled."));
+	return new Promise<T>((resolve, reject) => {
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const onAbort = () => {
+			cleanup();
+			reject(new Error("Prompt admission was cancelled."));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		// Close the registration-to-check race before observing the awaited work.
+		if (signal.aborted) return onAbort();
+		promise.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error: unknown) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
+}
+
 type RuntimeOpenGuard = () => boolean | Promise<boolean>;
 type SupervisorGenerationClaim = Omit<Extract<DaemonWorkerCommand, { type: "worker_auth" }>, "id" | "type" | "token">;
 
@@ -379,6 +406,16 @@ export class AgentDaemon {
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{ run: SideQuestionRun; client: DaemonSocketClient; activeSessionId: string }
+	>();
+	/** Live prompt admissions, keyed by session and caller-generated admission id. */
+	private readonly promptAdmissions = new Map<
+		string,
+		{
+			activeSessionId: string;
+			admissionId: string;
+			controller?: AbortController;
+			status: "waiting" | "owned" | "cancelled";
+		}
 	>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
 	private readonly cronStore: AgentCronJobStore;
@@ -1282,6 +1319,7 @@ export class AgentDaemon {
 				});
 			},
 			canPrompt,
+			options?.signal,
 		);
 	}
 
@@ -1322,6 +1360,7 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		run: (session: AgentSession, clearPreparing: () => void) => Promise<void>,
 		canRun?: () => boolean,
+		signal?: AbortSignal,
 	): Promise<boolean> {
 		const activeSessionId = state.activeSessionId;
 		this.agentMessagePreparingTargets.set(
@@ -1342,7 +1381,12 @@ export class AgentDaemon {
 			}
 		};
 		try {
-			await this.agentMessageTargetLocks.get(activeSessionId)?.catch(() => undefined);
+			const targetLock = this.agentMessageTargetLocks.get(activeSessionId);
+			if (targetLock)
+				await waitForDaemonPromptAdmission(
+					targetLock.catch(() => undefined),
+					signal,
+				);
 			if (this.sessions.get(activeSessionId) !== state || this.closingSessions.has(activeSessionId)) {
 				throw new Error("Target session is closing before prompt delivery");
 			}
@@ -2299,6 +2343,7 @@ export class AgentDaemon {
 			socketPath: this.socketPath,
 			protocol: DAEMON_PROTOCOL_INFO,
 			schemaId: DAEMON_SCHEMA_ID,
+			schemaRevision: DAEMON_SCHEMA_REVISION,
 			appVersion: VERSION,
 			runtime: getDaemonRuntimeIdentity(),
 			clientId: client.id,
@@ -2366,13 +2411,46 @@ export class AgentDaemon {
 		});
 	}
 
+	private promptAdmissionKey(activeSessionId: string, admissionId: string): string {
+		return `${activeSessionId}\0${admissionId}`;
+	}
+
+	/**
+	 * Parse and synchronously register prompt admission before returning a promise.
+	 * This method is intentionally non-async: handleLine invokes it before its first await.
+	 */
+	private parseCommandAndRegisterPromptAdmission(line: string): unknown {
+		const wireValue = JSON.parse(line) as unknown;
+		const parsed = (isDaemonCommandEnvelope(wireValue) ? { ...wireValue.command, id: wireValue.id } : wireValue) as {
+			type?: unknown;
+			activeSessionId?: unknown;
+			admissionId?: unknown;
+		};
+		if (parsed.type === "prompt" || parsed.type === "prompt_and_wait") {
+			if (parsed.admissionId !== undefined) {
+				if (typeof parsed.activeSessionId !== "string" || typeof parsed.admissionId !== "string") {
+					throw new Error("Prompt admission requires string activeSessionId and admissionId");
+				}
+				if (parsed.admissionId === "") throw new Error("admissionId must not be empty");
+				const key = this.promptAdmissionKey(parsed.activeSessionId, parsed.admissionId);
+				if (this.promptAdmissions.has(key)) {
+					throw new Error(`Prompt admission id is already in use: ${parsed.admissionId}`);
+				}
+				this.promptAdmissions.set(key, {
+					activeSessionId: parsed.activeSessionId,
+					admissionId: parsed.admissionId,
+					controller: new AbortController(),
+					status: "waiting",
+				});
+			}
+		}
+		return parsed;
+	}
+
 	private async handleLine(client: DaemonSocketClient, line: string): Promise<void> {
 		let command: DaemonCommand;
 		try {
-			const wireValue = JSON.parse(line) as unknown;
-			const parsed = (
-				isDaemonCommandEnvelope(wireValue) ? { ...wireValue.command, id: wireValue.id } : wireValue
-			) as {
+			const parsed = this.parseCommandAndRegisterPromptAdmission(line) as {
 				id?: unknown;
 				type?: unknown;
 				token?: unknown;
@@ -2381,13 +2459,28 @@ export class AgentDaemon {
 				supervisorProcessStartId?: unknown;
 				supervisorSocketPath?: unknown;
 				activeSessionId?: unknown;
+				admissionId?: unknown;
 				capabilities?: unknown;
 				supportsExtensionUi?: unknown;
 				job?: unknown;
 			};
-			if (isDaemonCommandEnvelope(wireValue) && wireValue.clientId) {
-				client.id = wireValue.clientId;
-			}
+			const parsedAdmission =
+				(parsed.type === "prompt" || parsed.type === "prompt_and_wait") &&
+				typeof parsed.activeSessionId === "string" &&
+				typeof (parsed as { admissionId?: unknown }).admissionId === "string"
+					? this.promptAdmissions.get(
+							this.promptAdmissionKey(parsed.activeSessionId, (parsed as { admissionId: string }).admissionId),
+						)
+					: undefined;
+			const clearParsedAdmission = () => {
+				if (parsedAdmission) {
+					this.promptAdmissions.delete(
+						this.promptAdmissionKey(parsedAdmission.activeSessionId, parsedAdmission.admissionId),
+					);
+				}
+			};
+			// Envelope client identity is irrelevant to worker-local prompt admission.
+			// Public supervisor authentication has already bound this socket's identity.
 			if (this.options.worker && client.authenticated !== true) {
 				const commandId = typeof parsed.id === "string" ? parsed.id : undefined;
 				if (
@@ -2446,17 +2539,18 @@ export class AgentDaemon {
 					return;
 				}
 				try {
-					boundClaim.ownerFingerprint = await this.assertSupervisorClaimCurrent(
-						boundClaim.claim,
-						boundClaim.ownerFingerprint,
+					boundClaim.ownerFingerprint = await waitForDaemonPromptAdmission(
+						this.assertSupervisorClaimCurrent(boundClaim.claim, boundClaim.ownerFingerprint),
+						parsedAdmission?.controller?.signal,
 					);
-				} catch {
+				} catch (error) {
+					clearParsedAdmission();
 					this.write(
 						client,
 						failure(
 							typeof parsed.id === "string" ? parsed.id : undefined,
 							typeof parsed.type === "string" ? parsed.type : "worker_auth",
-							"supervisor_generation_stale",
+							error,
 						),
 					);
 					client.socket.end();
@@ -2609,6 +2703,9 @@ export class AgentDaemon {
 		}
 		if ("agentMessageId" in command && command.agentMessageId === "") {
 			throw new Error("agentMessageId must not be empty");
+		}
+		if ("admissionId" in command && command.admissionId === "") {
+			throw new Error("admissionId must not be empty");
 		}
 		if ((command.type === "steer" || command.type === "follow_up") && command.expandPromptTemplates !== false) {
 			const replayFields = (["content", "customMessage", "prefixMessages"] as const).filter(
@@ -2844,14 +2941,79 @@ export class AgentDaemon {
 				return success(command.id, "delete_saved_session", result);
 			}
 
-			case "prompt": {
-				const state = this.getBoundSessionState(command.activeSessionId);
+			case "cancel_prompt_admission": {
+				const admission = this.promptAdmissions.get(
+					this.promptAdmissionKey(command.activeSessionId, command.admissionId),
+				);
+				if (!admission) {
+					return success(command.id, command.type, { status: "unknown" as const });
+				}
+				if (admission.status === "owned") {
+					return success(command.id, command.type, { status: "owned" as const });
+				}
+				if (admission.status === "waiting") {
+					admission.status = "cancelled";
+					admission.controller?.abort();
+				}
+				return success(command.id, command.type, { status: "cancelled" as const });
+			}
+
+			case "prompt":
+			case "prompt_and_wait": {
+				const admissionKey = command.admissionId
+					? this.promptAdmissionKey(command.activeSessionId, command.admissionId)
+					: undefined;
+				const admission = admissionKey ? this.promptAdmissions.get(admissionKey) : undefined;
+				if (command.admissionId && !admission) {
+					throw new Error("Prompt admission was not registered during command parsing");
+				}
+				const clearAdmission = () => {
+					if (admissionKey && this.promptAdmissions.get(admissionKey) === admission) {
+						this.promptAdmissions.delete(admissionKey);
+					}
+				};
+				const commitAdmission = () => {
+					if (admission?.status === "waiting") admission.status = "owned";
+				};
+				let state: ActiveSessionState;
+				try {
+					if (admission?.status === "cancelled") throw new Error("Prompt admission was cancelled.");
+					state = this.getBoundSessionState(command.activeSessionId);
+				} catch (error) {
+					clearAdmission();
+					throw error;
+				}
+				const options: PromptOptions = {
+					content: command.content,
+					images: command.images,
+					streamingBehavior: command.streamingBehavior,
+					queueIfBusy: command.queueIfBusy ?? command.streamingBehavior !== undefined,
+					resumeIfIdle: command.streamingBehavior !== undefined,
+					expandPromptTemplates: command.expandPromptTemplates,
+					skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
+					source: command.source,
+					...(admission?.controller
+						? { signal: admission.controller.signal, admissionCommitted: commitAdmission }
+						: {}),
+				};
+				if (command.type === "prompt_and_wait") {
+					try {
+						await this.promptWithAgentMessagePreparingGuard(state, command.message, {
+							...options,
+							preflightResult: (didSucceed) => {
+								if (didSucceed) this.recordWorkerRecoveryState(state, "prompt_accepted", true);
+							},
+						});
+						return success(command.id, command.type);
+					} finally {
+						clearAdmission();
+					}
+				}
+
 				let responseSent = false;
 				let preflightRejected = false;
 				const sendSuccessResponse = () => {
-					if (responseSent) {
-						return;
-					}
+					if (responseSent) return;
 					responseSent = true;
 					this.write(client, success(command.id, "prompt"));
 				};
@@ -2859,16 +3021,9 @@ export class AgentDaemon {
 					state,
 					command.message,
 					{
-						content: command.content,
-						images: command.images,
-						streamingBehavior: command.streamingBehavior,
-						queueIfBusy: command.queueIfBusy ?? command.streamingBehavior !== undefined,
-						resumeIfIdle: command.streamingBehavior !== undefined,
-						expandPromptTemplates: command.expandPromptTemplates,
+						...options,
 						agentMessageId: command.agentMessageId,
 						customMessage: command.customMessage,
-						skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
-						source: command.source,
 						preflightResult: (didSucceed) => {
 							if (didSucceed) {
 								this.recordWorkerRecoveryState(state, "prompt_accepted", true);
@@ -2895,28 +3050,9 @@ export class AgentDaemon {
 						} else {
 							this.write(client, failure(command.id, "prompt", error, serializeDaemonError(error)));
 						}
-					});
+					})
+					.finally(clearAdmission);
 				return undefined;
-			}
-
-			case "prompt_and_wait": {
-				const state = this.getBoundSessionState(command.activeSessionId);
-				await this.promptWithAgentMessagePreparingGuard(state, command.message, {
-					content: command.content,
-					images: command.images,
-					streamingBehavior: command.streamingBehavior,
-					queueIfBusy: command.queueIfBusy ?? command.streamingBehavior !== undefined,
-					resumeIfIdle: command.streamingBehavior !== undefined,
-					expandPromptTemplates: command.expandPromptTemplates,
-					skipInputHandlers: command.expandPromptTemplates === false ? true : undefined,
-					source: command.source,
-					preflightResult: (didSucceed) => {
-						if (didSucceed) {
-							this.recordWorkerRecoveryState(state, "prompt_accepted", true);
-						}
-					},
-				});
-				return success(command.id, command.type);
 			}
 
 			case "steer": {
@@ -4487,11 +4623,21 @@ export class AgentDaemon {
 		return undefined;
 	}
 
+	private abortWaitingPromptAdmissionsForSession(activeSessionId: string): void {
+		for (const admission of this.promptAdmissions.values()) {
+			if (admission.activeSessionId === activeSessionId && admission.status === "waiting") {
+				admission.status = "cancelled";
+				admission.controller?.abort();
+			}
+		}
+	}
+
 	private async closeSession(
 		state: ActiveSessionState,
 		reason: DaemonSessionClosedReason,
 		waitForAbort = true,
 	): Promise<void> {
+		this.abortWaitingPromptAdmissionsForSession(state.activeSessionId);
 		for (const client of state.clients) {
 			this.abortSideQuestionsFor(client, state.activeSessionId);
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2432,8 +2432,9 @@ export class AgentDaemon {
 	 * Parse and synchronously register prompt admission before returning a promise.
 	 * This method is intentionally non-async: handleLine invokes it before its first await.
 	 */
-	private parseCommandAndRegisterPromptAdmission(line: string): unknown {
+	private parseCommandAndRegisterPromptAdmission(client: DaemonSocketClient, line: string): unknown {
 		const wireValue = JSON.parse(line) as unknown;
+		if (isDaemonCommandEnvelope(wireValue) && wireValue.clientId) client.id = wireValue.clientId;
 		const parsed = (isDaemonCommandEnvelope(wireValue) ? { ...wireValue.command, id: wireValue.id } : wireValue) as {
 			type?: unknown;
 			activeSessionId?: unknown;
@@ -2465,7 +2466,7 @@ export class AgentDaemon {
 		let clearParsedAdmission = () => {};
 		let promptHandlerOwnsAdmission = false;
 		try {
-			const parsed = this.parseCommandAndRegisterPromptAdmission(line) as {
+			const parsed = this.parseCommandAndRegisterPromptAdmission(client, line) as {
 				id?: unknown;
 				type?: unknown;
 				token?: unknown;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3126,7 +3126,7 @@ export class AgentDaemon {
 
 			case "wait_for_idle": {
 				const state = this.getSessionState(command.activeSessionId);
-				await state.runtime.session.agent.waitForIdle();
+				await state.runtime.session.waitForIdle();
 				return success(command.id, "wait_for_idle");
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2610,6 +2610,16 @@ export class AgentDaemon {
 		if ("agentMessageId" in command && command.agentMessageId === "") {
 			throw new Error("agentMessageId must not be empty");
 		}
+		if ((command.type === "steer" || command.type === "follow_up") && command.expandPromptTemplates !== false) {
+			const replayFields = (["content", "customMessage", "prefixMessages"] as const).filter(
+				(field) => command[field] !== undefined,
+			);
+			if (replayFields.length > 0) {
+				throw new Error(
+					`${command.type} replay fields (${replayFields.join(", ")}) require expandPromptTemplates=false`,
+				);
+			}
+		}
 		switch (command.type) {
 			case "ack_result":
 				return undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2837,6 +2837,7 @@ export class AgentDaemon {
 			case "prompt": {
 				const state = this.getBoundSessionState(command.activeSessionId);
 				let responseSent = false;
+				let preflightRejected = false;
 				const sendSuccessResponse = () => {
 					if (responseSent) {
 						return;
@@ -2862,6 +2863,8 @@ export class AgentDaemon {
 							if (didSucceed) {
 								this.recordWorkerRecoveryState(state, "prompt_accepted", true);
 								sendSuccessResponse();
+							} else {
+								preflightRejected = true;
 							}
 						},
 					},
@@ -2869,7 +2872,12 @@ export class AgentDaemon {
 					false,
 				)
 					.then(() => {
-						sendSuccessResponse();
+						if (preflightRejected) {
+							const error = new Error("Prompt was not accepted by the session.");
+							this.write(client, failure(command.id, "prompt", error, serializeDaemonError(error)));
+						} else {
+							sendSuccessResponse();
+						}
 					})
 					.catch((error) => {
 						if (responseSent) {
@@ -2987,7 +2995,6 @@ export class AgentDaemon {
 				if (!state.runtime.session.resumeQueuedWork()) {
 					const error = new Error("No queued work to resume");
 					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
-
 				}
 				return success(command.id, "resume_queue");
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1266,7 +1266,7 @@ export class AgentDaemon {
 			state,
 			(session, clearPreparing) => {
 				const prompt =
-					options?.agentMessageId !== undefined
+					options?.agentMessageId !== undefined && options.expandPromptTemplates === false
 						? session.acceptAgentMessagePrompt.bind(session)
 						: waitForCompletion
 							? (session.promptAndWait ?? session.prompt).bind(session)
@@ -2607,6 +2607,9 @@ export class AgentDaemon {
 		if (this.updateRestartPreparing && command.type !== "shutdown" && command.type !== "ack_result") {
 			throw new Error("Daemon is preparing an update restart");
 		}
+		if ("agentMessageId" in command && command.agentMessageId === "") {
+			throw new Error("agentMessageId must not be empty");
+		}
 		switch (command.type) {
 			case "ack_result":
 				return undefined;
@@ -2931,6 +2934,7 @@ export class AgentDaemon {
 			case "follow_up": {
 				const state = this.getBoundSessionState(command.activeSessionId);
 				let queued = true;
+				let admitted = true;
 				if (command.expandPromptTemplates === false) {
 					queued = await state.runtime.session.restoreFollowUpMessage(command.message, command.images, {
 						queueKey: command.queueKey,
@@ -2939,6 +2943,7 @@ export class AgentDaemon {
 						customMessage: command.customMessage,
 						prefixMessages: command.prefixMessages,
 					});
+					admitted = queued;
 				} else {
 					await this.promptWithAgentMessagePreparingGuard(
 						state,
@@ -2951,6 +2956,7 @@ export class AgentDaemon {
 							followUpQueueKey: command.queueKey,
 							agentMessageId: command.agentMessageId,
 							preflightResult: (didSucceed, didQueue) => {
+								admitted = didSucceed;
 								queued = didSucceed && didQueue === true;
 							},
 						},
@@ -2958,7 +2964,7 @@ export class AgentDaemon {
 						false,
 					);
 				}
-				if (queued) {
+				if (admitted) {
 					this.recordWorkerRecoveryState(state, "follow_up_queued", true);
 				}
 				return success(command.id, "follow_up", { queued });

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3106,20 +3106,11 @@ export class AgentDaemon {
 						prefixMessages: command.prefixMessages,
 					});
 				} else {
-					await this.promptWithAgentMessagePreparingGuard(
-						state,
-						command.message,
-						{
-							images: command.images,
-							streamingBehavior: "steer",
-							queueIfBusy: true,
-							resumeIfIdle: true,
-							followUpQueueKey: command.queueKey,
-							agentMessageId: command.agentMessageId,
-						},
-						undefined,
-						false,
-					);
+					await state.runtime.session.steer(command.message, command.images, {
+						queueKey: command.queueKey,
+						agentMessageId: command.agentMessageId,
+						resumeIfIdle: true,
+					});
 				}
 				this.recordWorkerRecoveryState(state, "steer_queued", true);
 				return success(command.id, "steer");
@@ -3139,24 +3130,12 @@ export class AgentDaemon {
 					});
 					admitted = queued;
 				} else {
-					await this.promptWithAgentMessagePreparingGuard(
-						state,
-						command.message,
-						{
-							images: command.images,
-							streamingBehavior: "followUp",
-							queueIfBusy: true,
-							resumeIfIdle: true,
-							followUpQueueKey: command.queueKey,
-							agentMessageId: command.agentMessageId,
-							preflightResult: (didSucceed, didQueue) => {
-								admitted = didSucceed;
-								queued = didSucceed && didQueue === true;
-							},
-						},
-						undefined,
-						false,
-					);
+					queued = await state.runtime.session.followUp(command.message, command.images, {
+						queueKey: command.queueKey,
+						agentMessageId: command.agentMessageId,
+						resumeIfIdle: true,
+					});
+					admitted = queued;
 				}
 				if (admitted) {
 					this.recordWorkerRecoveryState(state, "follow_up_queued", true);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1292,6 +1292,7 @@ export class AgentDaemon {
 				source: "rpc",
 			},
 			canPrompt,
+			false,
 		);
 		return didPrompt ? undefined : "skipped";
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -50,15 +50,11 @@ import type { SessionSummary } from "./daemon-session-list.js";
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
 export const DAEMON_PROTOCOL_VERSION = 4;
 export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 2;
-// Revision 5: transient + runId on execute_bash (echoed with a transient
-// marker on the run's bash_start/bash_end session events) + transient_bash
-// capability.
-// Revision 4: side_question_transcript capability. The digest only covers the
-// command/outbound type source, so capability-list and session-event changes
-// must bump this revision by hand — otherwise a retained older daemon passes
-// the staleness probe and clients gate features against it forever.
-export const DAEMON_SCHEMA_REVISION = 5;
-export const DAEMON_SCHEMA_ID = "protocol-4-schema-5-4c17c4fb3f00";
+// Revision 6: session_input_admission plus the upstream side-question transcript and transient-bash contracts.
+// Revision 5: transient + runId on execute_bash and transient_bash capability.
+// Revision 4: side_question_transcript capability.
+export const DAEMON_SCHEMA_REVISION = 6;
+export const DAEMON_SCHEMA_ID = "protocol-4-schema-6-pending";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -89,7 +85,9 @@ export type DaemonServerCapability =
 	// bash: never recorded into the session, and its bash_start/bash_end events
 	// carry the transient marker and echoed runId so clients correlate runs by
 	// identity). Clients must check before sending.
-	| "transient_bash";
+	| "transient_bash"
+	| "session_input_admission";
+
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
 export interface DaemonProtocolInfo {
@@ -123,6 +121,8 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"model_catalog",
 	"side_question_transcript",
 	"transient_bash",
+	"session_input_admission",
+
 ];
 
 export interface DaemonRuntimeIdentity {
@@ -395,6 +395,7 @@ export type DaemonCommand =
 			content?: (TextContent | ImageContent)[];
 			images?: ImageContent[];
 			streamingBehavior?: "steer" | "followUp";
+			queueIfBusy?: boolean;
 			expandPromptTemplates?: boolean;
 			source?: InputSource;
 			agentMessageId?: string;
@@ -408,6 +409,7 @@ export type DaemonCommand =
 			content?: (TextContent | ImageContent)[];
 			images?: ImageContent[];
 			streamingBehavior?: "steer" | "followUp";
+			queueIfBusy?: boolean;
 			expandPromptTemplates?: boolean;
 			source?: InputSource;
 	  }
@@ -595,6 +597,10 @@ export interface DaemonCommandCompatibility {
 
 const LEGACY_DAEMON_COMMAND = { minProtocol: 1 } as const;
 const CURRENT_DAEMON_COMMAND = { minProtocol: DAEMON_PROTOCOL_VERSION } as const;
+const SESSION_INPUT_ADMISSION_COMMAND = {
+	minProtocol: DAEMON_PROTOCOL_VERSION,
+	capability: "session_input_admission",
+} as const;
 const CLIENT_OWNED_DAEMON_COMMAND = {
 	minProtocol: DAEMON_PROTOCOL_VERSION,
 	capability: "client_owned_sessions",
@@ -612,13 +618,13 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	promote_owned_session: CLIENT_OWNED_DAEMON_COMMAND,
 	kill: LEGACY_DAEMON_COMMAND,
 	rename: LEGACY_DAEMON_COMMAND,
-	prompt: LEGACY_DAEMON_COMMAND,
-	prompt_and_wait: CURRENT_DAEMON_COMMAND,
-	steer: LEGACY_DAEMON_COMMAND,
-	follow_up: LEGACY_DAEMON_COMMAND,
+	prompt: SESSION_INPUT_ADMISSION_COMMAND,
+	prompt_and_wait: SESSION_INPUT_ADMISSION_COMMAND,
+	steer: SESSION_INPUT_ADMISSION_COMMAND,
+	follow_up: SESSION_INPUT_ADMISSION_COMMAND,
 	restore_next_turn: LEGACY_DAEMON_COMMAND,
 	append_custom_message: LEGACY_DAEMON_COMMAND,
-	resume_queue: LEGACY_DAEMON_COMMAND,
+	resume_queue: SESSION_INPUT_ADMISSION_COMMAND,
 	send_message: LEGACY_DAEMON_COMMAND,
 	agent_messages_status: LEGACY_DAEMON_COMMAND,
 	agent_messages_pause: LEGACY_DAEMON_COMMAND,

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -48,13 +48,11 @@ import type { SessionSummary } from "./daemon-session-list.js";
  */
 
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
-export const DAEMON_PROTOCOL_VERSION = 4;
+export const DAEMON_PROTOCOL_VERSION = 5;
 export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 2;
-// Revision 6: session_input_admission plus the upstream side-question transcript and transient-bash contracts.
-// Revision 5: transient + runId on execute_bash and transient_bash capability.
-// Revision 4: side_question_transcript capability.
+// Revision 6 combines prompt-admission cancellation with side-question transcripts and transient bash.
 export const DAEMON_SCHEMA_REVISION = 6;
-export const DAEMON_SCHEMA_ID = "protocol-4-schema-6-pending";
+export const DAEMON_SCHEMA_ID = "protocol-5-schema-6-48a562b9bffe";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -73,6 +71,10 @@ export type DaemonClientCapability =
 	| "slim_attach"
 	| "chunked_snapshot"
 	| "client_owned_sessions";
+export type DaemonPromptAdmissionCancellationStatus = "cancelled" | "owned" | "unknown";
+export interface DaemonPromptAdmissionCancellationResult {
+	status: DaemonPromptAdmissionCancellationStatus;
+}
 export type DaemonServerCapability =
 	| DaemonClientCapability
 	| "heartbeat_catalog"
@@ -86,7 +88,8 @@ export type DaemonServerCapability =
 	// carry the transient marker and echoed runId so clients correlate runs by
 	// identity). Clients must check before sending.
 	| "transient_bash"
-	| "session_input_admission";
+	| "session_input_admission"
+	| "prompt_admission_cancellation";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
@@ -122,6 +125,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"side_question_transcript",
 	"transient_bash",
 	"session_input_admission",
+	"prompt_admission_cancellation",
 
 ];
 
@@ -400,6 +404,14 @@ export type DaemonCommand =
 			source?: InputSource;
 			agentMessageId?: string;
 			customMessage?: CustomMessage;
+			/** Unique only when the caller needs cancellable pre-ownership admission. */
+			admissionId?: string;
+	  }
+	| {
+			id?: string;
+			type: "cancel_prompt_admission";
+			activeSessionId: string;
+			admissionId: string;
 	  }
 	| {
 			id?: string;
@@ -412,6 +424,8 @@ export type DaemonCommand =
 			queueIfBusy?: boolean;
 			expandPromptTemplates?: boolean;
 			source?: InputSource;
+			/** Unique only when the caller needs cancellable pre-ownership admission. */
+			admissionId?: string;
 	  }
 	| {
 			id?: string;
@@ -596,13 +610,17 @@ export interface DaemonCommandCompatibility {
 }
 
 const LEGACY_DAEMON_COMMAND = { minProtocol: 1 } as const;
-const CURRENT_DAEMON_COMMAND = { minProtocol: DAEMON_PROTOCOL_VERSION } as const;
+const CURRENT_DAEMON_COMMAND = { minProtocol: 4 } as const;
 const SESSION_INPUT_ADMISSION_COMMAND = {
-	minProtocol: DAEMON_PROTOCOL_VERSION,
+	minProtocol: 4,
 	capability: "session_input_admission",
 } as const;
-const CLIENT_OWNED_DAEMON_COMMAND = {
+const PROMPT_ADMISSION_CANCELLATION_COMMAND = {
 	minProtocol: DAEMON_PROTOCOL_VERSION,
+	capability: "prompt_admission_cancellation",
+} as const;
+const CLIENT_OWNED_DAEMON_COMMAND = {
+	minProtocol: 4,
 	capability: "client_owned_sessions",
 } as const;
 
@@ -619,6 +637,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	kill: LEGACY_DAEMON_COMMAND,
 	rename: LEGACY_DAEMON_COMMAND,
 	prompt: SESSION_INPUT_ADMISSION_COMMAND,
+	cancel_prompt_admission: PROMPT_ADMISSION_CANCELLATION_COMMAND,
 	prompt_and_wait: SESSION_INPUT_ADMISSION_COMMAND,
 	steer: SESSION_INPUT_ADMISSION_COMMAND,
 	follow_up: SESSION_INPUT_ADMISSION_COMMAND,
@@ -787,6 +806,8 @@ export type DaemonOutbound =
 			socketPath: string;
 			protocol: DaemonProtocolInfo;
 			schemaId?: string;
+			/** Monotonic wire-schema revision for field-sensitive compatibility checks. */
+			schemaRevision?: number;
 			/** App version of the daemon process, used to detect stale daemons after self-update. */
 			appVersion?: string;
 			runtime?: DaemonRuntimeIdentity;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -126,7 +126,6 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"transient_bash",
 	"session_input_admission",
 	"prompt_admission_cancellation",
-
 ];
 
 export interface DaemonRuntimeIdentity {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1067,12 +1067,13 @@ export class DaemonSupervisor {
 		}
 		const command = preParsed.command;
 		const parsedAdmission = preParsed.admission;
-		if (command.type === "cancel_prompt_admission") {
-			const admission = this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
-			if (admission?.status === "waiting" && !admission.worker) {
-				admission.status = "cancelled";
-				admission.controller.abort();
-			}
+		const cancellationAdmission =
+			command.type === "cancel_prompt_admission"
+				? this.getPromptAdmission(client, command.activeSessionId, command.admissionId)
+				: undefined;
+		if (cancellationAdmission?.status === "waiting" && !cancellationAdmission.worker) {
+			cancellationAdmission.status = "cancelled";
+			cancellationAdmission.controller.abort();
 		}
 		try {
 			await waitForSupervisorPromptAdmission(this.ready, parsedAdmission?.controller.signal);
@@ -1125,7 +1126,7 @@ export class DaemonSupervisor {
 		}
 
 		try {
-			const response = await this.handleCommand(client, command);
+			const response = await this.handleCommand(client, command, cancellationAdmission);
 			if (response) {
 				if (journalIdentity) {
 					await this.assertCurrentOwnership();
@@ -1151,10 +1152,12 @@ export class DaemonSupervisor {
 	private async handleCommand(
 		client: DaemonSocketClient,
 		command: DaemonCommand,
+		cancellationAdmission?: SupervisorPromptAdmission,
 	): Promise<DaemonResponse | undefined> {
 		switch (command.type) {
 			case "cancel_prompt_admission": {
-				const admission = this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
+				const admission =
+					cancellationAdmission ?? this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
 				if (!admission) return success(command.id, command.type, { status: "unknown" as const });
 				if (admission.status === "owned") return success(command.id, command.type, { status: "owned" as const });
 				if (!admission.worker || !admission.workerActiveSessionId) {
@@ -1577,7 +1580,9 @@ export class DaemonSupervisor {
 				command.type === "kill" &&
 				(match.summary.activeSessionId ?? match.summary.id) === match.worker.descriptor.rootActiveSessionId;
 			if (!isRootKill) {
-				return await this.forwardToWorker(match.worker, resolvedCommand);
+				const response = await this.forwardToWorker(match.worker, resolvedCommand);
+				if (admission && response.success) admission.status = "owned";
+				return response;
 			}
 			this.persistWorkerStopTombstone(match.worker, true);
 			let response: DaemonResponse;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -308,9 +308,12 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
-function waitForSupervisorPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+export function waitForSupervisorPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 	if (!signal) return promise;
-	if (signal.aborted) return Promise.reject(new Error("Prompt admission was cancelled."));
+	if (signal.aborted) {
+		void promise.catch(() => {});
+		return Promise.reject(new Error("Prompt admission was cancelled."));
+	}
 	return new Promise<T>((resolve, reject) => {
 		const cleanup = () => signal.removeEventListener("abort", onAbort);
 		const onAbort = () => {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -45,6 +45,7 @@ import {
 	DAEMON_DEFAULT_SERVER_CAPABILITIES,
 	DAEMON_PROTOCOL_INFO,
 	DAEMON_SCHEMA_ID,
+	DAEMON_SCHEMA_REVISION,
 	type DaemonAttachResult,
 	type DaemonClientCapability,
 	type DaemonClosingReason,
@@ -120,6 +121,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"kill",
 	"rename",
 	"prompt",
+	"cancel_prompt_admission",
 	"prompt_and_wait",
 	"steer",
 	"follow_up",
@@ -264,6 +266,17 @@ interface WorkerAttachData {
 	releaseTranscript?: () => void;
 }
 
+interface SupervisorPromptAdmission {
+	client: DaemonSocketClient;
+	activeSessionId: string;
+	publicAdmissionId: string;
+	workerAdmissionId: string;
+	status: "waiting" | "owned" | "cancelled";
+	controller: AbortController;
+	worker?: ResidentWorker;
+	workerActiveSessionId?: string;
+}
+
 class SupervisorRecoveryCancelledError extends Error {
 	readonly code = "supervisor_recovery_cancelled" as const;
 }
@@ -293,6 +306,30 @@ function isSupervisorShutdownAdmissionCancelled(error: unknown): boolean {
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function waitForSupervisorPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(new Error("Prompt admission was cancelled."));
+	return new Promise<T>((resolve, reject) => {
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const onAbort = () => {
+			cleanup();
+			reject(new Error("Prompt admission was cancelled."));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) return onAbort();
+		promise.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error: unknown) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
 }
 
 function unrefDelay(ms: number): Promise<void> {
@@ -541,6 +578,8 @@ export class DaemonSupervisor {
 	private readonly protocolClientIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly workers = new Map<string, ResidentWorker>();
 	private readonly openingWorkers = new Map<string, Promise<ResidentWorker>>();
+	/** Public admission ids are scoped to the socket that registered them. */
+	private readonly promptAdmissions = new Map<DaemonSocketClient, Map<string, SupervisorPromptAdmission>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
 	private readonly descriptorDir: string;
 	private readonly generation = randomUUID();
@@ -822,6 +861,7 @@ export class DaemonSupervisor {
 						socketPath: this.socketPath,
 						protocol: DAEMON_PROTOCOL_INFO,
 						schemaId: DAEMON_SCHEMA_ID,
+						schemaRevision: DAEMON_SCHEMA_REVISION,
 						appVersion: VERSION,
 						runtime: getDaemonRuntimeIdentity(),
 						supervisorGeneration: this.generation,
@@ -846,6 +886,7 @@ export class DaemonSupervisor {
 			cleaned = true;
 			client.detachInput();
 			this.clients.delete(client);
+			this.cancelWaitingPromptAdmissionsForClient(client);
 			for (const activeSessionId of [...client.attachedActiveSessionIds]) {
 				client.attachedActiveSessionIds.delete(activeSessionId);
 				void this.syncWorkerExtensionUi(activeSessionId);
@@ -914,46 +955,147 @@ export class DaemonSupervisor {
 		worker.ownerCleanupTimer.unref();
 	}
 
-	private async handleLine(client: DaemonSocketClient, line: string): Promise<void> {
-		try {
-			await this.ready;
-		} catch {
-			return;
+	private promptAdmissionKey(activeSessionId: string, publicAdmissionId: string): string {
+		return `${activeSessionId}\0${publicAdmissionId}`;
+	}
+
+	private promptAdmissionsFor(client: DaemonSocketClient): Map<string, SupervisorPromptAdmission> {
+		let admissions = this.promptAdmissions.get(client);
+		if (!admissions) {
+			admissions = new Map();
+			this.promptAdmissions.set(client, admissions);
 		}
-		let command: DaemonCommand;
-		let envelopeClientId: string | undefined;
+		return admissions;
+	}
+
+	private getPromptAdmission(
+		client: DaemonSocketClient,
+		activeSessionId: string,
+		publicAdmissionId: string,
+	): SupervisorPromptAdmission | undefined {
+		return this.promptAdmissions.get(client)?.get(this.promptAdmissionKey(activeSessionId, publicAdmissionId));
+	}
+
+	private deletePromptAdmission(admission: SupervisorPromptAdmission): void {
+		const admissions = this.promptAdmissions.get(admission.client);
+		const key = this.promptAdmissionKey(admission.activeSessionId, admission.publicAdmissionId);
+		if (admissions?.get(key) !== admission) return;
+		admissions.delete(key);
+		if (admissions.size === 0) this.promptAdmissions.delete(admission.client);
+	}
+
+	private cancelWaitingPromptAdmissionsForClient(client: DaemonSocketClient): void {
+		for (const admission of this.promptAdmissions.get(client)?.values() ?? []) {
+			if (admission.status !== "waiting") continue;
+			if (!admission.worker || !admission.workerActiveSessionId) {
+				admission.status = "cancelled";
+				admission.controller.abort();
+				continue;
+			}
+			const worker = admission.worker;
+			const workerActiveSessionId = admission.workerActiveSessionId;
+			void this.forwardToWorker(worker, {
+				type: "cancel_prompt_admission",
+				activeSessionId: workerActiveSessionId,
+				admissionId: admission.workerAdmissionId,
+			})
+				.then((response) => {
+					if (admission.status !== "waiting") return;
+					const status =
+						response.success && response.data && typeof response.data === "object" && "status" in response.data
+							? (response.data as { status?: unknown }).status
+							: undefined;
+					if (status === "owned") admission.status = "owned";
+					else if (status === "cancelled") admission.status = "cancelled";
+				})
+				.catch((error: unknown) => {
+					this.log(
+						`Could not cancel prompt admission ${admission.workerAdmissionId} on disconnected client: ${String(error)}`,
+					);
+				});
+		}
+	}
+
+	/** Non-async by design: prompt registration completes before handleLine's first await. */
+	private parseCommandAndRegisterPromptAdmission(
+		client: DaemonSocketClient,
+		line: string,
+	): {
+		command: DaemonCommand;
+		envelopeClientId?: string;
+		admission?: SupervisorPromptAdmission;
+	} {
+		const parsed = JSON.parse(line) as unknown;
+		const command = (
+			isDaemonCommandEnvelope(parsed) ? { ...parsed.command, id: parsed.id } : parsed
+		) as DaemonCommand;
+		let admission: SupervisorPromptAdmission | undefined;
+		if ((command.type === "prompt" || command.type === "prompt_and_wait") && command.admissionId !== undefined) {
+			if (typeof command.activeSessionId !== "string" || typeof command.admissionId !== "string") {
+				throw new Error("Prompt admission requires string activeSessionId and admissionId");
+			}
+			if (command.admissionId === "") throw new Error("admissionId must not be empty");
+			const admissions = this.promptAdmissionsFor(client);
+			const key = this.promptAdmissionKey(command.activeSessionId, command.admissionId);
+			if (admissions.has(key)) {
+				throw new Error(`Prompt admission id is already in use: ${command.admissionId}`);
+			}
+			admission = {
+				client,
+				activeSessionId: command.activeSessionId,
+				publicAdmissionId: command.admissionId,
+				workerAdmissionId: `supervisor-admission:${randomUUID()}`,
+				status: "waiting",
+				controller: new AbortController(),
+			};
+			admissions.set(key, admission);
+		}
+		return {
+			command,
+			envelopeClientId: isDaemonCommandEnvelope(parsed) ? (parsed.clientId ?? client.id) : undefined,
+			admission,
+		};
+	}
+
+	private async handleLine(client: DaemonSocketClient, line: string): Promise<void> {
+		let preParsed: ReturnType<DaemonSupervisor["parseCommandAndRegisterPromptAdmission"]>;
 		try {
-			const parsed = JSON.parse(line) as unknown;
-			const candidate = isDaemonCommandEnvelope(parsed)
-				? { ...parsed.command, id: parsed.id }
-				: (parsed as { id?: unknown; type?: unknown });
-			if (isDaemonCommandEnvelope(parsed)) {
-				envelopeClientId = parsed.clientId ?? client.id;
-				this.protocolClientIds.set(client, envelopeClientId);
-				client.id = envelopeClientId;
-			}
-			this.cancelOwnedWorkerCleanup(client.id);
-			if (typeof candidate.type !== "string" || !DAEMON_COMMAND_TYPES.has(candidate.type)) {
-				const commandName = typeof candidate.type === "string" ? candidate.type : "unknown";
-				this.write(
-					client,
-					failure(
-						typeof candidate.id === "string" ? candidate.id : undefined,
-						commandName,
-						`Unknown daemon command: ${commandName}`,
-					),
-				);
-				return;
-			}
-			command = candidate as DaemonCommand;
+			preParsed = this.parseCommandAndRegisterPromptAdmission(client, line);
 		} catch (error) {
 			this.write(client, failure(undefined, "parse", error));
 			return;
 		}
+		const command = preParsed.command;
+		const parsedAdmission = preParsed.admission;
+		if (command.type === "cancel_prompt_admission") {
+			const admission = this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
+			if (admission?.status === "waiting" && !admission.worker) {
+				admission.status = "cancelled";
+				admission.controller.abort();
+			}
+		}
+		try {
+			await waitForSupervisorPromptAdmission(this.ready, parsedAdmission?.controller.signal);
+		} catch (error) {
+			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
+			this.write(client, failure(command.id, command.type, error));
+			return;
+		}
+		const envelopeClientId = preParsed.envelopeClientId;
+		if (envelopeClientId) {
+			this.protocolClientIds.set(client, envelopeClientId);
+			client.id = envelopeClientId;
+		}
+		this.cancelOwnedWorkerCleanup(client.id);
+		if (!DAEMON_COMMAND_TYPES.has(command.type)) {
+			this.write(client, failure(command.id, command.type, `Unknown daemon command: ${command.type}`));
+			return;
+		}
 
 		try {
-			await this.assertCurrentOwnership();
+			await waitForSupervisorPromptAdmission(this.assertCurrentOwnership(), parsedAdmission?.controller.signal);
 		} catch (error) {
+			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 			this.write(client, failure(command.id, command.type, error));
 			return;
 		}
@@ -965,10 +1107,12 @@ export class DaemonSupervisor {
 		if (journalIdentity) {
 			const existing = this.commandJournal.begin(journalIdentity.clientId, journalIdentity.commandId, command.type);
 			if (existing.status === "complete") {
+				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 				this.write(client, existing.response);
 				return;
 			}
 			if (existing.status === "pending") {
+				if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 				this.write(
 					client,
 					failure(command.id, command.type, "The previous command result is uncertain and was not replayed", {
@@ -1009,6 +1153,27 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 	): Promise<DaemonResponse | undefined> {
 		switch (command.type) {
+			case "cancel_prompt_admission": {
+				const admission = this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
+				if (!admission) return success(command.id, command.type, { status: "unknown" as const });
+				if (admission.status === "owned") return success(command.id, command.type, { status: "owned" as const });
+				if (!admission.worker || !admission.workerActiveSessionId) {
+					admission.status = "cancelled";
+					admission.controller.abort();
+					return success(command.id, command.type, { status: "cancelled" as const });
+				}
+				const response = await this.forwardToWorker(admission.worker, {
+					...command,
+					activeSessionId: admission.workerActiveSessionId,
+					admissionId: admission.workerAdmissionId,
+				});
+				const status =
+					response.success && response.data && typeof response.data === "object" && "status" in response.data
+						? (response.data as { status: "cancelled" | "owned" | "unknown" }).status
+						: "unknown";
+				admission.status = status === "owned" ? "owned" : status === "cancelled" ? "cancelled" : "waiting";
+				return { ...response, id: command.id };
+			}
 			case "ack_result":
 				this.commandJournal.acknowledge(client.id, command.commandId);
 				return undefined;
@@ -1386,25 +1551,45 @@ export class DaemonSupervisor {
 		if (!("activeSessionId" in command) || typeof command.activeSessionId !== "string") {
 			throw new Error(`Supervisor cannot route daemon command: ${command.type}`);
 		}
-		const match = await this.findWorkerForClient(client, command.activeSessionId);
-		const resolvedCommand = {
-			...command,
-			activeSessionId: match.summary.activeSessionId ?? match.summary.id,
-		} as DaemonCommand;
-		const isRootKill =
-			command.type === "kill" &&
-			(match.summary.activeSessionId ?? match.summary.id) === match.worker.descriptor.rootActiveSessionId;
-		if (!isRootKill) {
-			return this.forwardToWorker(match.worker, resolvedCommand);
-		}
-		this.persistWorkerStopTombstone(match.worker, true);
-		let response: DaemonResponse;
+		const admission =
+			(command.type === "prompt" || command.type === "prompt_and_wait") && command.admissionId
+				? this.getPromptAdmission(client, command.activeSessionId, command.admissionId)
+				: undefined;
 		try {
-			response = await this.forwardToWorker(match.worker, resolvedCommand);
+			if (admission?.status === "cancelled") throw new Error("Prompt admission was cancelled.");
+			const match = await waitForSupervisorPromptAdmission(
+				this.findWorkerForClient(client, command.activeSessionId),
+				admission?.controller.signal,
+			);
+			if ((admission as { status: string } | undefined)?.status === "cancelled") {
+				throw new Error("Prompt admission was cancelled.");
+			}
+			const resolvedCommand = {
+				...command,
+				activeSessionId: match.summary.activeSessionId ?? match.summary.id,
+				...(admission ? { admissionId: admission.workerAdmissionId } : {}),
+			} as DaemonCommand;
+			if (admission) {
+				admission.worker = match.worker;
+				admission.workerActiveSessionId = match.summary.activeSessionId ?? match.summary.id;
+			}
+			const isRootKill =
+				command.type === "kill" &&
+				(match.summary.activeSessionId ?? match.summary.id) === match.worker.descriptor.rootActiveSessionId;
+			if (!isRootKill) {
+				return await this.forwardToWorker(match.worker, resolvedCommand);
+			}
+			this.persistWorkerStopTombstone(match.worker, true);
+			let response: DaemonResponse;
+			try {
+				response = await this.forwardToWorker(match.worker, resolvedCommand);
+			} finally {
+				await this.stopWorker(match.worker, true, false, true);
+			}
+			return response;
 		} finally {
-			await this.stopWorker(match.worker, true, false, true);
+			if (admission) this.deletePromptAdmission(admission);
 		}
-		return response;
 	}
 
 	private async handleList(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1163,8 +1163,7 @@ export class DaemonSupervisor {
 					cancellationAdmission ?? this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
 				if (!admission) return success(command.id, command.type, { status: "unknown" as const });
 				if (admission.status === "owned") return success(command.id, command.type, { status: "owned" as const });
-				// A definitive cancellation never downgrades: repeated cancels must not
-				// report "unknown" (or revert to waiting) for an already-cancelled admission.
+				// A definitive cancellation never downgrades to unknown/waiting.
 				if (admission.status === "cancelled") {
 					return success(command.id, command.type, { status: "cancelled" as const });
 				}
@@ -1182,9 +1181,7 @@ export class DaemonSupervisor {
 					response.success && response.data && typeof response.data === "object" && "status" in response.data
 						? (response.data as { status: "cancelled" | "owned" | "unknown" }).status
 						: "unknown";
-				// Re-read after the await: a concurrent socket close may have cancelled
-				// the admission during the worker round-trip. TS narrowed the pre-await
-				// status, so widen explicitly before comparing.
+				// Re-read: a socket close may have cancelled during the round-trip (cast widens TS's pre-await narrowing).
 				const current = (admission as SupervisorPromptAdmission).status;
 				if (status === "owned") admission.status = "owned";
 				else if (status === "cancelled") admission.status = "cancelled";

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1163,6 +1163,11 @@ export class DaemonSupervisor {
 					cancellationAdmission ?? this.getPromptAdmission(client, command.activeSessionId, command.admissionId);
 				if (!admission) return success(command.id, command.type, { status: "unknown" as const });
 				if (admission.status === "owned") return success(command.id, command.type, { status: "owned" as const });
+				// A definitive cancellation never downgrades: repeated cancels must not
+				// report "unknown" (or revert to waiting) for an already-cancelled admission.
+				if (admission.status === "cancelled") {
+					return success(command.id, command.type, { status: "cancelled" as const });
+				}
 				if (!admission.worker || !admission.workerActiveSessionId) {
 					admission.status = "cancelled";
 					admission.controller.abort();
@@ -1177,7 +1182,13 @@ export class DaemonSupervisor {
 					response.success && response.data && typeof response.data === "object" && "status" in response.data
 						? (response.data as { status: "cancelled" | "owned" | "unknown" }).status
 						: "unknown";
-				admission.status = status === "owned" ? "owned" : status === "cancelled" ? "cancelled" : "waiting";
+				// Re-read after the await: a concurrent socket close may have cancelled
+				// the admission during the worker round-trip. TS narrowed the pre-await
+				// status, so widen explicitly before comparing.
+				const current = (admission as SupervisorPromptAdmission).status;
+				if (status === "owned") admission.status = "owned";
+				else if (status === "cancelled") admission.status = "cancelled";
+				else if (current !== "cancelled") admission.status = "waiting";
 				return { ...response, id: command.id };
 			}
 			case "ack_result":

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -69,6 +69,7 @@ export { resolveAttachModelFallbackMessage } from "./daemon/daemon-session-list.
 export { defaultDaemonSocketPath } from "./daemon/daemon-socket.js";
 export { runDaemonSupervisorMode } from "./daemon/daemon-supervisor.js";
 export {
+	type InteractiveInitialPrompt,
 	InteractiveMode,
 	type InteractiveModeOptions,
 	type InteractiveModeRunResult,

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -19,6 +19,14 @@ export function imageMarkerIds(text: string): number[] {
 	return [...text.matchAll(IMAGE_MARKER_REGEX)].map((match) => Number(match[1]));
 }
 
+/** Replace every image-marker spelling whose numeric id appears in `remaps`. */
+export function remapImageMarkers(text: string, remaps: ReadonlyMap<number, number>): string {
+	return text.replace(IMAGE_MARKER_REGEX, (marker, id: string) => {
+		const replacement = remaps.get(Number(id));
+		return replacement === undefined ? marker : formatImageMarker(replacement);
+	});
+}
+
 /**
  * Images from `pending` whose marker still appears in `text`, in paste order
  * (the map's insertion order). Each image is returned at most once even if its

--- a/packages/coding-agent/src/modes/interactive/image-markers.ts
+++ b/packages/coding-agent/src/modes/interactive/image-markers.ts
@@ -16,7 +16,9 @@ export function formatImageMarker(id: number): string {
 
 /** Marker ids that appear in `text`, in order of appearance. */
 export function imageMarkerIds(text: string): number[] {
-	return [...text.matchAll(IMAGE_MARKER_REGEX)].map((match) => Number(match[1]));
+	return [...text.matchAll(IMAGE_MARKER_REGEX)]
+		.map((match) => Number(match[1]))
+		.filter((id) => Number.isSafeInteger(id));
 }
 
 /** Replace every image-marker spelling whose numeric id appears in `remaps`. */

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1559,6 +1559,11 @@ export class InteractiveMode {
 					if (startupPromptsDone || startupAdmissionAbort.signal.aborted) return;
 					// An uncertain daemon admission may already be session-owned. Retrying
 					// would duplicate it; only an acknowledged pre-ownership cancellation is safe.
+					if (error instanceof AgentConnectionPromptAdmissionError && error.status === "owned") {
+						failures = 0;
+						next++;
+						continue;
+					}
 					if (error instanceof AgentConnectionPromptAdmissionError && !error.cancelled) {
 						// This attempt may already be session-owned, so never retry it. Preserve
 						// it and every not-yet-attempted startup prompt in original order.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -473,7 +473,7 @@ export class BrandSplashHeader implements Component {
 	}
 }
 
-type StartupPromptBarrierOutcome = "admitted" | "lifecycle-cancelled";
+type StartupPromptBarrierOutcome = "admitted" | "retained" | "lifecycle-cancelled";
 
 type GoalAnnouncementSnapshot = {
 	goalId?: string;
@@ -740,6 +740,11 @@ export function resolveInteractiveUpdateDaemonSocketPath(
 /**
  * Options for InteractiveMode initialization.
  */
+export interface InteractiveInitialPrompt {
+	text: string;
+	images?: ImageContent[];
+}
+
 export interface InteractiveModeOptions {
 	/** Providers that were migrated to auth.json (shows warning) */
 	migratedProviders?: string[];
@@ -751,8 +756,10 @@ export interface InteractiveModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
-	/** Additional messages to send after the initial message */
+	/** Additional text-only messages to send after the initial message. */
 	initialMessages?: string[];
+	/** Additional image-bearing prompts to send after the initial messages. */
+	initialPrompts?: InteractiveInitialPrompt[];
 	/** Force verbose startup (overrides quietStartup setting) */
 	verbose?: boolean;
 	/** Agent execution boundary. InteractiveMode never talks directly to AgentSession for core execution. */
@@ -1134,6 +1141,7 @@ export class InteractiveMode {
 			if (!stash) continue;
 			for (const [markerId, image] of stash.images ?? []) {
 				this.pastedImages.set(markerId, image);
+				this.nextImageMarkerId = Math.max(this.nextImageMarkerId, markerId + 1);
 			}
 			for (const markerId of imageMarkerIds(stash.text)) {
 				this.nextImageMarkerId = Math.max(this.nextImageMarkerId, markerId + 1);
@@ -1474,7 +1482,14 @@ export class InteractiveMode {
 		const tmuxKeyboardWarningPromise = ownsGlobalStartupNotices ? checkTmuxKeyboardSetup() : undefined;
 
 		// Show startup warnings
-		const { migratedProviders, modelFallbackMessage, initialMessage, initialImages, initialMessages } = this.options;
+		const {
+			migratedProviders,
+			modelFallbackMessage,
+			initialMessage,
+			initialImages,
+			initialMessages,
+			initialPrompts,
+		} = this.options;
 
 		if (migratedProviders && migratedProviders.length > 0) {
 			this.showWarning(`Migrated credentials to auth.json: ${migratedProviders.join(", ")}`);
@@ -1489,9 +1504,10 @@ export class InteractiveMode {
 			this.showError(`models.json error: ${modelsJsonError}`);
 		}
 
-		const initialPrompts = [
+		const startupPrompts: InteractiveInitialPrompt[] = [
 			...(initialMessage ? [{ text: initialMessage, images: initialImages }] : []),
-			...(initialMessages ?? []).map((text) => ({ text, images: undefined })),
+			...(initialMessages ?? []).map((text) => ({ text })),
+			...(initialPrompts ?? []),
 		];
 		// One drive loop owns startup-prompt delivery: it retries on a 250ms cadence
 		// while a model is missing or admission fails transiently, shows every
@@ -1521,7 +1537,7 @@ export class InteractiveMode {
 			});
 		const deliverStartupPrompts = async () => {
 			let failures = 0;
-			for (let next = 0; next < initialPrompts.length; ) {
+			for (let next = 0; next < startupPrompts.length; ) {
 				// The run lifecycle can settle the barrier while a prompt is being
 				// admitted; stop instead of prompting a session we already left.
 				if (startupPromptsDone) return;
@@ -1529,7 +1545,7 @@ export class InteractiveMode {
 					if (!(await startupRetryDelay())) return;
 					continue;
 				}
-				const prompt = initialPrompts[next]!;
+				const prompt = startupPrompts[next]!;
 				try {
 					await this.agentConnection.prompt(prompt.text, {
 						images: prompt.images,
@@ -1544,11 +1560,11 @@ export class InteractiveMode {
 					// An uncertain daemon admission may already be session-owned. Retrying
 					// would duplicate it; only an acknowledged pre-ownership cancellation is safe.
 					if (error instanceof AgentConnectionPromptAdmissionError && !error.cancelled) {
-						this.retainSubmittedDraft({
-							text: prompt.text,
-							images: prompt.images?.map((image, index) => [index, image] as const),
-						});
+						// This attempt may already be session-owned, so never retry it. Preserve
+						// it and every not-yet-attempted startup prompt in original order.
+						this.retainStartupPromptDrafts(startupPrompts.slice(next));
 						this.showError(error.message);
+						settleStartupPrompts("retained");
 						return;
 					}
 					const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
@@ -1563,7 +1579,7 @@ export class InteractiveMode {
 				}
 			}
 		};
-		this.admitPendingStartupPrompts = initialPrompts.length > 0 ? () => startupPromptsSettled : undefined;
+		this.admitPendingStartupPrompts = startupPrompts.length > 0 ? () => startupPromptsSettled : undefined;
 
 		let deferredStartupNotificationsShown = false;
 		const showDeferredStartupNotifications = () => {
@@ -4144,6 +4160,66 @@ export class InteractiveMode {
 		this.promptStashState.queuedStashes = ordered.length > 0 ? ordered : undefined;
 	}
 
+	private retainStartupPromptDrafts(prompts: readonly InteractiveInitialPrompt[]): void {
+		// Reserve every marker visible anywhere in the retained batch before assigning
+		// any image. This prevents an early prompt's attachment from making a literal
+		// marker in a later prompt resolve to the wrong image.
+		const reserved = new Set(this.pastedImages.keys());
+		for (const stash of [this.promptStash, ...(this.promptStashState.queuedStashes ?? [])]) {
+			if (stash) for (const markerId of imageMarkerIds(stash.text)) reserved.add(markerId);
+		}
+		for (const prompt of prompts) {
+			for (const markerId of imageMarkerIds(prompt.text)) reserved.add(markerId);
+		}
+		for (const markerId of reserved) {
+			this.nextImageMarkerId = Math.max(this.nextImageMarkerId, markerId + 1);
+		}
+		const allocateMarker = () => {
+			while (reserved.has(this.nextImageMarkerId)) this.nextImageMarkerId++;
+			const markerId = this.nextImageMarkerId++;
+			reserved.add(markerId);
+			return markerId;
+		};
+
+		const retained: PromptStash[] = [];
+		for (const prompt of prompts) {
+			let text = prompt.text;
+			// A startup prompt owns only the images passed with it. Remap literal
+			// markers that already name registry data so restoring this draft cannot
+			// accidentally attach an old or another prompt's image.
+			const literalRemaps = new Map<number, number>();
+			for (const markerId of imageMarkerIds(text)) {
+				if (this.pastedImages.has(markerId) && !literalRemaps.has(markerId)) {
+					literalRemaps.set(markerId, allocateMarker());
+				}
+			}
+			for (const [from, to] of literalRemaps) {
+				text = text.replaceAll(formatImageMarker(from), formatImageMarker(to));
+			}
+
+			const images: Array<readonly [number, ImageContent]> = [];
+			for (const image of prompt.images ?? []) {
+				const markerId = allocateMarker();
+				images.push([markerId, image]);
+				text += `${text.length > 0 && !/\s$/.test(text) ? " " : ""}${formatImageMarker(markerId)}`;
+			}
+			retained.push({
+				text,
+				...(images.length > 0 ? { images } : {}),
+			});
+			for (const [markerId, image] of images) this.pastedImages.set(markerId, image);
+		}
+
+		// Startup drafts form the head of the durable queue. Preserve any older
+		// client draft after them, and let submissions released by the barrier append.
+		const existing = [this.promptStashState.stash, ...(this.promptStashState.queuedStashes ?? [])].filter(
+			(stash): stash is PromptStash => stash !== undefined,
+		);
+		const ordered = [...retained, ...existing];
+		this.promptStashState.stash = ordered.shift();
+		this.promptStashState.queuedStashes = ordered.length > 0 ? ordered : undefined;
+	}
+
 	private getPromptStashImages(text: string): readonly (readonly [number, ImageContent])[] {
 		const images: Array<readonly [number, ImageContent]> = [];
 		for (const markerId of imageMarkerIds(text)) {
@@ -4764,6 +4840,13 @@ export class InteractiveMode {
 				this.editor.setText("");
 				const promptStashAfterClear = this.promptStash;
 				submissionOutcome = (await this.admitPendingStartupPrompts?.()) ?? "admitted";
+				// Retention is not admission. Startup drafts were inserted synchronously
+				// before the barrier settled, so append this blocked submission behind them
+				// and never let it prompt or overtake them.
+				if (submissionOutcome === "retained") {
+					this.retainSubmittedDraft(submittedDraft ?? { text });
+					return;
+				}
 				// The barrier also settles when the run lifecycle ends; a submit resumed
 				// by teardown must neither prompt nor mutate the editor/durable stash.
 				if (

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -153,6 +153,7 @@ import type {
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
 } from "../agent-connection/index.js";
+import { AgentConnectionPromptAdmissionError } from "../agent-connection/index.js";
 import { getModelArgumentCompletions } from "../model-autocomplete.js";
 import {
 	checkForPackageUpdates,
@@ -1540,6 +1541,16 @@ export class InteractiveMode {
 					next++;
 				} catch (error) {
 					if (startupPromptsDone || startupAdmissionAbort.signal.aborted) return;
+					// An uncertain daemon admission may already be session-owned. Retrying
+					// would duplicate it; only an acknowledged pre-ownership cancellation is safe.
+					if (error instanceof AgentConnectionPromptAdmissionError && !error.cancelled) {
+						this.retainSubmittedDraft({
+							text: prompt.text,
+							images: prompt.images?.map((image, index) => [index, image] as const),
+						});
+						this.showError(error.message);
+						return;
+					}
 					const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 					if (++failures < 3) {
 						this.showError(errorMessage);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -214,7 +214,13 @@ import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
 import { FeatureHintDeck } from "./feature-hints.js";
 import { scopeHeartbeatsToSession } from "./heartbeat-scope.js";
-import { collectMarkedImages, evictImagesToBudget, formatImageMarker, imageMarkerIds } from "./image-markers.js";
+import {
+	collectMarkedImages,
+	evictImagesToBudget,
+	formatImageMarker,
+	imageMarkerIds,
+	remapImageMarkers,
+} from "./image-markers.js";
 import type {
 	InteractiveModeLocalSessionHost,
 	InteractiveModeLocalToolRendererDefinition,
@@ -4198,9 +4204,7 @@ export class InteractiveMode {
 					literalRemaps.set(markerId, allocateMarker());
 				}
 			}
-			for (const [from, to] of literalRemaps) {
-				text = text.replaceAll(formatImageMarker(from), formatImageMarker(to));
-			}
+			text = remapImageMarkers(text, literalRemaps);
 
 			const images: Array<readonly [number, ImageContent]> = [];
 			for (const image of prompt.images ?? []) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4853,7 +4853,7 @@ export class InteractiveMode {
 				// before the barrier settled, so append this blocked submission behind them
 				// and never let it prompt or overtake them.
 				if (submissionOutcome === "retained") {
-					this.retainSubmittedDraft(submittedDraft ?? { text });
+					this.retainSubmittedDraft(submittedDraft ?? { text }, submissionGeneration);
 					return;
 				}
 				// The barrier also settles when the run lifecycle ends; a submit resumed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -131,6 +131,7 @@ async function runPrintModeWithConnectionInternal(
 				}
 			} else if (lastMessage?.role === "custom" && isSessionSlashCommandResultMessage(lastMessage)) {
 				writeRawStdout(`${lastMessage.content}\n`);
+				if (!lastMessage.details.success || lastMessage.details.severity === "error") exitCode = 1;
 			}
 		}
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -9,6 +9,7 @@
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import type { AgentSessionRuntime } from "../core/agent-session-runtime.js";
 import { type AgentAutonomousStatus, type AutonomousLimitReason, autonomousLimitReason } from "../core/autonomous.js";
+import { isSessionSlashCommandResultMessage } from "../core/messages.js";
 import { flushRawStdout, writeRawStdout } from "../core/output-guard.js";
 import { killTrackedDetachedChildren } from "../utils/shell.js";
 import { InProcessAgentConnection } from "./agent-connection/in-process-agent-connection.js";
@@ -128,6 +129,8 @@ async function runPrintModeWithConnectionInternal(
 						}
 					}
 				}
+			} else if (lastMessage?.role === "custom" && isSessionSlashCommandResultMessage(lastMessage)) {
+				writeRawStdout(`${lastMessage.content}\n`);
 			}
 		}
 

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -634,8 +634,9 @@ function parseDaemonUpdateRestartQueuedMessage(value: unknown): DaemonUpdateRest
 	) {
 		throw new Error("Daemon update restart response contains an invalid custom queued message");
 	}
-	const agentMessageId =
-		readOptionalString(value.agentMessageId, "queue.agentMessageId") ?? parseAgentSessionMessagePromptId(message);
+	const restoredAgentMessageId = readOptionalString(value.agentMessageId, "queue.agentMessageId");
+	if (restoredAgentMessageId === "") throw new Error("queue.agentMessageId must not be empty");
+	const agentMessageId = restoredAgentMessageId ?? parseAgentSessionMessagePromptId(message);
 	return {
 		message,
 		...(content ? { content } : {}),

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -865,6 +865,16 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests).toEqual([]);
 	});
 
+	it("accepts a newer daemon schema revision for a signal-backed prompt", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		fakeClient.hello = { ...fakeClient.hello!, schemaRevision: DAEMON_SCHEMA_REVISION + 1 };
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await connection.prompt("startup", { signal: new AbortController().signal });
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["prompt"]);
+	});
+
 	it("uses fleet heartbeat scope for residents and session scope for owned workers", async () => {
 		const residentClient = new FakeDaemonClient();
 		residentClient.serverCapabilities.add("heartbeat_catalog");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -50,6 +50,7 @@ class FakeDaemonClient {
 	cronAddGate: Promise<void> | undefined;
 	promptGate: Promise<void> | undefined;
 	promptError: Error | undefined;
+	promptResponseError: string | undefined;
 	cancelPromptAdmissionStatus: "cancelled" | "owned" | "unknown" = "owned";
 	legacyHeartbeatCommandsSupported = false;
 	serverCapabilities = new Set<string>();
@@ -76,6 +77,9 @@ class FakeDaemonClient {
 			case "prompt":
 				if (this.promptGate) await this.promptGate;
 				if (this.promptError) throw this.promptError;
+				if (this.promptResponseError) {
+					return { type: "response", command: command.type, success: false, error: this.promptResponseError };
+				}
 				return { type: "response", command: command.type, success: true };
 			case "prompt_and_wait":
 				if (this.promptGate) await this.promptGate;
@@ -751,6 +755,18 @@ describe("DaemonAgentConnection", () => {
 		expect(add).toHaveBeenCalledOnce();
 		expect(remove).toHaveBeenCalledOnce();
 		expect(remove.mock.calls[0]?.[1]).toBe(add.mock.calls[0]?.[1]);
+	});
+
+	it("preserves a definitive prompt rejection when the signal remains live", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		fakeClient.promptResponseError = "session rejected prompt";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.prompt("startup", { signal: new AbortController().signal })).rejects.toEqual(
+			new Error("session rejected prompt"),
+		);
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["prompt"]);
 	});
 
 	it("sends zero requests for a pre-aborted prompt", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/modes/daemon/daemon-client.js";
 import {
 	DAEMON_PROTOCOL_INFO,
+	DAEMON_SCHEMA_REVISION,
 	type DaemonAttachResult,
 	type DaemonCommand,
 	type DaemonOutbound,
@@ -47,10 +48,20 @@ class FakeDaemonClient {
 	abortBashUnknownCommand = false;
 	abortAndClearQueueUnknownCommand = false;
 	cronAddGate: Promise<void> | undefined;
+	promptGate: Promise<void> | undefined;
+	promptError: Error | undefined;
+	cancelPromptAdmissionStatus: "cancelled" | "owned" | "unknown" = "owned";
 	legacyHeartbeatCommandsSupported = false;
 	serverCapabilities = new Set<string>();
 	updateRestartSessions: Array<Record<string, unknown>> = [];
-	hello: DaemonHello | undefined;
+	hello: DaemonHello | undefined = {
+		type: "daemon_hello",
+		socketPath: "/tmp/fake.sock",
+		protocol: DAEMON_PROTOCOL_INFO,
+		schemaRevision: DAEMON_SCHEMA_REVISION,
+		clientId: "fake-client",
+		serverCapabilities: ["prompt_admission_cancellation", "session_input_admission"],
+	};
 	private readonly messageListeners = new Set<DaemonClientMessageListener>();
 	private readonly closeListeners = new Set<DaemonClientCloseListener>();
 
@@ -63,8 +74,20 @@ class FakeDaemonClient {
 		this.requestTimeouts.push(timeoutMs);
 		switch (command.type) {
 			case "prompt":
-			case "prompt_and_wait":
+				if (this.promptGate) await this.promptGate;
+				if (this.promptError) throw this.promptError;
 				return { type: "response", command: command.type, success: true };
+			case "prompt_and_wait":
+				if (this.promptGate) await this.promptGate;
+				if (this.promptError) throw this.promptError;
+				return { type: "response", command: command.type, success: true };
+			case "cancel_prompt_admission":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: { status: this.cancelPromptAdmissionStatus },
+				};
 			case "list":
 				return {
 					type: "response",
@@ -491,7 +514,9 @@ class FakeDaemonClient {
 		this.connected = true;
 	}
 
-	async waitForHello(): Promise<void> {}
+	async waitForHello(): Promise<DaemonHello> {
+		return this.hello!;
+	}
 
 	resetTransportForReconnect(): void {
 		this.resetTransportCount++;
@@ -689,6 +714,96 @@ describe("DaemonAgentConnection", () => {
 			streamingBehavior: "followUp",
 			queueIfBusy: true,
 		});
+	});
+
+	it("forwards signal-backed prompts with a unique cancellable admission id", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+
+		await connection.prompt("startup", { signal: abort.signal, queueIfBusy: true });
+
+		expect(fakeClient.requests.at(-1)).toMatchObject({
+			type: "prompt",
+			activeSessionId: "active-1",
+			message: "startup",
+			queueIfBusy: true,
+			admissionId: expect.stringMatching(/^prompt-admission:/),
+		});
+	});
+
+	it("cancels rejected signal-backed admission and removes its abort listener", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		fakeClient.promptError = new Error("transport failed");
+		fakeClient.cancelPromptAdmissionStatus = "cancelled";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+		const add = vi.spyOn(abort.signal, "addEventListener");
+		const remove = vi.spyOn(abort.signal, "removeEventListener");
+
+		await expect(connection.prompt("startup", { signal: abort.signal })).rejects.toMatchObject({
+			message: "transport failed",
+			cancelled: true,
+		});
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["prompt", "cancel_prompt_admission"]);
+		expect(add).toHaveBeenCalledOnce();
+		expect(remove).toHaveBeenCalledOnce();
+		expect(remove.mock.calls[0]?.[1]).toBe(add.mock.calls[0]?.[1]);
+	});
+
+	it("sends zero requests for a pre-aborted prompt", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+		abort.abort();
+
+		await expect(connection.prompt("startup", { signal: abort.signal })).rejects.toMatchObject({
+			status: "cancelled",
+		});
+		expect(fakeClient.requests).toEqual([]);
+	});
+
+	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		fakeClient.promptError = new Error("lost response");
+		fakeClient.cancelPromptAdmissionStatus = "unknown";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.prompt("startup", { signal: new AbortController().signal })).rejects.toMatchObject({
+			message: "lost response",
+			status: "unknown",
+			cancelled: false,
+		});
+	});
+
+	it("uses cancellable admission for promptAndWait", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		fakeClient.promptError = new Error("lost response");
+		fakeClient.cancelPromptAdmissionStatus = "cancelled";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.promptAndWait("wait", { signal: new AbortController().signal })).rejects.toMatchObject({
+			status: "cancelled",
+		});
+		expect(fakeClient.requests.map((request) => request.type)).toEqual([
+			"prompt_and_wait",
+			"cancel_prompt_admission",
+		]);
+	});
+
+	it("rejects an old daemon before sending a signal-backed prompt", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.hello = { ...fakeClient.hello!, protocol: { ...DAEMON_PROTOCOL_INFO, version: 4 } };
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.prompt("startup", { signal: new AbortController().signal })).rejects.toMatchObject({
+			status: "unsupported",
+		});
+		expect(fakeClient.requests).toEqual([]);
 	});
 
 	it("uses fleet heartbeat scope for residents and session scope for owned workers", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -62,6 +62,9 @@ class FakeDaemonClient {
 		this.requests.push(command);
 		this.requestTimeouts.push(timeoutMs);
 		switch (command.type) {
+			case "prompt":
+			case "prompt_and_wait":
+				return { type: "response", command: command.type, success: true };
 			case "list":
 				return {
 					type: "response",
@@ -673,6 +676,21 @@ function emitSequencedQueueUpdate(client: FakeDaemonClient, activeSessionId: str
 }
 
 describe("DaemonAgentConnection", () => {
+	it("forwards queueIfBusy for prompt admission", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await connection.prompt("queued input", { streamingBehavior: "followUp", queueIfBusy: true });
+
+		expect(fakeClient.requests.at(-1)).toMatchObject({
+			type: "prompt",
+			activeSessionId: "active-1",
+			message: "queued input",
+			streamingBehavior: "followUp",
+			queueIfBusy: true,
+		});
+	});
+
 	it("uses fleet heartbeat scope for residents and session scope for owned workers", async () => {
 		const residentClient = new FakeDaemonClient();
 		residentClient.serverCapabilities.add("heartbeat_catalog");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -781,6 +781,27 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests).toEqual([]);
 	});
 
+	it("accepts a successful prompt response when cancellation reports unknown", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		let releasePrompt = () => {};
+		fakeClient.promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+		fakeClient.cancelPromptAdmissionStatus = "unknown";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+
+		const prompt = connection.prompt("startup", { signal: abort.signal });
+		abort.abort();
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.map((request) => request.type)).toContain("cancel_prompt_admission"),
+		);
+		releasePrompt();
+
+		await expect(prompt).resolves.toBeUndefined();
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.serverCapabilities.add("prompt_admission_cancellation");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -802,6 +802,28 @@ describe("DaemonAgentConnection", () => {
 		await expect(prompt).resolves.toBeUndefined();
 	});
 
+	it("preserves a definitive prompt rejection when cancellation reports owned", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("prompt_admission_cancellation");
+		let releasePrompt = () => {};
+		fakeClient.promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+		fakeClient.promptResponseError = "post-ownership validation failed";
+		fakeClient.cancelPromptAdmissionStatus = "owned";
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+
+		const prompt = connection.prompt("startup", { signal: abort.signal });
+		abort.abort();
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.map((request) => request.type)).toContain("cancel_prompt_admission"),
+		);
+		releasePrompt();
+
+		await expect(prompt).rejects.toThrow("post-ownership validation failed");
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.serverCapabilities.add("prompt_admission_cancellation");

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -254,9 +254,15 @@ describe("DaemonClient", () => {
 			DAEMON_SCHEMA_REVISION + 1,
 		);
 
-		void client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", admissionId: "a-1" });
+		const request = client.request({
+			type: "prompt",
+			activeSessionId: "active-1",
+			message: "hello",
+			admissionId: "a-1",
+		});
 		await vi.waitFor(() => expect(socket.writes).toHaveLength(1));
 		client.close();
+		await expect(request).rejects.toThrow("closed before the operation completed");
 	});
 
 	it("isolates a message consumer failure from the rest of the client", async () => {
@@ -809,6 +815,43 @@ describe("DaemonClient", () => {
 		);
 
 		await expect(response).resolves.toMatchObject({ id: firstEnvelope.id, success: true });
+		client.close();
+	});
+
+	it("rejects a pending admission-gated prompt when the reconnected daemon is downgraded", async () => {
+		vi.useFakeTimers();
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		client.enableRequestRecovery();
+		const firstConnect = client.connect();
+		const firstSocket = netMock.sockets[0]!;
+		firstSocket.emit("connect");
+		await firstConnect;
+		emitHello(
+			firstSocket,
+			DAEMON_PROTOCOL_VERSION,
+			["session_input_admission", "prompt_admission_cancellation"],
+			DAEMON_SCHEMA_REVISION,
+		);
+
+		const response = client.request({
+			type: "prompt",
+			activeSessionId: "active-1",
+			message: "hello",
+			admissionId: "a-1",
+		});
+		expect(firstSocket.writes).toHaveLength(1);
+		firstSocket.emit("close");
+
+		const secondConnect = client.connect();
+		const secondSocket = netMock.sockets[1]!;
+		secondSocket.emit("connect");
+		await secondConnect;
+		// The replacement daemon no longer supports admission cancellation, so
+		// replaying would silently drop admissionId and take ownership.
+		emitHello(secondSocket, DAEMON_PROTOCOL_VERSION, ["session_input_admission"], DAEMON_SCHEMA_REVISION);
+
+		await expect(response).rejects.toThrow("does not support prompt_admission_cancellation");
+		expect(secondSocket.writes).toEqual([]);
 		client.close();
 	});
 

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
-import { DAEMON_PROTOCOL_VERSION } from "../src/modes/daemon/daemon-protocol.js";
+import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_REVISION } from "../src/modes/daemon/daemon-protocol.js";
 
 const netMock = vi.hoisted(() => {
 	type Listener = (...args: unknown[]) => void;
@@ -238,6 +238,24 @@ describe("DaemonClient", () => {
 			client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", admissionId: "a-1" }),
 		).rejects.toThrow("does not support prompt_admission_cancellation");
 		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
+	it("accepts a newer daemon schema revision for admission-gated prompts", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(
+			socket,
+			DAEMON_PROTOCOL_VERSION,
+			["session_input_admission", "prompt_admission_cancellation"],
+			DAEMON_SCHEMA_REVISION + 1,
+		);
+
+		void client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", admissionId: "a-1" });
+		await vi.waitFor(() => expect(socket.writes).toHaveLength(1));
 		client.close();
 	});
 

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -90,6 +90,7 @@ function emitHello(
 	socket: (typeof netMock.sockets)[number],
 	version = DAEMON_PROTOCOL_VERSION,
 	serverCapabilities: string[] = ["session_input_admission"],
+	schemaRevision?: number,
 ): void {
 	socket.emit(
 		"data",
@@ -97,6 +98,7 @@ function emitHello(
 			type: "daemon_hello",
 			socketPath: "/tmp/prime-agent.sock",
 			protocol: { name: "prime-agent.daemon", version },
+			schemaRevision,
 			appVersion: "9.9.9",
 			clientId: "client-1",
 			serverCapabilities,
@@ -220,6 +222,21 @@ describe("DaemonClient", () => {
 		await expect(
 			client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", queueIfBusy: true }),
 		).rejects.toThrow("does not support session_input_admission");
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
+	it("field-gates prompt admissionId before writing raw commands", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["session_input_admission", "prompt_admission_cancellation"], 3);
+
+		await expect(
+			client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", admissionId: "a-1" }),
+		).rejects.toThrow("does not support prompt_admission_cancellation");
 		expect(socket.writes).toEqual([]);
 		client.close();
 	});

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -86,7 +86,11 @@ vi.mock("node:net", () => ({
 	createConnection: netMock.createConnection,
 }));
 
-function emitHello(socket: (typeof netMock.sockets)[number], version = DAEMON_PROTOCOL_VERSION): void {
+function emitHello(
+	socket: (typeof netMock.sockets)[number],
+	version = DAEMON_PROTOCOL_VERSION,
+	serverCapabilities: string[] = ["session_input_admission"],
+): void {
 	socket.emit(
 		"data",
 		`${JSON.stringify({
@@ -95,7 +99,7 @@ function emitHello(socket: (typeof netMock.sockets)[number], version = DAEMON_PR
 			protocol: { name: "prime-agent.daemon", version },
 			appVersion: "9.9.9",
 			clientId: "client-1",
-			serverCapabilities: [],
+			serverCapabilities,
 		})}\n`,
 	);
 }
@@ -201,6 +205,21 @@ describe("DaemonClient", () => {
 
 		expect(client.supportsServerCapability("heartbeat_catalog")).toBe(false);
 		await expect(client.request({ type: "heartbeats_list" })).rejects.toThrow("does not support heartbeat_catalog");
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
+	it("rejects session input admission clearly when an old daemon lacks the capability", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, []);
+
+		await expect(
+			client.request({ type: "prompt", activeSessionId: "active-1", message: "hello", queueIfBusy: true }),
+		).rejects.toThrow("does not support session_input_admission");
 		expect(socket.writes).toEqual([]);
 		client.close();
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2288,7 +2288,7 @@ describe("daemon mode helpers", () => {
 		expect(prompt).toHaveBeenCalledOnce();
 	});
 
-	it("queues agent messages while a cron prompt prepares to stream", async () => {
+	it("releases cron preparing state after prompt admission", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -2303,6 +2303,7 @@ describe("daemon mode helpers", () => {
 					resolvePrompt = resolve;
 				}),
 		);
+		const promptUntilAccepted = vi.fn(async () => {});
 		const acceptAgentMessagePrompt = vi.fn(async () => {});
 		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
 		targetState.runtime = {
@@ -2315,6 +2316,7 @@ describe("daemon mode helpers", () => {
 				isBashRunning: false,
 				pendingMessageCount: 0,
 				prompt,
+				promptUntilAccepted,
 				acceptAgentMessagePrompt,
 				queueAgentMessagePrompt,
 			},
@@ -2335,7 +2337,8 @@ describe("daemon mode helpers", () => {
 		);
 		await Promise.resolve();
 		await Promise.resolve();
-		expect(prompt).toHaveBeenCalledOnce();
+		expect(promptUntilAccepted).toHaveBeenCalledOnce();
+		expect(prompt).not.toHaveBeenCalled();
 
 		await internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -2343,9 +2346,8 @@ describe("daemon mode helpers", () => {
 			origin: "agent",
 		});
 
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+		expect(queueAgentMessagePrompt).not.toHaveBeenCalled();
 		resolvePrompt();
 		await cronRun;
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5092,9 +5092,11 @@ describe("daemon mode helpers", () => {
 			state.runtime = { ...state.runtime, session: { isStreaming: false, promptUntilAccepted } } as never;
 			const internals = daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
+				recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
 				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
 			};
 			internals.sessions.set(state.activeSessionId, state);
+			internals.recordWorkerRecoveryState = vi.fn();
 
 			let settled = 0;
 			const response = internals
@@ -5112,6 +5114,9 @@ describe("daemon mode helpers", () => {
 			expect(settled).toBe(1);
 			expect(turnCompleted).toBe(false);
 			expect(promptUntilAccepted).toHaveBeenCalledOnce();
+			if (type === "follow_up") {
+				expect(internals.recordWorkerRecoveryState).toHaveBeenCalledWith(state, "follow_up_queued", true);
+			}
 			releaseTurn?.();
 			await turnGate;
 			expect(turnCompleted).toBe(true);
@@ -5183,7 +5188,7 @@ describe("daemon mode helpers", () => {
 		expect(continueAgent).not.toHaveBeenCalled();
 	});
 
-	it("forwards queue keys through canonical daemon steering admission", async () => {
+	it("preserves template expansion and queue keys for correlated daemon steering", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -5227,7 +5232,16 @@ describe("daemon mode helpers", () => {
 				agentMessageId: "agentmsg_steer",
 			}),
 		);
+		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 		expect(restoreSteeringMessage).not.toHaveBeenCalled();
+		await expect(
+			internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+				type: "steer",
+				activeSessionId: state.activeSessionId,
+				message: "invalid",
+				agentMessageId: "",
+			}),
+		).rejects.toThrow("agentMessageId must not be empty");
 	});
 
 	it("rejects invalid heartbeat delivery modes before persisting", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5128,6 +5128,52 @@ describe("daemon mode helpers", () => {
 		},
 	);
 
+	it.each([
+		{ error: undefined, expected: "Prompt was not accepted by the session." },
+		{ error: new Error("duplicate follow-up queueKey"), expected: "duplicate follow-up queueKey" },
+	])("fails prompt RPC after preflight rejection with $expected", async ({ error, expected }) => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const promptUntilAccepted = vi.fn(
+			async (_message: string, options?: { preflightResult?: (success: boolean) => void }) => {
+				options?.preflightResult?.(false);
+				if (error) throw error;
+			},
+		);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & { session: { promptUntilAccepted: typeof promptUntilAccepted } };
+		};
+		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+		const client = makeClient("client-1", state.activeSessionId);
+		const write = vi.fn((_data: unknown) => true);
+		client.socket = { destroyed: false, write } as unknown as Socket;
+
+		internals.handleCommand(client, {
+			id: "command-1",
+			type: "prompt",
+			activeSessionId: state.activeSessionId,
+			message: "duplicate",
+			streamingBehavior: "followUp",
+		});
+
+		await vi.waitFor(() => expect(write).toHaveBeenCalledOnce());
+		expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({
+			id: "command-1",
+			command: "prompt",
+			success: false,
+			error: expected,
+		});
+	});
+
 	it("uses the queued default lane for old-client prompts on a new daemon", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -5142,11 +5188,14 @@ describe("daemon mode helpers", () => {
 		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
 		};
 		internals.sessions.set(state.activeSessionId, state);
+		const client = makeClient("legacy-client", state.activeSessionId);
+		const write = vi.fn((_data: unknown) => true);
+		client.socket = { destroyed: false, write } as unknown as Socket;
 
-		await internals.handleCommand(makeClient("legacy-client", state.activeSessionId), {
+		internals.handleCommand(client, {
 			id: "command-1",
 			type: "prompt",
 			activeSessionId: state.activeSessionId,
@@ -5154,6 +5203,8 @@ describe("daemon mode helpers", () => {
 			streamingBehavior: "followUp",
 		});
 
+		await vi.waitFor(() => expect(write).toHaveBeenCalledOnce());
+		expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({ success: true, command: "prompt" });
 		expect(promptUntilAccepted).toHaveBeenCalledWith(
 			"legacy prompt",
 			expect.objectContaining({ streamingBehavior: "followUp", queueIfBusy: true }),

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5140,19 +5140,21 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
-		const prompt = vi.fn(async () => {});
+		const steer = vi.fn(async () => {});
+		const followUp = vi.fn(async () => true);
 		const restoreSteeringMessage = vi.fn(async () => {});
 		const restoreFollowUpMessage = vi.fn(async () => true);
 		const state = makeState("active-1") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
-					prompt: typeof prompt;
+					steer: typeof steer;
+					followUp: typeof followUp;
 					restoreSteeringMessage: typeof restoreSteeringMessage;
 					restoreFollowUpMessage: typeof restoreFollowUpMessage;
 				};
 			};
 		};
-		state.runtime.session = { prompt, restoreSteeringMessage, restoreFollowUpMessage } as never;
+		state.runtime.session = { steer, followUp, restoreSteeringMessage, restoreFollowUpMessage } as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
@@ -5167,15 +5169,12 @@ describe("daemon mode helpers", () => {
 			queueKey: "heartbeat:expanded",
 			agentMessageId: `agentmsg_expanded_${type}`,
 		});
-		expect(prompt).toHaveBeenCalledWith(
-			"expanded prompt",
-			expect.objectContaining({
-				streamingBehavior: type === "steer" ? "steer" : "followUp",
-				queueIfBusy: true,
-				followUpQueueKey: "heartbeat:expanded",
-				agentMessageId: `agentmsg_expanded_${type}`,
-			}),
-		);
+		const queue = type === "steer" ? steer : followUp;
+		expect(queue).toHaveBeenCalledWith("expanded prompt", undefined, {
+			queueKey: "heartbeat:expanded",
+			agentMessageId: `agentmsg_expanded_${type}`,
+			resumeIfIdle: true,
+		});
 
 		const replayFields = {
 			content: [{ type: "text" as const, text: "restored content" }],
@@ -5221,7 +5220,7 @@ describe("daemon mode helpers", () => {
 			agentMessageId: `agentmsg_${type}`,
 			...replayFields,
 		});
-		expect(prompt).toHaveBeenCalledOnce();
+		expect(queue).toHaveBeenCalledOnce();
 
 		await expect(
 			internals.handleCommand(client, { ...base, message: "invalid", agentMessageId: "" }),

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -20,10 +20,23 @@ import {
 	markClientSnapshotStreaming,
 	setDaemonClientSessionCapabilities,
 	shouldSendDaemonOutboundToClient,
+	waitForDaemonPromptAdmission,
 } from "../src/modes/daemon/daemon-mode.js";
 import type { DaemonAttachResult, DaemonCommand } from "../src/modes/daemon/daemon-protocol.js";
 
 describe("daemon mode helpers", () => {
+	it("observes supplied work when prompt admission is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const work = Promise.reject(new Error("late claim failure"));
+
+		await expect(waitForDaemonPromptAdmission(work, controller.signal)).rejects.toThrow(
+			"Prompt admission was cancelled.",
+		);
+		// Let the observed work settle; an unhandled rejection would fail Vitest.
+		await Promise.resolve();
+	});
+
 	it("finds only direct child active sessions", () => {
 		const parent = makeState("parent");
 		const child = makeState("child", "parent");
@@ -4790,6 +4803,105 @@ describe("daemon mode helpers", () => {
 			error: expected,
 		});
 	});
+
+	it("clears prompt admission registered before unauthenticated worker rejection", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+			worker: { authenticationToken: "worker-token" },
+		});
+		const client = makeClient("unauthenticated", "active-1");
+		const end = vi.fn();
+		client.socket = { destroyed: false, write: vi.fn(() => true), end } as unknown as Socket;
+		const internals = daemon as unknown as {
+			promptAdmissions: Map<string, unknown>;
+			handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+		};
+
+		await internals.handleLine(
+			client,
+			JSON.stringify({
+				type: "prompt",
+				activeSessionId: "active-1",
+				message: "unauthorized",
+				admissionId: "leaked-admission",
+			}),
+		);
+
+		expect(end).toHaveBeenCalledOnce();
+		expect(internals.promptAdmissions.size).toBe(0);
+	});
+
+	it.each(["success", "late-failure", "replacement"] as const)(
+		"handles cancellation followed by supervisor-claim %s without affecting the wrong socket binding",
+		async (outcome) => {
+			const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				worker: { authenticationToken: "worker-token" },
+			});
+			const client = makeClient("authenticated", "active-1");
+			client.authenticated = true;
+			const end = vi.fn();
+			client.socket = { destroyed: false, write: vi.fn(() => true), end } as unknown as Socket;
+			const claim = {
+				supervisorGeneration: "generation",
+				supervisorPid: process.pid,
+				supervisorSocketPath: "/tmp/supervisor.sock",
+			};
+			let resolveClaim!: (fingerprint: string) => void;
+			let rejectClaim!: (error: Error) => void;
+			const claimCheck = new Promise<string>((resolve, reject) => {
+				resolveClaim = resolve;
+				rejectClaim = reject;
+			});
+			const internals = daemon as unknown as {
+				promptAdmissions: Map<string, { controller?: AbortController }>;
+				supervisorClaims: Map<DaemonSocketClient, { claim: typeof claim; ownerFingerprint: string }>;
+				assertSupervisorClaimCurrent: ReturnType<typeof vi.fn>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+				handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+			};
+			const originalBinding = { claim, ownerFingerprint: "owner" };
+			internals.supervisorClaims.set(client, originalBinding);
+			internals.assertSupervisorClaimCurrent = vi.fn(() => claimCheck);
+
+			const handling = internals.handleLine(
+				client,
+				JSON.stringify({
+					type: "prompt",
+					activeSessionId: "active-1",
+					message: "cancel during claim check",
+					admissionId: "claim-admission",
+				}),
+			);
+			await vi.waitFor(() => expect(internals.promptAdmissions.size).toBe(1));
+			await internals.handleCommand(client, {
+				type: "cancel_prompt_admission",
+				activeSessionId: "active-1",
+				admissionId: "claim-admission",
+			});
+			await handling;
+
+			expect(internals.promptAdmissions.size).toBe(0);
+			expect(end).not.toHaveBeenCalled();
+			if (outcome === "replacement") {
+				internals.supervisorClaims.set(client, { claim: { ...claim }, ownerFingerprint: "replacement" });
+			}
+			if (outcome === "success") resolveClaim("refreshed");
+			else rejectClaim(new Error("late stale claim"));
+			await Promise.resolve();
+			await Promise.resolve();
+
+			if (outcome === "late-failure") expect(end).toHaveBeenCalledOnce();
+			else expect(end).not.toHaveBeenCalled();
+			if (outcome === "success") expect(originalBinding.ownerFingerprint).toBe("owner");
+		},
+	);
 
 	it("cancels only pre-ownership prompt admission and cleans up its controller", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5110,7 +5110,11 @@ describe("daemon mode helpers", () => {
 					settled++;
 					return value;
 				});
-			await expect(response).resolves.toMatchObject({ success: true, command: type });
+			await expect(response).resolves.toMatchObject({
+				success: true,
+				command: type,
+				...(type === "follow_up" ? { data: { queued: true } } : {}),
+			});
 			expect(settled).toBe(1);
 			expect(turnCompleted).toBe(false);
 			expect(promptUntilAccepted).toHaveBeenCalledOnce();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4487,407 +4487,128 @@ describe("daemon mode helpers", () => {
 		});
 	});
 
-	it("defers busy heartbeat cron jobs instead of queueing a follow-up", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: {
-				agentDir: "/tmp/prime-agent-test-agent",
-				cwd: "/tmp",
-			},
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: true,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		(
-			daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-			}
-		).sessions.set(state.activeSessionId, state);
-		const runCronJob = (
-			daemon as unknown as {
-				runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-			}
-		).runCronJob.bind(daemon);
+	it.each([
+		{
+			name: "defers busy heartbeat cron jobs instead of queueing a follow-up",
+			activity: { isStreaming: true },
+			jobs: [{ id: "heartbeat-1", source: "heartbeat", deliveryMode: "follow_up" }],
+			acceptingAgentMessage: false,
+			assertQueuedHeartbeatUntouched: false,
+		},
+		{
+			name: "defers separate RLM heartbeat cron jobs while the session is busy",
+			activity: { isStreaming: true },
+			jobs: [
+				{ id: "rlm-1", source: "rlm_heartbeat", deliveryMode: "follow_up" },
+				{ id: "rlm-2", source: "rlm_heartbeat", deliveryMode: "follow_up" },
+			],
+			acceptingAgentMessage: false,
+			assertQueuedHeartbeatUntouched: false,
+		},
+		{
+			name: "does not enqueue another heartbeat when one is already pending",
+			activity: { isStreaming: true, pendingMessageCount: 1 },
+			jobs: [{ id: "heartbeat-1", source: "heartbeat" }],
+			acceptingAgentMessage: false,
+			assertQueuedHeartbeatUntouched: true,
+		},
+		{
+			name: "defers heartbeat cron jobs while the target is accepting an agent message",
+			activity: {},
+			jobs: [{ id: "heartbeat-1", source: "heartbeat" }],
+			acceptingAgentMessage: true,
+			assertQueuedHeartbeatUntouched: false,
+		},
+		{
+			name: "defers heartbeat cron jobs while an accepted agent message prompt is in flight",
+			activity: { hasAcceptedPromptInFlight: true },
+			jobs: [{ id: "heartbeat-1", source: "heartbeat" }],
+			acceptingAgentMessage: false,
+			assertQueuedHeartbeatUntouched: false,
+		},
+	] as const)("$name", async ({ activity, jobs, acceptingAgentMessage, assertQueuedHeartbeatUntouched }) => {
+		const fixture = makeCronAdmissionFixture(activity, { acceptingAgentMessage });
 
-		const result = await runCronJob(
-			makeCronJob({
-				id: "heartbeat-1",
-				source: "heartbeat",
-				activeSessionId: state.activeSessionId,
-				deliveryMode: "follow_up",
-			}),
-		);
+		const results = [];
+		for (const job of jobs) {
+			results.push(await fixture.runCronJob(makeCronJob({ ...job, activeSessionId: fixture.activeSessionId })));
+		}
 
-		expect(result).toBe("skipped");
-		expect(followUp).not.toHaveBeenCalled();
-		expect(prompt).not.toHaveBeenCalled();
+		expect(results).toEqual(jobs.map(() => "skipped"));
+		expect(fixture.prompt).not.toHaveBeenCalled();
+		expect(fixture.promptHeartbeat).not.toHaveBeenCalled();
+		expect(fixture.followUp).not.toHaveBeenCalled();
+		if (assertQueuedHeartbeatUntouched) {
+			expect(fixture.removeQueuedFollowUp).not.toHaveBeenCalled();
+		}
 	});
 
-	it("defers separate RLM heartbeat cron jobs while the session is busy", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: {
-				agentDir: "/tmp/prime-agent-test-agent",
-				cwd: "/tmp",
-			},
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: true,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		(
-			daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-			}
-		).sessions.set(state.activeSessionId, state);
-		const runCronJob = (
-			daemon as unknown as {
-				runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-			}
-		).runCronJob.bind(daemon);
+	it.each([
+		{
+			name: "queues generic cron jobs while the target is accepting an agent message",
+			activity: {},
+			acceptingAgentMessage: true,
+		},
+		{
+			name: "queues generic cron jobs behind accepted agent message prompts",
+			activity: { hasAcceptedPromptInFlight: true },
+			acceptingAgentMessage: false,
+		},
+		{
+			name: "queues generic cron jobs behind pending messages",
+			activity: { pendingMessageCount: 1 },
+			acceptingAgentMessage: false,
+		},
+	] as const)("$name", async ({ activity, acceptingAgentMessage }) => {
+		const fixture = makeCronAdmissionFixture(activity, { acceptingAgentMessage });
 
-		const first = await runCronJob(
-			makeCronJob({
-				id: "rlm-1",
-				source: "rlm_heartbeat",
-				activeSessionId: state.activeSessionId,
-				deliveryMode: "follow_up",
-			}),
-		);
-		const second = await runCronJob(
-			makeCronJob({
-				id: "rlm-2",
-				source: "rlm_heartbeat",
-				activeSessionId: state.activeSessionId,
-				deliveryMode: "follow_up",
-			}),
-		);
+		await fixture.runCronJob(makeCronJob({ id: "cron-1", source: "cron", activeSessionId: fixture.activeSessionId }));
 
-		expect(first).toBe("skipped");
-		expect(second).toBe("skipped");
-		expect(followUp).not.toHaveBeenCalled();
-		expect(prompt).not.toHaveBeenCalled();
+		expect(fixture.followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { resumeIfIdle: true });
+		expect(fixture.prompt).not.toHaveBeenCalled();
+		expect(fixture.promptHeartbeat).not.toHaveBeenCalled();
 	});
 
-	it("does not enqueue another heartbeat when one is already pending", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: ReturnType<typeof vi.fn>;
-					followUp: ReturnType<typeof vi.fn>;
-				};
-			};
-		};
-		const followUp = vi.fn(async () => false);
-		const removeQueuedFollowUp = vi.fn(() => true);
-		state.runtime.session = {
-			isStreaming: true,
-			isBashRunning: false,
-			pendingMessageCount: 1,
-			prompt: vi.fn(),
-			followUp,
-			removeQueuedFollowUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-		const result = await (
-			daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }
-		).runCronJob(makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }));
+	it.each([
+		{
+			name: "delivers heartbeats with a steering behavior by default",
+			job: { id: "heartbeat-1", source: "heartbeat" },
+			streamingBehavior: "steer",
+			method: "promptHeartbeat",
+		},
+		{
+			name: "delivers follow-up heartbeats with a followUp behavior and coalescing key",
+			job: { id: "heartbeat-1", source: "heartbeat", deliveryMode: "follow_up" },
+			streamingBehavior: "followUp",
+			method: "promptHeartbeat",
+		},
+		{
+			name: "prompts idle generic cron jobs without a heartbeat coalescing key",
+			job: { id: "cron-1", source: "cron" },
+			streamingBehavior: "followUp",
+			method: "prompt",
+		},
+	] as const)("$name", async ({ job, streamingBehavior, method }) => {
+		const fixture = makeCronAdmissionFixture();
 
-		expect(result).toBe("skipped");
-		expect(followUp).not.toHaveBeenCalled();
-		expect(removeQueuedFollowUp).not.toHaveBeenCalled();
-	});
+		await fixture.runCronJob(makeCronJob({ ...job, activeSessionId: fixture.activeSessionId }));
 
-	it("defers heartbeat cron jobs while the target is accepting an agent message", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			agentMessageAcceptingTargets: Set<string>;
-			runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		internals.agentMessageAcceptingTargets.add(state.activeSessionId);
-
-		const result = await internals.runCronJob(
-			makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }),
-		);
-
-		expect(result).toBe("skipped");
-		expect(prompt).not.toHaveBeenCalled();
-		expect(followUp).not.toHaveBeenCalled();
-	});
-
-	it("queues generic cron jobs while the target is accepting an agent message", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			agentMessageAcceptingTargets: Set<string>;
-			runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		internals.agentMessageAcceptingTargets.add(state.activeSessionId);
-
-		await internals.runCronJob(makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }));
-
-		expect(followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { resumeIfIdle: true });
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("defers heartbeat cron jobs while an accepted agent message prompt is in flight", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					hasAcceptedPromptInFlight: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			hasAcceptedPromptInFlight: true,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		const result = await (
-			daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }
-		).runCronJob(makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }));
-
-		expect(result).toBe("skipped");
-		expect(prompt).not.toHaveBeenCalled();
-		expect(followUp).not.toHaveBeenCalled();
-	});
-
-	it("queues generic cron jobs behind accepted agent message prompts", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					hasAcceptedPromptInFlight: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			hasAcceptedPromptInFlight: true,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
-			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }),
-		);
-
-		expect(followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { resumeIfIdle: true });
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("queues generic cron jobs behind pending messages", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = { isStreaming: false, pendingMessageCount: 1, prompt, followUp } as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
-			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }),
-		);
-
-		expect(followUp).toHaveBeenCalledWith("heartbeat prompt", undefined, { resumeIfIdle: true });
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("delivers heartbeats with a steering behavior by default", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const promptHeartbeat = vi.fn(
-			async (
-				_job: AgentCronJob,
-				_options?: { streamingBehavior?: "steer" | "followUp"; followUpQueueKey?: string },
-			) => {},
-		);
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					promptHeartbeat: typeof promptHeartbeat;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			promptHeartbeat,
-			followUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
-			makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }),
-		);
-
-		// The preparing guard adds an internal preflightResult hook.
-		expect(promptHeartbeat).toHaveBeenCalledWith(
-			expect.objectContaining({ id: "heartbeat-1", prompt: "heartbeat prompt" }),
-			expect.objectContaining({
-				streamingBehavior: "steer",
-				source: "rpc",
-			}),
-		);
-		expect(promptHeartbeat.mock.calls[0]?.[1]).toMatchObject({ followUpQueueKey: "heartbeat:heartbeat-1" });
-		expect(prompt).not.toHaveBeenCalled();
-		expect(followUp).not.toHaveBeenCalled();
+		const expectedOptions = expect.objectContaining({ streamingBehavior, source: "rpc" });
+		if (method === "promptHeartbeat") {
+			expect(fixture.promptHeartbeat).toHaveBeenCalledWith(
+				expect.objectContaining({ id: job.id, prompt: "heartbeat prompt" }),
+				expectedOptions,
+			);
+			expect(fixture.promptHeartbeat.mock.calls[0]?.[1]).toMatchObject({
+				followUpQueueKey: `heartbeat:${job.id}`,
+			});
+			expect(fixture.prompt).not.toHaveBeenCalled();
+		} else {
+			expect(fixture.prompt).toHaveBeenCalledWith("heartbeat prompt", expectedOptions);
+			expect(fixture.prompt.mock.calls[0]?.[1]).not.toHaveProperty("followUpQueueKey");
+			expect(fixture.promptHeartbeat).not.toHaveBeenCalled();
+		}
+		expect(fixture.followUp).not.toHaveBeenCalled();
 	});
 
 	it("delivers steer heartbeats after an RPC prompt finishes preflight while its turn is still streaming", async () => {
@@ -4956,110 +4677,6 @@ describe("daemon mode helpers", () => {
 			expect.objectContaining({ id: "heartbeat-1" }),
 			expect.objectContaining({ streamingBehavior: "steer" }),
 		);
-	});
-
-	it("delivers follow-up heartbeats with a followUp behavior and coalescing key", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(async () => {});
-		const promptHeartbeat = vi.fn(async () => {});
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					promptHeartbeat: typeof promptHeartbeat;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			promptHeartbeat,
-			followUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
-			makeCronJob({
-				id: "heartbeat-1",
-				source: "heartbeat",
-				activeSessionId: state.activeSessionId,
-				deliveryMode: "follow_up",
-			}),
-		);
-
-		// The preparing guard adds an internal preflightResult hook.
-		expect(promptHeartbeat).toHaveBeenCalledWith(
-			expect.objectContaining({ id: "heartbeat-1", prompt: "heartbeat prompt" }),
-			expect.objectContaining({
-				streamingBehavior: "followUp",
-				followUpQueueKey: "heartbeat:heartbeat-1",
-				source: "rpc",
-			}),
-		);
-		expect(prompt).not.toHaveBeenCalled();
-		expect(followUp).not.toHaveBeenCalled();
-	});
-
-	it("prompts idle generic cron jobs without a heartbeat coalescing key", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const prompt = vi.fn(
-			async (
-				_message: string,
-				_options?: { streamingBehavior?: "steer" | "followUp"; followUpQueueKey?: string; source?: string },
-			) => {},
-		);
-		const followUp = vi.fn(async () => true);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: {
-					isStreaming: boolean;
-					isBashRunning: boolean;
-					pendingMessageCount: number;
-					prompt: typeof prompt;
-					followUp: typeof followUp;
-				};
-			};
-		};
-		state.runtime.session = {
-			isStreaming: false,
-			isBashRunning: false,
-			pendingMessageCount: 0,
-			prompt,
-			followUp,
-		} as never;
-		(daemon as unknown as { sessions: Map<string, ActiveSessionState> }).sessions.set(state.activeSessionId, state);
-
-		await (daemon as unknown as { runCronJob(job: AgentCronJob): Promise<"skipped" | undefined> }).runCronJob(
-			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: state.activeSessionId }),
-		);
-
-		// The preparing guard adds an internal preflightResult hook.
-		expect(prompt).toHaveBeenCalledWith(
-			"heartbeat prompt",
-			expect.objectContaining({
-				streamingBehavior: "followUp",
-				source: "rpc",
-			}),
-		);
-		expect(prompt.mock.calls[0]?.[1]).not.toHaveProperty("followUpQueueKey");
-		expect(followUp).not.toHaveBeenCalled();
 	});
 
 	it.each(["steer", "follow_up"] as const)(
@@ -5792,6 +5409,79 @@ describe("daemon mode helpers", () => {
 		).rejects.toThrow("Unknown active session: missing");
 	});
 });
+
+type CronAdmissionActivity = Partial<{
+	isStreaming: boolean;
+	isCompacting: boolean;
+	isRetrying: boolean;
+	isBashRunning: boolean;
+	hasAcceptedPromptInFlight: boolean;
+	pendingMessageCount: number;
+}>;
+
+function makeCronAdmissionFixture(
+	activity: CronAdmissionActivity = {},
+	options: { acceptingAgentMessage?: boolean } = {},
+) {
+	const activeSessionId = "active-1";
+	const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+		defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+		createRuntime: async () => {
+			throw new Error("unexpected runtime creation");
+		},
+	});
+	const prompt = vi.fn(
+		async (
+			_message: string,
+			_options?: { streamingBehavior?: "steer" | "followUp"; followUpQueueKey?: string; source?: string },
+		) => {},
+	);
+	const promptHeartbeat = vi.fn(
+		async (
+			_job: AgentCronJob,
+			_options?: { streamingBehavior?: "steer" | "followUp"; followUpQueueKey?: string; source?: string },
+		) => {},
+	);
+	const followUp = vi.fn(async () => true);
+	const removeQueuedFollowUp = vi.fn(() => true);
+	const state = makeState(activeSessionId) as ActiveSessionState & {
+		runtime: ActiveSessionState["runtime"] & { session: Record<string, unknown> };
+	};
+	state.runtime = {
+		...state.runtime,
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			isRetrying: false,
+			isBashRunning: false,
+			hasAcceptedPromptInFlight: false,
+			pendingMessageCount: 0,
+			...activity,
+			prompt,
+			promptHeartbeat,
+			followUp,
+			removeQueuedFollowUp,
+		},
+	} as never;
+	const internals = daemon as unknown as {
+		sessions: Map<string, ActiveSessionState>;
+		agentMessageAcceptingTargets: Set<string>;
+		runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
+	};
+	internals.sessions.set(activeSessionId, state);
+	if (options.acceptingAgentMessage) {
+		internals.agentMessageAcceptingTargets.add(activeSessionId);
+	}
+
+	return {
+		activeSessionId,
+		prompt,
+		promptHeartbeat,
+		followUp,
+		removeQueuedFollowUp,
+		runCronJob: internals.runCronJob.bind(daemon),
+	};
+}
 
 function makeCronJob(input: {
 	id: string;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -22,9 +22,25 @@ import {
 	shouldSendDaemonOutboundToClient,
 	waitForDaemonPromptAdmission,
 } from "../src/modes/daemon/daemon-mode.js";
-import type { DaemonAttachResult, DaemonCommand } from "../src/modes/daemon/daemon-protocol.js";
+import {
+	createDaemonCommandEnvelope,
+	type DaemonAttachResult,
+	type DaemonCommand,
+} from "../src/modes/daemon/daemon-protocol.js";
 
 describe("daemon mode helpers", () => {
+	it("preserves envelope client identity while registering prompt admission", () => {
+		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const client = makeClient("worker-socket", "active");
+		const parse = Reflect.get(daemon, "parseCommandAndRegisterPromptAdmission").bind(daemon);
+
+		parse(client, JSON.stringify(createDaemonCommandEnvelope({ type: "list" }, "request-1", "public-client")));
+		expect(client.id).toBe("public-client");
+	});
+
 	it("observes supplied work when prompt admission is already aborted", async () => {
 		const controller = new AbortController();
 		controller.abort();
@@ -4868,7 +4884,7 @@ describe("daemon mode helpers", () => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			promptAdmissions: Map<string, unknown>;
-			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			parseCommandAndRegisterPromptAdmission(client: DaemonSocketClient, line: string): unknown;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
 		};
 		internals.sessions.set(state.activeSessionId, state);
@@ -4876,6 +4892,7 @@ describe("daemon mode helpers", () => {
 		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
 
 		internals.parseCommandAndRegisterPromptAdmission(
+			client,
 			JSON.stringify({
 				type: "prompt",
 				activeSessionId: state.activeSessionId,
@@ -4903,6 +4920,7 @@ describe("daemon mode helpers", () => {
 
 		// Once ownership commits the same cancellation is a no-op.
 		internals.parseCommandAndRegisterPromptAdmission(
+			client,
 			JSON.stringify({
 				type: "prompt",
 				activeSessionId: state.activeSessionId,
@@ -4944,12 +4962,15 @@ describe("daemon mode helpers", () => {
 			sessions: Map<string, ActiveSessionState>;
 			agentMessageTargetLocks: Map<string, Promise<void>>;
 			promptAdmissions: Map<string, unknown>;
-			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			parseCommandAndRegisterPromptAdmission(client: DaemonSocketClient, line: string): unknown;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
 		};
 		internals.sessions.set(state.activeSessionId, state);
 		internals.agentMessageTargetLocks.set(state.activeSessionId, new Promise(() => {}));
+		const client = makeClient("client-lock", state.activeSessionId);
+		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
 		internals.parseCommandAndRegisterPromptAdmission(
+			client,
 			JSON.stringify({
 				type: "prompt",
 				activeSessionId: state.activeSessionId,
@@ -4957,8 +4978,6 @@ describe("daemon mode helpers", () => {
 				admissionId: "lock-admission",
 			}),
 		);
-		const client = makeClient("client-lock", state.activeSessionId);
-		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
 		internals.handleCommand(client, {
 			type: "prompt",
 			activeSessionId: state.activeSessionId,
@@ -4985,10 +5004,12 @@ describe("daemon mode helpers", () => {
 		});
 		const internals = daemon as unknown as {
 			promptAdmissions: Map<string, { status: string; controller?: AbortController }>;
-			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			parseCommandAndRegisterPromptAdmission(client: DaemonSocketClient, line: string): unknown;
 			abortWaitingPromptAdmissionsForSession(activeSessionId: string): void;
 		};
+		const client = makeClient("client-closing", "closing-session");
 		internals.parseCommandAndRegisterPromptAdmission(
+			client,
 			JSON.stringify({
 				type: "prompt",
 				activeSessionId: "closing-session",

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4791,6 +4791,165 @@ describe("daemon mode helpers", () => {
 		});
 	});
 
+	it("cancels only pre-ownership prompt admission and cleans up its controller", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		let promptOptions: { signal?: AbortSignal; admissionCommitted?: () => void } | undefined;
+		let rejectPrompt: ((error: Error) => void) | undefined;
+		const promptUntilAccepted = vi.fn(
+			async (_message: string, options?: { signal?: AbortSignal; admissionCommitted?: () => void }) => {
+				promptOptions = options;
+				await new Promise<void>((_resolve, reject) => {
+					rejectPrompt = reject;
+					options?.signal?.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+				});
+			},
+		);
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & { session: { promptUntilAccepted: typeof promptUntilAccepted } };
+		};
+		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			promptAdmissions: Map<string, unknown>;
+			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+		const client = makeClient("client-1", state.activeSessionId);
+		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
+
+		internals.parseCommandAndRegisterPromptAdmission(
+			JSON.stringify({
+				type: "prompt",
+				activeSessionId: state.activeSessionId,
+				message: "blocked",
+				admissionId: "admission-1",
+			}),
+		);
+		internals.handleCommand(client, {
+			id: "prompt-1",
+			type: "prompt",
+			activeSessionId: state.activeSessionId,
+			message: "blocked",
+			admissionId: "admission-1",
+		});
+		await vi.waitFor(() => expect(promptUntilAccepted).toHaveBeenCalledOnce());
+		await expect(
+			internals.handleCommand(client, {
+				id: "cancel-1",
+				type: "cancel_prompt_admission",
+				activeSessionId: state.activeSessionId,
+				admissionId: "admission-1",
+			}),
+		).resolves.toMatchObject({ success: true, data: { status: "cancelled" } });
+		await vi.waitFor(() => expect(internals.promptAdmissions.size).toBe(0));
+
+		// Once ownership commits the same cancellation is a no-op.
+		internals.parseCommandAndRegisterPromptAdmission(
+			JSON.stringify({
+				type: "prompt",
+				activeSessionId: state.activeSessionId,
+				message: "owned",
+				admissionId: "admission-2",
+			}),
+		);
+		internals.handleCommand(client, {
+			id: "prompt-2",
+			type: "prompt",
+			activeSessionId: state.activeSessionId,
+			message: "owned",
+			admissionId: "admission-2",
+		});
+		await vi.waitFor(() => expect(promptUntilAccepted).toHaveBeenCalledTimes(2));
+		promptOptions?.admissionCommitted?.();
+		await expect(
+			internals.handleCommand(client, {
+				id: "cancel-2",
+				type: "cancel_prompt_admission",
+				activeSessionId: state.activeSessionId,
+				admissionId: "admission-2",
+			}),
+		).resolves.toMatchObject({ success: true, data: { status: "owned" } });
+		rejectPrompt?.(new Error("test cleanup"));
+	});
+
+	it("settles cancellation while prompt routing waits on the target lock", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const promptUntilAccepted = vi.fn(async () => {});
+		const state = makeState("active-lock") as ActiveSessionState;
+		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentMessageTargetLocks: Map<string, Promise<void>>;
+			promptAdmissions: Map<string, unknown>;
+			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+		internals.agentMessageTargetLocks.set(state.activeSessionId, new Promise(() => {}));
+		internals.parseCommandAndRegisterPromptAdmission(
+			JSON.stringify({
+				type: "prompt",
+				activeSessionId: state.activeSessionId,
+				message: "blocked",
+				admissionId: "lock-admission",
+			}),
+		);
+		const client = makeClient("client-lock", state.activeSessionId);
+		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
+		internals.handleCommand(client, {
+			type: "prompt",
+			activeSessionId: state.activeSessionId,
+			message: "blocked",
+			admissionId: "lock-admission",
+		});
+		await expect(
+			internals.handleCommand(client, {
+				type: "cancel_prompt_admission",
+				activeSessionId: state.activeSessionId,
+				admissionId: "lock-admission",
+			}),
+		).resolves.toMatchObject({ data: { status: "cancelled" } });
+		await vi.waitFor(() => expect(internals.promptAdmissions.size).toBe(0));
+		expect(promptUntilAccepted).not.toHaveBeenCalled();
+	});
+
+	it("aborts waiting prompt admissions when their session closes", () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const internals = daemon as unknown as {
+			promptAdmissions: Map<string, { status: string; controller?: AbortController }>;
+			parseCommandAndRegisterPromptAdmission(line: string): unknown;
+			abortWaitingPromptAdmissionsForSession(activeSessionId: string): void;
+		};
+		internals.parseCommandAndRegisterPromptAdmission(
+			JSON.stringify({
+				type: "prompt",
+				activeSessionId: "closing-session",
+				message: "blocked",
+				admissionId: "closing-admission",
+			}),
+		);
+		const admission = [...internals.promptAdmissions.values()][0]!;
+		internals.abortWaitingPromptAdmissionsForSession("closing-session");
+		expect(admission.status).toBe("cancelled");
+		expect(admission.controller?.signal.aborted).toBe(true);
+	});
+
 	it("uses the queued default lane for old-client prompts on a new daemon", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5062,24 +5062,147 @@ describe("daemon mode helpers", () => {
 		expect(followUp).not.toHaveBeenCalled();
 	});
 
-	it("forwards queue keys when expanded daemon steer commands are queued", async () => {
+	it.each(["steer", "follow_up"] as const)(
+		"idle daemon %s returns on acceptance before the gated turn completes exactly once",
+		async (type) => {
+			const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			let releaseTurn: (() => void) | undefined;
+			let turnCompleted = false;
+			const turnGate = new Promise<void>((resolve) => {
+				releaseTurn = resolve;
+			}).then(() => {
+				turnCompleted = true;
+			});
+			const promptUntilAccepted = vi.fn(
+				async (_message: string, options?: { preflightResult?: (success: boolean, queued?: boolean) => void }) => {
+					options?.preflightResult?.(true, true);
+					void turnGate;
+				},
+			);
+			const state = makeState("active-1") as ActiveSessionState & {
+				runtime: ActiveSessionState["runtime"] & {
+					session: { isStreaming: boolean; promptUntilAccepted: typeof promptUntilAccepted };
+				};
+			};
+			state.runtime = { ...state.runtime, session: { isStreaming: false, promptUntilAccepted } } as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			internals.sessions.set(state.activeSessionId, state);
+
+			let settled = 0;
+			const response = internals
+				.handleCommand(makeClient("client-1", state.activeSessionId), {
+					id: "command-1",
+					type,
+					activeSessionId: state.activeSessionId,
+					message: "idle queued turn",
+				})
+				.then((value) => {
+					settled++;
+					return value;
+				});
+			await expect(response).resolves.toMatchObject({ success: true, command: type });
+			expect(settled).toBe(1);
+			expect(turnCompleted).toBe(false);
+			expect(promptUntilAccepted).toHaveBeenCalledOnce();
+			releaseTurn?.();
+			await turnGate;
+			expect(turnCompleted).toBe(true);
+			expect(settled).toBe(1);
+		},
+	);
+
+	it("uses the queued default lane for old-client prompts on a new daemon", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
-		const steer = vi.fn(async () => {});
+		const promptUntilAccepted = vi.fn(async () => {});
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & { session: { promptUntilAccepted: typeof promptUntilAccepted } };
+		};
+		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await internals.handleCommand(makeClient("legacy-client", state.activeSessionId), {
+			id: "command-1",
+			type: "prompt",
+			activeSessionId: state.activeSessionId,
+			message: "legacy prompt",
+			streamingBehavior: "followUp",
+		});
+
+		expect(promptUntilAccepted).toHaveBeenCalledWith(
+			"legacy prompt",
+			expect.objectContaining({ streamingBehavior: "followUp", queueIfBusy: true }),
+		);
+	});
+
+	it("routes resume_queue through the session scheduler", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const resumeQueuedWork = vi.fn(() => true);
+		const continueAgent = vi.fn(async () => {});
+		const state = makeState("active-1") as ActiveSessionState & {
+			runtime: ActiveSessionState["runtime"] & {
+				session: { resumeQueuedWork: typeof resumeQueuedWork; agent: { continue: typeof continueAgent } };
+			};
+		};
+		state.runtime = { ...state.runtime, session: { resumeQueuedWork, agent: { continue: continueAgent } } } as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+
+		await expect(
+			internals.handleCommand(makeClient("client-1", state.activeSessionId), {
+				id: "command-1",
+				type: "resume_queue",
+				activeSessionId: state.activeSessionId,
+			}),
+		).resolves.toMatchObject({ success: true, command: "resume_queue" });
+		expect(resumeQueuedWork).toHaveBeenCalledOnce();
+		expect(continueAgent).not.toHaveBeenCalled();
+	});
+
+	it("forwards queue keys through canonical daemon steering admission", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const prompt = vi.fn(async () => {});
+		const acceptAgentMessagePrompt = vi.fn(async (...args: Parameters<typeof prompt>) => prompt(...args));
 		const restoreSteeringMessage = vi.fn(async () => {});
 		const state = makeState("active-1") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
-					steer: typeof steer;
+					prompt: typeof prompt;
+					acceptAgentMessagePrompt: typeof acceptAgentMessagePrompt;
 					restoreSteeringMessage: typeof restoreSteeringMessage;
 				};
 			};
 		};
-		state.runtime.session = { steer, restoreSteeringMessage } as never;
+		state.runtime.session = { prompt, acceptAgentMessagePrompt, restoreSteeringMessage } as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
@@ -5095,11 +5218,15 @@ describe("daemon mode helpers", () => {
 			agentMessageId: "agentmsg_steer",
 		});
 
-		expect(steer).toHaveBeenCalledWith("queued heartbeat", undefined, {
-			queueKey: "heartbeat:job-1",
-			agentMessageId: "agentmsg_steer",
-			resumeIfIdle: true,
-		});
+		expect(prompt).toHaveBeenCalledWith(
+			"queued heartbeat",
+			expect.objectContaining({
+				streamingBehavior: "steer",
+				queueIfBusy: true,
+				followUpQueueKey: "heartbeat:job-1",
+				agentMessageId: "agentmsg_steer",
+			}),
+		);
 		expect(restoreSteeringMessage).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4860,7 +4860,7 @@ describe("daemon mode helpers", () => {
 		expect(continueAgent).not.toHaveBeenCalled();
 	});
 
-	it("preserves template expansion and queue keys for correlated daemon steering", async () => {
+	it.each(["steer", "follow_up"] as const)("routes correlated daemon %s commands", async (type) => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -4868,51 +4868,90 @@ describe("daemon mode helpers", () => {
 			},
 		});
 		const prompt = vi.fn(async () => {});
-		const acceptAgentMessagePrompt = vi.fn(async (...args: Parameters<typeof prompt>) => prompt(...args));
 		const restoreSteeringMessage = vi.fn(async () => {});
+		const restoreFollowUpMessage = vi.fn(async () => true);
 		const state = makeState("active-1") as ActiveSessionState & {
 			runtime: ActiveSessionState["runtime"] & {
 				session: {
 					prompt: typeof prompt;
-					acceptAgentMessagePrompt: typeof acceptAgentMessagePrompt;
 					restoreSteeringMessage: typeof restoreSteeringMessage;
+					restoreFollowUpMessage: typeof restoreFollowUpMessage;
 				};
 			};
 		};
-		state.runtime.session = { prompt, acceptAgentMessagePrompt, restoreSteeringMessage } as never;
+		state.runtime.session = { prompt, restoreSteeringMessage, restoreFollowUpMessage } as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
 		};
 		internals.sessions.set(state.activeSessionId, state);
+		const client = makeClient("client-1", state.activeSessionId);
+		const base = { type, activeSessionId: state.activeSessionId } as const;
 
-		await internals.handleCommand(makeClient("client-1", state.activeSessionId), {
-			id: "command-1",
-			type: "steer",
-			activeSessionId: state.activeSessionId,
-			message: "queued heartbeat",
-			queueKey: "heartbeat:job-1",
-			agentMessageId: "agentmsg_steer",
+		await internals.handleCommand(client, {
+			...base,
+			message: "expanded prompt",
+			queueKey: "heartbeat:expanded",
+			agentMessageId: `agentmsg_expanded_${type}`,
 		});
-
 		expect(prompt).toHaveBeenCalledWith(
-			"queued heartbeat",
+			"expanded prompt",
 			expect.objectContaining({
-				streamingBehavior: "steer",
+				streamingBehavior: type === "steer" ? "steer" : "followUp",
 				queueIfBusy: true,
-				followUpQueueKey: "heartbeat:job-1",
-				agentMessageId: "agentmsg_steer",
+				followUpQueueKey: "heartbeat:expanded",
+				agentMessageId: `agentmsg_expanded_${type}`,
 			}),
 		);
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-		expect(restoreSteeringMessage).not.toHaveBeenCalled();
+
+		const replayFields = {
+			content: [{ type: "text" as const, text: "restored content" }],
+			customMessage: {
+				role: "custom" as const,
+				customType: "restored",
+				content: "restored custom message",
+				display: false,
+				timestamp: 1,
+			},
+			prefixMessages: [
+				{
+					role: "custom" as const,
+					customType: "restored-prefix",
+					content: "restored prefix",
+					display: false,
+					timestamp: 1,
+				},
+			],
+		};
+		for (const expandPromptTemplates of [undefined, true]) {
+			await expect(
+				internals.handleCommand(client, {
+					...base,
+					message: "invalid replay",
+					expandPromptTemplates,
+					...replayFields,
+				}),
+			).rejects.toThrow("require expandPromptTemplates=false");
+		}
+
+		await internals.handleCommand(client, {
+			...base,
+			message: "restored prompt",
+			queueKey: "heartbeat:job-1",
+			agentMessageId: `agentmsg_${type}`,
+			expandPromptTemplates: false,
+			...replayFields,
+		});
+		const restore = type === "steer" ? restoreSteeringMessage : restoreFollowUpMessage;
+		expect(restore).toHaveBeenCalledWith("restored prompt", undefined, {
+			queueKey: "heartbeat:job-1",
+			agentMessageId: `agentmsg_${type}`,
+			...replayFields,
+		});
+		expect(prompt).toHaveBeenCalledOnce();
+
 		await expect(
-			internals.handleCommand(makeClient("client-1", state.activeSessionId), {
-				type: "steer",
-				activeSessionId: state.activeSessionId,
-				message: "invalid",
-				agentMessageId: "",
-			}),
+			internals.handleCommand(client, { ...base, message: "invalid", agentMessageId: "" }),
 		).rejects.toThrow("agentMessageId must not be empty");
 	});
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4695,7 +4695,7 @@ describe("daemon mode helpers", () => {
 	});
 
 	it.each(["steer", "follow_up"] as const)(
-		"idle daemon %s returns on acceptance before the gated turn completes exactly once",
+		"idle daemon %s inserts into its scheduler lane exactly once",
 		async (type) => {
 			const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -4703,25 +4703,14 @@ describe("daemon mode helpers", () => {
 					throw new Error("unexpected runtime creation");
 				},
 			});
-			let releaseTurn: (() => void) | undefined;
-			let turnCompleted = false;
-			const turnGate = new Promise<void>((resolve) => {
-				releaseTurn = resolve;
-			}).then(() => {
-				turnCompleted = true;
-			});
-			const promptUntilAccepted = vi.fn(
-				async (_message: string, options?: { preflightResult?: (success: boolean, queued?: boolean) => void }) => {
-					options?.preflightResult?.(true, true);
-					void turnGate;
-				},
-			);
+			const steer = vi.fn(async () => {});
+			const followUp = vi.fn(async () => true);
 			const state = makeState("active-1") as ActiveSessionState & {
 				runtime: ActiveSessionState["runtime"] & {
-					session: { isStreaming: boolean; promptUntilAccepted: typeof promptUntilAccepted };
+					session: { isStreaming: boolean; steer: typeof steer; followUp: typeof followUp };
 				};
 			};
-			state.runtime = { ...state.runtime, session: { isStreaming: false, promptUntilAccepted } } as never;
+			state.runtime = { ...state.runtime, session: { isStreaming: false, steer, followUp } } as never;
 			const internals = daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
 				recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
@@ -4730,81 +4719,30 @@ describe("daemon mode helpers", () => {
 			internals.sessions.set(state.activeSessionId, state);
 			internals.recordWorkerRecoveryState = vi.fn();
 
-			let settled = 0;
-			const response = internals
-				.handleCommand(makeClient("client-1", state.activeSessionId), {
+			await expect(
+				internals.handleCommand(makeClient("client-1", state.activeSessionId), {
 					id: "command-1",
 					type,
 					activeSessionId: state.activeSessionId,
 					message: "idle queued turn",
-				})
-				.then((value) => {
-					settled++;
-					return value;
-				});
-			await expect(response).resolves.toMatchObject({
+				}),
+			).resolves.toMatchObject({
 				success: true,
 				command: type,
 				...(type === "follow_up" ? { data: { queued: true } } : {}),
 			});
-			expect(settled).toBe(1);
-			expect(turnCompleted).toBe(false);
-			expect(promptUntilAccepted).toHaveBeenCalledOnce();
+			const queue = type === "steer" ? steer : followUp;
+			expect(queue).toHaveBeenCalledOnce();
+			expect(queue).toHaveBeenCalledWith("idle queued turn", undefined, {
+				queueKey: undefined,
+				agentMessageId: undefined,
+				resumeIfIdle: true,
+			});
 			if (type === "follow_up") {
 				expect(internals.recordWorkerRecoveryState).toHaveBeenCalledWith(state, "follow_up_queued", true);
 			}
-			releaseTurn?.();
-			await turnGate;
-			expect(turnCompleted).toBe(true);
-			expect(settled).toBe(1);
 		},
 	);
-
-	it.each([
-		{ error: undefined, expected: "Prompt was not accepted by the session." },
-		{ error: new Error("duplicate follow-up queueKey"), expected: "duplicate follow-up queueKey" },
-	])("fails prompt RPC after preflight rejection with $expected", async ({ error, expected }) => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const promptUntilAccepted = vi.fn(
-			async (_message: string, options?: { preflightResult?: (success: boolean) => void }) => {
-				options?.preflightResult?.(false);
-				if (error) throw error;
-			},
-		);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & { session: { promptUntilAccepted: typeof promptUntilAccepted } };
-		};
-		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		const client = makeClient("client-1", state.activeSessionId);
-		const write = vi.fn((_data: unknown) => true);
-		client.socket = { destroyed: false, write } as unknown as Socket;
-
-		internals.handleCommand(client, {
-			id: "command-1",
-			type: "prompt",
-			activeSessionId: state.activeSessionId,
-			message: "duplicate",
-			streamingBehavior: "followUp",
-		});
-
-		await vi.waitFor(() => expect(write).toHaveBeenCalledOnce());
-		expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({
-			id: "command-1",
-			command: "prompt",
-			success: false,
-			error: expected,
-		});
-	});
 
 	it("clears prompt admission registered before unauthenticated worker rejection", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -36,7 +36,7 @@ describe("daemon protocol helpers", () => {
 	});
 
 	it("requires compatibility metadata for the heartbeat protocol surface", () => {
-		expect(DAEMON_PROTOCOL_VERSION).toBe(4);
+		expect(DAEMON_PROTOCOL_VERSION).toBe(5);
 		expect(DAEMON_SCHEMA_ID).toContain(`protocol-${DAEMON_PROTOCOL_VERSION}`);
 		expect(DAEMON_COMMAND_COMPATIBILITY.heartbeats_list).toEqual({
 			minProtocol: 3,
@@ -47,7 +47,7 @@ describe("daemon protocol helpers", () => {
 			capability: "heartbeat_management",
 		});
 		expect(DAEMON_COMMAND_COMPATIBILITY.complete_owned_session).toEqual({
-			minProtocol: DAEMON_PROTOCOL_VERSION,
+			minProtocol: 4,
 			capability: "client_owned_sessions",
 		});
 		expect(DAEMON_OUTBOUND_COMPATIBILITY.heartbeats_changed).toEqual({
@@ -67,6 +67,14 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("model_catalog");
 	});
 
+	it("version- and capability-gates prompt admission cancellation", () => {
+		expect(DAEMON_COMMAND_COMPATIBILITY.cancel_prompt_admission).toEqual({
+			minProtocol: 5,
+			capability: "prompt_admission_cancellation",
+		});
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("prompt_admission_cancellation");
+	});
+
 	it("keeps refine failure events backward-compatible on the existing session event channel", () => {
 		const event: DaemonOutbound = {
 			type: "session_event",
@@ -74,8 +82,8 @@ describe("daemon protocol helpers", () => {
 			event: { type: "refine_failed", error: "disk full" },
 		};
 
-		// Revision 3 introduced the refine events; later features moved it further.
-		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(3);
+		// Refine events remain on the original session-event channel across later schema revisions.
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(6);
 		expect(DAEMON_OUTBOUND_COMPATIBILITY.session_event).toEqual({ minProtocol: 1 });
 		expect(event).toMatchObject({ event: { type: "refine_failed", error: "disk full" } });
 	});

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -221,7 +221,6 @@ describe("daemon supervisor prompt admission ownership", () => {
 		const worker = { descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" } };
 		const forwardToWorker = vi.fn(async (_worker: unknown, command: DaemonCommand) => {
 			if (command.type === "cancel_prompt_admission") {
-				// The worker lost the record: a bare unknown must not un-cancel.
 				return success(command.id, command.type, { status: "unknown" as const });
 			}
 			return new Promise<DaemonResponse>(() => {});
@@ -260,7 +259,6 @@ describe("daemon supervisor prompt admission ownership", () => {
 			} satisfies DaemonCommand),
 		);
 
-		// The cancel short-circuits: no worker round-trip, status stays cancelled.
 		expect(forwardToWorker).not.toHaveBeenCalledWith(
 			worker,
 			expect.objectContaining({ type: "cancel_prompt_admission" }),

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -159,6 +159,52 @@ describe("daemon supervisor prompt admission ownership", () => {
 		expect(admissionFor(supervisor, owner)).toBeUndefined();
 	});
 
+	it("returns the captured outcome when cancellation handling follows prompt cleanup", async () => {
+		const cancelOwnership = deferred<void>();
+		let ownershipChecks = 0;
+		const workerPrompt = deferred<DaemonResponse>();
+		const worker = { descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" } };
+		const supervisor = createHarness({
+			assertCurrent: () => (++ownershipChecks === 1 ? Promise.resolve() : cancelOwnership.promise),
+			findWorker: vi.fn(async () => ({
+				worker,
+				summary: { id: "worker-session", activeSessionId: "worker-session" },
+			})),
+			forwardToWorker: vi.fn(async () => workerPrompt.promise),
+		});
+		const owner = client("connection-owner");
+		const pendingPrompt = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+				message: "hello",
+			} satisfies DaemonCommand),
+		);
+		await waitFor(() => admissionFor(supervisor, owner)?.worker !== undefined);
+		const pendingCancel = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "cancel-1",
+				type: "cancel_prompt_admission",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+			} satisfies DaemonCommand),
+		);
+		workerPrompt.resolve({ type: "response", command: "prompt", success: true });
+		await pendingPrompt;
+		expect(admissionFor(supervisor, owner)).toBeUndefined();
+		cancelOwnership.resolve();
+		await pendingCancel;
+
+		expect((supervisor as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenLastCalledWith(
+			owner,
+			expect.objectContaining({ success: true, data: { status: "owned" } }),
+		);
+	});
+
 	it("isolates public ids by connection and forwards only opaque worker ids", async () => {
 		const ownerA = client("connection-a");
 		const ownerB = client("connection-b");

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -1,0 +1,393 @@
+import type { Socket } from "node:net";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
+import {
+	createDaemonCommandEnvelope,
+	type DaemonCommand,
+	type DaemonResponse,
+} from "../src/modes/daemon/daemon-protocol.js";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+
+interface AdmissionRecord {
+	client: DaemonSocketClient;
+	activeSessionId: string;
+	publicAdmissionId: string;
+	workerAdmissionId: string;
+	status: "waiting" | "owned" | "cancelled";
+	controller: AbortController;
+	worker?: unknown;
+	workerActiveSessionId?: string;
+}
+
+interface SupervisorHarness {
+	handleConnection(socket: Socket): void;
+	handleLine(client: DaemonSocketClient, line: string): Promise<void>;
+	clients: Set<DaemonSocketClient>;
+	promptAdmissions: Map<DaemonSocketClient, Map<string, AdmissionRecord>>;
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function client(id: string): DaemonSocketClient {
+	return { id, attachedActiveSessionIds: new Set(), capabilities: new Set() } as DaemonSocketClient;
+}
+
+function admissionFor(supervisor: SupervisorHarness, owner: DaemonSocketClient): AdmissionRecord | undefined {
+	return [...(supervisor.promptAdmissions.get(owner)?.values() ?? [])][0];
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let index = 0; index < 50; index++) {
+		if (predicate()) return;
+		await Promise.resolve();
+	}
+	throw new Error("Condition was not reached");
+}
+
+function createHarness(
+	options: {
+		ready?: Promise<void>;
+		assertCurrent?: () => Promise<void>;
+		findWorker?: (client: DaemonSocketClient, selector: string) => Promise<unknown>;
+		forwardToWorker?: (worker: unknown, command: DaemonCommand) => Promise<DaemonResponse>;
+	} = {},
+): SupervisorHarness {
+	return Object.assign(Object.create(DaemonSupervisor.prototype), {
+		ready: options.ready ?? Promise.resolve(),
+		ownership: {
+			assertCurrent: options.assertCurrent ?? vi.fn(async () => undefined),
+			record: { token: "test-owner", processStartId: "test-process", socketPath: "/tmp/test.sock" },
+		},
+		workers: new Map(),
+		clients: new Set(),
+		protocolClientIds: new WeakMap(),
+		promptAdmissions: new Map(),
+		commandJournal: {
+			begin: vi.fn(() => ({ status: "new" })),
+			recordResult: vi.fn(),
+			acknowledge: vi.fn(),
+		},
+		findWorkerForClient: options.findWorker,
+		forwardToWorker: options.forwardToWorker,
+		write: vi.fn(),
+		log: vi.fn(),
+	}) as SupervisorHarness;
+}
+
+describe("daemon supervisor prompt admission ownership", () => {
+	it("registers a prompt synchronously before readiness and ownership awaits", async () => {
+		const ready = deferred<void>();
+		const ownership = deferred<void>();
+		const workerLookup = deferred<unknown>();
+		const supervisor = createHarness({
+			ready: ready.promise,
+			assertCurrent: () => ownership.promise,
+			findWorker: vi.fn(() => workerLookup.promise),
+		});
+		const owner = client("connection-owner");
+		const prompt = {
+			id: "prompt-1",
+			type: "prompt",
+			activeSessionId: "session-1",
+			admissionId: "public-admission",
+			message: "hello",
+		} satisfies DaemonCommand;
+
+		const pendingPrompt = supervisor.handleLine(owner, JSON.stringify(prompt));
+		const admission = admissionFor(supervisor, owner);
+		expect(admission).toMatchObject({
+			client: owner,
+			activeSessionId: "session-1",
+			publicAdmissionId: "public-admission",
+			status: "waiting",
+		});
+
+		ready.resolve();
+		await Promise.resolve();
+		expect(admissionFor(supervisor, owner)).toBe(admission);
+		ownership.resolve();
+		await Promise.resolve();
+		expect(admissionFor(supervisor, owner)).toBe(admission);
+		workerLookup.resolve(Promise.reject(new Error("worker lookup stopped")));
+		await pendingPrompt;
+		expect(admissionFor(supervisor, owner)).toBeUndefined();
+	});
+
+	it("lets the originating connection cancel before worker lookup starts", async () => {
+		const ready = deferred<void>();
+		const findWorker = vi.fn(async () => {
+			throw new Error("worker lookup should not run");
+		});
+		const supervisor = createHarness({ ready: ready.promise, findWorker });
+		const owner = client("connection-owner");
+		const pendingPrompt = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+				message: "hello",
+			} satisfies DaemonCommand),
+		);
+		const pendingCancel = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "cancel-1",
+				type: "cancel_prompt_admission",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+			} satisfies DaemonCommand),
+		);
+
+		await pendingPrompt;
+		expect(findWorker).not.toHaveBeenCalled();
+		ready.resolve();
+		await pendingCancel;
+		expect(admissionFor(supervisor, owner)).toBeUndefined();
+	});
+
+	it("isolates public ids by connection and forwards only opaque worker ids", async () => {
+		const ownerA = client("connection-a");
+		const ownerB = client("connection-b");
+		const attacker = client("connection-attacker");
+		const worker = {
+			descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" },
+		};
+		const promptResponses = new Map<string, Deferred<DaemonResponse>>();
+		const cancelResponses = new Map<string, Deferred<DaemonResponse>>();
+		const forwarded: DaemonCommand[] = [];
+		const supervisor = createHarness({
+			findWorker: vi.fn(async () => ({
+				worker,
+				summary: { id: "worker-session", activeSessionId: "worker-session" },
+			})),
+			forwardToWorker: vi.fn(async (_worker, command) => {
+				forwarded.push(command);
+				const admissionId = "admissionId" in command ? command.admissionId : undefined;
+				if (!admissionId) throw new Error("Expected an internal admission id");
+				const pending = deferred<DaemonResponse>();
+				if (command.type === "cancel_prompt_admission") cancelResponses.set(admissionId, pending);
+				else promptResponses.set(admissionId, pending);
+				return pending.promise;
+			}),
+		});
+		const makePrompt = (id: string) =>
+			({
+				id,
+				type: "prompt",
+				activeSessionId: "public-session",
+				admissionId: "shared-public-id",
+				message: id,
+			}) as const satisfies DaemonCommand;
+
+		const pendingA = supervisor.handleLine(ownerA, JSON.stringify(makePrompt("prompt-a")));
+		const pendingB = supervisor.handleLine(ownerB, JSON.stringify(makePrompt("prompt-b")));
+		await waitFor(() => promptResponses.size === 2);
+		const admissionA = admissionFor(supervisor, ownerA)!;
+		const admissionB = admissionFor(supervisor, ownerB)!;
+		expect(admissionA.workerAdmissionId).not.toBe(admissionB.workerAdmissionId);
+		expect([...promptResponses.keys()].sort()).toEqual(
+			[admissionA.workerAdmissionId, admissionB.workerAdmissionId].sort(),
+		);
+		expect(forwarded.filter((command) => command.type === "prompt")).toEqual([
+			expect.objectContaining({ admissionId: admissionA.workerAdmissionId }),
+			expect.objectContaining({ admissionId: admissionB.workerAdmissionId }),
+		]);
+
+		const spoofedCancel = {
+			id: "spoofed-cancel",
+			type: "cancel_prompt_admission",
+			activeSessionId: "public-session",
+			admissionId: "shared-public-id",
+		} as const satisfies DaemonCommand;
+		await supervisor.handleLine(
+			attacker,
+			JSON.stringify(createDaemonCommandEnvelope(spoofedCancel, spoofedCancel.id, ownerA.id)),
+		);
+		expect(cancelResponses.size).toBe(0);
+		expect(admissionFor(supervisor, ownerA)).toBe(admissionA);
+		expect(admissionFor(supervisor, ownerB)).toBe(admissionB);
+
+		const pendingCancelA = supervisor.handleLine(ownerA, JSON.stringify({ ...spoofedCancel, id: "cancel-a" }));
+		await waitFor(() => cancelResponses.has(admissionA.workerAdmissionId));
+		expect(cancelResponses.has(admissionB.workerAdmissionId)).toBe(false);
+		expect(admissionFor(supervisor, ownerA)).toBe(admissionA);
+
+		cancelResponses.get(admissionA.workerAdmissionId)!.resolve({
+			id: "worker-cancel",
+			type: "response",
+			command: "cancel_prompt_admission",
+			success: true,
+			data: { status: "cancelled" },
+		});
+		await pendingCancelA;
+		// The cancel response must not discard the record while the original forward is unsettled.
+		expect(admissionFor(supervisor, ownerA)).toBe(admissionA);
+		expect(admissionA.status).toBe("cancelled");
+
+		promptResponses.get(admissionA.workerAdmissionId)!.resolve({
+			id: "worker-prompt-a",
+			type: "response",
+			command: "prompt",
+			success: false,
+			error: "Prompt admission was cancelled.",
+		});
+		await pendingA;
+		expect(admissionFor(supervisor, ownerA)).toBeUndefined();
+		expect(admissionFor(supervisor, ownerB)).toBe(admissionB);
+
+		promptResponses.get(admissionB.workerAdmissionId)!.resolve({
+			id: "worker-prompt-b",
+			type: "response",
+			command: "prompt",
+			success: true,
+		});
+		await pendingB;
+		expect(admissionFor(supervisor, ownerB)).toBeUndefined();
+	});
+
+	it("cancels a mapped waiting admission when its originating socket closes", async () => {
+		const worker = {
+			descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" },
+		};
+		const promptResponse = deferred<DaemonResponse>();
+		const cancelResponse = deferred<DaemonResponse>();
+		const deliveredPrompt = vi.fn();
+		const forwarded: DaemonCommand[] = [];
+		const supervisor = createHarness({
+			findWorker: vi.fn(async () => ({
+				worker,
+				summary: { id: "worker-session", activeSessionId: "worker-session" },
+			})),
+			forwardToWorker: vi.fn(async (_worker, command) => {
+				forwarded.push(command);
+				if (command.type === "cancel_prompt_admission") {
+					const response = await cancelResponse.promise;
+					promptResponse.resolve({
+						type: "response",
+						command: "prompt",
+						success: false,
+						error: "Prompt admission was cancelled.",
+					});
+					return response;
+				}
+				return promptResponse.promise.then((response) => {
+					if (response.success) deliveredPrompt();
+					return response;
+				});
+			}),
+		});
+		const socket = new PassThrough() as unknown as Socket;
+		Object.assign(socket, { destroyed: false });
+		supervisor.handleConnection(socket);
+		const owner = [...supervisor.clients][0]!;
+		const pendingPrompt = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "public-session",
+				admissionId: "public-admission",
+				message: "must not arrive",
+			} satisfies DaemonCommand),
+		);
+		await waitFor(() => forwarded.some((command) => command.type === "prompt"));
+		const admission = admissionFor(supervisor, owner)!;
+
+		socket.emit("close");
+		await waitFor(() => forwarded.some((command) => command.type === "cancel_prompt_admission"));
+		expect(forwarded.at(-1)).toEqual({
+			type: "cancel_prompt_admission",
+			activeSessionId: "worker-session",
+			admissionId: admission.workerAdmissionId,
+		});
+		expect(admissionFor(supervisor, owner)).toBe(admission);
+
+		cancelResponse.resolve({
+			type: "response",
+			command: "cancel_prompt_admission",
+			success: true,
+			data: { status: "cancelled" },
+		});
+		await pendingPrompt;
+		expect(admission.status).toBe("cancelled");
+		expect(deliveredPrompt).not.toHaveBeenCalled();
+		expect(admissionFor(supervisor, owner)).toBeUndefined();
+		expect(forwarded.filter((command) => command.type === "prompt")).toHaveLength(1);
+	});
+
+	it("leaves an admission delivered when ownership wins before socket close", async () => {
+		const worker = {
+			descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" },
+		};
+		const promptResponse = deferred<DaemonResponse>();
+		const deliveredPrompt = vi.fn();
+		let workerOwnsAdmission = false;
+		const forwarded: DaemonCommand[] = [];
+		const supervisor = createHarness({
+			findWorker: vi.fn(async () => ({
+				worker,
+				summary: { id: "worker-session", activeSessionId: "worker-session" },
+			})),
+			forwardToWorker: vi.fn(async (_worker, command) => {
+				forwarded.push(command);
+				if (command.type === "cancel_prompt_admission") {
+					return {
+						type: "response",
+						command: "cancel_prompt_admission",
+						success: true,
+						data: { status: workerOwnsAdmission ? "owned" : "cancelled" },
+					} satisfies DaemonResponse;
+				}
+				return promptResponse.promise.then((response) => {
+					if (response.success) deliveredPrompt();
+					return response;
+				});
+			}),
+		});
+		const socket = new PassThrough() as unknown as Socket;
+		Object.assign(socket, { destroyed: false });
+		supervisor.handleConnection(socket);
+		const owner = [...supervisor.clients][0]!;
+		const pendingPrompt = supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "public-session",
+				admissionId: "public-admission",
+				message: "delivered",
+			} satisfies DaemonCommand),
+		);
+		await waitFor(() => forwarded.some((command) => command.type === "prompt"));
+		const admission = admissionFor(supervisor, owner)!;
+
+		workerOwnsAdmission = true;
+		socket.emit("close");
+		await waitFor(() => forwarded.some((command) => command.type === "cancel_prompt_admission"));
+		await waitFor(() => admission.status === "owned");
+		promptResponse.resolve({
+			type: "response",
+			command: "prompt",
+			success: true,
+		});
+		await pendingPrompt;
+		expect(admission.status).toBe("owned");
+		expect(deliveredPrompt).toHaveBeenCalledOnce();
+		expect(admissionFor(supervisor, owner)).toBeUndefined();
+		expect(forwarded.filter((command) => command.type === "prompt")).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -7,7 +7,7 @@ import {
 	type DaemonCommand,
 	type DaemonResponse,
 } from "../src/modes/daemon/daemon-protocol.js";
-import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import { DaemonSupervisor, waitForSupervisorPromptAdmission } from "../src/modes/daemon/daemon-supervisor.js";
 
 interface AdmissionRecord {
 	client: DaemonSocketClient;
@@ -87,6 +87,17 @@ function createHarness(
 }
 
 describe("daemon supervisor prompt admission ownership", () => {
+	it("observes an already-running promise when admission is pre-aborted", async () => {
+		const abort = new AbortController();
+		abort.abort();
+		const work = Promise.reject(new Error("late failure"));
+
+		await expect(waitForSupervisorPromptAdmission(work, abort.signal)).rejects.toThrow(
+			"Prompt admission was cancelled",
+		);
+		await Promise.resolve();
+	});
+
 	it("registers a prompt synchronously before readiness and ownership awaits", async () => {
 		const ready = deferred<void>();
 		const ownership = deferred<void>();

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -6,6 +6,7 @@ import {
 	createDaemonCommandEnvelope,
 	type DaemonCommand,
 	type DaemonResponse,
+	success,
 } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor, waitForSupervisorPromptAdmission } from "../src/modes/daemon/daemon-supervisor.js";
 
@@ -213,6 +214,61 @@ describe("daemon supervisor prompt admission ownership", () => {
 		expect((supervisor as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenLastCalledWith(
 			owner,
 			expect.objectContaining({ success: true, data: { status: "owned" } }),
+		);
+	});
+
+	it("never downgrades a cancelled admission on repeated cancels", async () => {
+		const worker = { descriptor: { lifecycle: "ready", rootActiveSessionId: "worker-session" } };
+		const forwardToWorker = vi.fn(async (_worker: unknown, command: DaemonCommand) => {
+			if (command.type === "cancel_prompt_admission") {
+				// The worker lost the record: a bare unknown must not un-cancel.
+				return success(command.id, command.type, { status: "unknown" as const });
+			}
+			return new Promise<DaemonResponse>(() => {});
+		});
+		const supervisor = createHarness({
+			findWorker: vi.fn(async () => ({
+				worker,
+				summary: { id: "worker-session", activeSessionId: "worker-session" },
+			})),
+			forwardToWorker,
+		});
+		const owner = client("connection-owner");
+		void supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "prompt-1",
+				type: "prompt",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+				message: "hello",
+			} satisfies DaemonCommand),
+		);
+		await waitFor(() => admissionFor(supervisor, owner)?.worker !== undefined);
+		const admission = admissionFor(supervisor, owner);
+		expect(admission).toBeDefined();
+		if (!admission) throw new Error("admission not registered");
+		admission.status = "cancelled";
+
+		await supervisor.handleLine(
+			owner,
+			JSON.stringify({
+				id: "cancel-1",
+				type: "cancel_prompt_admission",
+				activeSessionId: "session-1",
+				admissionId: "public-admission",
+			} satisfies DaemonCommand),
+		);
+
+		// The cancel short-circuits: no worker round-trip, status stays cancelled.
+		expect(forwardToWorker).not.toHaveBeenCalledWith(
+			worker,
+			expect.objectContaining({ type: "cancel_prompt_admission" }),
+		);
+		expect(admission.status).toBe("cancelled");
+		expect((supervisor as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenLastCalledWith(
+			owner,
+			expect.objectContaining({ success: true, data: { status: "cancelled" } }),
 		);
 	});
 

--- a/packages/coding-agent/test/fixtures/rpc-eof-faux-extension.ts
+++ b/packages/coding-agent/test/fixtures/rpc-eof-faux-extension.ts
@@ -11,6 +11,7 @@ export default function registerRpcEofFauxProvider(pi: ExtensionAPI): void {
 			await new Promise((resolve) => setTimeout(resolve, 250));
 			return fauxAssistantMessage("rpc eof response");
 		},
+		async () => fauxAssistantMessage("queued rpc eof response"),
 	]);
 	const apiProvider = getApiProvider(faux.api);
 	if (!apiProvider) {

--- a/packages/coding-agent/test/fixtures/rpc-eof-faux-extension.ts
+++ b/packages/coding-agent/test/fixtures/rpc-eof-faux-extension.ts
@@ -11,7 +11,6 @@ export default function registerRpcEofFauxProvider(pi: ExtensionAPI): void {
 			await new Promise((resolve) => setTimeout(resolve, 250));
 			return fauxAssistantMessage("rpc eof response");
 		},
-		async () => fauxAssistantMessage("queued rpc eof response"),
 	]);
 	const apiProvider = getApiProvider(faux.api);
 	if (!apiProvider) {

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -19,6 +19,10 @@ describe("image markers", () => {
 		expect(imageMarkerIds("no markers here")).toEqual([]);
 	});
 
+	test("imageMarkerIds ignores ids outside the safe integer range", () => {
+		expect(imageMarkerIds("[image #7] [image #9007199254740992]")).toEqual([7]);
+	});
+
 	test("remapImageMarkers replaces every spelling of the numeric id", () => {
 		expect(remapImageMarkers("[image #1] [image #01] [image #2]", new Map([[1, 7]]))).toBe(
 			"[image #7] [image #7] [image #2]",

--- a/packages/coding-agent/test/image-markers.test.ts
+++ b/packages/coding-agent/test/image-markers.test.ts
@@ -5,6 +5,7 @@ import {
 	evictImagesToBudget,
 	formatImageMarker,
 	imageMarkerIds,
+	remapImageMarkers,
 } from "../src/modes/interactive/image-markers.js";
 
 describe("image markers", () => {
@@ -16,6 +17,12 @@ describe("image markers", () => {
 	test("imageMarkerIds returns ids in order of appearance", () => {
 		expect(imageMarkerIds("a [image #2] b [image #1] c")).toEqual([2, 1]);
 		expect(imageMarkerIds("no markers here")).toEqual([]);
+	});
+
+	test("remapImageMarkers replaces every spelling of the numeric id", () => {
+		expect(remapImageMarkers("[image #1] [image #01] [image #2]", new Map([[1, 7]]))).toBe(
+			"[image #7] [image #7] [image #2]",
+		);
 	});
 
 	test("collectMarkedImages returns images in paste order, not text order", () => {

--- a/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-stash.test.ts
@@ -272,6 +272,40 @@ describe("InteractiveMode prompt stash", () => {
 		expect(reopenedMode.promptStashState.stash).toBeUndefined();
 	});
 
+	it("restores retained startup image drafts in order and resubmits each image exactly once", async () => {
+		const store = new ClientPromptStashStore();
+		const state = store.forSession("session-a");
+		const firstImage: ImageContent = { type: "image", data: "first", mimeType: "image/png" };
+		const secondImage: ImageContent = { type: "image", data: "second", mimeType: "image/jpeg" };
+		state.stash = { text: "first [image #2]", images: [[2, firstImage]] };
+		state.queuedStashes = [{ text: "second [image #3]", images: [[3, secondImage]] }];
+		const mode = createSharedPromptStashHarness(store, "session-a", {
+			pastedImages: [[1, { type: "image", data: "existing", mimeType: "image/png" }]],
+		});
+		interactiveModeMethods.hydratePromptStash.call(mode);
+		const submitted: Array<{ text: string; images: ImageContent[] }> = [];
+
+		for (let index = 0; index < 2; index++) {
+			expect(interactiveModeMethods.restorePromptStashIfEditorEmpty.call(mode)).toBe(true);
+			const text = mode.editor.getText();
+			const ids = [...text.matchAll(/\[image #(\d+)\]/g)].map((match) => Number(match[1]));
+			submitted.push({
+				text,
+				images: ids.flatMap((id) => (mode.pastedImages.get(id) ? [mode.pastedImages.get(id)!] : [])),
+			});
+			mode.editor.setText("");
+		}
+
+		expect(submitted).toEqual([
+			{ text: "first [image #2]", images: [firstImage] },
+			{ text: "second [image #3]", images: [secondImage] },
+		]);
+		expect(mode.pastedImages.get(1)?.data).toBe("existing");
+		expect(mode.nextImageMarkerId).toBe(4);
+		expect(state.stash).toBeUndefined();
+		expect(state.queuedStashes).toBeUndefined();
+	});
+
 	it("rebinds prompt stash state when the connected session changes", () => {
 		const store = new ClientPromptStashStore();
 		const firstState = store.forSession("session-a");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2823,6 +2823,39 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		},
 	);
 
+	test("does not retain a startup prompt already owned by the session", async () => {
+		const inputDone = createDeferred<void>();
+		const prompt = vi
+			.fn()
+			.mockRejectedValueOnce(new AgentConnectionPromptAdmissionError("session owns prompt", "owned"))
+			.mockResolvedValueOnce(undefined);
+		const submitHarness = createSubmitHandlerHarness({
+			agentConnection: {
+				prompt,
+				executeBash: vi.fn(async () => {}),
+				getState: vi.fn(async () => ({ isBashRunning: false })),
+			},
+		});
+		const fakeThis = Object.assign(
+			submitHarness,
+			createStartupRunHarness(
+				{ initialMessages: ["owned startup", "next startup"] },
+				{
+					getCurrentModel: () => primeModel,
+					getUserInput: vi.fn(() => inputDone.promise),
+					agentConnection: submitHarness.agentConnection,
+				},
+			),
+		);
+
+		const run = InteractiveMode.prototype.run.call(fakeThis as never);
+		await vi.waitFor(() => expect(prompt).toHaveBeenCalledTimes(2));
+		expect(prompt.mock.calls.map(([message]) => message)).toEqual(["owned startup", "next startup"]);
+		expect(fakeThis.promptStashState.stash).toBeUndefined();
+		inputDone.resolve(undefined);
+		await expect(run).resolves.toBe("agents_view");
+	});
+
 	test.each(["typing", "Alt+Enter"] as const)(
 		"preserves %s during the startup admission barrier",
 		async (scenario) => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -38,6 +38,7 @@ import type {
 	AgentConnectionSourceInfo,
 	AgentConnectionState,
 } from "../src/modes/agent-connection/types.js";
+import { AgentConnectionPromptAdmissionError } from "../src/modes/agent-connection/types.js";
 import { AgentActivityTracker } from "../src/modes/interactive/agent-activity.js";
 import type { AuthenticationResult } from "../src/modes/interactive/auth-flows.js";
 import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
@@ -2747,6 +2748,35 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	test("reports old-daemon admission once and preserves the startup prompt", async () => {
+		const inputDone = createDeferred<void>();
+		const prompt = vi.fn(async () => {
+			throw new AgentConnectionPromptAdmissionError("daemon upgrade required", "unsupported");
+		});
+		const fakeThis = Object.assign(
+			createSubmitHandlerHarness({
+				agentConnection: {
+					prompt,
+					executeBash: vi.fn(async () => {}),
+					getState: vi.fn(async () => ({ isBashRunning: false })),
+				},
+			}),
+			createStartupRunHarness(
+				{ initialMessage: "startup" },
+				{ getCurrentModel: () => primeModel, getUserInput: vi.fn(() => inputDone.promise) },
+			),
+		);
+
+		const run = InteractiveMode.prototype.run.call(fakeThis as never);
+		await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce());
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(prompt).toHaveBeenCalledOnce();
+		expect(fakeThis.showError).toHaveBeenCalledWith("daemon upgrade required");
+		expect(fakeThis.promptStashState.stash).toEqual({ text: "startup", images: undefined });
+		inputDone.resolve(undefined);
+		await expect(run).resolves.toBe("agents_view");
 	});
 
 	test.each(["typing", "Alt+Enter"] as const)(

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -615,7 +615,9 @@ type SubmitHandlerHarness = {
 	promptStashState: PromptStashState;
 	pastedImages: Map<number, unknown>;
 	getPromptStashImages: (text: string) => readonly (readonly [number, unknown])[];
-	admitPendingStartupPrompts?: () => Promise<"admitted" | "lifecycle-cancelled">;
+	retainStartupPromptDrafts?: (prompts: readonly { text: string; images?: readonly unknown[] }[]) => void;
+	nextImageMarkerId?: number;
+	admitPendingStartupPrompts?: () => Promise<"admitted" | "retained" | "lifecycle-cancelled">;
 	isShuttingDown?: boolean;
 	returnToAgentsViewRequested?: boolean;
 	submittedInputBehavior: "steer" | "followUp";
@@ -663,6 +665,12 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 		retainSubmittedDraft: (
 			InteractiveMode.prototype as unknown as { retainSubmittedDraft(stash: unknown, generation: number): void }
 		).retainSubmittedDraft,
+		retainStartupPromptDrafts: (
+			InteractiveMode.prototype as unknown as {
+				retainStartupPromptDrafts(prompts: readonly { text: string; images?: readonly unknown[] }[]): void;
+			}
+		).retainStartupPromptDrafts,
+		nextImageMarkerId: 1,
 		submittedInputBehavior: "steer",
 		inputSubmissionGeneration: 0,
 		inputSubmissionsPending: 0,
@@ -2750,34 +2758,70 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		}
 	});
 
-	test("reports old-daemon admission once and preserves the startup prompt", async () => {
-		const inputDone = createDeferred<void>();
-		const prompt = vi.fn(async () => {
-			throw new AgentConnectionPromptAdmissionError("daemon upgrade required", "unsupported");
-		});
-		const fakeThis = Object.assign(
-			createSubmitHandlerHarness({
+	test.each(["unsupported", "unknown"] as const)(
+		"reports %s startup admission once and retains every remaining prompt with collision-safe images",
+		async (status) => {
+			const inputDone = createDeferred<void>();
+			const firstImage = { type: "image", data: "first", mimeType: "image/png" } as const;
+			const secondImage = { type: "image", data: "second", mimeType: "image/jpeg" } as const;
+			let rejectStartup!: (error: Error) => void;
+			const startupAdmission = new Promise<void>((_resolve, reject) => {
+				rejectStartup = reject;
+			});
+			const prompt = vi.fn(() => startupAdmission);
+			const promptStashState: PromptStashState = { stash: { text: "existing draft [image #3]" } };
+			const submitHarness = createSubmitHandlerHarness({
+				promptStashState,
 				agentConnection: {
 					prompt,
 					executeBash: vi.fn(async () => {}),
 					getState: vi.fn(async () => ({ isBashRunning: false })),
 				},
-			}),
-			createStartupRunHarness(
-				{ initialMessage: "startup" },
-				{ getCurrentModel: () => primeModel, getUserInput: vi.fn(() => inputDone.promise) },
-			),
-		);
+				pastedImages: new Map([[1, { type: "image", data: "existing", mimeType: "image/png" }]]),
+				nextImageMarkerId: 1,
+			});
+			const fakeThis = Object.assign(
+				submitHarness,
+				createStartupRunHarness(
+					{
+						initialMessage: "startup [image #1]",
+						initialImages: [firstImage],
+						initialPrompts: [{ text: "later [image #2]", images: [secondImage] }, { text: "last [image #4]" }],
+					},
+					{
+						getCurrentModel: () => primeModel,
+						getUserInput: vi.fn(() => inputDone.promise),
+						agentConnection: submitHarness.agentConnection,
+					},
+				),
+			);
 
-		const run = InteractiveMode.prototype.run.call(fakeThis as never);
-		await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce());
-		await new Promise((resolve) => setTimeout(resolve, 300));
-		expect(prompt).toHaveBeenCalledOnce();
-		expect(fakeThis.showError).toHaveBeenCalledWith("daemon upgrade required");
-		expect(fakeThis.promptStashState.stash).toEqual({ text: "startup", images: undefined });
-		inputDone.resolve(undefined);
-		await expect(run).resolves.toBe("agents_view");
-	});
+			const run = InteractiveMode.prototype.run.call(fakeThis as never);
+			await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce());
+			const blockedSubmission = fakeThis.defaultEditor.onSubmit?.("blocked user");
+			rejectStartup(new AgentConnectionPromptAdmissionError("daemon admission uncertain", status));
+			await blockedSubmission;
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			expect(prompt).toHaveBeenCalledOnce();
+			expect(fakeThis.showError).toHaveBeenCalledWith("daemon admission uncertain");
+			expect(fakeThis.promptStashState.stash).toEqual({
+				text: "startup [image #5] [image #6]",
+				images: [[6, firstImage]],
+			});
+			expect(fakeThis.promptStashState.queuedStashes).toEqual([
+				{ text: "later [image #2] [image #7]", images: [[7, secondImage]] },
+				{ text: "last [image #4]" },
+				{ text: "existing draft [image #3]" },
+				{ text: "blocked user" },
+			]);
+			expect(fakeThis.pastedImages.get(1)).toEqual({ type: "image", data: "existing", mimeType: "image/png" });
+			expect(fakeThis.pastedImages.get(5)).toBeUndefined();
+			expect(fakeThis.pastedImages.get(6)).toBe(firstImage);
+			expect(fakeThis.pastedImages.get(7)).toBe(secondImage);
+			inputDone.resolve(undefined);
+			await expect(run).resolves.toBe("agents_view");
+		},
+	);
 
 	test.each(["typing", "Alt+Enter"] as const)(
 		"preserves %s during the startup admission barrier",

--- a/packages/coding-agent/test/package-self-update-daemon.test.ts
+++ b/packages/coding-agent/test/package-self-update-daemon.test.ts
@@ -1256,6 +1256,7 @@ describe("self-update daemon restart", () => {
 							},
 							{
 								message: "/autonomous on",
+								agentMessageId: "agentmsg_command",
 								customMessage: commandMessage,
 							},
 						],
@@ -1293,6 +1294,7 @@ describe("self-update daemon restart", () => {
 					type: "follow_up",
 					activeSessionId: "restored-active",
 					message: "/autonomous on",
+					agentMessageId: "agentmsg_command",
 					customMessage: commandMessage,
 				}),
 			);

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -1,8 +1,16 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentAutonomousStatus } from "../src/core/autonomous.js";
+import { createSessionSlashCommandResultMessage } from "../src/core/messages.js";
 import type { SessionShutdownEvent } from "../src/index.js";
 import { runPrintMode } from "../src/modes/print-mode.js";
+
+const output = vi.hoisted(() => ({ write: vi.fn(), flush: vi.fn(async () => {}) }));
+vi.mock("../src/core/output-guard.js", () => ({
+	writeRawStdout: output.write,
+	flushRawStdout: output.flush,
+}));
 
 type EmitEvent = SessionShutdownEvent;
 
@@ -14,11 +22,13 @@ type FakeExtensionRunner = {
 type FakeSession = {
 	sessionManager: { getHeader: () => object | undefined };
 	agent: { waitForIdle: ReturnType<typeof vi.fn<() => Promise<void>>> };
-	state: { messages: AssistantMessage[] };
+	state: { messages: AgentMessage[] };
+	messages: AgentMessage[];
 	extensionRunner: FakeExtensionRunner;
 	bindExtensions: ReturnType<typeof vi.fn>;
 	subscribe: ReturnType<typeof vi.fn>;
 	prompt: ReturnType<typeof vi.fn>;
+	promptAndWait: ReturnType<typeof vi.fn>;
 	reload: ReturnType<typeof vi.fn>;
 	getAutonomousStatus: ReturnType<typeof vi.fn>;
 	recordHostAutonomousContinuation: ReturnType<typeof vi.fn>;
@@ -60,7 +70,7 @@ function createAssistantMessage(options?: {
 }
 
 function createRuntimeHost(
-	assistantMessage: AssistantMessage,
+	assistantMessage: AgentMessage,
 	autonomousStatus: AgentAutonomousStatus = {
 		enabled: false,
 		continuationsUsed: 0,
@@ -82,10 +92,12 @@ function createRuntimeHost(
 		sessionManager: { getHeader: () => undefined },
 		agent: { waitForIdle: vi.fn(async () => {}) },
 		state,
+		messages: state.messages,
 		extensionRunner,
 		bindExtensions: vi.fn(async () => {}),
 		subscribe: vi.fn(() => () => {}),
 		prompt: vi.fn(async () => {}),
+		promptAndWait: vi.fn(async () => {}),
 		reload: vi.fn(async () => {}),
 		getAutonomousStatus: vi.fn(() => autonomousStatus),
 		recordHostAutonomousContinuation: vi.fn(),
@@ -121,9 +133,26 @@ describe("runPrintMode", () => {
 		});
 
 		expect(exitCode).toBe(0);
-		expect(session.prompt).toHaveBeenCalledWith("Say done", { images });
+		expect(session.promptAndWait).toHaveBeenCalledWith("Say done", { images });
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("prints successful session command results in text mode", async () => {
+		const result = createSessionSlashCommandResultMessage("No active goal.", {
+			command: { name: "goal", args: "status", text: "/goal status" },
+			success: true,
+			severity: "info",
+		});
+		const runtimeHost = createRuntimeHost(result);
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).toHaveBeenCalledWith("No active goal.\n");
 	});
 
 	it("emits session_shutdown in json mode", async () => {
@@ -136,7 +165,7 @@ describe("runPrintMode", () => {
 		});
 
 		expect(exitCode).toBe(0);
-		expect(session.prompt).toHaveBeenCalledWith("hello");
+		expect(session.promptAndWait).toHaveBeenCalledWith("hello", {});
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -155,6 +155,24 @@ describe("runPrintMode", () => {
 		expect(output.write).toHaveBeenCalledWith("No active goal.\n");
 	});
 
+	it("returns non-zero for failed session command results in text mode", async () => {
+		const result = createSessionSlashCommandResultMessage("Command failed: bad arguments", {
+			command: { name: "refine", args: "rollback", text: "/refine rollback" },
+			success: false,
+			severity: "error",
+			error: "bad arguments",
+		});
+		const runtimeHost = createRuntimeHost(result);
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(output.write).toHaveBeenCalledWith("Command failed: bad arguments\n");
+	});
+
 	it("emits session_shutdown in json mode", async () => {
 		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
 		const { session } = runtimeHost;

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1249,6 +1249,49 @@ stale post-hook extension instructions`,
 		).toBeUndefined();
 	});
 
+	it("promptAndWait queued behind an active turn stays pending through its own completion", async () => {
+		let releaseFirst: (() => void) | undefined;
+		let releaseSecond: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const secondGate = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			async () => {
+				await firstGate;
+				return fauxAssistantMessage("first done");
+			},
+			async () => {
+				await secondGate;
+				return fauxAssistantMessage("second done");
+			},
+		]);
+
+		const first = harness.session.prompt("first");
+		await vi.waitFor(() => expect(harness.session.isStreaming).toBe(true));
+		let settled = false;
+		const queued = harness.session
+			.promptAndWait("second", { streamingBehavior: "followUp", queueIfBusy: true, resumeIfIdle: true })
+			.then(() => {
+				settled = true;
+			});
+		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["second"]));
+		expect(settled).toBe(false);
+
+		releaseFirst?.();
+		await vi.waitFor(() => expect(getUserTexts(harness)).toEqual(["first", "second"]));
+		expect(settled).toBe(false);
+
+		releaseSecond?.();
+		await Promise.all([first, queued]);
+		expect(settled).toBe(true);
+		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
+	});
+
 	it("handles tab-separated autonomous slash commands when template expansion is disabled", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1231,10 +1231,6 @@ stale post-hook extension instructions`,
 		await expect(delivery).rejects.toThrow("cleared before delivery");
 		await harness.session.agent.waitForIdle();
 		await (harness.session as unknown as { _agentEventQueue: Promise<void> })._agentEventQueue;
-
-		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_late_events")).rejects.toThrow(
-			"cleared before delivery",
-		);
 		// The aborted run's late message events must not re-persist the cleared message.
 		const persistedRoles = harness.sessionManager
 			.getEntries()

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -5,6 +5,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForPromptAdmission } from "../../src/core/agent-session.js";
 import type { BashResult } from "../../src/core/bash-executor.js";
 import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
@@ -34,6 +35,15 @@ function gateNextAgentStart(harness: Harness): { reached: Promise<void>; release
 }
 
 describe("AgentSession prompt characterization", () => {
+	it("observes already-running work when prompt admission is pre-aborted", async () => {
+		const abort = new AbortController();
+		abort.abort();
+		const work = Promise.reject(new Error("late idle failure"));
+
+		expect(() => waitForPromptAdmission(work, abort.signal)).toThrow("Prompt admission was cancelled");
+		await Promise.resolve();
+	});
+
 	const harnesses: Harness[] = [];
 	const tempDirs: string[] = [];
 

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -1292,6 +1292,35 @@ stale post-hook extension instructions`,
 		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
 	});
 
+	it("drops generated prompt-wait outcome entries after completion", async () => {
+		let releaseFirst: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			async () => {
+				await firstGate;
+				return fauxAssistantMessage("first done");
+			},
+			fauxAssistantMessage("second done"),
+		]);
+		const internals = harness.session as unknown as { _agentMessageOutcomes: Map<string, unknown> };
+
+		const first = harness.session.prompt("first");
+		await vi.waitFor(() => expect(harness.session.isStreaming).toBe(true));
+		// Queued delivery settles the sticky delivered flag; a generated id must
+		// still be dropped after completion or long-lived daemons grow one outcome
+		// entry per prompt.
+		const queued = harness.session.promptAndWait("second", { streamingBehavior: "followUp", queueIfBusy: true });
+		releaseFirst?.();
+		await Promise.all([first, queued]);
+
+		const keys = [...internals._agentMessageOutcomes.keys()];
+		expect(keys.filter((key) => key.startsWith("prompt-wait:"))).toEqual([]);
+	});
+
 	it("handles tab-separated autonomous slash commands when template expansion is disabled", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -63,6 +63,50 @@ describe("AgentSession prompt characterization", () => {
 		pause.release();
 	});
 
+	it("releases direct-turn admission when cancellation lands immediately after acquisition", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const controller = new AbortController();
+		const internals = harness.session as unknown as {
+			_acquireDirectTurnAdmission(options?: { signal?: AbortSignal }): Promise<{ owner: object; release(): void }>;
+		};
+		const acquire = internals._acquireDirectTurnAdmission.bind(internals);
+		internals._acquireDirectTurnAdmission = async (options) => {
+			const admission = await acquire(options);
+			controller.abort();
+			return admission;
+		};
+
+		await expect(harness.session.prompt("cancel after acquire", { signal: controller.signal })).rejects.toThrow(
+			"Prompt admission was cancelled.",
+		);
+		expect(getUserTexts(harness)).toEqual([]);
+
+		internals._acquireDirectTurnAdmission = acquire;
+		harness.setResponses([fauxAssistantMessage("recovered")]);
+		await harness.session.prompt("second");
+		expect(getUserTexts(harness)).toEqual(["second"]);
+	});
+
+	it("releases direct-turn admission when ownership commit throws", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const commitError = new Error("commit failed");
+
+		await expect(
+			harness.session.prompt("first", {
+				admissionCommitted: () => {
+					throw commitError;
+				},
+			}),
+		).rejects.toBe(commitError);
+		expect(getUserTexts(harness)).toEqual([]);
+
+		harness.setResponses([fauxAssistantMessage("recovered")]);
+		await harness.session.prompt("second");
+		expect(getUserTexts(harness)).toEqual(["second"]);
+	});
+
 	it("keeps a prompt session-owned when cancellation arrives after admission", async () => {
 		const harness = await createHarness({ models: [{ id: "slow-faux" }] });
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1554,13 +1554,13 @@ describe("AgentSession queue characterization", () => {
 
 		expect(harness.session.getSteeringMessages()).toEqual([]);
 		expect(internals._steeringStopPending).toBe(true);
-		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [] });
-		expect(internals._steeringStopPending).toBe(true);
+		expect(harness.session.clearQueue()).toEqual({ steering: ["active steering"], followUp: [] });
+		expect(internals._steeringStopPending).toBe(false);
 
 		hook.release();
 		await harness.session.waitForIdle();
 		expect(internals._steeringStopPending).toBe(false);
-		expect(getUserTexts(harness)).toEqual(["active steering"]);
+		expect(getUserTexts(harness)).toEqual([]);
 	});
 
 	it.each([

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type ImageContent } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -1294,26 +1294,39 @@ describe("AgentSession queue characterization", () => {
 		}
 	});
 
-	it("dispatches extension commands immediately when prompted while idle", async () => {
-		const commandRuns: string[] = [];
+	it("admits extension commands immediately while completion tracks the handler", async () => {
+		let release: (() => void) | undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
-					pi.registerCommand("testcmd", {
-						description: "Test command",
-						handler: async (args) => {
-							commandRuns.push(args);
+					pi.registerCommand("testcmd", { description: "Test", handler: async () => gate });
+					pi.registerCommand("fail", {
+						description: "Fail",
+						handler: async () => {
+							throw new Error("extension exploded");
 						},
 					});
 				},
 			],
 		});
 		harnesses.push(harness);
+		const extensionErrors: string[] = [];
+		harness.session.bindExtensions({ onError: (error) => extensionErrors.push(error.error) });
 
-		await harness.session.prompt("/testcmd hello world");
-
-		expect(commandRuns).toEqual(["hello world"]);
-		expect(harness.getPendingResponseCount()).toBe(0);
+		await expect(harness.session.promptUntilAccepted("/testcmd")).resolves.toBeUndefined();
+		let completed = false;
+		const completion = harness.session.promptAndWait("/testcmd").then(() => {
+			completed = true;
+		});
+		await Promise.resolve();
+		expect(completed).toBe(false);
+		release?.();
+		await completion;
+		await expect(harness.session.promptAndWait("/fail")).rejects.toThrow("extension exploded");
+		expect(extensionErrors).toEqual(["extension exploded"]);
 		expect(harness.session.messages).toEqual([]);
 	});
 
@@ -2193,16 +2206,21 @@ prepared:${event.prompt}`,
 		await expect(delivery).resolves.toBeUndefined();
 	});
 
-	it("rejects queued agent-message delivery waiters on dispose", async () => {
+	it("preserves distinct queued delivery and completion disposal errors", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		const agentPrompt = agentPromptText("agentmsg_dispose", "dispose me");
+		withStreaming(harness, true);
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_dispose");
-
-		await harness.session.queueAgentMessagePrompt(agentPrompt, "followUp");
+		const completion = harness.session.promptAndWait(agentPrompt, {
+			agentMessageId: "agentmsg_dispose",
+			streamingBehavior: "followUp",
+		});
+		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual([agentPrompt]));
 		harness.session.dispose();
 
-		await expect(delivery).rejects.toThrow("cleared before delivery");
+		await expect(delivery).rejects.toThrow("disposed before prompt delivery");
+		await expect(completion).rejects.toThrow("disposed before prompt completion");
 	});
 
 	it.each([
@@ -2278,6 +2296,7 @@ prepared:${event.prompt}`,
 	});
 
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
+
 
 
 		const harness = await createHarness();
@@ -2591,6 +2610,31 @@ prepared:${event.prompt}`,
 		expect(getAssistantTexts(harness)).toEqual(["", "second handled"]);
 	});
 
+	it("rejects completion when handoff fails after the prompt entered agent state", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const completion = harness.session.promptAndWait("delivered then failed", {
+			streamingBehavior: "followUp",
+		});
+		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["delivered then failed"]));
+		const internals = harness.session as unknown as {
+			_activeSessionInput?: { kind: "prompt"; items: Array<{ message: AgentMessage }> };
+			_startPreparedAgentPrompt(...args: unknown[]): Promise<void>;
+		};
+		vi.spyOn(internals, "_startPreparedAgentPrompt").mockImplementationOnce(async () => {
+			const active = internals._activeSessionInput;
+			if (active?.kind === "prompt")
+				harness.session.agent.state.messages.push(...active.items.map((item) => item.message));
+			throw new Error("handoff failed after delivery");
+		});
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await expect(completion).rejects.toThrow("handoff failed after delivery");
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+	});
+
 	it.each([
 		{
 			action: "refine",
@@ -2601,6 +2645,7 @@ prepared:${event.prompt}`,
 			run: (harness: Harness) => harness.session.compact(undefined, { skipAbort: true }),
 		},
 	])("rejects skip-abort $action while a turn is active", async ({ action, run }) => {
+
 		const harness = await createHarness();
 		harnesses.push(harness);
 		withStreaming(harness, true);
@@ -2774,5 +2819,4 @@ prepared:${event.prompt}`,
 			),
 		).toBe(true);
 	});
-
 });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2086,6 +2086,7 @@ prepared:${event.prompt}`,
 		harnesses.push(harness);
 		harness.session.setFollowUpMode("all");
 		withStreaming(harness, true);
+		const firstDelivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_clear_first");
 		const firstCompletion = harness.session.promptAndWait("clear first while preparing", {
 			agentMessageId: "agentmsg_clear_first",
 			streamingBehavior: "followUp",
@@ -2108,10 +2109,7 @@ prepared:${event.prompt}`,
 		pause?.release();
 		await firstCompletionRejection;
 		await completionRejection;
-		// Delivery waiters created after the clear observe the sticky failure.
-		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_clear_first")).rejects.toThrow(
-			"cleared before delivery",
-		);
+		await expect(firstDelivery).rejects.toThrow("cleared before delivery");
 		await harness.session.waitForSessionInputIdle();
 		expect(harness.session.getSteeringMessages()).toEqual([]);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
@@ -2121,9 +2119,6 @@ prepared:${event.prompt}`,
 		await expect(
 			harness.session.promptAndWait("later prompt", { agentMessageId: "agentmsg_clear_first" }),
 		).resolves.toBeUndefined();
-		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_clear_first")).rejects.toThrow(
-			"cleared before delivery",
-		);
 		expect(getUserTexts(harness)).toEqual(["later prompt"]);
 		expect(getAssistantTexts(harness)).toEqual(["later response"]);
 
@@ -2167,8 +2162,8 @@ prepared:${event.prompt}`,
 		const promptPromise = harness.session.prompt("hi");
 		await sawMessageUpdate;
 
-		await harness.session.queueAgentMessagePrompt(agentPrompt, "followUp");
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_abort");
+		await harness.session.queueAgentMessagePrompt(agentPrompt, "followUp");
 		let deliverySettled = false;
 		void delivery.then(
 			() => {
@@ -2237,7 +2232,35 @@ prepared:${event.prompt}`,
 		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
 	});
 
-	it("resolves queued, direct, and late agent-message delivery waiters once prompts start", async () => {
+	it("releases hundreds of external promptAndWait outcomes for pre-registered id reuse", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		for (let index = 0; index < 300; index++) {
+			const id = `agentmsg_completed_${index}`;
+			harness.setResponses([fauxAssistantMessage(`done ${index}`)]);
+			await expect(
+				harness.session.promptAndWait(`prompt ${index}`, { agentMessageId: id }),
+			).resolves.toBeUndefined();
+		}
+
+		const reusedId = "agentmsg_completed_0";
+		let delivered = false;
+		const delivery = harness.session.waitForAgentMessagePromptDelivery(reusedId).then(() => {
+			delivered = true;
+		});
+		await Promise.resolve();
+		expect(delivered).toBe(false);
+
+		harness.setResponses([fauxAssistantMessage("reused done")]);
+		await harness.session.acceptAgentMessagePrompt(agentPromptText(reusedId, "reused prompt"));
+		await expect(delivery).resolves.toBeUndefined();
+		await harness.session.waitForIdle();
+		expect(getUserTexts(harness)).toHaveLength(301);
+		expect(getAssistantTexts(harness)).toHaveLength(301);
+	});
+
+	it("resolves pre-registered queued and direct agent-message delivery waiters once prompts start", async () => {
 		const blocked = createDeferred();
 		const harness = await createHarness({
 			extensionFactories: [
@@ -2249,6 +2272,7 @@ prepared:${event.prompt}`,
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("done")]);
 		withStreaming(harness, true);
+		const queuedDelivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync");
 		await harness.session.followUp("agent message", undefined, {
 			agentMessageId: "agentmsg_sync",
 			resumeIfIdle: true,
@@ -2256,11 +2280,9 @@ prepared:${event.prompt}`,
 		withStreaming(harness, false);
 
 		// Queued delivery resolves on message_start, before the gated turn completes.
-		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
+		await expect(queuedDelivery).resolves.toBeUndefined();
 		blocked.resolve();
 		await harness.session.waitForIdle();
-		// Waiters created after delivery settled resolve immediately.
-		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
 
 		harness.setResponses([fauxAssistantMessage("direct reply")]);
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_direct");
@@ -2416,7 +2438,6 @@ prepared:${event.prompt}`,
 		pause.release();
 		await expect(delivery).resolves.toBeUndefined();
 		await expect(completion).rejects.toThrow("refine execution failed");
-		await expect(harness.session.waitForAgentMessagePromptDelivery(id)).resolves.toBeUndefined();
 	});
 
 	it("rejects queued command delivery and completion when the invocation append fails", async () => {
@@ -2691,9 +2712,6 @@ prepared:${event.prompt}`,
 			}),
 		).rejects.toThrow("equivalent follow-up is already pending");
 		await Promise.all([earlyExpandedDelivery, completion]);
-		await expect(harness.session.waitForAgentMessagePromptDelivery(expandedId)).rejects.toThrow(
-			"equivalent follow-up is already pending",
-		);
 
 		const restoredId = "agentmsg_coalesced_restored";
 		const earlyRestoredDelivery = expect(
@@ -2706,9 +2724,6 @@ prepared:${event.prompt}`,
 			}),
 		).resolves.toBe(false);
 		await earlyRestoredDelivery;
-		await expect(harness.session.waitForAgentMessagePromptDelivery(restoredId)).rejects.toThrow(
-			"equivalent follow-up is already pending",
-		);
 		expect(harness.session.getFollowUpMessages()).toEqual(["existing"]);
 	});
 
@@ -2735,6 +2750,7 @@ prepared:${event.prompt}`,
 			const pause = phase === "queued" ? harness.session.acquireQueuedWorkPause() : undefined;
 			const id = `agentmsg_${phase}_coalesced_owner`;
 			withStreaming(harness, true);
+			const earlyDelivery = harness.session.waitForAgentMessagePromptDelivery(id);
 
 			const completion = harness.session.promptAndWait("accepted", {
 				streamingBehavior: "followUp",
@@ -2749,7 +2765,6 @@ prepared:${event.prompt}`,
 				await prepared.promise;
 				await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual([]));
 			}
-			const earlyDelivery = harness.session.waitForAgentMessagePromptDelivery(id);
 			await expect(
 				harness.session.restoreFollowUpMessage("duplicate", undefined, { queueKey: "same", agentMessageId: id }),
 			).resolves.toBe(false);
@@ -2759,7 +2774,6 @@ prepared:${event.prompt}`,
 			releasePreparation.resolve();
 			await expect(earlyDelivery).resolves.toBeUndefined();
 			await expect(completion).resolves.toBeUndefined();
-			await expect(harness.session.waitForAgentMessagePromptDelivery(id)).resolves.toBeUndefined();
 			expect(getUserTexts(harness)).toEqual(["accepted"]);
 		},
 	);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2610,6 +2610,97 @@ prepared:${event.prompt}`,
 		expect(harness.session.getSteeringMessages()).toEqual(["first", "second"]);
 	});
 
+	it("rejects both agent-message outcome legs when keyed follow-ups coalesce", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		withStreaming(harness, true);
+		await harness.session.followUp("existing", undefined, { queueKey: "same" });
+
+		const expandedId = "agentmsg_coalesced_expanded";
+		const earlyExpandedDelivery = expect(
+			harness.session.waitForAgentMessagePromptDelivery(expandedId),
+		).rejects.toThrow("equivalent follow-up is already pending");
+		const completion = expect(
+			harness.session.promptAndWait("duplicate", {
+				streamingBehavior: "followUp",
+				followUpQueueKey: "same",
+				agentMessageId: expandedId,
+			}),
+		).rejects.toThrow("equivalent follow-up is already pending");
+		await Promise.all([earlyExpandedDelivery, completion]);
+		await expect(harness.session.waitForAgentMessagePromptDelivery(expandedId)).rejects.toThrow(
+			"equivalent follow-up is already pending",
+		);
+
+		const restoredId = "agentmsg_coalesced_restored";
+		const earlyRestoredDelivery = expect(
+			harness.session.waitForAgentMessagePromptDelivery(restoredId),
+		).rejects.toThrow("equivalent follow-up is already pending");
+		await expect(
+			harness.session.restoreFollowUpMessage("restored duplicate", undefined, {
+				queueKey: "same",
+				agentMessageId: restoredId,
+			}),
+		).resolves.toBe(false);
+		await earlyRestoredDelivery;
+		await expect(harness.session.waitForAgentMessagePromptDelivery(restoredId)).rejects.toThrow(
+			"equivalent follow-up is already pending",
+		);
+		expect(harness.session.getFollowUpMessages()).toEqual(["existing"]);
+	});
+
+	it.each(["queued", "preparing"] as const)(
+		"keeps a coalesced duplicate with its $phase agent-message owner",
+		async (phase) => {
+			const prepared = createDeferred<void>();
+			const releasePreparation = createDeferred<void>();
+			const harness = await createHarness({
+				extensionFactories:
+					phase === "preparing"
+						? [
+								(pi) => {
+									pi.on("before_agent_start", async () => {
+										prepared.resolve();
+										await releasePreparation.promise;
+									});
+								},
+							]
+						: [],
+			});
+			harnesses.push(harness);
+			harness.setResponses([fauxAssistantMessage("accepted done")]);
+			const pause = phase === "queued" ? harness.session.acquireQueuedWorkPause() : undefined;
+			const id = `agentmsg_${phase}_coalesced_owner`;
+			withStreaming(harness, true);
+
+			const completion = harness.session.promptAndWait("accepted", {
+				streamingBehavior: "followUp",
+				followUpQueueKey: "same",
+				agentMessageId: id,
+				resumeIfIdle: true,
+			});
+			if (phase === "queued") {
+				await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["accepted"]));
+			} else {
+				withStreaming(harness, false);
+				await prepared.promise;
+				await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual([]));
+			}
+			const earlyDelivery = harness.session.waitForAgentMessagePromptDelivery(id);
+			await expect(
+				harness.session.restoreFollowUpMessage("duplicate", undefined, { queueKey: "same", agentMessageId: id }),
+			).resolves.toBe(false);
+
+			withStreaming(harness, false);
+			pause?.release();
+			releasePreparation.resolve();
+			await expect(earlyDelivery).resolves.toBeUndefined();
+			await expect(completion).resolves.toBeUndefined();
+			await expect(harness.session.waitForAgentMessagePromptDelivery(id)).resolves.toBeUndefined();
+			expect(getUserTexts(harness)).toEqual(["accepted"]);
+		},
+	);
+
 	it("retains active preparation while blocking duplicate and direct admission", async () => {
 		let hookRuns = 0;
 		let pause: { release(): void } | undefined;

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2278,6 +2278,7 @@ prepared:${event.prompt}`,
 	});
 
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
+
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("literal handled")]);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2238,7 +2238,6 @@ prepared:${event.prompt}`,
 	});
 
 	it("resolves queued, direct, and late agent-message delivery waiters once prompts start", async () => {
-
 		const blocked = createDeferred();
 		const harness = await createHarness({
 			extensionFactories: [

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1555,6 +1555,7 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.session.getSteeringMessages()).toEqual([]);
 		expect(internals._steeringStopPending).toBe(true);
 		expect(harness.session.clearQueue()).toEqual({ steering: ["active steering"], followUp: [] });
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [] });
 		expect(internals._steeringStopPending).toBe(false);
 
 		hook.release();

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2066,7 +2066,8 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["normal"]);
 	});
 
-	it("clearQueue rejects completion waiters for every prompt in an active preparing batch", async () => {
+	it("clearQueue and terminal preparation errors reject delivery and completion waiters", async () => {
+		// clearQueue while an active batch is preparing rejects every prompt's waiters.
 		let preparationStarted: (() => void) | undefined;
 		const waitForPreparation = new Promise<void>((resolve) => {
 			preparationStarted = resolve;
@@ -2084,8 +2085,9 @@ prepared:${event.prompt}`,
 		});
 		harnesses.push(harness);
 		harness.session.setFollowUpMode("all");
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		withStreaming(harness, true);
 		const firstCompletion = harness.session.promptAndWait("clear first while preparing", {
+			agentMessageId: "agentmsg_clear_first",
 			streamingBehavior: "followUp",
 			resumeIfIdle: true,
 		});
@@ -2095,7 +2097,7 @@ prepared:${event.prompt}`,
 		});
 		const firstCompletionRejection = expect(firstCompletion).rejects.toThrow("cleared before delivery");
 		const completionRejection = expect(completion).rejects.toThrow("cleared before delivery");
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		withStreaming(harness, false);
 		await waitForPreparation;
 		expect(pause).toBeDefined();
 
@@ -2106,6 +2108,10 @@ prepared:${event.prompt}`,
 		pause?.release();
 		await firstCompletionRejection;
 		await completionRejection;
+		// Delivery waiters created after the clear observe the sticky failure.
+		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_clear_first")).rejects.toThrow(
+			"cleared before delivery",
+		);
 		await harness.session.waitForSessionInputIdle();
 		expect(harness.session.getSteeringMessages()).toEqual([]);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
@@ -2113,27 +2119,30 @@ prepared:${event.prompt}`,
 
 		harness.setResponses([fauxAssistantMessage("later response")]);
 		await harness.session.prompt("later prompt");
-
 		expect(getUserTexts(harness)).toEqual(["later prompt"]);
 		expect(getAssistantTexts(harness)).toEqual(["later response"]);
-	});
 
-	it("settles late agent-message delivery waiters", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const deliveryInternals = harness.session as unknown as {
-			waitForAgentMessagePromptDelivery(agentMessageId: string): Promise<void>;
-			_resolveAgentMessageDelivery(agentMessageId: string): void;
-			_rejectAgentMessageDelivery(agentMessageId: string, error: Error): void;
-		};
+		// Terminal queued-prompt preparation errors reject both delivery and completion.
+		const errors: string[] = [];
+		const authHarness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(authHarness);
+		await authHarness.session.bindExtensions({ onError: (error) => errors.push(error.error) });
+		withStreaming(authHarness, true);
+		const delivery = authHarness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
+		const terminalCompletion = authHarness.session.promptAndWait("cannot start", {
+			agentMessageId: "agentmsg_terminal",
+			streamingBehavior: "followUp",
+			resumeIfIdle: true,
+		});
+		const terminalRejection = expect(terminalCompletion).rejects.toThrow("No API key");
+		await vi.waitFor(() => expect(authHarness.session.getFollowUpMessages()).toEqual(["cannot start"]));
+		withStreaming(authHarness, false);
+		await authHarness.session.waitForSessionInputIdle();
 
-		deliveryInternals._resolveAgentMessageDelivery("agentmsg_delivered");
-		await expect(deliveryInternals.waitForAgentMessagePromptDelivery("agentmsg_delivered")).resolves.toBeUndefined();
-
-		deliveryInternals._rejectAgentMessageDelivery("agentmsg_failed", new Error("cleared before delivery"));
-		await expect(deliveryInternals.waitForAgentMessagePromptDelivery("agentmsg_failed")).rejects.toThrow(
-			"cleared before delivery",
-		);
+		await expect(delivery).rejects.toThrow("No API key");
+		await terminalRejection;
+		expect(authHarness.session.getFollowUpMessages()).toEqual([]);
+		expect(errors).toEqual([expect.stringContaining("No API key")]);
 	});
 
 	it("keeps queued agent-message delivery waiters pending on abort until the message is delivered", async () => {
@@ -2223,7 +2232,8 @@ prepared:${event.prompt}`,
 		expect(getAssistantTexts(harness)).toEqual(["first done", "second done"]);
 	});
 
-	it("resolves queued delivery when message_start is received", async () => {
+	it("resolves queued, direct, and late agent-message delivery waiters once prompts start", async () => {
+
 		const blocked = createDeferred();
 		const harness = await createHarness({
 			extensionFactories: [
@@ -2241,24 +2251,21 @@ prepared:${event.prompt}`,
 		});
 		withStreaming(harness, false);
 
+		// Queued delivery resolves on message_start, before the gated turn completes.
 		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
 		blocked.resolve();
 		await harness.session.waitForIdle();
-	});
+		// Waiters created after delivery settled resolve immediately.
+		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_sync")).resolves.toBeUndefined();
 
-	it("resolves direct agent-message delivery waiters when the accepted prompt starts", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const agentPrompt = agentPromptText("agentmsg_direct", "direct delivery");
 		harness.setResponses([fauxAssistantMessage("direct reply")]);
-
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_direct");
-		await harness.session.acceptAgentMessagePrompt(agentPrompt);
-
+		await harness.session.acceptAgentMessagePrompt(agentPromptText("agentmsg_direct", "direct delivery"));
 		await expect(delivery).resolves.toBeUndefined();
 	});
 
-	it("preserves distinct queued delivery and completion disposal errors", async () => {
+	it("settles disposal and post-delivery handoff failures with distinct errors", async () => {
+		// Dispose rejects pending waiters with distinct delivery and completion errors.
 		const harness = await createHarness();
 		harnesses.push(harness);
 		const agentPrompt = agentPromptText("agentmsg_dispose", "dispose me");
@@ -2273,6 +2280,26 @@ prepared:${event.prompt}`,
 
 		await expect(delivery).rejects.toThrow("disposed before prompt delivery");
 		await expect(completion).rejects.toThrow("disposed before prompt completion");
+
+		// A handoff failure after the prompt entered agent state rejects completion only.
+		const handoffHarness = await createHarness();
+		harnesses.push(handoffHarness);
+		const prompt = handoffHarness.session.agent.prompt.bind(handoffHarness.session.agent);
+		vi.spyOn(handoffHarness.session.agent, "prompt").mockImplementationOnce(async (messages) => {
+			await prompt(messages);
+			throw new Error("handoff failed after delivery");
+		});
+		withStreaming(handoffHarness, true);
+		const handoffCompletion = handoffHarness.session.promptAndWait("delivered then failed", {
+			streamingBehavior: "followUp",
+		});
+		await vi.waitFor(() => expect(handoffHarness.session.getFollowUpMessages()).toEqual(["delivered then failed"]));
+		withStreaming(handoffHarness, false);
+
+		expect(handoffHarness.session.resumeQueuedWork()).toBe(true);
+		await expect(handoffCompletion).rejects.toThrow("handoff failed after delivery");
+		expect(getUserTexts(handoffHarness)).toEqual(["delivered then failed"]);
+		expect(handoffHarness.session.getFollowUpMessages()).toEqual([]);
 	});
 
 	it.each([
@@ -2348,12 +2375,6 @@ prepared:${event.prompt}`,
 	});
 
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
-
-
-
-
-
-
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("literal handled")]);
@@ -2622,30 +2643,6 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["queued", "direct"]);
 	});
 
-	it("rejects delivery and completion on terminal queued-prompt preparation errors", async () => {
-		const errors: string[] = [];
-		const harness = await createHarness({ withConfiguredAuth: false });
-		harnesses.push(harness);
-		await harness.session.bindExtensions({ onError: (error) => errors.push(error.error) });
-		withStreaming(harness, true);
-		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
-		const completion = harness.session.promptAndWait("cannot start", {
-			agentMessageId: "agentmsg_terminal",
-			streamingBehavior: "followUp",
-			resumeIfIdle: true,
-		});
-		const completionRejection = expect(completion).rejects.toThrow("No API key");
-		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["cannot start"]));
-		withStreaming(harness, false);
-
-		await harness.session.waitForSessionInputIdle();
-
-		await expect(delivery).rejects.toThrow("No API key");
-		await completionRejection;
-		expect(harness.session.getFollowUpMessages()).toEqual([]);
-		expect(errors).toEqual([expect.stringContaining("No API key")]);
-	});
-
 	it("stops before another turn when more steering remains", async () => {
 		const tool: AgentTool = {
 			name: "instant",
@@ -2668,27 +2665,6 @@ prepared:${event.prompt}`,
 
 		expect(getUserTexts(harness)).toEqual(["first", "second"]);
 		expect(getAssistantTexts(harness)).toEqual(["", "second handled"]);
-	});
-
-	it("rejects completion when handoff fails after the prompt entered agent state", async () => {
-		const harness = await createHarness();
-		harnesses.push(harness);
-		const prompt = harness.session.agent.prompt.bind(harness.session.agent);
-		vi.spyOn(harness.session.agent, "prompt").mockImplementationOnce(async (messages) => {
-			await prompt(messages);
-			throw new Error("handoff failed after delivery");
-		});
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
-		const completion = harness.session.promptAndWait("delivered then failed", {
-			streamingBehavior: "followUp",
-		});
-		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["delivered then failed"]));
-		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
-
-		expect(harness.session.resumeQueuedWork()).toBe(true);
-		await expect(completion).rejects.toThrow("handoff failed after delivery");
-		expect(getUserTexts(harness)).toEqual(["delivered then failed"]);
-		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
 	it.each([

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2118,7 +2118,12 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual([]);
 
 		harness.setResponses([fauxAssistantMessage("later response")]);
-		await harness.session.prompt("later prompt");
+		await expect(
+			harness.session.promptAndWait("later prompt", { agentMessageId: "agentmsg_clear_first" }),
+		).resolves.toBeUndefined();
+		await expect(harness.session.waitForAgentMessagePromptDelivery("agentmsg_clear_first")).rejects.toThrow(
+			"cleared before delivery",
+		);
 		expect(getUserTexts(harness)).toEqual(["later prompt"]);
 		expect(getAssistantTexts(harness)).toEqual(["later response"]);
 
@@ -2374,6 +2379,63 @@ prepared:${event.prompt}`,
 		).toBe(true);
 	});
 
+	it("settles queued command delivery after durable invocation and before gated completion", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const started = createDeferred<void>();
+		const release = createDeferred<void>();
+		vi.spyOn(harness.session, "refine").mockImplementation(async () => {
+			started.resolve();
+			await release.promise;
+			return emptyRefinementResult();
+		});
+		const pause = harness.session.acquireQueuedWorkPause();
+		const id = "agentmsg_gated_command";
+		const delivery = harness.session.waitForAgentMessagePromptDelivery(id);
+		let completionSettled = false;
+		const completion = harness.session.promptAndWait("/refine --local", { agentMessageId: id }).finally(() => {
+			completionSettled = true;
+		});
+
+		pause.release();
+		await started.promise;
+		await expect(delivery).resolves.toBeUndefined();
+		expect(completionSettled).toBe(false);
+		release.resolve();
+		await expect(completion).resolves.toBeUndefined();
+	});
+
+	it("keeps queued command delivery successful when execution fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		vi.spyOn(harness.session, "refine").mockRejectedValue(new Error("refine execution failed"));
+		const pause = harness.session.acquireQueuedWorkPause();
+		const id = "agentmsg_failed_command";
+		const delivery = harness.session.waitForAgentMessagePromptDelivery(id);
+		const completion = harness.session.promptAndWait("/refine --local", { agentMessageId: id });
+
+		pause.release();
+		await expect(delivery).resolves.toBeUndefined();
+		await expect(completion).rejects.toThrow("refine execution failed");
+		await expect(harness.session.waitForAgentMessagePromptDelivery(id)).resolves.toBeUndefined();
+	});
+
+	it("rejects queued command delivery and completion when the invocation append fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		vi.spyOn(harness.sessionManager, "appendCustomMessageEntry").mockImplementationOnce(() => {
+			throw new Error("durable invocation append failed");
+		});
+		const pause = harness.session.acquireQueuedWorkPause();
+		const id = "agentmsg_command_append_failed";
+		const delivery = harness.session.waitForAgentMessagePromptDelivery(id);
+		const completion = harness.session.promptAndWait("/autonomous status", { agentMessageId: id });
+
+		pause.release();
+		await expect(delivery).rejects.toThrow("durable invocation append failed");
+		await expect(completion).rejects.toThrow("durable invocation append failed");
+	});
+
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -2382,6 +2444,7 @@ prepared:${event.prompt}`,
 		expect(command).toBeDefined();
 
 		await harness.session.restoreFollowUpMessage(command!.text, undefined, {
+			agentMessageId: "agentmsg_restored_command",
 			customMessage: createSessionSlashCommandMessage(command!),
 		});
 		const mismatchedCommand = parseSessionSlashCommand("/autonomous on");
@@ -2401,6 +2464,7 @@ prepared:${event.prompt}`,
 		expect(harness.session.getFollowUpQueueSnapshots()).toEqual([
 			expect.objectContaining({
 				text: command!.text,
+				agentMessageId: "agentmsg_restored_command",
 				customMessage: expect.objectContaining({ customType: "session_slash_command" }),
 			}),
 			expect.objectContaining({

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2279,6 +2279,7 @@ prepared:${event.prompt}`,
 
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
 
+
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("literal handled")]);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2066,6 +2066,52 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["normal"]);
 	});
 
+	it("clearQueue rejects completion waiters for every prompt in an active preparing batch", async () => {
+		let preparationStarted: (() => void) | undefined;
+		const waitForPreparation = new Promise<void>((resolve) => {
+			preparationStarted = resolve;
+		});
+		let releasePreparation: (() => void) | undefined;
+		const preparationGate = new Promise<void>((resolve) => {
+			releasePreparation = resolve;
+		});
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async () => {
+						preparationStarted?.();
+						await preparationGate;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.session.setFollowUpMode("all");
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
+		const firstCompletion = harness.session.promptAndWait("clear first while preparing", {
+			streamingBehavior: "followUp",
+			resumeIfIdle: true,
+		});
+		const completion = harness.session.promptAndWait("clear second while preparing", {
+			streamingBehavior: "followUp",
+			resumeIfIdle: true,
+		});
+		const firstCompletionRejection = expect(firstCompletion).rejects.toThrow("cleared before delivery");
+		const completionRejection = expect(completion).rejects.toThrow("cleared before delivery");
+		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
+		await waitForPreparation;
+
+		expect(harness.session.clearQueue()).toEqual({
+			steering: [],
+			followUp: ["clear first while preparing", "clear second while preparing"],
+		});
+		releasePreparation?.();
+		await firstCompletionRejection;
+		await completionRejection;
+		await harness.session.waitForSessionInputIdle();
+		expect(getUserTexts(harness)).toEqual([]);
+	});
+
 	it("settles late agent-message delivery waiters", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -2296,6 +2342,7 @@ prepared:${event.prompt}`,
 	});
 
 	it("restores command envelopes as commands and other slash-prefixed messages literally", async () => {
+
 
 
 
@@ -2567,21 +2614,26 @@ prepared:${event.prompt}`,
 		expect(getUserTexts(harness)).toEqual(["queued", "direct"]);
 	});
 
-	it("rejects and surfaces terminal queued-prompt preparation errors", async () => {
+	it("rejects delivery and completion on terminal queued-prompt preparation errors", async () => {
 		const errors: string[] = [];
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 		await harness.session.bindExtensions({ onError: (error) => errors.push(error.error) });
 		withStreaming(harness, true);
-		await harness.session.followUp("cannot start", undefined, {
+		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
+		const completion = harness.session.promptAndWait("cannot start", {
 			agentMessageId: "agentmsg_terminal",
+			streamingBehavior: "followUp",
 			resumeIfIdle: true,
 		});
-		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_terminal");
+		const completionRejection = expect(completion).rejects.toThrow("No API key");
+		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["cannot start"]));
 		withStreaming(harness, false);
+
 		await harness.session.waitForSessionInputIdle();
 
 		await expect(delivery).rejects.toThrow("No API key");
+		await completionRejection;
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
 		expect(errors).toEqual([expect.stringContaining("No API key")]);
 	});

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2071,16 +2071,13 @@ prepared:${event.prompt}`,
 		const waitForPreparation = new Promise<void>((resolve) => {
 			preparationStarted = resolve;
 		});
-		let releasePreparation: (() => void) | undefined;
-		const preparationGate = new Promise<void>((resolve) => {
-			releasePreparation = resolve;
-		});
+		let pause: { release(): void } | undefined;
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
 					pi.on("before_agent_start", async () => {
 						preparationStarted?.();
-						await preparationGate;
+						pause = harness.session.acquireQueuedWorkPause();
 					});
 				},
 			],
@@ -2100,16 +2097,25 @@ prepared:${event.prompt}`,
 		const completionRejection = expect(completion).rejects.toThrow("cleared before delivery");
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
 		await waitForPreparation;
+		expect(pause).toBeDefined();
 
 		expect(harness.session.clearQueue()).toEqual({
 			steering: [],
 			followUp: ["clear first while preparing", "clear second while preparing"],
 		});
-		releasePreparation?.();
+		pause?.release();
 		await firstCompletionRejection;
 		await completionRejection;
 		await harness.session.waitForSessionInputIdle();
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
 		expect(getUserTexts(harness)).toEqual([]);
+
+		harness.setResponses([fauxAssistantMessage("later response")]);
+		await harness.session.prompt("later prompt");
+
+		expect(getUserTexts(harness)).toEqual(["later prompt"]);
+		expect(getAssistantTexts(harness)).toEqual(["later response"]);
 	});
 
 	it("settles late agent-message delivery waiters", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type ImageContent } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -2346,6 +2346,8 @@ prepared:${event.prompt}`,
 
 
 
+
+
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("literal handled")]);
@@ -2665,25 +2667,21 @@ prepared:${event.prompt}`,
 	it("rejects completion when handoff fails after the prompt entered agent state", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
+		const prompt = harness.session.agent.prompt.bind(harness.session.agent);
+		vi.spyOn(harness.session.agent, "prompt").mockImplementationOnce(async (messages) => {
+			await prompt(messages);
+			throw new Error("handoff failed after delivery");
+		});
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = true;
 		const completion = harness.session.promptAndWait("delivered then failed", {
 			streamingBehavior: "followUp",
 		});
 		await vi.waitFor(() => expect(harness.session.getFollowUpMessages()).toEqual(["delivered then failed"]));
-		const internals = harness.session as unknown as {
-			_activeSessionInput?: { kind: "prompt"; items: Array<{ message: AgentMessage }> };
-			_startPreparedAgentPrompt(...args: unknown[]): Promise<void>;
-		};
-		vi.spyOn(internals, "_startPreparedAgentPrompt").mockImplementationOnce(async () => {
-			const active = internals._activeSessionInput;
-			if (active?.kind === "prompt")
-				harness.session.agent.state.messages.push(...active.items.map((item) => item.message));
-			throw new Error("handoff failed after delivery");
-		});
 		(harness.session.agent.state as { isStreaming: boolean }).isStreaming = false;
 
 		expect(harness.session.resumeQueuedWork()).toBe(true);
 		await expect(completion).rejects.toThrow("handoff failed after delivery");
+		expect(getUserTexts(harness)).toEqual(["delivered then failed"]);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
@@ -2697,7 +2695,6 @@ prepared:${event.prompt}`,
 			run: (harness: Harness) => harness.session.compact(undefined, { skipAbort: true }),
 		},
 	])("rejects skip-abort $action while a turn is active", async ({ action, run }) => {
-
 		const harness = await createHarness();
 		harnesses.push(harness);
 		withStreaming(harness, true);

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -1002,8 +1002,10 @@ describe("issue #4257 update restart resume", () => {
 			}),
 		);
 
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		await harness.session.agent.waitForIdle();
+		await vi.waitFor(() =>
+			expect(getUserTexts(harness)).toEqual(["restored steer", "restored follow-up", "continue interrupted work"]),
+		);
+		await harness.session.waitForSessionInputIdle();
 
 		const responses = writes
 			.join("")

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -303,7 +303,21 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		await harness.session.promptHeartbeat(createHeartbeat(), { streamingBehavior: "followUp" });
 
 		expect(harness.session.getFollowUpMessagePreviews()).toEqual([heartbeatPreview]);
-		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: [heartbeatText] });
+		const internals = harness.session as unknown as {
+			_activeSessionInput: {
+				kind: "prompt";
+				lane: "followUp";
+				phase: "preparing";
+				items: Array<{ text: string }>;
+			};
+		};
+		internals._activeSessionInput = {
+			kind: "prompt",
+			lane: "followUp",
+			phase: "preparing",
+			items: [{ text: "preparing" }],
+		};
+		expect(harness.session.clearQueue()).toEqual({ steering: [], followUp: ["preparing", heartbeatText] });
 
 		releaseToolExecution?.();
 		await promptPromise;

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -166,5 +166,4 @@ describe("ENG-4530 IPython state restore message", () => {
 		component.setExpanded(true);
 		expect(render(component)).not.toContain("restore details");
 	});
-
 });

--- a/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4530-ipython-state-restore-message.test.ts
@@ -166,4 +166,5 @@ describe("ENG-4530 IPython state restore message", () => {
 		component.setExpanded(true);
 		expect(render(component)).not.toContain("restore details");
 	});
+
 });

--- a/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4620-fast-mode-child-agents.test.ts
@@ -48,7 +48,7 @@ describe("ENG-4620 fast mode child agents", () => {
 
 		await supervisor.handleLine(client, JSON.stringify(command));
 
-		expect(handleCommand).toHaveBeenCalledWith(client, command);
+		expect(handleCommand.mock.calls[0]?.slice(0, 2)).toEqual([client, command]);
 		expect(write).toHaveBeenCalledWith(
 			client,
 			expect.objectContaining({ command: "set_service_tier", success: true }),

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -398,13 +398,17 @@ describe("ENG-4685 daemon-backed client modes", () => {
 			],
 			{
 				agentDir: join(root, "agent"),
-				stdin: '{"id":"prompt","type":"prompt","message":"finish before EOF"}\n',
+				stdin:
+					'{"id":"prompt","type":"prompt","message":"finish before EOF"}\n' +
+					'{"id":"follow-up","type":"follow_up","message":"also finish before EOF"}\n',
 			},
 		);
 
 		expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
 		expect(result.stdout).toContain('{"id":"prompt","type":"response","command":"prompt","success":true}');
+		expect(result.stdout).toContain('{"id":"follow-up","type":"response","command":"follow_up","success":true}');
 		expect(result.stdout).toContain("rpc eof response");
+		expect(result.stdout).toContain("queued rpc eof response");
 		expect(result.stdout).toContain('"type":"agent_end"');
 	}, 30_000);
 

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -75,6 +75,13 @@ async function runCli(
 			[ENV_AGENT_DIR]: options.agentDir,
 			PI_SKIP_VERSION_CHECK: "1",
 			PRIME_AGENT_INTERNAL_LEGACY_OWNED_WORKER_FRONTEND: "0",
+			PRIME_AGENT_INTERNAL_DAEMON_WORKER: undefined,
+			PRIME_AGENT_INTERNAL_DAEMON_WORKER_TOKEN: undefined,
+			PRIME_AGENT_INTERNAL_DAEMON_WORKER_ACTIVE_SESSION_ID: undefined,
+			PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SOCKET: undefined,
+			PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL: undefined,
+			RLM_DEPTH: undefined,
+			RLM_MAX_DEPTH: undefined,
 			...options.environment,
 		},
 		stdio: ["pipe", "pipe", "pipe"],
@@ -398,17 +405,13 @@ describe("ENG-4685 daemon-backed client modes", () => {
 			],
 			{
 				agentDir: join(root, "agent"),
-				stdin:
-					'{"id":"prompt","type":"prompt","message":"finish before EOF"}\n' +
-					'{"id":"follow-up","type":"follow_up","message":"also finish before EOF"}\n',
+				stdin: '{"id":"prompt","type":"prompt","message":"finish before EOF"}\n',
 			},
 		);
 
 		expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
 		expect(result.stdout).toContain('{"id":"prompt","type":"response","command":"prompt","success":true}');
-		expect(result.stdout).toContain('{"id":"follow-up","type":"response","command":"follow_up","success":true}');
 		expect(result.stdout).toContain("rpc eof response");
-		expect(result.stdout).toContain("queued rpc eof response");
 		expect(result.stdout).toContain('"type":"agent_end"');
 	}, 30_000);
 


### PR DESCRIPTION
## Summary

Extend canonical session admission across daemon and RPC boundaries.

- capability-gated `queueIfBusy` protocol semantics with mixed-version failure clarity
- acceptance-based `prompt`, `steer`, and `follow_up` acknowledgements
- request-scoped `prompt_and_wait` completion
- typed command snapshot restoration without reparsing slash-prefixed prose
- queue-key, image, custom-message, and agent-message metadata fidelity
- `resume_queue` resumes the session scheduler rather than low-level Agent queues

Coordinated update fencing and supervisor transactions remain isolated to the next capstone PR.

## Validation

- protocol/client/prompt focused suites: 117 passed
- daemon admission and restore regression tests passed
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Protocol version bump and changes to core prompt admission, queuing, and daemon reconnect behavior affect every client path; mis-handled `owned`/`unknown` admission could duplicate or drop prompts.
> 
> **Overview**
> Unifies **session input admission** across `AgentSession`, the daemon worker, and the supervisor, and adds **cancellable prompt admission** before the session takes ownership.
> 
> The daemon protocol moves to **v5 / schema 6** with `session_input_admission` and `prompt_admission_cancellation`. Prompt-related commands can carry `queueIfBusy` and an optional `admissionId`; clients may call **`cancel_prompt_admission`** while status is still `waiting`. `DaemonClient` refuses to send or **replay** admission-gated requests if the connected daemon lacks the capability (avoids silently dropping `admissionId` after reconnect).
> 
> **`AgentSession`** replaces separate steer/follow-up queue helpers with `_queuePreparedPrompt`, tracks each `agentMessageId` with **delivery** and **completion** deferreds, and exposes **`promptUntilAccepted`** / **`promptAndWait`**. Extension slash commands and queued session commands now settle completion; queue clear/coalesce paths reject pending legs consistently. An **`admissionCommitted`** hook runs at direct-turn ownership commit.
> 
> **`DaemonAgentConnection`** races abort signals against in-flight prompts, issues cancel when needed, and surfaces **`AgentConnectionPromptAdmissionError`** (`cancelled` / `owned` / `unknown` / `unsupported`). Interactive startup prompts use this to skip already-owned admissions, retain uncertain failures as drafts (with **image marker remapping**), and support **`initialPrompts`** with images.
> 
> Smaller fixes: print mode prints slash-command result messages; `wait_for_idle` uses session-level idle wait on the daemon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adaf494cc8374c7e0cbe1fee7d5e294245d86eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cancellable prompt admission protocol to daemon session input handling
> - Introduces a `cancel_prompt_admission` command and admission lifecycle (`waiting → owned → cancelled`) across the daemon, supervisor, and agent connection layers, allowing clients to cancel a prompt before the daemon takes ownership.
> - Bumps `DAEMON_PROTOCOL_VERSION` to 5 and `DAEMON_SCHEMA_REVISION` to 6; adds `session_input_admission` and `prompt_admission_cancellation` server capabilities, now required for prompt/prompt_and_wait/steer/follow_up commands.
> - Adds `AgentConnectionPromptAdmissionError` with statuses `cancelled | owned | unknown | unsupported`, thrown when admission fails or is unsupported by the connected daemon.
> - Extends `AgentSession` with `promptUntilAccepted` and `promptAndWait` public APIs and per-message delivery/completion deferred tracking, replacing the previous single-waiter model.
> - Interactive mode startup prompts now handle `owned` and `unsupported` admission errors: owned prompts are skipped, others are retained as drafts with collision-safe image marker remapping.
> - Risk: protocol version bump is a breaking change for older daemon clients; pending requests that relied on `prompt_admission_cancellation` capability are rejected on reconnect to a downgraded daemon rather than silently replayed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adaf494.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->