### PR TITLE
declutter feature hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed feature hints crowding queued messages and side questions by placing them below the recap and hiding them while messages are queued ([ENG-4741](https://linear.app/primeintellect/issue/ENG-4741/recap-queuefollow-upmessage-hint-looks-cluttered)).
 - Fixed `/btw` truncating long answers by rendering side questions in the scrollable transcript.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -842,6 +842,7 @@ export class InteractiveMode {
 	private featureHintAnimationTimer: NodeJS.Timeout | undefined;
 	private featureHintComponent: FeatureHintComponent | undefined;
 	private featureHintRunPending = false;
+	private featureHintSuppressedByQueue = false;
 	private pulseTimer: NodeJS.Timeout | undefined = undefined;
 	private pulseFrame = 0;
 	private readonly activityTracker = new AgentActivityTracker();
@@ -2685,6 +2686,7 @@ export class InteractiveMode {
 		this.queuedMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
 		this.connectionQueue = { steering: [], followUp: [] };
+		this.featureHintSuppressedByQueue = false;
 		if (options?.clearPromptStash) {
 			this.promptStash = undefined;
 		}
@@ -6844,7 +6846,8 @@ export class InteractiveMode {
 		// their own container below the execution indicator and recap.
 		this.queuedMessagesContainer.clear();
 		const { steering: steeringMessages, followUp: followUpMessages } = this.getAllQueuedMessages();
-		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
+		const hasQueuedMessages = steeringMessages.length > 0 || followUpMessages.length > 0;
+		if (hasQueuedMessages) {
 			this.queuedMessagesContainer.addChild(new Spacer(1));
 			for (const message of steeringMessages) {
 				const text = theme.fg("dim", formatQueuedMessagePreview(message, "Steering"));
@@ -6858,9 +6861,11 @@ export class InteractiveMode {
 			const hintText = theme.fg("dim", `╰─ ${dequeueHint} to edit all queued messages`);
 			this.queuedMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
-		if (this.shouldSuppressFeatureHint()) {
+		if (hasQueuedMessages && !this.featureHintSuppressedByQueue) {
+			this.featureHintSuppressedByQueue = true;
 			this.clearFeatureHintPresentation();
-		} else {
+		} else if (!hasQueuedMessages && this.featureHintSuppressedByQueue) {
+			this.featureHintSuppressedByQueue = false;
 			this.resumeFeatureHintPresentation();
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1344,19 +1344,17 @@ export class InteractiveMode {
 		this.renderWidgets(); // Initialize with default spacer
 		this.mainContainer.addChild(this.widgetContainerAbove);
 		this.renderRecap();
-		this.mainContainer.addChild(this.recapContainer);
-		this.mainContainer.addChild(this.queuedMessagesContainer);
-		this.mainContainer.addChild(this.sideQuestionContainer);
-		this.mainContainer.addChild(this.featureHintContainer);
+		for (const container of this.getPromptContextContainers()) {
+			this.mainContainer.addChild(container);
+		}
 		this.mainContainer.addChild(this.editorContainer);
 		this.mainContainer.addChild(this.childAgentSummary);
 		this.mainContainer.addChild(this.widgetContainerBelow);
 		this.footerSlot.addChild(this.footer);
 		this.mainContainer.addChild(this.footerSlot);
-		this.promptDock.addChild(this.featureHintContainer);
-		this.promptDock.addChild(this.editorContainer);
-		this.promptDock.addChild(this.childAgentSummary);
-		this.promptDock.addChild(this.footerSlot);
+		for (const component of this.getPromptDockComponents()) {
+			this.promptDock.addChild(component);
+		}
 		this.ui.addChild(this.mainContainer);
 		this.ui.setFocus(this.editor);
 
@@ -3042,7 +3040,7 @@ export class InteractiveMode {
 
 	private startFeatureHintPresentation(): void {
 		this.clearFeatureHintPresentation();
-		if (this.childAgentPanelMode) {
+		if (this.shouldSuppressFeatureHint()) {
 			return;
 		}
 		if (this.featureHintEligibleAt === 0) {
@@ -3062,6 +3060,7 @@ export class InteractiveMode {
 
 	private showFeatureHint(): void {
 		if (
+			this.shouldSuppressFeatureHint() ||
 			!this.loadingAnimation ||
 			!this.shouldShowWorkingLoader() ||
 			!this.statusContainer.children.includes(this.loadingAnimation)
@@ -3108,12 +3107,21 @@ export class InteractiveMode {
 
 	private resumeFeatureHintPresentation(): void {
 		if (
+			!this.shouldSuppressFeatureHint() &&
 			this.loadingAnimation &&
 			this.shouldShowWorkingLoader() &&
 			this.statusContainer.children.includes(this.loadingAnimation)
 		) {
 			this.startFeatureHintPresentation();
 		}
+	}
+
+	private shouldSuppressFeatureHint(): boolean {
+		if (this.childAgentPanelMode) {
+			return true;
+		}
+		const { steering, followUp } = this.getAllQueuedMessages();
+		return steering.length > 0 || followUp.length > 0;
 	}
 
 	private endFeatureHintRun(): void {
@@ -6595,6 +6603,14 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private getPromptContextContainers(): Container[] {
+		return [this.recapContainer, this.featureHintContainer, this.queuedMessagesContainer, this.sideQuestionContainer];
+	}
+
+	private getPromptDockComponents(): Component[] {
+		return [this.editorContainer, this.childAgentSummary, this.footerSlot];
+	}
+
 	/** Enter or leave fullscreen rendering without touching the persisted setting. */
 	private applyFullscreen(enabled: boolean): void {
 		if (enabled) {
@@ -6604,9 +6620,7 @@ export class InteractiveMode {
 					this.headerContainer,
 					this.mainViewContainer,
 					this.widgetContainerAbove,
-					this.recapContainer,
-					this.queuedMessagesContainer,
-					this.sideQuestionContainer,
+					...this.getPromptContextContainers(),
 					this.widgetContainerBelow,
 				],
 				dock: this.promptDock,
@@ -6843,6 +6857,11 @@ export class InteractiveMode {
 			const dequeueHint = this.getAppKeyDisplay("app.message.dequeue");
 			const hintText = theme.fg("dim", `╰─ ${dequeueHint} to edit all queued messages`);
 			this.queuedMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
+		}
+		if (this.shouldSuppressFeatureHint()) {
+			this.clearFeatureHintPresentation();
+		} else {
+			this.resumeFeatureHintPresentation();
 		}
 	}
 

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -44,6 +44,8 @@ function createMode() {
 		featureHintComponent: undefined,
 		featureHintRunPending: false,
 		childAgentPanelMode: undefined,
+		connectionQueue: { steering: [], followUp: [] },
+		compactionQueuedMessages: [],
 		options: { returnToAgentsView: true },
 		ui: { requestRender },
 	};

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -764,6 +764,7 @@ describe("InteractiveMode pending bash components", () => {
 			queuedMessagesContainer: new Container(),
 			pendingBashComponents: [component],
 			getAllQueuedMessages: () => ({ steering: [], followUp: [] }),
+			featureHintSuppressedByQueue: false,
 		} as unknown as InteractiveMode;
 
 		(
@@ -784,6 +785,8 @@ describe("InteractiveMode pending bash components", () => {
 				followUp: ["Heartbeat prompt: check status", "Goal context: continue goal", "plain follow-up"],
 			}),
 			getAppKeyDisplay: () => "Ctrl+Q",
+			featureHintSuppressedByQueue: false,
+			clearFeatureHintPresentation: vi.fn(),
 		} as unknown as InteractiveMode;
 
 		(

--- a/packages/coding-agent/test/suite/regressions/4741-hint-placement.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4741-hint-placement.test.ts
@@ -38,6 +38,7 @@ function createFeatureHintMode() {
 		featureHintAnimationTimer: undefined,
 		featureHintComponent: undefined,
 		featureHintRunPending: false,
+		featureHintSuppressedByQueue: false,
 		childAgentPanelMode: undefined,
 		options: { returnToAgentsView: true },
 		getAppKeyDisplay: () => "Ctrl+Q",
@@ -155,5 +156,9 @@ describe("ENG-4741 hint placement", () => {
 		mode.connectionQueue.followUp = [];
 		callPrivate(mode, "updatePendingMessagesDisplay");
 		expect(featureHintContainer.children).toHaveLength(1);
+
+		const restoredHint = featureHintContainer.children[0];
+		callPrivate(mode, "updatePendingMessagesDisplay");
+		expect(featureHintContainer.children).toEqual([restoredHint]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4741-hint-placement.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4741-hint-placement.test.ts
@@ -1,0 +1,159 @@
+import { type Component, Container } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+
+class FakeLoader implements Component {
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return ["loader".padEnd(width)];
+	}
+}
+
+function callPrivate(mode: object, name: string, ...args: unknown[]): unknown {
+	return Reflect.get(InteractiveMode.prototype, name).call(mode, ...args);
+}
+
+function createFeatureHintMode() {
+	const loader = new FakeLoader();
+	const statusContainer = new Container();
+	statusContainer.addChild(loader);
+	const featureHintContainer = new Container();
+	const mode = Object.assign(Object.create(InteractiveMode.prototype), {
+		statusContainer,
+		featureHintContainer,
+		pendingMessagesContainer: new Container(),
+		pendingBashComponents: [],
+		queuedMessagesContainer: new Container(),
+		connectionQueue: { steering: [] as string[], followUp: [] as string[] },
+		compactionQueuedMessages: [],
+		loadingAnimation: loader,
+		workingVisible: true,
+		connectionState: { isStreaming: true },
+		featureHintDeck: { next: vi.fn(() => ({ id: "test", text: "A useful feature hint." })) },
+		currentFeatureHint: undefined,
+		featureHintEligibleAt: 0,
+		featureHintTimer: undefined,
+		featureHintAnimationTimer: undefined,
+		featureHintComponent: undefined,
+		featureHintRunPending: false,
+		childAgentPanelMode: undefined,
+		options: { returnToAgentsView: true },
+		getAppKeyDisplay: () => "Ctrl+Q",
+		ui: { requestRender: vi.fn() },
+	});
+	return { mode, featureHintContainer };
+}
+
+describe("ENG-4741 hint placement", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("orders hints below the recap and above queued messages and side questions", () => {
+		const recapContainer = new Container();
+		const featureHintContainer = new Container();
+		const queuedMessagesContainer = new Container();
+		const sideQuestionContainer = new Container();
+		const editorContainer = new Container();
+		const childAgentSummary = new Container();
+		const footerSlot = new Container();
+		const mode = Object.assign(Object.create(InteractiveMode.prototype), {
+			recapContainer,
+			featureHintContainer,
+			queuedMessagesContainer,
+			sideQuestionContainer,
+			editorContainer,
+			childAgentSummary,
+			footerSlot,
+		});
+
+		expect(callPrivate(mode, "getPromptContextContainers")).toEqual([
+			recapContainer,
+			featureHintContainer,
+			queuedMessagesContainer,
+			sideQuestionContainer,
+		]);
+		expect(callPrivate(mode, "getPromptDockComponents")).toEqual([editorContainer, childAgentSummary, footerSlot]);
+	});
+
+	it("keeps hints in the fullscreen transcript instead of the prompt dock", () => {
+		const previousIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+		try {
+			const headerContainer = new Container();
+			const mainViewContainer = new Container();
+			const widgetContainerAbove = new Container();
+			const recapContainer = new Container();
+			const featureHintContainer = new Container();
+			const queuedMessagesContainer = new Container();
+			const sideQuestionContainer = new Container();
+			const widgetContainerBelow = new Container();
+			const promptDock = new Container();
+			const enterFullscreen = vi.fn();
+			const mode = Object.assign(Object.create(InteractiveMode.prototype), {
+				headerContainer,
+				mainViewContainer,
+				widgetContainerAbove,
+				recapContainer,
+				featureHintContainer,
+				queuedMessagesContainer,
+				sideQuestionContainer,
+				widgetContainerBelow,
+				promptDock,
+				ui: { enterFullscreen },
+				uiServices: { settingsManager: { getFullscreenMouse: () => true } },
+			});
+
+			callPrivate(mode, "applyFullscreen", true);
+
+			expect(enterFullscreen).toHaveBeenCalledWith({
+				scroll: [
+					headerContainer,
+					mainViewContainer,
+					widgetContainerAbove,
+					recapContainer,
+					featureHintContainer,
+					queuedMessagesContainer,
+					sideQuestionContainer,
+					widgetContainerBelow,
+				],
+				dock: promptDock,
+				mouse: true,
+			});
+			expect(promptDock.children).not.toContain(featureHintContainer);
+		} finally {
+			if (previousIsTTY) {
+				Object.defineProperty(process.stdout, "isTTY", previousIsTTY);
+			} else {
+				Reflect.deleteProperty(process.stdout, "isTTY");
+			}
+		}
+	});
+
+	it("hides a visible hint while messages are queued and restores it when the queue clears", () => {
+		const { mode, featureHintContainer } = createFeatureHintMode();
+
+		callPrivate(mode, "startFeatureHintPresentation");
+		vi.advanceTimersByTime(5_000);
+		expect(featureHintContainer.children).toHaveLength(1);
+
+		mode.connectionQueue.followUp = ["Continue after this turn"];
+		callPrivate(mode, "updatePendingMessagesDisplay");
+		expect(featureHintContainer.children).toHaveLength(0);
+
+		mode.connectionQueue.followUp = [];
+		callPrivate(mode, "updatePendingMessagesDisplay");
+		expect(featureHintContainer.children).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
- feature hints now appear below the recap instead of between side questions and the prompt.
- hints hide while steers or follow-ups are queued, then resume when the queue clears.
- added regression coverage for inline and fullscreen ordering plus queued-message suppression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI layout and feature-hint visibility only; no auth, persistence, or agent-runtime behavior changes.
> 
> **Overview**
> **Declutters the interactive prompt area** by moving feature hints out of the pinned prompt dock and into the scrollable transcript, and by hiding them while steering or follow-up messages are queued.
> 
> Feature hints now sit **below the recap** and **above** queued previews and side questions, via shared `getPromptContextContainers()` / `getPromptDockComponents()` helpers so normal and fullscreen layouts stay consistent (hints scroll with transcript content; the dock is editor, child-agent summary, and footer only).
> 
> **Queue-aware suppression:** `shouldSuppressFeatureHint()` treats any queued steer/follow-up (and existing child-agent panel mode) as a signal to skip showing hints; `updatePendingMessagesDisplay` clears a visible hint when the queue becomes non-empty and calls `resumeFeatureHintPresentation()` when it clears. Session reset clears the suppression flag.
> 
> Regression coverage in `4741-hint-placement.test.ts` plus small test fixture updates for the new queue/hint behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47cbb9c63c4ad9102876d53e7e846fc14f7d667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move feature hints below recap and hide them while messages are queued
> - Feature hints are relocated from the prompt dock into the scrollable transcript, appearing below the recap and above queued messages and side questions.
> - When steering or follow-up messages enter the queue, any visible feature hint is hidden; it is restored when the queue clears.
> - A new `shouldSuppressFeatureHint` helper centralizes suppression logic (child-agent panel mode or non-empty queue) used by start, show, and resume paths.
> - A regression test suite in [4741-hint-placement.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/526/files#diff-c786bc437d12064bae5617075c7fe4b7f46bb99b7a607b23e0884ea54023a22b) codifies container ordering, fullscreen scroll behavior, and queue-driven suppression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e47cbb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->