### PR TITLE
recover daemon startup from empty owner records

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
+
 ## [0.3.3] - 2026-07-23
 
 - Removed the bundled orchestration heartbeat skill from the model system prompt.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -623,6 +623,12 @@ function readOwnerRecordForScope(
 		return owner;
 	}
 	const scope = readOwnerScope(directory);
+	if (!scope && readdirSync(directory).length === 0) {
+		const abandonedDirectory = `${directory}.abandoned-${randomUUID()}`;
+		renameSync(directory, abandonedDirectory);
+		rmSync(abandonedDirectory, { recursive: true, force: true });
+		return undefined;
+	}
 	if (!scope || isRelevant(scope)) {
 		throw new Error(`Invalid daemon supervisor owner record: ${directory}`);
 	}

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -891,6 +891,25 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		}
 	});
 
+	it("reclaims empty owner directories left by interrupted startup", async () => {
+		const paths = await createPaths();
+		const abandonedDirectory = join(paths.registryDir, "abandoned-owner.owner");
+		mkdirSync(abandonedDirectory, { recursive: true });
+
+		const owner = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "healthy-owner",
+			registryDir: paths.registryDir,
+			socketPath: paths.socketPath,
+		});
+
+		expect(existsSync(abandonedDirectory)).toBe(false);
+		expect(owner.record.generation).toBe("healthy-owner");
+		await owner.release();
+	});
+
 	it("persists a fence when immutable scope proves a corrupt owner is unrelated", async () => {
 		const paths = await createPaths();
 		const targetOwner = await acquireDaemonSupervisorOwnership({


### PR DESCRIPTION
- empty supervisor owner directories could permanently block daemon startup after updating.
- reclaim only empty orphan directories while preserving fail-closed behavior for malformed ownership metadata.
- covered by the daemon singleton regression suite, and full repository checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to orphan empty registry dirs during acquisition; corrupt or scoped ownership still errors as before.
> 
> **Overview**
> **Fixes daemon startup** when an interrupted supervisor leaves an **empty** `*.owner` registry directory (no `owner.json` or `scope.json`), which previously surfaced as a permanent **invalid owner record** error.
> 
> During ownership acquisition, `readOwnerRecordForScope` now **detects empty orphan directories**, renames them aside, deletes them, and treats them as absent so a new supervisor can take ownership. **Malformed or non-empty corrupt metadata still fails closed** unchanged.
> 
> Regression coverage was added in the supervisor singleton suite; the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50da80fe5120bf4f44887b3e6e320dcb4edb7d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon startup failure when supervisor leaves an empty ownership directory
> When an interrupted supervisor startup leaves behind an empty ownership directory, `readOwnerRecordForScope` in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/532/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) previously threw an error instead of recovering. The fix renames the empty directory to a `.abandoned-<uuid>` sibling, removes it, and returns `undefined`, allowing ownership acquisition to proceed normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50da80f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->