### PR TITLE
fix(coding-agent): reap deleted subagent runtimes on compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed compaction retaining runtime resources after an explicitly deleted subagent had a transient cleanup failure.
+
 ## [0.4.0] - 2026-08-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6555,8 +6555,14 @@ export class AgentSession {
 			});
 		}
 		await this._notifyKernelStateAfterCompaction();
+		await this._reapDeletedRlmSubagentRuntimesAfterCompaction();
 
 		return { summary, firstKeptEntryId, tokensBefore, details };
+	}
+
+	private async _reapDeletedRlmSubagentRuntimesAfterCompaction(): Promise<void> {
+		const childIds = [...this._retryableRlmSubagentDeletions.keys()];
+		await Promise.allSettled(childIds.map((childId) => this.deleteRlmSubagent(childId)));
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -114,6 +114,7 @@ interface InspectableRlmSession {
 	_retainedRlmChildSessions: Map<string, AgentSession>;
 	_retainedRlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
+	_reapDeletedRlmSubagentRuntimesAfterCompaction(): Promise<void>;
 }
 
 interface KernelPumpTestApi {
@@ -1206,7 +1207,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(deleteRuntime).toHaveBeenCalledTimes(1);
 		expect(disposeHostedChild).not.toHaveBeenCalled();
 
-		await expect(root.deleteRlmSubagent("starting-worker")).resolves.toEqual({ subagent: starting });
+		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
 		expect(deleteRuntime).toHaveBeenCalledTimes(2);
 		expect(disposeHostedChild).toHaveBeenCalledOnce();
 		expect(internals._retryableRlmSubagentDeletions.size).toBe(0);

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -102,6 +102,38 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.messages[0]?.role).toBe("compactionSummary");
 	});
 
+	it("retries cleanup for explicitly deleted subagents after compaction", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "summary from extension",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		const retryableDeletions = (
+			harness.session as unknown as { _retryableRlmSubagentDeletions: Map<string, unknown> }
+		)._retryableRlmSubagentDeletions;
+		retryableDeletions.set("deleted-child", {});
+		const retryDeletion = vi
+			.spyOn(harness.session, "deleteRlmSubagent")
+			.mockRejectedValue(new Error("cleanup still unavailable"));
+
+		await expect(harness.session.compact()).resolves.toMatchObject({ summary: "summary from extension" });
+		expect(retryDeletion).toHaveBeenCalledWith("deleted-child");
+	});
+
 	it("compacts through the model summarizer, persists metadata, emits events, and remains usable", async () => {
 		const harness = await createHarness({
 			settings: { compaction: { keepRecentTokens: 1 } },


### PR DESCRIPTION
## Summary

- retry cleanup of explicitly deleted direct subagents after successful compaction
- keep cleanup best-effort so transient host failures do not fail compaction
- preserve retained reusable subagents and their registry entries

## Tests

- `test/agent-session-recursion.test.ts`
- `test/suite/agent-session-compaction.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle fix after compaction with best-effort cleanup; existing deletion and retention behavior is unchanged aside from the new retry pass.
> 
> **Overview**
> After a successful compaction, **`AgentSession`** now runs **`_reapDeletedRlmSubagentRuntimesAfterCompaction()`**, which retries **`deleteRlmSubagent`** for every child still listed in **`_retryableRlmSubagentDeletions`** (explicit deletes that failed transient host/runtime cleanup). Retries are parallel and **`Promise.allSettled`**, so a failed retry does not fail compaction.
> 
> The recursion test now asserts cleanup via that reap helper instead of a second manual delete call; compaction tests cover that reap invokes retry deletion without breaking compaction when cleanup still fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a285611a7e4046b8afbe52499ce80243a698d646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry deleted subagent runtime cleanup on compaction in `AgentSession`
> Subagent runtimes that failed to delete transiently (tracked in `_retryableRlmSubagentDeletions`) are now retried during compaction via a new `_reapDeletedRlmSubagentRuntimesAfterCompaction()` method. Retries run in parallel using `Promise.allSettled`, so individual failures do not block compaction from completing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a285611.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->