### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,10 +3,19 @@ name: Bug report
 description: Report something that isn't working as expected
 labels: ["bug"]
 body:
-  - type: markdown
+  - type: dropdown
+    id: package
     attributes:
-      value: |
-        Thanks for taking the time to file a bug report!
+      label: Package
+      description: Which package is affected? A maintainer will apply the matching `pkg:*` label.
+      options:
+        - agent
+        - ai
+        - coding-agent
+        - tui
+        - Not sure
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
@@ -36,7 +45,7 @@ body:
     id: actual
     attributes:
       label: Actual behavior
-      description: What actually happened. Include error messages, logs, or screenshots if possible.
+      description: What actually happened. Include error messages, logs, or screenshots if possible. Redact API keys, tokens, and other secrets before pasting.
     validations:
       required: true
   - type: input
@@ -62,6 +71,6 @@ body:
     id: context
     attributes:
       label: Additional context
-      description: Any other context, configuration, or environment details.
+      description: Any other context, configuration, or environment details. Redact secrets before sharing.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,67 @@
+---
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reliably reproduce the issue.
+      placeholder: |
+        1. Run `prime-agent ...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, logs, or screenshots if possible.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Prime Agent version
+      description: Output of `prime-agent --version`.
+      placeholder: "e.g. 0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, configuration, or environment details.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -1,0 +1,47 @@
+---
+name: Documentation improvement
+description: Report missing, incorrect, or unclear documentation
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief summary of the documentation gap or issue.
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Affected documentation
+      description: Which docs are affected? List file paths, section headings, or URLs.
+      placeholder: |
+        - docs/models.md — "Minimal Example" section
+        - docs/quickstart.md — "Authenticate" section
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing
+      description: Describe what is incorrect, outdated, unclear, or absent. Be specific — quote the text that needs changing if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: What should the docs say instead, or what content should be added?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context — links, screenshots, or related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -3,10 +3,19 @@ name: Documentation improvement
 description: Report missing, incorrect, or unclear documentation
 labels: ["documentation"]
 body:
-  - type: markdown
+  - type: dropdown
+    id: package
     attributes:
-      value: |
-        Thanks for helping improve the docs!
+      label: Package
+      description: Which package's docs are affected? A maintainer will apply the matching `pkg:*` label.
+      options:
+        - agent
+        - ai
+        - coding-agent
+        - tui
+        - Not sure / general
+    validations:
+      required: true
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,10 +3,19 @@ name: Feature request
 description: Suggest a new feature or enhancement
 labels: ["enhancement"]
 body:
-  - type: markdown
+  - type: dropdown
+    id: package
     attributes:
-      value: |
-        Thanks for suggesting a feature!
+      label: Package
+      description: Which package would this feature affect? A maintainer will apply the matching `pkg:*` label.
+      options:
+        - agent
+        - ai
+        - coding-agent
+        - tui
+        - Not sure
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+---
+name: Feature request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What are you trying to do that you can't today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see happen, and any ideas for how it could work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, mockups, or examples.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

This PR adds structured issue templates and a config file for the issue chooser.

## Templates

| Template | Labels | Purpose |
|----------|--------|---------|
| Bug report | `bug` | Report something that isn't working |
| Feature request | `enhancement` | Suggest a new feature or improvement |
| Documentation improvement | `documentation` | Report missing, incorrect, or unclear docs |

`config.yml` enables blank issues as a fallback (GitHub Discussions are not currently enabled on this repo).

## Motivation

The repository has no issue templates, so every issue starts from a blank page. Structured templates ensure:

- **Consistency** — reporters provide the right details (version, OS, reproduction steps) without being prompted.
- **Auto-labeling** — each template applies its label automatically, reducing triage overhead.
- **Lower friction** — a documentation-specific template is especially valuable since doc issues have different needs (affected file paths, suggested fixes) than code bugs.

## Testing

- Templates validated against the [GitHub issue form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).
- `config.yml` disables the discussions contact link (not enabled on this repo) and allows blank issues as a fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds GitHub issue template YAML; no application code, runtime behavior, or security-sensitive paths change.
> 
> **Overview**
> Introduces **structured GitHub issue forms** under `.github/ISSUE_TEMPLATE/` so new issues collect consistent triage details instead of starting empty.
> 
> The **bug report** template auto-applies the `bug` label and requires package, reproduction steps, expected vs actual behavior, `prime-agent --version`, and OS, with optional context and reminders to redact secrets. **Feature requests** get the `enhancement` label with required problem and proposed solution fields. **Documentation improvement** uses the `documentation` label and asks for affected paths/sections and what’s wrong or missing, with an optional suggested fix.
> 
> `config.yml` sets **`blank_issues_enabled: true`** so reporters can still open unstructured issues when none of the forms fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2970c4799eec5d1bd121b3331633a997b48ae3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub issue templates for bug reports, feature requests, and documentation improvements
> Adds three GitHub Issue Forms templates and a config file under `.github/ISSUE_TEMPLATE/`: bug reports, feature requests, and documentation improvements. Each template includes required fields for affected package and relevant details, with optional fields for additional context. Blank issues are also enabled via [config.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/533/files#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2970c47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->