### PR TITLE
feat(tui): new session shortcut and steer/queue reply delivery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added starting a new session directly from the agents view with `ctrl+n`.
+- Added queueing a reply as a follow-up with `alt+enter` in the agents-view reply composer; plain Enter now steers a streaming agent.
 - Fixed `prime-agent agents` opening a new chat when running with a process-local session.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -37,6 +37,7 @@ export interface AppKeybindings {
 	"app.agents.open": true;
 	"app.modal.back": true;
 	"app.agents.reply": true;
+	"app.agents.new": true;
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
@@ -123,6 +124,7 @@ export const KEYBINDINGS = {
 	"app.agents.open": { defaultKeys: "right", description: "Open chat view for selected agent" },
 	"app.modal.back": { defaultKeys: "left", description: "Go back / close the current dialog" },
 	"app.agents.reply": { defaultKeys: "space", description: "Reply to selected agent" },
+	"app.agents.new": { defaultKeys: "ctrl+n", description: "Start a new session from the agents view" },
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
@@ -247,6 +249,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	resume: "app.session.resume",
 	agentsBack: "app.agents.back",
 	agentsReply: "app.agents.reply",
+	agentsNew: "app.agents.new",
 	agentsDelete: "app.agents.delete",
 	agentsProgram: "app.agents.program",
 	agentsRename: "app.agents.rename",

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -651,6 +651,11 @@ export class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		if (this.keybindings.matches(data, "app.clear")) {
+			// The composer hints advertise ctrl+c as cancel; it must not start the exit flow.
+			if (this.replyTarget) {
+				this.setReplyTarget(undefined);
+				return;
+			}
 			this.handleCtrlC();
 			return;
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1469,36 +1469,52 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	/** Create a fresh daemon session and open it in the chat view. */
+	/**
+	 * Create a fresh daemon session and open it in the chat view. Runs over a
+	 * dedicated connection: finish() closes the shared client, which would
+	 * reject an in-flight create while the daemon still materializes the
+	 * session, making the orphan unkillable.
+	 */
 	private async createNewSession(): Promise<boolean> {
 		if (this.creatingNewSession || this.stopped) return false;
 		this.creatingNewSession = true;
-		const client = this.requireClient();
 		try {
-			this.setStatusMessage("Creating session...");
-			const response = await client.request({
-				type: "create",
-				config: this.options.config,
-				env: collectDaemonClientEnv(),
-			});
-			const created = expectSessionSummary(requireDaemonData(response));
-			// The view can finish while create is in flight; kill the fresh empty
-			// session instead of leaving an orphan resident in the agents list.
-			if (this.stopped) {
-				if (created.activeSessionId && client.isConnected) {
-					await client.request({ type: "kill", activeSessionId: created.activeSessionId }).catch(() => undefined);
+			const client = await this.connectDedicatedClient();
+			try {
+				this.setStatusMessage("Creating session...");
+				const response = await client.request({
+					type: "create",
+					config: this.options.config,
+					env: collectDaemonClientEnv(),
+				});
+				const created = expectSessionSummary(requireDaemonData(response));
+				// The view can finish while create is in flight; kill the fresh empty
+				// session instead of leaving an orphan resident in the agents list.
+				if (this.stopped) {
+					if (created.activeSessionId) {
+						await client
+							.request({ type: "kill", activeSessionId: created.activeSessionId })
+							.catch(() => undefined);
+					}
+					return false;
 				}
-				return false;
+				this.selectSummary(created);
+				this.finish({ type: "open", summary: created });
+				return true;
+			} finally {
+				client.close();
 			}
-			this.selectSummary(created);
-			this.finish({ type: "open", summary: created });
-			return true;
 		} catch (error) {
 			if (!this.stopped) this.setStatusMessage(formatError("Failed to create session", error));
 			return false;
 		} finally {
 			this.creatingNewSession = false;
 		}
+	}
+
+	/** A connection that outlives finish(), which closes the shared client. */
+	private async connectDedicatedClient(): Promise<DaemonClient> {
+		return connectAgentsViewDaemonClient(this.requireSocketPath());
 	}
 
 	/** Point selection (and its persisted key) at a freshly resumed session row. */

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1470,8 +1470,8 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	/** Create a fresh daemon session and open it in the chat view. */
-	private async createNewSession(): Promise<void> {
-		if (this.creatingNewSession || this.stopped) return;
+	private async createNewSession(): Promise<boolean> {
+		if (this.creatingNewSession || this.stopped) return false;
 		this.creatingNewSession = true;
 		const client = this.requireClient();
 		try {
@@ -1488,12 +1488,14 @@ export class AgentsViewMode implements Component, Focusable {
 				if (created.activeSessionId && client.isConnected) {
 					await client.request({ type: "kill", activeSessionId: created.activeSessionId }).catch(() => undefined);
 				}
-				return;
+				return false;
 			}
 			this.selectSummary(created);
 			this.finish({ type: "open", summary: created });
+			return true;
 		} catch (error) {
 			if (!this.stopped) this.setStatusMessage(formatError("Failed to create session", error));
+			return false;
 		} finally {
 			this.creatingNewSession = false;
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -20,6 +20,7 @@ import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connecti
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../daemon/daemon-client.js";
 import {
+	collectDaemonClientEnv,
 	type DaemonClosingReason,
 	type DaemonCommand,
 	type DaemonResponse,
@@ -499,6 +500,7 @@ export class AgentsViewMode implements Component, Focusable {
 	private selectionAnchorPending = false;
 	/** Armed reply composer target: a live agent or a saved session to resume on send. */
 	private replyTarget: { key: string; summary: SessionSummary } | undefined;
+	private creatingNewSession = false;
 	private replyLastAssistantText: string | undefined;
 	private replyLastAssistantTextLoading = false;
 	private replyHeaderTime = "";
@@ -669,6 +671,14 @@ export class AgentsViewMode implements Component, Focusable {
 			this.editor.getText().length === 0
 		) {
 			void this.toggleReplyTarget();
+			return;
+		}
+		if (!this.options.adapter && this.keybindings.matches(data, "app.agents.new")) {
+			void this.createNewSession();
+			return;
+		}
+		if (this.replyTarget && this.keybindings.matches(data, "app.message.followUp")) {
+			this.handleReplyFollowUp();
 			return;
 		}
 		if (this.editor.getText().length === 0 && this.keybindings.matches(data, "app.agents.program")) {
@@ -1044,7 +1054,7 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	private async submit(value: string): Promise<void> {
+	private async submit(value: string, delivery: "steer" | "followUp" = "steer"): Promise<void> {
 		if (this.renameTarget) {
 			await this.confirmRename(value);
 			return;
@@ -1054,7 +1064,7 @@ export class AgentsViewMode implements Component, Focusable {
 			const text = value.trim();
 			if (text) {
 				this.editor.setText("");
-				const sent = await this.sendReply(target, text);
+				const sent = await this.sendReply(target, text, delivery);
 				if (sent) {
 					if (this.replyTarget === target && this.editor.getText().length === 0) {
 						this.setReplyTarget(undefined);
@@ -1070,6 +1080,14 @@ export class AgentsViewMode implements Component, Focusable {
 		// The normal editor is search-only: Enter opens the selection and never
 		// interprets text as a command or a prompt for a new agent.
 		this.openSelected();
+	}
+
+	/** Alt+Enter in the reply composer queues the reply as a follow-up. */
+	private handleReplyFollowUp(): void {
+		if (!this.replyTarget) return;
+		const text = this.editor.getText();
+		if (!text.trim()) return;
+		void this.submit(text, "followUp");
 	}
 
 	private getSavedSessionCwd(): string {
@@ -1403,7 +1421,11 @@ export class AgentsViewMode implements Component, Focusable {
 		return data.text;
 	}
 
-	private async sendReply(target: { key: string; summary: SessionSummary }, text: string): Promise<boolean> {
+	private async sendReply(
+		target: { key: string; summary: SessionSummary },
+		text: string,
+		delivery: "steer" | "followUp" = "steer",
+	): Promise<boolean> {
 		const currentSummary = resolveCurrentReplyTargetSummary(this.unifiedRecords ?? [], target, (activeSessionId) =>
 			this.findSummaryByActiveSessionId(activeSessionId),
 		);
@@ -1432,7 +1454,7 @@ export class AgentsViewMode implements Component, Focusable {
 				// belongs to the current composer. Do not steal it after cancellation.
 				if (this.replyTarget === target) this.selectSummary(resumed.summary);
 			}
-			const behavior = liveSummary?.isStreaming ? "followUp" : undefined;
+			const behavior = delivery === "followUp" ? "followUp" : liveSummary?.isStreaming ? "steer" : undefined;
 			this.setStatusMessage("Sending reply...");
 			await this.sendPrompt(activeSessionId, text, behavior);
 			// The fallback-directory notice must outlive the transient send statuses.
@@ -1443,6 +1465,27 @@ export class AgentsViewMode implements Component, Focusable {
 			this.setStatusMessage(formatError("Failed to send reply", error));
 			if (didResume) await this.refreshSessions({ preserveStatusOnError: true });
 			return false;
+		}
+	}
+
+	/** Create a fresh daemon session and open it in the chat view. */
+	private async createNewSession(): Promise<void> {
+		if (this.creatingNewSession) return;
+		this.creatingNewSession = true;
+		try {
+			this.setStatusMessage("Creating session...");
+			const response = await this.requireClient().request({
+				type: "create",
+				config: this.options.config,
+				env: collectDaemonClientEnv(),
+			});
+			const created = expectSessionSummary(requireDaemonData(response));
+			this.selectSummary(created);
+			this.finish({ type: "open", summary: created });
+		} catch (error) {
+			this.setStatusMessage(formatError("Failed to create session", error));
+		} finally {
+			this.creatingNewSession = false;
 		}
 	}
 
@@ -2219,6 +2262,9 @@ export class AgentsViewMode implements Component, Focusable {
 			const hint = `${keyText("tui.select.confirm")} save   ${keyText("tui.select.cancel")} cancel`;
 			return truncateToWidth(theme.fg("muted", hint), width);
 		}
+		if (this.replyTarget) {
+			return truncateToWidth(theme.fg("muted", this.renderReplyComposerHints()), width);
+		}
 		// Replying is reserved for top-level agents; subagents can be stopped.
 		const selectedRow = this.rows[this.selectedIndex];
 		const selectedAgent = selectedRow?.kind === "agent";
@@ -2230,17 +2276,33 @@ export class AgentsViewMode implements Component, Focusable {
 			selectedAgent && !this.options.adapter
 				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
 				: undefined,
+			!this.options.adapter ? `${keyText("app.agents.new")} new` : undefined,
 			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
 			selectedAgent && (!this.options.adapter || selectedRow?.section === "inactive")
 				? `${keyText("app.agents.delete")} ${selectedRow?.section === "inactive" ? "delete" : "stop/deactivate"}`
 				: undefined,
 			selectedSubagent ? `${keyText("app.agents.delete")} stop` : undefined,
 			this.selectedRowCanShowProgram() ? `${keyText("app.agents.program")} program` : undefined,
-			this.replyTarget ? `${keyText("app.agents.back")} back` : undefined,
 		]
 			.filter((hint): hint is string => hint !== undefined)
 			.join("   ");
 		return truncateToWidth(theme.fg("muted", hints), width);
+	}
+
+	private renderReplyComposerHints(): string {
+		const target = this.replyTarget!;
+		const current = resolveCurrentReplyTargetSummary(this.unifiedRecords ?? [], target, (activeSessionId) =>
+			this.findSummaryByActiveSessionId(activeSessionId),
+		);
+		const streaming = current.activeSessionId !== undefined && current.isStreaming;
+		const hasText = this.editor.getText().trim().length > 0;
+		return [
+			`${keyText("tui.select.confirm")} ${streaming ? "steer" : current.activeSessionId ? "send" : "resume & send"}`,
+			hasText ? `${keyText("app.message.followUp")} queue` : undefined,
+			`${keyText("tui.select.cancel")} cancel`,
+		]
+			.filter((hint): hint is string => hint !== undefined)
+			.join("   ");
 	}
 
 	private visibleListRows(): number {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -673,7 +673,7 @@ export class AgentsViewMode implements Component, Focusable {
 			void this.toggleReplyTarget();
 			return;
 		}
-		if (!this.options.adapter && this.keybindings.matches(data, "app.agents.new")) {
+		if (!this.options.adapter && !this.replyTarget && this.keybindings.matches(data, "app.agents.new")) {
 			void this.createNewSession();
 			return;
 		}
@@ -1085,7 +1085,8 @@ export class AgentsViewMode implements Component, Focusable {
 	/** Alt+Enter in the reply composer queues the reply as a follow-up. */
 	private handleReplyFollowUp(): void {
 		if (!this.replyTarget) return;
-		const text = this.editor.getText();
+		// Unlike Enter, this path skips submitValue, so expand paste markers here.
+		const text = this.editor.getExpandedText();
 		if (!text.trim()) return;
 		void this.submit(text, "followUp");
 	}
@@ -1470,20 +1471,29 @@ export class AgentsViewMode implements Component, Focusable {
 
 	/** Create a fresh daemon session and open it in the chat view. */
 	private async createNewSession(): Promise<void> {
-		if (this.creatingNewSession) return;
+		if (this.creatingNewSession || this.stopped) return;
 		this.creatingNewSession = true;
+		const client = this.requireClient();
 		try {
 			this.setStatusMessage("Creating session...");
-			const response = await this.requireClient().request({
+			const response = await client.request({
 				type: "create",
 				config: this.options.config,
 				env: collectDaemonClientEnv(),
 			});
 			const created = expectSessionSummary(requireDaemonData(response));
+			// The view can finish while create is in flight; kill the fresh empty
+			// session instead of leaving an orphan resident in the agents list.
+			if (this.stopped) {
+				if (created.activeSessionId && client.isConnected) {
+					await client.request({ type: "kill", activeSessionId: created.activeSessionId }).catch(() => undefined);
+				}
+				return;
+			}
 			this.selectSummary(created);
 			this.finish({ type: "open", summary: created });
 		} catch (error) {
-			this.setStatusMessage(formatError("Failed to create session", error));
+			if (!this.stopped) this.setStatusMessage(formatError("Failed to create session", error));
 		} finally {
 			this.creatingNewSession = false;
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1469,12 +1469,7 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	/**
-	 * Create a fresh daemon session and open it in the chat view. Runs over a
-	 * dedicated connection: finish() closes the shared client, which would
-	 * reject an in-flight create while the daemon still materializes the
-	 * session, making the orphan unkillable.
-	 */
+	/** Create a fresh daemon session and open it in the chat view. */
 	private async createNewSession(): Promise<boolean> {
 		if (this.creatingNewSession || this.stopped) return false;
 		this.creatingNewSession = true;
@@ -1512,7 +1507,11 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	/** A connection that outlives finish(), which closes the shared client. */
+	/**
+	 * A connection that outlives finish(), which closes the shared client and
+	 * would reject an in-flight create while the daemon still materializes the
+	 * session, leaving that orphan unkillable.
+	 */
 	private async connectDedicatedClient(): Promise<DaemonClient> {
 		return connectAgentsViewDaemonClient(this.requireSocketPath());
 	}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1483,8 +1483,7 @@ export class AgentsViewMode implements Component, Focusable {
 					env: collectDaemonClientEnv(),
 				});
 				const created = expectSessionSummary(requireDaemonData(response));
-				// The view can finish while create is in flight; kill the fresh empty
-				// session instead of leaving an orphan resident in the agents list.
+				// The view can finish mid-create; kill the fresh session instead of orphaning it.
 				if (this.stopped) {
 					if (created.activeSessionId) {
 						await client
@@ -1508,9 +1507,8 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	/**
-	 * A connection that outlives finish(), which closes the shared client and
-	 * would reject an in-flight create while the daemon still materializes the
-	 * session, leaving that orphan unkillable.
+	 * Outlives finish(), which closes the shared client and would reject an
+	 * in-flight create while the daemon still materializes the session.
 	 */
 	private async connectDedicatedClient(): Promise<DaemonClient> {
 		return connectAgentsViewDaemonClient(this.requireSocketPath());

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -376,6 +376,24 @@ describe("agents view reply on inactive sessions", () => {
 		expect(submit).toHaveBeenCalledWith("expanded paste body", "followUp");
 	});
 
+	it("ctrl+c disarms the composer instead of starting the exit flow", () => {
+		const setReplyTarget = vi.fn();
+		const handleCtrlC = vi.fn();
+		const self: Record<string, unknown> = {
+			clearStickyStatusMessage: vi.fn(),
+			renameTarget: undefined,
+			keybindings: { matches: (_d: string, action: string) => action === "app.clear" },
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			setReplyTarget,
+			handleCtrlC,
+		};
+
+		invoke("handleInput", self, "\x03");
+
+		expect(setReplyTarget).toHaveBeenCalledWith(undefined);
+		expect(handleCtrlC).not.toHaveBeenCalled();
+	});
+
 	it("creates a new daemon session over a dedicated connection and opens it", async () => {
 		const created = summary({ id: "active-new", activeSessionId: "active-new", lifecycle: "live" });
 		const request = vi.fn(async () => ({ success: true, data: created }));

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -408,14 +408,15 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.selectSummary).not.toHaveBeenCalled();
 	});
 
-	it("creates a new daemon session and opens it", async () => {
+	it("creates a new daemon session over a dedicated connection and opens it", async () => {
 		const created = summary({ id: "active-new", activeSessionId: "active-new", lifecycle: "live" });
 		const request = vi.fn(async () => ({ success: true, data: created }));
+		const close = vi.fn();
 		const finish = vi.fn();
 		const self: Record<string, unknown> = {
 			creatingNewSession: false,
 			options: { config: { cwd: process.cwd() } },
-			requireClient: () => ({ request }),
+			connectDedicatedClient: vi.fn(async () => ({ request, close })),
 			setStatusMessage: vi.fn(),
 			selectSummary: vi.fn(),
 			finish,
@@ -426,6 +427,7 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "create" }));
 		expect(self.selectSummary).toHaveBeenCalledWith(created);
 		expect(finish).toHaveBeenCalledWith({ type: "open", summary: created });
+		expect(close).toHaveBeenCalled();
 	});
 
 	it("kills a session created after the view already finished", async () => {
@@ -435,15 +437,15 @@ describe("agents view reply on inactive sessions", () => {
 			creatingNewSession: false,
 			stopped: false,
 			options: { config: {} },
-			requireClient: () => ({
-				isConnected: true,
+			connectDedicatedClient: vi.fn(async () => ({
+				close: vi.fn(),
 				request: vi.fn(async (command: { type: string }) => {
 					requests.push(command);
 					// The view finishes while create is in flight.
 					self.stopped = true;
 					return { success: true, data: created };
 				}),
-			}),
+			})),
 			setStatusMessage: vi.fn(),
 			selectSummary: vi.fn(),
 			finish: vi.fn(),
@@ -478,16 +480,30 @@ describe("agents view reply on inactive sessions", () => {
 		const self: Record<string, unknown> = {
 			creatingNewSession: false,
 			options: { config: {} },
-			requireClient: () => ({ request }),
+			connectDedicatedClient: vi.fn(async () => ({ request, close: vi.fn() })),
 			setStatusMessage,
 			selectSummary: vi.fn(),
 			finish,
 		};
 
-		await invoke("createNewSession", self);
+		await expect(invoke("createNewSession", self)).resolves.toBe(false);
 
 		expect(finish).not.toHaveBeenCalled();
 		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("Failed to create session"));
+		expect(self.creatingNewSession).toBe(false);
+	});
+
+	it("resets the guard when no daemon connection is available", async () => {
+		const self: Record<string, unknown> = {
+			creatingNewSession: false,
+			options: { config: {} },
+			connectDedicatedClient: vi.fn(async () => {
+				throw new Error("Agents view daemon socket is not configured");
+			}),
+			setStatusMessage: vi.fn(),
+		};
+
+		await expect(invoke("createNewSession", self)).resolves.toBe(false);
 		expect(self.creatingNewSession).toBe(false);
 	});
 

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -367,7 +367,7 @@ describe("agents view reply on inactive sessions", () => {
 		const submit = vi.fn(async () => {});
 		const self = {
 			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
-			editor: { getText: () => "queued reply" },
+			editor: { getExpandedText: () => "queued reply" },
 			submit,
 		};
 
@@ -378,10 +378,10 @@ describe("agents view reply on inactive sessions", () => {
 
 	it("ignores the follow-up keybinding without an armed target or text", () => {
 		const submit = vi.fn(async () => {});
-		invoke("handleReplyFollowUp", { replyTarget: undefined, editor: { getText: () => "text" }, submit });
+		invoke("handleReplyFollowUp", { replyTarget: undefined, editor: { getExpandedText: () => "text" }, submit });
 		invoke("handleReplyFollowUp", {
 			replyTarget: { key: "a", summary: summary({}) },
-			editor: { getText: () => "   " },
+			editor: { getExpandedText: () => "   " },
 			submit,
 		});
 		expect(submit).not.toHaveBeenCalled();
@@ -426,6 +426,47 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "create" }));
 		expect(self.selectSummary).toHaveBeenCalledWith(created);
 		expect(finish).toHaveBeenCalledWith({ type: "open", summary: created });
+	});
+
+	it("kills a session created after the view already finished", async () => {
+		const created = summary({ id: "active-new", activeSessionId: "active-new", lifecycle: "live" });
+		const requests: { type: string }[] = [];
+		const self: Record<string, unknown> = {
+			creatingNewSession: false,
+			stopped: false,
+			options: { config: {} },
+			requireClient: () => ({
+				isConnected: true,
+				request: vi.fn(async (command: { type: string }) => {
+					requests.push(command);
+					// The view finishes while create is in flight.
+					self.stopped = true;
+					return { success: true, data: created };
+				}),
+			}),
+			setStatusMessage: vi.fn(),
+			selectSummary: vi.fn(),
+			finish: vi.fn(),
+		};
+
+		await invoke("createNewSession", self);
+
+		expect(requests.map((r) => r.type)).toEqual(["create", "kill"]);
+		expect(self.finish).not.toHaveBeenCalled();
+		expect(self.selectSummary).not.toHaveBeenCalled();
+	});
+
+	it("expands paste markers for the alt+enter follow-up path", () => {
+		const submit = vi.fn(async () => {});
+		const self = {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			editor: { getExpandedText: () => "expanded paste body" },
+			submit,
+		};
+
+		invoke("handleReplyFollowUp", self);
+
+		expect(submit).toHaveBeenCalledWith("expanded paste body", "followUp");
 	});
 
 	it("reports a create failure without leaving the view", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -331,23 +331,7 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
 	});
 
-	it("queues a follow-up when Alt+Enter delivery is requested", async () => {
-		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
-		const self: Record<string, unknown> = {
-			options: { config: {} },
-			requireClient: () => ({ request: vi.fn() }),
-			findSummaryByActiveSessionId: () => liveSummary,
-			setStatusMessage: vi.fn(),
-			selectSummary: vi.fn(),
-			sendPrompt: vi.fn(async () => {}),
-		};
-
-		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "later please", "followUp");
-
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "later please", "followUp");
-	});
-
-	it("steers a streaming session on plain submit", async () => {
+	it("steers on plain submit and queues a follow-up on Alt+Enter delivery", async () => {
 		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
 		const self: Record<string, unknown> = {
 			options: { config: {} },
@@ -359,21 +343,10 @@ describe("agents view reply on inactive sessions", () => {
 		};
 
 		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "change course");
-
 		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "change course", "steer");
-	});
 
-	it("routes the follow-up keybinding through submit with followUp delivery", () => {
-		const submit = vi.fn(async () => {});
-		const self = {
-			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
-			editor: { getExpandedText: () => "queued reply" },
-			submit,
-		};
-
-		invoke("handleReplyFollowUp", self);
-
-		expect(submit).toHaveBeenCalledWith("queued reply", "followUp");
+		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "later please", "followUp");
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "later please", "followUp");
 	});
 
 	it("ignores the follow-up keybinding without an armed target or text", () => {
@@ -458,7 +431,7 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.selectSummary).not.toHaveBeenCalled();
 	});
 
-	it("expands paste markers for the alt+enter follow-up path", () => {
+	it("submits the expanded editor text with followUp delivery on alt+enter", () => {
 		const submit = vi.fn(async () => {});
 		const self = {
 			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
@@ -471,38 +444,33 @@ describe("agents view reply on inactive sessions", () => {
 		expect(submit).toHaveBeenCalledWith("expanded paste body", "followUp");
 	});
 
-	it("reports a create failure without leaving the view", async () => {
-		const request = vi.fn(async () => {
-			throw new Error("daemon busy");
-		});
+	it("reports create failures and resets the guard", async () => {
+		// Failure after connecting.
 		const finish = vi.fn();
 		const setStatusMessage = vi.fn();
 		const self: Record<string, unknown> = {
 			creatingNewSession: false,
 			options: { config: {} },
-			connectDedicatedClient: vi.fn(async () => ({ request, close: vi.fn() })),
+			connectDedicatedClient: vi.fn(async () => ({
+				request: vi.fn(async () => {
+					throw new Error("daemon busy");
+				}),
+				close: vi.fn(),
+			})),
 			setStatusMessage,
 			selectSummary: vi.fn(),
 			finish,
 		};
-
 		await expect(invoke("createNewSession", self)).resolves.toBe(false);
-
 		expect(finish).not.toHaveBeenCalled();
 		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("Failed to create session"));
 		expect(self.creatingNewSession).toBe(false);
-	});
 
-	it("resets the guard when no daemon connection is available", async () => {
-		const self: Record<string, unknown> = {
-			creatingNewSession: false,
-			options: { config: {} },
-			connectDedicatedClient: vi.fn(async () => {
-				throw new Error("Agents view daemon socket is not configured");
-			}),
-			setStatusMessage: vi.fn(),
-		};
-
+		// Failure to connect at all must also reset the guard.
+		self.creatingNewSession = false;
+		self.connectDedicatedClient = vi.fn(async () => {
+			throw new Error("Agents view daemon socket is not configured");
+		});
 		await expect(invoke("createNewSession", self)).resolves.toBe(false);
 		expect(self.creatingNewSession).toBe(false);
 	});

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -331,25 +331,34 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
 	});
 
-	it("steers on plain submit and queues a follow-up on Alt+Enter delivery", async () => {
-		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
+	it("replies to live sessions without resuming, steering or queueing per delivery", async () => {
+		let liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const request = vi.fn();
 		const self: Record<string, unknown> = {
 			options: { config: {} },
-			requireClient: () => ({ request: vi.fn() }),
+			requireClient: () => ({ request }),
 			findSummaryByActiveSessionId: () => liveSummary,
 			setStatusMessage: vi.fn(),
 			selectSummary: vi.fn(),
 			sendPrompt: vi.fn(async () => {}),
 		};
+		const target = () => ({ key: "active-1", summary: liveSummary });
 
-		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "change course");
+		await invoke("sendReply", self, target(), "hello");
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "hello", undefined);
+
+		liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
+		await invoke("sendReply", self, target(), "change course");
 		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "change course", "steer");
 
-		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "later please", "followUp");
+		await invoke("sendReply", self, target(), "later please", "followUp");
 		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "later please", "followUp");
+
+		expect(request).not.toHaveBeenCalled();
+		expect(self.selectSummary).not.toHaveBeenCalled();
 	});
 
-	it("ignores the follow-up keybinding without an armed target or text", () => {
+	it("alt+enter submits expanded text as followUp, only with an armed target and text", () => {
 		const submit = vi.fn(async () => {});
 		invoke("handleReplyFollowUp", { replyTarget: undefined, editor: { getExpandedText: () => "text" }, submit });
 		invoke("handleReplyFollowUp", {
@@ -358,27 +367,13 @@ describe("agents view reply on inactive sessions", () => {
 			submit,
 		});
 		expect(submit).not.toHaveBeenCalled();
-	});
 
-	it("replies to live sessions without resuming", async () => {
-		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const request = vi.fn();
-		const self: Record<string, unknown> = {
-			options: { config: {} },
-			requireClient: () => ({ request }),
-			findSummaryByActiveSessionId: () => liveSummary,
-			setStatusMessage: vi.fn(),
-			setReplyTarget: vi.fn(),
-			refreshSessions: vi.fn(async () => true),
-			selectSummary: vi.fn(),
-			sendPrompt: vi.fn(async () => {}),
-		};
-
-		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "hello");
-
-		expect(request).not.toHaveBeenCalled();
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "hello", undefined);
-		expect(self.selectSummary).not.toHaveBeenCalled();
+		invoke("handleReplyFollowUp", {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			editor: { getExpandedText: () => "expanded paste body" },
+			submit,
+		});
+		expect(submit).toHaveBeenCalledWith("expanded paste body", "followUp");
 	});
 
 	it("creates a new daemon session over a dedicated connection and opens it", async () => {
@@ -429,19 +424,6 @@ describe("agents view reply on inactive sessions", () => {
 		expect(requests.map((r) => r.type)).toEqual(["create", "kill"]);
 		expect(self.finish).not.toHaveBeenCalled();
 		expect(self.selectSummary).not.toHaveBeenCalled();
-	});
-
-	it("submits the expanded editor text with followUp delivery on alt+enter", () => {
-		const submit = vi.fn(async () => {});
-		const self = {
-			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
-			editor: { getExpandedText: () => "expanded paste body" },
-			submit,
-		};
-
-		invoke("handleReplyFollowUp", self);
-
-		expect(submit).toHaveBeenCalledWith("expanded paste body", "followUp");
 	});
 
 	it("reports create failures and resets the guard", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { setKeybindings } from "@earendil-works/pi-tui";
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
 import { AgentsViewMode } from "../src/modes/agents-view/agents-view-mode.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 
@@ -37,6 +40,10 @@ function editorWithText(initial: string) {
 }
 
 describe("agents view reply on inactive sessions", () => {
+	beforeAll(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
 	const savedSummary = summary({
 		sessionFile: "/tmp/sessions/saved-1.jsonl",
 		cwd: process.cwd(),
@@ -111,7 +118,7 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
 		);
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", "followUp");
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", "steer");
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
@@ -324,6 +331,62 @@ describe("agents view reply on inactive sessions", () => {
 		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
 	});
 
+	it("queues a follow-up when Alt+Enter delivery is requested", async () => {
+		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
+		const self: Record<string, unknown> = {
+			options: { config: {} },
+			requireClient: () => ({ request: vi.fn() }),
+			findSummaryByActiveSessionId: () => liveSummary,
+			setStatusMessage: vi.fn(),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "later please", "followUp");
+
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "later please", "followUp");
+	});
+
+	it("steers a streaming session on plain submit", async () => {
+		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
+		const self: Record<string, unknown> = {
+			options: { config: {} },
+			requireClient: () => ({ request: vi.fn() }),
+			findSummaryByActiveSessionId: () => liveSummary,
+			setStatusMessage: vi.fn(),
+			selectSummary: vi.fn(),
+			sendPrompt: vi.fn(async () => {}),
+		};
+
+		await invoke("sendReply", self, { key: "active-1", summary: liveSummary }, "change course");
+
+		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "change course", "steer");
+	});
+
+	it("routes the follow-up keybinding through submit with followUp delivery", () => {
+		const submit = vi.fn(async () => {});
+		const self = {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			editor: { getText: () => "queued reply" },
+			submit,
+		};
+
+		invoke("handleReplyFollowUp", self);
+
+		expect(submit).toHaveBeenCalledWith("queued reply", "followUp");
+	});
+
+	it("ignores the follow-up keybinding without an armed target or text", () => {
+		const submit = vi.fn(async () => {});
+		invoke("handleReplyFollowUp", { replyTarget: undefined, editor: { getText: () => "text" }, submit });
+		invoke("handleReplyFollowUp", {
+			replyTarget: { key: "a", summary: summary({}) },
+			editor: { getText: () => "   " },
+			submit,
+		});
+		expect(submit).not.toHaveBeenCalled();
+	});
+
 	it("replies to live sessions without resuming", async () => {
 		const liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live" });
 		const request = vi.fn();
@@ -343,5 +406,72 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).not.toHaveBeenCalled();
 		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "hello", undefined);
 		expect(self.selectSummary).not.toHaveBeenCalled();
+	});
+
+	it("creates a new daemon session and opens it", async () => {
+		const created = summary({ id: "active-new", activeSessionId: "active-new", lifecycle: "live" });
+		const request = vi.fn(async () => ({ success: true, data: created }));
+		const finish = vi.fn();
+		const self: Record<string, unknown> = {
+			creatingNewSession: false,
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			setStatusMessage: vi.fn(),
+			selectSummary: vi.fn(),
+			finish,
+		};
+
+		await invoke("createNewSession", self);
+
+		expect(request).toHaveBeenCalledWith(expect.objectContaining({ type: "create" }));
+		expect(self.selectSummary).toHaveBeenCalledWith(created);
+		expect(finish).toHaveBeenCalledWith({ type: "open", summary: created });
+	});
+
+	it("reports a create failure without leaving the view", async () => {
+		const request = vi.fn(async () => {
+			throw new Error("daemon busy");
+		});
+		const finish = vi.fn();
+		const setStatusMessage = vi.fn();
+		const self: Record<string, unknown> = {
+			creatingNewSession: false,
+			options: { config: {} },
+			requireClient: () => ({ request }),
+			setStatusMessage,
+			selectSummary: vi.fn(),
+			finish,
+		};
+
+		await invoke("createNewSession", self);
+
+		expect(finish).not.toHaveBeenCalled();
+		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("Failed to create session"));
+		expect(self.creatingNewSession).toBe(false);
+	});
+
+	it("shows composer-mode hints that track target state and typed text", () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
+		const self: Record<string, unknown> = {
+			replyTarget: { key: "active-1", summary: live },
+			unifiedRecords: [],
+			findSummaryByActiveSessionId: () => live,
+			editor: editorWithText(""),
+		};
+
+		const idleHints = stripAnsi(invoke("renderReplyComposerHints", self) as string);
+		expect(idleHints).toContain("steer");
+		expect(idleHints).toContain("cancel");
+		expect(idleHints).not.toContain("queue");
+
+		self.editor = editorWithText("some reply");
+		const typedHints = stripAnsi(invoke("renderReplyComposerHints", self) as string);
+		expect(typedHints).toContain("queue");
+
+		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl" });
+		self.replyTarget = { key: "saved-1", summary: saved };
+		self.findSummaryByActiveSessionId = () => undefined;
+		const savedHints = stripAnsi(invoke("renderReplyComposerHints", self) as string);
+		expect(savedHints).toContain("resume & send");
 	});
 });


### PR DESCRIPTION
Stacked on #528 (`feat/space-reply-inactive`).

First of three composer follow-ups to the unified session view.

## What

- **New session from the agents view**: `ctrl+n` (`app.agents.new`, configurable) creates a fresh daemon session and opens it in the chat view. Creation runs over a dedicated short-lived connection so a view that finishes mid-create can still kill the fresh session instead of orphaning it; the shortcut is inert while the reply composer is armed.
- **Reply delivery choice in the space composer**: Enter now **steers** a streaming agent (previously replies were silently queued as follow-ups); `alt+enter` (`app.message.followUp`, same binding as the in-session editor) **queues** the reply as a follow-up, expanding paste markers like Enter does.
- **Mode-aware hints**: while the composer is armed, the bottom hint row switches to composer hints — `⏎ steer` / `send` / `resume & send` (tracks the live target's streaming/inactive state), `⌥⏎ queue` (shown once text is typed), and `esc cancel`. Search mode keeps the existing hints.

## Why

The reply composer previously always queued, with no way to steer a running agent and no indication of what Enter would do. Delivery reuses the existing `streamingBehavior` plumbing end to end; no daemon protocol changes.

## Tests

`agents-view-inactive-reply.test.ts`: delivery threading through `submit`/`sendReply` (no-steer when idle, steer when streaming, queue via alt+enter, ignore without target/text), `createNewSession` success, orphan-kill after the view finished, failure/guard-reset paths, and composer-hint states (steer vs send vs resume & send, queue only with text).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI and agents-view input/hint changes only; prompt delivery reuses existing daemon `streamingBehavior` with no protocol changes.
> 
> **Overview**
> Extends the **agents view** with faster session creation and explicit control over how replies are delivered to running agents.
> 
> **`ctrl+n`** (`app.agents.new`) starts a **new daemon session** and opens it in chat. Creation uses a **dedicated short-lived daemon client** so an in-flight create can still **kill** the new session if the view exits mid-request; the shortcut is disabled while the reply composer is armed.
> 
> In the **space reply composer**, **Enter** now **steers** streaming agents (via existing `streamingBehavior: "steer"`) instead of implicitly queueing; **`alt+enter`** queues a **follow-up** (`followUp`), expanding paste markers like Enter. **`ctrl+c`** cancels the composer without triggering the double-press exit flow. Bottom hints switch to **composer mode** (steer / send / resume & send, queue when text is present, cancel).
> 
> Adds **`app.agents.new`** to keybindings and expands **`agents-view-inactive-reply`** tests for delivery modes, follow-up submission, create/orphan-kill paths, and hint text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2809ea4a9729f45931732423b3f07166adb2e3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ctrl+n` new session shortcut and rework steer/queue reply delivery in agents view
> - `ctrl+n` in the agents view creates a new daemon session via a dedicated client and opens it; if the view is closed mid-create, the session is killed to avoid orphaning.
> - `Enter` in the reply composer now steers a live streaming agent (`behavior='steer'`) instead of queueing a follow-up.
> - `Alt+Enter` queues the composed text as a follow-up (`behavior='followUp'`).
> - `ctrl+c` while the reply composer is active now cancels the composer instead of triggering the exit flow.
> - Footer hints update dynamically to reflect composer state, including the new steer/queue/cancel verbs and the `new` shortcut.
> - Behavioral Change: previously, sending a reply while a session was streaming implicitly used `followUp`; it now uses `steer` by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2809ea4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->