### PR TITLE
separate agent and user message queues

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixed cancelled extension commands remaining alive when spawned processes ignored SIGTERM ([#458](https://github.com/PrimeIntellect-ai/prime-agent/pull/458) by [@snimu](https://github.com/snimu)).
 - Fixed OAuth browser launch URLs being interpreted by the system shell.
 - Changed long live session opens to render a bounded recent transcript tail while preserving full prompt history ([#343](https://github.com/PrimeIntellect-ai/prime-agent/pull/343) by [@sethkarten](https://github.com/sethkarten)).
-
+- Fixed queued agent messages being restored into the user editor or cancelled when editing queued user input ([ENG-4775](https://linear.app/primeintellect/issue/ENG-4775/separate-agent-and-user-message-queues)).
 
 ## [0.3.2] - 2026-07-20
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -192,9 +192,9 @@ Submit messages while the agent is working:
 
 - **Enter** queues a *steering* message, delivered after the current assistant turn finishes executing its tool calls
 - **Alt+Enter** queues a *follow-up* message, delivered only after the agent finishes all work
-- **Ctrl+C** interrupts active work and restores queued messages to the editor
+- **Ctrl+C** interrupts active work and restores queued user messages to the editor
 - **Escape** clears the input without interrupting active work
-- **Alt+Up** retrieves queued messages back to editor
+- **Alt+Up** retrieves queued user messages back to editor
 
 On Windows Terminal, `Alt+Enter` is fullscreen by default. Remap it in [docs/terminal-setup.md](docs/terminal-setup.md) so Prime Agent can receive the follow-up shortcut.
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -132,7 +132,7 @@ Use `tab` to cycle through Providers, Models, and MCP Connections, and `escape` 
 |--------|---------|-------------|
 | `app.tools.expand` | `ctrl+o` | Collapse or expand tool output |
 | `app.message.followUp` | `alt+enter` | Queue follow-up message |
-| `app.message.dequeue` | `alt+up` | Restore queued messages to editor |
+| `app.message.dequeue` | `alt+up` | Restore queued user messages to editor |
 
 ### Tree Navigation
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -70,7 +70,7 @@ You can submit messages while the agent is still working:
 - **Alt+Enter** queues a follow-up message, delivered after the agent finishes all work.
 - **Ctrl+C** interrupts the current operation and briefly shows the exit hint; press it again while the hint is visible to exit.
 - **Escape** clears the input bar without interrupting the agent.
-- **Alt+Up** retrieves queued messages back to the editor.
+- **Alt+Up** retrieves queued user messages back to the editor; agent-to-agent messages remain queued.
 
 On Windows Terminal, Alt+Enter is fullscreen by default. Remap it as described in [Terminal setup](terminal-setup.md) if you want Prime Agent to receive the shortcut.
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -276,6 +276,16 @@ export interface RlmChildAgentSnapshot {
 
 export type CompactionReason = "manual" | "threshold" | "overflow" | "requested";
 
+export interface AgentSessionQueueBucket {
+	steering: string[];
+	followUp: string[];
+}
+
+export interface AgentSessionQueueState {
+	user: AgentSessionQueueBucket;
+	agent: AgentSessionQueueBucket;
+}
+
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| AgentEvent
@@ -284,6 +294,7 @@ export type AgentSessionEvent =
 			type: "queue_update";
 			steering: readonly string[];
 			followUp: readonly string[];
+			queue?: AgentSessionQueueState;
 	  }
 	| { type: "compaction_start"; reason: CompactionReason; customInstructions?: string }
 	| { type: "session_info_changed"; name: string | undefined }
@@ -544,6 +555,10 @@ function queuedAgentMessagePreview(message: QueuedSteeringMessage | QueuedFollow
 		return `${AGENT_MESSAGE_RECEIVED_PREVIEW_LABEL}: ${message.message.details.message}`;
 	}
 	return queuedMessagePreview(message);
+}
+
+function isQueuedAgentMessage(message: QueuedSteeringMessage | QueuedFollowUpMessage): boolean {
+	return message.agentMessageId !== undefined;
 }
 
 const IPYTHON_SENT_AGENT_MESSAGE_CUSTOM_ENTRY = "ipython_sent_agent_message";
@@ -1115,6 +1130,7 @@ export class AgentSession {
 			type: "queue_update",
 			steering: this._steeringMessages.map(queuedAgentMessagePreview),
 			followUp: this._followUpMessages.map(queuedAgentMessagePreview),
+			queue: this.getQueueState(),
 		});
 	}
 
@@ -4049,7 +4065,38 @@ export class AgentSession {
 		return { steering, followUp };
 	}
 
-	clearQueuedUserMessagesMatching(predicate: (text: string) => boolean): { steering: string[]; followUp: string[] } {
+	clearUserQueue(): { steering: string[]; followUp: string[] } {
+		const steering = this._steeringMessages.filter((message) => !isQueuedAgentMessage(message));
+		const followUp = this._followUpMessages.filter((message) => !isQueuedAgentMessage(message));
+		if (steering.length === 0 && followUp.length === 0) {
+			return { steering: [], followUp: [] };
+		}
+		const steeringMessages = new Set<AgentMessage>(steering.map((message) => message.message));
+		const followUpMessages = new Set<AgentMessage>(followUp.map((message) => message.message));
+		const removedMessages = new Set(
+			this.agent.removeQueuedMessages((message) => steeringMessages.has(message) || followUpMessages.has(message)),
+		);
+		const removedSteering = steering.filter((message) => removedMessages.has(message.message));
+		const removedFollowUp = followUp.filter((message) => removedMessages.has(message.message));
+		const removedSteeringMessages = new Set(removedSteering.map((message) => message.message));
+		const removedFollowUpMessages = new Set(removedFollowUp.map((message) => message.message));
+		this._steeringMessages = this._steeringMessages.filter(
+			(message) => !removedSteeringMessages.has(message.message),
+		);
+		this._followUpMessages = this._followUpMessages.filter(
+			(message) => !removedFollowUpMessages.has(message.message),
+		);
+		this._emitQueueUpdate();
+		return {
+			steering: removedSteering.map((message) => message.text),
+			followUp: removedFollowUp.map((message) => message.text),
+		};
+	}
+
+	clearQueuedAgentMessagesMatching(predicate: (text: string) => boolean): {
+		steering: string[];
+		followUp: string[];
+	} {
 		const steering = this._steeringMessages.filter(
 			(message) => message.agentMessageId !== undefined && predicate(message.text),
 		);
@@ -4129,6 +4176,23 @@ export class AgentSession {
 
 	getFollowUpMessagePreviews(): readonly string[] {
 		return this._followUpMessages.map(queuedAgentMessagePreview);
+	}
+
+	getQueueState(): AgentSessionQueueState {
+		return {
+			user: {
+				steering: this._steeringMessages
+					.filter((message) => !isQueuedAgentMessage(message))
+					.map(queuedAgentMessagePreview),
+				followUp: this._followUpMessages
+					.filter((message) => !isQueuedAgentMessage(message))
+					.map(queuedAgentMessagePreview),
+			},
+			agent: {
+				steering: this._steeringMessages.filter(isQueuedAgentMessage).map(queuedAgentMessagePreview),
+				followUp: this._followUpMessages.filter(isQueuedAgentMessage).map(queuedAgentMessagePreview),
+			},
+		};
 	}
 
 	getSteeringQueueSnapshots(): readonly QueuedAgentInputSnapshot[] {

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -119,7 +119,7 @@ export const KEYBINDINGS = {
 	},
 	"app.message.dequeue": {
 		defaultKeys: "alt+up",
-		description: "Restore queued messages",
+		description: "Restore queued user messages",
 	},
 	"app.clipboard.pasteImage": {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -273,6 +273,7 @@ export {
 	type AgentConnectionExtensionUiResponse,
 	type AgentConnectionModel,
 	type AgentConnectionModelCycleResult,
+	type AgentConnectionQueueBucket,
 	type AgentConnectionQueueState,
 	type AgentConnectionResourceSnapshot,
 	type AgentConnectionRlmChildAgentSnapshot,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -31,6 +31,7 @@ import {
 	type DaemonCommand,
 	type DaemonEventCursor,
 	type DaemonOutbound,
+	type DaemonQueueState,
 	type DaemonReplayInfo,
 	type DaemonSessionClosedReason,
 	type DaemonSessionSnapshot,
@@ -58,6 +59,7 @@ import type {
 	AgentConnectionNavigateTreeResult,
 	AgentConnectionNewSessionOptions,
 	AgentConnectionPromptOptions,
+	AgentConnectionQueueBucket,
 	AgentConnectionQueueMode,
 	AgentConnectionQueueState,
 	AgentConnectionResourceSnapshot,
@@ -81,6 +83,19 @@ import type {
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
 type DaemonSnapshotBegin = Extract<DaemonOutbound, { type: "session_snapshot_begin" }>;
+
+function normalizeDaemonQueueState(queue: DaemonQueueState): AgentConnectionQueueState {
+	if (queue.queue) {
+		return {
+			user: { steering: [...queue.queue.user.steering], followUp: [...queue.queue.user.followUp] },
+			agent: { steering: [...queue.queue.agent.steering], followUp: [...queue.queue.agent.followUp] },
+		};
+	}
+	return {
+		user: { steering: [...queue.steering], followUp: [...queue.followUp] },
+		agent: { steering: [], followUp: [] },
+	};
+}
 
 interface DaemonSnapshotAssembly {
 	begin?: DaemonSnapshotBegin;
@@ -485,22 +500,23 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async getQueue(): Promise<AgentConnectionQueueState> {
-		return this.requestData<AgentConnectionQueueState>({
+		const queue = await this.requestData<DaemonQueueState>({
 			type: "get_queue",
 			activeSessionId: this.activeSessionId,
 		});
+		return normalizeDaemonQueueState(queue);
 	}
 
-	async clearQueue(): Promise<AgentConnectionQueueState> {
-		return this.requestData<AgentConnectionQueueState>({
+	async clearQueue(): Promise<AgentConnectionQueueBucket> {
+		return this.requestData<AgentConnectionQueueBucket>({
 			type: "clear_queue",
 			activeSessionId: this.activeSessionId,
 		});
 	}
 
-	async abortAndClearQueue(): Promise<AgentConnectionQueueState> {
+	async abortAndClearQueue(): Promise<AgentConnectionQueueBucket> {
 		try {
-			return await this.requestData<AgentConnectionQueueState>({
+			return await this.requestData<AgentConnectionQueueBucket>({
 				type: "abort_and_clear_queue",
 				activeSessionId: this.activeSessionId,
 			});
@@ -510,6 +526,24 @@ export class DaemonAgentConnection implements AgentConnection {
 			}
 			throw error;
 		}
+	}
+
+	async clearUserQueue(): Promise<AgentConnectionQueueBucket> {
+		const type = this.client.supportsServerCapability("separate_message_queues") ? "clear_user_queue" : "clear_queue";
+		return this.requestData<AgentConnectionQueueBucket>({
+			type,
+			activeSessionId: this.activeSessionId,
+		});
+	}
+
+	async abortAndClearUserQueue(): Promise<AgentConnectionQueueBucket> {
+		const type = this.client.supportsServerCapability("separate_message_queues")
+			? "abort_and_clear_user_queue"
+			: "abort_and_clear_queue";
+		return this.requestData<AgentConnectionQueueBucket>({
+			type,
+			activeSessionId: this.activeSessionId,
+		});
 	}
 
 	async listCronJobs(options: { includeInactive?: boolean } = {}): Promise<AgentCronJob[]> {
@@ -1338,7 +1372,11 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (message.type === "session_event") {
 			this.observeStreamingMessage(message.event);
 			this.latestSnapshotIsFresh = false;
-			await this.emit({ type: "session_event", event: message.event });
+			const event =
+				message.event.type === "queue_update" && !message.event.queue
+					? { ...message.event, queue: normalizeDaemonQueueState(message.event) }
+					: message.event;
+			await this.emit({ type: "session_event", event });
 			return;
 		}
 		if (message.type === "side_question_event") {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -186,18 +186,29 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async getQueue(): Promise<AgentConnectionQueueState> {
+		const queue = this.session.getQueueState();
 		return {
-			steering: [...this.session.getSteeringMessagePreviews()],
-			followUp: [...this.session.getFollowUpMessagePreviews()],
+			user: { steering: [...queue.user.steering], followUp: [...queue.user.followUp] },
+			agent: { steering: [...queue.agent.steering], followUp: [...queue.agent.followUp] },
 		};
 	}
 
-	async clearQueue(): Promise<AgentConnectionQueueState> {
+	async clearQueue(): Promise<AgentConnectionQueueState["user"]> {
 		return this.session.clearQueue();
 	}
 
-	async abortAndClearQueue(): Promise<AgentConnectionQueueState> {
+	async abortAndClearQueue(): Promise<AgentConnectionQueueState["user"]> {
 		const queue = this.session.clearQueue();
+		this.session.requestAbort();
+		return queue;
+	}
+
+	async clearUserQueue(): Promise<AgentConnectionQueueState["user"]> {
+		return this.session.clearUserQueue();
+	}
+
+	async abortAndClearUserQueue(): Promise<AgentConnectionQueueState["user"]> {
+		const queue = this.session.clearUserQueue();
 		this.session.requestAbort();
 		return queue;
 	}

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -28,6 +28,7 @@ export type {
 	AgentConnectionNewSessionOptions,
 	AgentConnectionParentMetadata,
 	AgentConnectionPromptOptions,
+	AgentConnectionQueueBucket,
 	AgentConnectionQueueMode,
 	AgentConnectionQueueState,
 	AgentConnectionReplayInfo,

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -473,9 +473,14 @@ export interface AgentConnectionUserMessage {
 	text: string;
 }
 
-export interface AgentConnectionQueueState {
+export interface AgentConnectionQueueBucket {
 	steering: string[];
 	followUp: string[];
+}
+
+export interface AgentConnectionQueueState {
+	user: AgentConnectionQueueBucket;
+	agent: AgentConnectionQueueBucket;
 }
 
 export interface AgentConnectionHeartbeat {
@@ -531,6 +536,7 @@ export type AgentConnectionSessionEvent =
 			type: "queue_update";
 			steering: readonly string[];
 			followUp: readonly string[];
+			queue?: AgentConnectionQueueState;
 	  }
 	| {
 			type: "compaction_start";
@@ -605,8 +611,10 @@ export interface AgentConnection {
 		callbacks?: AgentConnectionSessionListCallbacks,
 	): Promise<AgentConnectionSavedSessionInfo[]>;
 	getQueue(): Promise<AgentConnectionQueueState>;
-	clearQueue(): Promise<AgentConnectionQueueState>;
-	abortAndClearQueue(): Promise<AgentConnectionQueueState>;
+	clearQueue(): Promise<AgentConnectionQueueBucket>;
+	abortAndClearQueue(): Promise<AgentConnectionQueueBucket>;
+	clearUserQueue(): Promise<AgentConnectionQueueBucket>;
+	abortAndClearUserQueue(): Promise<AgentConnectionQueueBucket>;
 	listCronJobs(options?: { includeInactive?: boolean }): Promise<AgentCronJob[]>;
 	listHeartbeats(): Promise<AgentConnectionHeartbeat[]>;
 	manageHeartbeat(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -243,6 +243,8 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_queue",
 	"clear_queue",
 	"abort_and_clear_queue",
+	"clear_user_queue",
+	"abort_and_clear_user_queue",
 	"cron_list",
 	"heartbeats_list",
 	"heartbeat_manage",
@@ -2983,7 +2985,7 @@ export class AgentDaemon {
 				const state = this.getSessionState(command.activeSessionId);
 				const cleared = await this.withAgentMessageTargetLock(state.activeSessionId, async () => {
 					this.agentMessageRateLimiter.clearMatching((key) => key.endsWith(`->${state.activeSessionId}`));
-					return state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt);
+					return state.runtime.session.clearQueuedAgentMessagesMatching(isAgentSessionMessagePrompt);
 				});
 				return success(command.id, "agent_messages_clear", cleared);
 			}
@@ -3165,6 +3167,7 @@ export class AgentDaemon {
 				return success(command.id, "get_queue", {
 					steering: [...state.runtime.session.getSteeringMessagePreviews()],
 					followUp: [...state.runtime.session.getFollowUpMessagePreviews()],
+					queue: state.runtime.session.getQueueState(),
 				});
 			}
 
@@ -3178,6 +3181,18 @@ export class AgentDaemon {
 				const queue = state.runtime.session.clearQueue();
 				state.runtime.session.requestAbort();
 				return success(command.id, "abort_and_clear_queue", queue);
+			}
+
+			case "clear_user_queue": {
+				const state = this.getSessionState(command.activeSessionId);
+				return success(command.id, "clear_user_queue", state.runtime.session.clearUserQueue());
+			}
+
+			case "abort_and_clear_user_queue": {
+				const state = this.getSessionState(command.activeSessionId);
+				const queue = state.runtime.session.clearUserQueue();
+				state.runtime.session.requestAbort();
+				return success(command.id, "abort_and_clear_user_queue", queue);
 			}
 
 			case "cron_list": {
@@ -3883,7 +3898,7 @@ export class AgentDaemon {
 
 	private async clearQueuedAgentSessionMessagesForState(state: ActiveSessionState) {
 		return this.withAgentMessageTargetLock(state.activeSessionId, async () =>
-			state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt),
+			state.runtime.session.clearQueuedAgentMessagesMatching(isAgentSessionMessagePrompt),
 		);
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -23,6 +23,7 @@ import type {
 	AgentConnectionAgentStatus,
 	AgentConnectionHeartbeat,
 	AgentConnectionQueueMode,
+	AgentConnectionQueueState,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionRlmChildAgentSnapshot,
 	AgentConnectionSavedSessionScope,
@@ -49,8 +50,8 @@ import type { SessionSummary } from "./daemon-session-list.js";
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
 export const DAEMON_PROTOCOL_VERSION = 4;
 export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 2;
-export const DAEMON_SCHEMA_REVISION = 2;
-export const DAEMON_SCHEMA_ID = "protocol-4-schema-2-cbdbe20e7ce4";
+export const DAEMON_SCHEMA_REVISION = 3;
+export const DAEMON_SCHEMA_ID = "protocol-4-schema-3-2a9d89cdc4e1";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -73,7 +74,8 @@ export type DaemonServerCapability =
 	| DaemonClientCapability
 	| "heartbeat_catalog"
 	| "heartbeat_management"
-	| "model_catalog";
+	| "model_catalog"
+	| "separate_message_queues";
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
 export interface DaemonProtocolInfo {
@@ -105,7 +107,14 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"heartbeat_catalog",
 	"heartbeat_management",
 	"model_catalog",
+	"separate_message_queues",
 ];
+
+export interface DaemonQueueState {
+	steering: readonly string[];
+	followUp: readonly string[];
+	queue?: AgentConnectionQueueState;
+}
 
 export interface DaemonRuntimeIdentity {
 	buildId: string;
@@ -472,6 +481,8 @@ export type DaemonCommand =
 	| { id?: string; type: "get_queue"; activeSessionId: string }
 	| { id?: string; type: "clear_queue"; activeSessionId: string }
 	| { id?: string; type: "abort_and_clear_queue"; activeSessionId: string }
+	| { id?: string; type: "clear_user_queue"; activeSessionId: string }
+	| { id?: string; type: "abort_and_clear_user_queue"; activeSessionId: string }
 	| { id?: string; type: "cron_list"; activeSessionId?: string; includeInactive?: boolean }
 	| { id?: string; type: "heartbeats_list"; activeSessionId?: string }
 	| {
@@ -578,6 +589,10 @@ const CLIENT_OWNED_DAEMON_COMMAND = {
 	minProtocol: DAEMON_PROTOCOL_VERSION,
 	capability: "client_owned_sessions",
 } as const;
+const SEPARATE_MESSAGE_QUEUES_DAEMON_COMMAND = {
+	minProtocol: DAEMON_PROTOCOL_VERSION,
+	capability: "separate_message_queues",
+} as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
@@ -624,6 +639,8 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	get_queue: LEGACY_DAEMON_COMMAND,
 	clear_queue: LEGACY_DAEMON_COMMAND,
 	abort_and_clear_queue: LEGACY_DAEMON_COMMAND,
+	clear_user_queue: SEPARATE_MESSAGE_QUEUES_DAEMON_COMMAND,
+	abort_and_clear_user_queue: SEPARATE_MESSAGE_QUEUES_DAEMON_COMMAND,
 	cron_list: LEGACY_DAEMON_COMMAND,
 	heartbeats_list: { minProtocol: 3, capability: "heartbeat_catalog" },
 	heartbeat_manage: { minProtocol: 3, capability: "heartbeat_management" },

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -153,6 +153,8 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_queue",
 	"clear_queue",
 	"abort_and_clear_queue",
+	"clear_user_queue",
+	"abort_and_clear_user_queue",
 	"cron_list",
 	"heartbeats_list",
 	"heartbeat_manage",

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -11,6 +11,7 @@ export type {
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionModel,
 	AgentConnectionModelCycleResult,
+	AgentConnectionQueueBucket,
 	AgentConnectionQueueState,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionRlmChildAgentSnapshot,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -955,7 +955,10 @@ export class InteractiveMode {
 
 	// Messages queued while compaction is running
 	private compactionQueuedMessages: CompactionQueuedMessage[] = [];
-	private connectionQueue: AgentConnectionQueueState = { steering: [], followUp: [] };
+	private connectionQueue: AgentConnectionQueueState = {
+		user: { steering: [], followUp: [] },
+		agent: { steering: [], followUp: [] },
+	};
 
 	// Shutdown state
 	private shutdownRequested = false;
@@ -1316,7 +1319,7 @@ export class InteractiveMode {
 						hint("app.prompt.stash", "to stash prompt"),
 						rawKeyHint("/", "for commands"),
 						hint("app.message.followUp", "to queue follow-up"),
-						hint("app.message.dequeue", "to edit all queued messages"),
+						hint("app.message.dequeue", "to edit queued user messages"),
 						hint("app.clipboard.pasteImage", "to paste image"),
 						rawKeyHint("drop files", "to attach"),
 					].join("\n")
@@ -2686,7 +2689,10 @@ export class InteractiveMode {
 		this.pendingMessagesContainer.clear();
 		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
-		this.connectionQueue = { steering: [], followUp: [] };
+		this.connectionQueue = {
+			user: { steering: [], followUp: [] },
+			agent: { steering: [], followUp: [] },
+		};
 		if (options?.clearPromptStash) {
 			this.promptStash = undefined;
 		}
@@ -4096,7 +4102,7 @@ export class InteractiveMode {
 		for (const msg of this.compactionQueuedMessages) {
 			add(msg.text);
 		}
-		for (const msg of [...this.connectionQueue.steering, ...this.connectionQueue.followUp]) {
+		for (const msg of [...this.connectionQueue.user.steering, ...this.connectionQueue.user.followUp]) {
 			add(msg);
 		}
 		return ids;
@@ -4797,9 +4803,9 @@ export class InteractiveMode {
 				break;
 
 			case "queue_update":
-				this.connectionQueue = {
-					steering: [...event.steering],
-					followUp: [...event.followUp],
+				this.connectionQueue = event.queue ?? {
+					user: { steering: [...event.steering], followUp: [...event.followUp] },
+					agent: { steering: [], followUp: [] },
 				};
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
@@ -6582,9 +6588,9 @@ export class InteractiveMode {
 	private async handleDequeue(): Promise<void> {
 		const restored = await this.restoreQueuedMessagesToEditor();
 		if (restored === 0) {
-			this.showStatus("No queued messages to restore");
+			this.showStatus("No queued user messages to restore");
 		} else {
-			this.showStatus(`Restored ${restored} queued message${restored > 1 ? "s" : ""} to editor`);
+			this.showStatus(`Restored ${restored} queued user message${restored > 1 ? "s" : ""} to editor`);
 		}
 	}
 
@@ -6781,30 +6787,33 @@ export class InteractiveMode {
 	 * Get all queued messages (read-only).
 	 * Combines session queue and compaction queue.
 	 */
-	private getAllQueuedMessages(): { steering: string[]; followUp: string[] } {
+	private getAllQueuedUserMessages(): { steering: string[]; followUp: string[] } {
 		return {
 			steering: [
-				...this.connectionQueue.steering,
+				...this.connectionQueue.user.steering,
 				...this.compactionQueuedMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text),
 			],
 			followUp: [
-				...this.connectionQueue.followUp,
+				...this.connectionQueue.user.followUp,
 				...this.compactionQueuedMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text),
 			],
 		};
 	}
 
 	/**
-	 * Clear all queued messages and return their contents.
-	 * Clears both session queue and compaction queue.
+	 * Clear queued user messages and return their contents.
+	 * Agent messages remain queued for delivery.
 	 */
-	private async clearAllQueues(
+	private async clearUserQueues(
 		options: { abort?: boolean } = {},
 	): Promise<{ steering: string[]; followUp: string[] }> {
 		const { steering, followUp } = options.abort
-			? await this.agentConnection.abortAndClearQueue()
-			: await this.agentConnection.clearQueue();
-		this.connectionQueue = { steering: [], followUp: [] };
+			? await this.agentConnection.abortAndClearUserQueue()
+			: await this.agentConnection.clearUserQueue();
+		this.connectionQueue = {
+			...this.connectionQueue,
+			user: { steering: [], followUp: [] },
+		};
 		const compactionSteering = this.compactionQueuedMessages
 			.filter((msg) => msg.mode === "steer")
 			.map((msg) => msg.text);
@@ -6829,20 +6838,26 @@ export class InteractiveMode {
 		// Queued steering/follow-up previews are future turns, so they render in
 		// their own container below the execution indicator and recap.
 		this.queuedMessagesContainer.clear();
-		const { steering: steeringMessages, followUp: followUpMessages } = this.getAllQueuedMessages();
-		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
+		const { steering: userSteering, followUp: userFollowUp } = this.getAllQueuedUserMessages();
+		const { steering: agentSteering, followUp: agentFollowUp } = this.connectionQueue.agent;
+		if (userSteering.length > 0 || userFollowUp.length > 0 || agentSteering.length > 0 || agentFollowUp.length > 0) {
 			this.queuedMessagesContainer.addChild(new Spacer(1));
-			for (const message of steeringMessages) {
+			for (const message of userSteering) {
 				const text = theme.fg("dim", formatQueuedMessagePreview(message, "Steering"));
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
-			for (const message of followUpMessages) {
+			for (const message of userFollowUp) {
 				const text = theme.fg("dim", formatQueuedMessagePreview(message, "Follow-up"));
 				this.queuedMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
-			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");
-			const hintText = theme.fg("dim", `╰─ ${dequeueHint} to edit all queued messages`);
-			this.queuedMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
+			for (const message of [...agentSteering, ...agentFollowUp]) {
+				this.queuedMessagesContainer.addChild(new TruncatedText(theme.fg("dim", message), 1, 0));
+			}
+			if (userSteering.length > 0 || userFollowUp.length > 0) {
+				const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");
+				const hintText = theme.fg("dim", `╰─ ${dequeueHint} to edit queued user messages`);
+				this.queuedMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
+			}
 		}
 	}
 
@@ -6856,7 +6871,7 @@ export class InteractiveMode {
 	}
 
 	private async restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): Promise<number> {
-		const { steering, followUp } = await this.clearAllQueues({ abort: options?.abort });
+		const { steering, followUp } = await this.clearUserQueues({ abort: options?.abort });
 		const allQueued = [...steering, ...followUp];
 		if (allQueued.length === 0) {
 			this.updatePendingMessagesDisplay();
@@ -6903,8 +6918,11 @@ export class InteractiveMode {
 		this.updatePendingMessagesDisplay();
 
 		const restoreQueue = async (error: unknown) => {
-			await this.agentConnection.clearQueue().catch(() => undefined);
-			this.connectionQueue = { steering: [], followUp: [] };
+			await this.agentConnection.clearUserQueue().catch(() => undefined);
+			this.connectionQueue = {
+				...this.connectionQueue,
+				user: { steering: [], followUp: [] },
+			};
 			this.compactionQueuedMessages = queuedMessages;
 			this.updatePendingMessagesDisplay();
 			this.showError(
@@ -9334,7 +9352,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 | \`${externalEditor}\` | Edit message in external editor |
 | \`${promptStash}\` | Stash or restore draft prompt |
 | \`${followUp}\` | Queue follow-up message |
-| \`${dequeue}\` | Restore queued messages |
+| \`${dequeue}\` | Restore queued user messages |
 | \`${pasteImage}\` | Paste image from clipboard |
 | \`/\` | Slash commands |
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -45,7 +45,6 @@ class FakeDaemonClient {
 	connectionStateGate: Promise<void> | undefined;
 	connectionStateFactory: ((activeSessionId: string) => AgentConnectionState) | undefined;
 	abortBashUnknownCommand = false;
-	abortAndClearQueueUnknownCommand = false;
 	cronAddGate: Promise<void> | undefined;
 	legacyHeartbeatCommandsSupported = false;
 	serverCapabilities = new Set<string>();
@@ -99,7 +98,21 @@ class FakeDaemonClient {
 					type: "response",
 					command: command.type,
 					success: true,
-					data: { steering: ["steer"], followUp: ["follow"] },
+					data: {
+						steering: ["steer", "Agent message received: inspect"],
+						followUp: ["follow"],
+						...(this.serverCapabilities.has("separate_message_queues")
+							? {
+									queue: {
+										user: { steering: ["steer"], followUp: ["follow"] },
+										agent: {
+											steering: ["Agent message received: inspect"],
+											followUp: [],
+										},
+									},
+								}
+							: {}),
+					},
 				};
 			case "get_connection_state":
 				await this.connectionStateGate;
@@ -226,19 +239,25 @@ class FakeDaemonClient {
 					data: { steering: ["cleared"], followUp: [] },
 				};
 			case "abort_and_clear_queue":
-				if (this.abortAndClearQueueUnknownCommand) {
-					return {
-						type: "response",
-						command: command.type,
-						success: false,
-						error: "Unknown daemon command: abort_and_clear_queue",
-					};
-				}
 				return {
 					type: "response",
 					command: command.type,
 					success: true,
 					data: { steering: ["aborted"], followUp: ["cleared"] },
+				};
+			case "clear_user_queue":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: { steering: ["user-cleared"], followUp: [] },
+				};
+			case "abort_and_clear_user_queue":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: { steering: ["user-aborted"], followUp: ["user-cleared"] },
 				};
 			case "heartbeats_list":
 				return this.legacyHeartbeatCommandsSupported || this.serverCapabilities.has("heartbeat_catalog")
@@ -2018,9 +2037,15 @@ describe("DaemonAgentConnection", () => {
 		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
 		await connection.attach();
 
-		await expect(connection.getQueue()).resolves.toEqual({ steering: ["steer"], followUp: ["follow"] });
-		await expect(connection.clearQueue()).resolves.toEqual({ steering: ["cleared"], followUp: [] });
-		await expect(connection.abortAndClearQueue()).resolves.toEqual({ steering: ["aborted"], followUp: ["cleared"] });
+		await expect(connection.getQueue()).resolves.toEqual({
+			user: { steering: ["steer", "Agent message received: inspect"], followUp: ["follow"] },
+			agent: { steering: [], followUp: [] },
+		});
+		await expect(connection.clearUserQueue()).resolves.toEqual({ steering: ["cleared"], followUp: [] });
+		await expect(connection.abortAndClearUserQueue()).resolves.toEqual({
+			steering: ["aborted"],
+			followUp: ["cleared"],
+		});
 		await connection.waitForIdle();
 		const model = getModel("anthropic", "claude-sonnet-4-5");
 		if (!model) {
@@ -2045,11 +2070,29 @@ describe("DaemonAgentConnection", () => {
 			activeSessionId: "active-1",
 			scopedModels: [{ model, thinkingLevel: "high" }],
 		});
+	});
 
-		fakeClient.abortAndClearQueueUnknownCommand = true;
-		await expect(connection.abortAndClearQueue()).rejects.toThrow(
-			"the daemon is running an older build; restart the daemon and try again",
-		);
+	it("uses separated queue commands when the daemon advertises support", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("separate_message_queues");
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		await connection.attach();
+
+		await expect(connection.getQueue()).resolves.toEqual({
+			user: { steering: ["steer"], followUp: ["follow"] },
+			agent: { steering: ["Agent message received: inspect"], followUp: [] },
+		});
+		await expect(connection.clearUserQueue()).resolves.toEqual({ steering: ["user-cleared"], followUp: [] });
+		await expect(connection.abortAndClearUserQueue()).resolves.toEqual({
+			steering: ["user-aborted"],
+			followUp: ["user-cleared"],
+		});
+		expect(fakeClient.requests.map((request) => request.type)).toEqual([
+			"attach",
+			"get_queue",
+			"clear_user_queue",
+			"abort_and_clear_user_queue",
+		]);
 	});
 
 	it("cancels rlm child runs through the daemon protocol", async () => {
@@ -2288,6 +2331,10 @@ describe("DaemonAgentConnection", () => {
 					type: "queue_update",
 					steering: ["interrupt"],
 					followUp: ["later"],
+					queue: {
+						user: { steering: ["interrupt"], followUp: ["later"] },
+						agent: { steering: [], followUp: [] },
+					},
 				},
 			},
 		]);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -955,7 +955,7 @@ describe("daemon mode helpers", () => {
 					prompt: vi.fn(async () => {}),
 					followUp: vi.fn(async () => true),
 					clearQueue: vi.fn(() => ({ cleared: 0 })),
-					clearQueuedUserMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
+					clearQueuedAgentMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
 				},
 			} as never;
 		}
@@ -1024,7 +1024,7 @@ describe("daemon mode helpers", () => {
 		const targetState = makeState("target");
 		const agentMessageText =
 			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_test\n\nhello";
-		const clearQueuedUserMessagesMatching = vi.fn((predicate: (text: string) => boolean) => ({
+		const clearQueuedAgentMessagesMatching = vi.fn((predicate: (text: string) => boolean) => ({
 			steering: [agentMessageText].filter(predicate),
 			followUp: [],
 		}));
@@ -1037,7 +1037,7 @@ describe("daemon mode helpers", () => {
 				sessionName: "Target",
 				isStreaming: false,
 				pendingMessageCount: 2,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessagesMatching,
 				clearQueue,
 			},
 		} as never;
@@ -1053,8 +1053,8 @@ describe("daemon mode helpers", () => {
 			activeSessionId: targetState.activeSessionId,
 		});
 
-		expect(clearQueuedUserMessagesMatching).toHaveBeenCalledOnce();
-		const predicate = clearQueuedUserMessagesMatching.mock.calls[0]?.[0];
+		expect(clearQueuedAgentMessagesMatching).toHaveBeenCalledOnce();
+		const predicate = clearQueuedAgentMessagesMatching.mock.calls[0]?.[0];
 		expect(predicate?.(agentMessageText)).toBe(true);
 		expect(predicate?.("ordinary queued follow-up")).toBe(false);
 		expect(clearQueue).not.toHaveBeenCalled();
@@ -1071,7 +1071,7 @@ describe("daemon mode helpers", () => {
 		const secondState = makeState("target-2");
 		const firstClear = vi.fn(() => ({ steering: [], followUp: ["agent message"] }));
 		const secondClear = vi.fn(() => ({ steering: ["agent message"], followUp: [] }));
-		for (const [state, clearQueuedUserMessagesMatching] of [
+		for (const [state, clearQueuedAgentMessagesMatching] of [
 			[firstState, firstClear],
 			[secondState, secondClear],
 		] as const) {
@@ -1083,7 +1083,7 @@ describe("daemon mode helpers", () => {
 					sessionName: state.activeSessionId,
 					isStreaming: false,
 					pendingMessageCount: 1,
-					clearQueuedUserMessagesMatching,
+					clearQueuedAgentMessagesMatching,
 				},
 			} as never;
 		}
@@ -1123,7 +1123,7 @@ describe("daemon mode helpers", () => {
 				}),
 		);
 		const readyClear = vi.fn(() => ({ steering: [], followUp: ["agent message"] }));
-		for (const [state, clearQueuedUserMessagesMatching] of [
+		for (const [state, clearQueuedAgentMessagesMatching] of [
 			[blockedState, blockedClear],
 			[readyState, readyClear],
 		] as const) {
@@ -1135,7 +1135,7 @@ describe("daemon mode helpers", () => {
 					sessionName: state.activeSessionId,
 					isStreaming: false,
 					pendingMessageCount: 1,
-					clearQueuedUserMessagesMatching,
+					clearQueuedAgentMessagesMatching,
 				},
 			} as never;
 		}
@@ -1246,7 +1246,7 @@ describe("daemon mode helpers", () => {
 				isStreaming: true,
 				pendingMessageCount: 19,
 				clearQueue: vi.fn(() => ({ cleared: 0 })),
-				clearQueuedUserMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
+				clearQueuedAgentMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
 				queueAgentMessagePrompt,
 				prompt: vi.fn(async () => {}),
 			},
@@ -2535,7 +2535,7 @@ describe("daemon mode helpers", () => {
 				});
 			},
 		);
-		const clearQueuedUserMessagesMatching = vi.fn(() => ({ steering: [], followUp: [] }));
+		const clearQueuedAgentMessagesMatching = vi.fn(() => ({ steering: [], followUp: [] }));
 		targetState.runtime = {
 			...targetState.runtime,
 			cwd: "/tmp",
@@ -2545,7 +2545,7 @@ describe("daemon mode helpers", () => {
 				isStreaming: false,
 				pendingMessageCount: 0,
 				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessagesMatching,
 			},
 		} as never;
 		const internals = daemon as unknown as {
@@ -2573,12 +2573,12 @@ describe("daemon mode helpers", () => {
 			activeSessionId: targetState.activeSessionId,
 		});
 		await Promise.resolve();
-		expect(clearQueuedUserMessagesMatching).not.toHaveBeenCalled();
+		expect(clearQueuedAgentMessagesMatching).not.toHaveBeenCalled();
 
 		resolvePrompt();
 		await send;
 		await clear;
-		expect(clearQueuedUserMessagesMatching).toHaveBeenCalledOnce();
+		expect(clearQueuedAgentMessagesMatching).toHaveBeenCalledOnce();
 	});
 
 	it("rejects agent messages when pause wins the target lock", async () => {
@@ -2590,7 +2590,7 @@ describe("daemon mode helpers", () => {
 		});
 		const targetState = makeState("target");
 		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
+		const clearQueuedAgentMessagesMatching = vi.fn(
 			() =>
 				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
 					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
@@ -2606,7 +2606,7 @@ describe("daemon mode helpers", () => {
 				isStreaming: false,
 				pendingMessageCount: 0,
 				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessagesMatching,
 			},
 		} as never;
 		const internals = daemon as unknown as {
@@ -2650,7 +2650,7 @@ describe("daemon mode helpers", () => {
 		});
 		const targetState = makeState("target");
 		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
+		const clearQueuedAgentMessagesMatching = vi.fn(
 			() =>
 				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
 					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
@@ -2666,7 +2666,7 @@ describe("daemon mode helpers", () => {
 				isStreaming: false,
 				pendingMessageCount: 0,
 				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessagesMatching,
 			},
 		} as never;
 		const internals = daemon as unknown as {
@@ -2712,7 +2712,7 @@ describe("daemon mode helpers", () => {
 		const targetState = makeState("target");
 		targetState.extensionUiRequests = new Map();
 		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
+		const clearQueuedAgentMessagesMatching = vi.fn(
 			() =>
 				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
 					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
@@ -2732,7 +2732,7 @@ describe("daemon mode helpers", () => {
 				pendingMessageCount: 0,
 				messages: [],
 				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessagesMatching,
 				abort: vi.fn(async () => {}),
 				dispose: vi.fn(),
 				sessionManager: { appendSessionState: vi.fn(), hasUserContent: () => true },

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -66,6 +66,18 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("model_catalog");
 	});
 
+	it("capability-gates separated message queue mutation", () => {
+		expect(DAEMON_COMMAND_COMPATIBILITY.clear_user_queue).toEqual({
+			minProtocol: DAEMON_PROTOCOL_VERSION,
+			capability: "separate_message_queues",
+		});
+		expect(DAEMON_COMMAND_COMPATIBILITY.abort_and_clear_user_queue).toEqual({
+			minProtocol: DAEMON_PROTOCOL_VERSION,
+			capability: "separate_message_queues",
+		});
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("separate_message_queues");
+	});
+
 	it("creates versioned command and event envelopes", () => {
 		const command = { id: "cmd-1", type: "attach", activeSessionId: "active-1" } as const;
 		const commandEnvelope = createDaemonCommandEnvelope(command, "cmd-1", "client-1");

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -25,12 +25,15 @@ type FakeInteractiveMode = {
 		isBashRunning: boolean;
 		retryAttempt: number;
 	};
-	connectionQueue: { steering: string[]; followUp: string[] };
+	connectionQueue: {
+		user: { steering: string[]; followUp: string[] };
+		agent: { steering: string[]; followUp: string[] };
+	};
 	compactionQueuedMessages: Array<{ text: string; mode: "steer" | "followUp" }>;
 	agentConnection: {
 		abort: Mock;
-		clearQueue: Mock;
-		abortAndClearQueue: Mock;
+		clearUserQueue: Mock;
+		abortAndClearUserQueue: Mock;
 		abortRetry: Mock;
 		abortCompaction: Mock;
 		abortBranchSummary: Mock;
@@ -95,12 +98,15 @@ function createInteractiveFake(options: {
 			isBashRunning: options.bashRunning ?? false,
 			retryAttempt: options.retryAttempt ?? 0,
 		},
-		connectionQueue: { steering: [], followUp: [] },
+		connectionQueue: {
+			user: { steering: [], followUp: [] },
+			agent: { steering: [], followUp: [] },
+		},
 		compactionQueuedMessages: [],
 		agentConnection: {
 			abort: vi.fn().mockResolvedValue(undefined),
-			clearQueue: vi.fn().mockResolvedValue({ steering: [], followUp: [] }),
-			abortAndClearQueue: vi.fn().mockResolvedValue({ steering: [], followUp: [] }),
+			clearUserQueue: vi.fn().mockResolvedValue({ steering: [], followUp: [] }),
+			abortAndClearUserQueue: vi.fn().mockResolvedValue({ steering: [], followUp: [] }),
 			abortRetry: vi.fn(),
 			abortCompaction: vi.fn(),
 			abortBranchSummary: vi.fn(),
@@ -169,7 +175,8 @@ describe("InteractiveMode interrupt shortcuts", () => {
 
 	it("restores queued messages through the atomic abort-and-clear path", async () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
-		mode.agentConnection.abortAndClearQueue.mockResolvedValue({
+		mode.connectionQueue.agent.followUp = ["Agent message received: keep working"];
+		mode.agentConnection.abortAndClearUserQueue.mockResolvedValue({
 			steering: ["steer"],
 			followUp: ["follow"],
 		});
@@ -178,10 +185,11 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		const restored = await restoreQueuedMessagesToEditor.call(mode, { abort: true });
 
 		expect(restored).toBe(2);
-		expect(mode.agentConnection.abortAndClearQueue).toHaveBeenCalledTimes(1);
-		expect(mode.agentConnection.clearQueue).not.toHaveBeenCalled();
+		expect(mode.agentConnection.abortAndClearUserQueue).toHaveBeenCalledTimes(1);
+		expect(mode.agentConnection.clearUserQueue).not.toHaveBeenCalled();
 		expect(mode.agentConnection.abort).not.toHaveBeenCalled();
 		expect(mode.editor.getText()).toBe("steer\n\nfollow\n\ndraft");
+		expect(mode.connectionQueue.agent.followUp).toEqual(["Agent message received: keep working"]);
 	});
 
 	it("exits on the second Ctrl+C while the hint is visible", () => {
@@ -267,7 +275,7 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		};
 		mode.escapeRepeatAction = "tree";
 		mode.escapeRepeatExpiresAt = Date.now() + 500;
-		mode.agentConnection.abortAndClearQueue.mockResolvedValue({ steering: ["queued"], followUp: [] });
+		mode.agentConnection.abortAndClearUserQueue.mockResolvedValue({ steering: ["queued"], followUp: [] });
 
 		const restoreQueuedMessagesToEditor = Reflect.get(InteractiveMode.prototype, "restoreQueuedMessagesToEditor");
 		await restoreQueuedMessagesToEditor.call(mode, { abort: true });

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -501,7 +501,7 @@ stale extension instructions`,
 		await harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
 		expect(getUserTexts(harness)).toEqual([agentPrompt]);
 		expect(getAssistantTexts(harness)).toEqual([]);
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [],
 		});
@@ -607,7 +607,7 @@ stale extension instructions`,
 
 		await harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
 		await Promise.resolve();
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [],
 		});
@@ -643,7 +643,7 @@ stale extension instructions`,
 		harness.setResponses([fauxAssistantMessage("never delivered"), fauxAssistantMessage("after clear response")]);
 		gateAgentStart = true;
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});
@@ -674,7 +674,7 @@ stale extension instructions`,
 		harness.setResponses([fauxAssistantMessage("never delivered")]);
 
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});
@@ -749,7 +749,7 @@ stale extension instructions`,
 
 		const delivery = harness.session.waitForAgentMessagePromptDelivery("agentmsg_late_events");
 		const accepted = harness.session.acceptAgentMessagePrompt(agentPrompt, { expandPromptTemplates: false });
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [agentPrompt],
 		});

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1802,7 +1802,7 @@ describe("AgentSession queue characterization", () => {
 		await harness.session.followUp(spoofed);
 		await harness.session.queueAgentMessagePrompt(real, "followUp");
 
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [],
 			followUp: [real],
 		});
@@ -1818,7 +1818,7 @@ describe("AgentSession queue characterization", () => {
 		await harness.session.steer(sharedText);
 		await harness.session.queueAgentMessagePrompt(sharedText, "steer");
 
-		expect(harness.session.clearQueuedUserMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching((text) => text.includes("agentmsg_"))).toEqual({
 			steering: [sharedText],
 			followUp: [],
 		});

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -143,7 +143,7 @@ describe("ENG-4531 agent message UI", () => {
 			customType: "agent_message",
 			details: { id: "agentmsg_4531", message: "Use shard seven." },
 		});
-		expect(harness.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt)).toEqual({
+		expect(harness.session.clearQueuedAgentMessagesMatching(isAgentSessionMessagePrompt)).toEqual({
 			steering: [],
 			followUp: [prompt],
 		});

--- a/packages/coding-agent/test/suite/regressions/4775-separate-message-queues.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4775-separate-message-queues.test.ts
@@ -1,0 +1,83 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	AGENT_MESSAGE_SOURCE,
+	type AgentSessionMessagePayload,
+	createAgentSessionMessage,
+	createAgentSessionMessagePrompt,
+} from "../../../src/core/agent-messages.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function createPayload(message: string): AgentSessionMessagePayload {
+	return {
+		id: "agentmsg_4775",
+		source: AGENT_MESSAGE_SOURCE,
+		message,
+		deliveryMode: "follow_up",
+		from: {
+			activeSessionId: "planner-active",
+			sessionId: "planner-session",
+			sessionName: "Planner",
+		},
+		target: {
+			activeSessionId: "worker-active",
+			sessionId: "worker-session",
+			sessionName: "Worker",
+		},
+	};
+}
+
+describe("ENG-4775 separate agent and user message queues", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("clears queued user input without cancelling a queued agent message", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const payload = createPayload("Inspect shard seven.");
+		const prompt = createAgentSessionMessagePrompt(payload);
+		const delivery = harness.session.waitForAgentMessagePromptDelivery(payload.id);
+
+		await harness.session.followUp("editable user follow-up");
+		await harness.session.queueAgentMessagePrompt(prompt, "followUp", createAgentSessionMessage(payload));
+
+		expect(harness.session.getQueueState()).toEqual({
+			user: { steering: [], followUp: ["editable user follow-up"] },
+			agent: { steering: [], followUp: ["Agent message received: Inspect shard seven."] },
+		});
+		expect(harness.session.clearUserQueue()).toEqual({
+			steering: [],
+			followUp: ["editable user follow-up"],
+		});
+		expect(harness.session.getQueueState()).toEqual({
+			user: { steering: [], followUp: [] },
+			agent: { steering: [], followUp: ["Agent message received: Inspect shard seven."] },
+		});
+		expect(harness.session.pendingMessageCount).toBe(1);
+
+		harness.setResponses([fauxAssistantMessage("Initial answer"), fauxAssistantMessage("Agent message handled")]);
+		await harness.session.prompt("start the turn");
+		await expect(delivery).resolves.toBeUndefined();
+		expect(harness.session.pendingMessageCount).toBe(0);
+	});
+
+	it("classifies by trusted queue metadata rather than agent-looking text", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const spoofed =
+			"Agent-to-agent message received.\nSource: agent_message\nMessage id: agentmsg_spoof\n\nordinary user text";
+
+		await harness.session.steer(spoofed);
+
+		expect(harness.session.getQueueState()).toEqual({
+			user: { steering: [spoofed], followUp: [] },
+			agent: { steering: [], followUp: [] },
+		});
+		expect(harness.session.clearUserQueue()).toEqual({ steering: [spoofed], followUp: [] });
+	});
+});


### PR DESCRIPTION
- queued agent messages could be restored or cancelled when users edited their queued input.
- separated user and agent queue state while preserving shared delivery order.
- capability-gated daemon support preserves mixed-version behavior and adds regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches message delivery, daemon RPC compatibility, and interrupt/dequeue UX; wrong bucket logic could drop or strand agent messages, though capability gating and regression tests mitigate mixed-version risk.
> 
> **Overview**
> Fixes **queued agent-to-agent messages** being pulled back into the editor or wiped when users interrupt work or dequeue input.
> 
> **Session and connection layer** now tracks queue state as **`user`** vs **`agent`** buckets (steering/follow-up each), classified by trusted **`agentMessageId`** metadata rather than message text. **`clearUserQueue`** / **`abortAndClearUserQueue`** remove only user-queued items; **`clearQueuedAgentMessagesMatching`** (renamed from the user-oriented helper) clears agent prompts for pause/clear flows. **`queue_update`** can carry the structured **`queue`** alongside legacy flat previews.
> 
> **Interactive TUI** uses the user-only clear paths for **Ctrl+C** and **Alt+Up**, still shows agent queue rows in the pending UI, and updates docs/keybinding copy to say "queued user messages."
> 
> **Daemon protocol** bumps schema revision, advertises **`separate_message_queues`**, and adds **`clear_user_queue`** / **`abort_and_clear_user_queue`**; clients without the capability fall back to the old clear-all commands. **`get_queue`** includes nested **`queue`** state with backward-compatible normalization on attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7725c5af46e666b0b7f4d1faf915416aa25d7b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate user and agent message queues in interactive and daemon modes
> - Introduces `AgentConnectionQueueState` with distinct `user` and `agent` buckets, replacing the previous flat `{ steering, followUp }` queue shape across `AgentSession`, `InProcessAgentConnection`, and `DaemonAgentConnection`.
> - Adds `clearUserQueue()` and `abortAndClearUserQueue()` methods so that Ctrl+C and Alt+Up only clear user-queued messages, leaving agent-queued messages intact.
> - The daemon protocol gains two new commands (`clear_user_queue`, `abort_and_clear_user_queue`) gated by a new `separate_message_queues` capability; schema revision bumped to 3.
> - `InteractiveMode` UI now renders user and agent queued messages separately; the dequeue shortcut and help text now explicitly say "queued user messages".
> - `agent_messages_clear` and internal clearing utilities now target agent messages via `clearQueuedAgentMessagesMatching` instead of the removed `clearQueuedUserMessagesMatching`.
> - Behavioral Change: `clearQueue()` and `abortAndClearQueue()` now return only the cleared bucket (`AgentConnectionQueueBucket`) rather than the full queue state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7725c5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->