### PR TITLE
ENG-4919: restore collapsed diff summaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed collapsed edit and IPython tool calls to show compact per-file line-change summaries while keeping full diffs available when expanded.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 
 ## [0.3.3] - 2026-07-23

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -4,6 +4,7 @@ import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
 import { type Static, Type } from "typebox";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
+import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import {
 	applyEditsToNormalizedContent,
@@ -251,14 +252,25 @@ function buildEditCallComponent(
 	component: EditCallRenderComponent,
 	args: RenderableEditArgs | undefined,
 	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
+	expanded: boolean,
+	showExpandHint: boolean,
 ): EditCallRenderComponent {
 	component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
 	component.clear();
-	component.addChild(new Text(formatEditCall(args, theme), 0, 0));
+	const canExpand = component.preview !== undefined && !("error" in component.preview);
+	const expandHint =
+		canExpand && showExpandHint
+			? `${theme.fg("dim", " · ")}${keyHint("app.tools.expand", expanded ? "to collapse" : "to expand")}`
+			: "";
+	component.addChild(new Text(`${formatEditCall(args, theme)}${expandHint}`, 0, 0));
 
 	const body =
 		component.preview &&
-		("error" in component.preview ? theme.fg("error", component.preview.error) : renderDiff(component.preview.diff));
+		("error" in component.preview
+			? theme.fg("error", component.preview.error)
+			: expanded
+				? renderDiff(component.preview.diff)
+				: undefined);
 	if (body) {
 		component.addChild(new Spacer(1));
 		component.addChild(new Text(body, 0, 0));
@@ -437,7 +449,7 @@ export function createEditToolDefinition(
 				});
 			}
 
-			return buildEditCallComponent(component, args, theme);
+			return buildEditCallComponent(component, args, theme, context.expanded, context.showExpandHint !== false);
 		},
 		renderResult(result, _options, theme, context) {
 			const callComponent = context.state.callComponent;
@@ -462,7 +474,13 @@ export function createEditToolDefinition(
 					changed = true;
 				}
 				if (changed) {
-					buildEditCallComponent(callComponent, context.args as RenderableEditArgs | undefined, theme);
+					buildEditCallComponent(
+						callComponent,
+						context.args as RenderableEditArgs | undefined,
+						theme,
+						context.expanded,
+						context.showExpandHint !== false,
+					);
 				}
 			}
 

--- a/packages/coding-agent/src/modes/interactive/components/edit-summary.ts
+++ b/packages/coding-agent/src/modes/interactive/components/edit-summary.ts
@@ -1,10 +1,12 @@
+import { isAbsolute } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { EditToolDetails } from "../../../core/tools/edit.js";
 import { generateDiffString } from "../../../core/tools/edit-diff.js";
 import type { IpythonToolDetails } from "../../../core/tools/ipython.js";
 import { resolveToCwd } from "../../../core/tools/path-utils.js";
