### PR TITLE
feat(tui): view commands in the agents view

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added starting a new session directly from the agents view with `ctrl+n`.
 - Added queueing a reply as a follow-up with `alt+enter` in the agents-view reply composer; plain Enter now steers a streaming agent.
 - Added session-owned slash commands (`/compact`, `/refine`, `/goal`, `/autonomous`) with autocomplete to the agents-view reply composer; other built-in commands are rejected with guidance instead of being sent as prompt text.
+- Added `/new`, `/fork`, `/name`, and `/kill` view commands to the agents view, usable from the search editor on the selected row and from the armed reply composer on its target.
 - Fixed `prime-agent agents` opening a new chat when running with a process-local session.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added starting a new session directly from the agents view with `ctrl+n`.
 - Added queueing a reply as a follow-up with `alt+enter` in the agents-view reply composer; plain Enter now steers a streaming agent.
 - Added session-owned slash commands (`/compact`, `/refine`, `/goal`, `/autonomous`) with autocomplete to the agents-view reply composer; other built-in commands are rejected with guidance instead of being sent as prompt text.
-- Added `/new`, `/fork`, `/name`, and `/kill` view commands to the agents view, usable from the search editor on the selected row and from the armed reply composer on its target.
+- Added `/new`, `/name`, and `/kill` view commands to the agents view, usable from the search editor on the selected row and from the armed reply composer on its target.
 - Fixed `prime-agent agents` opening a new chat when running with a process-local session.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1739,9 +1739,15 @@ export class AgentsViewMode implements Component, Focusable {
 						this.setStatusMessage("/kill needs a running agent; this session is inactive", { tone: "warning" });
 						return false;
 					}
-					requireDaemonData(
-						await this.requireClient().request({ type: "kill", activeSessionId: target.activeSessionId }),
-					);
+					try {
+						requireDaemonData(
+							await this.requireClient().request({ type: "kill", activeSessionId: target.activeSessionId }),
+						);
+					} catch (error) {
+						// Same tolerance as deactivatePendingAgent: the agent can finish
+						// between listing and the command; that still counts as stopped.
+						if (!isUnknownActiveSessionError(error)) throw error;
+					}
 					disarmIfUnchanged();
 					this.setStatusMessage("Agent stopped");
 					await this.refreshBothCatalogs();

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -660,7 +660,10 @@ export class AgentsViewMode implements Component, Focusable {
 				if (this.replyTarget) {
 					return this.replyAutocomplete?.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) ?? null;
 				}
-				if (this.options.adapter || this.renameTarget || !this.editor.getText().startsWith("/")) return null;
+				// Same predicate as the filter freeze: "/tmp/" is a path query, not a command.
+				if (this.options.adapter || this.renameTarget || !isAgentsViewCommandInput(this.editor.getText())) {
+					return null;
+				}
 				return searchAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions);
 			},
 			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
@@ -1561,11 +1564,8 @@ export class AgentsViewMode implements Component, Focusable {
 					name,
 				);
 			}
-			const refreshed = await Promise.all([
-				this.refreshSessions({ preserveStatusOnError: true }),
-				this.refreshSavedSessions({ preserveStatusOnError: true }),
-			]);
-			this.setStatusMessage(refreshed.every(Boolean) ? `Renamed to ${name}` : `Renamed to ${name}; refresh failed`);
+			const refreshed = await this.refreshBothCatalogs();
+			this.setStatusMessage(refreshed ? `Renamed to ${name}` : `Renamed to ${name}; refresh failed`);
 		} catch (error) {
 			this.setStatusMessage(
 				isUnknownDaemonCommandError(error, "rename")
@@ -1742,12 +1742,7 @@ export class AgentsViewMode implements Component, Focusable {
 						return false;
 					}
 					this.setStatusMessage(`Session renamed to ${name}`);
-					// Both catalogs, like confirmRename: the saved entry keeps the old
-					// name otherwise and resurfaces it once the agent is killed.
-					await Promise.all([
-						this.refreshSessions({ preserveStatusOnError: true }),
-						this.refreshSavedSessions({ preserveStatusOnError: true }),
-					]);
+					await this.refreshBothCatalogs();
 					return true;
 				}
 				case "kill": {
@@ -1760,7 +1755,7 @@ export class AgentsViewMode implements Component, Focusable {
 					);
 					disarmIfUnchanged();
 					this.setStatusMessage("Agent stopped");
-					await this.refreshSessions({ preserveStatusOnError: true });
+					await this.refreshBothCatalogs();
 					return true;
 				}
 			}
@@ -2095,6 +2090,15 @@ export class AgentsViewMode implements Component, Focusable {
 		this.applyPendingAncestorExpansion();
 		this.restoreSelection();
 		this.ui.requestRender();
+	}
+
+	/** A session appears in both catalogs; mutations must refresh both. */
+	private async refreshBothCatalogs(): Promise<boolean> {
+		const results = await Promise.all([
+			this.refreshSessions({ preserveStatusOnError: true }),
+			this.refreshSavedSessions({ preserveStatusOnError: true }),
+		]);
+		return results.every(Boolean);
 	}
 
 	private async refreshSavedSessions(

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1548,30 +1548,40 @@ export class AgentsViewMode implements Component, Focusable {
 			return;
 		}
 		this.exitRenameMode();
+		await this.renameSession(target.summary, name);
+	}
+
+	/** Shared by rename mode and /name: rename, refresh both catalogs, report. */
+	private async renameSession(summary: SessionSummary, name: string): Promise<boolean> {
 		this.setStatusMessage("Renaming agent...");
 		try {
 			if (this.options.adapter) {
-				await this.options.adapter.rename(target.summary, name);
-			} else if (target.activeSessionId) {
+				await this.options.adapter.rename(summary, name);
+			} else if (summary.activeSessionId) {
 				requireDaemonData(
-					await this.requireClient().request({ type: "rename", activeSessionId: target.activeSessionId, name }),
+					await this.requireClient().request({ type: "rename", activeSessionId: summary.activeSessionId, name }),
 				);
-			} else if (target.sessionFile) {
+			} else if (summary.sessionFile) {
 				await renameDaemonSavedSession(
 					this.requireClient(),
 					this.getSavedSessionCatalogContext(),
-					target.sessionFile,
+					summary.sessionFile,
 					name,
 				);
+			} else {
+				this.setStatusMessage("This session cannot be renamed", { tone: "warning" });
+				return false;
 			}
 			const refreshed = await this.refreshBothCatalogs();
 			this.setStatusMessage(refreshed ? `Renamed to ${name}` : `Renamed to ${name}; refresh failed`);
+			return true;
 		} catch (error) {
 			this.setStatusMessage(
 				isUnknownDaemonCommandError(error, "rename")
 					? "Failed to rename: the daemon is running an older build; restart the daemon and try again"
 					: formatError("Failed to rename agent", error),
 			);
+			return false;
 		}
 	}
 
@@ -1722,28 +1732,7 @@ export class AgentsViewMode implements Component, Focusable {
 						this.setStatusMessage("Usage: /name <session name>", { tone: "warning" });
 						return false;
 					}
-					if (target.activeSessionId) {
-						requireDaemonData(
-							await this.requireClient().request({
-								type: "rename",
-								activeSessionId: target.activeSessionId,
-								name,
-							}),
-						);
-					} else if (target.sessionFile) {
-						await renameDaemonSavedSession(
-							this.requireClient(),
-							this.getSavedSessionCatalogContext(),
-							target.sessionFile,
-							name,
-						);
-					} else {
-						this.setStatusMessage("This session cannot be renamed", { tone: "warning" });
-						return false;
-					}
-					this.setStatusMessage(`Session renamed to ${name}`);
-					await this.refreshBothCatalogs();
-					return true;
+					return await this.renameSession(target, name);
 				}
 				case "kill": {
 					if (!target.activeSessionId) {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -468,11 +468,7 @@ const AGENTS_VIEW_COMMAND_TYPING_TARGETS: readonly string[] = AGENTS_VIEW_COMMAN
 	return [name, ...(builtin?.aliases ?? [])];
 });
 
