### PR TITLE
ENG-4918: improve session search ranking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed collapsed edit and IPython tool calls to show compact per-file line-change summaries while keeping full diffs available when expanded.
+- Changed session search to rank exact name and first-message matches before prefix, substring, and stricter transcript fuzzy matches.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 
 ## [0.3.3] - 2026-07-23

--- a/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
@@ -23,6 +23,11 @@ function normalizeWhitespaceLower(text: string): string {
 	return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+function normalizeSessionTitle(value: string | undefined): string {
+	if (value === "(no messages)" || value === "(large message)") return "";
+	return normalizeWhitespaceLower(value ?? "");
+}
+
 function getSessionSearchText(session: AgentConnectionSavedSessionInfo): string {
 	return `${session.id} ${session.name ?? ""} ${session.allMessagesText} ${session.cwd}`;
 }
@@ -121,44 +126,60 @@ export function parseSearchQuery(query: string): ParsedSearchQuery {
 	return { mode: "tokens", tokens, regex: null };
 }
 
+const STRICT_FUZZY_MAX_TOKEN_SCORE = 25;
+const SCORE_TIER_SIZE = 1000;
+
 export function matchSession(session: AgentConnectionSavedSessionInfo, parsed: ParsedSearchQuery): MatchResult {
 	const text = getSessionSearchText(session);
 
 	if (parsed.mode === "regex") {
-		if (!parsed.regex) {
-			return { matches: false, score: 0 };
-		}
+		if (!parsed.regex) return { matches: false, score: 0 };
 		const idx = text.search(parsed.regex);
-		if (idx < 0) return { matches: false, score: 0 };
-		return { matches: true, score: idx * 0.1 };
+		return idx < 0 ? { matches: false, score: 0 } : { matches: true, score: idx * 0.1 };
+	}
+	if (parsed.tokens.length === 0) return { matches: true, score: 0 };
+
+	const titles = [session.name, session.firstMessage].map(normalizeSessionTitle);
+	if (parsed.tokens.length > 1 && parsed.tokens.every((token) => token.kind === "fuzzy")) {
+		const query = parsed.tokens.map((token) => normalizeWhitespaceLower(token.value)).join(" ");
+		const exact = titles.indexOf(query);
+		const prefix = titles.findIndex((title) => title.startsWith(query));
+		const substring = titles.findIndex((title) => title.includes(query));
+		if (exact >= 0) return { matches: true, score: exact };
+		if (prefix >= 0) return { matches: true, score: SCORE_TIER_SIZE + prefix };
+		if (substring >= 0) return { matches: true, score: SCORE_TIER_SIZE * 2 + substring };
 	}
 
-	if (parsed.tokens.length === 0) {
-		return { matches: true, score: 0 };
-	}
-
-	let totalScore = 0;
-	let normalizedText: string | null = null;
-
+	const normalizedText = normalizeWhitespaceLower(text);
+	let worstTier = 0;
+	let tieScore = 0;
+	let matchedTokens = 0;
 	for (const token of parsed.tokens) {
-		if (token.kind === "phrase") {
-			if (normalizedText === null) {
-				normalizedText = normalizeWhitespaceLower(text);
+		const needle = normalizeWhitespaceLower(token.value);
+		if (!needle) continue;
+		const exact = titles.indexOf(needle);
+		const prefix = titles.findIndex((title) => title.startsWith(needle));
+		const substring = titles.findIndex((title) => title.includes(needle));
+		let tier: number;
+		let tie: number;
+		if (exact >= 0) [tier, tie] = [3, exact];
+		else if (prefix >= 0) [tier, tie] = [4, prefix];
+		else if (substring >= 0) [tier, tie] = [5, substring];
+		else {
+			const position = normalizedText.indexOf(needle);
+			if (position >= 0) [tier, tie] = [6, position];
+			else {
+				if (token.kind === "phrase") return { matches: false, score: 0 };
+				const match = fuzzyMatch(token.value, text);
+				if (!match.matches || match.score > STRICT_FUZZY_MAX_TOKEN_SCORE) return { matches: false, score: 0 };
+				[tier, tie] = [7, match.score];
 			}
-			const phrase = normalizeWhitespaceLower(token.value);
-			if (!phrase) continue;
-			const idx = normalizedText.indexOf(phrase);
-			if (idx < 0) return { matches: false, score: 0 };
-			totalScore += idx * 0.1;
-			continue;
 		}
-
-		const m = fuzzyMatch(token.value, text);
-		if (!m.matches) return { matches: false, score: 0 };
-		totalScore += m.score;
+		worstTier = Math.max(worstTier, tier);
+		tieScore += 0.5 + Math.atan(tie) / Math.PI;
+		matchedTokens++;
 	}
-
-	return { matches: true, score: totalScore };
+	return { matches: true, score: worstTier * SCORE_TIER_SIZE + tieScore / Math.max(1, matchedTokens) };
 }
 
 export function filterAndSortSessions(


### PR DESCRIPTION
- rank exact session-name and first-message matches ahead of prefix and substring matches
-  better matches always appear before weaker matches:
    - a full session-name match beats a match on separate words.
    - an exact phrase found in the transcript beats an approximate fuzzy match.
- preserve quoted phrase behavior for exact string matching
- preserve explicit `re:` query behavior for regex search

References ENG-4918.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve session search ranking to prioritize exact and prefix matches over fuzzy matches
> - Reworks scoring in [`session-selector-search.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/545/files#diff-27ed2afcf70bc6280d26b892aa932413ca923ae02b6a009a1140327245e07166) to use 1000-point tiers: exact name/first-message matches rank first, then prefix, substring, transcript substring, and finally strict fuzzy matches.
> - Adds a `normalizeSessionTitle` helper that maps placeholder titles `(no messages)` and `(large message)` to empty strings so they don't contribute to exact/prefix/substring scoring.
> - Caps fuzzy token matches at a distance score of 25 (`STRICT_FUZZY_MAX_TOKEN_SCORE`); tokens exceeding this threshold are rejected entirely.
> - Multi-token all-fuzzy queries are now joined and matched as a whole phrase against session name and first message before falling back to per-token matching.
> - Behavioral Change: sessions previously surfaced via loose fuzzy matches with score >25 will no longer appear in results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67ecfc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to interactive session picker search scoring; no auth, persistence, or daemon protocol impact.
> 
> **Overview**
> **Session search** in the resume/session picker now ranks matches by quality instead of summing fuzzy distances across the full transcript.
> 
> Scoring uses fixed **tiers** (exact name or first-message match, then prefix, substring, transcript substring, and finally fuzzy). Multi-word queries that are all fuzzy tokens are first tried as a single phrase against name and first message. Placeholder titles `(no messages)` and `(large message)` are ignored for title matching. **Fuzzy** matches must stay within a max distance of 25 or the session is dropped from results—looser fuzzy hits that used to appear will no longer show up. Quoted phrases and `re:` regex queries behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ecfc60bda0e71274f069623cecd48efdefb209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