-import { canonicalizePath } from "../../../utils/paths.js";
+import { canonicalizePath, formatPathRelativeToCwdOrAbsolute } from "../../../utils/paths.js";
 import { theme } from "../theme/theme.js";
 
 export interface FileChangeSummary {
@@ -79,6 +81,33 @@ export function mergeTurnFileChanges(
 
 function counts(change: Pick<FileChangeSummary, "added" | "removed">): string {
 	return `${theme.fg("toolDiffAdded", `+${change.added}`)} ${theme.fg("toolDiffRemoved", `-${change.removed}`)}`;
+}
+
+function formatFileChangePath(path: string, cwd: string): string {
+	const resolvedPath = resolveToCwd(path, cwd);
+	const lexicalPath = formatPathRelativeToCwdOrAbsolute(resolvedPath, cwd);
+	if (!isAbsolute(lexicalPath)) return lexicalPath;
+	return formatPathRelativeToCwdOrAbsolute(canonicalizePath(resolvedPath), canonicalizePath(cwd));
+}
+
+export class FileChangeSummaryComponent implements Component {
+	constructor(
+		private readonly changes: readonly FileChangeSummary[],
+		private readonly cwd: string,
+	) {}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const prefix = theme.fg("dim", "    ╰─ ");
+		return this.changes.map((change) => {
+			const suffix = `${theme.fg("dim", " ")}${counts(change)}`;
+			const available = Math.max(1, safeWidth - visibleWidth(prefix) - visibleWidth(suffix));
+			const path = truncateToWidth(formatFileChangePath(change.path, this.cwd), available, "…");
+			return truncateToWidth(`${prefix}${theme.fg("muted", path)}${suffix}`, safeWidth, "");
+		});
+	}
+
+	invalidate(): void {}
 }
 
 export function formatTotalChangeSummary(changes: readonly FileChangeSummary[]): string {

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -359,7 +359,7 @@ export class IPythonCellComponent implements Component {
 		const lines = [truncateToWidth(` ${this.collapsedLine(details)}`, safeWidth, "")];
 
 		const hasCode = this.state.expanded ? this.renderCode(lines, safeWidth) : false;
-		if ((details.diffs?.length ?? 0) > 0) {
+		if ((details.diffs?.length ?? 0) > 0 && this.state.expanded) {
 			this.renderDiffs(lines, safeWidth, details.diffs ?? [], this.marker(details));
 		}
 		if ((details.sentAgentMessages?.length ?? 0) > 0) {

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -9,6 +9,7 @@ import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/rend
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
 import { type Theme, theme } from "../theme/theme.js";
 import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
+import { FileChangeSummaryComponent, getToolFileChanges } from "./edit-summary.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
 import { ToolPanel } from "./tool-panel.js";
 
@@ -384,6 +385,18 @@ export class ToolExecutionComponent extends Container {
 				);
 				this.imageComponents.push(imageComponent);
 				this.addChild(imageComponent);
+			}
+		}
+
+		const isBuiltInEdit =
+			this.toolName === "edit" &&
+			(this.toolDefinition === undefined || this.toolDefinition.replayBuiltInToolName === "edit");
+		if (!this.expanded && this.result && (isBuiltInEdit || this.shouldUseIpythonRenderer())) {
+			const changes = getToolFileChanges(this.toolName, this.args, this.result, this.cwd);
+			if (changes.length > 0) {
+				const container = this.usesSelfRenderShell() ? this.selfRenderContainer : this.contentPanel;
+				container.addChild(new FileChangeSummaryComponent(changes, this.cwd));
+				hasContent = true;
 			}
 		}
 

--- a/packages/coding-agent/test/ipython-cell-diff.test.ts
+++ b/packages/coding-agent/test/ipython-cell-diff.test.ts
@@ -224,9 +224,9 @@ describe("IPythonCellComponent diff rendering", () => {
 			expanded: false,
 		});
 		expect(collapsed).toContain("to expand");
-		expect(collapsed).toContain("big.py");
-		expect(collapsed).toContain("old");
-		expect(collapsed).toContain("NEW");
+		expect(collapsed).not.toContain("big.py");
+		expect(collapsed).not.toContain("old");
+		expect(collapsed).not.toContain("NEW");
 	});
 
 	it("hides edit source when collapsed and shows it when globally expanded", () => {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -690,9 +690,9 @@ describe("ToolExecutionComponent parity", () => {
 
 		const collapsed = stripAnsi(component.render(120).join("\n"));
 		expect(collapsed).not.toContain("hidden_side_effect");
-		expect(collapsed).toMatch(/✓ README\.md\s+\+1 -1/);
-		expect(collapsed).toMatch(/1 - before/);
-		expect(collapsed).toMatch(/1 \+ after/);
+		expect(collapsed).toContain("╰─ README.md +1 -1");
+		expect(collapsed).not.toMatch(/1 - before/);
+		expect(collapsed).not.toMatch(/1 \+ after/);
 
 		component.setExpanded(true);
 		const expanded = stripAnsi(component.render(120).join("\n"));


### PR DESCRIPTION
Solves [ENG-4919](https://linear.app/primeintellect/issue/ENG-4919/add-a-preference-for-collapsed-tool-call-file-edit-display)

## Summary

- restore the compact collapsed edit/IPython diff summaries introduced in #393 and explicitly removed by #428
- show one per-file `+/-` line for every edited file, with no file cap or remainder aggregation
- keep expanded edit and built-in IPython behavior on the current full source/diff rendering path

## Retained behavior

This is intentionally not a wholesale revert or cherry-pick. Current behavior retained from #393 and later work includes the aggregate agent-run edit total, latest-tool expand hint behavior, canonical path coalescing/display, and current spacing/rendering infrastructure. The change reuses the existing `edit-summary.ts` extraction and tests rather than restoring unrelated historical changes.

## Examples

Before:

<img width="1244" height="852" alt="image" src="https://github.com/user-attachments/assets/ef5d8b26-271b-45e0-891e-08cd1cc8404f" />

After:

<img width="1262" height="220" alt="image" src="https://github.com/user-attachments/assets/2c57209b-8af5-4f2f-9aac-872e151a0ef5" />

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/edit-summary.test.ts test/ipython-cell-diff.test.ts test/tool-execution-component.test.ts` (56 tests)
- `npm run check`
- final source/test review confirms collapsed summaries map all file changes without a limit or hidden remainder


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore collapsed diff summaries for edit and IPython tool calls in the coding agent
> - Collapsed edit and IPython tool executions now show a compact per-file line-change summary (e.g. `╰─ path +N -M`) instead of the full diff; expanding restores full content.
> - Adds [`FileChangeSummaryComponent`](https://github.com/PrimeIntellect-ai/prime-agent/pull/543/files#diff-cade1f5aed8ea0721ac6b97b32304ba7255a570d289b8e1dee03e85057da323f) to render width-aware, cwd-relative file change lines with `+/-` counts.
> - Updates [`buildEditCallComponent`](https://github.com/PrimeIntellect-ai/prime-agent/pull/543/files#diff-64402f2abfe7a1c0c56ebb951df914be2717f2dd36237d9201c353067d40d87a) to accept `expanded` and `showExpandHint` flags, suppressing the diff body when collapsed and prepending a keybinding hint when a preview is available.
> - Updates [`IPythonCellComponent`](https://github.com/PrimeIntellect-ai/prime-agent/pull/543/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf) so diffs render only when the cell is expanded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf1b25f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive TUI presentation only; no changes to edit execution, file I/O, or agent protocol behavior.
> 
> **Overview**
> **Restores compact collapsed views** for built-in **edit** and **IPython** tool rows: instead of hiding diffs or showing full hunks while collapsed, the transcript shows one **`╰─` per-file line** with **`+/-` counts** (all edited files, no cap).
> 
> **Full unified diffs** return only when the tool row is **expanded** (`edit.ts` gates `renderDiff`; `ipython-cell.ts` skips `renderDiffs` when collapsed). The edit header keeps the existing **expand/collapse key hint** tied to `context.expanded`.
> 
> **`FileChangeSummaryComponent`** in `edit-summary.ts` formats paths relative to the session cwd; **`ToolExecutionComponent`** mounts it under collapsed built-in edit/IPython results via **`getToolFileChanges`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf1b25fae47674f939e8ddeaf8b5e92774792c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->