### PR TITLE
import coding harness sessions during onboarding

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed invalid historical tool names causing provider request failures when resuming imported sessions ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373)).
 - Fixed Vertex Gemini 2.5 Flash-Lite minimal reasoning requests to use the supported 512-token thinking budget.
 
 ## [0.3.2] - 2026-07-20

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -40,5 +40,6 @@ export type {
 } from "./utils/oauth/types.js";
 export * from "./utils/overflow.js";
 export * from "./utils/stream-failure.js";
+export * from "./utils/tool-names.js";
 export * from "./utils/typebox-helpers.js";
 export * from "./utils/validation.js";

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -8,6 +8,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.js";
+import { normalizeToolName } from "../utils/tool-names.js";
 
 const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
 const NON_VISION_TOOL_IMAGE_PLACEHOLDER = "(tool image omitted: model does not support images)";
@@ -68,6 +69,7 @@ export function transformMessages<TApi extends Api>(
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
+	const toolCallNameMap = new Map<string, string>();
 	const imageAwareMessages = downgradeUnsupportedImages(messages, model);
 
 	// First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
@@ -80,8 +82,13 @@ export function transformMessages<TApi extends Api>(
 		// Handle toolResult messages - normalize toolCallId if we have a mapping
 		if (msg.role === "toolResult") {
 			const normalizedId = toolCallIdMap.get(msg.toolCallId);
-			if (normalizedId && normalizedId !== msg.toolCallId) {
-				return { ...msg, toolCallId: normalizedId };
+			const normalizedName = toolCallNameMap.get(msg.toolCallId) ?? normalizeToolName(msg.toolName);
+			if ((normalizedId && normalizedId !== msg.toolCallId) || (normalizedName && normalizedName !== msg.toolName)) {
+				return {
+					...msg,
+					toolCallId: normalizedId ?? msg.toolCallId,
+					toolName: normalizedName,
+				};
 			}
 			return msg;
 		}
@@ -124,9 +131,15 @@ export function transformMessages<TApi extends Api>(
 				if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
 					let normalizedToolCall: ToolCall = toolCall;
+					const normalizedName = normalizeToolName(toolCall.name);
+					toolCallNameMap.set(toolCall.id, normalizedName);
+
+					if (normalizedName !== toolCall.name) {
+						normalizedToolCall = { ...normalizedToolCall, name: normalizedName };
+					}
 
 					if (!isSameModel && toolCall.thoughtSignature) {
-						normalizedToolCall = { ...toolCall };
+						normalizedToolCall = { ...normalizedToolCall };
 						delete (normalizedToolCall as { thoughtSignature?: string }).thoughtSignature;
 					}
 

--- a/packages/ai/src/utils/tool-names.ts
+++ b/packages/ai/src/utils/tool-names.ts
@@ -1,0 +1,6 @@
+const MAX_TOOL_NAME_LENGTH = 64;
+
+export function normalizeToolName(name: string): string {
+	const normalized = name.replace(/[^a-zA-Z0-9_-]+/g, "_") || "tool";
+	return normalized.slice(0, MAX_TOOL_NAME_LENGTH);
+}

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -133,6 +133,43 @@ describe("OpenAI to Anthropic session migration for Copilot Claude", () => {
 		expect(toolCall.thoughtSignature).toBeUndefined();
 	});
 
+	it("normalizes historical tool names and their results", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "rename the task", timestamp: Date.now() },
+			makeAssistantMessage([
+				{
+					type: "toolCall",
+					id: "call_123",
+					name: "codex_app.set_thread_title",
+					arguments: { title: "Imported session" },
+					thoughtSignature: "opaque",
+				},
+			]),
+			{
+				role: "toolResult",
+				toolCallId: "call_123",
+				toolName: "codex_app.set_thread_title",
+				content: [{ type: "text", text: "done" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+		const assistant = result.find((message) => message.role === "assistant") as AssistantMessage;
+		const toolCall = assistant.content.find((block) => block.type === "toolCall") as ToolCall;
+		const toolResult = result.find((message) => message.role === "toolResult");
+
+		expect(toolCall.name).toBe("codex_app_set_thread_title");
+		expect(toolCall.thoughtSignature).toBeUndefined();
+		expect(toolResult).toMatchObject({
+			role: "toolResult",
+			toolCallId: "call_123",
+			toolName: "codex_app_set_thread_title",
+		});
+	});
+
 	it("adds synthetic tool results for trailing orphaned tool calls", () => {
 		const model = makeCopilotClaudeModel();
 		const messages: Message[] = [

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi sessions and skills ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi sessions and skills, with direct Claude Code and Codex JSONL imports ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added safe first-run import for Claude Code, Codex, OpenCode, and Pi sessions and skills ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports that use Prime Agent's configured model ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run import for Claude Code, Codex, OpenCode, and Pi sessions and skills ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi sessions and skills ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports that use Prime Agent's configured model ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports that use Prime Agent's configured model and tools ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi sessions and skills, with direct Claude Code and Codex JSONL imports ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added safe first-run and repeatable `/import` migration for recent Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports that use Prime Agent's configured model and tools ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
+- Added safe first-run and repeatable `/import` migration for recent top-level Claude Code, Codex, OpenCode, and Pi Mono sessions and skills, with direct harness session-file imports, configured-model continuation, and compact historical tool rendering ([ENG-4373](https://linear.app/primeintellect/issue/ENG-4373/import-claudecodexopencodepi-sessions-in-onboarding)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/src/core/session-import/adapters/claude.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/claude.ts
@@ -114,8 +114,21 @@ function parseClaudeAssistant(
 			}
 			case "thinking": {
 				const thinking = asString(block?.thinking);
-				if (thinking) {
-					content.push(thinkingContent(thinking));
+				const signature = asString(block?.signature);
+				if (thinking || signature) {
+					content.push(thinkingContent(thinking ?? "", { thinkingSignature: signature }));
+				}
+				break;
+			}
+			case "redacted_thinking": {
+				const data = asString(block?.data);
+				if (data) {
+					content.push(
+						thinkingContent("[Reasoning redacted]", {
+							thinkingSignature: data,
+							redacted: true,
+						}),
+					);
 				}
 				break;
 			}

--- a/packages/coding-agent/src/core/session-import/adapters/claude.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/claude.ts
@@ -1,0 +1,244 @@
+import { basename } from "node:path";
+import type {
+	AssistantMessage,
+	ImageContent,
+	Message,
+	StopReason,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+	Usage,
+} from "@earendil-works/pi-ai";
+import { readJsonLines } from "../jsonl.js";
+import {
+	asArray,
+	asBoolean,
+	asNumber,
+	asRecord,
+	asString,
+	createAssistantMessage,
+	createToolResultMessage,
+	createUserMessage,
+	createZeroUsage,
+	deriveSessionTitle,
+	parseTimestamp,
+	sanitizeImportedMessages,
+	stringifyUnknown,
+	textContent,
+	thinkingContent,
+	toolCallContent,
+} from "../shared.js";
+import type { ImportedSession } from "../types.js";
+
+function claudeUsage(message: Record<string, unknown>): Usage {
+	const usage = asRecord(message.usage);
+	const input = asNumber(usage?.input_tokens) ?? 0;
+	const output = asNumber(usage?.output_tokens) ?? 0;
+	const cacheRead = asNumber(usage?.cache_read_input_tokens) ?? 0;
+	const cacheWrite = asNumber(usage?.cache_creation_input_tokens) ?? 0;
+	return createZeroUsage({
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+	});
+}
+
+function claudeStopReason(value: unknown): StopReason {
+	switch (value) {
+		case "tool_use":
+			return "toolUse";
+		case "max_tokens":
+			return "length";
+		case "error":
+			return "error";
+		default:
+			return "stop";
+	}
+}
+
+function parseImage(value: unknown): ImageContent | undefined {
+	const source = asRecord(asRecord(value)?.source);
+	const data = asString(source?.data);
+	const mimeType = asString(source?.media_type);
+	if (!data || !mimeType || asString(source?.type) !== "base64") {
+		return undefined;
+	}
+	return { type: "image", data, mimeType };
+}
+
+function parseToolResultContent(value: unknown): (TextContent | ImageContent)[] {
+	if (typeof value === "string") {
+		return [textContent(value)];
+	}
+	const content: (TextContent | ImageContent)[] = [];
+	for (const item of asArray(value)) {
+		const block = asRecord(item);
+		if (asString(block?.type) === "text") {
+			const text = asString(block?.text);
+			if (text) {
+				content.push(textContent(text));
+			}
+		} else if (asString(block?.type) === "image") {
+			const image = parseImage(block);
+			if (image) {
+				content.push(image);
+			}
+		}
+	}
+	if (content.length === 0 && value !== undefined) {
+		content.push(textContent(stringifyUnknown(value)));
+	}
+	return content;
+}
+
+function parseClaudeAssistant(
+	message: Record<string, unknown>,
+	timestamp: number,
+	toolNames: Map<string, string>,
+): AssistantMessage | undefined {
+	const content: (TextContent | ThinkingContent | ToolCall)[] = [];
+	if (typeof message.content === "string" && message.content) {
+		content.push(textContent(message.content));
+	}
+	for (const item of asArray(message.content)) {
+		const block = asRecord(item);
+		switch (asString(block?.type)) {
+			case "text": {
+				const text = asString(block?.text);
+				if (text) {
+					content.push(textContent(text));
+				}
+				break;
+			}
+			case "thinking": {
+				const thinking = asString(block?.thinking);
+				if (thinking) {
+					content.push(thinkingContent(thinking));
+				}
+				break;
+			}
+			case "tool_use": {
+				const id = asString(block?.id);
+				const name = asString(block?.name);
+				if (id && name) {
+					content.push(toolCallContent(id, name, block?.input));
+					toolNames.set(id, name);
+				}
+				break;
+			}
+		}
+	}
+	if (content.length === 0) {
+		return undefined;
+	}
+	const model = asString(message.model) ?? "claude";
+	return createAssistantMessage(content, {
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model,
+		timestamp,
+		usage: claudeUsage(message),
+		stopReason: claudeStopReason(message.stop_reason),
+	});
+}
+
+export async function parseClaudeSession(filePath: string): Promise<ImportedSession | undefined> {
+	const messages: Message[] = [];
+	const toolNames = new Map<string, string>();
+	let sourceId: string | undefined;
+	let cwd = "";
+	let createdAt = Number.POSITIVE_INFINITY;
+
+	await readJsonLines(filePath, (value) => {
+		const entry = asRecord(value);
+		if (!entry || asBoolean(entry.isSidechain) || asBoolean(entry.isMeta)) {
+			return;
+		}
+		sourceId ??= asString(entry.sessionId);
+		cwd ||= asString(entry.cwd) ?? "";
+		const timestamp = parseTimestamp(entry.timestamp);
+		createdAt = Math.min(createdAt, timestamp);
+		const message = asRecord(entry.message);
+		if (!message) {
+			return;
+		}
+
+		if (asString(entry.type) === "assistant" && asString(message.role) === "assistant") {
+			const assistant = parseClaudeAssistant(message, timestamp, toolNames);
+			if (assistant) {
+				messages.push(assistant);
+			}
+			return;
+		}
+
+		if (asString(entry.type) !== "user" || asString(message.role) !== "user") {
+			return;
+		}
+
+		if (typeof message.content === "string") {
+			messages.push(createUserMessage(message.content, timestamp));
+			return;
+		}
+
+		let userContent: (TextContent | ImageContent)[] = [];
+		const flushUserContent = () => {
+			if (userContent.length > 0) {
+				messages.push(createUserMessage(userContent, timestamp));
+				userContent = [];
+			}
+		};
+		for (const item of asArray(message.content)) {
+			const block = asRecord(item);
+			switch (asString(block?.type)) {
+				case "text": {
+					const text = asString(block?.text);
+					if (text) {
+						userContent.push(textContent(text));
+					}
+					break;
+				}
+				case "image": {
+					const image = parseImage(block);
+					if (image) {
+						userContent.push(image);
+					}
+					break;
+				}
+				case "tool_result": {
+					const toolCallId = asString(block?.tool_use_id);
+					if (!toolCallId) {
+						break;
+					}
+					flushUserContent();
+					messages.push(
+						createToolResultMessage(
+							toolCallId,
+							toolNames.get(toolCallId) ?? "tool",
+							parseToolResultContent(block?.content),
+							asBoolean(block?.is_error) ?? false,
+							timestamp,
+						),
+					);
+					break;
+				}
+			}
+		}
+		flushUserContent();
+	});
+
+	const sanitized = sanitizeImportedMessages(messages);
+	if (sanitized.length === 0) {
+		return undefined;
+	}
+	const fallbackId = basename(filePath, ".jsonl");
+	return {
+		source: "claude",
+		sourceId: sourceId ?? fallbackId,
+		cwd,
+		title: deriveSessionTitle(sanitized),
+		createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+		messages: sanitized,
+	};
+}

--- a/packages/coding-agent/src/core/session-import/adapters/codex.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/codex.ts
@@ -1,0 +1,219 @@
+import { basename } from "node:path";
+import type { Message, TextContent, ThinkingContent, ToolCall } from "@earendil-works/pi-ai";
+import { readJsonLines } from "../jsonl.js";
+import {
+	asArray,
+	asRecord,
+	asString,
+	contentToText,
+	createAssistantMessage,
+	createToolResultMessage,
+	createUserMessage,
+	deriveSessionTitle,
+	parseTimestamp,
+	sanitizeImportedMessages,
+	stringifyUnknown,
+	textContent,
+	thinkingContent,
+	toolCallContent,
+} from "../shared.js";
+import type { ImportedSession } from "../types.js";
+
+interface PendingAssistant {
+	content: (TextContent | ThinkingContent | ToolCall)[];
+	timestamp: number;
+}
+
+function contentText(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	const parts: string[] = [];
+	for (const item of asArray(value)) {
+		const block = asRecord(item);
+		const text = asString(block?.text) ?? asString(block?.output_text) ?? asString(block?.input_text);
+		if (text) {
+			parts.push(text);
+		}
+	}
+	return parts.length > 0 ? parts.join("\n") : stringifyUnknown(value);
+}
+
+function responseMessageText(payload: Record<string, unknown>): string {
+	return asArray(payload.content)
+		.map((item) => {
+			const block = asRecord(item);
+			return asString(block?.text) ?? "";
+		})
+		.filter(Boolean)
+		.join("\n");
+}
+
+function reasoningText(payload: Record<string, unknown>): string {
+	const blocks = [...asArray(payload.summary), ...asArray(payload.content)];
+	return blocks
+		.map((item) => asString(asRecord(item)?.text) ?? "")
+		.filter(Boolean)
+		.join("\n");
+}
+
+function isInjectedCodexContext(text: string): boolean {
+	const normalized = text.trimStart();
+	return (
+		normalized.startsWith("<permissions instructions>") ||
+		normalized.startsWith("<app-context>") ||
+		normalized.startsWith("<skills_instructions>") ||
+		normalized.startsWith("<environment_context>") ||
+		normalized.startsWith("# AGENTS.md instructions")
+	);
+}
+
+export async function parseCodexSession(filePath: string): Promise<ImportedSession | undefined> {
+	const messages: Message[] = [];
+	const fallbackUserMessages = new Set<Message>();
+	let sourceId: string | undefined;
+	let cwd = "";
+	let provider = "openai-codex";
+	let model = "codex";
+	let createdAt = Number.POSITIVE_INFINITY;
+	let sawEventUser = false;
+	let pending: PendingAssistant | undefined;
+
+	const flushAssistant = () => {
+		if (!pending || pending.content.length === 0) {
+			pending = undefined;
+			return;
+		}
+		messages.push(
+			createAssistantMessage(pending.content, {
+				api: "openai-codex-responses",
+				provider,
+				model,
+				timestamp: pending.timestamp,
+			}),
+		);
+		pending = undefined;
+	};
+
+	const addAssistantContent = (content: TextContent | ThinkingContent | ToolCall, timestamp: number) => {
+		pending ??= { content: [], timestamp };
+		pending.content.push(content);
+	};
+
+	await readJsonLines(filePath, (value) => {
+		const entry = asRecord(value);
+		const payload = asRecord(entry?.payload);
+		if (!entry || !payload) {
+			return;
+		}
+		const timestamp = parseTimestamp(entry.timestamp);
+		createdAt = Math.min(createdAt, timestamp);
+
+		if (asString(entry.type) === "session_meta") {
+			sourceId ??= asString(payload.id);
+			cwd ||= asString(payload.cwd) ?? "";
+			provider = asString(payload.model_provider) ?? provider;
+			return;
+		}
+		if (asString(entry.type) === "turn_context") {
+			cwd ||= asString(payload.cwd) ?? "";
+			model = asString(payload.model) ?? model;
+			return;
+		}
+		if (asString(entry.type) === "event_msg" && asString(payload.type) === "user_message") {
+			const text = asString(payload.message);
+			if (text) {
+				flushAssistant();
+				sawEventUser = true;
+				messages.push(createUserMessage(text, timestamp));
+			}
+			return;
+		}
+		if (asString(entry.type) !== "response_item") {
+			return;
+		}
+
+		const itemType = asString(payload.type);
+		if (itemType === "message" && asString(payload.role) === "user") {
+			const text = responseMessageText(payload);
+			if (text) {
+				flushAssistant();
+				const userMessage = createUserMessage(text, timestamp);
+				messages.push(userMessage);
+				fallbackUserMessages.add(userMessage);
+			}
+			return;
+		}
+		if (itemType === "message" && asString(payload.role) === "assistant") {
+			const text = responseMessageText(payload);
+			if (text) {
+				addAssistantContent(textContent(text), timestamp);
+			}
+			return;
+		}
+		if (itemType === "reasoning") {
+			const text = reasoningText(payload);
+			if (text) {
+				addAssistantContent(thinkingContent(text), timestamp);
+			}
+			return;
+		}
+
+		const isCall = itemType === "function_call" || itemType === "custom_tool_call" || itemType === "tool_search_call";
+		if (isCall) {
+			const callId = asString(payload.call_id);
+			const name =
+				asString(payload.name) ??
+				(itemType === "tool_search_call" ? "tool_search" : (itemType?.replace(/_call$/, "") ?? "tool"));
+			if (callId) {
+				const namespace = asString(payload.namespace);
+				addAssistantContent(
+					toolCallContent(callId, namespace ? `${namespace}.${name}` : name, payload.arguments ?? payload.input),
+					timestamp,
+				);
+			}
+			return;
+		}
+
+		const isOutput =
+			itemType === "function_call_output" ||
+			itemType === "custom_tool_call_output" ||
+			itemType === "tool_search_output";
+		if (isOutput) {
+			const callId = asString(payload.call_id);
+			if (!callId) {
+				return;
+			}
+			flushAssistant();
+			messages.push(
+				createToolResultMessage(
+					callId,
+					itemType === "tool_search_output" ? "tool_search" : "tool",
+					[textContent(contentText(payload.output ?? payload.tools ?? payload.execution))],
+					asString(payload.status) === "failed",
+					timestamp,
+				),
+			);
+		}
+	});
+	flushAssistant();
+
+	const selectedMessages = messages.filter((message) => {
+		if (!fallbackUserMessages.has(message)) {
+			return true;
+		}
+		return !sawEventUser && message.role === "user" && !isInjectedCodexContext(contentToText(message.content));
+	});
+	const sanitized = sanitizeImportedMessages(selectedMessages);
+	if (sanitized.length === 0) {
+		return undefined;
+	}
+	return {
+		source: "codex",
+		sourceId: sourceId ?? basename(filePath, ".jsonl"),
+		cwd,
+		title: deriveSessionTitle(sanitized),
+		createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+		messages: sanitized,
+	};
+}

--- a/packages/coding-agent/src/core/session-import/adapters/codex.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/codex.ts
@@ -112,7 +112,8 @@ export async function parseCodexSession(filePath: string): Promise<ImportedSessi
 		if (asString(entry.type) === "session_meta") {
 			sourceId ??= asString(payload.id);
 			cwd ||= asString(payload.cwd) ?? "";
-			provider = asString(payload.model_provider) ?? provider;
+			const sourceProvider = asString(payload.model_provider);
+			provider = sourceProvider === "openai" ? "openai-codex" : (sourceProvider ?? provider);
 			return;
 		}
 		if (asString(entry.type) === "turn_context") {

--- a/packages/coding-agent/src/core/session-import/adapters/codex.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/codex.ts
@@ -39,13 +39,29 @@ function contentText(value: unknown): string {
 	return parts.length > 0 ? parts.join("\n") : stringifyUnknown(value);
 }
 
-function responseMessageText(payload: Record<string, unknown>): string {
+function isInjectedCodexContext(text: string): boolean {
+	const normalized = text.trimStart();
+	return (
+		normalized.startsWith("<permissions instructions>") ||
+		normalized.startsWith("<app-context>") ||
+		normalized.startsWith("<apps_instructions>") ||
+		normalized.startsWith("<collaboration_mode>") ||
+		normalized.startsWith("<in-app-browser-context") ||
+		normalized.startsWith("<plugins_instructions>") ||
+		normalized.startsWith("<recommended_plugins>") ||
+		normalized.startsWith("<skills_instructions>") ||
+		normalized.startsWith("<environment_context>") ||
+		normalized.startsWith("# AGENTS.md instructions")
+	);
+}
+
+function responseMessageText(payload: Record<string, unknown>, excludeInjectedContext = false): string {
 	return asArray(payload.content)
 		.map((item) => {
 			const block = asRecord(item);
-			return asString(block?.text) ?? "";
+			return asString(block?.text) ?? asString(block?.output_text) ?? asString(block?.input_text) ?? "";
 		})
-		.filter(Boolean)
+		.filter((text) => text && (!excludeInjectedContext || !isInjectedCodexContext(text)))
 		.join("\n");
 }
 
@@ -57,26 +73,15 @@ function reasoningText(payload: Record<string, unknown>): string {
 		.join("\n");
 }
 
-function isInjectedCodexContext(text: string): boolean {
-	const normalized = text.trimStart();
-	return (
-		normalized.startsWith("<permissions instructions>") ||
-		normalized.startsWith("<app-context>") ||
-		normalized.startsWith("<skills_instructions>") ||
-		normalized.startsWith("<environment_context>") ||
-		normalized.startsWith("# AGENTS.md instructions")
-	);
-}
-
 export async function parseCodexSession(filePath: string): Promise<ImportedSession | undefined> {
 	const messages: Message[] = [];
 	const fallbackUserMessages = new Set<Message>();
+	const eventUserMessages: { text: string; timestamp: number }[] = [];
 	let sourceId: string | undefined;
 	let cwd = "";
 	let provider = "openai-codex";
 	let model = "codex";
 	let createdAt = Number.POSITIVE_INFINITY;
-	let sawEventUser = false;
 	let pending: PendingAssistant | undefined;
 
 	const flushAssistant = () => {
@@ -124,7 +129,7 @@ export async function parseCodexSession(filePath: string): Promise<ImportedSessi
 			const text = asString(payload.message);
 			if (text) {
 				flushAssistant();
-				sawEventUser = true;
+				eventUserMessages.push({ text, timestamp });
 				messages.push(createUserMessage(text, timestamp));
 			}
 			return;
@@ -135,7 +140,7 @@ export async function parseCodexSession(filePath: string): Promise<ImportedSessi
 
 		const itemType = asString(payload.type);
 		if (itemType === "message" && asString(payload.role) === "user") {
-			const text = responseMessageText(payload);
+			const text = responseMessageText(payload, true);
 			if (text) {
 				flushAssistant();
 				const userMessage = createUserMessage(text, timestamp);
@@ -202,7 +207,17 @@ export async function parseCodexSession(filePath: string): Promise<ImportedSessi
 		if (!fallbackUserMessages.has(message)) {
 			return true;
 		}
-		return !sawEventUser && message.role === "user" && !isInjectedCodexContext(contentToText(message.content));
+		if (message.role !== "user") {
+			return false;
+		}
+		const text = contentToText(message.content);
+		if (isInjectedCodexContext(text)) {
+			return false;
+		}
+		return !eventUserMessages.some(
+			(eventMessage) =>
+				eventMessage.text === text && Math.abs(eventMessage.timestamp - (message.timestamp ?? 0)) <= 1_000,
+		);
 	});
 	const sanitized = sanitizeImportedMessages(selectedMessages);
 	if (sanitized.length === 0) {

--- a/packages/coding-agent/src/core/session-import/adapters/codex.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/codex.ts
@@ -112,8 +112,7 @@ export async function parseCodexSession(filePath: string): Promise<ImportedSessi
 		if (asString(entry.type) === "session_meta") {
 			sourceId ??= asString(payload.id);
 			cwd ||= asString(payload.cwd) ?? "";
-			const sourceProvider = asString(payload.model_provider);
-			provider = sourceProvider === "openai" ? "openai-codex" : (sourceProvider ?? provider);
+			provider = asString(payload.model_provider) ?? provider;
 			return;
 		}
 		if (asString(entry.type) === "turn_context") {

--- a/packages/coding-agent/src/core/session-import/adapters/opencode.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/opencode.ts
@@ -37,6 +37,16 @@ interface JsonDataRow {
 	data: string;
 }
 
+interface OpenCodeSessionListRow {
+	id: string;
+	timestamp?: number;
+}
+
+export interface OpenCodeSessionCandidate {
+	id: string;
+	modifiedAt: number;
+}
+
 interface OpenCodeMessageRecord {
 	message: Record<string, unknown>;
 	parts: Record<string, unknown>[];
@@ -236,15 +246,44 @@ function runOpenCode(command: string, args: string[], cwd: string, timeout: numb
 	return result.status === 0 ? result.stdout.trim() : undefined;
 }
 
-export function listOpenCodeCliSessionIds(command: string, cwd: string): string[] | undefined {
+function openCodeListTimestamp(value: Record<string, unknown>): number {
+	const time = asRecord(value.time);
+	return parseTimestamp(
+		time?.updated ??
+			time?.created ??
+			value.time_updated ??
+			value.time_created ??
+			value.updatedAt ??
+			value.updated_at ??
+			value.createdAt ??
+			value.created_at,
+		0,
+	);
+}
+
+export function listOpenCodeCliSessions(
+	command: string,
+	cwd: string,
+	cutoff: number,
+	limit: number,
+): OpenCodeSessionCandidate[] | undefined {
 	const output = runOpenCode(command, ["session", "list", "--format", "json", "--pure"], cwd, 5_000);
 	if (!output) {
 		return undefined;
 	}
 	try {
-		return asArray(JSON.parse(output) as unknown)
-			.map((value) => asString(asRecord(value)?.id))
-			.filter((id): id is string => id !== undefined);
+		const parsed = JSON.parse(output) as unknown;
+		const values = Array.isArray(parsed) ? parsed : asArray(asRecord(parsed)?.sessions);
+		return values
+			.map((value) => {
+				const record = asRecord(value);
+				const id = asString(record?.id);
+				const timestamp = record ? openCodeListTimestamp(record) : 0;
+				return id && timestamp >= cutoff ? { id, modifiedAt: timestamp } : undefined;
+			})
+			.filter((session): session is OpenCodeSessionCandidate => session !== undefined)
+			.sort((a, b) => b.modifiedAt - a.modifiedAt || a.id.localeCompare(b.id))
+			.slice(0, limit);
 	} catch {
 		return undefined;
 	}
@@ -293,7 +332,7 @@ function queryRows<T>(database: NodeDatabaseSync, sql: string, ...params: (strin
 	return database.prepare(sql).all(...params) as T[];
 }
 
-export function listOpenCodeSessionIds(databasePath: string): string[] {
+export function listOpenCodeSessions(databasePath: string, cutoff: number, limit: number): OpenCodeSessionCandidate[] {
 	const database = openDatabase(databasePath);
 	try {
 		const tables = queryRows<{ name: string }>(
@@ -303,16 +342,26 @@ export function listOpenCodeSessionIds(databasePath: string): string[] {
 		if (new Set(tables.map((row) => row.name)).size !== 3) {
 			return [];
 		}
-		try {
-			return queryRows<{ id: string }>(
-				database,
-				"SELECT id FROM session WHERE parent_id IS NULL ORDER BY time_updated, id",
-			).map((row) => row.id);
-		} catch {
-			return queryRows<{ id: string }>(database, "SELECT id FROM session ORDER BY time_updated, id").map(
-				(row) => row.id,
-			);
+		const columns = new Set(
+			queryRows<{ name: string }>(database, "PRAGMA table_info(session)").map((column) => column.name),
+		);
+		const timeColumn = columns.has("time_updated")
+			? "time_updated"
+			: columns.has("time_created")
+				? "time_created"
+				: "";
+		if (!timeColumn) {
+			return [];
 		}
+		const rootFilter = columns.has("parent_id") ? " WHERE parent_id IS NULL" : "";
+		return queryRows<OpenCodeSessionListRow>(
+			database,
+			`SELECT id, ${timeColumn} AS timestamp FROM session${rootFilter}`,
+		)
+			.map((row) => ({ id: row.id, modifiedAt: parseTimestamp(row.timestamp, 0) }))
+			.filter((session) => session.id && session.modifiedAt >= cutoff)
+			.sort((a, b) => b.modifiedAt - a.modifiedAt || a.id.localeCompare(b.id))
+			.slice(0, limit);
 	} finally {
 		database.close();
 	}

--- a/packages/coding-agent/src/core/session-import/adapters/opencode.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/opencode.ts
@@ -1,8 +1,10 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { basename } from "node:path";
 import type { DatabaseSync as NodeDatabaseSync } from "node:sqlite";
 import type { AssistantMessage, Message, TextContent, ThinkingContent, ToolCall, Usage } from "@earendil-works/pi-ai";
 import { shouldUseWindowsShell } from "../../../utils/child-process.js";
+import { readJsonDocument } from "../jsonl.js";
 import {
 	asArray,
 	asNumber,
@@ -246,6 +248,40 @@ function runOpenCode(command: string, args: string[], cwd: string, timeout: numb
 	return result.status === 0 ? result.stdout.trim() : undefined;
 }
 
+function parseOpenCodeExport(value: unknown, fallbackId: string): ImportedSession | undefined {
+	const exported = asRecord(value);
+	const info = asRecord(exported?.info);
+	if (!info) {
+		return undefined;
+	}
+	const id = asString(info.id) ?? fallbackId;
+	const time = asRecord(info.time);
+	const records = asArray(exported?.messages)
+		.map((messageValue): OpenCodeMessageRecord | undefined => {
+			const record = asRecord(messageValue);
+			const message = asRecord(record?.info);
+			if (!message) {
+				return undefined;
+			}
+			return {
+				message,
+				parts: asArray(record?.parts)
+					.map(asRecord)
+					.filter((part): part is Record<string, unknown> => part !== undefined),
+			};
+		})
+		.filter((record): record is OpenCodeMessageRecord => record !== undefined);
+	return convertOpenCodeSession(
+		{
+			id,
+			directory: asString(info.directory),
+			title: asString(info.title),
+			time_created: parseTimestamp(time?.created),
+		},
+		records,
+	);
+}
+
 function openCodeListTimestamp(value: Record<string, unknown>): number {
 	const time = asRecord(value.time);
 	return parseTimestamp(
@@ -298,34 +334,15 @@ export async function parseOpenCodeCliSession(
 	if (!output) {
 		return undefined;
 	}
-	const exported = asRecord(JSON.parse(output) as unknown);
-	const info = asRecord(exported?.info);
-	const id = asString(info?.id) ?? sessionId;
-	const time = asRecord(info?.time);
-	const records = asArray(exported?.messages)
-		.map((value): OpenCodeMessageRecord | undefined => {
-			const record = asRecord(value);
-			const message = asRecord(record?.info);
-			if (!message) {
-				return undefined;
-			}
-			return {
-				message,
-				parts: asArray(record?.parts)
-					.map(asRecord)
-					.filter((part): part is Record<string, unknown> => part !== undefined),
-			};
-		})
-		.filter((record): record is OpenCodeMessageRecord => record !== undefined);
-	return convertOpenCodeSession(
-		{
-			id,
-			directory: asString(info?.directory),
-			title: asString(info?.title),
-			time_created: parseTimestamp(time?.created),
-		},
-		records,
-	);
+	try {
+		return parseOpenCodeExport(JSON.parse(output) as unknown, sessionId);
+	} catch {
+		return undefined;
+	}
+}
+
+export async function parseOpenCodeExportFile(filePath: string): Promise<ImportedSession | undefined> {
+	return parseOpenCodeExport(await readJsonDocument(filePath), basename(filePath, ".json"));
 }
 
 function queryRows<T>(database: NodeDatabaseSync, sql: string, ...params: (string | number)[]): T[] {

--- a/packages/coding-agent/src/core/session-import/adapters/opencode.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/opencode.ts
@@ -154,11 +154,13 @@ function convertOpenCodeSession(
 
 		let pending: (TextContent | ThinkingContent | ToolCall)[] = [];
 		const usage = messageUsage(message);
+		let usageEmitted = false;
 		const provider = asString(message.providerID) ?? "opencode";
 		const model = asString(message.modelID) ?? "opencode";
 		const errorMessage = openCodeErrorMessage(message.error);
+		let errorEmitted = false;
 		const flushAssistant = (partTime = timestamp) => {
-			if (pending.length === 0 && !errorMessage) {
+			if (pending.length === 0 && (!errorMessage || errorEmitted)) {
 				return;
 			}
 			messages.push(
@@ -167,11 +169,13 @@ function convertOpenCodeSession(
 					provider,
 					model,
 					timestamp: partTime,
-					usage,
+					usage: usageEmitted ? createZeroUsage() : usage,
 					stopReason: errorMessage ? "error" : finishReason(message.finish),
 					errorMessage,
 				}),
 			);
+			usageEmitted = true;
+			errorEmitted = !!errorMessage;
 			pending = [];
 		};
 
@@ -289,6 +293,8 @@ function openCodeListTimestamp(value: Record<string, unknown>): number {
 			time?.created ??
 			value.time_updated ??
 			value.time_created ??
+			value.updated ??
+			value.created ??
 			value.updatedAt ??
 			value.updated_at ??
 			value.createdAt ??
@@ -362,18 +368,32 @@ export function listOpenCodeSessions(databasePath: string, cutoff: number, limit
 		const columns = new Set(
 			queryRows<{ name: string }>(database, "PRAGMA table_info(session)").map((column) => column.name),
 		);
-		const timeColumn = columns.has("time_updated")
-			? "time_updated"
-			: columns.has("time_created")
-				? "time_created"
+		const messageColumns = new Set(
+			queryRows<{ name: string }>(database, "PRAGMA table_info(message)").map((column) => column.name),
+		);
+		const partColumns = new Set(
+			queryRows<{ name: string }>(database, "PRAGMA table_info(part)").map((column) => column.name),
+		);
+		const timeColumn = columns.has("time_created")
+			? "time_created"
+			: columns.has("time_updated")
+				? "time_updated"
 				: "";
 		if (!timeColumn) {
 			return [];
 		}
+		const timestamps = [`COALESCE(s.${timeColumn}, 0)`];
+		if (messageColumns.has("session_id") && messageColumns.has("time_created")) {
+			timestamps.push("COALESCE((SELECT MAX(m.time_created) FROM message m WHERE m.session_id = s.id), 0)");
+		}
+		if (partColumns.has("session_id") && partColumns.has("time_created")) {
+			timestamps.push("COALESCE((SELECT MAX(p.time_created) FROM part p WHERE p.session_id = s.id), 0)");
+		}
+		const timestampExpression = timestamps.length === 1 ? timestamps[0] : `MAX(${timestamps.join(", ")})`;
 		const rootFilter = columns.has("parent_id") ? " WHERE parent_id IS NULL" : "";
 		return queryRows<OpenCodeSessionListRow>(
 			database,
-			`SELECT id, ${timeColumn} AS timestamp FROM session${rootFilter}`,
+			`SELECT s.id, ${timestampExpression} AS timestamp FROM session s${rootFilter}`,
 		)
 			.map((row) => ({ id: row.id, modifiedAt: parseTimestamp(row.timestamp, 0) }))
 			.filter((session) => session.id && session.modifiedAt >= cutoff)

--- a/packages/coding-agent/src/core/session-import/adapters/opencode.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/opencode.ts
@@ -1,0 +1,361 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import type { DatabaseSync as NodeDatabaseSync } from "node:sqlite";
+import type { AssistantMessage, Message, TextContent, ThinkingContent, ToolCall, Usage } from "@earendil-works/pi-ai";
+import { shouldUseWindowsShell } from "../../../utils/child-process.js";
+import {
+	asArray,
+	asNumber,
+	asRecord,
+	asString,
+	createAssistantMessage,
+	createToolResultMessage,
+	createUserMessage,
+	createZeroUsage,
+	deriveSessionTitle,
+	parseTimestamp,
+	sanitizeImportedMessages,
+	textContent,
+	thinkingContent,
+	toolCallContent,
+} from "../shared.js";
+import type { ImportedSession } from "../types.js";
+
+interface OpenCodeSessionRow {
+	id: string;
+	directory?: string;
+	title?: string;
+	time_created?: number;
+}
+
+interface MessageDataRow {
+	id: string;
+	data: string;
+}
+
+interface JsonDataRow {
+	data: string;
+}
+
+interface OpenCodeMessageRecord {
+	message: Record<string, unknown>;
+	parts: Record<string, unknown>[];
+}
+
+interface NodeSqliteModule {
+	DatabaseSync: new (path: string, options: { readOnly: boolean }) => NodeDatabaseSync;
+}
+
+function openDatabase(path: string): NodeDatabaseSync {
+	const require = createRequire(import.meta.url);
+	const sqlite = require("node:sqlite") as NodeSqliteModule;
+	return new sqlite.DatabaseSync(path, { readOnly: true });
+}
+
+function parseData(value: string): Record<string, unknown> | undefined {
+	try {
+		return asRecord(JSON.parse(value) as unknown);
+	} catch {
+		return undefined;
+	}
+}
+
+function messageUsage(message: Record<string, unknown>): Usage {
+	const tokens = asRecord(message.tokens);
+	const cache = asRecord(tokens?.cache);
+	const input = asNumber(tokens?.input) ?? 0;
+	const output = asNumber(tokens?.output) ?? 0;
+	const cacheRead = asNumber(cache?.read) ?? 0;
+	const cacheWrite = asNumber(cache?.write) ?? 0;
+	return createZeroUsage({
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: asNumber(tokens?.total) ?? input + output + cacheRead + cacheWrite,
+	});
+}
+
+function partTimestamp(part: Record<string, unknown>, fallback: number): number {
+	const time = asRecord(part.time);
+	return parseTimestamp(time?.start, fallback);
+}
+
+function finishReason(value: unknown): AssistantMessage["stopReason"] {
+	switch (value) {
+		case "tool-calls":
+		case "tool_use":
+			return "toolUse";
+		case "length":
+			return "length";
+		case "error":
+			return "error";
+		default:
+			return "stop";
+	}
+}
+
+function userPartContent(part: Record<string, unknown>): TextContent | undefined {
+	switch (asString(part.type)) {
+		case "text": {
+			const text = asString(part.text);
+			return text ? textContent(text) : undefined;
+		}
+		case "file": {
+			const filename = asString(part.filename) ?? asString(part.url);
+			return filename ? textContent(`[Attached file: ${filename}]`) : undefined;
+		}
+		case "subtask": {
+			const prompt = asString(part.prompt);
+			return prompt ? textContent(prompt) : undefined;
+		}
+		default:
+			return undefined;
+	}
+}
+
+function openCodeErrorMessage(value: unknown): string | undefined {
+	const error = asRecord(value);
+	const data = asRecord(error?.data);
+	return asString(data?.message) ?? asString(error?.message);
+}
+
+function convertOpenCodeSession(
+	session: OpenCodeSessionRow,
+	records: OpenCodeMessageRecord[],
+): ImportedSession | undefined {
+	const messages: Message[] = [];
+	for (const { message, parts } of records) {
+		const role = asString(message.role);
+		if (role !== "user" && role !== "assistant") {
+			continue;
+		}
+		const time = asRecord(message.time);
+		const timestamp = parseTimestamp(time?.created, session.time_created ?? Date.now());
+		if (role === "user") {
+			const content = parts.map(userPartContent).filter((part): part is TextContent => part !== undefined);
+			if (content.length > 0) {
+				messages.push(createUserMessage(content, timestamp));
+			}
+			continue;
+		}
+
+		let pending: (TextContent | ThinkingContent | ToolCall)[] = [];
+		const usage = messageUsage(message);
+		const provider = asString(message.providerID) ?? "opencode";
+		const model = asString(message.modelID) ?? "opencode";
+		const errorMessage = openCodeErrorMessage(message.error);
+		const flushAssistant = (partTime = timestamp) => {
+			if (pending.length === 0 && !errorMessage) {
+				return;
+			}
+			messages.push(
+				createAssistantMessage(pending, {
+					api: "openai-completions",
+					provider,
+					model,
+					timestamp: partTime,
+					usage,
+					stopReason: errorMessage ? "error" : finishReason(message.finish),
+					errorMessage,
+				}),
+			);
+			pending = [];
+		};
+
+		for (const part of parts) {
+			const partTime = partTimestamp(part, timestamp);
+			switch (asString(part.type)) {
+				case "text": {
+					const text = asString(part.text);
+					if (text) {
+						pending.push(textContent(text));
+					}
+					break;
+				}
+				case "reasoning": {
+					const reasoning = asString(part.text);
+					if (reasoning) {
+						pending.push(thinkingContent(reasoning));
+					}
+					break;
+				}
+				case "tool": {
+					const callId = asString(part.callID);
+					const toolName = asString(part.tool);
+					const state = asRecord(part.state);
+					if (!callId || !toolName || !state) {
+						break;
+					}
+					pending.push(toolCallContent(callId, toolName, state.input));
+					flushAssistant(partTime);
+					const status = asString(state.status);
+					if (status === "completed" || status === "error") {
+						const output = status === "error" ? asString(state.error) : asString(state.output);
+						messages.push(
+							createToolResultMessage(
+								callId,
+								toolName,
+								[textContent(output ?? "(No tool output)")],
+								status === "error",
+								parseTimestamp(asRecord(state.time)?.end, partTime),
+							),
+						);
+					}
+					break;
+				}
+			}
+		}
+		flushAssistant();
+	}
+
+	const sanitized = sanitizeImportedMessages(messages);
+	if (sanitized.length === 0) {
+		return undefined;
+	}
+	return {
+		source: "opencode",
+		sourceId: session.id,
+		cwd: session.directory ?? "",
+		title: session.title?.trim() || deriveSessionTitle(sanitized),
+		createdAt: parseTimestamp(session.time_created),
+		messages: sanitized,
+	};
+}
+
+function runOpenCode(command: string, args: string[], cwd: string, timeout: number): string | undefined {
+	const result = spawnSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		env: { ...process.env, NO_COLOR: "1" },
+		maxBuffer: 64 * 1024 * 1024,
+		shell: shouldUseWindowsShell(command),
+		stdio: ["ignore", "pipe", "pipe"],
+		timeout,
+	});
+	return result.status === 0 ? result.stdout.trim() : undefined;
+}
+
+export function listOpenCodeCliSessionIds(command: string, cwd: string): string[] | undefined {
+	const output = runOpenCode(command, ["session", "list", "--format", "json", "--pure"], cwd, 5_000);
+	if (!output) {
+		return undefined;
+	}
+	try {
+		return asArray(JSON.parse(output) as unknown)
+			.map((value) => asString(asRecord(value)?.id))
+			.filter((id): id is string => id !== undefined);
+	} catch {
+		return undefined;
+	}
+}
+
+export async function parseOpenCodeCliSession(
+	command: string,
+	cwd: string,
+	sessionId: string,
+): Promise<ImportedSession | undefined> {
+	const output = runOpenCode(command, ["export", sessionId, "--pure"], cwd, 30_000);
+	if (!output) {
+		return undefined;
+	}
+	const exported = asRecord(JSON.parse(output) as unknown);
+	const info = asRecord(exported?.info);
+	const id = asString(info?.id) ?? sessionId;
+	const time = asRecord(info?.time);
+	const records = asArray(exported?.messages)
+		.map((value): OpenCodeMessageRecord | undefined => {
+			const record = asRecord(value);
+			const message = asRecord(record?.info);
+			if (!message) {
+				return undefined;
+			}
+			return {
+				message,
+				parts: asArray(record?.parts)
+					.map(asRecord)
+					.filter((part): part is Record<string, unknown> => part !== undefined),
+			};
+		})
+		.filter((record): record is OpenCodeMessageRecord => record !== undefined);
+	return convertOpenCodeSession(
+		{
+			id,
+			directory: asString(info?.directory),
+			title: asString(info?.title),
+			time_created: parseTimestamp(time?.created),
+		},
+		records,
+	);
+}
+
+function queryRows<T>(database: NodeDatabaseSync, sql: string, ...params: (string | number)[]): T[] {
+	return database.prepare(sql).all(...params) as T[];
+}
+
+export function listOpenCodeSessionIds(databasePath: string): string[] {
+	const database = openDatabase(databasePath);
+	try {
+		const tables = queryRows<{ name: string }>(
+			database,
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('session', 'message', 'part')",
+		);
+		if (new Set(tables.map((row) => row.name)).size !== 3) {
+			return [];
+		}
+		try {
+			return queryRows<{ id: string }>(
+				database,
+				"SELECT id FROM session WHERE parent_id IS NULL ORDER BY time_updated, id",
+			).map((row) => row.id);
+		} catch {
+			return queryRows<{ id: string }>(database, "SELECT id FROM session ORDER BY time_updated, id").map(
+				(row) => row.id,
+			);
+		}
+	} finally {
+		database.close();
+	}
+}
+
+export async function parseOpenCodeSession(
+	databasePath: string,
+	sessionId: string,
+): Promise<ImportedSession | undefined> {
+	const database = openDatabase(databasePath);
+	try {
+		const session = database
+			.prepare("SELECT id, directory, title, time_created FROM session WHERE id = ?")
+			.get(sessionId) as OpenCodeSessionRow | undefined;
+		if (!session) {
+			return undefined;
+		}
+
+		const records: OpenCodeMessageRecord[] = [];
+		const messageRows = queryRows<MessageDataRow>(
+			database,
+			"SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created, id",
+			sessionId,
+		);
+		for (const row of messageRows) {
+			const message = parseData(row.data);
+			const messageId = row.id;
+			const role = asString(message?.role);
+			if (!message || !messageId || (role !== "user" && role !== "assistant")) {
+				continue;
+			}
+			const parts = queryRows<JsonDataRow>(
+				database,
+				"SELECT data FROM part WHERE session_id = ? AND message_id = ? ORDER BY time_created, id",
+				sessionId,
+				messageId,
+			)
+				.map((part) => parseData(part.data))
+				.filter((part): part is Record<string, unknown> => part !== undefined);
+			records.push({ message, parts });
+		}
+		return convertOpenCodeSession(session, records);
+	} finally {
+		database.close();
+	}
+}

--- a/packages/coding-agent/src/core/session-import/adapters/pi.ts
+++ b/packages/coding-agent/src/core/session-import/adapters/pi.ts
@@ -1,0 +1,45 @@
+import type { Message } from "@earendil-works/pi-ai";
+import {
+	buildSessionContext,
+	loadEntriesFromFile,
+	migrateSessionEntries,
+	type SessionHeader,
+	type SessionInfoEntry,
+} from "../../session-manager.js";
+import { deriveSessionTitle, sanitizeImportedMessages } from "../shared.js";
+import type { ImportedSession } from "../types.js";
+
+function isMessage(value: unknown): value is Message {
+	if (typeof value !== "object" || value === null || !("role" in value)) {
+		return false;
+	}
+	const role = (value as { role?: unknown }).role;
+	return role === "user" || role === "assistant" || role === "toolResult";
+}
+
+export async function parsePiSession(filePath: string): Promise<ImportedSession | undefined> {
+	const entries = loadEntriesFromFile(filePath);
+	if (entries.length === 0 || entries[0]?.type !== "session") {
+		return undefined;
+	}
+	migrateSessionEntries(entries);
+	const header = entries[0] as SessionHeader;
+	const sessionEntries = entries.slice(1).filter((entry) => entry.type !== "session");
+	const context = buildSessionContext(sessionEntries);
+	const messages = sanitizeImportedMessages(context.messages.filter(isMessage));
+	if (messages.length === 0) {
+		return undefined;
+	}
+
+	const titleEntry = [...sessionEntries]
+		.reverse()
+		.find((entry): entry is SessionInfoEntry => entry.type === "session_info" && !!entry.name?.trim());
+	return {
+		source: "pi",
+		sourceId: header.id,
+		cwd: header.cwd,
+		title: titleEntry?.name?.trim() || deriveSessionTitle(messages),
+		createdAt: Date.parse(header.timestamp) || Date.now(),
+		messages,
+	};
+}

--- a/packages/coding-agent/src/core/session-import/file.ts
+++ b/packages/coding-agent/src/core/session-import/file.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { getAgentDir, getSessionsDir } from "../../config.js";
 import { SessionImportFileNotFoundError } from "../session-import-errors.js";
@@ -74,6 +73,6 @@ export async function importExternalSessionFile(
 		return { source, sessionFile, status: "existing" };
 	}
 
-	persistImportedSession(session, contentHash, sessionDir, options.homeDir ?? homedir(), "active");
+	persistImportedSession(session, contentHash, sessionDir, options.cwd ?? process.cwd(), "active");
 	return { source, sessionFile, status: "imported" };
 }

--- a/packages/coding-agent/src/core/session-import/file.ts
+++ b/packages/coding-agent/src/core/session-import/file.ts
@@ -5,12 +5,13 @@ import { getAgentDir, getSessionsDir } from "../../config.js";
 import { SessionImportFileNotFoundError } from "../session-import-errors.js";
 import { parseClaudeSession } from "./adapters/claude.js";
 import { parseCodexSession } from "./adapters/codex.js";
-import { readJsonLinePrefix } from "./jsonl.js";
-import { asRecord, asString, importedSessionContentHash } from "./shared.js";
+import { parseOpenCodeExportFile } from "./adapters/opencode.js";
+import { readJsonDocument, readJsonLinePrefix } from "./jsonl.js";
+import { asArray, asRecord, asString, importedSessionContentHash } from "./shared.js";
 import { importedSessionPath, persistImportedSession } from "./storage.js";
 import type { SessionImportOptions } from "./types.js";
 
-export type SessionImportFileKind = "native" | "claude" | "codex" | "unknown";
+export type SessionImportFileKind = "native" | "claude" | "codex" | "opencode" | "unknown";
 export type ExternalSessionImportFileKind = Exclude<SessionImportFileKind, "native" | "unknown">;
 
 export interface ImportedExternalSessionFile {
@@ -41,6 +42,10 @@ export async function detectSessionImportFileKind(filePath: string): Promise<Ses
 			return "claude";
 		}
 	}
+	const document = asRecord(await readJsonDocument(resolvedPath));
+	if (asRecord(document?.info) && asArray(document?.messages).length > 0) {
+		return "opencode";
+	}
 	return "unknown";
 }
 
@@ -50,9 +55,15 @@ export async function importExternalSessionFile(
 	options: SessionImportOptions = {},
 ): Promise<ImportedExternalSessionFile> {
 	const resolvedPath = resolve(filePath);
-	const session = source === "claude" ? await parseClaudeSession(resolvedPath) : await parseCodexSession(resolvedPath);
+	const session =
+		source === "claude"
+			? await parseClaudeSession(resolvedPath)
+			: source === "codex"
+				? await parseCodexSession(resolvedPath)
+				: await parseOpenCodeExportFile(resolvedPath);
 	if (!session) {
-		throw new Error(`No importable ${source === "claude" ? "Claude Code" : "Codex"} messages found`);
+		const label = source === "claude" ? "Claude Code" : source === "codex" ? "Codex" : "OpenCode";
+		throw new Error(`No importable ${label} messages found`);
 	}
 
 	const agentDir = options.agentDir ?? getAgentDir();

--- a/packages/coding-agent/src/core/session-import/file.ts
+++ b/packages/coding-agent/src/core/session-import/file.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { getAgentDir, getSessionsDir } from "../../config.js";
+import { SessionImportFileNotFoundError } from "../session-import-errors.js";
+import { parseClaudeSession } from "./adapters/claude.js";
+import { parseCodexSession } from "./adapters/codex.js";
+import { readJsonLinePrefix } from "./jsonl.js";
+import { asRecord, asString, importedSessionContentHash } from "./shared.js";
+import { importedSessionPath, persistImportedSession } from "./storage.js";
+import type { SessionImportOptions } from "./types.js";
+
+export type SessionImportFileKind = "native" | "claude" | "codex" | "unknown";
+export type ExternalSessionImportFileKind = Exclude<SessionImportFileKind, "native" | "unknown">;
+
+export interface ImportedExternalSessionFile {
+	source: ExternalSessionImportFileKind;
+	sessionFile: string;
+	status: "imported" | "existing";
+}
+
+export async function detectSessionImportFileKind(filePath: string): Promise<SessionImportFileKind> {
+	const resolvedPath = resolve(filePath);
+	if (!existsSync(resolvedPath)) {
+		throw new SessionImportFileNotFoundError(resolvedPath);
+	}
+	const values = await readJsonLinePrefix(resolvedPath, 100);
+	for (const value of values) {
+		const record = asRecord(value);
+		const type = asString(record?.type);
+		if (type === "session") {
+			return "native";
+		}
+		if (
+			record?.payload &&
+			(type === "session_meta" || type === "turn_context" || type === "event_msg" || type === "response_item")
+		) {
+			return "codex";
+		}
+		if ((type === "user" || type === "assistant") && record?.message) {
+			return "claude";
+		}
+	}
+	return "unknown";
+}
+
+export async function importExternalSessionFile(
+	filePath: string,
+	source: ExternalSessionImportFileKind,
+	options: SessionImportOptions = {},
+): Promise<ImportedExternalSessionFile> {
+	const resolvedPath = resolve(filePath);
+	const session = source === "claude" ? await parseClaudeSession(resolvedPath) : await parseCodexSession(resolvedPath);
+	if (!session) {
+		throw new Error(`No importable ${source === "claude" ? "Claude Code" : "Codex"} messages found`);
+	}
+
+	const agentDir = options.agentDir ?? getAgentDir();
+	const sessionDir = getSessionsDir(agentDir);
+	const contentHash = importedSessionContentHash(session);
+	const sessionFile = importedSessionPath(session, contentHash, sessionDir);
+	if (existsSync(sessionFile)) {
+		return { source, sessionFile, status: "existing" };
+	}
+
+	persistImportedSession(session, contentHash, sessionDir, options.homeDir ?? homedir(), "active");
+	return { source, sessionFile, status: "imported" };
+}

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -1,16 +1,17 @@
-import { type Dirent, existsSync, readdirSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { getAgentDir, getSessionsDir } from "../../config.js";
 import { parseClaudeSession } from "./adapters/claude.js";
 import { parseCodexSession } from "./adapters/codex.js";
 import {
-	listOpenCodeCliSessionIds,
-	listOpenCodeSessionIds,
+	listOpenCodeCliSessions,
+	listOpenCodeSessions,
 	parseOpenCodeCliSession,
 	parseOpenCodeSession,
 } from "./adapters/opencode.js";
 import { parsePiSession } from "./adapters/pi.js";
+import { importedSessionContentHash } from "./shared.js";
 import { discoverSkillDirectories, importSkillDirectory } from "./skills.js";
 import { collectImportedSessionKeys, persistImportedSession, sessionImportKey } from "./storage.js";
 import {
@@ -39,14 +40,32 @@ const SOURCE_LABELS: Record<SessionImportSource, string> = {
 	opencode: "OpenCode",
 	pi: "Pi",
 };
-const MAX_DISCOVERED_SESSIONS = 50_000;
+const MAX_RECENT_SESSIONS = 50;
+const MAX_SESSION_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
-function listJsonlFiles(root: string, excludeDirectory?: (name: string) => boolean): string[] {
-	const files: string[] = [];
-	const visit = (directory: string) => {
-		if (files.length >= MAX_DISCOVERED_SESSIONS) {
-			return;
-		}
+interface JsonlSearchRoot {
+	path: string;
+	recursive: boolean;
+	excludeDirectory?: (name: string) => boolean;
+}
+
+interface RecentFile {
+	path: string;
+	modifiedAt: number;
+}
+
+function listRecentJsonlFiles(roots: JsonlSearchRoot[], cutoff: number): string[] {
+	const files = new Map<string, RecentFile>();
+	const addFile = (path: string) => {
+		try {
+			const modifiedAt = statSync(path).mtimeMs;
+			if (modifiedAt >= cutoff) {
+				const normalized = resolve(path);
+				files.set(normalized, { path: normalized, modifiedAt });
+			}
+		} catch {}
+	};
+	const visit = (root: JsonlSearchRoot, directory: string) => {
 		let entries: Dirent<string>[];
 		try {
 			entries = readdirSync(directory, { withFileTypes: true, encoding: "utf8" });
@@ -59,33 +78,25 @@ function listJsonlFiles(root: string, excludeDirectory?: (name: string) => boole
 			}
 			const path = join(directory, entry.name);
 			if (entry.isDirectory()) {
-				if (!excludeDirectory?.(entry.name)) {
-					visit(path);
+				if (root.recursive && !root.excludeDirectory?.(entry.name)) {
+					visit(root, path);
 				}
 			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
-				files.push(path);
-			}
-			if (files.length >= MAX_DISCOVERED_SESSIONS) {
-				return;
+				addFile(path);
 			}
 		}
 	};
-	visit(root);
-	return files;
+	for (const root of roots) {
+		visit(root, root.path);
+	}
+	return [...files.values()]
+		.sort((a, b) => b.modifiedAt - a.modifiedAt || a.path.localeCompare(b.path))
+		.slice(0, MAX_RECENT_SESSIONS)
+		.map((file) => file.path);
 }
 
 function fileReferences(paths: string[]): SessionImportReference[] {
-	return [...new Set(paths.map((path) => resolve(path)))].map((path) => ({ kind: "file", path }));
-}
-
-function listDirectJsonlFiles(root: string): string[] {
-	try {
-		return readdirSync(root, { withFileTypes: true, encoding: "utf8" })
-			.filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".jsonl"))
-			.map((entry) => join(root, entry.name));
-	} catch {
-		return [];
-	}
+	return paths.map((path) => ({ kind: "file", path }));
 }
 
 function uniqueExistingDirectories(paths: string[]): string[] {
@@ -119,7 +130,12 @@ function makeInventory(
 	};
 }
 
-function discoverOpenCodeReferences(home: string, env: NodeJS.ProcessEnv, cwd: string): SessionImportReference[] {
+function discoverOpenCodeReferences(
+	home: string,
+	env: NodeJS.ProcessEnv,
+	cwd: string,
+	cutoff: number,
+): SessionImportReference[] {
 	const configuredDataDirectories = env.OPENCODE_DATA_HOME
 		? [env.OPENCODE_DATA_HOME]
 		: env.XDG_DATA_HOME
@@ -133,20 +149,26 @@ function discoverOpenCodeReferences(home: string, env: NodeJS.ProcessEnv, cwd: s
 		.map((directory) => join(directory, "opencode.db"))
 		.filter(existsSync);
 
-	const references: SessionImportReference[] = [];
-	const seen = new Set<string>();
+	const candidatesById = new Map<string, { id: string; reference: SessionImportReference; modifiedAt: number }>();
 	for (const databasePath of candidates) {
 		try {
-			for (const sessionId of listOpenCodeSessionIds(databasePath)) {
-				if (!seen.has(sessionId)) {
-					seen.add(sessionId);
-					references.push({ kind: "opencode", databasePath, sessionId });
+			for (const session of listOpenCodeSessions(databasePath, cutoff, MAX_RECENT_SESSIONS)) {
+				const existing = candidatesById.get(session.id);
+				if (!existing || session.modifiedAt > existing.modifiedAt) {
+					candidatesById.set(session.id, {
+						id: session.id,
+						reference: { kind: "opencode", databasePath, sessionId: session.id },
+						modifiedAt: session.modifiedAt,
+					});
 				}
 			}
 		} catch {}
 	}
-	if (references.length > 0) {
-		return references;
+	if (candidatesById.size > 0) {
+		return [...candidatesById.values()]
+			.sort((a, b) => b.modifiedAt - a.modifiedAt || a.id.localeCompare(b.id))
+			.slice(0, MAX_RECENT_SESSIONS)
+			.map((candidate) => candidate.reference);
 	}
 
 	const commands = [
@@ -155,16 +177,13 @@ function discoverOpenCodeReferences(home: string, env: NodeJS.ProcessEnv, cwd: s
 		"opencode",
 	].filter((command): command is string => !!command);
 	for (const command of commands) {
-		const sessionIds = listOpenCodeCliSessionIds(command, cwd);
-		if (sessionIds === undefined) {
+		const sessions = listOpenCodeCliSessions(command, cwd, cutoff, MAX_RECENT_SESSIONS);
+		if (sessions === undefined) {
 			continue;
 		}
-		for (const sessionId of sessionIds) {
-			references.push({ kind: "opencode-cli", command, cwd, sessionId });
-		}
-		break;
+		return sessions.map((session) => ({ kind: "opencode-cli", command, cwd, sessionId: session.id }));
 	}
-	return references;
+	return [];
 }
 
 export function discoverSessionImports(options: SessionImportOptions = {}): SessionImportInventory[] {
@@ -172,6 +191,7 @@ export function discoverSessionImports(options: SessionImportOptions = {}): Sess
 	const env = options.env ?? process.env;
 	const cwd = options.cwd ?? process.cwd();
 	const agentDir = resolve(options.agentDir ?? getAgentDir());
+	const cutoff = Date.now() - MAX_SESSION_AGE_MS;
 	const claudeDir = resolve(env.CLAUDE_CONFIG_DIR ?? join(home, ".claude"));
 	const codexDir = resolve(env.CODEX_HOME ?? join(home, ".codex"));
 	const piDir = resolve(env.PI_CODING_AGENT_DIR ?? env.PI_AGENT_DIR ?? join(home, ".pi", "agent"));
@@ -184,18 +204,34 @@ export function discoverSessionImports(options: SessionImportOptions = {}): Sess
 	const inventories = [
 		makeInventory(
 			"claude",
-			fileReferences(listJsonlFiles(join(claudeDir, "projects"), (name) => name === "subagents")),
+			fileReferences(
+				listRecentJsonlFiles(
+					[
+						{
+							path: join(claudeDir, "projects"),
+							recursive: true,
+							excludeDirectory: (name) => name === "subagents",
+						},
+					],
+					cutoff,
+				),
+			),
 			[join(claudeDir, "skills")],
 		),
 		makeInventory(
 			"codex",
-			fileReferences([
-				...listJsonlFiles(join(codexDir, "sessions")),
-				...listJsonlFiles(join(codexDir, "archived_sessions")),
-			]),
+			fileReferences(
+				listRecentJsonlFiles(
+					[
+						{ path: join(codexDir, "sessions"), recursive: true },
+						{ path: join(codexDir, "archived_sessions"), recursive: true },
+					],
+					cutoff,
+				),
+			),
 			[join(codexDir, "skills")],
 		),
-		makeInventory("opencode", discoverOpenCodeReferences(home, env, cwd), [
+		makeInventory("opencode", discoverOpenCodeReferences(home, env, cwd, cutoff), [
 			...configuredOpenCodeSkillDirectories,
 			join(home, ".config", "opencode", "skills"),
 			join(home, ".opencode", "skills"),
@@ -204,7 +240,15 @@ export function discoverSessionImports(options: SessionImportOptions = {}): Sess
 			? undefined
 			: makeInventory(
 					"pi",
-					fileReferences([...listJsonlFiles(join(piDir, "sessions")), ...listDirectJsonlFiles(piDir)]),
+					fileReferences(
+						listRecentJsonlFiles(
+							[
+								{ path: join(piDir, "sessions"), recursive: true },
+								{ path: piDir, recursive: false },
+							],
+							cutoff,
+						),
+					),
 					[join(piDir, "skills")],
 				),
 	];
@@ -287,12 +331,13 @@ export async function importSessionsAndSkills(
 					result.sessionsSkipped++;
 					continue;
 				}
-				const key = sessionImportKey(session.source, session.sourceId);
+				const contentHash = importedSessionContentHash(session);
+				const key = sessionImportKey(session.source, session.sourceId, contentHash);
 				if (importedKeys.has(key)) {
 					result.sessionsSkipped++;
 					continue;
 				}
-				persistImportedSession(session, sessionDir, home);
+				persistImportedSession(session, contentHash, sessionDir, home);
 				importedKeys.add(key);
 				result.sessionsImported++;
 			} catch {

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -72,7 +72,9 @@ function listRecentJsonlFiles(roots: JsonlSearchRoot[], cutoff: number): string[
 				const normalized = resolve(path);
 				files.set(normalized, { path: normalized, modifiedAt });
 			}
-		} catch {}
+		} catch {
+			// Files can disappear or become unreadable while discovery is scanning.
+		}
 	};
 	const visit = (root: JsonlSearchRoot, directory: string) => {
 		let entries: Dirent<string>[];
@@ -194,7 +196,9 @@ function discoverOpenCodeReferences(
 					});
 				}
 			}
-		} catch {}
+		} catch {
+			// A bad database should not prevent trying the remaining OpenCode locations.
+		}
 	}
 	if (candidatesById.size > 0) {
 		return [...candidatesById.values()]

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -25,6 +25,13 @@ import {
 	type SessionImportSourceResult,
 } from "./types.js";
 
+export {
+	detectSessionImportFileKind,
+	type ExternalSessionImportFileKind,
+	type ImportedExternalSessionFile,
+	importExternalSessionFile,
+	type SessionImportFileKind,
+} from "./file.js";
 export type {
 	SessionImportInventory,
 	SessionImportOptions,

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -1,0 +1,340 @@
+import { type Dirent, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { getAgentDir, getSessionsDir } from "../../config.js";
+import { parseClaudeSession } from "./adapters/claude.js";
+import { parseCodexSession } from "./adapters/codex.js";
+import {
+	listOpenCodeCliSessionIds,
+	listOpenCodeSessionIds,
+	parseOpenCodeCliSession,
+	parseOpenCodeSession,
+} from "./adapters/opencode.js";
+import { parsePiSession } from "./adapters/pi.js";
+import { discoverSkillDirectories, importSkillDirectory } from "./skills.js";
+import { collectImportedSessionKeys, persistImportedSession, sessionImportKey } from "./storage.js";
+import {
+	type ImportedSession,
+	SESSION_IMPORT_SOURCES,
+	type SessionImportInventory,
+	type SessionImportOptions,
+	type SessionImportReference,
+	type SessionImportResult,
+	type SessionImportSource,
+	type SessionImportSourceResult,
+} from "./types.js";
+
+export type {
+	SessionImportInventory,
+	SessionImportOptions,
+	SessionImportResult,
+	SessionImportSource,
+	SessionImportSourceResult,
+} from "./types.js";
+export { SESSION_IMPORT_SOURCES } from "./types.js";
+
+const SOURCE_LABELS: Record<SessionImportSource, string> = {
+	claude: "Claude Code",
+	codex: "Codex",
+	opencode: "OpenCode",
+	pi: "Pi",
+};
+const MAX_DISCOVERED_SESSIONS = 50_000;
+
+function listJsonlFiles(root: string, excludeDirectory?: (name: string) => boolean): string[] {
+	const files: string[] = [];
+	const visit = (directory: string) => {
+		if (files.length >= MAX_DISCOVERED_SESSIONS) {
+			return;
+		}
+		let entries: Dirent<string>[];
+		try {
+			entries = readdirSync(directory, { withFileTypes: true, encoding: "utf8" });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry.isSymbolicLink()) {
+				continue;
+			}
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				if (!excludeDirectory?.(entry.name)) {
+					visit(path);
+				}
+			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+				files.push(path);
+			}
+			if (files.length >= MAX_DISCOVERED_SESSIONS) {
+				return;
+			}
+		}
+	};
+	visit(root);
+	return files;
+}
+
+function fileReferences(paths: string[]): SessionImportReference[] {
+	return [...new Set(paths.map((path) => resolve(path)))].map((path) => ({ kind: "file", path }));
+}
+
+function listDirectJsonlFiles(root: string): string[] {
+	try {
+		return readdirSync(root, { withFileTypes: true, encoding: "utf8" })
+			.filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".jsonl"))
+			.map((entry) => join(root, entry.name));
+	} catch {
+		return [];
+	}
+}
+
+function uniqueExistingDirectories(paths: string[]): string[] {
+	const seen = new Set<string>();
+	return paths.filter((path) => {
+		const normalized = resolve(path);
+		if (seen.has(normalized) || !existsSync(normalized)) {
+			return false;
+		}
+		seen.add(normalized);
+		return true;
+	});
+}
+
+function makeInventory(
+	source: SessionImportSource,
+	sessionReferences: SessionImportReference[],
+	skillRoots: string[],
+): SessionImportInventory | undefined {
+	const skillDirectories = uniqueExistingDirectories(skillRoots).flatMap(discoverSkillDirectories);
+	if (sessionReferences.length === 0 && skillDirectories.length === 0) {
+		return undefined;
+	}
+	return {
+		source,
+		label: SOURCE_LABELS[source],
+		sessionCount: sessionReferences.length,
+		skillCount: skillDirectories.length,
+		sessionReferences,
+		skillDirectories,
+	};
+}
+
+function discoverOpenCodeReferences(home: string, env: NodeJS.ProcessEnv, cwd: string): SessionImportReference[] {
+	const configuredDataDirectories = env.OPENCODE_DATA_HOME
+		? [env.OPENCODE_DATA_HOME]
+		: env.XDG_DATA_HOME
+			? [join(env.XDG_DATA_HOME, "opencode")]
+			: [];
+	const candidates = uniqueExistingDirectories([
+		...configuredDataDirectories,
+		join(home, ".local", "share", "opencode"),
+		join(home, "Library", "Application Support", "opencode"),
+	])
+		.map((directory) => join(directory, "opencode.db"))
+		.filter(existsSync);
+
+	const references: SessionImportReference[] = [];
+	const seen = new Set<string>();
+	for (const databasePath of candidates) {
+		try {
+			for (const sessionId of listOpenCodeSessionIds(databasePath)) {
+				if (!seen.has(sessionId)) {
+					seen.add(sessionId);
+					references.push({ kind: "opencode", databasePath, sessionId });
+				}
+			}
+		} catch {}
+	}
+	if (references.length > 0) {
+		return references;
+	}
+
+	const commands = [
+		env.OPENCODE_BIN,
+		join(home, ".opencode", "bin", process.platform === "win32" ? "opencode.exe" : "opencode"),
+		"opencode",
+	].filter((command): command is string => !!command);
+	for (const command of commands) {
+		const sessionIds = listOpenCodeCliSessionIds(command, cwd);
+		if (sessionIds === undefined) {
+			continue;
+		}
+		for (const sessionId of sessionIds) {
+			references.push({ kind: "opencode-cli", command, cwd, sessionId });
+		}
+		break;
+	}
+	return references;
+}
+
+export function discoverSessionImports(options: SessionImportOptions = {}): SessionImportInventory[] {
+	const home = options.homeDir ?? homedir();
+	const env = options.env ?? process.env;
+	const cwd = options.cwd ?? process.cwd();
+	const agentDir = resolve(options.agentDir ?? getAgentDir());
+	const claudeDir = resolve(env.CLAUDE_CONFIG_DIR ?? join(home, ".claude"));
+	const codexDir = resolve(env.CODEX_HOME ?? join(home, ".codex"));
+	const piDir = resolve(env.PI_CODING_AGENT_DIR ?? env.PI_AGENT_DIR ?? join(home, ".pi", "agent"));
+	const configuredOpenCodeSkillDirectories = env.OPENCODE_CONFIG_DIR
+		? [join(env.OPENCODE_CONFIG_DIR, "skills")]
+		: env.XDG_CONFIG_HOME
+			? [join(env.XDG_CONFIG_HOME, "opencode", "skills")]
+			: [];
+
+	const inventories = [
+		makeInventory(
+			"claude",
+			fileReferences(listJsonlFiles(join(claudeDir, "projects"), (name) => name === "subagents")),
+			[join(claudeDir, "skills")],
+		),
+		makeInventory(
+			"codex",
+			fileReferences([
+				...listJsonlFiles(join(codexDir, "sessions")),
+				...listJsonlFiles(join(codexDir, "archived_sessions")),
+			]),
+			[join(codexDir, "skills")],
+		),
+		makeInventory("opencode", discoverOpenCodeReferences(home, env, cwd), [
+			...configuredOpenCodeSkillDirectories,
+			join(home, ".config", "opencode", "skills"),
+			join(home, ".opencode", "skills"),
+		]),
+		resolve(piDir) === agentDir
+			? undefined
+			: makeInventory(
+					"pi",
+					fileReferences([...listJsonlFiles(join(piDir, "sessions")), ...listDirectJsonlFiles(piDir)]),
+					[join(piDir, "skills")],
+				),
+	];
+	return inventories.filter((inventory): inventory is SessionImportInventory => inventory !== undefined);
+}
+
+async function parseSessionReference(
+	source: SessionImportSource,
+	reference: SessionImportReference,
+): Promise<ImportedSession | undefined> {
+	if (reference.kind === "opencode-cli") {
+		return source === "opencode"
+			? parseOpenCodeCliSession(reference.command, reference.cwd, reference.sessionId)
+			: undefined;
+	}
+	if (reference.kind === "opencode") {
+		return source === "opencode" ? parseOpenCodeSession(reference.databasePath, reference.sessionId) : undefined;
+	}
+	switch (source) {
+		case "claude":
+			return parseClaudeSession(reference.path);
+		case "codex":
+			return parseCodexSession(reference.path);
+		case "pi":
+			return parsePiSession(reference.path);
+		case "opencode":
+			return undefined;
+	}
+}
+
+function emptySourceResult(source: SessionImportSource): SessionImportSourceResult {
+	return {
+		source,
+		sessionsImported: 0,
+		sessionsSkipped: 0,
+		sessionFailures: 0,
+		skillsImported: 0,
+		skillsSkipped: 0,
+		skillFailures: 0,
+	};
+}
+
+function combineResults(sources: SessionImportSourceResult[]): SessionImportResult {
+	return {
+		sources,
+		sessionsImported: sources.reduce((sum, result) => sum + result.sessionsImported, 0),
+		sessionsSkipped: sources.reduce((sum, result) => sum + result.sessionsSkipped, 0),
+		sessionFailures: sources.reduce((sum, result) => sum + result.sessionFailures, 0),
+		skillsImported: sources.reduce((sum, result) => sum + result.skillsImported, 0),
+		skillsSkipped: sources.reduce((sum, result) => sum + result.skillsSkipped, 0),
+		skillFailures: sources.reduce((sum, result) => sum + result.skillFailures, 0),
+	};
+}
+
+export async function importSessionsAndSkills(
+	inventories: SessionImportInventory[],
+	selectedSources: readonly SessionImportSource[],
+	options: SessionImportOptions = {},
+): Promise<SessionImportResult> {
+	const agentDir = options.agentDir ?? getAgentDir();
+	const home = options.homeDir ?? homedir();
+	const sessionDir = getSessionsDir(agentDir);
+	const skillDir = join(agentDir, "skills");
+	const selected = new Set(selectedSources);
+	const importedKeys = collectImportedSessionKeys(sessionDir);
+	const sourceResults: SessionImportSourceResult[] = [];
+
+	for (const inventory of inventories) {
+		if (!selected.has(inventory.source)) {
+			continue;
+		}
+		const result = emptySourceResult(inventory.source);
+		sourceResults.push(result);
+		options.onProgress?.(`Importing ${inventory.label}...`);
+
+		for (const reference of inventory.sessionReferences) {
+			try {
+				const session = await parseSessionReference(inventory.source, reference);
+				if (!session) {
+					result.sessionsSkipped++;
+					continue;
+				}
+				const key = sessionImportKey(session.source, session.sourceId);
+				if (importedKeys.has(key)) {
+					result.sessionsSkipped++;
+					continue;
+				}
+				persistImportedSession(session, sessionDir, home);
+				importedKeys.add(key);
+				result.sessionsImported++;
+			} catch {
+				result.sessionFailures++;
+			}
+		}
+
+		for (const sourceSkillDir of inventory.skillDirectories) {
+			try {
+				const status = importSkillDirectory(sourceSkillDir, skillDir);
+				if (status === "imported") {
+					result.skillsImported++;
+				} else {
+					result.skillsSkipped++;
+				}
+			} catch {
+				result.skillFailures++;
+			}
+		}
+	}
+
+	return combineResults(sourceResults);
+}
+
+export function formatSessionImportResult(result: SessionImportResult): string {
+	const imported: string[] = [];
+	if (result.sessionsImported > 0) {
+		imported.push(`${result.sessionsImported} session${result.sessionsImported === 1 ? "" : "s"}`);
+	}
+	if (result.skillsImported > 0) {
+		imported.push(`${result.skillsImported} skill${result.skillsImported === 1 ? "" : "s"}`);
+	}
+	const failures = result.sessionFailures + result.skillFailures;
+	if (imported.length === 0) {
+		return failures > 0
+			? `No data imported; ${failures} item${failures === 1 ? "" : "s"} could not be read`
+			: "No new data to import";
+	}
+	return `Imported ${imported.join(" and ")}${failures > 0 ? `; skipped ${failures} unreadable item${failures === 1 ? "" : "s"}` : ""}`;
+}
+
+export function orderedSelectedSources(sources: Iterable<SessionImportSource>): SessionImportSource[] {
+	const selected = new Set(sources);
+	return SESSION_IMPORT_SOURCES.filter((source) => selected.has(source));
+}

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -2,6 +2,7 @@ import { type Dirent, existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { getAgentDir, getSessionsDir } from "../../config.js";
+import { readFirstLineSync } from "../../utils/file-lines.js";
 import { parseClaudeSession } from "./adapters/claude.js";
 import { parseCodexSession } from "./adapters/codex.js";
 import {
@@ -54,6 +55,7 @@ interface JsonlSearchRoot {
 	path: string;
 	recursive: boolean;
 	excludeDirectory?: (name: string) => boolean;
+	includeFile?: (path: string) => boolean;
 }
 
 interface RecentFile {
@@ -88,7 +90,7 @@ function listRecentJsonlFiles(roots: JsonlSearchRoot[], cutoff: number): string[
 				if (root.recursive && !root.excludeDirectory?.(entry.name)) {
 					visit(root, path);
 				}
-			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+			} else if (entry.isFile() && entry.name.endsWith(".jsonl") && (root.includeFile?.(path) ?? true)) {
 				addFile(path);
 			}
 		}
@@ -104,6 +106,29 @@ function listRecentJsonlFiles(roots: JsonlSearchRoot[], cutoff: number): string[
 
 function fileReferences(paths: string[]): SessionImportReference[] {
 	return paths.map((path) => ({ kind: "file", path }));
+}
+
+function isTopLevelCodexSession(path: string): boolean {
+	try {
+		const firstLine = readFirstLineSync(path, 1024 * 1024);
+		if (!firstLine) {
+			return true;
+		}
+		const entry = JSON.parse(firstLine) as {
+			type?: unknown;
+			payload?: { thread_source?: unknown; source?: unknown };
+		};
+		if (entry.type !== "session_meta" || !entry.payload) {
+			return true;
+		}
+		if (entry.payload.thread_source === "subagent") {
+			return false;
+		}
+		const source = entry.payload.source;
+		return !(typeof source === "object" && source !== null && "subagent" in source);
+	} catch {
+		return true;
+	}
 }
 
 function uniqueExistingDirectories(paths: string[]): string[] {
@@ -230,8 +255,8 @@ export function discoverSessionImports(options: SessionImportOptions = {}): Sess
 			fileReferences(
 				listRecentJsonlFiles(
 					[
-						{ path: join(codexDir, "sessions"), recursive: true },
-						{ path: join(codexDir, "archived_sessions"), recursive: true },
+						{ path: join(codexDir, "sessions"), recursive: true, includeFile: isTopLevelCodexSession },
+						{ path: join(codexDir, "archived_sessions"), recursive: true, includeFile: isTopLevelCodexSession },
 					],
 					cutoff,
 				),

--- a/packages/coding-agent/src/core/session-import/index.ts
+++ b/packages/coding-agent/src/core/session-import/index.ts
@@ -114,14 +114,14 @@ function isTopLevelCodexSession(path: string): boolean {
 	try {
 		const firstLine = readFirstLineSync(path, 1024 * 1024);
 		if (!firstLine) {
-			return true;
+			return false;
 		}
 		const entry = JSON.parse(firstLine) as {
 			type?: unknown;
 			payload?: { thread_source?: unknown; source?: unknown };
 		};
 		if (entry.type !== "session_meta" || !entry.payload) {
-			return true;
+			return false;
 		}
 		if (entry.payload.thread_source === "subagent") {
 			return false;
@@ -129,7 +129,7 @@ function isTopLevelCodexSession(path: string): boolean {
 		const source = entry.payload.source;
 		return !(typeof source === "object" && source !== null && "subagent" in source);
 	} catch {
-		return true;
+		return false;
 	}
 }
 
@@ -214,7 +214,7 @@ function discoverOpenCodeReferences(
 	].filter((command): command is string => !!command);
 	for (const command of commands) {
 		const sessions = listOpenCodeCliSessions(command, cwd, cutoff, MAX_RECENT_SESSIONS);
-		if (sessions === undefined) {
+		if (!sessions || sessions.length === 0) {
 			continue;
 		}
 		return sessions.map((session) => ({ kind: "opencode-cli", command, cwd, sessionId: session.id }));
@@ -345,7 +345,7 @@ export async function importSessionsAndSkills(
 	options: SessionImportOptions = {},
 ): Promise<SessionImportResult> {
 	const agentDir = options.agentDir ?? getAgentDir();
-	const home = options.homeDir ?? homedir();
+	const fallbackCwd = options.cwd ?? process.cwd();
 	const sessionDir = getSessionsDir(agentDir);
 	const skillDir = join(agentDir, "skills");
 	const selected = new Set(selectedSources);
@@ -373,7 +373,7 @@ export async function importSessionsAndSkills(
 					result.sessionsSkipped++;
 					continue;
 				}
-				persistImportedSession(session, contentHash, sessionDir, home);
+				persistImportedSession(session, contentHash, sessionDir, fallbackCwd);
 				importedKeys.add(key);
 				result.sessionsImported++;
 			} catch {

--- a/packages/coding-agent/src/core/session-import/jsonl.ts
+++ b/packages/coding-agent/src/core/session-import/jsonl.ts
@@ -26,7 +26,9 @@ export async function readJsonLinePrefix(filePath: string, limit: number): Promi
 				if (values.length >= limit) {
 					break;
 				}
-			} catch {}
+			} catch {
+				// Skip malformed records so later valid JSONL entries remain importable.
+			}
 		}
 	} finally {
 		lines.close();

--- a/packages/coding-agent/src/core/session-import/jsonl.ts
+++ b/packages/coding-agent/src/core/session-import/jsonl.ts
@@ -1,0 +1,34 @@
+import { createReadStream, statSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const MAX_IMPORT_FILE_BYTES = 256 * 1024 * 1024;
+
+export async function readJsonLines(
+	filePath: string,
+	onValue: (value: unknown) => void,
+): Promise<{ malformedLines: number }> {
+	const size = statSync(filePath).size;
+	if (size > MAX_IMPORT_FILE_BYTES) {
+		throw new Error(`Session file exceeds the ${MAX_IMPORT_FILE_BYTES / 1024 / 1024} MB import limit`);
+	}
+
+	let malformedLines = 0;
+	const input = createReadStream(filePath, { encoding: "utf8" });
+	const lines = createInterface({ input, crlfDelay: Infinity });
+	try {
+		for await (const line of lines) {
+			if (!line.trim()) {
+				continue;
+			}
+			try {
+				onValue(JSON.parse(line) as unknown);
+			} catch {
+				malformedLines++;
+			}
+		}
+	} finally {
+		lines.close();
+		input.destroy();
+	}
+	return { malformedLines };
+}

--- a/packages/coding-agent/src/core/session-import/jsonl.ts
+++ b/packages/coding-agent/src/core/session-import/jsonl.ts
@@ -5,8 +5,11 @@ import { createInterface } from "node:readline";
 const MAX_IMPORT_FILE_BYTES = 256 * 1024 * 1024;
 
 function validateImportFileSize(filePath: string): void {
-	const size = statSync(filePath).size;
-	if (size > MAX_IMPORT_FILE_BYTES) {
+	const stats = statSync(filePath);
+	if (!stats.isFile()) {
+		throw new Error("Session import source must be a regular file");
+	}
+	if (stats.size > MAX_IMPORT_FILE_BYTES) {
 		throw new Error(`Session file exceeds the ${MAX_IMPORT_FILE_BYTES / 1024 / 1024} MB import limit`);
 	}
 }

--- a/packages/coding-agent/src/core/session-import/jsonl.ts
+++ b/packages/coding-agent/src/core/session-import/jsonl.ts
@@ -3,14 +3,42 @@ import { createInterface } from "node:readline";
 
 const MAX_IMPORT_FILE_BYTES = 256 * 1024 * 1024;
 
-export async function readJsonLines(
-	filePath: string,
-	onValue: (value: unknown) => void,
-): Promise<{ malformedLines: number }> {
+function validateImportFileSize(filePath: string): void {
 	const size = statSync(filePath).size;
 	if (size > MAX_IMPORT_FILE_BYTES) {
 		throw new Error(`Session file exceeds the ${MAX_IMPORT_FILE_BYTES / 1024 / 1024} MB import limit`);
 	}
+}
+
+export async function readJsonLinePrefix(filePath: string, limit: number): Promise<unknown[]> {
+	validateImportFileSize(filePath);
+	const values: unknown[] = [];
+	const input = createReadStream(filePath, { encoding: "utf8" });
+	const lines = createInterface({ input, crlfDelay: Infinity });
+	try {
+		for await (const line of lines) {
+			if (!line.trim()) {
+				continue;
+			}
+			try {
+				values.push(JSON.parse(line) as unknown);
+				if (values.length >= limit) {
+					break;
+				}
+			} catch {}
+		}
+	} finally {
+		lines.close();
+		input.destroy();
+	}
+	return values;
+}
+
+export async function readJsonLines(
+	filePath: string,
+	onValue: (value: unknown) => void,
+): Promise<{ malformedLines: number }> {
+	validateImportFileSize(filePath);
 
 	let malformedLines = 0;
 	const input = createReadStream(filePath, { encoding: "utf8" });

--- a/packages/coding-agent/src/core/session-import/jsonl.ts
+++ b/packages/coding-agent/src/core/session-import/jsonl.ts
@@ -1,4 +1,5 @@
 import { createReadStream, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
 
 const MAX_IMPORT_FILE_BYTES = 256 * 1024 * 1024;
@@ -32,6 +33,15 @@ export async function readJsonLinePrefix(filePath: string, limit: number): Promi
 		input.destroy();
 	}
 	return values;
+}
+
+export async function readJsonDocument(filePath: string): Promise<unknown | undefined> {
+	validateImportFileSize(filePath);
+	try {
+		return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+	} catch {
+		return undefined;
+	}
 }
 
 export async function readJsonLines(

--- a/packages/coding-agent/src/core/session-import/shared.ts
+++ b/packages/coding-agent/src/core/session-import/shared.ts
@@ -1,16 +1,17 @@
 import { createHash } from "node:crypto";
-import type {
-	Api,
-	AssistantMessage,
-	ImageContent,
-	Message,
-	StopReason,
-	TextContent,
-	ThinkingContent,
-	ToolCall,
-	ToolResultMessage,
-	Usage,
-	UserMessage,
+import {
+	type Api,
+	type AssistantMessage,
+	type ImageContent,
+	type Message,
+	normalizeToolName,
+	type StopReason,
+	type TextContent,
+	type ThinkingContent,
+	type ToolCall,
+	type ToolResultMessage,
+	type Usage,
+	type UserMessage,
 } from "@earendil-works/pi-ai";
 import type { ImportedSession } from "./types.js";
 
@@ -158,7 +159,7 @@ export function thinkingContent(thinking: string): ThinkingContent {
 }
 
 export function toolCallContent(id: string, name: string, args: unknown): ToolCall {
-	return { type: "toolCall", id, name, arguments: parseToolArguments(args) };
+	return { type: "toolCall", id, name: normalizeToolName(name), arguments: parseToolArguments(args) };
 }
 
 export function contentToText(content: Message["content"]): string {

--- a/packages/coding-agent/src/core/session-import/shared.ts
+++ b/packages/coding-agent/src/core/session-import/shared.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
 	Api,
 	AssistantMessage,
@@ -11,6 +12,7 @@ import type {
 	Usage,
 	UserMessage,
 } from "@earendil-works/pi-ai";
+import type { ImportedSession } from "./types.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -260,4 +262,17 @@ export function deriveSessionTitle(messages: Message[], fallback?: string): stri
 		return undefined;
 	}
 	return normalizedFallback.length > 80 ? `${normalizedFallback.slice(0, 77)}...` : normalizedFallback;
+}
+
+export function importedSessionContentHash(session: ImportedSession): string {
+	const messages = session.messages.map(({ timestamp: _timestamp, ...message }) => message);
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				cwd: session.cwd,
+				title: session.title,
+				messages,
+			}),
+		)
+		.digest("hex");
 }

--- a/packages/coding-agent/src/core/session-import/shared.ts
+++ b/packages/coding-agent/src/core/session-import/shared.ts
@@ -154,8 +154,11 @@ export function textContent(text: string): TextContent {
 	return { type: "text", text };
 }
 
-export function thinkingContent(thinking: string): ThinkingContent {
-	return { type: "thinking", thinking };
+export function thinkingContent(
+	thinking: string,
+	options?: Pick<ThinkingContent, "thinkingSignature" | "redacted">,
+): ThinkingContent {
+	return { type: "thinking", thinking, ...options };
 }
 
 export function toolCallContent(id: string, name: string, args: unknown): ToolCall {
@@ -198,6 +201,7 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 
 	const sanitized: Message[] = [];
 	const emittedCalls = new Set<string>();
+	const emittedResults = new Set<string>();
 	for (const message of messages) {
 		if (message.role === "assistant") {
 			const content: AssistantMessage["content"] = [];
@@ -205,7 +209,7 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 				if (block.type !== "toolCall") {
 					if (
 						(block.type === "text" && block.text.trim()) ||
-						(block.type === "thinking" && block.thinking.trim())
+						(block.type === "thinking" && (block.thinking.trim() || block.thinkingSignature || block.redacted))
 					) {
 						content.push(block);
 					}
@@ -229,7 +233,7 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 		}
 
 		if (message.role === "toolResult") {
-			if (!emittedCalls.has(message.toolCallId)) {
+			if (!emittedCalls.has(message.toolCallId) || emittedResults.has(message.toolCallId)) {
 				continue;
 			}
 			const content = message.content.filter(
@@ -241,6 +245,7 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 				content: content.length > 0 ? content : [textContent("(No tool output)")],
 			};
 			sanitized.push(next);
+			emittedResults.add(message.toolCallId);
 			continue;
 		}
 

--- a/packages/coding-agent/src/core/session-import/shared.ts
+++ b/packages/coding-agent/src/core/session-import/shared.ts
@@ -1,0 +1,263 @@
+import type {
+	Api,
+	AssistantMessage,
+	ImageContent,
+	Message,
+	StopReason,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+	ToolResultMessage,
+	Usage,
+	UserMessage,
+} from "@earendil-works/pi-ai";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return isRecord(value) ? value : undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+export function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+export function asArray(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+export function parseTimestamp(value: unknown, fallback = Date.now()): number {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value < 10_000_000_000 ? value * 1000 : value;
+	}
+	if (typeof value === "string") {
+		const parsed = Date.parse(value);
+		if (Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+	return fallback;
+}
+
+export function stringifyUnknown(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	try {
+		return JSON.stringify(value, null, 2) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+export function parseToolArguments(value: unknown): Record<string, unknown> {
+	if (isRecord(value)) {
+		return value;
+	}
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value) as unknown;
+			if (isRecord(parsed)) {
+				return parsed;
+			}
+		} catch {
+			return { raw: value };
+		}
+		return { raw: value };
+	}
+	return value === undefined ? {} : { value };
+}
+
+export function createZeroUsage(overrides?: Partial<Usage>): Usage {
+	const input = overrides?.input ?? 0;
+	const output = overrides?.output ?? 0;
+	const cacheRead = overrides?.cacheRead ?? 0;
+	const cacheWrite = overrides?.cacheWrite ?? 0;
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: overrides?.totalTokens ?? input + output + cacheRead + cacheWrite,
+		cost: {
+			input: overrides?.cost?.input ?? 0,
+			output: overrides?.cost?.output ?? 0,
+			cacheRead: overrides?.cost?.cacheRead ?? 0,
+			cacheWrite: overrides?.cost?.cacheWrite ?? 0,
+			total: overrides?.cost?.total ?? 0,
+		},
+	};
+}
+
+export interface ImportedAssistantOptions {
+	api: Api;
+	provider: string;
+	model: string;
+	timestamp: number;
+	usage?: Usage;
+	stopReason?: StopReason;
+	errorMessage?: string;
+}
+
+export function createAssistantMessage(
+	content: (TextContent | ThinkingContent | ToolCall)[],
+	options: ImportedAssistantOptions,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: options.api,
+		provider: options.provider,
+		model: options.model,
+		usage: options.usage ?? createZeroUsage(),
+		stopReason: options.stopReason ?? (content.some((block) => block.type === "toolCall") ? "toolUse" : "stop"),
+		errorMessage: options.errorMessage,
+		timestamp: options.timestamp,
+	};
+}
+
+export function createUserMessage(content: string | (TextContent | ImageContent)[], timestamp: number): UserMessage {
+	return { role: "user", content, timestamp };
+}
+
+export function createToolResultMessage(
+	toolCallId: string,
+	toolName: string,
+	content: (TextContent | ImageContent)[],
+	isError: boolean,
+	timestamp: number,
+): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content,
+		isError,
+		timestamp,
+	};
+}
+
+export function textContent(text: string): TextContent {
+	return { type: "text", text };
+}
+
+export function thinkingContent(thinking: string): ThinkingContent {
+	return { type: "thinking", thinking };
+}
+
+export function toolCallContent(id: string, name: string, args: unknown): ToolCall {
+	return { type: "toolCall", id, name, arguments: parseToolArguments(args) };
+}
+
+export function contentToText(content: Message["content"]): string {
+	if (typeof content === "string") {
+		return content;
+	}
+	return content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+function isNonEmptyMessage(message: Message): boolean {
+	if (message.role === "user") {
+		return typeof message.content === "string" ? message.content.trim().length > 0 : message.content.length > 0;
+	}
+	return message.content.length > 0;
+}
+
+export function sanitizeImportedMessages(messages: Message[]): Message[] {
+	const toolNames = new Map<string, string>();
+	const resultIds = new Set(
+		messages.filter((message) => message.role === "toolResult").map((message) => message.toolCallId),
+	);
+
+	for (const message of messages) {
+		if (message.role !== "assistant") {
+			continue;
+		}
+		for (const block of message.content) {
+			if (block.type === "toolCall" && block.id && block.name) {
+				toolNames.set(block.id, block.name);
+			}
+		}
+	}
+
+	const sanitized: Message[] = [];
+	const emittedCalls = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			const content: AssistantMessage["content"] = [];
+			for (const block of message.content) {
+				if (block.type !== "toolCall") {
+					if (
+						(block.type === "text" && block.text.trim()) ||
+						(block.type === "thinking" && block.thinking.trim())
+					) {
+						content.push(block);
+					}
+					continue;
+				}
+				if (!block.id || !block.name || emittedCalls.has(block.id)) {
+					continue;
+				}
+				if (resultIds.has(block.id)) {
+					content.push(block);
+					emittedCalls.add(block.id);
+				} else {
+					content.push(textContent(`[Tool call: ${block.name}]\n${stringifyUnknown(block.arguments)}`));
+				}
+			}
+			const next = { ...message, content };
+			if (isNonEmptyMessage(next)) {
+				sanitized.push(next);
+			}
+			continue;
+		}
+
+		if (message.role === "toolResult") {
+			if (!emittedCalls.has(message.toolCallId)) {
+				continue;
+			}
+			const content = message.content.filter(
+				(block) => block.type === "image" || (block.type === "text" && block.text.trim().length > 0),
+			);
+			const next = {
+				...message,
+				toolName: toolNames.get(message.toolCallId) ?? message.toolName,
+				content: content.length > 0 ? content : [textContent("(No tool output)")],
+			};
+			sanitized.push(next);
+			continue;
+		}
+
+		if (isNonEmptyMessage(message)) {
+			sanitized.push(message);
+		}
+	}
+
+	return sanitized.some((message) => message.role === "user") ? sanitized : [];
+}
+
+export function deriveSessionTitle(messages: Message[], fallback?: string): string | undefined {
+	const firstUser = messages.find((message) => message.role === "user");
+	const text = firstUser ? contentToText(firstUser.content).replace(/\s+/g, " ").trim() : "";
+	if (text) {
+		return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+	}
+	const normalizedFallback = fallback?.replace(/\s+/g, " ").trim();
+	if (!normalizedFallback) {
+		return undefined;
+	}
+	return normalizedFallback.length > 80 ? `${normalizedFallback.slice(0, 77)}...` : normalizedFallback;
+}

--- a/packages/coding-agent/src/core/session-import/skills.ts
+++ b/packages/coding-agent/src/core/session-import/skills.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import { copyFileSync, type Dirent, existsSync, lstatSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const MAX_SKILL_FILES = 2_000;
+const MAX_SKILL_BYTES = 64 * 1024 * 1024;
+const EXCLUDED_DIRECTORIES = new Set([".git", ".venv", "__pycache__", "node_modules"]);
+
+export function discoverSkillDirectories(root: string): string[] {
+	let entries: Dirent<string>[];
+	try {
+		entries = readdirSync(root, { withFileTypes: true, encoding: "utf8" });
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((entry) => entry.isDirectory() && !entry.isSymbolicLink() && entry.name !== ".system")
+		.map((entry) => join(root, entry.name))
+		.filter((directory) => existsSync(join(directory, "SKILL.md")));
+}
+
+function copySkillTree(source: string, destination: string, budget: { files: number; bytes: number }): void {
+	mkdirSync(destination, { recursive: true });
+	for (const entry of readdirSync(source, { withFileTypes: true, encoding: "utf8" })) {
+		if (entry.isSymbolicLink()) {
+			continue;
+		}
+		const sourcePath = join(source, entry.name);
+		const destinationPath = join(destination, entry.name);
+		if (entry.isDirectory()) {
+			if (!EXCLUDED_DIRECTORIES.has(entry.name)) {
+				copySkillTree(sourcePath, destinationPath, budget);
+			}
+			continue;
+		}
+		if (!entry.isFile()) {
+			continue;
+		}
+		const size = lstatSync(sourcePath).size;
+		budget.files++;
+		budget.bytes += size;
+		if (budget.files > MAX_SKILL_FILES || budget.bytes > MAX_SKILL_BYTES) {
+			throw new Error("Skill exceeds safe import size limits");
+		}
+		copyFileSync(sourcePath, destinationPath);
+	}
+}
+
+export function importSkillDirectory(source: string, destinationRoot: string): "imported" | "skipped" {
+	const name = basename(source);
+	if (!name || name === "." || name === "..") {
+		throw new Error("Invalid skill directory name");
+	}
+	mkdirSync(destinationRoot, { recursive: true });
+	const destination = join(destinationRoot, name);
+	if (existsSync(destination)) {
+		return "skipped";
+	}
+
+	const temporary = join(destinationRoot, `.${name}.import-${randomUUID()}`);
+	try {
+		copySkillTree(source, temporary, { files: 0, bytes: 0 });
+		if (!existsSync(join(temporary, "SKILL.md"))) {
+			throw new Error("Imported skill has no SKILL.md");
+		}
+		renameSync(temporary, destination);
+		return "imported";
+	} catch (error) {
+		rmSync(temporary, { recursive: true, force: true });
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/core/session-import/skills.ts
+++ b/packages/coding-agent/src/core/session-import/skills.ts
@@ -19,7 +19,7 @@ export function discoverSkillDirectories(root: string): string[] {
 		.filter((directory) => existsSync(join(directory, "SKILL.md")));
 }
 
-function copySkillTree(source: string, destination: string, budget: { files: number; bytes: number }): void {
+function copySkillTree(source: string, destination: string, budget: { entries: number; bytes: number }): void {
 	mkdirSync(destination, { recursive: true });
 	for (const entry of readdirSync(source, { withFileTypes: true, encoding: "utf8" })) {
 		if (entry.isSymbolicLink()) {
@@ -29,6 +29,10 @@ function copySkillTree(source: string, destination: string, budget: { files: num
 		const destinationPath = join(destination, entry.name);
 		if (entry.isDirectory()) {
 			if (!EXCLUDED_DIRECTORIES.has(entry.name)) {
+				budget.entries++;
+				if (budget.entries > MAX_SKILL_FILES) {
+					throw new Error("Skill exceeds safe import size limits");
+				}
 				copySkillTree(sourcePath, destinationPath, budget);
 			}
 			continue;
@@ -37,9 +41,9 @@ function copySkillTree(source: string, destination: string, budget: { files: num
 			continue;
 		}
 		const size = lstatSync(sourcePath).size;
-		budget.files++;
+		budget.entries++;
 		budget.bytes += size;
-		if (budget.files > MAX_SKILL_FILES || budget.bytes > MAX_SKILL_BYTES) {
+		if (budget.entries > MAX_SKILL_FILES || budget.bytes > MAX_SKILL_BYTES) {
 			throw new Error("Skill exceeds safe import size limits");
 		}
 		copyFileSync(sourcePath, destinationPath);
@@ -59,7 +63,7 @@ export function importSkillDirectory(source: string, destinationRoot: string): "
 
 	const temporary = join(destinationRoot, `.${name}.import-${randomUUID()}`);
 	try {
-		copySkillTree(source, temporary, { files: 0, bytes: 0 });
+		copySkillTree(source, temporary, { entries: 0, bytes: 0 });
 		if (!existsSync(join(temporary, "SKILL.md"))) {
 			throw new Error("Imported skill has no SKILL.md");
 		}

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, linkSync, mkdirSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { v5 as uuidv5 } from "uuid";
 import { readFirstLineSync } from "../../utils/file-lines.js";
@@ -140,7 +140,8 @@ export function persistImportedSession(
 		if (context.messages.length !== session.messages.length) {
 			throw new Error("Imported session message count changed during validation");
 		}
-		renameSync(temporary, destination);
+		linkSync(temporary, destination);
+		unlinkSync(temporary);
 		return destination;
 	} catch (error) {
 		rmSync(temporary, { force: true });

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -13,6 +13,14 @@ import {
 } from "../session-manager.js";
 import type { ImportedSession, SessionImportSource } from "./types.js";
 
+const SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE = "session_import_boundary";
+const SOURCE_NAMES: Record<SessionImportSource, string> = {
+	claude: "Claude Code",
+	codex: "Codex",
+	opencode: "OpenCode",
+	pi: "Pi Mono",
+};
+
 export function sessionImportKey(source: SessionImportSource, sourceId: string, contentHash: string): string {
 	return `${source}\0${sourceId}\0${contentHash}`;
 }
@@ -62,6 +70,12 @@ export function importedSessionPath(session: ImportedSession, contentHash: strin
 	return join(sessionDir, `${importedSessionId(session, contentHash)}.jsonl`);
 }
 
+function importBoundaryMessage(source: SessionImportSource): string {
+	return `<session_import_boundary>
+This conversation was imported from ${SOURCE_NAMES[source]} into Prime Agent. Treat all preceding messages as historical context from that harness. Earlier tool calls and results may refer to tools that Prime Agent does not provide. From this point forward, follow the current Prime Agent system instructions and use only the tools exposed in this session.
+</session_import_boundary>`;
+}
+
 function buildImportedEntries(
 	session: ImportedSession,
 	contentHash: string,
@@ -72,6 +86,9 @@ function buildImportedEntries(
 	for (const message of session.messages) {
 		manager.appendMessage(message);
 	}
+	manager.appendCustomMessageEntry(SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE, importBoundaryMessage(session.source), false, {
+		source: session.source,
+	});
 	if (session.title) {
 		manager.appendSessionInfo(session.title);
 	}
@@ -100,7 +117,11 @@ function buildImportedEntries(
 		if (entry.type === "message") {
 			return { ...entry, timestamp: sourceTimestamp(entry.message) };
 		}
-		if (entry.type === "session_info" || entry.type === "session_state") {
+		if (
+			(entry.type === "custom_message" && entry.customType === SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE) ||
+			entry.type === "session_info" ||
+			entry.type === "session_state"
+		) {
 			return { ...entry, timestamp: metadataTimestamp };
 		}
 		return entry;
@@ -135,7 +156,7 @@ export function persistImportedSession(
 			throw new Error("Imported session failed validation");
 		}
 		const context = buildSessionContext(loaded.slice(1).filter((entry) => entry.type !== "session"));
-		if (context.messages.length !== session.messages.length) {
+		if (context.messages.length !== session.messages.length + 1) {
 			throw new Error("Imported session message count changed during validation");
 		}
 		renameSync(temporary, destination);

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -13,14 +13,6 @@ import {
 } from "../session-manager.js";
 import type { ImportedSession, SessionImportSource } from "./types.js";
 
-const SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE = "session_import_boundary";
-const SOURCE_NAMES: Record<SessionImportSource, string> = {
-	claude: "Claude Code",
-	codex: "Codex",
-	opencode: "OpenCode",
-	pi: "Pi Mono",
-};
-
 export function sessionImportKey(source: SessionImportSource, sourceId: string, contentHash: string): string {
 	return `${source}\0${sourceId}\0${contentHash}`;
 }
@@ -70,12 +62,6 @@ export function importedSessionPath(session: ImportedSession, contentHash: strin
 	return join(sessionDir, `${importedSessionId(session, contentHash)}.jsonl`);
 }
 
-function importBoundaryMessage(source: SessionImportSource): string {
-	return `<session_import_boundary>
-This conversation was imported from ${SOURCE_NAMES[source]} into Prime Agent. Treat all preceding messages as historical context from that harness. Earlier tool calls and results may refer to tools that Prime Agent does not provide. From this point forward, follow the current Prime Agent system instructions and use only the tools exposed in this session.
-</session_import_boundary>`;
-}
-
 function buildImportedEntries(
 	session: ImportedSession,
 	contentHash: string,
@@ -86,9 +72,6 @@ function buildImportedEntries(
 	for (const message of session.messages) {
 		manager.appendMessage(message);
 	}
-	manager.appendCustomMessageEntry(SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE, importBoundaryMessage(session.source), false, {
-		source: session.source,
-	});
 	if (session.title) {
 		manager.appendSessionInfo(session.title);
 	}
@@ -117,11 +100,7 @@ function buildImportedEntries(
 		if (entry.type === "message") {
 			return { ...entry, timestamp: sourceTimestamp(entry.message) };
 		}
-		if (
-			(entry.type === "custom_message" && entry.customType === SESSION_IMPORT_BOUNDARY_CUSTOM_TYPE) ||
-			entry.type === "session_info" ||
-			entry.type === "session_state"
-		) {
+		if (entry.type === "session_info" || entry.type === "session_state") {
 			return { ...entry, timestamp: metadataTimestamp };
 		}
 		return entry;
@@ -156,7 +135,7 @@ export function persistImportedSession(
 			throw new Error("Imported session failed validation");
 		}
 		const context = buildSessionContext(loaded.slice(1).filter((entry) => entry.type !== "session"));
-		if (context.messages.length !== session.messages.length + 1) {
+		if (context.messages.length !== session.messages.length) {
 			throw new Error("Imported session message count changed during validation");
 		}
 		renameSync(temporary, destination);

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -12,8 +12,8 @@ import {
 } from "../session-manager.js";
 import type { ImportedSession, SessionImportSource } from "./types.js";
 
-export function sessionImportKey(source: SessionImportSource, sourceId: string): string {
-	return `${source}\0${sourceId}`;
+export function sessionImportKey(source: SessionImportSource, sourceId: string, contentHash: string): string {
+	return `${source}\0${sourceId}\0${contentHash}`;
 }
 
 export function collectImportedSessionKeys(sessionDir: string): Set<string> {
@@ -34,8 +34,9 @@ export function collectImportedSessionKeys(sessionDir: string): Set<string> {
 			const header = JSON.parse(firstLine) as Partial<SessionHeader>;
 			const source = header.importedFrom?.source;
 			const id = header.importedFrom?.id;
-			if (source && id) {
-				keys.add(`${source}\0${id}`);
+			const contentHash = header.importedFrom?.contentHash;
+			if (source && id && contentHash) {
+				keys.add(sessionImportKey(source as SessionImportSource, id, contentHash));
 			}
 		} catch {}
 	}
@@ -52,7 +53,7 @@ function sourceTimestamp(message: unknown): string {
 	return new Date(timestamp).toISOString();
 }
 
-function buildImportedEntries(session: ImportedSession, fallbackCwd: string): FileEntry[] {
+function buildImportedEntries(session: ImportedSession, contentHash: string, fallbackCwd: string): FileEntry[] {
 	const manager = SessionManager.inMemory(session.cwd || fallbackCwd);
 	for (const message of session.messages) {
 		manager.appendMessage(message);
@@ -68,11 +69,12 @@ function buildImportedEntries(session: ImportedSession, fallbackCwd: string): Fi
 	}
 	const header: SessionHeader = {
 		...originalHeader,
-		id: uuidv5(`prime-agent-import:${session.source}:${session.sourceId}`, uuidv5.URL),
+		id: uuidv5(`prime-agent-import:${session.source}:${session.sourceId}:${contentHash}`, uuidv5.URL),
 		timestamp: new Date(session.createdAt).toISOString(),
 		importedFrom: {
 			source: session.source,
 			id: session.sourceId,
+			contentHash,
 		},
 	};
 	const lastMessageTimestamp = session.messages.reduce(
@@ -92,9 +94,14 @@ function buildImportedEntries(session: ImportedSession, fallbackCwd: string): Fi
 	return [header, ...entries];
 }
 
-export function persistImportedSession(session: ImportedSession, sessionDir: string, fallbackCwd: string): string {
+export function persistImportedSession(
+	session: ImportedSession,
+	contentHash: string,
+	sessionDir: string,
+	fallbackCwd: string,
+): string {
 	mkdirSync(sessionDir, { recursive: true });
-	const entries = buildImportedEntries(session, fallbackCwd);
+	const entries = buildImportedEntries(session, contentHash, fallbackCwd);
 	const header = entries[0] as SessionHeader;
 	const destination = join(sessionDir, `${header.id}.jsonl`);
 	if (existsSync(destination)) {

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -9,6 +9,7 @@ import {
 	loadEntriesFromFile,
 	type SessionHeader,
 	SessionManager,
+	type SessionStateStatus,
 } from "../session-manager.js";
 import type { ImportedSession, SessionImportSource } from "./types.js";
 
@@ -53,7 +54,20 @@ function sourceTimestamp(message: unknown): string {
 	return new Date(timestamp).toISOString();
 }
 
-function buildImportedEntries(session: ImportedSession, contentHash: string, fallbackCwd: string): FileEntry[] {
+function importedSessionId(session: ImportedSession, contentHash: string): string {
+	return uuidv5(`prime-agent-import:${session.source}:${session.sourceId}:${contentHash}`, uuidv5.URL);
+}
+
+export function importedSessionPath(session: ImportedSession, contentHash: string, sessionDir: string): string {
+	return join(sessionDir, `${importedSessionId(session, contentHash)}.jsonl`);
+}
+
+function buildImportedEntries(
+	session: ImportedSession,
+	contentHash: string,
+	fallbackCwd: string,
+	status: SessionStateStatus,
+): FileEntry[] {
 	const manager = SessionManager.inMemory(session.cwd || fallbackCwd);
 	for (const message of session.messages) {
 		manager.appendMessage(message);
@@ -61,7 +75,7 @@ function buildImportedEntries(session: ImportedSession, contentHash: string, fal
 	if (session.title) {
 		manager.appendSessionInfo(session.title);
 	}
-	manager.appendSessionState({ status: "archived" });
+	manager.appendSessionState({ status });
 
 	const originalHeader = manager.getHeader();
 	if (!originalHeader) {
@@ -69,7 +83,7 @@ function buildImportedEntries(session: ImportedSession, contentHash: string, fal
 	}
 	const header: SessionHeader = {
 		...originalHeader,
-		id: uuidv5(`prime-agent-import:${session.source}:${session.sourceId}:${contentHash}`, uuidv5.URL),
+		id: importedSessionId(session, contentHash),
 		timestamp: new Date(session.createdAt).toISOString(),
 		importedFrom: {
 			source: session.source,
@@ -99,16 +113,17 @@ export function persistImportedSession(
 	contentHash: string,
 	sessionDir: string,
 	fallbackCwd: string,
+	status: SessionStateStatus = "archived",
 ): string {
 	mkdirSync(sessionDir, { recursive: true });
-	const entries = buildImportedEntries(session, contentHash, fallbackCwd);
-	const header = entries[0] as SessionHeader;
-	const destination = join(sessionDir, `${header.id}.jsonl`);
+	const entries = buildImportedEntries(session, contentHash, fallbackCwd, status);
+	const sessionId = importedSessionId(session, contentHash);
+	const destination = importedSessionPath(session, contentHash, sessionDir);
 	if (existsSync(destination)) {
 		throw new Error(`Session destination already exists: ${destination}`);
 	}
 
-	const temporary = join(sessionDir, `.${header.id}.import-${randomUUID()}.tmp`);
+	const temporary = join(sessionDir, `.${sessionId}.import-${randomUUID()}.tmp`);
 	try {
 		writeFileSync(temporary, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
 			encoding: "utf8",

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -39,7 +39,9 @@ export function collectImportedSessionKeys(sessionDir: string): Set<string> {
 			if (source && id && contentHash) {
 				keys.add(sessionImportKey(source as SessionImportSource, id, contentHash));
 			}
-		} catch {}
+		} catch {
+			// Unreadable sessions cannot contribute a reliable deduplication key.
+		}
 	}
 	return keys;
 }

--- a/packages/coding-agent/src/core/session-import/storage.ts
+++ b/packages/coding-agent/src/core/session-import/storage.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { v5 as uuidv5 } from "uuid";
+import { readFirstLineSync } from "../../utils/file-lines.js";
+import {
+	buildSessionContext,
+	type FileEntry,
+	loadEntriesFromFile,
+	type SessionHeader,
+	SessionManager,
+} from "../session-manager.js";
+import type { ImportedSession, SessionImportSource } from "./types.js";
+
+export function sessionImportKey(source: SessionImportSource, sourceId: string): string {
+	return `${source}\0${sourceId}`;
+}
+
+export function collectImportedSessionKeys(sessionDir: string): Set<string> {
+	const keys = new Set<string>();
+	let files: string[];
+	try {
+		files = readdirSync(sessionDir).filter((file) => file.endsWith(".jsonl"));
+	} catch {
+		return keys;
+	}
+
+	for (const file of files) {
+		try {
+			const firstLine = readFirstLineSync(join(sessionDir, file));
+			if (!firstLine) {
+				continue;
+			}
+			const header = JSON.parse(firstLine) as Partial<SessionHeader>;
+			const source = header.importedFrom?.source;
+			const id = header.importedFrom?.id;
+			if (source && id) {
+				keys.add(`${source}\0${id}`);
+			}
+		} catch {}
+	}
+	return keys;
+}
+
+function sourceTimestamp(message: unknown): string {
+	const timestampValue =
+		typeof message === "object" && message !== null && "timestamp" in message
+			? (message as { timestamp?: unknown }).timestamp
+			: undefined;
+	const timestamp =
+		typeof timestampValue === "number" && Number.isFinite(timestampValue) ? timestampValue : Date.now();
+	return new Date(timestamp).toISOString();
+}
+
+function buildImportedEntries(session: ImportedSession, fallbackCwd: string): FileEntry[] {
+	const manager = SessionManager.inMemory(session.cwd || fallbackCwd);
+	for (const message of session.messages) {
+		manager.appendMessage(message);
+	}
+	if (session.title) {
+		manager.appendSessionInfo(session.title);
+	}
+	manager.appendSessionState({ status: "archived" });
+
+	const originalHeader = manager.getHeader();
+	if (!originalHeader) {
+		throw new Error("Unable to create imported session header");
+	}
+	const header: SessionHeader = {
+		...originalHeader,
+		id: uuidv5(`prime-agent-import:${session.source}:${session.sourceId}`, uuidv5.URL),
+		timestamp: new Date(session.createdAt).toISOString(),
+		importedFrom: {
+			source: session.source,
+			id: session.sourceId,
+		},
+	};
+	const lastMessageTimestamp = session.messages.reduce(
+		(latest, message) => Math.max(latest, Number.isFinite(message.timestamp) ? message.timestamp : 0),
+		session.createdAt,
+	);
+	const metadataTimestamp = new Date(lastMessageTimestamp).toISOString();
+	const entries = manager.getEntries().map((entry) => {
+		if (entry.type === "message") {
+			return { ...entry, timestamp: sourceTimestamp(entry.message) };
+		}
+		if (entry.type === "session_info" || entry.type === "session_state") {
+			return { ...entry, timestamp: metadataTimestamp };
+		}
+		return entry;
+	});
+	return [header, ...entries];
+}
+
+export function persistImportedSession(session: ImportedSession, sessionDir: string, fallbackCwd: string): string {
+	mkdirSync(sessionDir, { recursive: true });
+	const entries = buildImportedEntries(session, fallbackCwd);
+	const header = entries[0] as SessionHeader;
+	const destination = join(sessionDir, `${header.id}.jsonl`);
+	if (existsSync(destination)) {
+		throw new Error(`Session destination already exists: ${destination}`);
+	}
+
+	const temporary = join(sessionDir, `.${header.id}.import-${randomUUID()}.tmp`);
+	try {
+		writeFileSync(temporary, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		const loaded = loadEntriesFromFile(temporary);
+		if (loaded.length !== entries.length || loaded[0]?.type !== "session") {
+			throw new Error("Imported session failed validation");
+		}
+		const context = buildSessionContext(loaded.slice(1).filter((entry) => entry.type !== "session"));
+		if (context.messages.length !== session.messages.length) {
+			throw new Error("Imported session message count changed during validation");
+		}
+		renameSync(temporary, destination);
+		return destination;
+	} catch (error) {
+		rmSync(temporary, { force: true });
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/core/session-import/types.ts
+++ b/packages/coding-agent/src/core/session-import/types.ts
@@ -1,0 +1,74 @@
+import type { Message } from "@earendil-works/pi-ai";
+
+export const SESSION_IMPORT_SOURCES = ["claude", "codex", "opencode", "pi"] as const;
+
+export type SessionImportSource = (typeof SESSION_IMPORT_SOURCES)[number];
+
+export interface SessionImportFileReference {
+	kind: "file";
+	path: string;
+}
+
+export interface OpenCodeSessionReference {
+	kind: "opencode";
+	databasePath: string;
+	sessionId: string;
+}
+
+export interface OpenCodeCliSessionReference {
+	kind: "opencode-cli";
+	command: string;
+	cwd: string;
+	sessionId: string;
+}
+
+export type SessionImportReference =
+	| SessionImportFileReference
+	| OpenCodeSessionReference
+	| OpenCodeCliSessionReference;
+
+export interface SessionImportInventory {
+	source: SessionImportSource;
+	label: string;
+	sessionCount: number;
+	skillCount: number;
+	sessionReferences: SessionImportReference[];
+	skillDirectories: string[];
+}
+
+export interface ImportedSession {
+	source: SessionImportSource;
+	sourceId: string;
+	cwd: string;
+	title?: string;
+	createdAt: number;
+	messages: Message[];
+}
+
+export interface SessionImportSourceResult {
+	source: SessionImportSource;
+	sessionsImported: number;
+	sessionsSkipped: number;
+	sessionFailures: number;
+	skillsImported: number;
+	skillsSkipped: number;
+	skillFailures: number;
+}
+
+export interface SessionImportResult {
+	sources: SessionImportSourceResult[];
+	sessionsImported: number;
+	sessionsSkipped: number;
+	sessionFailures: number;
+	skillsImported: number;
+	skillsSkipped: number;
+	skillFailures: number;
+}
+
+export interface SessionImportOptions {
+	homeDir?: string;
+	agentDir?: string;
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	onProgress?: (message: string) => void;
+}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -59,6 +59,7 @@ export interface SessionHeader {
 	importedFrom?: {
 		source: string;
 		id: string;
+		contentHash: string;
 	};
 }
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -56,6 +56,10 @@ export interface SessionHeader {
 	cwd: string;
 	parentSession?: string;
 	git?: GitContext;
+	importedFrom?: {
+		source: string;
+		id: string;
+	};
 }
 
 export interface NewSessionOptions {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -258,6 +258,13 @@ export interface SessionContext {
 	model: { provider: string; modelId: string } | null;
 }
 
+function normalizeLegacyCodexAssistant(message: AssistantMessage): AssistantMessage {
+	if (message.api === "openai-codex-responses" && message.provider === "openai") {
+		return { ...message, provider: "openai-codex" };
+	}
+	return message;
+}
+
 export interface SessionInfo {
 	path: string;
 	id: string;
@@ -499,7 +506,8 @@ export function buildSessionContext(
 		} else if (entry.type === "model_change") {
 			model = { provider: entry.provider, modelId: entry.modelId };
 		} else if (entry.type === "message" && entry.message.role === "assistant") {
-			model = { provider: entry.message.provider, modelId: entry.message.model };
+			const assistantMessage = normalizeLegacyCodexAssistant(entry.message);
+			model = { provider: assistantMessage.provider, modelId: assistantMessage.model };
 		} else if (entry.type === "compaction") {
 			compaction = entry;
 		}
@@ -514,7 +522,9 @@ export function buildSessionContext(
 
 	const appendMessage = (entry: SessionEntry) => {
 		if (entry.type === "message") {
-			messages.push(entry.message);
+			messages.push(
+				entry.message.role === "assistant" ? normalizeLegacyCodexAssistant(entry.message) : entry.message,
+			);
 		} else if (entry.type === "custom_message") {
 			messages.push(
 				createCustomMessage(entry.customType, entry.content, entry.display, entry.details, entry.timestamp),

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -258,13 +258,6 @@ export interface SessionContext {
 	model: { provider: string; modelId: string } | null;
 }
 
-function normalizeLegacyCodexAssistant(message: AssistantMessage): AssistantMessage {
-	if (message.api === "openai-codex-responses" && message.provider === "openai") {
-		return { ...message, provider: "openai-codex" };
-	}
-	return message;
-}
-
 export interface SessionInfo {
 	path: string;
 	id: string;
@@ -506,8 +499,7 @@ export function buildSessionContext(
 		} else if (entry.type === "model_change") {
 			model = { provider: entry.provider, modelId: entry.modelId };
 		} else if (entry.type === "message" && entry.message.role === "assistant") {
-			const assistantMessage = normalizeLegacyCodexAssistant(entry.message);
-			model = { provider: assistantMessage.provider, modelId: assistantMessage.model };
+			model = { provider: entry.message.provider, modelId: entry.message.model };
 		} else if (entry.type === "compaction") {
 			compaction = entry;
 		}
@@ -522,9 +514,7 @@ export function buildSessionContext(
 
 	const appendMessage = (entry: SessionEntry) => {
 		if (entry.type === "message") {
-			messages.push(
-				entry.message.role === "assistant" ? normalizeLegacyCodexAssistant(entry.message) : entry.message,
-			);
+			messages.push(entry.message);
 		} else if (entry.type === "custom_message") {
 			messages.push(
 				createCustomMessage(entry.customType, entry.content, entry.display, entry.details, entry.timestamp),
@@ -1699,7 +1689,9 @@ export class SessionManager {
 		// the header), so the entries argument is only a fallback for an undefined
 		// leaf — never hit here since leafId is always set or null. Avoids an O(n)
 		// array copy on every call (attach, get_session_context, agent init, ...).
-		return buildSessionContext(this.fileEntries as SessionEntry[], this.leafId, this.byId);
+		const context = buildSessionContext(this.fileEntries as SessionEntry[], this.leafId, this.byId);
+		const header = this.fileEntries[0];
+		return header?.type === "session" && header.importedFrom ? { ...context, model: null } : context;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -42,7 +42,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import harness history, or import and resume a supported JSONL file" },
+	{ name: "import", description: "Import harness history, or import and resume a supported session file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -42,7 +42,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import and resume a session from a JSONL file" },
+	{ name: "import", description: "Import harness history, or resume a session from a JSONL file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -42,7 +42,7 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import harness history, or resume a session from a JSONL file" },
+	{ name: "import", description: "Import harness history, or import and resume a supported JSONL file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{

--- a/packages/coding-agent/src/modes/interactive/components/onboarding-import-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/onboarding-import-selector.ts
@@ -1,0 +1,105 @@
+import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
+import type { SessionImportInventory, SessionImportSource } from "../../../core/session-import/index.js";
+import { orderedSelectedSources } from "../../../core/session-import/index.js";
+import { keyHint, rawKeyHint } from "./keybinding-hints.js";
+import { MenuList, MenuPanel, MenuRow } from "./menu-panel.js";
+
+function countLabel(count: number, singular: string): string {
+	return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+export class OnboardingImportSelectorComponent extends Container {
+	private readonly selectedSources: Set<SessionImportSource>;
+	private readonly list = new MenuList({ compact: true });
+	private selectedIndex = 0;
+
+	constructor(
+		private readonly inventories: SessionImportInventory[],
+		private readonly onSelect: (sources: SessionImportSource[]) => void,
+		private readonly onCancel: () => void,
+	) {
+		super();
+		this.selectedSources = new Set(inventories.map((inventory) => inventory.source));
+		const panel = new MenuPanel({
+			title: "Bring your work with you",
+			subtitle: "Import local sessions and skills. Existing Prime data is never overwritten.",
+		});
+		panel.addChild(this.list);
+		panel.addChild(new Spacer(1));
+		panel.addChild(
+			new Text(
+				rawKeyHint("↑↓", "navigate") +
+					"  " +
+					keyHint("tui.select.confirm", "toggle / continue") +
+					"  " +
+					keyHint("tui.select.cancel", "skip"),
+				1,
+				0,
+			),
+		);
+		this.addChild(panel);
+		this.updateList();
+	}
+
+	handleInput(keyData: string): void {
+		const kb = getKeybindings();
+		const itemCount = this.inventories.length + 1;
+		if (kb.matches(keyData, "tui.select.up")) {
+			this.selectedIndex = (this.selectedIndex - 1 + itemCount) % itemCount;
+			this.updateList();
+			return;
+		}
+		if (kb.matches(keyData, "tui.select.down")) {
+			this.selectedIndex = (this.selectedIndex + 1) % itemCount;
+			this.updateList();
+			return;
+		}
+		if (kb.matches(keyData, "tui.select.cancel")) {
+			this.onCancel();
+			return;
+		}
+		if (!kb.matches(keyData, "tui.select.confirm")) {
+			return;
+		}
+		const inventory = this.inventories[this.selectedIndex];
+		if (inventory) {
+			if (this.selectedSources.has(inventory.source)) {
+				this.selectedSources.delete(inventory.source);
+			} else {
+				this.selectedSources.add(inventory.source);
+			}
+			this.updateList();
+			return;
+		}
+		this.onSelect(orderedSelectedSources(this.selectedSources));
+	}
+
+	private updateList(): void {
+		this.list.clear();
+		for (const [index, inventory] of this.inventories.entries()) {
+			const selected = this.selectedSources.has(inventory.source);
+			const counts = [
+				inventory.sessionCount > 0 ? countLabel(inventory.sessionCount, "session") : undefined,
+				inventory.skillCount > 0 ? countLabel(inventory.skillCount, "skill") : undefined,
+			]
+				.filter((value): value is string => value !== undefined)
+				.join(", ");
+			this.list.addChild(
+				new MenuRow({
+					primary: `${selected ? "✓" : " "}  ${inventory.label}`,
+					secondary: counts,
+					meta: selected ? "selected" : "not selected",
+					selected: index === this.selectedIndex,
+				}),
+			);
+		}
+		const selectedCount = this.selectedSources.size;
+		this.list.addChild(
+			new MenuRow({
+				primary: selectedCount > 0 ? "Import selected" : "Continue without importing",
+				meta: selectedCount > 0 ? `${selectedCount} selected` : undefined,
+				selected: this.selectedIndex === this.inventories.length,
+			}),
+		);
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/session-import-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-import-selector.ts
@@ -20,6 +20,7 @@ export class SessionImportSelectorComponent extends Container {
 	) {
 		super();
 		this.selectedSources = new Set(inventories.map((inventory) => inventory.source));
+		this.selectedIndex = inventories.length;
 		const panel = new MenuPanel({
 			title: "Bring your work with you",
 			subtitle: "Import local sessions and skills. Existing Prime data is never overwritten.",
@@ -30,7 +31,7 @@ export class SessionImportSelectorComponent extends Container {
 			new Text(
 				rawKeyHint("↑↓", "navigate") +
 					"  " +
-					keyHint("tui.select.confirm", "toggle / continue") +
+					keyHint("tui.select.confirm", "toggle / confirm") +
 					"  " +
 					keyHint("tui.select.cancel", "skip"),
 				1,
@@ -94,10 +95,11 @@ export class SessionImportSelectorComponent extends Container {
 			);
 		}
 		const selectedCount = this.selectedSources.size;
+		this.list.addChild(new Spacer(1));
 		this.list.addChild(
 			new MenuRow({
-				primary: selectedCount > 0 ? "Import selected" : "Continue without importing",
-				meta: selectedCount > 0 ? `${selectedCount} selected` : undefined,
+				primary: selectedCount > 0 ? "Import selected sessions and skills" : "Continue without importing",
+				meta: selectedCount > 0 ? `${countLabel(selectedCount, "source")} selected` : undefined,
 				selected: this.selectedIndex === this.inventories.length,
 			}),
 		);

--- a/packages/coding-agent/src/modes/interactive/components/session-import-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-import-selector.ts
@@ -8,7 +8,7 @@ function countLabel(count: number, singular: string): string {
 	return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
-export class OnboardingImportSelectorComponent extends Container {
+export class SessionImportSelectorComponent extends Container {
 	private readonly selectedSources: Set<SessionImportSource>;
 	private readonly list = new MenuList({ compact: true });
 	private selectedIndex = 0;

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -16,6 +16,8 @@ export interface ToolExecutionOptions {
 	showImages?: boolean;
 	/** Whether image metadata may parse dimensions from base64 data. */
 	includeImageDimensions?: boolean;
+	/** Whether completed generic tools should show only their header until expanded. */
+	compactCompleted?: boolean;
 }
 
 export interface ToolExecutionRendererDefinition {
@@ -81,6 +83,7 @@ export class ToolExecutionComponent extends Container {
 	private showExpandHint = true;
 	private showImages: boolean;
 	private includeImageDimensions: boolean;
+	private compactCompleted: boolean;
 	private isPartial = true;
 	private toolDefinition?: ToolExecutionDefinition;
 	private builtInToolDefinition?: ToolDefinition<any, any>;
@@ -113,6 +116,7 @@ export class ToolExecutionComponent extends Container {
 		this.builtInToolDefinition = createReplayBuiltInToolDefinition(toolName, cwd, toolDefinition);
 		this.showImages = options.showImages ?? true;
 		this.includeImageDimensions = options.includeImageDimensions ?? true;
+		this.compactCompleted = options.compactCompleted ?? false;
 		this.ui = ui;
 		this.cwd = cwd;
 
@@ -479,7 +483,7 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private formatToolExecution(): string {
-		if (this.result && !this.isPartial && !this.expanded) {
+		if (this.compactCompleted && this.result && !this.isPartial && !this.expanded) {
 			return "";
 		}
 		const parts: string[] = [];

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -479,6 +479,9 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private formatToolExecution(): string {
+		if (this.result && !this.isPartial && !this.expanded) {
+			return "";
+		}
 		const parts: string[] = [];
 		const content = JSON.stringify(this.args, null, 2);
 		if (content) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -109,8 +109,11 @@ import { resolvePrimeInferencePostLoginModelAction } from "../../core/prime-infe
 import { parseCommandArgs } from "../../core/prompt-templates.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import {
+	detectSessionImportFileKind,
 	discoverSessionImports,
+	type ExternalSessionImportFileKind,
 	formatSessionImportResult,
+	importExternalSessionFile,
 	importSessionsAndSkills,
 	type SessionImportInventory,
 	type SessionImportSource,
@@ -4361,7 +4364,7 @@ export class InteractiveMode {
 				}
 				if (commandName === "import") {
 					if (commandArgs) {
-						await this.handleImportCommand(canonicalCommandText);
+						await this.handleAutoImportCommand(canonicalCommandText);
 					} else {
 						await this.handleHarnessImportCommand();
 					}
@@ -8568,6 +8571,59 @@ export class InteractiveMode {
 			return;
 		}
 
+		await this.importAndResumeSession(inputPath, `Session imported from: ${inputPath}`);
+	}
+
+	private async handleAutoImportCommand(text: string): Promise<void> {
+		const inputPath = this.getPathCommandArgument(text, "/import");
+		if (!inputPath) {
+			this.showError("Usage: /import <path.jsonl>");
+			return;
+		}
+
+		try {
+			const kind = await detectSessionImportFileKind(inputPath);
+			if (kind === "native") {
+				await this.handleImportCommand(text);
+				return;
+			}
+			if (kind === "claude" || kind === "codex") {
+				await this.handleExternalSessionImport(inputPath, kind);
+				return;
+			}
+			this.showError("Unsupported session JSONL. Expected a Prime Agent, Pi, Claude Code, or Codex session.");
+		} catch (error) {
+			if (error instanceof SessionImportFileNotFoundError) {
+				this.showError(`Failed to import session: ${error.message}`);
+				return;
+			}
+			this.showError(`Failed to inspect session: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private async handleExternalSessionImport(inputPath: string, source: ExternalSessionImportFileKind): Promise<void> {
+		const label = source === "claude" ? "Claude Code" : "Codex";
+		const confirmed = await this.showExtensionConfirm(
+			"Import session",
+			`Import and resume ${label} session from ${inputPath}?`,
+		);
+		if (!confirmed) {
+			this.showStatus("Import cancelled");
+			return;
+		}
+
+		let imported: Awaited<ReturnType<typeof importExternalSessionFile>>;
+		try {
+			imported = await importExternalSessionFile(inputPath, source, { agentDir: getAgentDir() });
+		} catch (error) {
+			this.showError(`Failed to import ${label} session: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
+		const action = imported.status === "imported" ? "imported and resumed" : "already imported; resumed";
+		await this.importAndResumeSession(imported.sessionFile, `${label} session ${action} from: ${inputPath}`);
+	}
+
+	private async importAndResumeSession(inputPath: string, successMessage: string): Promise<void> {
 		try {
 			this.stopWorkingLoader();
 			const result = await this.agentConnection.importFromJsonl(inputPath);
@@ -8576,7 +8632,7 @@ export class InteractiveMode {
 				return;
 			}
 			await this.renderCurrentSessionState();
-			this.showStatus(`Session imported from: ${inputPath}`);
+			this.showStatus(successMessage);
 		} catch (error: unknown) {
 			if (error instanceof MissingSessionCwdError) {
 				const selectedCwd = await this.promptForMissingSessionCwd(error);
@@ -8590,7 +8646,7 @@ export class InteractiveMode {
 					return;
 				}
 				await this.renderCurrentSessionState();
-				this.showStatus(`Session imported from: ${inputPath}`);
+				this.showStatus(successMessage);
 				return;
 			}
 			if (error instanceof SessionImportFileNotFoundError) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -108,6 +108,13 @@ import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.
 import { resolvePrimeInferencePostLoginModelAction } from "../../core/prime-inference-model-selection.js";
 import { parseCommandArgs } from "../../core/prompt-templates.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
+import {
+	discoverSessionImports,
+	formatSessionImportResult,
+	importSessionsAndSkills,
+	type SessionImportInventory,
+	type SessionImportSource,
+} from "../../core/session-import/index.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
 import {
@@ -191,6 +198,7 @@ import { HeartbeatManagerComponent } from "./components/heartbeat-manager.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./components/injected-prompt-message.js";
 import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import type { AuthSelectorProvider } from "./components/oauth-selector.js";
+import { OnboardingImportSelectorComponent } from "./components/onboarding-import-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SessionPickerScreen } from "./components/session-picker-screen.js";
@@ -214,7 +222,12 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
-import { type OnboardingStartupState, shouldRunOnboarding, shouldRunPrimeCliOnboardingSplash } from "./onboarding.js";
+import {
+	isOnboardingModelReady,
+	type OnboardingStartupState,
+	shouldRunOnboarding,
+	shouldRunPrimeCliOnboardingSplash,
+} from "./onboarding.js";
 import type { ClientPromptStashStore, PromptStash, PromptStashState } from "./prompt-stash-state.js";
 import { formatResumeHint } from "./resume-hint.js";
 import {
@@ -1617,11 +1630,71 @@ export class InteractiveMode {
 			return false;
 		}
 
+		const modelReady = isOnboardingModelReady(this.getOnboardingState());
 		const showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash();
 		this.markOnboardingShown();
 		await this.settingsManager.flush();
-		await this.runOnboardingFlow(showPrimeCliSplash);
+		await this.runOnboardingImportFlow();
+		if (showPrimeCliSplash || !modelReady) {
+			await this.runOnboardingFlow(showPrimeCliSplash);
+		}
 		return true;
+	}
+
+	private async runOnboardingImportFlow(): Promise<void> {
+		try {
+			const inventories = discoverSessionImports({ agentDir: getAgentDir() });
+			if (inventories.length === 0) {
+				return;
+			}
+			const selectedSources = await this.showOnboardingImportSelector(inventories);
+			if (!selectedSources || selectedSources.length === 0) {
+				return;
+			}
+			const result = await importSessionsAndSkills(inventories, selectedSources, {
+				agentDir: getAgentDir(),
+				onProgress: (message) => {
+					this.showStatus(message);
+					this.ui.requestRender();
+				},
+			});
+			this.showStatus(formatSessionImportResult(result));
+			if (result.skillsImported > 0) {
+				try {
+					await this.agentConnection.reload();
+				} catch {
+					this.showWarning("Skills were imported, but will become available after the next reload.");
+				}
+			}
+		} catch {
+			this.showWarning("Local session import failed safely; onboarding will continue.");
+		}
+	}
+
+	private showOnboardingImportSelector(
+		inventories: SessionImportInventory[],
+	): Promise<SessionImportSource[] | undefined> {
+		return new Promise((resolve) => {
+			let settled = false;
+			let handle: OverlayHandle | undefined;
+			const settle = (result: SessionImportSource[] | undefined) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				handle?.hide();
+				this.ui.requestRender();
+				resolve(result);
+			};
+			const selector = new OnboardingImportSelectorComponent(
+				inventories,
+				(sources) => settle(sources),
+				() => settle(undefined),
+			);
+			handle = this.showFullPaneOverlay(selector, 80);
+			handle.focus();
+			this.ui.requestRender();
+		});
 	}
 
 	private async showOnboardingModelSelection(splash: OnboardingSplashHandle): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -119,6 +119,7 @@ import {
 	type SessionImportSource,
 } from "../../core/session-import/index.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
+import type { SessionHeader } from "../../core/session-manager.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
 import {
 	BUILTIN_SLASH_COMMANDS,
@@ -132,6 +133,7 @@ import { PRIME_BUTTERFLY_LOGO } from "../../themes/prime-logo.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { readClipboardImage } from "../../utils/clipboard-image.js";
+import { readFirstLineSync } from "../../utils/file-lines.js";
 import { parseGitUrl } from "../../utils/git.js";
 import { resizeImage } from "../../utils/image-resize.js";
 import { getCwdRelativePath } from "../../utils/paths.js";
@@ -628,6 +630,22 @@ function omitOrphanToolResults(messages: AgentMessage[]): AgentMessage[] {
 	return renderableMessages;
 }
 
+function isImportedSessionFile(sessionFile: string | undefined): boolean {
+	if (!sessionFile) {
+		return false;
+	}
+	try {
+		const firstLine = readFirstLineSync(sessionFile);
+		if (!firstLine) {
+			return false;
+		}
+		const header = JSON.parse(firstLine) as Partial<SessionHeader>;
+		return header.type === "session" && header.importedFrom !== undefined;
+	} catch {
+		return false;
+	}
+}
+
 function isDeadTerminalError(error: unknown): boolean {
 	if (!error || typeof error !== "object" || !("code" in error)) {
 		return false;
@@ -925,6 +943,7 @@ export class InteractiveMode {
 
 	// Tool output expansion state
 	private toolOutputExpanded = false;
+	private compactImportedToolHistory = false;
 
 	// Thinking block visibility state
 	private hideThinkingBlock = false;
@@ -2834,6 +2853,7 @@ export class InteractiveMode {
 		const compactionFinished = this.isAgentCompacting() && !snapshot.state.isCompacting;
 		const bashFinished = this.isBashRunning() && !snapshot.state.isBashRunning;
 		this.applyConnectionStateSnapshot(snapshot.state);
+		this.compactImportedToolHistory = isImportedSessionFile(snapshot.state.sessionFile);
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.replaceChildAgentInspector(snapshot.children);
@@ -6209,6 +6229,7 @@ export class InteractiveMode {
 							{
 								showImages: this.settingsManager.getShowImages(),
 								includeImageDimensions: false,
+								compactCompleted: this.compactImportedToolHistory,
 							},
 							this.getCachedToolDefinition(content.name),
 							this.ui,
@@ -6263,6 +6284,7 @@ export class InteractiveMode {
 		const context = this.getSessionContextFromConnectionSnapshot(snapshot);
 		const state = snapshot.state;
 		const streamingMessage = snapshot.streamingMessage;
+		this.compactImportedToolHistory = isImportedSessionFile(state.sessionFile);
 		this.seedChildAgentInspector(snapshot.children);
 		this.setSessionHasMessages(context.messages.length > 0);
 		this.applyConnectionStateSnapshot(state);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1653,9 +1653,9 @@ export class InteractiveMode {
 
 		const modelReady = isOnboardingModelReady(this.getOnboardingState());
 		const showPrimeCliSplash = this.shouldRunPrimeCliOnboardingSplash();
+		await this.runOnboardingImportFlow();
 		this.markOnboardingShown();
 		await this.settingsManager.flush();
-		await this.runOnboardingImportFlow();
 		if (showPrimeCliSplash || !modelReady) {
 			await this.runOnboardingFlow(showPrimeCliSplash);
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -198,9 +198,9 @@ import { HeartbeatManagerComponent } from "./components/heartbeat-manager.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./components/injected-prompt-message.js";
 import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import type { AuthSelectorProvider } from "./components/oauth-selector.js";
-import { OnboardingImportSelectorComponent } from "./components/onboarding-import-selector.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
+import { SessionImportSelectorComponent } from "./components/session-import-selector.js";
 import { SessionPickerScreen } from "./components/session-picker-screen.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
@@ -1642,13 +1642,23 @@ export class InteractiveMode {
 	}
 
 	private async runOnboardingImportFlow(): Promise<void> {
+		await this.runSessionImportFlow("onboarding");
+	}
+
+	private async runSessionImportFlow(trigger: "onboarding" | "command"): Promise<void> {
 		try {
 			const inventories = discoverSessionImports({ agentDir: getAgentDir() });
 			if (inventories.length === 0) {
+				if (trigger === "command") {
+					this.showStatus("No recent harness sessions or skills found");
+				}
 				return;
 			}
-			const selectedSources = await this.showOnboardingImportSelector(inventories);
+			const selectedSources = await this.showSessionImportSelector(inventories);
 			if (!selectedSources || selectedSources.length === 0) {
+				if (trigger === "command") {
+					this.showStatus("Import cancelled");
+				}
 				return;
 			}
 			const result = await importSessionsAndSkills(inventories, selectedSources, {
@@ -1667,11 +1677,19 @@ export class InteractiveMode {
 				}
 			}
 		} catch {
-			this.showWarning("Local session import failed safely; onboarding will continue.");
+			this.showWarning(
+				trigger === "onboarding"
+					? "Local session import failed safely; onboarding will continue."
+					: "Local session import failed safely.",
+			);
 		}
 	}
 
-	private showOnboardingImportSelector(
+	private async handleHarnessImportCommand(): Promise<void> {
+		await this.runSessionImportFlow("command");
+	}
+
+	private showSessionImportSelector(
 		inventories: SessionImportInventory[],
 	): Promise<SessionImportSource[] | undefined> {
 		return new Promise((resolve) => {
@@ -1686,7 +1704,7 @@ export class InteractiveMode {
 				this.ui.requestRender();
 				resolve(result);
 			};
-			const selector = new OnboardingImportSelectorComponent(
+			const selector = new SessionImportSelectorComponent(
 				inventories,
 				(sources) => settle(sources),
 				() => settle(undefined),
@@ -4342,7 +4360,11 @@ export class InteractiveMode {
 					return;
 				}
 				if (commandName === "import") {
-					await this.handleImportCommand(canonicalCommandText);
+					if (commandArgs) {
+						await this.handleImportCommand(canonicalCommandText);
+					} else {
+						await this.handleHarnessImportCommand();
+					}
 					this.editor.setText("");
 					return;
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8587,11 +8587,13 @@ export class InteractiveMode {
 				await this.handleImportCommand(text);
 				return;
 			}
-			if (kind === "claude" || kind === "codex") {
+			if (kind === "claude" || kind === "codex" || kind === "opencode") {
 				await this.handleExternalSessionImport(inputPath, kind);
 				return;
 			}
-			this.showError("Unsupported session JSONL. Expected a Prime Agent, Pi, Claude Code, or Codex session.");
+			this.showError(
+				"Unsupported session file. Expected a Prime Agent, Pi Mono, Claude Code, Codex, or OpenCode export.",
+			);
 		} catch (error) {
 			if (error instanceof SessionImportFileNotFoundError) {
 				this.showError(`Failed to import session: ${error.message}`);
@@ -8602,7 +8604,7 @@ export class InteractiveMode {
 	}
 
 	private async handleExternalSessionImport(inputPath: string, source: ExternalSessionImportFileKind): Promise<void> {
-		const label = source === "claude" ? "Claude Code" : "Codex";
+		const label = source === "claude" ? "Claude Code" : source === "codex" ? "Codex" : "OpenCode";
 		const confirmed = await this.showExtensionConfirm(
 			"Import session",
 			`Import and resume ${label} session from ${inputPath}?`,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -119,7 +119,6 @@ import {
 	type SessionImportSource,
 } from "../../core/session-import/index.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
-import type { SessionHeader } from "../../core/session-manager.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
 import {
 	BUILTIN_SLASH_COMMANDS,
@@ -639,7 +638,7 @@ function isImportedSessionFile(sessionFile: string | undefined): boolean {
 		if (!firstLine) {
 			return false;
 		}
-		const header = JSON.parse(firstLine) as Partial<SessionHeader>;
+		const header = JSON.parse(firstLine) as { type?: unknown; importedFrom?: unknown };
 		return header.type === "session" && header.importedFrom !== undefined;
 	} catch {
 		return false;

--- a/packages/coding-agent/src/modes/interactive/onboarding.ts
+++ b/packages/coding-agent/src/modes/interactive/onboarding.ts
@@ -38,8 +38,5 @@ export function shouldRunOnboarding(state: OnboardingStartupState): boolean {
 		return false;
 	}
 	state.modelRegistry.refresh();
-	if (shouldRunPrimeCliOnboardingSplash(state)) {
-		return true;
-	}
-	return !isOnboardingModelReady(state);
+	return true;
 }

--- a/packages/coding-agent/test/interactive-mode-import-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-import-command.test.ts
@@ -18,7 +18,7 @@ type InteractiveModePrototype = {
 type AutoImportCommandContext = {
 	getPathCommandArgument: (text: string, command: PathCommand) => string | undefined;
 	handleImportCommand: (text: string) => Promise<void>;
-	handleExternalSessionImport: (inputPath: string, source: "claude" | "codex") => Promise<void>;
+	handleExternalSessionImport: (inputPath: string, source: "claude" | "codex" | "opencode") => Promise<void>;
 	showError: (message: string) => void;
 };
 
@@ -52,18 +52,19 @@ describe("InteractiveMode /import parsing", () => {
 		expect(runSessionImportFlow).toHaveBeenCalledWith("command");
 	});
 
-	it("routes supported JSONL files to native or external import", async () => {
+	it("routes supported session files to native or external import", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-agent-import-command-"));
 		try {
-			const nativePath = join(root, "native.jsonl");
+			const piPath = join(root, "pi-mono.jsonl");
 			const claudePath = join(root, "claude.jsonl");
 			const codexPath = join(root, "codex.jsonl");
+			const openCodePath = join(root, "opencode.json");
 			writeFileSync(
-				nativePath,
+				piPath,
 				`${JSON.stringify({
 					type: "session",
 					version: 3,
-					id: "native",
+					id: "pi-mono",
 					timestamp: "2026-01-01T00:00:00.000Z",
 					cwd: root,
 				})}\n`,
@@ -82,6 +83,13 @@ describe("InteractiveMode /import parsing", () => {
 					payload: { id: "codex", cwd: root },
 				})}\n`,
 			);
+			writeFileSync(
+				openCodePath,
+				JSON.stringify({
+					info: { id: "opencode", directory: root },
+					messages: [{ info: { role: "user" }, parts: [{ type: "text", text: "OpenCode prompt" }] }],
+				}),
+			);
 
 			const handleImportCommand = vi.fn(async () => {});
 			const handleExternalSessionImport = vi.fn(async () => {});
@@ -92,14 +100,17 @@ describe("InteractiveMode /import parsing", () => {
 				showError: vi.fn(),
 			};
 
-			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${nativePath}"`);
-			expect(handleImportCommand).toHaveBeenLastCalledWith(`/import "${nativePath}"`);
+			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${piPath}"`);
+			expect(handleImportCommand).toHaveBeenLastCalledWith(`/import "${piPath}"`);
 
 			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${claudePath}"`);
 			expect(handleExternalSessionImport).toHaveBeenLastCalledWith(claudePath, "claude");
 
 			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${codexPath}"`);
 			expect(handleExternalSessionImport).toHaveBeenLastCalledWith(codexPath, "codex");
+
+			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${openCodePath}"`);
+			expect(handleExternalSessionImport).toHaveBeenLastCalledWith(openCodePath, "opencode");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/interactive-mode-import-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-import-command.test.ts
@@ -6,7 +6,12 @@ type PathCommand = "/export" | "/import";
 
 type InteractiveModePrototype = {
 	getPathCommandArgument(this: unknown, text: string, command: PathCommand): string | undefined;
+	handleHarnessImportCommand(this: HarnessImportCommandContext): Promise<void>;
 	handleImportCommand(this: ImportCommandContext, text: string): Promise<void>;
+};
+
+type HarnessImportCommandContext = {
+	runSessionImportFlow: (trigger: "onboarding" | "command") => Promise<void>;
 };
 
 type ImportCommandContext = {
@@ -26,6 +31,14 @@ type ImportCommandContext = {
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
 
 describe("InteractiveMode /import parsing", () => {
+	it("opens harness import when no path is provided", async () => {
+		const runSessionImportFlow = vi.fn(async () => {});
+
+		await interactiveModePrototype.handleHarnessImportCommand.call({ runSessionImportFlow });
+
+		expect(runSessionImportFlow).toHaveBeenCalledWith("command");
+	});
+
 	it("strips quotes from /import path arguments", () => {
 		expect(interactiveModePrototype.getPathCommandArgument('/import "path/to/session.jsonl"', "/import")).toBe(
 			"path/to/session.jsonl",

--- a/packages/coding-agent/test/interactive-mode-import-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-import-command.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SessionImportFileNotFoundError } from "../src/core/session-import-errors.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
@@ -6,8 +9,17 @@ type PathCommand = "/export" | "/import";
 
 type InteractiveModePrototype = {
 	getPathCommandArgument(this: unknown, text: string, command: PathCommand): string | undefined;
+	handleAutoImportCommand(this: AutoImportCommandContext, text: string): Promise<void>;
 	handleHarnessImportCommand(this: HarnessImportCommandContext): Promise<void>;
 	handleImportCommand(this: ImportCommandContext, text: string): Promise<void>;
+	importAndResumeSession(this: ImportCommandContext, inputPath: string, successMessage: string): Promise<void>;
+};
+
+type AutoImportCommandContext = {
+	getPathCommandArgument: (text: string, command: PathCommand) => string | undefined;
+	handleImportCommand: (text: string) => Promise<void>;
+	handleExternalSessionImport: (inputPath: string, source: "claude" | "codex") => Promise<void>;
+	showError: (message: string) => void;
 };
 
 type HarnessImportCommandContext = {
@@ -26,6 +38,7 @@ type ImportCommandContext = {
 	handleFatalRuntimeError: (prefix: string, error: unknown) => Promise<never>;
 	promptForMissingSessionCwd: (error: unknown) => Promise<string | undefined>;
 	getPathCommandArgument: (text: string, command: PathCommand) => string | undefined;
+	importAndResumeSession: (inputPath: string, successMessage: string) => Promise<void>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
@@ -37,6 +50,59 @@ describe("InteractiveMode /import parsing", () => {
 		await interactiveModePrototype.handleHarnessImportCommand.call({ runSessionImportFlow });
 
 		expect(runSessionImportFlow).toHaveBeenCalledWith("command");
+	});
+
+	it("routes supported JSONL files to native or external import", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-import-command-"));
+		try {
+			const nativePath = join(root, "native.jsonl");
+			const claudePath = join(root, "claude.jsonl");
+			const codexPath = join(root, "codex.jsonl");
+			writeFileSync(
+				nativePath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "native",
+					timestamp: "2026-01-01T00:00:00.000Z",
+					cwd: root,
+				})}\n`,
+			);
+			writeFileSync(
+				claudePath,
+				`${JSON.stringify({
+					type: "user",
+					message: { role: "user", content: "Claude prompt" },
+				})}\n`,
+			);
+			writeFileSync(
+				codexPath,
+				`${JSON.stringify({
+					type: "session_meta",
+					payload: { id: "codex", cwd: root },
+				})}\n`,
+			);
+
+			const handleImportCommand = vi.fn(async () => {});
+			const handleExternalSessionImport = vi.fn(async () => {});
+			const context: AutoImportCommandContext = {
+				getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
+				handleImportCommand,
+				handleExternalSessionImport,
+				showError: vi.fn(),
+			};
+
+			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${nativePath}"`);
+			expect(handleImportCommand).toHaveBeenLastCalledWith(`/import "${nativePath}"`);
+
+			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${claudePath}"`);
+			expect(handleExternalSessionImport).toHaveBeenLastCalledWith(claudePath, "claude");
+
+			await interactiveModePrototype.handleAutoImportCommand.call(context, `/import "${codexPath}"`);
+			expect(handleExternalSessionImport).toHaveBeenLastCalledWith(codexPath, "codex");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("strips quotes from /import path arguments", () => {
@@ -83,6 +149,7 @@ describe("InteractiveMode /import parsing", () => {
 			}),
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
+			importAndResumeSession: interactiveModePrototype.importAndResumeSession,
 		};
 
 		await interactiveModePrototype.handleImportCommand.call(context, '/import "path/to/session.jsonl"');
@@ -115,6 +182,7 @@ describe("InteractiveMode /import parsing", () => {
 			}),
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
+			importAndResumeSession: interactiveModePrototype.importAndResumeSession,
 		};
 
 		await interactiveModePrototype.handleImportCommand.call(context, "/import john's/session.jsonl");
@@ -146,6 +214,7 @@ describe("InteractiveMode /import parsing", () => {
 			handleFatalRuntimeError,
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
+			importAndResumeSession: interactiveModePrototype.importAndResumeSession,
 		};
 
 		await interactiveModePrototype.handleImportCommand.call(context, "/import /tmp/missing-session.jsonl");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2486,7 +2486,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).toHaveBeenCalledWith(true);
 	});
 
-	test("persists onboarding before opening the one-shot flow", async () => {
+	test("persists onboarding after import completes and before opening the one-shot flow", async () => {
 		let shown = false;
 		let flushed = false;
 		const fakeThis = createPrimeCliHarness(false);
@@ -2496,6 +2496,10 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		});
 		fakeThis.uiServices.settingsManager.flush = vi.fn(async () => {
 			flushed = true;
+		});
+		fakeThis.runOnboardingImportFlow = vi.fn(async () => {
+			expect(shown).toBe(false);
+			expect(flushed).toBe(false);
 		});
 		fakeThis.runOnboardingFlow = vi.fn(async (showPrimeCliSplash?: boolean) => {
 			expect(showPrimeCliSplash).toBe(true);
@@ -2509,6 +2513,18 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		expect(fakeThis.uiServices.settingsManager.flush).toHaveBeenCalledTimes(1);
 		expect(fakeThis.runOnboardingImportFlow).toHaveBeenCalledTimes(1);
 		expect(fakeThis.runOnboardingFlow).toHaveBeenCalledWith(true);
+	});
+
+	test("does not suppress onboarding when import is interrupted", async () => {
+		const fakeThis = createPrimeCliHarness(false);
+		fakeThis.runOnboardingImportFlow = vi.fn(async () => {
+			throw new Error("interrupted");
+		});
+
+		await expect(runStartupOnboarding.call(fakeThis)).rejects.toThrow("interrupted");
+
+		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).not.toHaveBeenCalled();
+		expect(fakeThis.uiServices.settingsManager.flush).not.toHaveBeenCalled();
 	});
 
 	test("imports first-launch data without reopening model setup for a ready model", async () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2336,6 +2336,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 		shouldRunOnboarding(): boolean;
 		markOnboardingShown(): void;
 		runStartupOnboarding(): Promise<boolean>;
+		runOnboardingImportFlow(): Promise<void>;
 		runOnboardingFlow(showPrimeCliSplash?: boolean): Promise<void>;
 		applySelectedModel(model: AgentConnectionModel): Promise<void>;
 		prepareForModelSelectionAfterLogin(authResult: AuthenticationResult): Promise<boolean>;
@@ -2460,6 +2461,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 			},
 		};
 		fakeThis.getModelCandidates = vi.fn(async () => [primeModel]);
+		fakeThis.runOnboardingImportFlow = vi.fn(async () => {});
 		return fakeThis;
 	}
 
@@ -2505,7 +2507,20 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 
 		expect(fakeThis.uiServices.settingsManager.setOnboardingShown).toHaveBeenCalledWith(true);
 		expect(fakeThis.uiServices.settingsManager.flush).toHaveBeenCalledTimes(1);
+		expect(fakeThis.runOnboardingImportFlow).toHaveBeenCalledTimes(1);
 		expect(fakeThis.runOnboardingFlow).toHaveBeenCalledWith(true);
+	});
+
+	test("imports first-launch data without reopening model setup for a ready model", async () => {
+		const fakeThis = createPrimeCliHarness(false);
+		const readyModel = { ...primeModel, provider: "anthropic" };
+		fakeThis.connectionState = createConnectionState({ model: readyModel });
+		fakeThis.runOnboardingFlow = vi.fn(async () => {});
+
+		await expect(runStartupOnboarding.call(fakeThis)).resolves.toBe(true);
+
+		expect(fakeThis.runOnboardingImportFlow).toHaveBeenCalledTimes(1);
+		expect(fakeThis.runOnboardingFlow).not.toHaveBeenCalled();
 	});
 
 	test("cancelled Prime CLI splash exits onboarding before opening configuration", async () => {

--- a/packages/coding-agent/test/onboarding-startup.test.ts
+++ b/packages/coding-agent/test/onboarding-startup.test.ts
@@ -71,7 +71,7 @@ describe("startup onboarding decision", () => {
 		expect(shouldRunOnboarding(state)).toBe(false);
 	});
 
-	test("skips the Prime CLI splash for non-Prime providers with ready auth", () => {
+	test("runs first-launch onboarding for non-Prime providers with ready auth", () => {
 		const state = makeState({
 			onboardingShown: false,
 			model: makeModel("anthropic"),
@@ -79,6 +79,6 @@ describe("startup onboarding decision", () => {
 			primeAuthSource: "stored",
 		});
 		expect(shouldRunPrimeCliOnboardingSplash(state)).toBe(false);
-		expect(shouldRunOnboarding(state)).toBe(false);
+		expect(shouldRunOnboarding(state)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -33,6 +33,12 @@ describe("built-in slash commands", () => {
 		});
 	});
 
+	test("describes both /import modes", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "import")).toMatchObject({
+			description: "Import harness history, or resume a session from a JSONL file",
+		});
+	});
+
 	test("exposes /btw as an argument command with /side as an alias", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "btw")).toMatchObject({
 			argumentHint: "<question>",

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -35,7 +35,7 @@ describe("built-in slash commands", () => {
 
 	test("describes both /import modes", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "import")).toMatchObject({
-			description: "Import harness history, or resume a session from a JSONL file",
+			description: "Import harness history, or import and resume a supported JSONL file",
 		});
 	});
 

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -35,7 +35,7 @@ describe("built-in slash commands", () => {
 
 	test("describes both /import modes", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "import")).toMatchObject({
-			description: "Import harness history, or import and resume a supported JSONL file",
+			description: "Import harness history, or import and resume a supported session file",
 		});
 	});
 

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -509,9 +509,10 @@ describe("ENG-4373 onboarding session import", () => {
 			const entries = loadEntriesFromFile(imported.sessionFile);
 			const header = entries[0] as SessionHeader;
 			const state = [...entries].reverse().find((entry) => entry.type === "session_state");
-			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
+			const context = SessionManager.open(imported.sessionFile, getSessionsDir(agentDir)).buildSessionContext();
 			expect(header.importedFrom?.source).toBe(imported.source);
 			expect(state?.type === "session_state" ? state.state.status : undefined).toBe("active");
+			expect(context.model).toBeNull();
 			expect(
 				context.messages.some(
 					(message) =>
@@ -524,7 +525,7 @@ describe("ENG-4373 onboarding session import", () => {
 				.slice(1)
 				.filter((entry) => entry.type !== "session"),
 		);
-		expect(codexContext.messages.find((message) => message.role === "assistant")?.provider).toBe("openai-codex");
+		expect(codexContext.messages.find((message) => message.role === "assistant")?.provider).toBe("openai");
 		expect(
 			codexContext.messages
 				.filter((message) => message.role === "assistant")
@@ -540,7 +541,7 @@ describe("ENG-4373 onboarding session import", () => {
 		});
 	});
 
-	it("restores legacy Codex imports through the Codex subscription provider", () => {
+	it("keeps normal model restoration for native Prime Agent sessions", () => {
 		const manager = SessionManager.inMemory("/workspace/codex");
 		manager.appendMessage({
 			role: "assistant",
@@ -555,8 +556,8 @@ describe("ENG-4373 onboarding session import", () => {
 
 		const context = manager.buildSessionContext();
 
-		expect(context.model).toEqual({ provider: "openai-codex", modelId: "gpt-5.6-sol" });
-		expect(context.messages.find((message) => message.role === "assistant")?.provider).toBe("openai-codex");
+		expect(context.model).toEqual({ provider: "openai", modelId: "gpt-5.6-sol" });
+		expect(context.messages.find((message) => message.role === "assistant")?.provider).toBe("openai");
 	});
 
 	it("continues importing other sources when one source disappears", async () => {

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -121,7 +121,13 @@ function createCodexFixture(home: string): void {
 		{
 			type: "response_item",
 			timestamp: "2026-01-02T00:00:04.000Z",
-			payload: { type: "function_call", call_id: "codex-tool", name: "exec", arguments: '{"cmd":"pwd"}' },
+			payload: {
+				type: "function_call",
+				call_id: "codex-tool",
+				namespace: "codex_app",
+				name: "set_thread_title",
+				arguments: '{"title":"Imported session"}',
+			},
 		},
 		{
 			type: "response_item",
@@ -508,6 +514,17 @@ describe("ENG-4373 onboarding session import", () => {
 				),
 			).toBe(true);
 		}
+		const codexContext = buildSessionContext(
+			loadEntriesFromFile(codex.sessionFile)
+				.slice(1)
+				.filter((entry) => entry.type !== "session"),
+		);
+		expect(
+			codexContext.messages
+				.filter((message) => message.role === "assistant")
+				.flatMap((message) => message.content)
+				.find((content) => content.type === "toolCall")?.name,
+		).toBe("codex_app_set_thread_title");
 
 		await expect(
 			importExternalSessionFile(claudePath, "claude", { homeDir: home, agentDir, env: {} }),

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -8,7 +8,9 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { getSessionsDir } from "../../../src/config.js";
 import { KeybindingsManager } from "../../../src/core/keybindings.js";
 import {
+	detectSessionImportFileKind,
 	discoverSessionImports,
+	importExternalSessionFile,
 	importSessionsAndSkills,
 	type SessionImportInventory,
 } from "../../../src/core/session-import/index.js";
@@ -416,6 +418,45 @@ describe("ENG-4373 onboarding session import", () => {
 		expect(paths).toContain(join(project, "recent-00.jsonl"));
 		expect(paths).not.toContain(join(project, "recent-54.jsonl"));
 		expect(paths).not.toContain(oldPath);
+	});
+
+	it("detects and imports individual Claude Code and Codex JSONL files", async () => {
+		const claudePath = join(home, ".claude", "projects", "-project", "claude-session.jsonl");
+		const codexPath = join(home, ".codex", "sessions", "2026", "01", "01", "codex-session.jsonl");
+		const piPath = join(home, ".pi", "agent", "sessions", "project", "pi-session.jsonl");
+		const malformedPath = join(home, ".claude", "projects", "-project", "malformed.jsonl");
+
+		await expect(detectSessionImportFileKind(claudePath)).resolves.toBe("claude");
+		await expect(detectSessionImportFileKind(codexPath)).resolves.toBe("codex");
+		await expect(detectSessionImportFileKind(piPath)).resolves.toBe("native");
+		await expect(detectSessionImportFileKind(malformedPath)).resolves.toBe("unknown");
+
+		const claude = await importExternalSessionFile(claudePath, "claude", { homeDir: home, agentDir, env: {} });
+		const codex = await importExternalSessionFile(codexPath, "codex", { homeDir: home, agentDir, env: {} });
+		expect(claude.status).toBe("imported");
+		expect(codex.status).toBe("imported");
+
+		for (const imported of [claude, codex]) {
+			const entries = loadEntriesFromFile(imported.sessionFile);
+			const header = entries[0] as SessionHeader;
+			const state = [...entries].reverse().find((entry) => entry.type === "session_state");
+			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
+			expect(header.importedFrom?.source).toBe(imported.source);
+			expect(state?.type === "session_state" ? state.state.status : undefined).toBe("active");
+			expect(
+				context.messages.some(
+					(message) =>
+						message.role === "assistant" && message.content.some((content) => content.type === "thinking"),
+				),
+			).toBe(true);
+		}
+
+		await expect(
+			importExternalSessionFile(claudePath, "claude", { homeDir: home, agentDir, env: {} }),
+		).resolves.toMatchObject({
+			sessionFile: claude.sessionFile,
+			status: "existing",
+		});
 	});
 
 	it("continues importing other sources when one source disappears", async () => {

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -14,7 +14,12 @@ import {
 	importSessionsAndSkills,
 	type SessionImportInventory,
 } from "../../../src/core/session-import/index.js";
-import { buildSessionContext, loadEntriesFromFile, type SessionHeader } from "../../../src/core/session-manager.js";
+import {
+	buildSessionContext,
+	loadEntriesFromFile,
+	type SessionHeader,
+	SessionManager,
+} from "../../../src/core/session-manager.js";
 import { SessionImportSelectorComponent } from "../../../src/modes/interactive/components/session-import-selector.js";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
 
@@ -90,7 +95,7 @@ function createCodexFixture(home: string): void {
 			payload: {
 				id: "codex-session",
 				cwd: "/workspace/codex",
-				model_provider: "openai-codex",
+				model_provider: "openai",
 			},
 		},
 		{
@@ -519,6 +524,7 @@ describe("ENG-4373 onboarding session import", () => {
 				.slice(1)
 				.filter((entry) => entry.type !== "session"),
 		);
+		expect(codexContext.messages.find((message) => message.role === "assistant")?.provider).toBe("openai-codex");
 		expect(
 			codexContext.messages
 				.filter((message) => message.role === "assistant")
@@ -532,6 +538,25 @@ describe("ENG-4373 onboarding session import", () => {
 			sessionFile: claude.sessionFile,
 			status: "existing",
 		});
+	});
+
+	it("restores legacy Codex imports through the Codex subscription provider", () => {
+		const manager = SessionManager.inMemory("/workspace/codex");
+		manager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "Imported Codex response" }],
+			api: "openai-codex-responses",
+			provider: "openai",
+			model: "gpt-5.6-sol",
+			usage: ZERO_USAGE,
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+
+		const context = manager.buildSessionContext();
+
+		expect(context.model).toEqual({ provider: "openai-codex", modelId: "gpt-5.6-sol" });
+		expect(context.messages.find((message) => message.role === "assistant")?.provider).toBe("openai-codex");
 	});
 
 	it("continues importing other sources when one source disappears", async () => {

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -7,7 +7,6 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSessionsDir } from "../../../src/config.js";
 import { KeybindingsManager } from "../../../src/core/keybindings.js";
-import { convertToLlm } from "../../../src/core/messages.js";
 import {
 	detectSessionImportFileKind,
 	discoverSessionImports,
@@ -139,6 +138,27 @@ function createCodexFixture(home: string): void {
 			type: "response_item",
 			timestamp: "2026-01-02T00:00:05.000Z",
 			payload: { type: "function_call_output", call_id: "codex-tool", output: "Codex tool output" },
+		},
+	]);
+	writeJsonl(join(home, ".codex", "sessions", "2026", "01", "01", "codex-subagent.jsonl"), [
+		{
+			type: "session_meta",
+			timestamp: "2026-01-02T00:00:00.000Z",
+			payload: {
+				id: "codex-subagent",
+				cwd: "/workspace/codex",
+				thread_source: "subagent",
+				source: { subagent: { other: "guardian" } },
+				model_provider: "openai",
+			},
+		},
+		{
+			type: "event_msg",
+			timestamp: "2026-01-02T00:00:01.000Z",
+			payload: {
+				type: "user_message",
+				message: "The following is the Codex agent history whose request action you are assessing.",
+			},
 		},
 	]);
 	createSkill(home, join(".codex", "skills"), "codex-skill");
@@ -352,6 +372,13 @@ describe("ENG-4373 onboarding session import", () => {
 	it("imports all supported harnesses with thoughts, tool calls, results, and skills", async () => {
 		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} });
 		expect(inventories.map((inventory) => inventory.source)).toEqual(["claude", "codex", "opencode", "pi"]);
+		const codexInventory = inventories.find((inventory) => inventory.source === "codex");
+		expect(codexInventory?.sessionCount).toBe(1);
+		expect(
+			codexInventory?.sessionReferences.some(
+				(reference) => reference.kind === "file" && reference.path.endsWith("codex-subagent.jsonl"),
+			),
+		).toBe(false);
 
 		const result = await importSessionsAndSkills(
 			inventories,
@@ -376,21 +403,6 @@ describe("ENG-4373 onboarding session import", () => {
 			expect(header.importedFrom?.contentHash).toMatch(/^[a-f0-9]{64}$/);
 			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
 			expect(context.messages.some((message) => message.role === "user")).toBe(true);
-			expect(context.messages.at(-1)).toMatchObject({
-				role: "custom",
-				customType: "session_import_boundary",
-				display: false,
-				details: { source: header.importedFrom?.source },
-			});
-			expect(convertToLlm(context.messages).at(-1)).toMatchObject({
-				role: "user",
-				content: [
-					{
-						type: "text",
-						text: expect.stringContaining("use only the tools exposed in this session"),
-					},
-				],
-			});
 			expect(
 				context.messages.some(
 					(message) =>
@@ -529,12 +541,6 @@ describe("ENG-4373 onboarding session import", () => {
 			expect(header.importedFrom?.source).toBe(imported.source);
 			expect(state?.type === "session_state" ? state.state.status : undefined).toBe("active");
 			expect(context.model).toBeNull();
-			expect(context.messages.at(-1)).toMatchObject({
-				role: "custom",
-				customType: "session_import_boundary",
-				display: false,
-				details: { source: imported.source },
-			});
 			expect(
 				context.messages.some(
 					(message) =>

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -13,7 +13,7 @@ import {
 	type SessionImportInventory,
 } from "../../../src/core/session-import/index.js";
 import { buildSessionContext, loadEntriesFromFile, type SessionHeader } from "../../../src/core/session-manager.js";
-import { OnboardingImportSelectorComponent } from "../../../src/modes/interactive/components/onboarding-import-selector.js";
+import { SessionImportSelectorComponent } from "../../../src/modes/interactive/components/session-import-selector.js";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
 
 const ZERO_USAGE = {
@@ -133,6 +133,7 @@ function createCodexFixture(home: string): void {
 function createOpenCodeFixture(home: string): void {
 	const directory = join(home, ".local", "share", "opencode");
 	mkdirSync(directory, { recursive: true });
+	const now = Date.now();
 	const database = new DatabaseSync(join(directory, "opencode.db"));
 	try {
 		database.exec(`
@@ -149,14 +150,14 @@ function createOpenCodeFixture(home: string): void {
 		`);
 		database
 			.prepare("INSERT INTO session VALUES (?, NULL, ?, ?, ?, ?)")
-			.run("opencode-session", "/workspace/opencode", "OpenCode title", 1_767_312_000_000, 1_767_312_010_000);
+			.run("opencode-session", "/workspace/opencode", "OpenCode title", now, now + 10_000);
 		database.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
 			"opencode-user",
 			"opencode-session",
-			1_767_312_001_000,
+			now + 1_000,
 			JSON.stringify({
 				role: "user",
-				time: { created: 1_767_312_001_000 },
+				time: { created: now + 1_000 },
 				model: { providerID: "openai", modelID: "gpt-test" },
 			}),
 		);
@@ -166,16 +167,16 @@ function createOpenCodeFixture(home: string): void {
 				"opencode-user-text",
 				"opencode-user",
 				"opencode-session",
-				1_767_312_001_000,
+				now + 1_000,
 				JSON.stringify({ type: "text", text: "OpenCode user prompt" }),
 			);
 		database.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
 			"opencode-assistant",
 			"opencode-session",
-			1_767_312_002_000,
+			now + 2_000,
 			JSON.stringify({
 				role: "assistant",
-				time: { created: 1_767_312_002_000 },
+				time: { created: now + 2_000 },
 				providerID: "openai",
 				modelID: "gpt-test",
 				finish: "tool-calls",
@@ -187,21 +188,21 @@ function createOpenCodeFixture(home: string): void {
 			"opencode-reasoning",
 			"opencode-assistant",
 			"opencode-session",
-			1_767_312_002_000,
-			JSON.stringify({ type: "reasoning", text: "OpenCode thinking", time: { start: 1_767_312_002_000 } }),
+			now + 2_000,
+			JSON.stringify({ type: "reasoning", text: "OpenCode thinking", time: { start: now + 2_000 } }),
 		);
 		insertPart.run(
 			"opencode-text",
 			"opencode-assistant",
 			"opencode-session",
-			1_767_312_003_000,
+			now + 3_000,
 			JSON.stringify({ type: "text", text: "OpenCode assistant" }),
 		);
 		insertPart.run(
 			"opencode-tool",
 			"opencode-assistant",
 			"opencode-session",
-			1_767_312_004_000,
+			now + 4_000,
 			JSON.stringify({
 				type: "tool",
 				callID: "opencode-tool",
@@ -210,7 +211,7 @@ function createOpenCodeFixture(home: string): void {
 					status: "completed",
 					input: { command: "pwd" },
 					output: "OpenCode tool output",
-					time: { start: 1_767_312_004_000, end: 1_767_312_005_000 },
+					time: { start: now + 4_000, end: now + 5_000 },
 				},
 			}),
 		);
@@ -308,6 +309,7 @@ describe("ENG-4373 onboarding session import", () => {
 			const entries = loadEntriesFromFile(sessionFile);
 			const header = entries[0] as SessionHeader;
 			importedSources.add(header.importedFrom?.source ?? "");
+			expect(header.importedFrom?.contentHash).toMatch(/^[a-f0-9]{64}$/);
 			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
 			expect(context.messages.some((message) => message.role === "user")).toBe(true);
 			expect(
@@ -341,6 +343,79 @@ describe("ENG-4373 onboarding session import", () => {
 		expect(retry.sessionsSkipped).toBe(5);
 		expect(retry.skillsImported).toBe(0);
 		expect(retry.skillsSkipped).toBe(4);
+
+		const claudeReference = inventories
+			.find((inventory) => inventory.source === "claude")
+			?.sessionReferences.find(
+				(reference) => reference.kind === "file" && reference.path.endsWith("claude-session.jsonl"),
+			);
+		expect(claudeReference?.kind).toBe("file");
+		if (claudeReference?.kind === "file") {
+			writeFileSync(
+				claudeReference.path,
+				`${JSON.stringify({
+					type: "user",
+					sessionId: "claude-session",
+					cwd: "/workspace/claude",
+					timestamp: "2026-01-01T00:00:03.000Z",
+					message: { role: "user", content: "Continued Claude prompt" },
+				})}\n`,
+				{ flag: "a" },
+			);
+		}
+
+		const continued = await importSessionsAndSkills(
+			inventories,
+			inventories.map((inventory) => inventory.source),
+			{ homeDir: home, agentDir, env: {} },
+		);
+		expect(continued.sessionsImported).toBe(1);
+		expect(continued.sessionsSkipped).toBe(4);
+		expect(readdirSync(getSessionsDir(agentDir)).filter((file) => file.endsWith(".jsonl"))).toHaveLength(5);
+	});
+
+	it("considers only the 50 most recently modified sessions from the last 30 days", () => {
+		const project = join(home, ".claude", "projects", "-recent");
+		const now = Date.now();
+		for (let index = 0; index < 55; index++) {
+			const path = join(project, `recent-${index.toString().padStart(2, "0")}.jsonl`);
+			writeJsonl(path, [
+				{
+					type: "user",
+					sessionId: `recent-${index}`,
+					cwd: "/workspace/claude",
+					timestamp: new Date(now - index * 1_000).toISOString(),
+					message: { role: "user", content: `Recent prompt ${index}` },
+				},
+			]);
+			const modifiedAt = new Date(now + 10_000 - index * 1_000);
+			utimesSync(path, modifiedAt, modifiedAt);
+		}
+		const oldPath = join(project, "old.jsonl");
+		writeJsonl(oldPath, [
+			{
+				type: "user",
+				sessionId: "old",
+				cwd: "/workspace/claude",
+				timestamp: "2020-01-01T00:00:00.000Z",
+				message: { role: "user", content: "Old prompt" },
+			},
+		]);
+		const oldTime = new Date(now - 31 * 24 * 60 * 60 * 1_000);
+		utimesSync(oldPath, oldTime, oldTime);
+
+		const claude = discoverSessionImports({ homeDir: home, agentDir, env: {} }).find(
+			(inventory) => inventory.source === "claude",
+		);
+		const paths =
+			claude?.sessionReferences
+				.filter((reference) => reference.kind === "file")
+				.map((reference) => reference.path) ?? [];
+
+		expect(claude?.sessionCount).toBe(50);
+		expect(paths).toContain(join(project, "recent-00.jsonl"));
+		expect(paths).not.toContain(join(project, "recent-54.jsonl"));
+		expect(paths).not.toContain(oldPath);
 	});
 
 	it("continues importing other sources when one source disappears", async () => {
@@ -365,7 +440,7 @@ describe("ENG-4373 onboarding session import", () => {
 	it("selects harnesses rather than individual data types", () => {
 		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} }).slice(0, 2);
 		const onSelect = vi.fn();
-		const selector = new OnboardingImportSelectorComponent(inventories, onSelect, vi.fn());
+		const selector = new SessionImportSelectorComponent(inventories, onSelect, vi.fn());
 
 		selector.handleInput("\r");
 		selector.handleInput("\x1b[B");

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -223,6 +223,56 @@ function createOpenCodeFixture(home: string): void {
 	createSkill(home, join(".config", "opencode", "skills"), "opencode-skill");
 }
 
+function createOpenCodeExportFixture(home: string): string {
+	const path = join(home, "opencode-session.json");
+	writeFileSync(
+		path,
+		JSON.stringify(
+			{
+				info: {
+					id: "opencode-export",
+					directory: "/workspace/opencode-export",
+					title: "OpenCode export",
+					time: { created: 1_767_571_200_000 },
+				},
+				messages: [
+					{
+						info: { role: "user", time: { created: 1_767_571_201_000 } },
+						parts: [{ type: "text", text: "OpenCode export prompt" }],
+					},
+					{
+						info: {
+							role: "assistant",
+							time: { created: 1_767_571_202_000 },
+							providerID: "openai",
+							modelID: "gpt-test",
+							finish: "tool-calls",
+						},
+						parts: [
+							{ type: "reasoning", text: "OpenCode export thinking" },
+							{ type: "text", text: "OpenCode export response" },
+							{
+								type: "tool",
+								callID: "opencode-export-tool",
+								tool: "bash",
+								state: {
+									status: "completed",
+									input: { command: "pwd" },
+									output: "OpenCode export tool output",
+									time: { start: 1_767_571_203_000, end: 1_767_571_204_000 },
+								},
+							},
+						],
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	return path;
+}
+
 function createPiFixture(home: string): void {
 	const user: Message = {
 		role: "user",
@@ -420,23 +470,31 @@ describe("ENG-4373 onboarding session import", () => {
 		expect(paths).not.toContain(oldPath);
 	});
 
-	it("detects and imports individual Claude Code and Codex JSONL files", async () => {
+	it("detects and imports individual harness session files", async () => {
 		const claudePath = join(home, ".claude", "projects", "-project", "claude-session.jsonl");
 		const codexPath = join(home, ".codex", "sessions", "2026", "01", "01", "codex-session.jsonl");
 		const piPath = join(home, ".pi", "agent", "sessions", "project", "pi-session.jsonl");
+		const openCodePath = createOpenCodeExportFixture(home);
 		const malformedPath = join(home, ".claude", "projects", "-project", "malformed.jsonl");
 
 		await expect(detectSessionImportFileKind(claudePath)).resolves.toBe("claude");
 		await expect(detectSessionImportFileKind(codexPath)).resolves.toBe("codex");
 		await expect(detectSessionImportFileKind(piPath)).resolves.toBe("native");
+		await expect(detectSessionImportFileKind(openCodePath)).resolves.toBe("opencode");
 		await expect(detectSessionImportFileKind(malformedPath)).resolves.toBe("unknown");
 
 		const claude = await importExternalSessionFile(claudePath, "claude", { homeDir: home, agentDir, env: {} });
 		const codex = await importExternalSessionFile(codexPath, "codex", { homeDir: home, agentDir, env: {} });
+		const openCode = await importExternalSessionFile(openCodePath, "opencode", {
+			homeDir: home,
+			agentDir,
+			env: {},
+		});
 		expect(claude.status).toBe("imported");
 		expect(codex.status).toBe("imported");
+		expect(openCode.status).toBe("imported");
 
-		for (const imported of [claude, codex]) {
+		for (const imported of [claude, codex, openCode]) {
 			const entries = loadEntriesFromFile(imported.sessionFile);
 			const header = entries[0] as SessionHeader;
 			const state = [...entries].reverse().find((entry) => entry.type === "session_state");

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -7,6 +7,7 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSessionsDir } from "../../../src/config.js";
 import { KeybindingsManager } from "../../../src/core/keybindings.js";
+import { convertToLlm } from "../../../src/core/messages.js";
 import {
 	detectSessionImportFileKind,
 	discoverSessionImports,
@@ -375,6 +376,21 @@ describe("ENG-4373 onboarding session import", () => {
 			expect(header.importedFrom?.contentHash).toMatch(/^[a-f0-9]{64}$/);
 			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
 			expect(context.messages.some((message) => message.role === "user")).toBe(true);
+			expect(context.messages.at(-1)).toMatchObject({
+				role: "custom",
+				customType: "session_import_boundary",
+				display: false,
+				details: { source: header.importedFrom?.source },
+			});
+			expect(convertToLlm(context.messages).at(-1)).toMatchObject({
+				role: "user",
+				content: [
+					{
+						type: "text",
+						text: expect.stringContaining("use only the tools exposed in this session"),
+					},
+				],
+			});
 			expect(
 				context.messages.some(
 					(message) =>
@@ -513,6 +529,12 @@ describe("ENG-4373 onboarding session import", () => {
 			expect(header.importedFrom?.source).toBe(imported.source);
 			expect(state?.type === "session_state" ? state.state.status : undefined).toBe("active");
 			expect(context.model).toBeNull();
+			expect(context.messages.at(-1)).toMatchObject({
+				role: "custom",
+				customType: "session_import_boundary",
+				display: false,
+				details: { source: imported.source },
+			});
 			expect(
 				context.messages.some(
 					(message) =>

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -7,6 +7,7 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSessionsDir } from "../../../src/config.js";
 import { KeybindingsManager } from "../../../src/core/keybindings.js";
+import { listOpenCodeSessions } from "../../../src/core/session-import/adapters/opencode.js";
 import {
 	detectSessionImportFileKind,
 	discoverSessionImports,
@@ -14,6 +15,7 @@ import {
 	importSessionsAndSkills,
 	type SessionImportInventory,
 } from "../../../src/core/session-import/index.js";
+import { importSkillDirectory } from "../../../src/core/session-import/skills.js";
 import {
 	buildSessionContext,
 	loadEntriesFromFile,
@@ -64,7 +66,8 @@ function createClaudeFixture(home: string): void {
 				stop_reason: "tool_use",
 				usage: { input_tokens: 2, output_tokens: 3 },
 				content: [
-					{ type: "thinking", thinking: "Claude thinking" },
+					{ type: "thinking", thinking: "Claude thinking", signature: "claude-thinking-signature" },
+					{ type: "redacted_thinking", data: "claude-redacted-payload" },
 					{ type: "text", text: "Claude assistant" },
 					{ type: "tool_use", id: "claude-tool", name: "read", input: { path: "README.md" } },
 				],
@@ -138,6 +141,11 @@ function createCodexFixture(home: string): void {
 			type: "response_item",
 			timestamp: "2026-01-02T00:00:05.000Z",
 			payload: { type: "function_call_output", call_id: "codex-tool", output: "Codex tool output" },
+		},
+		{
+			type: "response_item",
+			timestamp: "2026-01-02T00:00:05.500Z",
+			payload: { type: "function_call_output", call_id: "codex-tool", output: "Duplicate Codex tool output" },
 		},
 	]);
 	writeJsonl(join(home, ".codex", "sessions", "2026", "01", "01", "codex-subagent.jsonl"), [
@@ -248,6 +256,13 @@ function createOpenCodeFixture(home: string): void {
 					time: { start: now + 4_000, end: now + 5_000 },
 				},
 			}),
+		);
+		insertPart.run(
+			"opencode-after-tool",
+			"opencode-assistant",
+			"opencode-session",
+			now + 6_000,
+			JSON.stringify({ type: "text", text: "OpenCode after tool" }),
 		);
 	} finally {
 		database.close();
@@ -418,6 +433,30 @@ describe("ENG-4373 onboarding session import", () => {
 				).toBe(true);
 				expect(context.messages.some((message) => message.role === "toolResult")).toBe(true);
 			}
+			if (header.importedFrom?.source === "claude") {
+				const thinking = context.messages
+					.filter((message) => message.role === "assistant")
+					.flatMap((message) => message.content)
+					.filter((content) => content.type === "thinking");
+				expect(thinking).toContainEqual(
+					expect.objectContaining({ thinkingSignature: "claude-thinking-signature" }),
+				);
+				expect(thinking).toContainEqual(
+					expect.objectContaining({
+						thinkingSignature: "claude-redacted-payload",
+						redacted: true,
+					}),
+				);
+			}
+			if (header.importedFrom?.source === "codex") {
+				expect(context.messages.filter((message) => message.role === "toolResult")).toHaveLength(1);
+			}
+			if (header.importedFrom?.source === "opencode") {
+				const totalUsage = context.messages
+					.filter((message) => message.role === "assistant")
+					.reduce((sum, message) => sum + message.usage.totalTokens, 0);
+				expect(totalUsage).toBe(6);
+			}
 		}
 		expect(importedSources).toEqual(new Set(["claude", "codex", "opencode", "pi"]));
 
@@ -567,6 +606,235 @@ describe("ENG-4373 onboarding session import", () => {
 			sessionFile: claude.sessionFile,
 			status: "existing",
 		});
+	});
+
+	it("preserves response-only Codex turns while removing event duplicates and injected context", async () => {
+		const path = join(home, "codex-mixed-users.jsonl");
+		writeJsonl(path, [
+			{
+				type: "session_meta",
+				timestamp: "2026-01-02T00:00:00.000Z",
+				payload: { id: "codex-mixed-users", cwd: "/workspace/codex", model_provider: "openai" },
+			},
+			{
+				type: "response_item",
+				timestamp: "2026-01-02T00:00:01.000Z",
+				payload: {
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: "First Codex turn" }],
+				},
+			},
+			{
+				type: "event_msg",
+				timestamp: "2026-01-02T00:00:01.000Z",
+				payload: { type: "user_message", message: "First Codex turn" },
+			},
+			{
+				type: "response_item",
+				timestamp: "2026-01-02T00:00:02.000Z",
+				payload: {
+					type: "message",
+					role: "assistant",
+					content: [{ type: "output_text", text: "First Codex answer" }],
+				},
+			},
+			{
+				type: "response_item",
+				timestamp: "2026-01-02T00:00:03.000Z",
+				payload: {
+					type: "message",
+					role: "user",
+					content: [
+						{ type: "input_text", text: "<permissions instructions>ignored</permissions instructions>" },
+						{ type: "input_text", text: "Second Codex turn" },
+					],
+				},
+			},
+			{
+				type: "response_item",
+				timestamp: "2026-01-02T00:00:04.000Z",
+				payload: {
+					type: "message",
+					role: "assistant",
+					content: [{ type: "text", text: "Second Codex answer" }],
+				},
+			},
+		]);
+
+		const imported = await importExternalSessionFile(path, "codex", {
+			agentDir,
+			cwd: "/fallback/codex",
+		});
+		const context = SessionManager.open(imported.sessionFile, getSessionsDir(agentDir)).buildSessionContext();
+		const users = context.messages
+			.filter((message) => message.role === "user")
+			.map((message) =>
+				typeof message.content === "string"
+					? message.content
+					: message.content.map((content) => (content.type === "text" ? content.text : "")).join("\n"),
+			);
+		const assistantText = context.messages
+			.filter((message) => message.role === "assistant")
+			.flatMap((message) => message.content)
+			.filter((content) => content.type === "text")
+			.map((content) => content.text);
+
+		expect(users).toEqual(["First Codex turn", "Second Codex turn"]);
+		expect(assistantText).toEqual(["First Codex answer", "Second Codex answer"]);
+	});
+
+	it("uses the requested cwd when imported source metadata has no cwd", async () => {
+		const path = join(home, "claude-no-cwd.jsonl");
+		writeJsonl(path, [
+			{
+				type: "user",
+				sessionId: "claude-no-cwd",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				message: { role: "user", content: "No cwd prompt" },
+			},
+		]);
+
+		const directAgentDir = join(root, "direct-agent");
+		const direct = await importExternalSessionFile(path, "claude", {
+			agentDir: directAgentDir,
+			cwd: "/fallback/direct",
+		});
+		expect((loadEntriesFromFile(direct.sessionFile)[0] as SessionHeader).cwd).toBe("/fallback/direct");
+
+		const bulkAgentDir = join(root, "bulk-agent");
+		const result = await importSessionsAndSkills(
+			[
+				{
+					source: "claude",
+					label: "Claude Code",
+					sessionCount: 1,
+					skillCount: 0,
+					sessionReferences: [{ kind: "file", path }],
+					skillDirectories: [],
+				},
+			],
+			["claude"],
+			{ agentDir: bulkAgentDir, cwd: "/fallback/bulk" },
+		);
+		expect(result.sessionsImported).toBe(1);
+		const bulkFile = readdirSync(getSessionsDir(bulkAgentDir)).find((file) => file.endsWith(".jsonl"));
+		expect(bulkFile).toBeDefined();
+		expect((loadEntriesFromFile(join(getSessionsDir(bulkAgentDir), bulkFile!))[0] as SessionHeader).cwd).toBe(
+			"/fallback/bulk",
+		);
+	});
+
+	it("rejects non-regular import sources and oversized empty skill trees", async () => {
+		await expect(detectSessionImportFileKind(home)).rejects.toThrow("regular file");
+
+		const skill = join(root, "too-many-directories");
+		mkdirSync(skill, { recursive: true });
+		writeFileSync(join(skill, "SKILL.md"), "---\nname: too-many\ndescription: too-many\n---\n");
+		for (let index = 0; index < 2_000; index++) {
+			mkdirSync(join(skill, `empty-${index}`));
+		}
+		expect(() => importSkillDirectory(skill, join(root, "skills"))).toThrow("safe import size limits");
+	});
+
+	it("filters Codex files without trustworthy top-level metadata", () => {
+		const path = join(home, ".codex", "sessions", "2026", "01", "01", "codex-malformed-prefix.jsonl");
+		mkdirSync(join(path, ".."), { recursive: true });
+		writeFileSync(
+			path,
+			`not json\n${JSON.stringify({
+				type: "session_meta",
+				timestamp: "2026-01-02T00:00:00.000Z",
+				payload: {
+					id: "codex-malformed-prefix",
+					cwd: "/workspace/codex",
+					model_provider: "openai",
+				},
+			})}\n`,
+		);
+
+		const codex = discoverSessionImports({ homeDir: home, agentDir, env: {} }).find(
+			(inventory) => inventory.source === "codex",
+		);
+		expect(
+			codex?.sessionReferences.some(
+				(reference) => reference.kind === "file" && reference.path.endsWith("codex-malformed-prefix.jsonl"),
+			),
+		).toBe(false);
+	});
+
+	it("derives OpenCode database recency from messages and parts", () => {
+		const databasePath = join(home, ".local", "share", "opencode", "opencode.db");
+		const database = new DatabaseSync(databasePath);
+		const now = Date.now();
+		const old = now - 60 * 24 * 60 * 60 * 1_000;
+		try {
+			database
+				.prepare("INSERT INTO session VALUES (?, NULL, ?, ?, ?, ?)")
+				.run("opencode-stale-refresh", "/workspace/stale", "Stale", old, now);
+			database
+				.prepare("INSERT INTO message VALUES (?, ?, ?, ?)")
+				.run(
+					"opencode-stale-message",
+					"opencode-stale-refresh",
+					old,
+					JSON.stringify({ role: "user", time: { created: old } }),
+				);
+			database
+				.prepare("INSERT INTO session VALUES (?, NULL, ?, ?, ?, ?)")
+				.run("opencode-recent-part", "/workspace/recent", "Recent", old, old);
+			database
+				.prepare("INSERT INTO message VALUES (?, ?, ?, ?)")
+				.run(
+					"opencode-recent-message",
+					"opencode-recent-part",
+					old,
+					JSON.stringify({ role: "user", time: { created: old } }),
+				);
+			database
+				.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?)")
+				.run(
+					"opencode-recent-text",
+					"opencode-recent-message",
+					"opencode-recent-part",
+					now,
+					JSON.stringify({ type: "text", text: "Recent part" }),
+				);
+		} finally {
+			database.close();
+		}
+
+		const sessions = listOpenCodeSessions(databasePath, now - 30 * 24 * 60 * 60 * 1_000, 50);
+		expect(sessions.map((session) => session.id)).toContain("opencode-recent-part");
+		expect(sessions.map((session) => session.id)).not.toContain("opencode-stale-refresh");
+	});
+
+	it("tries later OpenCode binaries when an earlier CLI returns no sessions", () => {
+		if (process.platform === "win32") {
+			return;
+		}
+		const cliHome = join(root, "cli-home");
+		const emptyCommand = join(cliHome, "empty-opencode");
+		const workingCommand = join(cliHome, ".opencode", "bin", "opencode");
+		mkdirSync(join(workingCommand, ".."), { recursive: true });
+		writeFileSync(emptyCommand, '#!/bin/sh\nprintf "[]\\n"\n');
+		writeFileSync(
+			workingCommand,
+			`#!/bin/sh\nprintf '[{"id":"cli-session","updated":${Date.now()},"created":${Date.now()}}]\\n'\n`,
+		);
+		chmodSync(emptyCommand, 0o755);
+		chmodSync(workingCommand, 0o755);
+
+		const opencode = discoverSessionImports({
+			homeDir: cliHome,
+			agentDir,
+			cwd: root,
+			env: { OPENCODE_BIN: emptyCommand },
+		}).find((inventory) => inventory.source === "opencode");
+
+		expect(opencode?.sessionReferences).toContainEqual(
+			expect.objectContaining({ kind: "opencode-cli", command: workingCommand, sessionId: "cli-session" }),
+		);
 	});
 
 	it("keeps normal model restoration for native Prime Agent sessions", () => {

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -1,0 +1,377 @@
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getSessionsDir } from "../../../src/config.js";
+import { KeybindingsManager } from "../../../src/core/keybindings.js";
+import {
+	discoverSessionImports,
+	importSessionsAndSkills,
+	type SessionImportInventory,
+} from "../../../src/core/session-import/index.js";
+import { buildSessionContext, loadEntriesFromFile, type SessionHeader } from "../../../src/core/session-manager.js";
+import { OnboardingImportSelectorComponent } from "../../../src/modes/interactive/components/onboarding-import-selector.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+
+const ZERO_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function writeJsonl(path: string, entries: unknown[]): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+}
+
+function createSkill(home: string, relativeRoot: string, name: string): void {
+	const directory = join(home, relativeRoot, name);
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(join(directory, "SKILL.md"), `---\nname: ${name}\ndescription: ${name}\n---\n`);
+}
+
+function createClaudeFixture(home: string): void {
+	const path = join(home, ".claude", "projects", "-project", "claude-session.jsonl");
+	writeJsonl(path, [
+		{
+			type: "user",
+			sessionId: "claude-session",
+			cwd: "/workspace/claude",
+			timestamp: "2026-01-01T00:00:00.000Z",
+			message: { role: "user", content: "Claude user prompt" },
+		},
+		{
+			type: "assistant",
+			sessionId: "claude-session",
+			cwd: "/workspace/claude",
+			timestamp: "2026-01-01T00:00:01.000Z",
+			message: {
+				role: "assistant",
+				model: "claude-test",
+				stop_reason: "tool_use",
+				usage: { input_tokens: 2, output_tokens: 3 },
+				content: [
+					{ type: "thinking", thinking: "Claude thinking" },
+					{ type: "text", text: "Claude assistant" },
+					{ type: "tool_use", id: "claude-tool", name: "read", input: { path: "README.md" } },
+				],
+			},
+		},
+		{
+			type: "user",
+			sessionId: "claude-session",
+			cwd: "/workspace/claude",
+			timestamp: "2026-01-01T00:00:02.000Z",
+			message: {
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "claude-tool", content: "Claude tool output" }],
+			},
+		},
+	]);
+	mkdirSync(join(home, ".claude", "projects", "-project"), { recursive: true });
+	writeFileSync(join(home, ".claude", "projects", "-project", "malformed.jsonl"), "not json\n");
+	createSkill(home, join(".claude", "skills"), "claude-skill");
+}
+
+function createCodexFixture(home: string): void {
+	const path = join(home, ".codex", "sessions", "2026", "01", "01", "codex-session.jsonl");
+	writeJsonl(path, [
+		{
+			type: "session_meta",
+			timestamp: "2026-01-02T00:00:00.000Z",
+			payload: {
+				id: "codex-session",
+				cwd: "/workspace/codex",
+				model_provider: "openai-codex",
+			},
+		},
+		{
+			type: "turn_context",
+			timestamp: "2026-01-02T00:00:00.500Z",
+			payload: { model: "gpt-test", cwd: "/workspace/codex" },
+		},
+		{
+			type: "event_msg",
+			timestamp: "2026-01-02T00:00:01.000Z",
+			payload: { type: "user_message", message: "Codex user prompt" },
+		},
+		{
+			type: "response_item",
+			timestamp: "2026-01-02T00:00:02.000Z",
+			payload: { type: "reasoning", summary: [{ type: "summary_text", text: "Codex thinking" }] },
+		},
+		{
+			type: "response_item",
+			timestamp: "2026-01-02T00:00:03.000Z",
+			payload: {
+				type: "message",
+				role: "assistant",
+				phase: "commentary",
+				content: [{ type: "output_text", text: "Codex assistant" }],
+			},
+		},
+		{
+			type: "response_item",
+			timestamp: "2026-01-02T00:00:04.000Z",
+			payload: { type: "function_call", call_id: "codex-tool", name: "exec", arguments: '{"cmd":"pwd"}' },
+		},
+		{
+			type: "response_item",
+			timestamp: "2026-01-02T00:00:05.000Z",
+			payload: { type: "function_call_output", call_id: "codex-tool", output: "Codex tool output" },
+		},
+	]);
+	createSkill(home, join(".codex", "skills"), "codex-skill");
+}
+
+function createOpenCodeFixture(home: string): void {
+	const directory = join(home, ".local", "share", "opencode");
+	mkdirSync(directory, { recursive: true });
+	const database = new DatabaseSync(join(directory, "opencode.db"));
+	try {
+		database.exec(`
+			CREATE TABLE session (
+				id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT, title TEXT,
+				time_created INTEGER, time_updated INTEGER
+			);
+			CREATE TABLE message (
+				id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+			);
+			CREATE TABLE part (
+				id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT
+			);
+		`);
+		database
+			.prepare("INSERT INTO session VALUES (?, NULL, ?, ?, ?, ?)")
+			.run("opencode-session", "/workspace/opencode", "OpenCode title", 1_767_312_000_000, 1_767_312_010_000);
+		database.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
+			"opencode-user",
+			"opencode-session",
+			1_767_312_001_000,
+			JSON.stringify({
+				role: "user",
+				time: { created: 1_767_312_001_000 },
+				model: { providerID: "openai", modelID: "gpt-test" },
+			}),
+		);
+		database
+			.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?)")
+			.run(
+				"opencode-user-text",
+				"opencode-user",
+				"opencode-session",
+				1_767_312_001_000,
+				JSON.stringify({ type: "text", text: "OpenCode user prompt" }),
+			);
+		database.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
+			"opencode-assistant",
+			"opencode-session",
+			1_767_312_002_000,
+			JSON.stringify({
+				role: "assistant",
+				time: { created: 1_767_312_002_000 },
+				providerID: "openai",
+				modelID: "gpt-test",
+				finish: "tool-calls",
+				tokens: { input: 2, output: 3, cache: { read: 1, write: 0 } },
+			}),
+		);
+		const insertPart = database.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?)");
+		insertPart.run(
+			"opencode-reasoning",
+			"opencode-assistant",
+			"opencode-session",
+			1_767_312_002_000,
+			JSON.stringify({ type: "reasoning", text: "OpenCode thinking", time: { start: 1_767_312_002_000 } }),
+		);
+		insertPart.run(
+			"opencode-text",
+			"opencode-assistant",
+			"opencode-session",
+			1_767_312_003_000,
+			JSON.stringify({ type: "text", text: "OpenCode assistant" }),
+		);
+		insertPart.run(
+			"opencode-tool",
+			"opencode-assistant",
+			"opencode-session",
+			1_767_312_004_000,
+			JSON.stringify({
+				type: "tool",
+				callID: "opencode-tool",
+				tool: "bash",
+				state: {
+					status: "completed",
+					input: { command: "pwd" },
+					output: "OpenCode tool output",
+					time: { start: 1_767_312_004_000, end: 1_767_312_005_000 },
+				},
+			}),
+		);
+	} finally {
+		database.close();
+	}
+	createSkill(home, join(".config", "opencode", "skills"), "opencode-skill");
+}
+
+function createPiFixture(home: string): void {
+	const user: Message = {
+		role: "user",
+		content: "Pi user prompt",
+		timestamp: 1_767_398_401_000,
+	};
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: "Pi thinking" },
+			{ type: "text", text: "Pi assistant" },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-test",
+		usage: ZERO_USAGE,
+		stopReason: "stop",
+		timestamp: 1_767_398_402_000,
+	};
+	writeJsonl(join(home, ".pi", "agent", "sessions", "project", "pi-session.jsonl"), [
+		{
+			type: "session",
+			version: 3,
+			id: "pi-session",
+			timestamp: "2026-01-03T00:00:00.000Z",
+			cwd: "/workspace/pi",
+		},
+		{ type: "message", id: "pi-user", parentId: null, timestamp: "2026-01-03T00:00:01.000Z", message: user },
+		{
+			type: "message",
+			id: "pi-assistant",
+			parentId: "pi-user",
+			timestamp: "2026-01-03T00:00:02.000Z",
+			message: assistant,
+		},
+	]);
+	createSkill(home, join(".pi", "agent", "skills"), "pi-skill");
+}
+
+describe("ENG-4373 onboarding session import", () => {
+	let root: string;
+	let home: string;
+	let agentDir: string;
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+		root = join(tmpdir(), `prime-agent-4373-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		home = join(root, "home");
+		agentDir = join(root, "prime-agent");
+		mkdirSync(home, { recursive: true });
+		createClaudeFixture(home);
+		createCodexFixture(home);
+		createOpenCodeFixture(home);
+		createPiFixture(home);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("imports all supported harnesses with thoughts, tool calls, results, and skills", async () => {
+		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} });
+		expect(inventories.map((inventory) => inventory.source)).toEqual(["claude", "codex", "opencode", "pi"]);
+
+		const result = await importSessionsAndSkills(
+			inventories,
+			inventories.map((inventory) => inventory.source),
+			{ homeDir: home, agentDir, env: {} },
+		);
+		expect(result.sessionsImported).toBe(4);
+		expect(result.sessionsSkipped).toBe(1);
+		expect(result.sessionFailures).toBe(0);
+		expect(result.skillsImported).toBe(4);
+
+		const sessionFiles = readdirSync(getSessionsDir(agentDir))
+			.filter((file) => file.endsWith(".jsonl"))
+			.map((file) => join(getSessionsDir(agentDir), file));
+		expect(sessionFiles).toHaveLength(4);
+
+		const importedSources = new Set<string>();
+		for (const sessionFile of sessionFiles) {
+			const entries = loadEntriesFromFile(sessionFile);
+			const header = entries[0] as SessionHeader;
+			importedSources.add(header.importedFrom?.source ?? "");
+			const context = buildSessionContext(entries.slice(1).filter((entry) => entry.type !== "session"));
+			expect(context.messages.some((message) => message.role === "user")).toBe(true);
+			expect(
+				context.messages.some(
+					(message) =>
+						message.role === "assistant" && message.content.some((content) => content.type === "thinking"),
+				),
+			).toBe(true);
+			if (header.importedFrom?.source !== "pi") {
+				expect(
+					context.messages.some(
+						(message) =>
+							message.role === "assistant" && message.content.some((content) => content.type === "toolCall"),
+					),
+				).toBe(true);
+				expect(context.messages.some((message) => message.role === "toolResult")).toBe(true);
+			}
+		}
+		expect(importedSources).toEqual(new Set(["claude", "codex", "opencode", "pi"]));
+
+		for (const skill of ["claude-skill", "codex-skill", "opencode-skill", "pi-skill"]) {
+			expect(readdirSync(join(agentDir, "skills", skill))).toContain("SKILL.md");
+		}
+
+		const retry = await importSessionsAndSkills(
+			inventories,
+			inventories.map((inventory) => inventory.source),
+			{ homeDir: home, agentDir, env: {} },
+		);
+		expect(retry.sessionsImported).toBe(0);
+		expect(retry.sessionsSkipped).toBe(5);
+		expect(retry.skillsImported).toBe(0);
+		expect(retry.skillsSkipped).toBe(4);
+	});
+
+	it("continues importing other sources when one source disappears", async () => {
+		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} });
+		const codex = inventories.find((inventory) => inventory.source === "codex") as SessionImportInventory;
+		const codexPath = codex.sessionReferences[0];
+		expect(codexPath?.kind).toBe("file");
+		if (codexPath?.kind === "file") {
+			rmSync(codexPath.path);
+		}
+
+		const result = await importSessionsAndSkills(
+			inventories,
+			inventories.map((inventory) => inventory.source),
+			{ homeDir: home, agentDir, env: {} },
+		);
+		expect(result.sessionsImported).toBe(3);
+		expect(result.sessionFailures).toBe(1);
+		expect(result.skillsImported).toBe(4);
+	});
+
+	it("selects harnesses rather than individual data types", () => {
+		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} }).slice(0, 2);
+		const onSelect = vi.fn();
+		const selector = new OnboardingImportSelectorComponent(inventories, onSelect, vi.fn());
+
+		selector.handleInput("\r");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\r");
+
+		expect(onSelect).toHaveBeenCalledWith(["codex"]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4373-session-import-onboarding.test.ts
@@ -541,11 +541,24 @@ describe("ENG-4373 onboarding session import", () => {
 		const onSelect = vi.fn();
 		const selector = new SessionImportSelectorComponent(inventories, onSelect, vi.fn());
 
+		selector.handleInput("\x1b[A");
+		selector.handleInput("\x1b[A");
 		selector.handleInput("\r");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\r");
 
 		expect(onSelect).toHaveBeenCalledWith(["codex"]);
+	});
+
+	it("presents the import action as the default CTA", () => {
+		const inventories = discoverSessionImports({ homeDir: home, agentDir, env: {} }).slice(0, 2);
+		const onSelect = vi.fn();
+		const selector = new SessionImportSelectorComponent(inventories, onSelect, vi.fn());
+
+		expect(selector.render(100).join("\n")).toContain("Import selected sessions and skills");
+		selector.handleInput("\r");
+
+		expect(onSelect).toHaveBeenCalledWith(["claude", "codex"]);
 	});
 });

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -638,6 +638,29 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("custom_tool");
 		expect(rendered).toContain("done");
 	});
+	test("collapses completed unknown tool details until expanded", () => {
+		const component = new ToolExecutionComponent(
+			"imported_tool",
+			"tool-imported",
+			{ command: "large historical command" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.markExecutionStarted();
+		component.updateResult({ content: [{ type: "text", text: "large historical output" }], isError: false }, false);
+
+		const collapsed = stripAnsi(component.render(120).join("\n"));
+		expect(collapsed).toContain("imported_tool · done");
+		expect(collapsed).not.toContain("large historical command");
+		expect(collapsed).not.toContain("large historical output");
+
+		component.setExpanded(true);
+		const expanded = stripAnsi(component.render(120).join("\n"));
+		expect(expanded).toContain("large historical command");
+		expect(expanded).toContain("large historical output");
+	});
 	test("does not add built-in edit stats to custom IPython renderers", () => {
 		const component = new ToolExecutionComponent(
 			"ipython",

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -643,7 +643,7 @@ describe("ToolExecutionComponent parity", () => {
 			"imported_tool",
 			"tool-imported",
 			{ command: "large historical command" },
-			{},
+			{ compactCompleted: true },
 			undefined,
 			createFakeTui(),
 			process.cwd(),


### PR DESCRIPTION
- onboarding and bare `/import` discover skills and up to 50 recent sessions per harness from claude code, codex, opencode, and pi mono.
- `/import <path>` handles native prime agent/pi mono, claude code, codex, and opencode session files, then resumes them safely.
- semantic hashes keep reruns idempotent, while tool-name normalization keeps imported history replayable across providers.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add session import from Claude, Codex, and OpenCode harnesses during onboarding
> - Adds a session/skill import flow that runs at first launch and is accessible via `/import` without arguments, presenting an interactive `SessionImportSelectorComponent` to pick sources (Claude, Codex, OpenCode, Pi).
> - Extends `/import <path>` to auto-detect file format (`claude`, `codex`, `opencode`, `native`) via [`detectSessionImportFileKind`](https://github.com/PrimeIntellect-ai/prime-agent/pull/524/files#diff-7087574126b67985f6d71fbdaa1209087812d98b9f4d3a07e9a96a3551408480) and route to the appropriate adapter or existing native import.
> - Adds adapters in [`packages/coding-agent/src/core/session-import/adapters/`](https://github.com/PrimeIntellect-ai/prime-agent/pull/524/files#diff-8e9e7891266ecd47d959674f56bf04afc37fb68031605e47a6fb591552fc249c) to parse Claude JSONL, Codex JSONL, OpenCode SQLite DB and CLI export, and native Pi session files into a normalized `ImportedSession` with messages, tool calls, usage, and thinking blocks.
> - Persists imported sessions with content-hash deduplication, deterministic v5 UUID filenames, and atomic write semantics; imports skill directories with budget limits and idempotency.
> - Normalizes tool names (replacing non-`[a-zA-Z0-9_-]` characters) in `transformMessages` to fix invalid historical tool names when resuming imported sessions.
> - Collapses completed tool execution bodies in `ToolExecutionComponent` when viewing an imported session until the user expands them.
> - Behavioral Change: `shouldRunOnboarding` now returns `true` on first launch regardless of model readiness or splash conditions, so the import flow always runs before the model selector.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8490ac4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new import surface touches session files, SQLite, and onboarding gating; first-launch onboarding now runs for all users regardless of prior model readiness.
> 
> **Overview**
> Adds **session and skill import** from Claude Code, Codex, OpenCode, and Pi Mono: discovery (recent sessions + skill dirs), per-format parsers, deduplication via content hashes and `importedFrom` headers, and persistence into the agent session store.
> 
> **Onboarding** now always runs once on first launch (including when a model is already configured), runs the import selector **before** marking onboarding complete, and only opens the Prime splash / model setup when the model is not ready or Prime CLI splash applies.
> 
> **`/import`** without a path opens the same harness picker; with a path it auto-detects native Pi/Prime, Claude, Codex, or OpenCode files and imports/resumes. Imported sessions clear the stored model in session context so continuation uses the user’s configured model.
> 
> In **pi-ai**, `normalizeToolName` is applied in `transformMessages` (and on import) so dotted or invalid historical tool names do not break cross-provider replay.
> 
> **UI**: completed tools in imported sessions render **compact** until expanded. Orphan tool calls without results are collapsed to text in sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8490ac4a79be05def3a0a1fbd7896968d882fcb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->