### PR TITLE
retry failed production release builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -93,6 +93,9 @@ jobs:
                 echo "Retrying production v${production_version} for ${GITHUB_SHA_VALUE}."
               fi
               publish_production=true
+            elif ! git show-ref --verify --quiet "refs/tags/v${production_version}"; then
+              echo "Production v${production_version} has no tag; retrying the failed release."
+              publish_production=true
             else
               echo "Package version is unchanged at ${production_version}; only beta will advance."
             fi

--- a/packages/ai/test/openai-responses-reasoning-replay-e2e.test.ts
+++ b/packages/ai/test/openai-responses-reasoning-replay-e2e.test.ts
@@ -84,14 +84,14 @@ describe.skipIf(!process.env.OPENAI_API_KEY || !process.env.ANTHROPIC_API_KEY)(
 		it("handles same-provider different-model handoff with tool calls", { retry: 2 }, async () => {
 			// This tests the scenario where:
 			// 1. Model A (gpt-5-mini) generates reasoning + function_call
-			// 2. User switches to Model B (gpt-5.2-codex) - same provider, different model
+			// 2. User switches to Model B (gpt-5.4) - same provider, different model
 			// 3. transform-messages: isSameModel=false, thinking converted to text
 			// 4. But tool call ID still has OpenAI pairing history (fc_xxx paired with rs_xxx)
 			// 5. Without fix: OpenAI returns 400 "function_call without required reasoning item"
 			// 6. With fix: tool calls/results converted to text, conversation continues
 
 			const modelA = getModel("openai", "gpt-5-mini");
-			const modelB = getModel("openai", "gpt-5.2-codex");
+			const modelB = getModel("openai", "gpt-5.4");
 
 			const apiKey = getEnvApiKey("openai");
 			if (!apiKey) {
@@ -181,16 +181,16 @@ describe.skipIf(!process.env.OPENAI_API_KEY || !process.env.ANTHROPIC_API_KEY)(
 			expect(responseText).toContain("42");
 		});
 
-		it("handles cross-provider handoff from Anthropic to OpenAI Codex", { retry: 2 }, async () => {
+		it("handles cross-provider handoff from Anthropic to OpenAI", { retry: 2 }, async () => {
 			// This tests cross-provider handoff:
 			// 1. Anthropic model generates thinking + function_call (toolu_xxx ID)
-			// 2. User switches to OpenAI Codex
+			// 2. User switches to OpenAI
 			// 3. transform-messages: isSameModel=false, thinking converted to text
 			// 4. Tool call ID is Anthropic format (toolu_xxx), no OpenAI pairing history
 			// 5. Should work because foreign IDs have no pairing expectation
 
 			const anthropicModel = getModel("anthropic", "claude-sonnet-4-5");
-			const codexModel = getModel("openai", "gpt-5.2-codex");
+			const openaiModel = getModel("openai", "gpt-5.4");
 
 			const anthropicApiKey = getEnvApiKey("anthropic");
 			const openaiApiKey = getEnvApiKey("openai");
@@ -253,7 +253,7 @@ describe.skipIf(!process.env.OPENAI_API_KEY || !process.env.ANTHROPIC_API_KEY)(
 			};
 
 			let capturedPayload: any = null;
-			const response = await complete(codexModel, context, {
+			const response = await complete(openaiModel, context, {
 				apiKey: openaiApiKey,
 				reasoningEffort: "high",
 				onPayload: (payload) => {
@@ -266,7 +266,7 @@ describe.skipIf(!process.env.OPENAI_API_KEY || !process.env.ANTHROPIC_API_KEY)(
 			const functionCalls = input?.filter((item: any) => item.type === "function_call") || [];
 			const reasoningItems = input?.filter((item: any) => item.type === "reasoning") || [];
 
-			console.log("Payload sent to Codex:");
+			console.log("Payload sent to OpenAI:");
 			console.log("- function_calls:", functionCalls.length);
 			console.log("- reasoning items:", reasoningItems.length);
 			if (functionCalls.length > 0) {


### PR DESCRIPTION
- replaces a removed openai catalog model in reasoning replay tests so generated-model checks pass.
- retries an unchanged production version when its release tag is missing after a failed run.
- merging this should rebuild and publish stable 0.3.3 while still advancing beta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI release gating and test model IDs only; no runtime product logic changes.
> 
> **Overview**
> **Release workflow:** On pushes to `main`, if `package.json` version is unchanged from the previous commit, production publish is now enabled when the matching `v*` tag is missing—so a failed stable release (e.g. 0.3.3) can be retried on a later commit while beta still advances.
> 
> **Tests:** OpenAI reasoning-replay e2e cases now use **`gpt-5.4`** instead of removed **`gpt-5.2-codex`**, with comment/variable renames only; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c340a85d08d6c79a9c9f2213dbe278ed136f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry failed production release builds when the production tag is missing
> - In [build-binaries.yml](.github/workflows/build-binaries.yml), adds a fallback check: if the package version is unchanged but the expected tag `refs/tags/v${production_version}` does not exist, sets `publish_production=true` to retry the release instead of skipping it.
> - Updates e2e replay tests to target model `gpt-5.4` instead of `gpt-5.2-codex` and renames `codexModel`/`Codex` references to `openaiModel`/`OpenAI`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49c340a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->