### PR TITLE
feat(tui): resume saved sessions from the reply composer

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5113,12 +5113,17 @@ export class AgentSession {
 
 	private _surfaceSessionInputError(error: unknown): void {
 		const normalized = this._asError(error);
-		this._extensionRunner.emitError({
-			extensionPath: "<session-input>",
-			event: "session_input",
-			error: normalized.message,
-			stack: normalized.stack,
-		});
+		try {
+			this._extensionRunner.emitError({
+				extensionPath: "<session-input>",
+				event: "session_input",
+				error: normalized.message,
+				stack: normalized.stack,
+			});
+		} catch {
+			// Surfacing is best-effort; a throwing error listener must never break
+			// the pump's requeue/settle path.
+		}
 	}
 
 	private async _startPreparedPromptItems(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5136,8 +5136,7 @@ export class AgentSession {
 				stack: normalized.stack,
 			});
 		} catch {
-			// Surfacing is best-effort; a throwing error listener must never break
-			// the pump's requeue/settle path.
+			// Best-effort: a throwing error listener must not break the pump's requeue path.
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1909,10 +1909,6 @@ export class AgentSession {
 		return true;
 	}
 
-	/**
-	 * Derived, never cached: the agent loop's synchronous stop hooks must see
-	 * queued steering (or an in-flight steer handoff) the instant it exists.
-	 */
 	private get _steeringStopPending(): boolean {
 		const activeSteeringHandoff =
 			this._activeSessionInput?.kind === "prompt" &&
@@ -5108,9 +5104,7 @@ export class AgentSession {
 		if (error instanceof DeferredSessionInputError) return true;
 		if (epoch !== this._sessionInputPumpEpoch) return true;
 		if (this._isBusyForSessionInput("pump")) {
-			// The input is still requeued, but the failure was not a deliberate
-			// deferral: surface it so a genuine handoff error is never silently
-			// swallowed by a coincidentally-busy session.
+			// Requeue, but surface the error: this was not a deliberate deferral.
 			this._surfaceSessionInputError(error);
 			return true;
 		}
@@ -5701,12 +5695,7 @@ export class AgentSession {
 		}
 	}
 
-	/**
-	 * Resume the session-input scheduler after an abort or update-restart
-	 * suspended it (requestAbort/abortForUpdateRestart). Returns whether any
-	 * queued work remains to run. Owned pause leases are unaffected: they are
-	 * released only by their holders via acquireQueuedWorkPause().release().
-	 */
+	/** Resume the scheduler after requestAbort/abortForUpdateRestart suspended it; owned pause leases are unaffected. */
 	resumeQueuedWork(): boolean {
 		this._sessionInputPumpSuspended = false;
 		this._scheduleSessionInputPump();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -183,6 +183,7 @@ import {
 	isSessionSlashCommandMessage,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
+import { throwIfPromptAdmissionCancelled, waitForPromptAdmission } from "./prompt-admission.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import {
 	type AutoRefineReason,
@@ -567,38 +568,6 @@ function oncePreflight(
 			preflightResult?.(success, queued);
 		}
 	};
-}
-
-function throwIfPromptAdmissionCancelled(signal: AbortSignal | undefined): void {
-	if (signal?.aborted) throw new Error("Prompt admission was cancelled.");
-}
-
-export function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-	if (!signal) return promise;
-	if (signal.aborted) {
-		void promise.catch(() => {});
-		throwIfPromptAdmissionCancelled(signal);
-	}
-	return new Promise<T>((resolve, reject) => {
-		const onAbort = () => {
-			cleanup();
-			reject(new Error("Prompt admission was cancelled."));
-		};
-		const cleanup = () => signal.removeEventListener("abort", onAbort);
-		signal.addEventListener("abort", onAbort, { once: true });
-		// Close the listener-registration race before observing the awaited work.
-		if (signal.aborted) return onAbort();
-		promise.then(
-			(value) => {
-				cleanup();
-				resolve(value);
-			},
-			(error: unknown) => {
-				cleanup();
-				reject(error);
-			},
-		);
-	});
 }
 
 interface PreparedCommandInput {
@@ -1019,7 +988,6 @@ export class AgentSession {
 	private _turnAdmissionTail: Promise<void> = Promise.resolve();
 	private _turnAdmissionOwner: symbol | undefined;
 	private readonly _turnAdmissionContext = new AsyncLocalStorage<symbol>();
-	private _legacyQueuedWorkPause: { release(): void } | undefined;
 	private _pumpingSessionInput = false;
 	private _activeSessionInput:
 		| {
@@ -1036,7 +1004,6 @@ export class AgentSession {
 	private _directPromptSectionCount = 0;
 	/** One-shot waiters resolved when a dispatched message reaches message_start. */
 	private _directDispatchObservers = new Set<{ message: AgentMessage; resolve: () => void }>();
-	private _steeringStopPending = false;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 
@@ -1547,7 +1514,6 @@ export class AgentSession {
 		this._removeActivePreparingPrompts(isGoalContext);
 		this._steeringMessages = this._steeringMessages.filter((input) => !isGoalContext(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isGoalContext(input));
-		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 	}
 
@@ -1943,14 +1909,18 @@ export class AgentSession {
 		return true;
 	}
 
-	private _syncSteeringStopPending(): void {
+	/**
+	 * Derived, never cached: the agent loop's synchronous stop hooks must see
+	 * queued steering (or an in-flight steer handoff) the instant it exists.
+	 */
+	private get _steeringStopPending(): boolean {
 		const activeSteeringHandoff =
 			this._activeSessionInput?.kind === "prompt" &&
 			this._activeSessionInput.lane === "steer" &&
 			this._activeSessionInput.phase === "preparing" &&
 			!this._activeSessionInput.cancelled &&
 			this._activeSessionInput.items.length > 0;
-		this._steeringStopPending = this._steeringMessages.length > 0 || activeSteeringHandoff;
+		return this._steeringMessages.length > 0 || activeSteeringHandoff;
 	}
 
 	private _shouldStopBeforeTurn(): boolean {
@@ -2558,7 +2528,6 @@ export class AgentSession {
 			input.kind === "prompt" && queuedMessageSet.has(input.message);
 		this._steeringMessages = this._steeringMessages.filter((input) => !isQueuedContinuation(input));
 		this._followUpMessages = this._followUpMessages.filter((input) => !isQueuedContinuation(input));
-		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 		if (options.restoreAutonomousState) {
 			for (const queuedMessage of queuedMessages) {
@@ -3716,7 +3685,6 @@ export class AgentSession {
 			}
 			this._steeringMessages = [];
 			this._followUpMessages = [];
-			this._syncSteeringStopPending();
 			this.agent.clearAllQueues();
 			this._extensionRunner.invalidate(
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
@@ -4952,7 +4920,6 @@ export class AgentSession {
 		}
 		queue.push(input);
 		this._sessionInputArrivalEpoch++;
-		this._syncSteeringStopPending();
 		this._emitQueueUpdate();
 		if (
 			!options.restore &&
@@ -5026,7 +4993,6 @@ export class AgentSession {
 					if (first.kind === "command") {
 						queue.shift();
 						this._activeSessionInput = { kind: "command", lane, item: first, phase: "executing" };
-						this._syncSteeringStopPending();
 						this._notifySessionInputCheckpointChange();
 						this._emitQueueUpdate();
 						try {
@@ -5036,7 +5002,6 @@ export class AgentSession {
 							this._rejectAgentMessage(first.agentMessageId, this._asError(error));
 						} finally {
 							this._activeSessionInput = undefined;
-							this._syncSteeringStopPending();
 							this._notifySessionInputCheckpointChange();
 						}
 						continue;
@@ -5048,7 +5013,6 @@ export class AgentSession {
 					}
 					if (epoch !== this._sessionInputPumpEpoch) {
 						queue.unshift(...prompts);
-						this._syncSteeringStopPending();
 						return;
 					}
 					this._activeSessionInput = {
@@ -5057,7 +5021,6 @@ export class AgentSession {
 						items: prompts,
 						phase: "preparing",
 					};
-					this._syncSteeringStopPending();
 					this._notifySessionInputCheckpointChange();
 					this._emitQueueUpdate();
 					try {
@@ -5075,7 +5038,6 @@ export class AgentSession {
 						if (this._isDeferredSessionInputError(error, epoch)) {
 							if (!this._activeSessionInput?.cancelled && undelivered.length > 0) {
 								queue.unshift(...undelivered);
-								this._syncSteeringStopPending();
 								this._emitQueueUpdate();
 							}
 							blocked = true;
@@ -5091,7 +5053,6 @@ export class AgentSession {
 						this._surfaceSessionInputError(error);
 					} finally {
 						this._activeSessionInput = undefined;
-						this._syncSteeringStopPending();
 						this._notifySessionInputCheckpointChange();
 					}
 				} finally {
@@ -5100,7 +5061,6 @@ export class AgentSession {
 			}
 		} finally {
 			this._pumpingSessionInput = false;
-			this._syncSteeringStopPending();
 			if (!blocked && epoch === this._sessionInputPumpEpoch && this.pendingMessageCount > 0) {
 				this._scheduleSessionInputPump();
 			}
@@ -5145,7 +5105,16 @@ export class AgentSession {
 	}
 
 	private _isDeferredSessionInputError(error: unknown, epoch: number): boolean {
-		return error instanceof DeferredSessionInputError || this._isSessionInputHandoffDeferred(epoch);
+		if (error instanceof DeferredSessionInputError) return true;
+		if (epoch !== this._sessionInputPumpEpoch) return true;
+		if (this._isBusyForSessionInput("pump")) {
+			// The input is still requeued, but the failure was not a deliberate
+			// deferral: surface it so a genuine handoff error is never silently
+			// swallowed by a coincidentally-busy session.
+			this._surfaceSessionInputError(error);
+			return true;
+		}
+		return false;
 	}
 
 	private _surfaceSessionInputError(error: unknown): void {
@@ -5231,7 +5200,6 @@ export class AgentSession {
 			}
 			if (this._activeSessionInput?.kind === "prompt") {
 				this._activeSessionInput.phase = "handedOff";
-				this._syncSteeringStopPending();
 				this._notifySessionInputCheckpointChange();
 			}
 			const promptPromise = this.agent.prompt(messages);
@@ -5458,7 +5426,6 @@ export class AgentSession {
 		this._rejectQueuedAgentMessageDeliveries(new Error("Queued agent message was cleared before delivery."));
 		this._steeringMessages = [];
 		this._followUpMessages = [];
-		this._syncSteeringStopPending();
 		this.agent.clearAllQueues();
 		this._emitQueueUpdate();
 		return { steering, followUp };
@@ -5507,7 +5474,6 @@ export class AgentSession {
 		this._followUpMessages = this._followUpMessages.filter(
 			(message) => !followUpSet.has(message as PreparedPromptInput),
 		);
-		this._syncSteeringStopPending();
 		for (const message of [...steering, ...followUp]) {
 			this._rejectAgentMessage(
 				message.agentMessageId,
@@ -5735,23 +5701,15 @@ export class AgentSession {
 		}
 	}
 
-	/** Compatibility wrapper for callers migrating to owned pause leases. */
-	pauseQueuedWork(): boolean {
-		if (this._legacyQueuedWorkPause) return false;
-		this._legacyQueuedWorkPause = this.acquireQueuedWorkPause();
-		return true;
-	}
-
-	/** Compatibility wrapper that releases only the pause acquired by pauseQueuedWork(). */
+	/**
+	 * Resume the session-input scheduler after an abort or update-restart
+	 * suspended it (requestAbort/abortForUpdateRestart). Returns whether any
+	 * queued work remains to run. Owned pause leases are unaffected: they are
+	 * released only by their holders via acquireQueuedWorkPause().release().
+	 */
 	resumeQueuedWork(): boolean {
 		this._sessionInputPumpSuspended = false;
-		const pause = this._legacyQueuedWorkPause;
-		if (pause) {
-			this._legacyQueuedWorkPause = undefined;
-			pause.release();
-		} else {
-			this._scheduleSessionInputPump();
-		}
+		this._scheduleSessionInputPump();
 		return this.pendingMessageCount > 0;
 	}
 
@@ -5830,7 +5788,6 @@ export class AgentSession {
 		const removed = new Set<QueuedSessionInput>([...removedSteering, ...removedFollowUp]);
 		this._steeringMessages = this._steeringMessages.filter((message) => !removed.has(message));
 		this._followUpMessages = this._followUpMessages.filter((message) => !removed.has(message));
-		this._syncSteeringStopPending();
 		for (const message of removed) {
 			this._rejectAgentMessage(
 				message.agentMessageId,

--- a/packages/coding-agent/src/core/prompt-admission.ts
+++ b/packages/coding-agent/src/core/prompt-admission.ts
@@ -1,10 +1,3 @@
-/**
- * Shared prompt-admission cancellation primitives used by the session core,
- * the daemon, and the supervisor. Admission cancellation is uncertain and
- * non-retryable by design: cancelling only wins while the original request is
- * still waiting, so every layer must reject with the same typed error and
- * observe the underlying work to avoid unhandled rejections.
- */
 export class PromptAdmissionCancelledError extends Error {
 	constructor() {
 		super("Prompt admission was cancelled.");
@@ -17,9 +10,8 @@ export function throwIfPromptAdmissionCancelled(signal: AbortSignal | undefined)
 }
 
 /**
- * Await `promise` unless `signal` aborts first. A pre-aborted signal rejects
- * immediately but still observes the supplied work's eventual rejection so a
- * cancelled admission never produces an unhandled rejection.
+ * Await `promise` unless `signal` aborts first. Always observes the supplied
+ * work's rejection so a cancelled admission never leaks an unhandled rejection.
  */
 export function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
 	if (!signal) return promise;

--- a/packages/coding-agent/src/core/prompt-admission.ts
+++ b/packages/coding-agent/src/core/prompt-admission.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared prompt-admission cancellation primitives used by the session core,
+ * the daemon, and the supervisor. Admission cancellation is uncertain and
+ * non-retryable by design: cancelling only wins while the original request is
+ * still waiting, so every layer must reject with the same typed error and
+ * observe the underlying work to avoid unhandled rejections.
+ */
+export class PromptAdmissionCancelledError extends Error {
+	constructor() {
+		super("Prompt admission was cancelled.");
+		this.name = "PromptAdmissionCancelledError";
+	}
+}
+
+export function throwIfPromptAdmissionCancelled(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) throw new PromptAdmissionCancelledError();
+}
+
+/**
+ * Await `promise` unless `signal` aborts first. A pre-aborted signal rejects
+ * immediately but still observes the supplied work's eventual rejection so a
+ * cancelled admission never produces an unhandled rejection.
+ */
+export function waitForPromptAdmission<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) {
+		void promise.catch(() => {});
+		return Promise.reject(new PromptAdmissionCancelledError());
+	}
+	return new Promise<T>((resolve, reject) => {
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const onAbort = () => {
+			cleanup();
+			reject(new PromptAdmissionCancelledError());
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		// Close the listener-registration race before observing the awaited work.
+		if (signal.aborted) return onAbort();
+		promise.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error: unknown) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
+}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1035,7 +1035,9 @@ export class AgentsViewMode implements Component, Focusable {
 				this.editor.setText("");
 				const sent = await this.sendReply(target, text);
 				if (sent) {
-					if (this.replyTarget === target) this.setReplyTarget(undefined);
+					if (this.replyTarget === target && this.editor.getText().length === 0) {
+						this.setReplyTarget(undefined);
+					}
 					await this.refreshSessions();
 				} else if (this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -67,6 +67,7 @@ import {
 	resolveAgentsViewSelectionState,
 	sectionTitle,
 	shouldShowAgentsViewSession,
+	summaryForUnifiedRecord,
 	type UnifiedSessionRecord,
 } from "./agents-view-state.js";
 import { matchesSearchText } from "./session-view-search.js";
@@ -431,6 +432,24 @@ export async function runAgentsViewMode(options: Omit<AgentsViewModeOptions, "ad
 			persistentState.statusMessage = formatError("Failed to open agent", error);
 		}
 	}
+}
+
+export function resolveCurrentReplyTargetSummary(
+	records: readonly UnifiedSessionRecord[],
+	target: { key: string; summary: SessionSummary },
+	findLive: (activeSessionId: string) => SessionSummary | undefined,
+): SessionSummary {
+	const identity = getSummaryIdentity(target.summary);
+	const current = records.find((record) => record.identity === identity || record.identityAliases.includes(identity));
+	if (current) return summaryForUnifiedRecord(current);
+	const live = target.summary.activeSessionId ? findLive(target.summary.activeSessionId) : undefined;
+	if (live) return live;
+	// A persisted target missing from the current live catalog can still be
+	// resumed from its captured file, but its captured runtime id is stale.
+	if (target.summary.sessionFile && target.summary.activeSessionId) {
+		return { ...target.summary, activeSessionId: undefined, lifecycle: "archived", activity: "idle" };
+	}
+	return target.summary;
 }
 
 export class AgentsViewMode implements Component, Focusable {
@@ -1382,8 +1401,11 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<boolean> {
-		let activeSessionId = target.summary.activeSessionId;
-		let liveSummary = this.findSummaryByActiveSessionId(activeSessionId ?? target.key);
+		const currentSummary = resolveCurrentReplyTargetSummary(this.unifiedRecords ?? [], target, (activeSessionId) =>
+			this.findSummaryByActiveSessionId(activeSessionId),
+		);
+		let activeSessionId = currentSummary.activeSessionId;
+		let liveSummary = activeSessionId ? currentSummary : undefined;
 		let cwdFallbackNotice: string | undefined;
 		let didResume = false;
 		try {
@@ -1394,7 +1416,7 @@ export class AgentsViewMode implements Component, Focusable {
 				const resumed = await resumeSavedAgentsViewSession(
 					this.requireClient(),
 					this.options.config,
-					target.summary,
+					currentSummary,
 				);
 				activeSessionId = resumed.activeSessionId;
 				didResume = true;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1059,8 +1059,7 @@ export class AgentsViewMode implements Component, Focusable {
 					if (this.replyTarget === target && this.editor.getText().length === 0) {
 						this.setReplyTarget(undefined);
 					}
-					// A refresh failure must not clobber the send outcome (or a sticky
-					// cwd-fallback notice) that sendReply just surfaced.
+					// Keep the send outcome (or sticky cwd notice) that sendReply just surfaced.
 					await this.refreshSessions({ preserveStatusOnError: true });
 				} else if (this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1385,6 +1385,7 @@ export class AgentsViewMode implements Component, Focusable {
 		let activeSessionId = target.summary.activeSessionId;
 		let liveSummary = this.findSummaryByActiveSessionId(activeSessionId ?? target.key);
 		let cwdFallbackNotice: string | undefined;
+		let didResume = false;
 		try {
 			if (!activeSessionId) {
 				// Saved session: resume it into the daemon first, then deliver the
@@ -1396,6 +1397,7 @@ export class AgentsViewMode implements Component, Focusable {
 					target.summary,
 				);
 				activeSessionId = resumed.activeSessionId;
+				didResume = true;
 				// The rows are still pre-resume; the fresh summary is the authoritative
 				// streaming state for scheduling the prompt.
 				liveSummary = resumed.summary;
@@ -1414,6 +1416,7 @@ export class AgentsViewMode implements Component, Focusable {
 			return true;
 		} catch (error) {
 			this.setStatusMessage(formatError("Failed to send reply", error));
+			if (didResume) await this.refreshSessions();
 			return false;
 		}
 	}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1399,7 +1399,9 @@ export class AgentsViewMode implements Component, Focusable {
 				liveSummary = resumed.summary;
 				cwdFallbackNotice = resumed.cwdFallbackNotice;
 				this.inactiveAgentIdentities.delete(getSummaryIdentity(target.summary));
-				this.selectSummary(resumed.summary);
+				// The resume and delivery still belong to this submission, but selection
+				// belongs to the current composer. Do not steal it after cancellation.
+				if (this.replyTarget === target) this.selectSummary(resumed.summary);
 			}
 			const behavior = liveSummary?.isStreaming ? "followUp" : undefined;
 			this.setStatusMessage("Sending reply...");

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1059,7 +1059,9 @@ export class AgentsViewMode implements Component, Focusable {
 					if (this.replyTarget === target && this.editor.getText().length === 0) {
 						this.setReplyTarget(undefined);
 					}
-					await this.refreshSessions();
+					// A refresh failure must not clobber the send outcome (or a sticky
+					// cwd-fallback notice) that sendReply just surfaced.
+					await this.refreshSessions({ preserveStatusOnError: true });
 				} else if (this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);
 				}
@@ -1440,7 +1442,7 @@ export class AgentsViewMode implements Component, Focusable {
 			return true;
 		} catch (error) {
 			this.setStatusMessage(formatError("Failed to send reply", error));
-			if (didResume) await this.refreshSessions();
+			if (didResume) await this.refreshSessions({ preserveStatusOnError: true });
 			return false;
 		}
 	}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1029,10 +1029,17 @@ export class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		if (this.replyTarget) {
+			const target = this.replyTarget;
 			const text = value.trim();
 			if (text) {
 				this.editor.setText("");
-				await this.sendReply(this.replyTarget, text);
+				const sent = await this.sendReply(target, text);
+				if (sent) {
+					if (this.replyTarget === target) this.setReplyTarget(undefined);
+					await this.refreshSessions();
+				} else if (this.replyTarget === target && this.editor.getText().length === 0) {
+					this.editor.setText(value);
+				}
 			}
 			return;
 		}
@@ -1372,7 +1379,7 @@ export class AgentsViewMode implements Component, Focusable {
 		return data.text;
 	}
 
-	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<void> {
+	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<boolean> {
 		let activeSessionId = target.summary.activeSessionId;
 		let liveSummary = this.findSummaryByActiveSessionId(activeSessionId ?? target.key);
 		let cwdFallbackNotice: string | undefined;
@@ -1391,6 +1398,7 @@ export class AgentsViewMode implements Component, Focusable {
 				// streaming state for scheduling the prompt.
 				liveSummary = resumed.summary;
 				cwdFallbackNotice = resumed.cwdFallbackNotice;
+				this.inactiveAgentIdentities.delete(getSummaryIdentity(target.summary));
 				this.selectSummary(resumed.summary);
 			}
 			const behavior = liveSummary?.isStreaming ? "followUp" : undefined;
@@ -1399,10 +1407,10 @@ export class AgentsViewMode implements Component, Focusable {
 			// The fallback-directory notice must outlive the transient send statuses.
 			if (cwdFallbackNotice) this.setStatusMessage(cwdFallbackNotice, { sticky: true });
 			else this.setStatusMessage("Reply sent");
-			this.setReplyTarget(undefined);
-			await this.refreshSessions();
+			return true;
 		} catch (error) {
 			this.setStatusMessage(formatError("Failed to send reply", error));
+			return false;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1374,6 +1374,8 @@ export class AgentsViewMode implements Component, Focusable {
 
 	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<void> {
 		let activeSessionId = target.summary.activeSessionId;
+		let liveSummary = this.findSummaryByActiveSessionId(activeSessionId ?? target.key);
+		let cwdFallbackNotice: string | undefined;
 		try {
 			if (!activeSessionId) {
 				// Saved session: resume it into the daemon first, then deliver the
@@ -1385,13 +1387,18 @@ export class AgentsViewMode implements Component, Focusable {
 					target.summary,
 				);
 				activeSessionId = resumed.activeSessionId;
-				if (resumed.cwdFallbackNotice) this.setStatusMessage(resumed.cwdFallbackNotice, { sticky: true });
+				// The rows are still pre-resume; the fresh summary is the authoritative
+				// streaming state for scheduling the prompt.
+				liveSummary = resumed.summary;
+				cwdFallbackNotice = resumed.cwdFallbackNotice;
 				this.selectSummary(resumed.summary);
 			}
-			const behavior = this.findSummaryByActiveSessionId(activeSessionId)?.isStreaming ? "followUp" : undefined;
+			const behavior = liveSummary?.isStreaming ? "followUp" : undefined;
 			this.setStatusMessage("Sending reply...");
 			await this.sendPrompt(activeSessionId, text, behavior);
-			this.setStatusMessage("Reply sent");
+			// The fallback-directory notice must outlive the transient send statuses.
+			if (cwdFallbackNotice) this.setStatusMessage(cwdFallbackNotice, { sticky: true });
+			else this.setStatusMessage("Reply sent");
 			this.setReplyTarget(undefined);
 			await this.refreshSessions();
 		} catch (error) {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -80,6 +80,7 @@ const DELETE_CONFIRM_DURATION_MS = 2000;
 const STATUS_MESSAGE_DURATION_MS = 4500;
 const SEARCH_PROMPT_PLACEHOLDER = "Search sessions";
 const REPLY_PROMPT_FALLBACK_PLACEHOLDER = "Write a reply to this agent";
+const RESUME_PROMPT_PLACEHOLDER = "Write a prompt to resume this session";
 const COMPLETED_ROW_ICON = "✓";
 const NEEDS_INPUT_ROW_ICON = "●";
 const SELECTED_ROW_MARKER = "\0agents-view-selected-row\0";
@@ -264,25 +265,45 @@ async function openAgentsViewSession(
 		throw new Error("Cannot open agent without an active runtime or saved session file");
 	}
 
-	const { overrideCwd, notice } = resolveAgentsViewOpenCwd(summary, options.config.cwd);
 	try {
-		const response = await client.request({
-			type: "create",
-			config: createAgentsViewResumeConfig(options.config, overrideCwd),
-			sessionPath: summary.sessionFile,
-		});
-		const createdSummary = expectSessionSummary(requireDaemonData(response));
-		const activeSessionId = getRequiredActiveSessionId(createdSummary);
-		const connection = await DaemonAgentConnection.attach(client, activeSessionId, {
+		const resumed = await resumeSavedAgentsViewSession(client, options.config, summary);
+		const connection = await DaemonAgentConnection.attach(client, resumed.activeSessionId, {
 			closeClientOnDispose: true,
 			recoverDaemon: options.recoverDaemon,
 			reconnectTimeoutMs: options.reconnectTimeoutMs,
 		});
-		return { connection, summary: createdSummary, cwdFallbackNotice: notice };
+		return { connection, summary: resumed.summary, cwdFallbackNotice: resumed.cwdFallbackNotice };
 	} catch (error) {
 		client.close();
 		throw error;
 	}
+}
+
+/**
+ * Resume a saved session file into the daemon and return the live summary.
+ * The daemon's create-with-sessionPath is idempotent for this client: an
+ * already-resident session is reused instead of resumed twice.
+ */
+async function resumeSavedAgentsViewSession(
+	client: DaemonClient,
+	config: AgentSessionRuntimeConfig,
+	summary: SessionSummary,
+): Promise<{ summary: SessionSummary; activeSessionId: string; cwdFallbackNotice?: string }> {
+	if (!summary.sessionFile) {
+		throw new Error("Cannot resume a session without a saved session file");
+	}
+	const { overrideCwd, notice } = resolveAgentsViewOpenCwd(summary, config.cwd);
+	const response = await client.request({
+		type: "create",
+		config: createAgentsViewResumeConfig(config, overrideCwd),
+		sessionPath: summary.sessionFile,
+	});
+	const createdSummary = expectSessionSummary(requireDaemonData(response));
+	return {
+		summary: createdSummary,
+		activeSessionId: getRequiredActiveSessionId(createdSummary),
+		cwdFallbackNotice: notice,
+	};
 }
 
 async function connectAgentsViewDaemonClient(socketPath: string): Promise<DaemonClient> {
@@ -457,7 +478,8 @@ export class AgentsViewMode implements Component, Focusable {
 	private selectedActiveSessionId: string | undefined;
 	private selectedSessionKey: AgentsViewSelectionKey | undefined;
 	private selectionAnchorPending = false;
-	private replyActiveSessionId: string | undefined;
+	/** Armed reply composer target: a live agent or a saved session to resume on send. */
+	private replyTarget: { key: string; summary: SessionSummary } | undefined;
 	private replyLastAssistantText: string | undefined;
 	private replyLastAssistantTextLoading = false;
 	private replyHeaderTime = "";
@@ -507,7 +529,7 @@ export class AgentsViewMode implements Component, Focusable {
 			this.finish({ type: "exit" });
 		};
 		this.editor.onAgentsBack = () => {
-			if (this.replyActiveSessionId) {
+			if (this.replyTarget) {
 				this.setReplyTarget(undefined);
 				return true;
 			}
@@ -517,7 +539,7 @@ export class AgentsViewMode implements Component, Focusable {
 			return true;
 		};
 		this.editor.onEscape = () => {
-			if (this.replyActiveSessionId) {
+			if (this.replyTarget) {
 				this.setReplyTarget(undefined);
 			} else if (this.editor.getText().length > 0) {
 				this.setSearchQuery("");
@@ -634,18 +656,18 @@ export class AgentsViewMode implements Component, Focusable {
 			this.cycleProgramForSelected();
 			return;
 		}
-		if (!this.replyActiveSessionId && this.keybindings.matches(data, "app.agents.open")) {
+		if (!this.replyTarget && this.keybindings.matches(data, "app.agents.open")) {
 			if (this.editor.getText().length === 0 || this.isSearchCursorAtEnd()) {
 				this.openSelected();
 				return;
 			}
 		}
-		if (!this.replyActiveSessionId && this.handleListNavigation(data)) {
+		if (!this.replyTarget && this.handleListNavigation(data)) {
 			return;
 		}
 		const previous = this.editor.getText();
 		this.editor.handleInput(data);
-		if (!this.replyActiveSessionId && this.editor.getText() !== previous) {
+		if (!this.replyTarget && this.editor.getText() !== previous) {
 			this.queryChanged();
 		}
 	}
@@ -898,8 +920,8 @@ export class AgentsViewMode implements Component, Focusable {
 		// targets; nested rows share the parent's session id but are read-only.
 		const selectedRow = this.rows[this.selectedIndex];
 		if (
-			this.replyActiveSessionId &&
-			(selectedRow?.kind !== "agent" || this.replyActiveSessionId !== this.selectedActiveSessionId)
+			this.replyTarget &&
+			(selectedRow?.kind !== "agent" || this.replyTarget.key !== this.selectedActiveSessionId)
 		) {
 			this.setReplyTarget(undefined);
 		}
@@ -980,8 +1002,7 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
-		const query =
-			this.replyActiveSessionId || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
+		const query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
 		return filterUnifiedSessions(this.unifiedRecords, (text) => matchesSearchText(text, query));
 	}
 
@@ -1007,11 +1028,11 @@ export class AgentsViewMode implements Component, Focusable {
 			await this.confirmRename(value);
 			return;
 		}
-		if (this.replyActiveSessionId) {
+		if (this.replyTarget) {
 			const text = value.trim();
 			if (text) {
 				this.editor.setText("");
-				await this.sendReply(this.replyActiveSessionId, text);
+				await this.sendReply(this.replyTarget, text);
 			}
 			return;
 		}
@@ -1180,48 +1201,67 @@ export class AgentsViewMode implements Component, Focusable {
 		if (selectedRow?.kind !== "agent") {
 			return;
 		}
-		const activeSessionId = selectedRow.summary.activeSessionId;
-		if (!activeSessionId) {
+		const summary = selectedRow.summary;
+		// Live agents reply directly; saved sessions are resumed when the reply is
+		// sent. Rows with neither runtime nor file have nothing to receive a prompt.
+		if (!summary.activeSessionId && !summary.sessionFile) {
 			return;
 		}
 		if (this.pendingDeleteAgent?.identity === getSelectedRowIdentity(selectedRow)) {
 			return;
 		}
-		if (this.replyActiveSessionId === activeSessionId) {
+		const key = summary.activeSessionId ?? summary.id;
+		if (this.replyTarget?.key === key) {
 			this.setReplyTarget(undefined);
 			return;
 		}
-		this.setReplyTarget(activeSessionId);
+		this.setReplyTarget({ key, summary });
+		if (!summary.activeSessionId) {
+			// Inactive sessions have no live transcript endpoint; the persisted recap
+			// (or opener) is the best preview and needs no daemon round-trip.
+			this.replyLastAssistantText = summary.summary ?? summary.firstMessage;
+			this.ui.requestRender();
+			return;
+		}
+		const activeSessionId = summary.activeSessionId;
 		this.replyLastAssistantTextLoading = true;
 		try {
 			const latestAssistantText = await this.getLastAssistantText(activeSessionId);
-			if (this.replyActiveSessionId === activeSessionId) {
+			if (this.replyTarget?.key === key) {
 				this.replyLastAssistantText = latestAssistantText;
 				this.replyLastAssistantTextLoading = false;
 				this.ui.requestRender();
 			}
 		} catch (error) {
-			if (this.replyActiveSessionId === activeSessionId) {
+			if (this.replyTarget?.key === key) {
 				this.replyLastAssistantTextLoading = false;
 				this.setStatusMessage(formatError("Failed to load latest response", error));
 			}
 		}
 	}
 
-	private setReplyTarget(activeSessionId: string | undefined): void {
-		if (activeSessionId && !this.replyActiveSessionId) {
+	private setReplyTarget(target: { key: string; summary: SessionSummary } | undefined): void {
+		if (target && !this.replyTarget) {
 			this.actionModeSearchQuery = this.editor.getText();
 			this.editor.setText("");
-		} else if (!activeSessionId && this.replyActiveSessionId) {
+		} else if (!target && this.replyTarget) {
 			this.editor.setText(this.actionModeSearchQuery ?? this.persistentState.query ?? "");
 			this.actionModeSearchQuery = undefined;
 		}
-		this.replyActiveSessionId = activeSessionId;
+		this.replyTarget = target;
 		this.replyLastAssistantText = undefined;
 		this.replyLastAssistantTextLoading = false;
-		this.replyHeaderTime = activeSessionId ? this.getReplyHeaderTime(activeSessionId) : "";
-		this.editor.setPlaceholder(activeSessionId ? REPLY_PROMPT_FALLBACK_PLACEHOLDER : SEARCH_PROMPT_PLACEHOLDER);
-		if (!activeSessionId) this.rebuildRows();
+		this.replyHeaderTime = target
+			? formatAgentsViewRelativeTime(target.summary.modified ?? target.summary.created)
+			: "";
+		this.editor.setPlaceholder(
+			target
+				? target.summary.activeSessionId
+					? REPLY_PROMPT_FALLBACK_PLACEHOLDER
+					: RESUME_PROMPT_PLACEHOLDER
+				: SEARCH_PROMPT_PLACEHOLDER,
+		);
+		if (!target) this.rebuildRows();
 		this.ui.requestRender();
 	}
 
@@ -1297,11 +1337,6 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	private getReplyHeaderTime(activeSessionId: string): string {
-		const summary = this.findSummaryByActiveSessionId(activeSessionId);
-		return formatAgentsViewRelativeTime(summary?.modified ?? summary?.created);
-	}
-
 	private findSummaryByActiveSessionId(activeSessionId: string): SessionSummary | undefined {
 		return this.rows.find((row) => (row.summary.activeSessionId ?? row.summary.id) === activeSessionId)?.summary;
 	}
@@ -1310,7 +1345,7 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.renameTarget) {
 			return theme.fg("warning", "Rename agent session");
 		}
-		if (!this.replyActiveSessionId) {
+		if (!this.replyTarget) {
 			return undefined;
 		}
 		const headline =
@@ -1337,10 +1372,24 @@ export class AgentsViewMode implements Component, Focusable {
 		return data.text;
 	}
 
-	private async sendReply(activeSessionId: string, text: string): Promise<void> {
-		const behavior = this.findSummaryByActiveSessionId(activeSessionId)?.isStreaming ? "followUp" : undefined;
-		this.setStatusMessage("Sending reply...");
+	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<void> {
+		let activeSessionId = target.summary.activeSessionId;
 		try {
+			if (!activeSessionId) {
+				// Saved session: resume it into the daemon first, then deliver the
+				// prompt through the same path as a live reply.
+				this.setStatusMessage("Resuming session...");
+				const resumed = await resumeSavedAgentsViewSession(
+					this.requireClient(),
+					this.options.config,
+					target.summary,
+				);
+				activeSessionId = resumed.activeSessionId;
+				if (resumed.cwdFallbackNotice) this.setStatusMessage(resumed.cwdFallbackNotice, { sticky: true });
+				this.selectSummary(resumed.summary);
+			}
+			const behavior = this.findSummaryByActiveSessionId(activeSessionId)?.isStreaming ? "followUp" : undefined;
+			this.setStatusMessage("Sending reply...");
 			await this.sendPrompt(activeSessionId, text, behavior);
 			this.setStatusMessage("Reply sent");
 			this.setReplyTarget(undefined);
@@ -1348,6 +1397,15 @@ export class AgentsViewMode implements Component, Focusable {
 		} catch (error) {
 			this.setStatusMessage(formatError("Failed to send reply", error));
 		}
+	}
+
+	/** Point selection (and its persisted key) at a freshly resumed session row. */
+	private selectSummary(summary: SessionSummary): void {
+		this.selectedRowIdentity = getSummaryIdentity(summary);
+		this.selectedActiveSessionId = summary.activeSessionId ?? summary.id;
+		this.selectedSessionKey = getAgentsViewSelectionKey(summary);
+		this.persistentState.selectedRowIdentity = this.selectedRowIdentity;
+		this.persistentState.selectedSessionKey = this.selectedSessionKey;
 	}
 
 	private async handleDeleteSelected(): Promise<void> {
@@ -2118,14 +2176,16 @@ export class AgentsViewMode implements Component, Focusable {
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open`,
 			`${keyText("app.agents.open")} open`,
-			selectedAgent && !this.options.adapter ? `${keyText("app.agents.reply")} reply` : undefined,
+			selectedAgent && !this.options.adapter
+				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
+				: undefined,
 			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
 			selectedAgent && (!this.options.adapter || selectedRow?.section === "inactive")
 				? `${keyText("app.agents.delete")} ${selectedRow?.section === "inactive" ? "delete" : "stop/deactivate"}`
 				: undefined,
 			selectedSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
 			this.selectedRowCanShowProgram() ? `${keyText("app.agents.program")} program` : undefined,
-			this.replyActiveSessionId ? `${keyText("app.agents.back")} back` : undefined,
+			this.replyTarget ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)
 			.join("   ");

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -90,6 +90,7 @@ import {
 	shouldDeferHeartbeatCronJob,
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
+import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
 import type {
 	CreateRlmSubagentRuntimeOptions,
 	RlmSubagentRuntime,
@@ -326,43 +327,6 @@ const RECOVERY_CHECKPOINT_EVENTS: ReadonlySet<string> = new Set([
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
-}
-
-class DaemonPromptAdmissionCancelledError extends Error {
-	constructor() {
-		super("Prompt admission was cancelled.");
-		this.name = "DaemonPromptAdmissionCancelledError";
-	}
-}
-
-export function waitForDaemonPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-	if (!signal) return promise;
-	if (signal.aborted) {
-		// The caller supplied already-running work. Observe its eventual rejection
-		// even though admission cancellation wins immediately.
-		void promise.catch(() => {});
-		return Promise.reject(new DaemonPromptAdmissionCancelledError());
-	}
-	return new Promise<T>((resolve, reject) => {
-		const cleanup = () => signal.removeEventListener("abort", onAbort);
-		const onAbort = () => {
-			cleanup();
-			reject(new DaemonPromptAdmissionCancelledError());
-		};
-		signal.addEventListener("abort", onAbort, { once: true });
-		// Close the registration-to-check race before observing the awaited work.
-		if (signal.aborted) return onAbort();
-		promise.then(
-			(value) => {
-				cleanup();
-				resolve(value);
-			},
-			(error: unknown) => {
-				cleanup();
-				reject(error);
-			},
-		);
-	});
 }
 
 type RuntimeOpenGuard = () => boolean | Promise<boolean>;
@@ -1467,7 +1431,7 @@ export class AgentDaemon {
 		try {
 			const targetLock = this.agentMessageTargetLocks.get(activeSessionId);
 			if (targetLock)
-				await waitForDaemonPromptAdmission(
+				await waitForPromptAdmission(
 					targetLock.catch(() => undefined),
 					signal,
 				);
@@ -2635,17 +2599,14 @@ export class AgentDaemon {
 				// wins the command wait below.
 				void claimCheck.catch(() => {});
 				try {
-					const ownerFingerprint = await waitForDaemonPromptAdmission(
-						claimCheck,
-						parsedAdmission?.controller?.signal,
-					);
+					const ownerFingerprint = await waitForPromptAdmission(claimCheck, parsedAdmission?.controller?.signal);
 					if (this.supervisorClaims.get(client) !== boundClaim || client.socket.destroyed) {
 						clearParsedAdmission();
 						return;
 					}
 					boundClaim.ownerFingerprint = ownerFingerprint;
 				} catch (error) {
-					const admissionCancelled = error instanceof DaemonPromptAdmissionCancelledError;
+					const admissionCancelled = error instanceof PromptAdmissionCancelledError;
 					if (admissionCancelled) {
 						// The fence check remains authoritative after cancellation. Its rejection
 						// revokes only the exact binding that initiated it; replacements survive.
@@ -3143,7 +3104,7 @@ export class AgentDaemon {
 				};
 				let state: ActiveSessionState;
 				try {
-					if (admission?.status === "cancelled") throw new Error("Prompt admission was cancelled.");
+					if (admission?.status === "cancelled") throw new PromptAdmissionCancelledError();
 					state = this.getBoundSessionState(command.activeSessionId);
 				} catch (error) {
 					clearAdmission();

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1592,8 +1592,6 @@ export class DaemonSupervisor {
 				this.findWorkerForClient(client, command.activeSessionId),
 				admission?.controller.signal,
 			);
-			// Re-check after the await: a cancel command may have settled the
-			// admission while worker routing was in flight.
 			throwIfAdmissionCancelled(admission);
 			const resolvedCommand = {
 				...command,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -27,6 +27,7 @@ import {
 	ORPHAN_PROCESS_JOURNAL_ENV,
 	readActiveOrphanProcesses,
 } from "../../core/orphan-process-journal.js";
+import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import type { SessionInfo } from "../../core/session-manager.js";
 import { signalProcessGroupOrProcess } from "../../utils/child-process.js";
@@ -286,6 +287,10 @@ interface SupervisorPromptAdmission {
 	workerActiveSessionId?: string;
 }
 
+function throwIfAdmissionCancelled(admission: SupervisorPromptAdmission | undefined): void {
+	if (admission?.status === "cancelled") throw new PromptAdmissionCancelledError();
+}
+
 class SupervisorRecoveryCancelledError extends Error {
 	readonly code = "supervisor_recovery_cancelled" as const;
 }
@@ -315,33 +320,6 @@ function isSupervisorShutdownAdmissionCancelled(error: unknown): boolean {
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
-}
-
-export function waitForSupervisorPromptAdmission<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-	if (!signal) return promise;
-	if (signal.aborted) {
-		void promise.catch(() => {});
-		return Promise.reject(new Error("Prompt admission was cancelled."));
-	}
-	return new Promise<T>((resolve, reject) => {
-		const cleanup = () => signal.removeEventListener("abort", onAbort);
-		const onAbort = () => {
-			cleanup();
-			reject(new Error("Prompt admission was cancelled."));
-		};
-		signal.addEventListener("abort", onAbort, { once: true });
-		if (signal.aborted) return onAbort();
-		promise.then(
-			(value) => {
-				cleanup();
-				resolve(value);
-			},
-			(error: unknown) => {
-				cleanup();
-				reject(error);
-			},
-		);
-	});
 }
 
 function unrefDelay(ms: number): Promise<void> {
@@ -1094,7 +1072,7 @@ export class DaemonSupervisor {
 			cancellationAdmission.controller.abort();
 		}
 		try {
-			await waitForSupervisorPromptAdmission(this.ready, parsedAdmission?.controller.signal);
+			await waitForPromptAdmission(this.ready, parsedAdmission?.controller.signal);
 		} catch (error) {
 			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 			this.write(client, failure(command.id, command.type, error));
@@ -1112,7 +1090,7 @@ export class DaemonSupervisor {
 		}
 
 		try {
-			await waitForSupervisorPromptAdmission(this.assertCurrentOwnership(), parsedAdmission?.controller.signal);
+			await waitForPromptAdmission(this.assertCurrentOwnership(), parsedAdmission?.controller.signal);
 		} catch (error) {
 			if (parsedAdmission) this.deletePromptAdmission(parsedAdmission);
 			this.write(client, failure(command.id, command.type, error));
@@ -1609,14 +1587,14 @@ export class DaemonSupervisor {
 				? this.getPromptAdmission(client, command.activeSessionId, command.admissionId)
 				: undefined;
 		try {
-			if (admission?.status === "cancelled") throw new Error("Prompt admission was cancelled.");
-			const match = await waitForSupervisorPromptAdmission(
+			throwIfAdmissionCancelled(admission);
+			const match = await waitForPromptAdmission(
 				this.findWorkerForClient(client, command.activeSessionId),
 				admission?.controller.signal,
 			);
-			if ((admission as { status: string } | undefined)?.status === "cancelled") {
-				throw new Error("Prompt admission was cancelled.");
-			}
+			// Re-check after the await: a cancel command may have settled the
+			// admission while worker routing was in flight.
+			throwIfAdmissionCancelled(admission);
 			const resolvedCommand = {
 				...command,
 				activeSessionId: match.summary.activeSessionId ?? match.summary.id,

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -22,6 +22,16 @@ function invoke(method: string, self: object, ...args: unknown[]): unknown {
 	return Reflect.get(AgentsViewMode.prototype, method).call(self, ...args);
 }
 
+function editorWithText(initial: string) {
+	let text = initial;
+	return {
+		getText: () => text,
+		setText: vi.fn((next: string) => {
+			text = next;
+		}),
+	};
+}
+
 describe("agents view reply on inactive sessions", () => {
 	const savedSummary = summary({
 		sessionFile: "/tmp/sessions/saved-1.jsonl",
@@ -82,6 +92,7 @@ describe("agents view reply on inactive sessions", () => {
 			// Stale pre-resume rows do not know the resumed session; scheduling must
 			// come from the resume response instead.
 			findSummaryByActiveSessionId: () => undefined,
+			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
 			setStatusMessage: vi.fn(),
 			setReplyTarget: vi.fn(),
 			refreshSessions: vi.fn(async () => true),
@@ -96,7 +107,80 @@ describe("agents view reply on inactive sessions", () => {
 		);
 		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", "followUp");
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
-		expect(self.setReplyTarget).toHaveBeenCalledWith(undefined);
+		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
+		expect(self.setReplyTarget).not.toHaveBeenCalled();
+	});
+
+	it("preserves a replacement composer when an older reply succeeds", async () => {
+		const editor = editorWithText("old reply");
+		const oldTarget = { key: "saved-1", summary: savedSummary };
+		const newTarget = {
+			key: "active-2",
+			summary: summary({ id: "active-2", activeSessionId: "active-2", lifecycle: "live" }),
+		};
+		const self: Record<string, unknown> = {
+			replyTarget: oldTarget,
+			editor,
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			sendReply: vi.fn(async () => {
+				self.replyTarget = newTarget;
+				editor.setText("new reply");
+				return true;
+			}),
+		};
+
+		await invoke("submit", self, "old reply");
+
+		expect(self.replyTarget).toBe(newTarget);
+		expect(editor.getText()).toBe("new reply");
+		expect(self.setReplyTarget).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ name: "resume failure", failure: "resume", remainsInactive: true },
+		{ name: "send failure", failure: "send", remainsInactive: false },
+		{
+			name: "replacement text entered during send failure",
+			failure: "send",
+			replacement: "replacement",
+			remainsInactive: false,
+		},
+	] as const)("handles $name", async ({ failure, replacement, remainsInactive }) => {
+		const editor = editorWithText("wake up");
+		const target = { key: "saved-1", summary: savedSummary };
+		const inactiveAgentIdentities = new Set(["file:/tmp/sessions/saved-1.jsonl"]);
+		const request = vi.fn(async () => {
+			if (failure === "resume") throw new Error("resume failed");
+			return {
+				success: true,
+				data: { ...savedSummary, lifecycle: "live", activeSessionId: "active-9" },
+			};
+		});
+		const sendPrompt = vi.fn(async () => {
+			if (replacement) editor.setText(replacement);
+			throw new Error("send failed");
+		});
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			findSummaryByActiveSessionId: () => undefined,
+			inactiveAgentIdentities,
+			replyTarget: target,
+			editor,
+			setStatusMessage: vi.fn(),
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			selectSummary: vi.fn(),
+			sendPrompt,
+			sendReply: (replyTarget: unknown, text: string) => invoke("sendReply", self, replyTarget, text),
+		};
+
+		await invoke("submit", self, "wake up");
+
+		expect(editor.setText).toHaveBeenNthCalledWith(1, "");
+		expect(editor.getText()).toBe(replacement ?? "wake up");
+		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(remainsInactive);
 	});
 
 	it("keeps the cwd-fallback notice visible after the reply is sent", async () => {
@@ -111,6 +195,7 @@ describe("agents view reply on inactive sessions", () => {
 			options: { config: { cwd: process.cwd() } },
 			requireClient: () => ({ request }),
 			findSummaryByActiveSessionId: () => undefined,
+			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
 			setStatusMessage: vi.fn((message: string, options?: { sticky?: boolean }) => {
 				statuses.push([message, options]);
 			}),

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -244,6 +244,7 @@ describe("agents view reply on inactive sessions", () => {
 		expect(editor.setText).toHaveBeenNthCalledWith(1, "");
 		expect(editor.getText()).toBe(replacement ?? "wake up");
 		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(remainsInactive);
+		expect(self.refreshSessions).toHaveBeenCalledTimes(remainsInactive ? 0 : 1);
 	});
 
 	it("keeps the cwd-fallback notice visible after the reply is sent", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -86,9 +86,11 @@ describe("agents view reply on inactive sessions", () => {
 			}
 			return { success: true, data: {} };
 		});
+		const target = { key: "saved-1", summary: savedSummary };
 		const self: Record<string, unknown> = {
 			options: { config: { cwd: process.cwd() } },
 			requireClient: () => ({ request }),
+			replyTarget: target,
 			// Stale pre-resume rows do not know the resumed session; scheduling must
 			// come from the resume response instead.
 			findSummaryByActiveSessionId: () => undefined,
@@ -100,7 +102,7 @@ describe("agents view reply on inactive sessions", () => {
 			sendPrompt: vi.fn(async () => {}),
 		};
 
-		await invoke("sendReply", self, { key: "saved-1", summary: savedSummary }, "wake up");
+		await invoke("sendReply", self, target, "wake up");
 
 		expect(request).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
@@ -109,6 +111,46 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
+	});
+
+	it("does not select a resumed session after its reply target is cancelled", async () => {
+		let finishResume: ((result: { success: true; data: SessionSummary }) => void) | undefined;
+		const request = vi.fn(
+			() =>
+				new Promise<{ success: true; data: SessionSummary }>((resolve) => {
+					finishResume = resolve;
+				}),
+		);
+		const target = { key: "saved-1", summary: savedSummary };
+		const selection = { activeSessionId: "active-2" };
+		const selectSummary = vi.fn((next: SessionSummary) => {
+			selection.activeSessionId = next.activeSessionId ?? next.id;
+		});
+		const sendPrompt = vi.fn(async () => {});
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			findSummaryByActiveSessionId: () => undefined,
+			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
+			replyTarget: target,
+			setStatusMessage: vi.fn(),
+			selectSummary,
+			sendPrompt,
+		};
+
+		const reply = invoke("sendReply", self, target, "wake up") as Promise<boolean>;
+		await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+		self.replyTarget = undefined;
+		finishResume?.({
+			success: true,
+			data: { ...savedSummary, lifecycle: "live", activeSessionId: "active-9" },
+		});
+
+		await expect(reply).resolves.toBe(true);
+		expect(selectSummary).not.toHaveBeenCalled();
+		expect(selection.activeSessionId).toBe("active-2");
+		expect(sendPrompt).toHaveBeenCalledWith("active-9", "wake up", undefined);
+		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 	});
 
 	it("preserves a replacement composer when an older reply succeeds", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -18,8 +18,13 @@ function summary(overrides: Partial<SessionSummary>): SessionSummary {
 	};
 }
 
+/** Guarded private invocation: fails with a clear message if the member is renamed. */
 function invoke(method: string, self: object, ...args: unknown[]): unknown {
-	return Reflect.get(AgentsViewMode.prototype, method).call(self, ...args);
+	const member = Reflect.get(AgentsViewMode.prototype, method) as ((...a: unknown[]) => unknown) | undefined;
+	if (typeof member !== "function") {
+		throw new Error(`AgentsViewMode.${method} no longer exists; update this test harness`);
+	}
+	return member.call(self, ...args);
 }
 
 function editorWithText(initial: string) {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -69,13 +69,18 @@ describe("agents view reply on inactive sessions", () => {
 	it("resumes a saved session before delivering the reply", async () => {
 		const request = vi.fn(async (command: { type: string }) => {
 			if (command.type === "create") {
-				return { success: true, data: { ...savedSummary, lifecycle: "live", activeSessionId: "active-9" } };
+				return {
+					success: true,
+					data: { ...savedSummary, lifecycle: "live", activeSessionId: "active-9", isStreaming: true },
+				};
 			}
 			return { success: true, data: {} };
 		});
 		const self: Record<string, unknown> = {
 			options: { config: { cwd: process.cwd() } },
 			requireClient: () => ({ request }),
+			// Stale pre-resume rows do not know the resumed session; scheduling must
+			// come from the resume response instead.
 			findSummaryByActiveSessionId: () => undefined,
 			setStatusMessage: vi.fn(),
 			setReplyTarget: vi.fn(),
@@ -89,9 +94,37 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
 		);
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", undefined);
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", "followUp");
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
 		expect(self.setReplyTarget).toHaveBeenCalledWith(undefined);
+	});
+
+	it("keeps the cwd-fallback notice visible after the reply is sent", async () => {
+		const missingCwd = "/definitely/not/a/real/dir/for/this/test";
+		const savedWithMissingCwd = { ...savedSummary, cwd: missingCwd };
+		const request = vi.fn(async () => ({
+			success: true,
+			data: { ...savedWithMissingCwd, lifecycle: "live", activeSessionId: "active-9" },
+		}));
+		const statuses: Array<[string, { sticky?: boolean } | undefined]> = [];
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			findSummaryByActiveSessionId: () => undefined,
+			setStatusMessage: vi.fn((message: string, options?: { sticky?: boolean }) => {
+				statuses.push([message, options]);
+			}),
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "saved-1", summary: savedWithMissingCwd }, "wake up");
+
+		const last = statuses.at(-1);
+		expect(last?.[0]).toContain("Original directory is missing");
+		expect(last?.[1]).toEqual({ sticky: true });
 	});
 
 	it("replies to live sessions without resuming", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentsViewMode } from "../src/modes/agents-view/agents-view-mode.js";
+import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+
+function summary(overrides: Partial<SessionSummary>): SessionSummary {
+	return {
+		id: "saved-1",
+		lifecycle: "archived",
+		activity: "idle",
+		sessionId: "saved-1",
+		cwd: process.cwd(),
+		isStreaming: false,
+		isCompacting: false,
+		attachedClients: 0,
+		messageCount: 3,
+		pendingMessageCount: 0,
+		...overrides,
+	};
+}
+
+function invoke(method: string, self: object, ...args: unknown[]): unknown {
+	return Reflect.get(AgentsViewMode.prototype, method).call(self, ...args);
+}
+
+describe("agents view reply on inactive sessions", () => {
+	const savedSummary = summary({
+		sessionFile: "/tmp/sessions/saved-1.jsonl",
+		cwd: process.cwd(),
+		summary: "Persisted recap text",
+		firstMessage: "opener",
+	});
+
+	it("arms the composer on a saved-only row using the persisted recap", async () => {
+		const setReplyTarget = vi.fn();
+		const requestRender = vi.fn();
+		const self: Record<string, unknown> = {
+			rows: [
+				{ kind: "agent", selectable: true, identity: "file:/tmp/sessions/saved-1.jsonl", summary: savedSummary },
+			],
+			selectedIndex: 0,
+			pendingDeleteAgent: undefined,
+			replyTarget: undefined,
+			setReplyTarget,
+			ui: { requestRender },
+			requireClient: () => {
+				throw new Error("saved rows must not hit the daemon for a preview");
+			},
+		};
+
+		await invoke("toggleReplyTarget", self);
+
+		expect(setReplyTarget).toHaveBeenCalledWith({ key: "saved-1", summary: savedSummary });
+		expect(self.replyLastAssistantText).toBe("Persisted recap text");
+	});
+
+	it("ignores rows with neither a runtime nor a session file", async () => {
+		const setReplyTarget = vi.fn();
+		const self = {
+			rows: [{ kind: "agent", selectable: true, identity: "session:saved-1", summary: summary({}) }],
+			selectedIndex: 0,
+			setReplyTarget,
+		};
+
+		await invoke("toggleReplyTarget", self);
+
+		expect(setReplyTarget).not.toHaveBeenCalled();
+	});
+
+	it("resumes a saved session before delivering the reply", async () => {
+		const request = vi.fn(async (command: { type: string }) => {
+			if (command.type === "create") {
+				return { success: true, data: { ...savedSummary, lifecycle: "live", activeSessionId: "active-9" } };
+			}
+			return { success: true, data: {} };
+		});
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			findSummaryByActiveSessionId: () => undefined,
+			setStatusMessage: vi.fn(),
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "saved-1", summary: savedSummary }, "wake up");
+
+		expect(request).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
+		);
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", undefined);
+		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
+		expect(self.setReplyTarget).toHaveBeenCalledWith(undefined);
+	});
+
+	it("replies to live sessions without resuming", async () => {
+		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const request = vi.fn();
+		const self: Record<string, unknown> = {
+			options: { config: {} },
+			requireClient: () => ({ request }),
+			findSummaryByActiveSessionId: () => liveSummary,
+			setStatusMessage: vi.fn(),
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "hello");
+
+		expect(request).not.toHaveBeenCalled();
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "hello", undefined);
+		expect(self.selectSummary).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -181,8 +181,6 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.replyTarget).toBe(newTarget);
 		expect(editor.getText()).toBe("new reply");
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
-		// The post-send refresh must not clobber sendReply's status (e.g. the
-		// sticky cwd-fallback notice) when the catalog refresh fails.
 		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
@@ -253,7 +251,6 @@ describe("agents view reply on inactive sessions", () => {
 		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(remainsInactive);
 		expect(self.refreshSessions).toHaveBeenCalledTimes(remainsInactive ? 0 : 1);
 		if (!remainsInactive) {
-			// The failure status set by sendReply must survive a failing refresh.
 			expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 		}
 	});

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -179,6 +179,27 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
 	});
 
+	it("preserves new text entered while the same reply succeeds", async () => {
+		const editor = editorWithText("first reply");
+		const target = { key: "saved-1", summary: savedSummary };
+		const self: Record<string, unknown> = {
+			replyTarget: target,
+			editor,
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			sendReply: vi.fn(async () => {
+				editor.setText("next reply");
+				return true;
+			}),
+		};
+
+		await invoke("submit", self, "first reply");
+
+		expect(self.replyTarget).toBe(target);
+		expect(editor.getText()).toBe("next reply");
+		expect(self.setReplyTarget).not.toHaveBeenCalled();
+	});
+
 	it.each([
 		{ name: "resume failure", failure: "resume", remainsInactive: true },
 		{ name: "send failure", failure: "send", remainsInactive: false },

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -276,6 +276,46 @@ describe("agents view reply on inactive sessions", () => {
 		expect(last?.[1]).toEqual({ sticky: true });
 	});
 
+	it("resumes the current saved row when an armed live target becomes inactive", async () => {
+		const capturedLive = summary({
+			activeSessionId: "active-dead",
+			lifecycle: "live",
+			sessionFile: savedSummary.sessionFile,
+		});
+		const currentSaved = { ...savedSummary, activeSessionId: undefined };
+		const request = vi.fn(async () => ({
+			success: true,
+			data: { ...currentSaved, lifecycle: "live", activeSessionId: "active-new" },
+		}));
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			unifiedRecords: [
+				{
+					daemon: currentSaved,
+					identity: "file:/tmp/sessions/saved-1.jsonl",
+					identityAliases: ["file:/tmp/sessions/saved-1.jsonl"],
+					section: "inactive",
+					searchableText: "",
+				},
+			],
+			findSummaryByActiveSessionId: () => undefined,
+			inactiveAgentIdentities: new Set<string>(),
+			replyTarget: undefined,
+			setStatusMessage: vi.fn(),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "active-dead", summary: capturedLive }, "wake up");
+
+		expect(request).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
+		);
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-new", "wake up", undefined);
+		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
+	});
+
 	it("replies to live sessions without resuming", async () => {
 		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live" });
 		const request = vi.fn();

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -18,7 +18,6 @@ function summary(overrides: Partial<SessionSummary>): SessionSummary {
 	};
 }
 
-/** Guarded private invocation: fails with a clear message if the member is renamed. */
 function invoke(method: string, self: object, ...args: unknown[]): unknown {
 	const member = Reflect.get(AgentsViewMode.prototype, method) as ((...a: unknown[]) => unknown) | undefined;
 	if (typeof member !== "function") {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -181,6 +181,9 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.replyTarget).toBe(newTarget);
 		expect(editor.getText()).toBe("new reply");
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
+		// The post-send refresh must not clobber sendReply's status (e.g. the
+		// sticky cwd-fallback notice) when the catalog refresh fails.
+		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
 	it("preserves new text entered while the same reply succeeds", async () => {
@@ -249,6 +252,10 @@ describe("agents view reply on inactive sessions", () => {
 		expect(editor.getText()).toBe(replacement ?? "wake up");
 		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(remainsInactive);
 		expect(self.refreshSessions).toHaveBeenCalledTimes(remainsInactive ? 0 : 1);
+		if (!remainsInactive) {
+			// The failure status set by sendReply must survive a failing refresh.
+			expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		}
 	});
 
 	it("keeps the cwd-fallback notice visible after the reply is sent", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -27,7 +27,6 @@ import {
 	markClientSnapshotStreaming,
 	setDaemonClientSessionCapabilities,
 	shouldSendDaemonOutboundToClient,
-	waitForDaemonPromptAdmission,
 } from "../src/modes/daemon/daemon-mode.js";
 import {
 	createDaemonCommandEnvelope,
@@ -46,18 +45,6 @@ describe("daemon mode helpers", () => {
 
 		parse(client, JSON.stringify(createDaemonCommandEnvelope({ type: "list" }, "request-1", "public-client")));
 		expect(client.id).toBe("public-client");
-	});
-
-	it("observes supplied work when prompt admission is already aborted", async () => {
-		const controller = new AbortController();
-		controller.abort();
-		const work = Promise.reject(new Error("late claim failure"));
-
-		await expect(waitForDaemonPromptAdmission(work, controller.signal)).rejects.toThrow(
-			"Prompt admission was cancelled.",
-		);
-		// Let the observed work settle; an unhandled rejection would fail Vitest.
-		await Promise.resolve();
 	});
 
 	it("finds only direct child active sessions", () => {

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -45,14 +45,8 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 	throw new Error("Condition was not reached");
 }
 
-/**
- * Constructor-bypass harness: DaemonSupervisor's constructor spawns file
- * watchers and requires a live socket dir, so admission ordering is tested
- * against a prototype instance with exactly the private fields handleLine
- * touches. This list is coupled to the class by hand — when a supervisor
- * refactor renames one of these fields, update it here; handleLine failing
- * with "undefined is not a function/Map" in this file means exactly that.
- */
+// Constructor-bypass harness: the real constructor spawns watchers and needs a
+// socket dir. The field list is hand-coupled to what handleLine touches.
 function createHarness(
 	options: {
 		ready?: Promise<void>;

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
+import { type Deferred, createDeferred as deferred } from "./suite/scheduling.js";
 
 interface AdmissionRecord {
 	client: DaemonSocketClient;
@@ -28,22 +29,6 @@ interface SupervisorHarness {
 	promptAdmissions: Map<DaemonSocketClient, Map<string, AdmissionRecord>>;
 }
 
-interface Deferred<T> {
-	promise: Promise<T>;
-	resolve(value: T): void;
-	reject(error: unknown): void;
-}
-
-function deferred<T>(): Deferred<T> {
-	let resolve!: (value: T) => void;
-	let reject!: (error: unknown) => void;
-	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-		resolve = resolvePromise;
-		reject = rejectPromise;
-	});
-	return { promise, resolve, reject };
-}
-
 function client(id: string): DaemonSocketClient {
 	return { id, attachedActiveSessionIds: new Set(), capabilities: new Set() } as DaemonSocketClient;
 }
@@ -60,6 +45,14 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 	throw new Error("Condition was not reached");
 }
 
+/**
+ * Constructor-bypass harness: DaemonSupervisor's constructor spawns file
+ * watchers and requires a live socket dir, so admission ordering is tested
+ * against a prototype instance with exactly the private fields handleLine
+ * touches. This list is coupled to the class by hand — when a supervisor
+ * refactor renames one of these fields, update it here; handleLine failing
+ * with "undefined is not a function/Map" in this file means exactly that.
+ */
 function createHarness(
 	options: {
 		ready?: Promise<void>;

--- a/packages/coding-agent/test/daemon-supervisor-admission.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-admission.test.ts
@@ -7,7 +7,7 @@ import {
 	type DaemonCommand,
 	type DaemonResponse,
 } from "../src/modes/daemon/daemon-protocol.js";
-import { DaemonSupervisor, waitForSupervisorPromptAdmission } from "../src/modes/daemon/daemon-supervisor.js";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
 
 interface AdmissionRecord {
@@ -101,17 +101,6 @@ function createHarness(
 }
 
 describe("daemon supervisor prompt admission ownership", () => {
-	it("observes an already-running promise when admission is pre-aborted", async () => {
-		const abort = new AbortController();
-		abort.abort();
-		const work = Promise.reject(new Error("late failure"));
-
-		await expect(waitForSupervisorPromptAdmission(work, abort.signal)).rejects.toThrow(
-			"Prompt admission was cancelled",
-		);
-		await Promise.resolve();
-	});
-
 	it("registers a prompt synchronously before readiness and ownership awaits", async () => {
 		const ready = deferred<void>();
 		const ownership = deferred<void>();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3249,8 +3249,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 			const blockedSubmission = fakeThis.defaultEditor.onSubmit?.("blocked user");
 			rejectStartup(new AgentConnectionPromptAdmissionError("daemon admission uncertain", status));
 			await blockedSubmission;
-			// Drain scheduled continuations deterministically: an erroneous retry
-			// would have been queued by the settled submission above, not by time.
+			// An erroneous retry would already be scheduled; drain continuations.
 			for (let i = 0; i < 25; i++) await new Promise((resolve) => setImmediate(resolve));
 			expect(prompt).toHaveBeenCalledOnce();
 			expect(fakeThis.showError).toHaveBeenCalledWith("daemon admission uncertain");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3249,7 +3249,9 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 			const blockedSubmission = fakeThis.defaultEditor.onSubmit?.("blocked user");
 			rejectStartup(new AgentConnectionPromptAdmissionError("daemon admission uncertain", status));
 			await blockedSubmission;
-			await new Promise((resolve) => setTimeout(resolve, 300));
+			// Drain scheduled continuations deterministically: an erroneous retry
+			// would have been queued by the settled submission above, not by time.
+			for (let i = 0; i < 25; i++) await new Promise((resolve) => setImmediate(resolve));
 			expect(prompt).toHaveBeenCalledOnce();
 			expect(fakeThis.showError).toHaveBeenCalledWith("daemon admission uncertain");
 			expect(fakeThis.promptStashState.stash).toEqual({

--- a/packages/coding-agent/test/prompt-admission.test.ts
+++ b/packages/coding-agent/test/prompt-admission.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../src/core/prompt-admission.js";
+
+describe("waitForPromptAdmission", () => {
+	it("observes already-running work when admission is pre-aborted", async () => {
+		const abort = new AbortController();
+		abort.abort();
+		const work = Promise.reject(new Error("late failure"));
+
+		await expect(waitForPromptAdmission(work, abort.signal)).rejects.toThrow("Prompt admission was cancelled.");
+		// Let the observed work settle; an unhandled rejection would fail Vitest.
+		await Promise.resolve();
+	});
+
+	it("rejects with the typed cancellation error when the signal aborts mid-wait", async () => {
+		const abort = new AbortController();
+		const wait = waitForPromptAdmission(new Promise(() => {}), abort.signal);
+		abort.abort();
+		await expect(wait).rejects.toBeInstanceOf(PromptAdmissionCancelledError);
+	});
+
+	it("passes work through untouched without a signal and settles with the work otherwise", async () => {
+		const resolved = Promise.resolve("value");
+		expect(waitForPromptAdmission(resolved, undefined)).toBe(resolved);
+		await expect(waitForPromptAdmission(resolved, new AbortController().signal)).resolves.toBe("value");
+		await expect(
+			waitForPromptAdmission(Promise.reject(new Error("work failed")), new AbortController().signal),
+		).rejects.toThrow("work failed");
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -5,7 +5,6 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { waitForPromptAdmission } from "../../src/core/agent-session.js";
 import type { BashResult } from "../../src/core/bash-executor.js";
 import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
@@ -33,15 +32,6 @@ function gateNextAgentStart(harness: Harness): { reached: Promise<void>; release
 }
 
 describe("AgentSession prompt characterization", () => {
-	it("observes already-running work when prompt admission is pre-aborted", async () => {
-		const abort = new AbortController();
-		abort.abort();
-		const work = Promise.reject(new Error("late idle failure"));
-
-		expect(() => waitForPromptAdmission(work, abort.signal)).toThrow("Prompt admission was cancelled");
-		await Promise.resolve();
-	});
-
 	const harnesses: Harness[] = [];
 	const tempDirs: string[] = [];
 

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1763,8 +1763,6 @@ prepared:${event.prompt}`,
 		releaseFirst?.();
 		await first.catch(() => undefined);
 		await harness.session.agent.waitForIdle();
-		// Deterministic settle point: the pump chain is quiescent, so an
-		// erroneously scheduled turn would already have called the provider.
 		await harness.session.waitForSessionInputIdle();
 
 		// The queued input must survive into the restart manifest instead of

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2717,7 +2717,7 @@ prepared:${event.prompt}`,
 	it("does not coalesce steering inputs that share a follow-up queue key", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
-		harness.session.pauseQueuedWork();
+		harness.session.acquireQueuedWorkPause();
 		withStreaming(harness, true);
 
 		await harness.session.steer("first", undefined, { queueKey: "same" });

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1763,7 +1763,9 @@ prepared:${event.prompt}`,
 		releaseFirst?.();
 		await first.catch(() => undefined);
 		await harness.session.agent.waitForIdle();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		// Deterministic settle point: the pump chain is quiescent, so an
+		// erroneously scheduled turn would already have called the provider.
+		await harness.session.waitForSessionInputIdle();
 
 		// The queued input must survive into the restart manifest instead of
 		// starting a fresh turn during teardown.

--- a/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
@@ -25,7 +25,7 @@ type SerializedInternals = {
 		abort: AbortController,
 	): Promise<unknown>;
 	_serializedRefine: boolean;
-	_steeringStopPending: boolean;
+	_steeringMessages: unknown[];
 	_pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
 	_assistantTurnsSinceAutoRefine: number;
 	_lastAutoRefineReviewAt: number;
@@ -310,7 +310,12 @@ describe("Serialized agent-callable refine", () => {
 		const internals = harness.session as unknown as SerializedInternals;
 		const { applyRefine } = mockSerializedRefine(harness);
 		internals._pendingRequestedRefine = { instructions: "capture a lesson" };
-		internals._steeringStopPending = true;
+		internals._steeringMessages.push({
+			kind: "prompt",
+			text: "steer",
+			prefixMessages: [],
+			message: { role: "user", content: "steer" },
+		});
 		const compactionSpy = vi
 			.spyOn(
 				internals as unknown as { _shouldStopForThresholdCompaction: (ctx: unknown) => Promise<boolean> },
@@ -1705,7 +1710,12 @@ describe("P0 concurrency regressions", () => {
 		});
 		harnesses.push(harness);
 		const internals = harness.session as unknown as SerializedInternals;
-		internals._steeringStopPending = true;
+		internals._steeringMessages.push({
+			kind: "prompt",
+			text: "steer",
+			prefixMessages: [],
+			message: { role: "user", content: "steer" },
+		});
 
 		let planResolved = false;
 		let applyFinished = false;

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -48,11 +48,6 @@ function refreshHarness() {
 	};
 }
 
-/**
- * These regressions exercise AgentsViewMode internals directly because the
- * mode class has no injectable seams yet. The guard turns a renamed/removed
- * private into an explicit failure instead of a cryptic undefined-call error.
- */
 function privateMethod<T>(name: string): T {
 	const member = Reflect.get(AgentsViewMode.prototype, name) as T;
 	if (typeof member !== "function") {

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -2,6 +2,7 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, test, vi } from "vitest";
 import { AgentsViewMode } from "../../../src/modes/agents-view/agents-view-mode.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
+import { createDeferred as deferred } from "../scheduling.js";
 
 function summary(id: string): SessionSummary {
 	return {
@@ -17,14 +18,6 @@ function summary(id: string): SessionSummary {
 		messageCount: 1,
 		pendingMessageCount: 0,
 	};
-}
-
-function deferred<T>() {
-	let resolve!: (value: T) => void;
-	const promise = new Promise<T>((done) => {
-		resolve = done;
-	});
-	return { promise, resolve };
 }
 
 function refreshHarness() {
@@ -55,8 +48,17 @@ function refreshHarness() {
 	};
 }
 
+/**
+ * These regressions exercise AgentsViewMode internals directly because the
+ * mode class has no injectable seams yet. The guard turns a renamed/removed
+ * private into an explicit failure instead of a cryptic undefined-call error.
+ */
 function privateMethod<T>(name: string): T {
-	return Reflect.get(AgentsViewMode.prototype, name) as T;
+	const member = Reflect.get(AgentsViewMode.prototype, name) as T;
+	if (typeof member !== "function") {
+		throw new Error(`AgentsViewMode.${name} no longer exists; update this regression harness`);
+	}
+	return member;
 }
 
 describe("#502 unified session view regressions", () => {

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -392,7 +392,7 @@ describe("#502 unified session view regressions", () => {
 
 	test.each(["reply", "rename"] as const)("%s refresh keeps the captured search filter", (mode) => {
 		const harness = {
-			replyActiveSessionId: mode === "reply" ? "active" : undefined,
+			replyTarget: mode === "reply" ? { key: "active", summary: {} } : undefined,
 			renameTarget: mode === "rename" ? { identity: "target" } : undefined,
 			actionModeSearchQuery: "needle",
 			editor: { getText: () => "action editor text" },


### PR DESCRIPTION
## What

Pressing space on an **inactive** (saved, non-resident) session now opens the same reply composer as on active sessions. Sending the message resumes the saved conversation into the daemon and delivers the prompt in one motion: the row migrates from Inactive to Running and the reply arrives as the next turn.

## How

The view was already unified at the data layer (`UnifiedSessionRecord`); this unifies the **action layer** where the reply path still branched on `activeSessionId`:

- `resumeSavedAgentsViewSession(client, config, summary)` extracts the create-with-`sessionPath` block from `openAgentsViewSession`, which now composes to "resume, then attach". The daemon's `create` with `sessionPath` is idempotent for the owning client (`reuseWorkerForCreate`), so a session that became active between the catalog refresh and Enter is reused, not double-resumed.
- The reply composer state (`replyActiveSessionId: string`) becomes `replyTarget: { key, summary }` — key stays `activeSessionId ?? id`, matching the selection-follow convention, so the arm/disarm lifecycle (query stash, placeholder, header, Escape/Left) is shared verbatim between live and saved targets.
- `sendReply` resolves the target: live → prompt directly (unchanged); saved → `resumeSavedAgentsViewSession` then the same `sendPrompt`, with selection pointed at the resumed row (identity aliases keep it stable across the id change).
- Preview: live targets keep `get_last_assistant_text`; saved targets use the persisted recap (`summary` / `firstMessage`) with no daemon round-trip.
- Footer hint reads `space resume` on inactive rows; the composer placeholder says "Write a prompt to resume this session".

Local-adapter mode keeps space disabled, as reply already was (nothing to resume into without a daemon).

## Notes

- A cwd-fallback notice from `resolveAgentsViewOpenCwd` is surfaced as a sticky status, same as the open path.
- If the prompt fails after the resume, the session intentionally stays resident (the user asked to wake it); the row shows truthfully in Idle.

## Testing

- New `agents-view-inactive-reply.test.ts`: composer arms on saved-only rows using the recap without a daemon call; rows with neither runtime nor file stay ignored; saved targets resume (create with `sessionPath`) before `prompt` and reselect the resumed row; live targets prompt without resuming.
- `agents-view-state`, `agents-view-missing-cwd`, `interactive-mode-startup` suites pass; `npm run check` and build pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session input pump, prompt admission, and daemon/supervisor prompt paths alongside new resume-on-send UX; behavior changes are covered by new and updated tests but runtime scheduling edge cases warrant review.
> 
> **Overview**
> **Agents view** extends the reply composer to **inactive** saved sessions: arming uses a `replyTarget` (`key` + `summary`) instead of only a live `activeSessionId`, shows a resume placeholder and persisted recap preview without a daemon call, and **send** resumes via shared `resumeSavedAgentsViewSession` then delivers the prompt (with `resolveCurrentReplyTargetSummary` for stale IDs). Submit/selection/status handling covers success, failure, cancellation, and sticky cwd notices; footer hints distinguish **resume** vs **reply**.
> 
> **Session core** moves `waitForPromptAdmission` / `PromptAdmissionCancelledError` into `prompt-admission.ts` (daemon, supervisor, and agent-session import it). `AgentSession` drops legacy `pauseQueuedWork`, makes `_steeringStopPending` a computed getter, tightens deferred session-input handling (busy requeue surfaces errors; extension error emit is try/caught), and simplifies `resumeQueuedWork` to always reschedule the pump.
> 
> **Tests** add `agents-view-inactive-reply.test.ts` and `prompt-admission.test.ts`; queue/restart tests use `waitForSessionInputIdle` / `acquireQueuedWorkPause`; serialized-refine tests seed steering via `_steeringMessages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e51bc0c151f4f4d13d510d6cebccc3363d35fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resume of saved sessions from the reply composer in agents view
> - Users can now arm the reply composer on inactive (saved-only) session rows; submitting the reply transparently resumes the session before delivering the prompt.
> - `AgentsViewMode.sendReply` resolves stale runtime IDs via a new `resolveCurrentReplyTargetSummary` helper, resumes via `resumeSavedAgentsViewSession` (idempotent create-with-sessionPath), then sends the prompt.
> - The composer placeholder changes to "Resume" when the target session is inactive, and help hints clarify resume vs. reply.
> - Prompt admission wait/cancel logic is extracted into a shared [`prompt-admission.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/528/files#diff-75f495f4ca7a4305169d34d4b859bdc733947cdd3223557df554595135c50b9c) module, replacing duplicated implementations in the daemon and supervisor.
> - `AgentSession._steeringStopPending` is converted from a mutable flag with side-effect updaters to a computed getter, and the legacy `pauseQueuedWork` API is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75e51bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->