### PR TITLE
ENG-4893: tighten adjacent tool spacing

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -16,6 +16,7 @@ const LOGIN_RECOVERY_SUFFIX = `\n\n${LOGIN_RECOVERY_MESSAGE}`;
 
 export interface AssistantMessageComponentOptions {
 	expanded?: boolean;
+	precededByToolActivity?: boolean;
 }
 
 function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
@@ -68,6 +69,7 @@ export class AssistantMessageComponent extends Container {
 	private lastSignature?: string;
 	private blockMarkdowns = new Map<number, Markdown>();
 	private lastBlockTexts = new Map<number, string>();
+	private precededByToolActivity: boolean;
 
 	constructor(
 		message?: AssistantMessage,
@@ -82,6 +84,7 @@ export class AssistantMessageComponent extends Container {
 		this.markdownTheme = markdownTheme;
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
 		this.expanded = options.expanded ?? false;
+		this.precededByToolActivity = options.precededByToolActivity ?? false;
 
 		// Container for text/thinking content
 		this.contentContainer = new Container();
@@ -265,7 +268,7 @@ export class AssistantMessageComponent extends Container {
 			this.contentContainer.addChild(this.createErrorComponent(errorMsg, "Error"));
 		}
 
-		if (hasToolCalls) {
+		if (hasToolCalls && (hasVisibleContent || message.stopReason === "aborted" || !this.precededByToolActivity)) {
 			this.contentContainer.addChild(new Spacer(1));
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -52,7 +52,10 @@ export function buildConversationComponents(
 					options.hideThinkingBlock ?? false,
 					options.markdownTheme,
 					options.hiddenThinkingLabel ?? "Thinking...",
-					{ expanded },
+					{
+						expanded,
+						precededByToolActivity: components.at(-1) instanceof ToolExecutionComponent,
+					},
 				),
 			);
 			for (const content of message.content) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5392,7 +5392,10 @@ export class InteractiveMode {
 			this.hideThinkingBlock,
 			this.getMarkdownThemeWithSettings(),
 			this.hiddenThinkingLabel,
-			{ expanded: this.toolOutputExpanded },
+			{
+				expanded: this.toolOutputExpanded,
+				precededByToolActivity: this.chatContainer.children.at(-1) instanceof ToolExecutionComponent,
+			},
 		);
 		this.streamingMessage = message;
 		this.chatContainer.addChild(this.streamingComponent);
@@ -6251,7 +6254,10 @@ export class InteractiveMode {
 					this.hideThinkingBlock,
 					this.getMarkdownThemeWithSettings(),
 					this.hiddenThinkingLabel,
-					{ expanded: this.toolOutputExpanded },
+					{
+						expanded: this.toolOutputExpanded,
+						precededByToolActivity: this.chatContainer.children.at(-1) instanceof ToolExecutionComponent,
+					},
 				);
 				this.chatContainer.addChild(assistantComponent);
 				break;


### PR DESCRIPTION
## Summary

- keep one leading blank row when a message starts with tool activity
- suppress that row when a tool-only assistant message continues visually adjacent tool activity from the previous assistant message
- cover the cross-message rendered output in the existing marquee component test

Image for illustration; on the left the new way, on the right the old way:

<img width="1286" height="674" alt="image" src="https://github.com/user-attachments/assets/077c1d9b-1fe2-4e40-b24e-16c8811c3836" />

References ENG-4893.

## Tests
- `npm --workspace packages/coding-agent test -- test/marquee-components.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten spacing between adjacent tool activity in assistant messages
> Adds a `precededByToolActivity` flag to `AssistantMessageComponent` that suppresses the trailing spacer when a tool-execution block immediately follows another tool-execution block. The flag is set in both the streaming path (`InteractiveMode`) and the static build path (`buildConversationComponents`) by checking whether the last rendered child is a `ToolExecutionComponent`. The spacer is still added when there is visible text content, the message was aborted, or no prior tool activity exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18b7705.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal layout/spacing only in the interactive chat renderer; no auth, data, or API behavior changes.
> 
> **Overview**
> Adds **`precededByToolActivity`** on `AssistantMessageComponent` so the trailing spacer before tool blocks is **skipped** when the last rendered chat child is already a `ToolExecutionComponent` and the assistant message has no visible text (tool-only continuation).
> 
> **`buildConversationComponents`** and **`InteractiveMode`** (streaming and history replay) set the flag from `chatContainer.children.at(-1) instanceof ToolExecutionComponent`. Spacers are still added when there is visible assistant text, the message was aborted, or tool activity is not immediately adjacent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b770550ccc97f6df69bc4d6e7497d99d625b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->