### PR TITLE
feat(tui): session-owned slash commands in the reply composer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added starting a new session directly from the agents view with `ctrl+n`.
 - Added queueing a reply as a follow-up with `alt+enter` in the agents-view reply composer; plain Enter now steers a streaming agent.
+- Added session-owned slash commands (`/compact`, `/refine`, `/goal`, `/autonomous`) with autocomplete to the agents-view reply composer; other built-in commands are rejected with guidance instead of being sent as prompt text.
 - Fixed `prime-agent agents` opening a new chat when running with a process-local session.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -581,9 +581,8 @@ export class AgentsViewMode implements Component, Focusable {
 			placeholder: SEARCH_PROMPT_PLACEHOLDER,
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
-		// Search mode must not autocomplete; the provider only answers while a
-		// reply target is armed. Rebuilt on arming so @-paths resolve in the
-		// target session's cwd, not the view's startup directory.
+		// The provider only answers while a target is armed; rebuilt on arming so
+		// @-paths resolve in the target's cwd, not the view's startup directory.
 		void ensureTool("fd").then((fdPath) => {
 			this.fdPath = fdPath;
 			// Rebind an already-armed provider so @-completion picks up fd.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -25,6 +25,7 @@ import {
 	resolveBuiltinSlashCommandName,
 } from "../../core/slash-commands.js";
 import { canonicalizePath } from "../../utils/paths.js";
+import { ensureTool } from "../../utils/tools-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../daemon/daemon-client.js";
@@ -459,7 +460,7 @@ export function getReplyComposerCommandRejection(text: string): string | undefin
 }
 
 /** Autocomplete for the reply composer: session-owned slash commands only. */
-export function createReplyComposerAutocompleteProvider(cwd: string): AutocompleteProvider {
+export function createReplyComposerAutocompleteProvider(cwd: string, fdPath?: string): AutocompleteProvider {
 	const sessionCommands = BUILTIN_SLASH_COMMANDS.filter((command) => isSessionSlashCommandName(command.name)).map(
 		(command) => ({
 			name: command.name,
@@ -469,7 +470,7 @@ export function createReplyComposerAutocompleteProvider(cwd: string): Autocomple
 			takesArgument: command.takesArgument,
 		}),
 	);
-	return new CombinedAutocompleteProvider(sessionCommands, cwd);
+	return new CombinedAutocompleteProvider(sessionCommands, cwd, fdPath ?? null);
 }
 
 export function resolveCurrentReplyTargetSummary(
@@ -539,6 +540,7 @@ export class AgentsViewMode implements Component, Focusable {
 	private replyTarget: { key: string; summary: SessionSummary } | undefined;
 	/** Provider bound to the armed target's cwd for file-path completions. */
 	private replyAutocomplete: AutocompleteProvider | undefined;
+	private fdPath: string | undefined;
 	private creatingNewSession = false;
 	private replyLastAssistantText: string | undefined;
 	private replyLastAssistantTextLoading = false;
@@ -582,6 +584,13 @@ export class AgentsViewMode implements Component, Focusable {
 		// Search mode must not autocomplete; the provider only answers while a
 		// reply target is armed. Rebuilt on arming so @-paths resolve in the
 		// target session's cwd, not the view's startup directory.
+		void ensureTool("fd").then((fdPath) => {
+			this.fdPath = fdPath;
+			// Rebind an already-armed provider so @-completion picks up fd.
+			if (this.replyTarget) {
+				this.replyAutocomplete = createReplyComposerAutocompleteProvider(this.replyTarget.summary.cwd, fdPath);
+			}
+		});
 		this.editor.setAutocompleteProvider({
 			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) =>
 				this.replyTarget && this.replyAutocomplete
@@ -1358,7 +1367,9 @@ export class AgentsViewMode implements Component, Focusable {
 			this.actionModeSearchQuery = undefined;
 		}
 		this.replyTarget = target;
-		this.replyAutocomplete = target ? createReplyComposerAutocompleteProvider(target.summary.cwd) : undefined;
+		this.replyAutocomplete = target
+			? createReplyComposerAutocompleteProvider(target.summary.cwd, this.fdPath)
+			: undefined;
 		this.replyLastAssistantText = undefined;
 		this.replyLastAssistantTextLoading = false;
 		this.replyHeaderTime = target

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -537,6 +537,8 @@ export class AgentsViewMode implements Component, Focusable {
 	private selectionAnchorPending = false;
 	/** Armed reply composer target: a live agent or a saved session to resume on send. */
 	private replyTarget: { key: string; summary: SessionSummary } | undefined;
+	/** Provider bound to the armed target's cwd for file-path completions. */
+	private replyAutocomplete: AutocompleteProvider | undefined;
 	private creatingNewSession = false;
 	private replyLastAssistantText: string | undefined;
 	private replyLastAssistantTextLoading = false;
@@ -577,14 +579,18 @@ export class AgentsViewMode implements Component, Focusable {
 			placeholder: SEARCH_PROMPT_PLACEHOLDER,
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
-		const replyAutocomplete = createReplyComposerAutocompleteProvider(options.uiServices.getInitialCwd());
 		// Search mode must not autocomplete; the provider only answers while a
-		// reply target is armed.
+		// reply target is armed. Rebuilt on arming so @-paths resolve in the
+		// target session's cwd, not the view's startup directory.
 		this.editor.setAutocompleteProvider({
 			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) =>
-				this.replyTarget ? replyAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) : null,
+				this.replyTarget && this.replyAutocomplete
+					? this.replyAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions)
+					: null,
 			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
-				replyAutocomplete.applyCompletion(lines, cursorLine, cursorCol, item, prefix),
+				(
+					this.replyAutocomplete ?? createReplyComposerAutocompleteProvider(this.getSavedSessionCwd())
+				).applyCompletion(lines, cursorLine, cursorCol, item, prefix),
 		});
 		this.editor.focused = true;
 		this.editor.getHeaderLine = () => this.renderReplyHeaderLine();
@@ -1110,6 +1116,8 @@ export class AgentsViewMode implements Component, Focusable {
 			const text = value.trim();
 			const rejection = getReplyComposerCommandRejection(text);
 			if (rejection) {
+				// submitValue cleared the buffer before onSubmit; keep the draft.
+				if (this.editor.getText().length === 0) this.editor.setText(value);
 				this.setStatusMessage(rejection, { tone: "warning" });
 				return;
 			}
@@ -1350,6 +1358,7 @@ export class AgentsViewMode implements Component, Focusable {
 			this.actionModeSearchQuery = undefined;
 		}
 		this.replyTarget = target;
+		this.replyAutocomplete = target ? createReplyComposerAutocompleteProvider(target.summary.cwd) : undefined;
 		this.replyLastAssistantText = undefined;
 		this.replyLastAssistantTextLoading = false;
 		this.replyHeaderTime = target

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import {
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
 	type Component,
 	clippedFullscreenDockHeight,
 	type Focusable,
@@ -15,6 +17,13 @@ import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSI
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { SessionManager } from "../../core/session-manager.js";
+import {
+	BUILTIN_SLASH_COMMANDS,
+	isBuiltinSlashCommandName,
+	isSessionSlashCommandName,
+	parseSlashCommand,
+	resolveBuiltinSlashCommandName,
+} from "../../core/slash-commands.js";
 import { canonicalizePath } from "../../utils/paths.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
@@ -435,6 +444,34 @@ export async function runAgentsViewMode(options: Omit<AgentsViewModeOptions, "ad
 	}
 }
 
+/**
+ * The reply composer delivers text through the daemon prompt path, which only
+ * executes session-owned slash commands. Reject other recognized built-ins
+ * instead of sending them to the model as plain text.
+ */
+export function getReplyComposerCommandRejection(text: string): string | undefined {
+	const parsed = parseSlashCommand(text);
+	if (!parsed) return undefined;
+	const name = resolveBuiltinSlashCommandName(parsed.name);
+	if (isSessionSlashCommandName(name)) return undefined;
+	if (!isBuiltinSlashCommandName(parsed.name)) return undefined;
+	return `/${parsed.name} is not available here; open the session to run it`;
+}
+
+/** Autocomplete for the reply composer: session-owned slash commands only. */
+export function createReplyComposerAutocompleteProvider(cwd: string): AutocompleteProvider {
+	const sessionCommands = BUILTIN_SLASH_COMMANDS.filter((command) => isSessionSlashCommandName(command.name)).map(
+		(command) => ({
+			name: command.name,
+			aliases: command.aliases,
+			description: command.description,
+			argumentHint: command.argumentHint,
+			takesArgument: command.takesArgument,
+		}),
+	);
+	return new CombinedAutocompleteProvider(sessionCommands, cwd);
+}
+
 export function resolveCurrentReplyTargetSummary(
 	records: readonly UnifiedSessionRecord[],
 	target: { key: string; summary: SessionSummary },
@@ -539,6 +576,15 @@ export class AgentsViewMode implements Component, Focusable {
 			autocompleteMaxVisible: options.uiServices.settingsManager.getAutocompleteMaxVisible(),
 			placeholder: SEARCH_PROMPT_PLACEHOLDER,
 			placeholderColor: (text) => theme.fg("dim", text),
+		});
+		const replyAutocomplete = createReplyComposerAutocompleteProvider(options.uiServices.getInitialCwd());
+		// Search mode must not autocomplete; the provider only answers while a
+		// reply target is armed.
+		this.editor.setAutocompleteProvider({
+			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) =>
+				this.replyTarget ? replyAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) : null,
+			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
+				replyAutocomplete.applyCompletion(lines, cursorLine, cursorCol, item, prefix),
 		});
 		this.editor.focused = true;
 		this.editor.getHeaderLine = () => this.renderReplyHeaderLine();
@@ -1062,6 +1108,11 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.replyTarget) {
 			const target = this.replyTarget;
 			const text = value.trim();
+			const rejection = getReplyComposerCommandRejection(text);
+			if (rejection) {
+				this.setStatusMessage(rejection, { tone: "warning" });
+				return;
+			}
 			if (text) {
 				this.editor.setText("");
 				const sent = await this.sendReply(target, text, delivery);

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -515,7 +515,7 @@ describe("reply composer slash commands", () => {
 		expect(getReplyComposerCommandRejection("plain reply")).toBeUndefined();
 	});
 
-	it("restores the draft when a command is rejected after submit cleared the buffer", async () => {
+	it("restores rejected-command drafts without overwriting newer typing", async () => {
 		// submitValue empties the editor before onSubmit runs.
 		const editor = editorWithText("");
 		const setStatusMessage = vi.fn();
@@ -528,25 +528,14 @@ describe("reply composer slash commands", () => {
 		};
 
 		await invoke("submit", self, "/model gpt-5");
-
 		expect(sendReply).not.toHaveBeenCalled();
 		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("not available here"), {
 			tone: "warning",
 		});
 		expect(editor.getText()).toBe("/model gpt-5");
-	});
 
-	it("does not overwrite newer typing when a rejection lands late", async () => {
-		const editor = editorWithText("newer draft");
-		const self: Record<string, unknown> = {
-			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
-			editor,
-			setStatusMessage: vi.fn(),
-			sendReply: vi.fn(),
-		};
-
+		editor.setText("newer draft");
 		await invoke("submit", self, "/settings");
-
 		expect(editor.getText()).toBe("newer draft");
 	});
 

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -2,7 +2,11 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
-import { AgentsViewMode } from "../src/modes/agents-view/agents-view-mode.js";
+import {
+	AgentsViewMode,
+	createReplyComposerAutocompleteProvider,
+	getReplyComposerCommandRejection,
+} from "../src/modes/agents-view/agents-view-mode.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 
 function summary(overrides: Partial<SessionSummary>): SessionSummary {
@@ -473,5 +477,53 @@ describe("agents view reply on inactive sessions", () => {
 		self.findSummaryByActiveSessionId = () => undefined;
 		const savedHints = stripAnsi(invoke("renderReplyComposerHints", self) as string);
 		expect(savedHints).toContain("resume & send");
+	});
+});
+
+describe("reply composer slash commands", () => {
+	it("lets session-owned commands pass through to the prompt path", () => {
+		expect(getReplyComposerCommandRejection("/compact focus on the API work")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/refine")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/goal ship it")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/autonomous")).toBeUndefined();
+	});
+
+	it("rejects recognized non-session built-ins with guidance", () => {
+		expect(getReplyComposerCommandRejection("/model gpt-5")).toContain("/model is not available here");
+		expect(getReplyComposerCommandRejection("/settings")).toContain("not available here");
+	});
+
+	it("treats unrecognized slash-prefixed text as a plain reply", () => {
+		expect(getReplyComposerCommandRejection("/usr/local/bin looks wrong")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("plain reply")).toBeUndefined();
+	});
+
+	it("blocks a rejected command in submit without clearing the editor", async () => {
+		const editor = editorWithText("/model gpt-5");
+		const setStatusMessage = vi.fn();
+		const sendReply = vi.fn();
+		const self: Record<string, unknown> = {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			editor,
+			setStatusMessage,
+			sendReply,
+		};
+
+		await invoke("submit", self, "/model gpt-5");
+
+		expect(sendReply).not.toHaveBeenCalled();
+		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("not available here"), {
+			tone: "warning",
+		});
+		expect(editor.getText()).toBe("/model gpt-5");
+	});
+
+	it("suggests only session-owned commands", async () => {
+		const provider = createReplyComposerAutocompleteProvider(process.cwd());
+		const suggestions = await provider.getSuggestions(["/"], 0, 1, { signal: new AbortController().signal });
+		const names = suggestions?.items.map((item) => item.value) ?? [];
+		expect(names).toEqual(expect.arrayContaining(["compact", "refine", "goal", "autonomous"]));
+		expect(names).not.toContain("model");
+		expect(names).not.toContain("settings");
 	});
 });

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -539,8 +539,9 @@ describe("reply composer slash commands", () => {
 		expect(getReplyComposerCommandRejection("plain reply")).toBeUndefined();
 	});
 
-	it("blocks a rejected command in submit without clearing the editor", async () => {
-		const editor = editorWithText("/model gpt-5");
+	it("restores the draft when a command is rejected after submit cleared the buffer", async () => {
+		// submitValue empties the editor before onSubmit runs.
+		const editor = editorWithText("");
 		const setStatusMessage = vi.fn();
 		const sendReply = vi.fn();
 		const self: Record<string, unknown> = {
@@ -557,6 +558,40 @@ describe("reply composer slash commands", () => {
 			tone: "warning",
 		});
 		expect(editor.getText()).toBe("/model gpt-5");
+	});
+
+	it("does not overwrite newer typing when a rejection lands late", async () => {
+		const editor = editorWithText("newer draft");
+		const self: Record<string, unknown> = {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			editor,
+			setStatusMessage: vi.fn(),
+			sendReply: vi.fn(),
+		};
+
+		await invoke("submit", self, "/settings");
+
+		expect(editor.getText()).toBe("newer draft");
+	});
+
+	it("binds reply autocomplete to the armed target's cwd", () => {
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			replyAutocomplete: undefined,
+			actionModeSearchQuery: undefined,
+			persistentState: {},
+			editor: Object.assign(editorWithText(""), { setPlaceholder: vi.fn() }),
+			replyLastAssistantText: undefined,
+			replyLastAssistantTextLoading: false,
+			replyHeaderTime: "",
+			rebuildRows: vi.fn(),
+			ui: { requestRender: vi.fn() },
+		};
+		const target = { key: "active-1", summary: summary({ activeSessionId: "active-1", cwd: "/tmp/elsewhere" }) };
+		invoke("setReplyTarget", self, target);
+		expect(self.replyAutocomplete).toBeDefined();
+		invoke("setReplyTarget", self, undefined);
+		expect(self.replyAutocomplete).toBeUndefined();
 	});
 
 	it("suggests only session-owned commands", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -538,19 +538,11 @@ describe("agents view reply on inactive sessions", () => {
 });
 
 describe("reply composer slash commands", () => {
-	it("lets session-owned commands pass through to the prompt path", () => {
+	it("classifies composer input: session commands pass, other built-ins reject, plain text flows", () => {
 		expect(getReplyComposerCommandRejection("/compact focus on the API work")).toBeUndefined();
-		expect(getReplyComposerCommandRejection("/refine")).toBeUndefined();
 		expect(getReplyComposerCommandRejection("/goal ship it")).toBeUndefined();
-		expect(getReplyComposerCommandRejection("/autonomous")).toBeUndefined();
-	});
-
-	it("rejects recognized non-session built-ins with guidance", () => {
 		expect(getReplyComposerCommandRejection("/model gpt-5")).toContain("/model is not available here");
 		expect(getReplyComposerCommandRejection("/settings")).toContain("not available here");
-	});
-
-	it("treats unrecognized slash-prefixed text as a plain reply", () => {
 		expect(getReplyComposerCommandRejection("/usr/local/bin looks wrong")).toBeUndefined();
 		expect(getReplyComposerCommandRejection("plain reply")).toBeUndefined();
 	});


### PR DESCRIPTION
Stacked on the composer PR below (`feat/agents-view-composer-1`).

## What

Session-owned slash commands — `/compact`, `/refine`, `/goal`, `/autonomous` — now work from the agents-view reply composer, delivered through the daemon prompt path like any reply (the session executes them via its queued-command machinery, so they schedule correctly against running work).

- Slash and `@`-path autocomplete in the composer, active **only while a reply target is armed** — the search editor never autocompletes. File completion resolves in the **target session's cwd** (not the view's startup directory), using the same fd-backed fuzzy search as the in-session editor.
- Other recognized built-ins (e.g. `/settings`) are rejected with guidance ("open the session to run it") instead of being sent to the model as prompt text; a rejected command's draft is restored unless newer text was typed. Unrecognized slash-prefixed text (e.g. an absolute path) still passes through as a plain reply.

## Tests

Pass-through for the four session commands, rejection with draft restore (including the late-rejection/newer-typing race), plain-text and path-like inputs untouched, and provider arm/disarm binding to the target's cwd.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only agents-view composer behavior with targeted tests; no auth, daemon protocol, or session persistence changes beyond existing prompt delivery.
> 
> **Overview**
> The **agents-view reply composer** can run session-owned slash commands (`/compact`, `/refine`, `/goal`, `/autonomous`) through the same daemon prompt path as normal replies. **Slash and `@` autocomplete** is enabled only while a reply target is armed; file completion uses the **armed session's cwd** (fd-backed), not the view's startup directory.
> 
> Other recognized built-ins (e.g. `/model`, `/settings`) are **blocked** with a warning to open the session instead of being sent as model text. On rejection, the submitted draft is **restored** unless the user typed something newer after submit cleared the buffer. Unrecognized slash-prefixed input (e.g. paths) still goes through as plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8848c4762da9ab7a113a2251c85b523c7f34e6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->