### PR TITLE
Fix model search ranking by intent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed model searches ranking stronger matches ahead of weaker signed-in matches while preferring signed-in providers for equivalent results ([#539](https://github.com/PrimeIntellect-ai/prime-agent/pull/539) by [@eliebak](https://github.com/eliebak)).
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -3,7 +3,7 @@ import {
 	type Component,
 	Container,
 	type Focusable,
-	fuzzyFilterScored,
+	fuzzyMatch,
 	getKeybindings,
 	Spacer,
 	Text,
@@ -31,6 +31,77 @@ interface ModelItem {
 interface ScopedModelItem {
 	model: Model<any>;
 	thinkingLevel?: string;
+}
+
+enum ModelSearchMatchQuality {
+	ExactShortId,
+	ExactFullId,
+	PrefixOrToken,
+	Fuzzy,
+}
+
+interface ModelSearchMatch {
+	quality: ModelSearchMatchQuality;
+	score: number;
+}
+
+function normalizeModelSearchText(value: string): string {
+	return value.toLowerCase().replace(/[\s\-_.:/]+/g, "");
+}
+
+function getModelSearchFields(item: ModelItem): { shortId: string; fullIds: string[]; all: string[] } {
+	const shortId = item.id.slice(item.id.lastIndexOf("/") + 1);
+	const fullIds = [item.id, `${item.provider}/${item.id}`];
+	return {
+		shortId,
+		fullIds,
+		all: [shortId, ...fullIds, item.model.name, item.provider],
+	};
+}
+
+function getBestFuzzyScore(queryTokens: string[], fields: string[]): number | null {
+	let total = 0;
+	for (const token of queryTokens) {
+		let best = Number.POSITIVE_INFINITY;
+		for (const field of fields) {
+			const match = fuzzyMatch(token, field);
+			if (match.matches) best = Math.min(best, match.score);
+		}
+		if (!Number.isFinite(best)) return null;
+		total += best;
+	}
+	return total;
+}
+
+function scoreModelSearch(item: ModelItem, query: string): ModelSearchMatch | null {
+	const queryTokens = query.trim().split(/\s+/);
+	const normalizedQuery = normalizeModelSearchText(query);
+	const normalizedTokens = queryTokens.map(normalizeModelSearchText).filter(Boolean);
+	if (!normalizedQuery || normalizedTokens.length === 0) return null;
+
+	const fields = getModelSearchFields(item);
+	if (normalizeModelSearchText(fields.shortId) === normalizedQuery) {
+		return { quality: ModelSearchMatchQuality.ExactShortId, score: 0 };
+	}
+	if (fields.fullIds.some((field) => normalizeModelSearchText(field) === normalizedQuery)) {
+		return { quality: ModelSearchMatchQuality.ExactFullId, score: 0 };
+	}
+
+	const normalizedFields = fields.all.map(normalizeModelSearchText);
+	const fieldTokens = fields.all
+		.flatMap((field) => field.split(/[\s/_-]+/))
+		.map(normalizeModelSearchText)
+		.filter(Boolean);
+	const fuzzyScore = getBestFuzzyScore(normalizedTokens, normalizedFields);
+	const isPrefixOrToken = normalizedTokens.every(
+		(token) =>
+			normalizedFields.some((field) => field.startsWith(token)) ||
+			fieldTokens.some((field) => field.startsWith(token)),
+	);
+	if (isPrefixOrToken && fuzzyScore !== null) {
+		return { quality: ModelSearchMatchQuality.PrefixOrToken, score: fuzzyScore };
+	}
+	return fuzzyScore === null ? null : { quality: ModelSearchMatchQuality.Fuzzy, score: fuzzyScore };
 }
 
 export interface ModelSelectorOptions {
@@ -321,18 +392,21 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		const queryChanged = query !== this.searchQuery;
 		this.searchQuery = query;
 		if (query.trim()) {
-			const scored = fuzzyFilterScored(
-				this.activeModels,
-				query,
-				({ id, provider }) => `${id} ${provider} ${provider}/${id} ${provider} ${id}`,
-			);
-			scored.sort(
+			const matches = this.activeModels.flatMap((item) => {
+				const match = scoreModelSearch(item, query);
+				return match ? [{ item, ...match }] : [];
+			});
+			matches.sort(
 				(a, b) =>
+					a.quality - b.quality ||
 					a.score - b.score ||
 					Number(this.isProviderConfigured(b.item)) - Number(this.isProviderConfigured(a.item)) ||
-					this.recentRankOf(a.item) - this.recentRankOf(b.item),
+					Number(modelsAreEqual(this.currentModel, b.item.model)) -
+						Number(modelsAreEqual(this.currentModel, a.item.model)) ||
+					this.recentRankOf(a.item) - this.recentRankOf(b.item) ||
+					this.getModelKey(a.item).localeCompare(this.getModelKey(b.item), undefined, { numeric: true }),
 			);
-			this.filteredModels = scored.map((r) => r.item);
+			this.filteredModels = matches.map(({ item }) => item);
 		} else {
 			this.filteredModels = this.activeModels;
 		}

--- a/packages/coding-agent/test/model-selector-actions.test.ts
+++ b/packages/coding-agent/test/model-selector-actions.test.ts
@@ -200,17 +200,21 @@ describe("ModelSelectorComponent", () => {
 		expect(output).toContain("(2/12)");
 	});
 
-	it("orders search matches by recency among equally-good fuzzy matches", async () => {
+	it("keeps exact matches ahead of weaker signed-in matches and prefers sign-in for equivalent matches", async () => {
 		const harness = await createHarness({
-			models: [
-				{ id: "glm-5", name: "GLM 5", reasoning: true },
-				{ id: "glm-5.1", name: "GLM 5.1", reasoning: true },
-				{ id: "glm-5.2", name: "GLM 5.2", reasoning: true },
-			],
+			models: [{ id: "base", name: "Base", reasoning: true }],
 		});
 		harnesses.push(harness);
 
-		const provider = harness.getModel("glm-5")!.provider;
+		const base = harness.getModel("base")!;
+		const signedInExact = { ...base, provider: "prime-inference", id: "z-ai/glm-5.2", name: "GLM 5.2" };
+		const signedOutExact = { ...base, provider: "opencode", id: "glm-5.2", name: "GLM 5.2" };
+		const signedInFuzzy = {
+			...base,
+			provider: "prime-inference",
+			id: "glorious-language-model-5.2",
+			name: "Glorious Language Model 5.2",
+		};
 		const selector = new ModelSelectorComponent(
 			createFakeTui(),
 			undefined,
@@ -218,19 +222,95 @@ describe("ModelSelectorComponent", () => {
 			[],
 			() => {},
 			() => {},
-			"glm",
-			{ recentModels: [`${provider}/glm-5.2`, `${provider}/glm-5.1`] },
+			"glm5.2",
+			{
+				availableModels: [signedInFuzzy, signedOutExact, signedInExact],
+				configuredProviders: new Set(["prime-inference"]),
+			},
 		);
 
 		await waitForAsyncRender();
 
 		const lines = stripAnsi(selector.render(120).join("\n")).split("\n");
-		const row52 = lines.findIndex((line) => /glm-5\.2/.test(line));
-		const row51 = lines.findIndex((line) => /glm-5\.1/.test(line));
-		const row5 = lines.findIndex((line) => /glm-5(?![.\d])/.test(line));
-		expect(row52).toBeGreaterThanOrEqual(0);
-		expect(row52).toBeLessThan(row51);
-		expect(row51).toBeLessThan(row5);
+		const signedInExactRow = lines.findIndex((line) => line.includes("z-ai/glm-5.2"));
+		const signedOutExactRow = lines.findIndex((line) => line.includes("opencode"));
+		const signedInFuzzyRow = lines.findIndex((line) => line.includes("glorious-language-model-5.2"));
+		expect(signedInExactRow).toBeGreaterThanOrEqual(0);
+		expect(signedInExactRow).toBeLessThan(signedOutExactRow);
+		expect(signedOutExactRow).toBeLessThan(signedInFuzzyRow);
+	});
+
+	it("orders provider-qualified exact, prefix, and fuzzy matches by quality", async () => {
+		const harness = await createHarness({
+			models: [{ id: "base", name: "Base", reasoning: true }],
+		});
+		harnesses.push(harness);
+
+		const base = harness.getModel("base")!;
+		const exact = { ...base, provider: "openai", id: "gpt-5", name: "GPT-5" };
+		const prefix = { ...base, provider: "prime-inference", id: "openai-gpt-5-preview", name: "GPT-5 Preview" };
+		const fuzzy = { ...base, provider: "prime-inference", id: "other-openai-gpt-5", name: "Other GPT-5" };
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			undefined,
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			"openai/gpt5",
+			{
+				availableModels: [fuzzy, prefix, exact],
+				configuredProviders: new Set(["prime-inference"]),
+			},
+		);
+
+		await waitForAsyncRender();
+
+		const lines = stripAnsi(selector.render(120).join("\n")).split("\n");
+		const exactRow = lines.findIndex(
+			(line) => line.includes("gpt-5") && !line.includes("preview") && !line.includes("other-"),
+		);
+		const prefixRow = lines.findIndex((line) => line.includes("openai-gpt-5-preview"));
+		const fuzzyRow = lines.findIndex((line) => line.includes("other-openai-gpt-5"));
+		expect(exactRow).toBeGreaterThanOrEqual(0);
+		expect(exactRow).toBeLessThan(prefixRow);
+		expect(prefixRow).toBeLessThan(fuzzyRow);
+	});
+
+	it("uses current model, recency, and alphabetical order for equivalent matches", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "glm-5", name: "GLM 5", reasoning: true },
+				{ id: "glm-5.1", name: "GLM 5.1", reasoning: true },
+				{ id: "glm-5.2", name: "GLM 5.2", reasoning: true },
+				{ id: "glm-6", name: "GLM 6", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+
+		const provider = harness.getModel("glm-5")!.provider;
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel("glm-5.1"),
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			"glm",
+			{ recentModels: [`${provider}/glm-5.2`] },
+		);
+
+		await waitForAsyncRender();
+
+		const lines = stripAnsi(selector.render(120).join("\n")).split("\n");
+		const currentRow = lines.findIndex((line) => /glm-5\.1/.test(line));
+		const recentRow = lines.findIndex((line) => /glm-5\.2/.test(line));
+		const alphabeticalRow = lines.findIndex((line) => /glm-5(?![.\d])/.test(line));
+		const lastRow = lines.findIndex((line) => /glm-6/.test(line));
+		expect(currentRow).toBeGreaterThanOrEqual(0);
+		expect(currentRow).toBeLessThan(recentRow);
+		expect(recentRow).toBeLessThan(alphabeticalRow);
+		expect(alphabeticalRow).toBeLessThan(lastRow);
 	});
 
 	it("treats a whitespace-only query as no search and keeps the current model first", async () => {


### PR DESCRIPTION
Fixes [ENG-5388](https://linear.app/primeintellect/issue/ENG-5388/make-model-search-ranking-respect-match-quality-and-sign-in-state)

## Summary

Model search now uses an explicit ranking contract:

1. Match quality: exact short model ID, exact full/provider-qualified ID, prefix or token match, then fuzzy match.
2. Configured or signed-in provider when matches are equivalent.
3. Current model.
4. Recent usage.
5. Stable alphabetical fallback.

Short IDs, full IDs, display names, and provider-qualified IDs are scored as separate fields. Separator-insensitive normalization makes searches such as `glm5.2` compare `z-ai/glm-5.2` fairly with a bare `glm-5.2`, without allowing a weak signed-in match to outrank an exact unsigned match.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-selector-actions.test.ts` (10 tests)
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive model picker ordering only; no auth, persistence, or API behavior changes beyond search result sort.
> 
> **Overview**
> **Model picker search** no longer uses generic `fuzzyFilterScored` on a single concatenated string. It now **scores each model** with normalized text on the short id (segment after the last `/`), full ids, display name, and provider, then buckets matches as **exact short id → exact full id → prefix/token → fuzzy**.
> 
> **Sort order** is match quality and fuzzy score first, then **configured (signed-in) provider** only as a tie-breaker—so a weak fuzzy hit from a signed-in provider cannot beat a stronger exact match elsewhere. Further ties use the **current model**, **recent models**, then **numeric-aware id** ordering.
> 
> Regression tests cover signed-in vs unsigned exact matches, quality tiers for `openai/gpt5`-style queries, and tie-break ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc12ebf28cac0cc54c9ffc3f35b3832512009d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model search ranking to prioritize stronger matches over signed-in provider status
> - Replaces `fuzzyFilterScored`-based search in [model-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/539/files#diff-0eea64beefbee1061fdf18121e74d8a9344b3ee1d5942193697b874e5db4c63b) with a custom multi-tier scoring system using a new `ModelSearchMatchQuality` enum (ExactShortId, ExactFullId, PrefixOrToken, Fuzzy).
> - Results are sorted by match quality first, then fuzzy score, then configured provider status, then current model, then recency, then alphabetical — so a strong match from a signed-out provider ranks above a weak match from a signed-in one.
> - Behavioral Change: previously, signed-in provider status could cause weaker matches to appear above stronger ones; now provider preference only breaks ties between equivalent match quality.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dc12eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->