-/**
- * True while search input is a view command or may still extend into one.
- * Prefix matching keeps mid-typing (like "/ki") from filtering the list,
- * while unknown terms such as "/foo" stay ordinary search text.
- */
+/** True while input is a view command or a prefix that may extend into one ("/ki"); "/foo" is not. */
 export function isAgentsViewCommandInput(text: string): boolean {
 	const trimmed = text.trim();
 	if (!trimmed.startsWith("/")) return false;
@@ -1170,8 +1166,7 @@ export class AgentsViewMode implements Component, Focusable {
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
 		let query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
-		// Command input is not a query: filtering on it (even mid-typing) would
-		// reshuffle the list out from under the selected target row.
+		// Filtering on command input would reshuffle the list under the selected row.
 		if (!this.replyTarget && !this.renameTarget && !this.options.adapter && isAgentsViewCommandInput(query)) {
 			query = "";
 		}
@@ -1205,8 +1200,7 @@ export class AgentsViewMode implements Component, Focusable {
 			const text = value.trim();
 			const viewCommand = parseAgentsViewCommand(text);
 			if (viewCommand && this.options.adapter) {
-				// Adapter sessions have no daemon RPCs behind view commands; treat
-				// them like any other unavailable built-in instead of prompt text.
+				// No daemon RPCs behind adapter rows; reject like other unavailable built-ins.
 				this.setStatusMessage(`/${viewCommand.name} is not available here`, { tone: "warning" });
 				if (this.editor.getText().length === 0) this.editor.setText(value);
 				return;
@@ -1218,9 +1212,7 @@ export class AgentsViewMode implements Component, Focusable {
 					target,
 					(activeSessionId) => this.findSummaryByActiveSessionId(activeSessionId),
 				);
-				// The buffer is already clear (submitValue), so re-submitting during the
-				// RPC cannot double-run; a failure restores the draft only if the same
-				// composer is still armed and the user has not typed anew.
+				// Restore the draft only if the same composer is armed and nothing new was typed.
 				const succeeded = await this.runAgentsViewCommand(viewCommand, currentSummary);
 				if (!succeeded && this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);
@@ -1249,8 +1241,7 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 			return;
 		}
-		// The search editor never treats text as a prompt; a recognized view
-		// command acts on the selected row, anything else opens the selection.
+		// Search text is never a prompt: commands act on the selected row, anything else opens it.
 		const viewCommand = parseAgentsViewCommand(value.trim());
 		if (viewCommand) {
 			if (this.options.adapter) {
@@ -1258,8 +1249,7 @@ export class AgentsViewMode implements Component, Focusable {
 				if (this.editor.getText().length === 0) this.setSearchQuery(value);
 				return;
 			}
-			// submitValue cleared the editor without queryChanged; drop the command
-			// from the persisted query so a remount cannot restore and re-run it.
+			// submitValue bypassed queryChanged; a remount must not restore and re-run the command.
 			this.persistentState.query = "";
 			const row = this.rows[this.selectedIndex];
 			const target = row?.kind === "agent" && row.selectable ? row.summary : undefined;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1732,13 +1732,17 @@ export class AgentsViewMode implements Component, Focusable {
 							target.sessionFile,
 							name,
 						);
-						await this.refreshSavedSessions({ preserveStatusOnError: true });
 					} else {
 						this.setStatusMessage("This session cannot be renamed", { tone: "warning" });
 						return false;
 					}
 					this.setStatusMessage(`Session renamed to ${name}`);
-					await this.refreshSessions({ preserveStatusOnError: true });
+					// Both catalogs, like confirmRename: the saved entry keeps the old
+					// name otherwise and resurfaces it once the agent is killed.
+					await Promise.all([
+						this.refreshSessions({ preserveStatusOnError: true }),
+						this.refreshSavedSessions({ preserveStatusOnError: true }),
+					]);
 					return true;
 				}
 				case "kill": {

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -646,8 +646,6 @@ export class AgentsViewMode implements Component, Focusable {
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
 		const searchAutocomplete = createSearchViewAutocompleteProvider(options.uiServices.getInitialCwd());
-		// Search text stays a query; only slash-prefixed input offers view commands.
-		// The armed provider is rebuilt on arming so @-paths resolve in the target's cwd.
 		void ensureTool("fd").then((fdPath) => {
 			this.fdPath = fdPath;
 			// Rebind an already-armed provider so @-completion picks up fd.
@@ -660,7 +658,6 @@ export class AgentsViewMode implements Component, Focusable {
 				if (this.replyTarget) {
 					return this.replyAutocomplete?.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) ?? null;
 				}
-				// Same predicate as the filter freeze: "/tmp/" is a path query, not a command.
 				if (this.options.adapter || this.renameTarget || !isAgentsViewCommandInput(this.editor.getText())) {
 					return null;
 				}
@@ -1208,7 +1205,6 @@ export class AgentsViewMode implements Component, Focusable {
 			const text = value.trim();
 			const viewCommand = parseAgentsViewCommand(text);
 			if (viewCommand && this.options.adapter) {
-				// No daemon RPCs behind adapter rows; reject like other unavailable built-ins.
 				this.setStatusMessage(`/${viewCommand.name} is not available here`, { tone: "warning" });
 				if (this.editor.getText().length === 0) this.editor.setText(value);
 				return;
@@ -1220,7 +1216,6 @@ export class AgentsViewMode implements Component, Focusable {
 					target,
 					(activeSessionId) => this.findSummaryByActiveSessionId(activeSessionId),
 				);
-				// Restore the draft only if the same composer is armed and nothing new was typed.
 				const succeeded = await this.runAgentsViewCommand(viewCommand, currentSummary);
 				if (!succeeded && this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);
@@ -1744,8 +1739,7 @@ export class AgentsViewMode implements Component, Focusable {
 							await this.requireClient().request({ type: "kill", activeSessionId: target.activeSessionId }),
 						);
 					} catch (error) {
-						// Same tolerance as deactivatePendingAgent: the agent can finish
-						// between listing and the command; that still counts as stopped.
+						// As in deactivatePendingAgent: an agent that already finished counts as stopped.
 						if (!isUnknownActiveSessionError(error)) throw error;
 					}
 					disarmIfUnchanged();

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1257,6 +1257,7 @@ export class AgentsViewMode implements Component, Focusable {
 		if (viewCommand) {
 			if (this.options.adapter) {
 				this.setStatusMessage(`/${viewCommand.name} is not available here`, { tone: "warning" });
+				if (this.editor.getText().length === 0) this.setSearchQuery(value);
 				return;
 			}
 			// submitValue cleared the editor without queryChanged; drop the command

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1238,11 +1238,14 @@ export class AgentsViewMode implements Component, Focusable {
 		// command acts on the selected row, anything else opens the selection.
 		const viewCommand = parseAgentsViewCommand(value.trim());
 		if (viewCommand && !this.options.adapter) {
+			// submitValue cleared the editor without queryChanged; drop the command
+			// from the persisted query so a remount cannot restore and re-run it.
+			this.persistentState.query = "";
 			const row = this.rows[this.selectedIndex];
 			const target = row?.kind === "agent" && row.selectable ? row.summary : undefined;
 			const succeeded = await this.runAgentsViewCommand(viewCommand, target);
 			if (!succeeded && !this.replyTarget && this.editor.getText().length === 0) {
-				this.editor.setText(value);
+				this.setSearchQuery(value);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -445,7 +445,7 @@ export async function runAgentsViewMode(options: Omit<AgentsViewModeOptions, "ad
 	}
 }
 
-const AGENTS_VIEW_COMMAND_NAMES = ["new", "fork", "name", "kill"] as const;
+const AGENTS_VIEW_COMMAND_NAMES = ["new", "name", "kill"] as const;
 export type AgentsViewCommandName = (typeof AGENTS_VIEW_COMMAND_NAMES)[number];
 const AGENTS_VIEW_COMMAND_NAME_SET: ReadonlySet<string> = new Set(AGENTS_VIEW_COMMAND_NAMES);
 
@@ -498,7 +498,6 @@ export function getReplyComposerCommandRejection(text: string): string | undefin
 const AGENTS_VIEW_COMMAND_DESCRIPTIONS: Record<AgentsViewCommandName, { description: string; argumentHint?: string }> =
 	{
 		new: { description: "Start a new session" },
-		fork: { description: "Fork this session from a previous user message" },
 		name: { description: "Set session display name", argumentHint: "<name>" },
 		kill: { description: "Stop this agent's runtime (session stays resumable)" },
 	};
@@ -1768,72 +1767,12 @@ export class AgentsViewMode implements Component, Focusable {
 					await this.refreshSessions({ preserveStatusOnError: true });
 					return true;
 				}
-				case "fork": {
-					const forked = await this.forkTargetSession(target);
-					if (forked) disarmIfUnchanged();
-					return forked;
-				}
 			}
 		} catch (error) {
 			this.setStatusMessage(formatError(`Failed to run /${command.name}`, error));
 			return false;
 		}
 		return false;
-	}
-
-	/**
-	 * Fork the target session at its current leaf. The daemon fork RPC rebinds
-	 * the running agent onto the forked file (in-session semantics); the
-	 * pre-fork history stays on disk as an inactive session. Saved rows are
-	 * resumed first so the same RPC applies.
-	 */
-	private async forkTargetSession(target: SessionSummary): Promise<boolean> {
-		let activeSessionId = target.activeSessionId;
-		let resumedForFork: string | undefined;
-		try {
-			if (!activeSessionId) {
-				this.setStatusMessage("Resuming session...");
-				const resumed = await resumeSavedAgentsViewSession(this.requireClient(), this.options.config, target);
-				activeSessionId = resumed.activeSessionId;
-				resumedForFork = resumed.activeSessionId;
-			}
-			const treeData = requireDaemonData(
-				await this.requireClient().request({ type: "get_session_tree", activeSessionId }),
-			) as { leafId: string | null };
-			if (!treeData.leafId) {
-				this.setStatusMessage("Nothing to fork yet", { tone: "warning" });
-				return false;
-			}
-			this.setStatusMessage("Forking session...");
-			const result = requireDaemonData(
-				await this.requireClient().request({
-					type: "fork",
-					activeSessionId,
-					entryId: treeData.leafId,
-					position: "at",
-				}),
-			) as { cancelled: boolean };
-			if (result.cancelled) {
-				this.setStatusMessage("Fork cancelled");
-				return false;
-			}
-			this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
-			resumedForFork = undefined;
-			this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
-			await this.refreshSessions({ preserveStatusOnError: true });
-			return true;
-		} finally {
-			// The resume existed only to serve the fork: on any failure path, stop
-			// the runtime again instead of leaving a silently activated agent.
-			if (resumedForFork) {
-				try {
-					await this.requireClient().request({ type: "kill", activeSessionId: resumedForFork });
-				} catch {
-					// Best effort; the refresh below surfaces the live row if it failed.
-				}
-				await this.refreshSessions({ preserveStatusOnError: true });
-			}
-		}
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1255,7 +1255,11 @@ export class AgentsViewMode implements Component, Focusable {
 		// The search editor never treats text as a prompt; a recognized view
 		// command acts on the selected row, anything else opens the selection.
 		const viewCommand = parseAgentsViewCommand(value.trim());
-		if (viewCommand && !this.options.adapter) {
+		if (viewCommand) {
+			if (this.options.adapter) {
+				this.setStatusMessage(`/${viewCommand.name} is not available here`, { tone: "warning" });
+				return;
+			}
 			// submitValue cleared the editor without queryChanged; drop the command
 			// from the persisted query so a remount cannot restore and re-run it.
 			this.persistentState.query = "";

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1154,7 +1154,12 @@ export class AgentsViewMode implements Component, Focusable {
 	}
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
-		const query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
+		let query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
+		// Slash-prefixed input is (partially typed) command input, not a query:
+		// filtering on it would reshuffle the list under the selected target row.
+		if (!this.replyTarget && !this.renameTarget && !this.options.adapter && query.trimStart().startsWith("/")) {
+			query = "";
+		}
 		return filterUnifiedSessions(this.unifiedRecords, (text) => matchesSearchText(text, query));
 	}
 
@@ -1184,11 +1189,24 @@ export class AgentsViewMode implements Component, Focusable {
 			const target = this.replyTarget;
 			const text = value.trim();
 			const viewCommand = parseAgentsViewCommand(text);
+			if (viewCommand && this.options.adapter) {
+				// Adapter sessions have no daemon RPCs behind view commands; treat
+				// them like any other unavailable built-in instead of prompt text.
+				this.setStatusMessage(`/${viewCommand.name} is not available here`, { tone: "warning" });
+				if (this.editor.getText().length === 0) this.editor.setText(value);
+				return;
+			}
 			if (viewCommand) {
+				// Stale summaries mis-route the RPCs after a runtime replacement.
+				const currentSummary = resolveCurrentReplyTargetSummary(
+					this.unifiedRecords ?? [],
+					target,
+					(activeSessionId) => this.findSummaryByActiveSessionId(activeSessionId),
+				);
 				// The buffer is already clear (submitValue), so re-submitting during the
 				// RPC cannot double-run; a failure restores the draft only if the same
 				// composer is still armed and the user has not typed anew.
-				const succeeded = await this.runAgentsViewCommand(viewCommand, target.summary);
+				const succeeded = await this.runAgentsViewCommand(viewCommand, currentSummary);
 				if (!succeeded && this.replyTarget === target && this.editor.getText().length === 0) {
 					this.editor.setText(value);
 				}
@@ -1751,14 +1769,13 @@ export class AgentsViewMode implements Component, Focusable {
 	 */
 	private async forkTargetSession(target: SessionSummary): Promise<boolean> {
 		let activeSessionId = target.activeSessionId;
-		let didResume = false;
+		let resumedForFork: string | undefined;
 		try {
 			if (!activeSessionId) {
 				this.setStatusMessage("Resuming session...");
 				const resumed = await resumeSavedAgentsViewSession(this.requireClient(), this.options.config, target);
 				activeSessionId = resumed.activeSessionId;
-				didResume = true;
-				this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
+				resumedForFork = resumed.activeSessionId;
 			}
 			const treeData = requireDaemonData(
 				await this.requireClient().request({ type: "get_session_tree", activeSessionId }),
@@ -1780,13 +1797,22 @@ export class AgentsViewMode implements Component, Focusable {
 				this.setStatusMessage("Fork cancelled");
 				return false;
 			}
+			this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
+			resumedForFork = undefined;
 			this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
-			didResume = false;
 			await this.refreshSessions({ preserveStatusOnError: true });
 			return true;
 		} finally {
-			// A session resumed for a fork that then failed must still appear live.
-			if (didResume) await this.refreshSessions({ preserveStatusOnError: true });
+			// The resume existed only to serve the fork: on any failure path, stop
+			// the runtime again instead of leaving a silently activated agent.
+			if (resumedForFork) {
+				try {
+					await this.requireClient().request({ type: "kill", activeSessionId: resumedForFork });
+				} catch {
+					// Best effort; the refresh below surfaces the live row if it failed.
+				}
+				await this.refreshSessions({ preserveStatusOnError: true });
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1657,8 +1657,7 @@ export class AgentsViewMode implements Component, Focusable {
 			if (armedAtStart && this.replyTarget === armedAtStart) this.setReplyTarget(undefined);
 		};
 		if (command.name === "new") {
-			await this.createNewSession();
-			return true;
+			return await this.createNewSession();
 		}
 		if (!target) {
 			this.setStatusMessage(`Select an agent row to use /${command.name}`, { tone: "warning" });
@@ -1730,35 +1729,43 @@ export class AgentsViewMode implements Component, Focusable {
 	 */
 	private async forkTargetSession(target: SessionSummary): Promise<boolean> {
 		let activeSessionId = target.activeSessionId;
-		if (!activeSessionId) {
-			this.setStatusMessage("Resuming session...");
-			const resumed = await resumeSavedAgentsViewSession(this.requireClient(), this.options.config, target);
-			activeSessionId = resumed.activeSessionId;
-			this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
+		let didResume = false;
+		try {
+			if (!activeSessionId) {
+				this.setStatusMessage("Resuming session...");
+				const resumed = await resumeSavedAgentsViewSession(this.requireClient(), this.options.config, target);
+				activeSessionId = resumed.activeSessionId;
+				didResume = true;
+				this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
+			}
+			const treeData = requireDaemonData(
+				await this.requireClient().request({ type: "get_session_tree", activeSessionId }),
+			) as { leafId: string | null };
+			if (!treeData.leafId) {
+				this.setStatusMessage("Nothing to fork yet", { tone: "warning" });
+				return false;
+			}
+			this.setStatusMessage("Forking session...");
+			const result = requireDaemonData(
+				await this.requireClient().request({
+					type: "fork",
+					activeSessionId,
+					entryId: treeData.leafId,
+					position: "at",
+				}),
+			) as { cancelled: boolean };
+			if (result.cancelled) {
+				this.setStatusMessage("Fork cancelled");
+				return false;
+			}
+			this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
+			didResume = false;
+			await this.refreshSessions({ preserveStatusOnError: true });
+			return true;
+		} finally {
+			// A session resumed for a fork that then failed must still appear live.
+			if (didResume) await this.refreshSessions({ preserveStatusOnError: true });
 		}
-		const treeData = requireDaemonData(
-			await this.requireClient().request({ type: "get_session_tree", activeSessionId }),
-		) as { leafId: string | null };
-		if (!treeData.leafId) {
-			this.setStatusMessage("Nothing to fork yet", { tone: "warning" });
-			return false;
-		}
-		this.setStatusMessage("Forking session...");
-		const result = requireDaemonData(
-			await this.requireClient().request({
-				type: "fork",
-				activeSessionId,
-				entryId: treeData.leafId,
-				position: "at",
-			}),
-		) as { cancelled: boolean };
-		if (result.cancelled) {
-			this.setStatusMessage("Fork cancelled");
-			return false;
-		}
-		this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
-		await this.refreshSessions({ preserveStatusOnError: true });
-		return true;
 	}
 
 	/** Point selection (and its persisted key) at a freshly resumed session row. */

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -444,21 +444,67 @@ export async function runAgentsViewMode(options: Omit<AgentsViewModeOptions, "ad
 	}
 }
 
+const AGENTS_VIEW_COMMAND_NAMES = ["new", "fork", "name", "kill"] as const;
+export type AgentsViewCommandName = (typeof AGENTS_VIEW_COMMAND_NAMES)[number];
+const AGENTS_VIEW_COMMAND_NAME_SET: ReadonlySet<string> = new Set(AGENTS_VIEW_COMMAND_NAMES);
+
+export interface AgentsViewCommand {
+	name: AgentsViewCommandName;
+	args: string;
+}
+
+/** Row-targeted commands the view maps onto existing RPCs; /new needs no row. */
+export function parseAgentsViewCommand(text: string): AgentsViewCommand | undefined {
+	const parsed = parseSlashCommand(text);
+	if (!parsed) return undefined;
+	const name = resolveBuiltinSlashCommandName(parsed.name);
+	if (!AGENTS_VIEW_COMMAND_NAME_SET.has(name)) return undefined;
+	return { name: name as AgentsViewCommandName, args: parsed.args };
+}
+
 /**
- * The reply composer delivers text through the daemon prompt path, which only
- * executes session-owned slash commands. Reject other recognized built-ins
- * instead of sending them to the model as plain text.
+ * Reject recognized built-ins that are neither session-owned nor view
+ * commands, so they are never sent to the model as plain prompt text.
  */
 export function getReplyComposerCommandRejection(text: string): string | undefined {
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return undefined;
 	const name = resolveBuiltinSlashCommandName(parsed.name);
 	if (isSessionSlashCommandName(name)) return undefined;
+	if (AGENTS_VIEW_COMMAND_NAME_SET.has(name)) return undefined;
 	if (!isBuiltinSlashCommandName(parsed.name)) return undefined;
 	return `/${parsed.name} is not available here; open the session to run it`;
 }
 
-/** Autocomplete for the reply composer: session-owned slash commands only. */
+const AGENTS_VIEW_COMMAND_DESCRIPTIONS: Record<AgentsViewCommandName, { description: string; argumentHint?: string }> =
+	{
+		new: { description: "Start a new session" },
+		fork: { description: "Fork this session from a previous user message" },
+		name: { description: "Set session display name", argumentHint: "<name>" },
+		kill: { description: "Stop this agent's runtime (session stays resumable)" },
+	};
+
+function agentsViewSlashCommands(): {
+	name: string;
+	aliases?: readonly string[];
+	description: string;
+	argumentHint?: string;
+	takesArgument?: boolean;
+}[] {
+	return AGENTS_VIEW_COMMAND_NAMES.map((name) => {
+		const builtin = BUILTIN_SLASH_COMMANDS.find((command) => command.name === name);
+		const display = AGENTS_VIEW_COMMAND_DESCRIPTIONS[name];
+		return {
+			name,
+			aliases: builtin?.aliases,
+			description: display.description,
+			argumentHint: display.argumentHint ?? builtin?.argumentHint,
+			takesArgument: name === "name" ? true : builtin?.takesArgument,
+		};
+	});
+}
+
+/** Autocomplete for the reply composer: session-owned plus view commands. */
 export function createReplyComposerAutocompleteProvider(cwd: string): AutocompleteProvider {
 	const sessionCommands = BUILTIN_SLASH_COMMANDS.filter((command) => isSessionSlashCommandName(command.name)).map(
 		(command) => ({
@@ -469,7 +515,12 @@ export function createReplyComposerAutocompleteProvider(cwd: string): Autocomple
 			takesArgument: command.takesArgument,
 		}),
 	);
-	return new CombinedAutocompleteProvider(sessionCommands, cwd);
+	return new CombinedAutocompleteProvider([...sessionCommands, ...agentsViewSlashCommands()], cwd);
+}
+
+/** Autocomplete for the search editor: view commands only, once "/" is typed. */
+export function createSearchViewAutocompleteProvider(cwd: string): AutocompleteProvider {
+	return new CombinedAutocompleteProvider(agentsViewSlashCommands(), cwd);
 }
 
 export function resolveCurrentReplyTargetSummary(
@@ -578,13 +629,22 @@ export class AgentsViewMode implements Component, Focusable {
 			placeholderColor: (text) => theme.fg("dim", text),
 		});
 		const replyAutocomplete = createReplyComposerAutocompleteProvider(options.uiServices.getInitialCwd());
-		// Search mode must not autocomplete; the provider only answers while a
-		// reply target is armed.
+		const searchAutocomplete = createSearchViewAutocompleteProvider(options.uiServices.getInitialCwd());
+		// Search text stays a query; only slash-prefixed input offers view commands.
 		this.editor.setAutocompleteProvider({
-			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) =>
-				this.replyTarget ? replyAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) : null,
+			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) => {
+				if (this.replyTarget) return replyAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions);
+				if (this.renameTarget || !this.editor.getText().startsWith("/")) return null;
+				return searchAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions);
+			},
 			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
-				replyAutocomplete.applyCompletion(lines, cursorLine, cursorCol, item, prefix),
+				(this.replyTarget ? replyAutocomplete : searchAutocomplete).applyCompletion(
+					lines,
+					cursorLine,
+					cursorCol,
+					item,
+					prefix,
+				),
 		});
 		this.editor.focused = true;
 		this.editor.getHeaderLine = () => this.renderReplyHeaderLine();
@@ -1108,6 +1168,11 @@ export class AgentsViewMode implements Component, Focusable {
 		if (this.replyTarget) {
 			const target = this.replyTarget;
 			const text = value.trim();
+			const viewCommand = parseAgentsViewCommand(text);
+			if (viewCommand) {
+				await this.runAgentsViewCommand(viewCommand, target.summary);
+				return;
+			}
 			const rejection = getReplyComposerCommandRejection(text);
 			if (rejection) {
 				this.setStatusMessage(rejection, { tone: "warning" });
@@ -1128,8 +1193,15 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 			return;
 		}
-		// The normal editor is search-only: Enter opens the selection and never
-		// interprets text as a command or a prompt for a new agent.
+		// The search editor never treats text as a prompt; a recognized view
+		// command acts on the selected row, anything else opens the selection.
+		const viewCommand = parseAgentsViewCommand(value.trim());
+		if (viewCommand && !this.options.adapter) {
+			const row = this.rows[this.selectedIndex];
+			const target = row?.kind === "agent" && row.selectable ? row.summary : undefined;
+			await this.runAgentsViewCommand(viewCommand, target);
+			return;
+		}
 		this.openSelected();
 	}
 
@@ -1538,6 +1610,110 @@ export class AgentsViewMode implements Component, Focusable {
 		} finally {
 			this.creatingNewSession = false;
 		}
+	}
+
+	/** Run a whitelisted view command against a target row (or none for /new). */
+	private async runAgentsViewCommand(command: AgentsViewCommand, target: SessionSummary | undefined): Promise<void> {
+		if (command.name === "new") {
+			this.editor.setText("");
+			await this.createNewSession();
+			return;
+		}
+		if (!target) {
+			this.setStatusMessage(`Select an agent row to use /${command.name}`, { tone: "warning" });
+			return;
+		}
+		try {
+			switch (command.name) {
+				case "name": {
+					const name = command.args.trim();
+					if (!name) {
+						this.setStatusMessage("Usage: /name <session name>", { tone: "warning" });
+						return;
+					}
+					if (target.activeSessionId) {
+						requireDaemonData(
+							await this.requireClient().request({
+								type: "rename",
+								activeSessionId: target.activeSessionId,
+								name,
+							}),
+						);
+					} else if (target.sessionFile) {
+						await renameDaemonSavedSession(
+							this.requireClient(),
+							this.getSavedSessionCatalogContext(),
+							target.sessionFile,
+							name,
+						);
+						await this.refreshSavedSessions({ preserveStatusOnError: true });
+					} else {
+						this.setStatusMessage("This session cannot be renamed", { tone: "warning" });
+						return;
+					}
+					this.editor.setText("");
+					this.setStatusMessage(`Session renamed to ${name}`);
+					await this.refreshSessions({ preserveStatusOnError: true });
+					return;
+				}
+				case "kill": {
+					if (!target.activeSessionId) {
+						this.setStatusMessage("/kill needs a running agent; this session is inactive", { tone: "warning" });
+						return;
+					}
+					requireDaemonData(
+						await this.requireClient().request({ type: "kill", activeSessionId: target.activeSessionId }),
+					);
+					this.editor.setText("");
+					if (this.replyTarget) this.setReplyTarget(undefined);
+					this.setStatusMessage("Agent stopped");
+					await this.refreshSessions({ preserveStatusOnError: true });
+					return;
+				}
+				case "fork": {
+					await this.forkTargetSession(target);
+					return;
+				}
+			}
+		} catch (error) {
+			this.setStatusMessage(formatError(`Failed to run /${command.name}`, error));
+		}
+	}
+
+	/**
+	 * Fork the target session at its current leaf. The daemon fork RPC rebinds
+	 * the running agent onto the forked file (in-session semantics); the
+	 * pre-fork history stays on disk as an inactive session. Saved rows are
+	 * resumed first so the same RPC applies.
+	 */
+	private async forkTargetSession(target: SessionSummary): Promise<void> {
+		let activeSessionId = target.activeSessionId;
+		if (!activeSessionId) {
+			this.setStatusMessage("Resuming session...");
+			const resumed = await resumeSavedAgentsViewSession(this.requireClient(), this.options.config, target);
+			activeSessionId = resumed.activeSessionId;
+			this.inactiveAgentIdentities.delete(getSummaryIdentity(target));
+		}
+		const treeData = requireDaemonData(
+			await this.requireClient().request({ type: "get_session_tree", activeSessionId }),
+		) as { leafId: string | null };
+		if (!treeData.leafId) {
+			this.setStatusMessage("Nothing to fork yet", { tone: "warning" });
+			return;
+		}
+		this.setStatusMessage("Forking session...");
+		requireDaemonData(
+			await this.requireClient().request({
+				type: "fork",
+				activeSessionId,
+				entryId: treeData.leafId,
+				position: "at",
+			}),
+		);
+		this.editor.setText("");
+		if (this.replyTarget) this.setReplyTarget(undefined);
+		this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
+		await this.refreshSessions({ preserveStatusOnError: true });
 	}
 
 	/** Point selection (and its persisted key) at a freshly resumed session row. */
@@ -2324,6 +2500,7 @@ export class AgentsViewMode implements Component, Focusable {
 			`${keyText("tui.select.up")}/${keyText("tui.select.down")} move`,
 			`${keyText("tui.select.confirm")} open`,
 			`${keyText("app.agents.open")} open`,
+			!this.options.adapter ? "/ commands" : undefined,
 			selectedAgent && !this.options.adapter
 				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
 				: undefined,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -633,13 +633,14 @@ export class AgentsViewMode implements Component, Focusable {
 		const searchAutocomplete = createSearchViewAutocompleteProvider(options.uiServices.getInitialCwd());
 		// Search text stays a query; only slash-prefixed input offers view commands.
 		// The armed provider is rebuilt on arming so @-paths resolve in the target
-		// session's cwd, not the view's startup directory.
+		// session's cwd, not the view's startup directory. The local adapter view
+		// runs no view commands, so it offers none either.
 		this.editor.setAutocompleteProvider({
 			getSuggestions: async (lines, cursorLine, cursorCol, suggestOptions) => {
 				if (this.replyTarget) {
 					return this.replyAutocomplete?.getSuggestions(lines, cursorLine, cursorCol, suggestOptions) ?? null;
 				}
-				if (this.renameTarget || !this.editor.getText().startsWith("/")) return null;
+				if (this.options.adapter || this.renameTarget || !this.editor.getText().startsWith("/")) return null;
 				return searchAutocomplete.getSuggestions(lines, cursorLine, cursorCol, suggestOptions);
 			},
 			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
@@ -1175,7 +1176,13 @@ export class AgentsViewMode implements Component, Focusable {
 			const text = value.trim();
 			const viewCommand = parseAgentsViewCommand(text);
 			if (viewCommand) {
-				await this.runAgentsViewCommand(viewCommand, target.summary);
+				// The buffer is already clear (submitValue), so re-submitting during the
+				// RPC cannot double-run; a failure restores the draft only if the same
+				// composer is still armed and the user has not typed anew.
+				const succeeded = await this.runAgentsViewCommand(viewCommand, target.summary);
+				if (!succeeded && this.replyTarget === target && this.editor.getText().length === 0) {
+					this.editor.setText(value);
+				}
 				return;
 			}
 			const rejection = getReplyComposerCommandRejection(text);
@@ -1206,7 +1213,10 @@ export class AgentsViewMode implements Component, Focusable {
 		if (viewCommand && !this.options.adapter) {
 			const row = this.rows[this.selectedIndex];
 			const target = row?.kind === "agent" && row.selectable ? row.summary : undefined;
-			await this.runAgentsViewCommand(viewCommand, target);
+			const succeeded = await this.runAgentsViewCommand(viewCommand, target);
+			if (!succeeded && !this.replyTarget && this.editor.getText().length === 0) {
+				this.editor.setText(value);
+			}
 			return;
 		}
 		this.openSelected();
@@ -1630,16 +1640,27 @@ export class AgentsViewMode implements Component, Focusable {
 		}
 	}
 
-	/** Run a whitelisted view command against a target row (or none for /new). */
-	private async runAgentsViewCommand(command: AgentsViewCommand, target: SessionSummary | undefined): Promise<void> {
+	/**
+	 * Run a whitelisted view command against a target row (or none for /new).
+	 * Returns whether the command completed, so callers can restore the draft.
+	 * The editor buffer is already empty here (submitValue cleared it), and any
+	 * composer disarm is guarded against re-arming during the awaited RPCs.
+	 */
+	private async runAgentsViewCommand(
+		command: AgentsViewCommand,
+		target: SessionSummary | undefined,
+	): Promise<boolean> {
+		const armedAtStart = this.replyTarget;
+		const disarmIfUnchanged = () => {
+			if (armedAtStart && this.replyTarget === armedAtStart) this.setReplyTarget(undefined);
+		};
 		if (command.name === "new") {
-			this.editor.setText("");
 			await this.createNewSession();
-			return;
+			return true;
 		}
 		if (!target) {
 			this.setStatusMessage(`Select an agent row to use /${command.name}`, { tone: "warning" });
-			return;
+			return false;
 		}
 		try {
 			switch (command.name) {
@@ -1647,7 +1668,7 @@ export class AgentsViewMode implements Component, Focusable {
 					const name = command.args.trim();
 					if (!name) {
 						this.setStatusMessage("Usage: /name <session name>", { tone: "warning" });
-						return;
+						return false;
 					}
 					if (target.activeSessionId) {
 						requireDaemonData(
@@ -1667,35 +1688,36 @@ export class AgentsViewMode implements Component, Focusable {
 						await this.refreshSavedSessions({ preserveStatusOnError: true });
 					} else {
 						this.setStatusMessage("This session cannot be renamed", { tone: "warning" });
-						return;
+						return false;
 					}
-					this.editor.setText("");
 					this.setStatusMessage(`Session renamed to ${name}`);
 					await this.refreshSessions({ preserveStatusOnError: true });
-					return;
+					return true;
 				}
 				case "kill": {
 					if (!target.activeSessionId) {
 						this.setStatusMessage("/kill needs a running agent; this session is inactive", { tone: "warning" });
-						return;
+						return false;
 					}
 					requireDaemonData(
 						await this.requireClient().request({ type: "kill", activeSessionId: target.activeSessionId }),
 					);
-					this.editor.setText("");
-					if (this.replyTarget) this.setReplyTarget(undefined);
+					disarmIfUnchanged();
 					this.setStatusMessage("Agent stopped");
 					await this.refreshSessions({ preserveStatusOnError: true });
-					return;
+					return true;
 				}
 				case "fork": {
-					await this.forkTargetSession(target);
-					return;
+					const forked = await this.forkTargetSession(target);
+					if (forked) disarmIfUnchanged();
+					return forked;
 				}
 			}
 		} catch (error) {
 			this.setStatusMessage(formatError(`Failed to run /${command.name}`, error));
+			return false;
 		}
+		return false;
 	}
 
 	/**
@@ -1704,7 +1726,7 @@ export class AgentsViewMode implements Component, Focusable {
 	 * pre-fork history stays on disk as an inactive session. Saved rows are
 	 * resumed first so the same RPC applies.
 	 */
-	private async forkTargetSession(target: SessionSummary): Promise<void> {
+	private async forkTargetSession(target: SessionSummary): Promise<boolean> {
 		let activeSessionId = target.activeSessionId;
 		if (!activeSessionId) {
 			this.setStatusMessage("Resuming session...");
@@ -1717,21 +1739,24 @@ export class AgentsViewMode implements Component, Focusable {
 		) as { leafId: string | null };
 		if (!treeData.leafId) {
 			this.setStatusMessage("Nothing to fork yet", { tone: "warning" });
-			return;
+			return false;
 		}
 		this.setStatusMessage("Forking session...");
-		requireDaemonData(
+		const result = requireDaemonData(
 			await this.requireClient().request({
 				type: "fork",
 				activeSessionId,
 				entryId: treeData.leafId,
 				position: "at",
 			}),
-		);
-		this.editor.setText("");
-		if (this.replyTarget) this.setReplyTarget(undefined);
+		) as { cancelled: boolean };
+		if (result.cancelled) {
+			this.setStatusMessage("Fork cancelled");
+			return false;
+		}
 		this.setStatusMessage("Forked to a new session; previous history stays available as inactive");
 		await this.refreshSessions({ preserveStatusOnError: true });
+		return true;
 	}
 
 	/** Point selection (and its persisted key) at a freshly resumed session row. */

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -463,6 +463,24 @@ export function parseAgentsViewCommand(text: string): AgentsViewCommand | undefi
 	return { name: name as AgentsViewCommandName, args: parsed.args };
 }
 
+const AGENTS_VIEW_COMMAND_TYPING_TARGETS: readonly string[] = AGENTS_VIEW_COMMAND_NAMES.flatMap((name) => {
+	const builtin = BUILTIN_SLASH_COMMANDS.find((command) => command.name === name);
+	return [name, ...(builtin?.aliases ?? [])];
+});
+
+/**
+ * True while search input is a view command or may still extend into one.
+ * Prefix matching keeps mid-typing (like "/ki") from filtering the list,
+ * while unknown terms such as "/foo" stay ordinary search text.
+ */
+export function isAgentsViewCommandInput(text: string): boolean {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("/")) return false;
+	if (parseAgentsViewCommand(trimmed)) return true;
+	const token = trimmed.slice(1).toLowerCase();
+	return !/\s/.test(token) && AGENTS_VIEW_COMMAND_TYPING_TARGETS.some((name) => name.startsWith(token));
+}
+
 /**
  * Reject recognized built-ins that are neither session-owned nor view
  * commands, so they are never sent to the model as plain prompt text.
@@ -1155,9 +1173,9 @@ export class AgentsViewMode implements Component, Focusable {
 
 	private getFilteredRecords(): UnifiedSessionRecord[] {
 		let query = this.replyTarget || this.renameTarget ? (this.actionModeSearchQuery ?? "") : this.editor.getText();
-		// Slash-prefixed input is (partially typed) command input, not a query:
-		// filtering on it would reshuffle the list under the selected target row.
-		if (!this.replyTarget && !this.renameTarget && !this.options.adapter && query.trimStart().startsWith("/")) {
+		// Command input is not a query: filtering on it (even mid-typing) would
+		// reshuffle the list out from under the selected target row.
+		if (!this.replyTarget && !this.renameTarget && !this.options.adapter && isAgentsViewCommandInput(query)) {
 			query = "";
 		}
 		return filterUnifiedSessions(this.unifiedRecords, (text) => matchesSearchText(text, query));

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -701,7 +701,7 @@ describe("agents view slash commands", () => {
 		});
 	});
 
-	it("renames a live target via the rename RPC", async () => {
+	it("renames a live target via the rename RPC and refreshes both catalogs", async () => {
 		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
 		const request = vi.fn(async () => ({ success: true, data: {} }));
 		const editor = editorWithText("/name Fresh Name");
@@ -710,12 +710,14 @@ describe("agents view slash commands", () => {
 			editor,
 			setStatusMessage: vi.fn(),
 			refreshSessions: vi.fn(async () => true),
+			refreshSavedSessions: vi.fn(async () => true),
 		};
 
 		await invoke("runAgentsViewCommand", self, { name: "name", args: "Fresh Name" }, live);
 
 		expect(request).toHaveBeenCalledWith({ type: "rename", activeSessionId: "active-1", name: "Fresh Name" });
 		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		expect(self.refreshSavedSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
 	it("kills a live target and disarms the composer", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -723,19 +723,22 @@ describe("agents view slash commands", () => {
 		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
 		const request = vi.fn(async () => ({ success: true, data: {} }));
 		const editor = editorWithText("/name Fresh Name");
+		const refreshSelf = {
+			refreshSessions: vi.fn(async () => true),
+			refreshSavedSessions: vi.fn(async () => true),
+		};
 		const self: Record<string, unknown> = {
 			requireClient: () => ({ request }),
 			editor,
 			setStatusMessage: vi.fn(),
-			refreshSessions: vi.fn(async () => true),
-			refreshSavedSessions: vi.fn(async () => true),
+			refreshBothCatalogs: () => invoke("refreshBothCatalogs", refreshSelf),
 		};
 
 		await invoke("runAgentsViewCommand", self, { name: "name", args: "Fresh Name" }, live);
 
 		expect(request).toHaveBeenCalledWith({ type: "rename", activeSessionId: "active-1", name: "Fresh Name" });
-		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
-		expect(self.refreshSavedSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		expect(refreshSelf.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		expect(refreshSelf.refreshSavedSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
 	it("kills a live target and disarms the composer", async () => {
@@ -748,13 +751,14 @@ describe("agents view slash commands", () => {
 			setStatusMessage: vi.fn(),
 			setReplyTarget,
 			replyTarget: { key: "active-1", summary: live },
-			refreshSessions: vi.fn(async () => true),
+			refreshBothCatalogs: vi.fn(async () => true),
 		};
 
 		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, live);
 
 		expect(request).toHaveBeenCalledWith({ type: "kill", activeSessionId: "active-1" });
 		expect(setReplyTarget).toHaveBeenCalledWith(undefined);
+		expect(self.refreshBothCatalogs).toHaveBeenCalled();
 	});
 
 	it("does not disarm a composer that was re-armed during the command", async () => {
@@ -774,7 +778,7 @@ describe("agents view slash commands", () => {
 			setStatusMessage: vi.fn(),
 			setReplyTarget,
 			replyTarget: originalTarget,
-			refreshSessions: vi.fn(async () => true),
+			refreshBothCatalogs: vi.fn(async () => true),
 		};
 
 		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, live);
@@ -820,11 +824,14 @@ describe("agents view slash commands", () => {
 		};
 		const filtered = () => (invoke("getFilteredRecords", self) as unknown[]).length;
 
-		// "/kill" and mid-typing "/ki" must not filter; unknown "/foo" still does.
+		// "/kill" and mid-typing "/ki" must not filter; unknown "/foo" and path
+		// queries like "/tmp/x" still do.
 		expect(filtered()).toBe(1);
 		editor.setText("/ki");
 		expect(filtered()).toBe(1);
 		editor.setText("/foo");
+		expect(filtered()).toBe(0);
+		editor.setText("/tmp/x");
 		expect(filtered()).toBe(0);
 	});
 

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -545,15 +545,6 @@ describe("reply composer slash commands", () => {
 		invoke("setReplyTarget", self, undefined);
 		expect(self.replyAutocomplete).toBeUndefined();
 	});
-
-	it("suggests only session-owned commands", async () => {
-		const provider = createReplyComposerAutocompleteProvider(process.cwd());
-		const suggestions = await provider.getSuggestions(["/"], 0, 1, { signal: new AbortController().signal });
-		const names = suggestions?.items.map((item) => item.value) ?? [];
-		expect(names).toEqual(expect.arrayContaining(["compact", "refine", "goal", "autonomous"]));
-		expect(names).not.toContain("model");
-		expect(names).not.toContain("settings");
-	});
 });
 
 describe("agents view slash commands", () => {
@@ -565,7 +556,6 @@ describe("agents view slash commands", () => {
 		expect(parseAgentsViewCommand("/compact")).toBeUndefined();
 		expect(parseAgentsViewCommand("plain search text")).toBeUndefined();
 		expect(getReplyComposerCommandRejection("/kill")).toBeUndefined();
-		// /fork is a builtin but not a view command; it is rejected with guidance.
 		expect(getReplyComposerCommandRejection("/fork")).toContain("not available here");
 	});
 
@@ -604,8 +594,7 @@ describe("agents view slash commands", () => {
 
 		expect(runAgentsViewCommand).toHaveBeenCalledWith({ name: "kill", args: "" }, live);
 		expect(self.openSelected).not.toHaveBeenCalled();
-		// A remount restores persistentState.query; it must not resurrect the
-		// command where Enter could re-run it on an arbitrary row.
+		// A remount must not restore and re-run the command from the persisted query.
 		expect(persistentState.query).toBe("");
 	});
 
@@ -630,14 +619,12 @@ describe("agents view slash commands", () => {
 
 		await invoke("submit", self, "/kill");
 
-		// The draft comes back through the query path so persistence agrees.
 		expect(editor.getText()).toBe("/kill");
 		expect(persistentState.query).toBe("/kill");
 	});
 
 	it("rejects view commands under the local adapter in both editors", async () => {
-		// Search editor: must warn instead of opening the selected row, and keep
-		// the cleared draft.
+		// Search editor: warn instead of opening the selected row; keep the draft.
 		const openSelected = vi.fn();
 		const searchEditor = editorWithText("");
 		const searchSelf: Record<string, unknown> = {
@@ -813,8 +800,7 @@ describe("agents view slash commands", () => {
 		};
 		const filtered = () => (invoke("getFilteredRecords", self) as unknown[]).length;
 
-		// "/kill" and the mid-typing prefix "/ki" must not act as fuzzy queries
-		// (they would drop the row), but "/foo" stays an ordinary search term.
+		// "/kill" and mid-typing "/ki" must not filter; unknown "/foo" still does.
 		expect(filtered()).toBe(1);
 		editor.setText("/ki");
 		expect(filtered()).toBe(1);

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -723,22 +723,28 @@ describe("agents view slash commands", () => {
 		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
 		const request = vi.fn(async () => ({ success: true, data: {} }));
 		const editor = editorWithText("/name Fresh Name");
-		const refreshSelf = {
-			refreshSessions: vi.fn(async () => true),
-			refreshSavedSessions: vi.fn(async () => true),
-		};
 		const self: Record<string, unknown> = {
+			options: {},
 			requireClient: () => ({ request }),
 			editor,
 			setStatusMessage: vi.fn(),
-			refreshBothCatalogs: () => invoke("refreshBothCatalogs", refreshSelf),
+			refreshSessions: vi.fn(async () => true),
+			refreshSavedSessions: vi.fn(async () => true),
+			renameSession(s: unknown, n: string) {
+				return invoke("renameSession", self, s, n);
+			},
+			refreshBothCatalogs() {
+				return invoke("refreshBothCatalogs", self);
+			},
 		};
 
-		await invoke("runAgentsViewCommand", self, { name: "name", args: "Fresh Name" }, live);
+		await expect(invoke("runAgentsViewCommand", self, { name: "name", args: "Fresh Name" }, live)).resolves.toBe(
+			true,
+		);
 
 		expect(request).toHaveBeenCalledWith({ type: "rename", activeSessionId: "active-1", name: "Fresh Name" });
-		expect(refreshSelf.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
-		expect(refreshSelf.refreshSavedSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+		expect(self.refreshSavedSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
 	it("kills a live target and disarms the composer", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -765,6 +765,13 @@ describe("agents view slash commands", () => {
 		expect(request).toHaveBeenCalledWith({ type: "kill", activeSessionId: "active-1" });
 		expect(setReplyTarget).toHaveBeenCalledWith(undefined);
 		expect(self.refreshBothCatalogs).toHaveBeenCalled();
+
+		// An agent that finished before the RPC still counts as stopped.
+		self.request = undefined;
+		self.requireClient = () => ({
+			request: vi.fn(async () => ({ success: false, error: "Unknown active session: active-1" })),
+		});
+		await expect(invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, live)).resolves.toBe(true);
 	});
 
 	it("does not disarm a composer that was re-armed during the command", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -666,14 +666,20 @@ describe("agents view slash commands", () => {
 	});
 
 	it("rejects view commands under the local adapter in both editors", async () => {
-		// Search editor: must warn instead of opening the selected row.
+		// Search editor: must warn instead of opening the selected row, and keep
+		// the cleared draft.
 		const openSelected = vi.fn();
+		const searchEditor = editorWithText("");
 		const searchSelf: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: { adapter: { kind: "local" } },
 			rows: [],
 			selectedIndex: 0,
+			editor: searchEditor,
+			setSearchQuery(query: string) {
+				searchEditor.setText(query);
+			},
 			setStatusMessage: vi.fn(),
 			runAgentsViewCommand: vi.fn(),
 			openSelected,
@@ -682,6 +688,7 @@ describe("agents view slash commands", () => {
 		expect(searchSelf.runAgentsViewCommand).not.toHaveBeenCalled();
 		expect(openSelected).not.toHaveBeenCalled();
 		expect(searchSelf.setStatusMessage).toHaveBeenCalledWith("/new is not available here", { tone: "warning" });
+		expect(searchEditor.getText()).toBe("/new");
 
 		// Armed composer: must warn instead of sending the command as a prompt.
 		const sendReply = vi.fn(async () => true);

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -641,7 +641,7 @@ describe("agents view slash commands", () => {
 
 	it("routes a search-editor command to the selected row", async () => {
 		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const runAgentsViewCommand = vi.fn(async () => {});
+		const runAgentsViewCommand = vi.fn(async () => true);
 		const self: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
@@ -656,6 +656,24 @@ describe("agents view slash commands", () => {
 
 		expect(runAgentsViewCommand).toHaveBeenCalledWith({ name: "kill", args: "" }, live);
 		expect(self.openSelected).not.toHaveBeenCalled();
+	});
+
+	it("restores the search-editor command when it fails", async () => {
+		const editor = editorWithText("");
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			rows: [],
+			selectedIndex: 0,
+			editor,
+			runAgentsViewCommand: vi.fn(async () => false),
+			openSelected: vi.fn(),
+		};
+
+		await invoke("submit", self, "/kill");
+
+		expect(editor.getText()).toBe("/kill");
 	});
 
 	it("keeps plain search text opening the selection", async () => {
@@ -678,13 +696,12 @@ describe("agents view slash commands", () => {
 
 	it("runs /new without a target row", async () => {
 		const createNewSession = vi.fn(async () => {});
-		const editor = editorWithText("/new");
-		const self: Record<string, unknown> = { createNewSession, editor };
+		const self: Record<string, unknown> = { createNewSession, replyTarget: undefined };
 
-		await invoke("runAgentsViewCommand", self, { name: "new", args: "" }, undefined);
+		const succeeded = await invoke("runAgentsViewCommand", self, { name: "new", args: "" }, undefined);
 
 		expect(createNewSession).toHaveBeenCalledOnce();
-		expect(editor.getText()).toBe("");
+		expect(succeeded).toBe(true);
 	});
 
 	it("requires a selected row for row-targeted commands", async () => {
@@ -732,6 +749,67 @@ describe("agents view slash commands", () => {
 
 		expect(request).toHaveBeenCalledWith({ type: "kill", activeSessionId: "active-1" });
 		expect(setReplyTarget).toHaveBeenCalledWith(undefined);
+	});
+
+	it("does not disarm a composer that was re-armed during the command", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const originalTarget = { key: "active-1", summary: live };
+		const newTarget = { key: "active-2", summary: summary({ activeSessionId: "active-2" }) };
+		const setReplyTarget = vi.fn();
+		const self: Record<string, unknown> = {
+			requireClient: () => ({
+				request: vi.fn(async () => {
+					// The user re-arms against a different agent mid-RPC.
+					self.replyTarget = newTarget;
+					return { success: true, data: {} };
+				}),
+			}),
+			editor: editorWithText(""),
+			setStatusMessage: vi.fn(),
+			setReplyTarget,
+			replyTarget: originalTarget,
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, live);
+
+		expect(setReplyTarget).not.toHaveBeenCalled();
+	});
+
+	it("restores the command draft when the armed command fails", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const target = { key: "active-1", summary: live };
+		const editor = editorWithText("");
+		const self: Record<string, unknown> = {
+			replyTarget: target,
+			editor,
+			setStatusMessage: vi.fn(),
+			runAgentsViewCommand: vi.fn(async () => false),
+		};
+
+		await invoke("submit", self, "/name");
+
+		expect(editor.getText()).toBe("/name");
+	});
+
+	it("reports a cancelled fork instead of claiming success", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const request = vi.fn(async (command: { type: string }) => {
+			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-1" } };
+			return { success: true, data: { cancelled: true } };
+		});
+		const setStatusMessage = vi.fn();
+		const self: Record<string, unknown> = {
+			requireClient: () => ({ request }),
+			setStatusMessage,
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		const forked = await invoke("forkTargetSession", self, live);
+
+		expect(forked).toBe(false);
+		expect(setStatusMessage).toHaveBeenCalledWith("Fork cancelled");
+		expect(self.refreshSessions).not.toHaveBeenCalled();
 	});
 
 	it("refuses /kill on an inactive row", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -666,8 +666,10 @@ describe("agents view slash commands", () => {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: {},
+			persistentState: { query: "/kill" },
 			rows: [{ kind: "agent", selectable: true, summary: live }],
 			selectedIndex: 0,
+			editor: editorWithText(""),
 			runAgentsViewCommand,
 			openSelected: vi.fn(),
 		};
@@ -680,20 +682,28 @@ describe("agents view slash commands", () => {
 
 	it("restores the search-editor command when it fails", async () => {
 		const editor = editorWithText("");
+		const persistentState: Record<string, unknown> = { query: "/kill" };
 		const self: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: {},
+			persistentState,
 			rows: [],
 			selectedIndex: 0,
 			editor,
+			setSearchQuery(query: string) {
+				editor.setText(query);
+				persistentState.query = query;
+			},
 			runAgentsViewCommand: vi.fn(async () => false),
 			openSelected: vi.fn(),
 		};
 
 		await invoke("submit", self, "/kill");
 
+		// The draft comes back through the query path so persistence agrees.
 		expect(editor.getText()).toBe("/kill");
+		expect(persistentState.query).toBe("/kill");
 	});
 
 	it("keeps plain search text opening the selection", async () => {
@@ -862,6 +872,27 @@ describe("agents view slash commands", () => {
 		expect(requests.map((r) => r.type)).toEqual(["create", "get_session_tree", "kill"]);
 		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(true);
 		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+	});
+
+	it("drops a submitted view command from the persisted query", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const persistentState: Record<string, unknown> = { query: "/kill" };
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			persistentState,
+			rows: [{ kind: "agent", selectable: true, summary: live }],
+			selectedIndex: 0,
+			editor: editorWithText(""),
+			runAgentsViewCommand: vi.fn(async () => true),
+		};
+
+		await invoke("submit", self, "/kill");
+
+		// A remount restores persistentState.query; it must not resurrect the
+		// command where Enter could re-run it on an arbitrary row.
+		expect(persistentState.query).toBe("");
 	});
 
 	it("freezes the session filter while a view command is typed", () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -895,6 +895,28 @@ describe("agents view slash commands", () => {
 		expect(persistentState.query).toBe("");
 	});
 
+	it("keeps filtering on unknown slash-prefixed search terms", () => {
+		const matching = {
+			daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
+			identity: "active:active-1",
+			identityAliases: ["active:active-1"],
+			section: "idle",
+			searchableText: "kilroy",
+		};
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			unifiedRecords: [matching],
+			editor: editorWithText("/foo"),
+		};
+
+		const records = invoke("getFilteredRecords", self) as unknown[];
+
+		// "/foo" is not a view command; it stays an ordinary (non-matching) query.
+		expect(records).toHaveLength(0);
+	});
+
 	it("freezes the session filter while a view command is typed", () => {
 		const matching = {
 			daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
@@ -913,8 +935,11 @@ describe("agents view slash commands", () => {
 
 		const records = invoke("getFilteredRecords", self) as unknown[];
 
-		// "/kill" must not be applied as a fuzzy query (it would drop the row).
+		// "/kill" must not be applied as a fuzzy query (it would drop the row),
+		// and neither must a mid-typing prefix like "/ki".
 		expect(records).toHaveLength(1);
+		(self.editor as { setText(t: string): void }).setText("/ki");
+		expect(invoke("getFilteredRecords", self) as unknown[]).toHaveLength(1);
 	});
 
 	it("re-resolves the armed target before dispatching a view command", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -694,14 +694,13 @@ describe("agents view slash commands", () => {
 		expect(self.runAgentsViewCommand).not.toHaveBeenCalled();
 	});
 
-	it("runs /new without a target row", async () => {
-		const createNewSession = vi.fn(async () => {});
-		const self: Record<string, unknown> = { createNewSession, replyTarget: undefined };
+	it("runs /new without a target row and propagates the outcome", async () => {
+		const self: Record<string, unknown> = { createNewSession: vi.fn(async () => true), replyTarget: undefined };
+		await expect(invoke("runAgentsViewCommand", self, { name: "new", args: "" }, undefined)).resolves.toBe(true);
+		expect(self.createNewSession).toHaveBeenCalledOnce();
 
-		const succeeded = await invoke("runAgentsViewCommand", self, { name: "new", args: "" }, undefined);
-
-		expect(createNewSession).toHaveBeenCalledOnce();
-		expect(succeeded).toBe(true);
+		const failing: Record<string, unknown> = { createNewSession: vi.fn(async () => false), replyTarget: undefined };
+		await expect(invoke("runAgentsViewCommand", failing, { name: "new", args: "" }, undefined)).resolves.toBe(false);
 	});
 
 	it("requires a selected row for row-targeted commands", async () => {
@@ -810,6 +809,29 @@ describe("agents view slash commands", () => {
 		expect(forked).toBe(false);
 		expect(setStatusMessage).toHaveBeenCalledWith("Fork cancelled");
 		expect(self.refreshSessions).not.toHaveBeenCalled();
+	});
+
+	it("refreshes the catalog when a resumed fork fails afterwards", async () => {
+		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl", cwd: process.cwd() });
+		const request = vi.fn(async (command: { type: string }) => {
+			if (command.type === "create") {
+				return { success: true, data: { ...saved, lifecycle: "live", activeSessionId: "active-9" } };
+			}
+			// Empty tree: fork aborts after the resume already made the row live.
+			return { success: true, data: { tree: [], leafId: null } };
+		});
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			setStatusMessage: vi.fn(),
+			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		const forked = await invoke("forkTargetSession", self, saved);
+
+		expect(forked).toBe(false);
+		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
 	it("refuses /kill on an inactive row", async () => {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -5,7 +5,9 @@ import { KeybindingsManager } from "../src/core/keybindings.js";
 import {
 	AgentsViewMode,
 	createReplyComposerAutocompleteProvider,
+	createSearchViewAutocompleteProvider,
 	getReplyComposerCommandRejection,
+	parseAgentsViewCommand,
 } from "../src/modes/agents-view/agents-view-mode.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 
@@ -525,5 +527,207 @@ describe("reply composer slash commands", () => {
 		expect(names).toEqual(expect.arrayContaining(["compact", "refine", "goal", "autonomous"]));
 		expect(names).not.toContain("model");
 		expect(names).not.toContain("settings");
+	});
+});
+
+describe("agents view slash commands", () => {
+	it("parses whitelisted view commands and aliases", () => {
+		expect(parseAgentsViewCommand("/new")).toEqual({ name: "new", args: "" });
+		expect(parseAgentsViewCommand("/fork")).toEqual({ name: "fork", args: "" });
+		expect(parseAgentsViewCommand("/name My Agent")).toEqual({ name: "name", args: "My Agent" });
+		expect(parseAgentsViewCommand("/rename My Agent")).toEqual({ name: "name", args: "My Agent" });
+		expect(parseAgentsViewCommand("/kill")).toEqual({ name: "kill", args: "" });
+		expect(parseAgentsViewCommand("/compact")).toBeUndefined();
+		expect(parseAgentsViewCommand("/settings")).toBeUndefined();
+		expect(parseAgentsViewCommand("plain search text")).toBeUndefined();
+	});
+
+	it("keeps view commands out of the composer rejection list", () => {
+		expect(getReplyComposerCommandRejection("/fork")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/name x")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/kill")).toBeUndefined();
+		expect(getReplyComposerCommandRejection("/new")).toBeUndefined();
+	});
+
+	it("suggests view commands in both composers and session commands only when armed", async () => {
+		const composer = createReplyComposerAutocompleteProvider(process.cwd());
+		const search = createSearchViewAutocompleteProvider(process.cwd());
+		const signal = new AbortController().signal;
+		const composerNames = (await composer.getSuggestions(["/"], 0, 1, { signal }))?.items.map((i) => i.value) ?? [];
+		const searchNames = (await search.getSuggestions(["/"], 0, 1, { signal }))?.items.map((i) => i.value) ?? [];
+		expect(composerNames).toEqual(
+			expect.arrayContaining(["compact", "refine", "goal", "autonomous", "new", "fork", "name", "kill"]),
+		);
+		expect(searchNames).toEqual(expect.arrayContaining(["new", "fork", "name", "kill"]));
+		expect(searchNames).not.toContain("compact");
+		expect(searchNames).not.toContain("settings");
+	});
+
+	it("routes a search-editor command to the selected row", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const runAgentsViewCommand = vi.fn(async () => {});
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			rows: [{ kind: "agent", selectable: true, summary: live }],
+			selectedIndex: 0,
+			runAgentsViewCommand,
+			openSelected: vi.fn(),
+		};
+
+		await invoke("submit", self, "/kill");
+
+		expect(runAgentsViewCommand).toHaveBeenCalledWith({ name: "kill", args: "" }, live);
+		expect(self.openSelected).not.toHaveBeenCalled();
+	});
+
+	it("keeps plain search text opening the selection", async () => {
+		const openSelected = vi.fn();
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			rows: [],
+			selectedIndex: 0,
+			runAgentsViewCommand: vi.fn(),
+			openSelected,
+		};
+
+		await invoke("submit", self, "release planner");
+
+		expect(openSelected).toHaveBeenCalledOnce();
+		expect(self.runAgentsViewCommand).not.toHaveBeenCalled();
+	});
+
+	it("runs /new without a target row", async () => {
+		const createNewSession = vi.fn(async () => {});
+		const editor = editorWithText("/new");
+		const self: Record<string, unknown> = { createNewSession, editor };
+
+		await invoke("runAgentsViewCommand", self, { name: "new", args: "" }, undefined);
+
+		expect(createNewSession).toHaveBeenCalledOnce();
+		expect(editor.getText()).toBe("");
+	});
+
+	it("requires a selected row for row-targeted commands", async () => {
+		const setStatusMessage = vi.fn();
+		const self: Record<string, unknown> = { setStatusMessage, createNewSession: vi.fn() };
+
+		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, undefined);
+
+		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("Select an agent row"), {
+			tone: "warning",
+		});
+	});
+
+	it("renames a live target via the rename RPC", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const request = vi.fn(async () => ({ success: true, data: {} }));
+		const editor = editorWithText("/name Fresh Name");
+		const self: Record<string, unknown> = {
+			requireClient: () => ({ request }),
+			editor,
+			setStatusMessage: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		await invoke("runAgentsViewCommand", self, { name: "name", args: "Fresh Name" }, live);
+
+		expect(request).toHaveBeenCalledWith({ type: "rename", activeSessionId: "active-1", name: "Fresh Name" });
+		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+	});
+
+	it("kills a live target and disarms the composer", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const request = vi.fn(async () => ({ success: true, data: {} }));
+		const setReplyTarget = vi.fn();
+		const self: Record<string, unknown> = {
+			requireClient: () => ({ request }),
+			editor: editorWithText("/kill"),
+			setStatusMessage: vi.fn(),
+			setReplyTarget,
+			replyTarget: { key: "active-1", summary: live },
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, live);
+
+		expect(request).toHaveBeenCalledWith({ type: "kill", activeSessionId: "active-1" });
+		expect(setReplyTarget).toHaveBeenCalledWith(undefined);
+	});
+
+	it("refuses /kill on an inactive row", async () => {
+		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl" });
+		const request = vi.fn();
+		const setStatusMessage = vi.fn();
+		const self: Record<string, unknown> = {
+			requireClient: () => ({ request }),
+			editor: editorWithText("/kill"),
+			setStatusMessage,
+		};
+
+		await invoke("runAgentsViewCommand", self, { name: "kill", args: "" }, saved);
+
+		expect(request).not.toHaveBeenCalled();
+		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("inactive"), { tone: "warning" });
+	});
+
+	it("forks a live target at its current leaf", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const requests: { type: string }[] = [];
+		const request = vi.fn(async (command: { type: string }) => {
+			requests.push(command);
+			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-9" } };
+			return { success: true, data: { cancelled: false } };
+		});
+		const self: Record<string, unknown> = {
+			requireClient: () => ({ request }),
+			editor: editorWithText("/fork"),
+			setStatusMessage: vi.fn(),
+			replyTarget: undefined,
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		await invoke("forkTargetSession", self, live);
+
+		expect(requests.map((r) => r.type)).toEqual(["get_session_tree", "fork"]);
+		expect(request).toHaveBeenCalledWith({
+			type: "fork",
+			activeSessionId: "active-1",
+			entryId: "leaf-9",
+			position: "at",
+		});
+	});
+
+	it("resumes a saved row before forking it", async () => {
+		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl", cwd: process.cwd() });
+		const requests: { type: string }[] = [];
+		const request = vi.fn(async (command: { type: string }) => {
+			requests.push(command);
+			if (command.type === "create") {
+				return { success: true, data: { ...saved, lifecycle: "live", activeSessionId: "active-9" } };
+			}
+			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-1" } };
+			return { success: true, data: { cancelled: false } };
+		});
+		const self: Record<string, unknown> = {
+			options: { config: { cwd: process.cwd() } },
+			requireClient: () => ({ request }),
+			editor: editorWithText("/fork"),
+			setStatusMessage: vi.fn(),
+			replyTarget: undefined,
+			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
+			refreshSessions: vi.fn(async () => true),
+		};
+
+		await invoke("forkTargetSession", self, saved);
+
+		expect(requests.map((r) => r.type)).toEqual(["create", "get_session_tree", "fork"]);
+		expect(request).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "fork", activeSessionId: "active-9", entryId: "leaf-1" }),
+		);
+		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 	});
 });

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -179,6 +179,7 @@ describe("agents view reply on inactive sessions", () => {
 		};
 		const self: Record<string, unknown> = {
 			replyTarget: oldTarget,
+			options: {},
 			editor,
 			setReplyTarget: vi.fn(),
 			refreshSessions: vi.fn(async () => true),
@@ -202,6 +203,7 @@ describe("agents view reply on inactive sessions", () => {
 		const target = { key: "saved-1", summary: savedSummary };
 		const self: Record<string, unknown> = {
 			replyTarget: target,
+			options: {},
 			editor,
 			setReplyTarget: vi.fn(),
 			refreshSessions: vi.fn(async () => true),
@@ -564,6 +566,7 @@ describe("reply composer slash commands", () => {
 		const sendReply = vi.fn();
 		const self: Record<string, unknown> = {
 			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			options: {},
 			editor,
 			setStatusMessage,
 			sendReply,
@@ -582,6 +585,7 @@ describe("reply composer slash commands", () => {
 		const editor = editorWithText("newer draft");
 		const self: Record<string, unknown> = {
 			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1" }) },
+			options: {},
 			editor,
 			setStatusMessage: vi.fn(),
 			sendReply: vi.fn(),
@@ -797,6 +801,9 @@ describe("agents view slash commands", () => {
 		const editor = editorWithText("");
 		const self: Record<string, unknown> = {
 			replyTarget: target,
+			options: {},
+			unifiedRecords: [],
+			findSummaryByActiveSessionId: () => live,
 			editor,
 			setStatusMessage: vi.fn(),
 			runAgentsViewCommand: vi.fn(async () => false),
@@ -827,27 +834,113 @@ describe("agents view slash commands", () => {
 		expect(self.refreshSessions).not.toHaveBeenCalled();
 	});
 
-	it("refreshes the catalog when a resumed fork fails afterwards", async () => {
+	it("stops a session resumed for a fork that then fails", async () => {
 		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl", cwd: process.cwd() });
+		const requests: { type: string }[] = [];
 		const request = vi.fn(async (command: { type: string }) => {
+			requests.push(command);
 			if (command.type === "create") {
 				return { success: true, data: { ...saved, lifecycle: "live", activeSessionId: "active-9" } };
 			}
 			// Empty tree: fork aborts after the resume already made the row live.
 			return { success: true, data: { tree: [], leafId: null } };
 		});
+		const inactiveAgentIdentities = new Set(["file:/tmp/sessions/saved-1.jsonl"]);
 		const self: Record<string, unknown> = {
 			options: { config: { cwd: process.cwd() } },
 			requireClient: () => ({ request }),
 			setStatusMessage: vi.fn(),
-			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
+			inactiveAgentIdentities,
 			refreshSessions: vi.fn(async () => true),
 		};
 
 		const forked = await invoke("forkTargetSession", self, saved);
 
 		expect(forked).toBe(false);
+		// The resume served only the fork: the runtime is stopped again and the
+		// row stays inactive.
+		expect(requests.map((r) => r.type)).toEqual(["create", "get_session_tree", "kill"]);
+		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(true);
 		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
+	});
+
+	it("freezes the session filter while a view command is typed", () => {
+		const matching = {
+			daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
+			identity: "active:active-1",
+			identityAliases: ["active:active-1"],
+			section: "idle",
+			searchableText: "kilroy",
+		};
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: {},
+			unifiedRecords: [matching],
+			editor: editorWithText("/kill"),
+		};
+
+		const records = invoke("getFilteredRecords", self) as unknown[];
+
+		// "/kill" must not be applied as a fuzzy query (it would drop the row).
+		expect(records).toHaveLength(1);
+	});
+
+	it("re-resolves the armed target before dispatching a view command", async () => {
+		const stale = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl" });
+		const liveNow = summary({
+			sessionFile: "/tmp/sessions/saved-1.jsonl",
+			activeSessionId: "active-9",
+			lifecycle: "live",
+		});
+		const runAgentsViewCommand = vi.fn(async () => true);
+		const self: Record<string, unknown> = {
+			replyTarget: { key: "saved-1", summary: stale },
+			options: {},
+			unifiedRecords: [
+				{
+					daemon: liveNow,
+					identity: "file:/tmp/sessions/saved-1.jsonl",
+					identityAliases: ["file:/tmp/sessions/saved-1.jsonl"],
+					section: "idle",
+					searchableText: "",
+				},
+			],
+			findSummaryByActiveSessionId: () => undefined,
+			editor: editorWithText(""),
+			runAgentsViewCommand,
+		};
+
+		await invoke("submit", self, "/kill");
+
+		expect(runAgentsViewCommand).toHaveBeenCalledWith(
+			{ name: "kill", args: "" },
+			expect.objectContaining({ activeSessionId: "active-9" }),
+		);
+	});
+
+	it("ignores view commands in the armed composer under the local adapter", async () => {
+		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const target = { key: "active-1", summary: live };
+		const runAgentsViewCommand = vi.fn();
+		const sendReply = vi.fn(async () => true);
+		const self: Record<string, unknown> = {
+			replyTarget: target,
+			options: { adapter: { kind: "local" } },
+			editor: editorWithText(""),
+			setStatusMessage: vi.fn(),
+			setReplyTarget: vi.fn(),
+			refreshSessions: vi.fn(async () => true),
+			runAgentsViewCommand,
+			sendReply,
+		};
+
+		await invoke("submit", self, "/kill");
+
+		// Adapter sessions cannot run view commands; reject instead of prompting.
+		expect(runAgentsViewCommand).not.toHaveBeenCalled();
+		expect(sendReply).not.toHaveBeenCalled();
+		expect(self.setStatusMessage).toHaveBeenCalledWith("/kill is not available here", { tone: "warning" });
 	});
 
 	it("refuses /kill on an inactive row", async () => {
@@ -879,6 +972,7 @@ describe("agents view slash commands", () => {
 			editor: editorWithText("/fork"),
 			setStatusMessage: vi.fn(),
 			replyTarget: undefined,
+			inactiveAgentIdentities: new Set<string>(),
 			refreshSessions: vi.fn(async () => true),
 		};
 

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -706,6 +706,26 @@ describe("agents view slash commands", () => {
 		expect(persistentState.query).toBe("/kill");
 	});
 
+	it("rejects view commands in the adapter search editor", async () => {
+		const openSelected = vi.fn();
+		const self: Record<string, unknown> = {
+			replyTarget: undefined,
+			renameTarget: undefined,
+			options: { adapter: { kind: "local" } },
+			rows: [],
+			selectedIndex: 0,
+			setStatusMessage: vi.fn(),
+			runAgentsViewCommand: vi.fn(),
+			openSelected,
+		};
+
+		await invoke("submit", self, "/new");
+
+		expect(self.runAgentsViewCommand).not.toHaveBeenCalled();
+		expect(openSelected).not.toHaveBeenCalled();
+		expect(self.setStatusMessage).toHaveBeenCalledWith("/new is not available here", { tone: "warning" });
+	});
+
 	it("keeps plain search text opening the selection", async () => {
 		const openSelected = vi.fn();
 		const self: Record<string, unknown> = {

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -594,8 +594,9 @@ describe("agents view slash commands", () => {
 		expect(parseAgentsViewCommand("/kill")).toEqual({ name: "kill", args: "" });
 		expect(parseAgentsViewCommand("/compact")).toBeUndefined();
 		expect(parseAgentsViewCommand("plain search text")).toBeUndefined();
-		expect(getReplyComposerCommandRejection("/fork")).toBeUndefined();
 		expect(getReplyComposerCommandRejection("/kill")).toBeUndefined();
+		// /fork is a builtin but not a view command; it is rejected with guidance.
+		expect(getReplyComposerCommandRejection("/fork")).toContain("not available here");
 	});
 
 	it("suggests view commands in both composers and session commands only when armed", async () => {
@@ -605,9 +606,10 @@ describe("agents view slash commands", () => {
 		const composerNames = (await composer.getSuggestions(["/"], 0, 1, { signal }))?.items.map((i) => i.value) ?? [];
 		const searchNames = (await search.getSuggestions(["/"], 0, 1, { signal }))?.items.map((i) => i.value) ?? [];
 		expect(composerNames).toEqual(
-			expect.arrayContaining(["compact", "refine", "goal", "autonomous", "new", "fork", "name", "kill"]),
+			expect.arrayContaining(["compact", "refine", "goal", "autonomous", "new", "name", "kill"]),
 		);
-		expect(searchNames).toEqual(expect.arrayContaining(["new", "fork", "name", "kill"]));
+		expect(searchNames).toEqual(expect.arrayContaining(["new", "name", "kill"]));
+		expect(searchNames).not.toContain("fork");
 		expect(searchNames).not.toContain("compact");
 		expect(searchNames).not.toContain("settings");
 	});
@@ -815,56 +817,6 @@ describe("agents view slash commands", () => {
 		expect(editor.getText()).toBe("/name");
 	});
 
-	it("reports a cancelled fork instead of claiming success", async () => {
-		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const request = vi.fn(async (command: { type: string }) => {
-			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-1" } };
-			return { success: true, data: { cancelled: true } };
-		});
-		const setStatusMessage = vi.fn();
-		const self: Record<string, unknown> = {
-			requireClient: () => ({ request }),
-			setStatusMessage,
-			refreshSessions: vi.fn(async () => true),
-		};
-
-		const forked = await invoke("forkTargetSession", self, live);
-
-		expect(forked).toBe(false);
-		expect(setStatusMessage).toHaveBeenCalledWith("Fork cancelled");
-		expect(self.refreshSessions).not.toHaveBeenCalled();
-	});
-
-	it("stops a session resumed for a fork that then fails", async () => {
-		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl", cwd: process.cwd() });
-		const requests: { type: string }[] = [];
-		const request = vi.fn(async (command: { type: string }) => {
-			requests.push(command);
-			if (command.type === "create") {
-				return { success: true, data: { ...saved, lifecycle: "live", activeSessionId: "active-9" } };
-			}
-			// Empty tree: fork aborts after the resume already made the row live.
-			return { success: true, data: { tree: [], leafId: null } };
-		});
-		const inactiveAgentIdentities = new Set(["file:/tmp/sessions/saved-1.jsonl"]);
-		const self: Record<string, unknown> = {
-			options: { config: { cwd: process.cwd() } },
-			requireClient: () => ({ request }),
-			setStatusMessage: vi.fn(),
-			inactiveAgentIdentities,
-			refreshSessions: vi.fn(async () => true),
-		};
-
-		const forked = await invoke("forkTargetSession", self, saved);
-
-		expect(forked).toBe(false);
-		// The resume served only the fork: the runtime is stopped again and the
-		// row stays inactive.
-		expect(requests.map((r) => r.type)).toEqual(["create", "get_session_tree", "kill"]);
-		expect(inactiveAgentIdentities.has("file:/tmp/sessions/saved-1.jsonl")).toBe(true);
-		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
-	});
-
 	it("freezes the filter for command input but not for unknown slash terms", () => {
 		const editor = editorWithText("/kill");
 		const self: Record<string, unknown> = {
@@ -940,63 +892,5 @@ describe("agents view slash commands", () => {
 
 		expect(request).not.toHaveBeenCalled();
 		expect(setStatusMessage).toHaveBeenCalledWith(expect.stringContaining("inactive"), { tone: "warning" });
-	});
-
-	it("forks a live target at its current leaf", async () => {
-		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const requests: { type: string }[] = [];
-		const request = vi.fn(async (command: { type: string }) => {
-			requests.push(command);
-			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-9" } };
-			return { success: true, data: { cancelled: false } };
-		});
-		const self: Record<string, unknown> = {
-			requireClient: () => ({ request }),
-			editor: editorWithText("/fork"),
-			setStatusMessage: vi.fn(),
-			replyTarget: undefined,
-			inactiveAgentIdentities: new Set<string>(),
-			refreshSessions: vi.fn(async () => true),
-		};
-
-		await invoke("forkTargetSession", self, live);
-
-		expect(requests.map((r) => r.type)).toEqual(["get_session_tree", "fork"]);
-		expect(request).toHaveBeenCalledWith({
-			type: "fork",
-			activeSessionId: "active-1",
-			entryId: "leaf-9",
-			position: "at",
-		});
-	});
-
-	it("resumes a saved row before forking it", async () => {
-		const saved = summary({ sessionFile: "/tmp/sessions/saved-1.jsonl", cwd: process.cwd() });
-		const requests: { type: string }[] = [];
-		const request = vi.fn(async (command: { type: string }) => {
-			requests.push(command);
-			if (command.type === "create") {
-				return { success: true, data: { ...saved, lifecycle: "live", activeSessionId: "active-9" } };
-			}
-			if (command.type === "get_session_tree") return { success: true, data: { tree: [], leafId: "leaf-1" } };
-			return { success: true, data: { cancelled: false } };
-		});
-		const self: Record<string, unknown> = {
-			options: { config: { cwd: process.cwd() } },
-			requireClient: () => ({ request }),
-			editor: editorWithText("/fork"),
-			setStatusMessage: vi.fn(),
-			replyTarget: undefined,
-			inactiveAgentIdentities: new Set(["file:/tmp/sessions/saved-1.jsonl"]),
-			refreshSessions: vi.fn(async () => true),
-		};
-
-		await invoke("forkTargetSession", self, saved);
-
-		expect(requests.map((r) => r.type)).toEqual(["create", "get_session_tree", "fork"]);
-		expect(request).toHaveBeenCalledWith(
-			expect.objectContaining({ type: "fork", activeSessionId: "active-9", entryId: "leaf-1" }),
-		);
-		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 	});
 });

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -587,22 +587,15 @@ describe("reply composer slash commands", () => {
 });
 
 describe("agents view slash commands", () => {
-	it("parses whitelisted view commands and aliases", () => {
+	it("parses whitelisted view commands, which the composer never rejects", () => {
 		expect(parseAgentsViewCommand("/new")).toEqual({ name: "new", args: "" });
-		expect(parseAgentsViewCommand("/fork")).toEqual({ name: "fork", args: "" });
 		expect(parseAgentsViewCommand("/name My Agent")).toEqual({ name: "name", args: "My Agent" });
 		expect(parseAgentsViewCommand("/rename My Agent")).toEqual({ name: "name", args: "My Agent" });
 		expect(parseAgentsViewCommand("/kill")).toEqual({ name: "kill", args: "" });
 		expect(parseAgentsViewCommand("/compact")).toBeUndefined();
-		expect(parseAgentsViewCommand("/settings")).toBeUndefined();
 		expect(parseAgentsViewCommand("plain search text")).toBeUndefined();
-	});
-
-	it("keeps view commands out of the composer rejection list", () => {
 		expect(getReplyComposerCommandRejection("/fork")).toBeUndefined();
-		expect(getReplyComposerCommandRejection("/name x")).toBeUndefined();
 		expect(getReplyComposerCommandRejection("/kill")).toBeUndefined();
-		expect(getReplyComposerCommandRejection("/new")).toBeUndefined();
 	});
 
 	it("suggests view commands in both composers and session commands only when armed", async () => {
@@ -619,14 +612,15 @@ describe("agents view slash commands", () => {
 		expect(searchNames).not.toContain("settings");
 	});
 
-	it("routes a search-editor command to the selected row", async () => {
+	it("routes a search-editor command to the selected row and drops it from the persisted query", async () => {
 		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
+		const persistentState: Record<string, unknown> = { query: "/kill" };
 		const runAgentsViewCommand = vi.fn(async () => true);
 		const self: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: {},
-			persistentState: { query: "/kill" },
+			persistentState,
 			rows: [{ kind: "agent", selectable: true, summary: live }],
 			selectedIndex: 0,
 			editor: editorWithText(""),
@@ -638,6 +632,9 @@ describe("agents view slash commands", () => {
 
 		expect(runAgentsViewCommand).toHaveBeenCalledWith({ name: "kill", args: "" }, live);
 		expect(self.openSelected).not.toHaveBeenCalled();
+		// A remount restores persistentState.query; it must not resurrect the
+		// command where Enter could re-run it on an arbitrary row.
+		expect(persistentState.query).toBe("");
 	});
 
 	it("restores the search-editor command when it fails", async () => {
@@ -666,9 +663,10 @@ describe("agents view slash commands", () => {
 		expect(persistentState.query).toBe("/kill");
 	});
 
-	it("rejects view commands in the adapter search editor", async () => {
+	it("rejects view commands under the local adapter in both editors", async () => {
+		// Search editor: must warn instead of opening the selected row.
 		const openSelected = vi.fn();
-		const self: Record<string, unknown> = {
+		const searchSelf: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: { adapter: { kind: "local" } },
@@ -678,12 +676,25 @@ describe("agents view slash commands", () => {
 			runAgentsViewCommand: vi.fn(),
 			openSelected,
 		};
-
-		await invoke("submit", self, "/new");
-
-		expect(self.runAgentsViewCommand).not.toHaveBeenCalled();
+		await invoke("submit", searchSelf, "/new");
+		expect(searchSelf.runAgentsViewCommand).not.toHaveBeenCalled();
 		expect(openSelected).not.toHaveBeenCalled();
-		expect(self.setStatusMessage).toHaveBeenCalledWith("/new is not available here", { tone: "warning" });
+		expect(searchSelf.setStatusMessage).toHaveBeenCalledWith("/new is not available here", { tone: "warning" });
+
+		// Armed composer: must warn instead of sending the command as a prompt.
+		const sendReply = vi.fn(async () => true);
+		const composerSelf: Record<string, unknown> = {
+			replyTarget: { key: "active-1", summary: summary({ activeSessionId: "active-1", lifecycle: "live" }) },
+			options: { adapter: { kind: "local" } },
+			editor: editorWithText(""),
+			setStatusMessage: vi.fn(),
+			runAgentsViewCommand: vi.fn(),
+			sendReply,
+		};
+		await invoke("submit", composerSelf, "/kill");
+		expect(composerSelf.runAgentsViewCommand).not.toHaveBeenCalled();
+		expect(sendReply).not.toHaveBeenCalled();
+		expect(composerSelf.setStatusMessage).toHaveBeenCalledWith("/kill is not available here", { tone: "warning" });
 	});
 
 	it("keeps plain search text opening the selection", async () => {
@@ -854,72 +865,32 @@ describe("agents view slash commands", () => {
 		expect(self.refreshSessions).toHaveBeenCalledWith({ preserveStatusOnError: true });
 	});
 
-	it("drops a submitted view command from the persisted query", async () => {
-		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const persistentState: Record<string, unknown> = { query: "/kill" };
+	it("freezes the filter for command input but not for unknown slash terms", () => {
+		const editor = editorWithText("/kill");
 		const self: Record<string, unknown> = {
 			replyTarget: undefined,
 			renameTarget: undefined,
 			options: {},
-			persistentState,
-			rows: [{ kind: "agent", selectable: true, summary: live }],
-			selectedIndex: 0,
-			editor: editorWithText(""),
-			runAgentsViewCommand: vi.fn(async () => true),
+			unifiedRecords: [
+				{
+					daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
+					identity: "active:active-1",
+					identityAliases: ["active:active-1"],
+					section: "idle",
+					searchableText: "kilroy",
+				},
+			],
+			editor,
 		};
+		const filtered = () => (invoke("getFilteredRecords", self) as unknown[]).length;
 
-		await invoke("submit", self, "/kill");
-
-		// A remount restores persistentState.query; it must not resurrect the
-		// command where Enter could re-run it on an arbitrary row.
-		expect(persistentState.query).toBe("");
-	});
-
-	it("keeps filtering on unknown slash-prefixed search terms", () => {
-		const matching = {
-			daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
-			identity: "active:active-1",
-			identityAliases: ["active:active-1"],
-			section: "idle",
-			searchableText: "kilroy",
-		};
-		const self: Record<string, unknown> = {
-			replyTarget: undefined,
-			renameTarget: undefined,
-			options: {},
-			unifiedRecords: [matching],
-			editor: editorWithText("/foo"),
-		};
-
-		const records = invoke("getFilteredRecords", self) as unknown[];
-
-		// "/foo" is not a view command; it stays an ordinary (non-matching) query.
-		expect(records).toHaveLength(0);
-	});
-
-	it("freezes the session filter while a view command is typed", () => {
-		const matching = {
-			daemon: summary({ activeSessionId: "active-1", sessionName: "kilroy" }),
-			identity: "active:active-1",
-			identityAliases: ["active:active-1"],
-			section: "idle",
-			searchableText: "kilroy",
-		};
-		const self: Record<string, unknown> = {
-			replyTarget: undefined,
-			renameTarget: undefined,
-			options: {},
-			unifiedRecords: [matching],
-			editor: editorWithText("/kill"),
-		};
-
-		const records = invoke("getFilteredRecords", self) as unknown[];
-
-		// "/kill" must not be applied as a fuzzy query (it would drop the row),
-		// and neither must a mid-typing prefix like "/ki".
-		expect(records).toHaveLength(1);
-		(self.editor as { setText(t: string): void }).setText("/ki");
-		expect(invoke("getFilteredRecords", self) as unknown[]).toHaveLength(1);
+		// "/kill" and the mid-typing prefix "/ki" must not act as fuzzy queries
+		// (they would drop the row), but "/foo" stays an ordinary search term.
+		expect(filtered()).toBe(1);
+		editor.setText("/ki");
+		expect(filtered()).toBe(1);
+		editor.setText("/foo");
+		expect(filtered()).toBe(0);
 	});
 
 	it("re-resolves the armed target before dispatching a view command", async () => {
@@ -953,30 +924,6 @@ describe("agents view slash commands", () => {
 			{ name: "kill", args: "" },
 			expect.objectContaining({ activeSessionId: "active-9" }),
 		);
-	});
-
-	it("ignores view commands in the armed composer under the local adapter", async () => {
-		const live = summary({ activeSessionId: "active-1", lifecycle: "live" });
-		const target = { key: "active-1", summary: live };
-		const runAgentsViewCommand = vi.fn();
-		const sendReply = vi.fn(async () => true);
-		const self: Record<string, unknown> = {
-			replyTarget: target,
-			options: { adapter: { kind: "local" } },
-			editor: editorWithText(""),
-			setStatusMessage: vi.fn(),
-			setReplyTarget: vi.fn(),
-			refreshSessions: vi.fn(async () => true),
-			runAgentsViewCommand,
-			sendReply,
-		};
-
-		await invoke("submit", self, "/kill");
-
-		// Adapter sessions cannot run view commands; reject instead of prompting.
-		expect(runAgentsViewCommand).not.toHaveBeenCalled();
-		expect(sendReply).not.toHaveBeenCalled();
-		expect(self.setStatusMessage).toHaveBeenCalledWith("/kill is not available here", { tone: "warning" });
 	});
 
 	it("refuses /kill on an inactive row", async () => {


### PR DESCRIPTION
Stacked on the composer PR below (`feat/agents-view-composer-2`). Completes the composer follow-up series.

## What

View commands, usable in **both** input contexts — the search editor acts on the **selected row**, the armed reply composer acts on **its target**:

- **`/new`** — create and open a fresh session (same path as `ctrl+n`; needs no row).
- **`/name <name>`** (alias `/rename`) — rename via the `rename` RPC for live rows, the saved-session catalog for inactive rows.
- **`/kill`** — stop the target's runtime (live rows only); disarms the composer if it pointed at the killed agent.

Supporting behavior:

- Search-editor autocomplete appears only once the text starts with `/`, and lists view commands only; the armed composer lists session + view commands.
- Plain text in the search editor remains a pure search query; typed command input (including prefixes like `/ki`) does not filter the list, so the selected row cannot shift before Enter; unknown `/foo` stays a search. Under the local adapter, view commands are rejected with a warning in both editors and the draft is restored.
- The search hint row now advertises `/ commands` (restoring the pre-unification agents-view precedent).

## Notes

- `/model` was considered and deliberately dropped from this iteration.
- `/fork` was implemented and then removed: the existing daemon fork RPC rebinds the running agent onto the fork in place, and the resume-then-fork path for saved rows needed rollback handling that carried a third of this PR's complexity. It returns once isolated (copy) forking exists.
- Commands on inactive rows that need a runtime (`/kill`) are rejected with a clear message until dormant activation lands.

## Tests

Parsing/aliases, composer-rejection whitelist, both autocomplete contexts, search-editor routing to the selected row (plain text still opens the selection) with persisted-query cleanup, failed-command draft restore, filter freeze vs unknown slash terms, adapter rejection with draft restore in both editors, stale-target re-resolution before dispatch, composer disarm guarded against re-arming, `/new` without a target, `/name` live + saved, and `/kill` live-only + composer disarm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Commands invoke daemon rename/kill/create RPCs and mutate catalog state; behavior is guarded (inactive /kill rejection, adapter blocks, stale-target resolution) but touches core agents-view submit and session lifecycle paths.
> 
> **Overview**
> Adds **agents-view slash commands** `/new`, `/name` (and `/rename`), and `/kill` so session management works from the list search field (on the **selected row**) and from the **armed reply composer** (on its target), without opening the chat.
> 
> **`/new`** reuses the existing create-session path. **`/name`** shares a new `renameSession` helper with inline rename (daemon `rename` for live rows, saved-session catalog for inactive). **`/kill`** calls the daemon `kill` RPC for live agents only, disarms the composer when appropriate, and refreshes both live and saved catalogs.
> 
> Supporting UX: view commands are **whitelisted** in `getReplyComposerCommandRejection` and merged into reply autocomplete; the search editor gets **view-only** autocomplete when input looks like a command (including prefixes like `/ki`). **List filtering is frozen** while typing a view command so the selection does not jump. Failed commands **restore the draft**; successful search-editor commands **clear persisted query** so remount does not re-run them. **Stale reply targets** are re-resolved before dispatch. View commands are **blocked under the local adapter** with a warning. Footer hints add **`/ commands`** when not on an adapter.
> 
> Changelog and extensive vitest coverage for parsing, routing, adapter rejection, filter freeze, and RPC behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8c38aaa783ceb81ef7d552a2f2b7ea74a89a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/new`, `/name`, and `/kill` view commands to the agents view
> - Adds three slash commands to the agents view: `/new` creates a session, `/name` renames the selected session, and `/kill` stops a running agent.
> - Commands are available from both the unarmed search editor and the armed reply composer, with autocomplete support in both contexts.
> - The session list stays stable while typing a view command prefix in the search editor, and commands are not persisted as search queries on submit.
> - Rename logic is refactored into a shared `renameSession` helper that updates both live and saved catalogs and works via adapter, daemon RPC, or file rename as appropriate.
> - Draft input is restored on command failure, and commands are blocked with a warning when using a local adapter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a8c38a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->