### PR TITLE
fix(daemon): transfer session trees as flat nodes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `/tree` overflowing the daemon serializer on very deep sessions by transferring a flat session tree.
+
 - Added starting a new session directly from the agents view with `ctrl+n`.
 - Added queueing a reply as a follow-up with `alt+enter` in the agents-view reply composer; plain Enter now steers a streaming agent.
 - Added session-owned slash commands (`/compact`, `/refine`, `/goal`, `/autonomous`) with autocomplete to the agents-view reply composer; other built-in commands are rejected with guidance instead of being sent as prompt text.

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -261,13 +261,16 @@ export type SessionEntry =
 export type FileEntry = SessionHeader | SessionEntry;
 
 /** Tree node for getTree() - defensive copy of session structure */
-export interface SessionTreeNode {
+export interface SessionTreeFlatNode {
 	entry: SessionEntry;
-	children: SessionTreeNode[];
 	/** Resolved label for this entry, if any */
 	label?: string;
 	/** Timestamp of the latest label change for this entry, if any */
 	labelTimestamp?: string;
+}
+
+export interface SessionTreeNode extends SessionTreeFlatNode {
+	children: SessionTreeNode[];
 }
 
 export interface SessionContext {
@@ -1797,20 +1800,27 @@ export class SessionManager {
 	 * A well-formed session has exactly one root (first entry with parentId === null).
 	 * Orphaned entries (broken parent chain) are also returned as roots.
 	 */
+	getFlatTree(): SessionTreeFlatNode[] {
+		return this.getEntries().map((entry) => ({
+			entry,
+			label: this.labelsById.get(entry.id),
+			labelTimestamp: this.labelTimestampsById.get(entry.id),
+		}));
+	}
+
 	getTree(): SessionTreeNode[] {
-		const entries = this.getEntries();
+		const entries = this.getFlatTree();
 		const nodeMap = new Map<string, SessionTreeNode>();
 		const roots: SessionTreeNode[] = [];
 
 		// Create nodes with resolved labels
-		for (const entry of entries) {
-			const label = this.labelsById.get(entry.id);
-			const labelTimestamp = this.labelTimestampsById.get(entry.id);
-			nodeMap.set(entry.id, { entry, children: [], label, labelTimestamp });
+		for (const flatNode of entries) {
+			nodeMap.set(flatNode.entry.id, { ...flatNode, children: [] });
 		}
 
 		// Build tree
-		for (const entry of entries) {
+		for (const flatNode of entries) {
+			const entry = flatNode.entry;
 			const node = nodeMap.get(entry.id)!;
 			if (entry.parentId === null || entry.parentId === entry.id) {
 				roots.push(node);

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -70,6 +70,7 @@ import type {
 	AgentConnectionSessionContext,
 	AgentConnectionSessionHeader,
 	AgentConnectionSessionListCallbacks,
+	AgentConnectionSessionTreeFlatNode,
 	AgentConnectionSessionTreeNode,
 	AgentConnectionSessionWatcher,
 	AgentConnectionSideQuestionEvent,
@@ -176,6 +177,24 @@ export interface DaemonAgentConnectionOptions {
  * InteractiveMode depends only on AgentConnection; local socket ownership and
  * daemon command details stay inside this adapter.
  */
+export function buildSessionTreeFromFlatNodes(
+	flatNodes: readonly AgentConnectionSessionTreeFlatNode[],
+): AgentConnectionSessionTreeNode[] {
+	const byId = new Map<string, AgentConnectionSessionTreeNode>();
+	const roots: AgentConnectionSessionTreeNode[] = [];
+	for (const flatNode of flatNodes) {
+		byId.set(flatNode.entry.id, { ...flatNode, children: [] });
+	}
+	for (const flatNode of flatNodes) {
+		const entry = flatNode.entry;
+		const node = byId.get(entry.id)!;
+		const parent = entry.parentId === null || entry.parentId === entry.id ? undefined : byId.get(entry.parentId);
+		if (parent) parent.children.push(node);
+		else roots.push(node);
+	}
+	return roots;
+}
+
 export class DaemonAgentConnection implements AgentConnection {
 	private readonly listeners = new Set<AgentConnectionEventListener>();
 	private readonly unsubscribeDaemonMessages: () => void;
@@ -477,10 +496,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (this.latestSnapshotIsFresh && this.latestSnapshot?.sessionTree) {
 			return this.latestSnapshot.sessionTree;
 		}
-		return this.requestData<{ tree: AgentConnectionSessionTreeNode[]; leafId: string | null }>({
+		const data = await this.requestData<{
+			flatNodes: AgentConnectionSessionTreeFlatNode[];
+			leafId: string | null;
+		}>({
 			type: "get_session_tree",
 			activeSessionId: this.activeSessionId,
 		});
+		return { tree: buildSessionTreeFromFlatNodes(data.flatNodes), leafId: data.leafId };
 	}
 
 	async listSavedSessions(

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -192,6 +192,13 @@ export function buildSessionTreeFromFlatNodes(
 		if (parent) parent.children.push(node);
 		else roots.push(node);
 	}
+	// Match SessionManager.getTree() ordering without recursively walking deep
+	// chains: every node is already indexed, so sort each sibling array directly.
+	for (const node of byId.values()) {
+		node.children.sort(
+			(left, right) => new Date(left.entry.timestamp).getTime() - new Date(right.entry.timestamp).getTime(),
+		);
+	}
 	return roots;
 }
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -248,11 +248,14 @@ export type AgentConnectionSessionEntry =
 	| AgentConnectionAgentStatusEntry
 	| AgentConnectionGitStateEntry;
 
-export interface AgentConnectionSessionTreeNode {
+export interface AgentConnectionSessionTreeFlatNode {
 	entry: AgentConnectionSessionEntry;
-	children: AgentConnectionSessionTreeNode[];
 	label?: string;
 	labelTimestamp?: string;
+}
+
+export interface AgentConnectionSessionTreeNode extends AgentConnectionSessionTreeFlatNode {
+	children: AgentConnectionSessionTreeNode[];
 }
 
 export interface AgentConnectionSessionContext {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3746,7 +3746,7 @@ export class AgentDaemon {
 			case "get_session_tree": {
 				const state = this.getSessionState(command.activeSessionId);
 				return success(command.id, "get_session_tree", {
-					tree: state.runtime.session.sessionManager.getTree(),
+					flatNodes: state.runtime.session.sessionManager.getFlatTree(),
 					leafId: state.runtime.session.sessionManager.getLeafId(),
 				});
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -48,11 +48,12 @@ import type { SessionSummary } from "./daemon-session-list.js";
  */
 
 export const DAEMON_PROTOCOL_NAME = "prime-agent.daemon";
-export const DAEMON_PROTOCOL_VERSION = 5;
+export const DAEMON_PROTOCOL_VERSION = 6;
 export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 2;
 // Revision 6 combines prompt-admission cancellation with side-question transcripts and transient bash.
-export const DAEMON_SCHEMA_REVISION = 6;
-export const DAEMON_SCHEMA_ID = "protocol-5-schema-6-48a562b9bffe";
+// Revision 7 makes get_session_tree return flatNodes instead of a recursively nested tree.
+export const DAEMON_SCHEMA_REVISION = 7;
+export const DAEMON_SCHEMA_ID = "protocol-6-schema-7-48a562b9bffe";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -616,13 +617,14 @@ const SESSION_INPUT_ADMISSION_COMMAND = {
 	capability: "session_input_admission",
 } as const;
 const PROMPT_ADMISSION_CANCELLATION_COMMAND = {
-	minProtocol: DAEMON_PROTOCOL_VERSION,
+	minProtocol: 5,
 	capability: "prompt_admission_cancellation",
 } as const;
 const CLIENT_OWNED_DAEMON_COMMAND = {
 	minProtocol: 4,
 	capability: "client_owned_sessions",
 } as const;
+const FLAT_SESSION_TREE_COMMAND = { minProtocol: DAEMON_PROTOCOL_VERSION } as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
@@ -707,7 +709,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	rename_saved_session: LEGACY_DAEMON_COMMAND,
 	delete_saved_session: LEGACY_DAEMON_COMMAND,
 	get_session_context: LEGACY_DAEMON_COMMAND,
-	get_session_tree: LEGACY_DAEMON_COMMAND,
+	get_session_tree: FLAT_SESSION_TREE_COMMAND,
 	get_user_messages_for_forking: LEGACY_DAEMON_COMMAND,
 	get_last_assistant_text: LEGACY_DAEMON_COMMAND,
 	get_system_prompt: LEGACY_DAEMON_COMMAND,

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -626,7 +626,7 @@ const CLIENT_OWNED_DAEMON_COMMAND = {
 	minProtocol: 4,
 	capability: "client_owned_sessions",
 } as const;
-const FLAT_SESSION_TREE_COMMAND = { minProtocol: DAEMON_PROTOCOL_VERSION } as const;
+const FLAT_SESSION_TREE_COMMAND = { minProtocol: 6 } as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -42,6 +42,7 @@ import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js
 import {
 	collectDaemonClientEnv,
 	createDaemonEventMeta,
+	DAEMON_COMMAND_COMPATIBILITY,
 	DAEMON_DEFAULT_CLIENT_CAPABILITIES,
 	DAEMON_DEFAULT_SERVER_CAPABILITIES,
 	DAEMON_PROTOCOL_INFO,
@@ -1015,12 +1016,12 @@ export class DaemonSupervisor {
 	): {
 		command: DaemonCommand;
 		envelopeClientId?: string;
+		protocolVersion: number;
 		admission?: SupervisorPromptAdmission;
 	} {
 		const parsed = JSON.parse(line) as unknown;
-		const command = (
-			isDaemonCommandEnvelope(parsed) ? { ...parsed.command, id: parsed.id } : parsed
-		) as DaemonCommand;
+		const envelope = isDaemonCommandEnvelope(parsed) ? parsed : undefined;
+		const command = (envelope ? { ...envelope.command, id: envelope.id } : parsed) as DaemonCommand;
 		let admission: SupervisorPromptAdmission | undefined;
 		if ((command.type === "prompt" || command.type === "prompt_and_wait") && command.admissionId !== undefined) {
 			if (typeof command.activeSessionId !== "string" || typeof command.admissionId !== "string") {
@@ -1044,7 +1045,8 @@ export class DaemonSupervisor {
 		}
 		return {
 			command,
-			envelopeClientId: isDaemonCommandEnvelope(parsed) ? (parsed.clientId ?? client.id) : undefined,
+			envelopeClientId: envelope ? (envelope.clientId ?? client.id) : undefined,
+			protocolVersion: envelope?.protocol.version ?? 1,
 			admission,
 		};
 	}
@@ -1086,6 +1088,20 @@ export class DaemonSupervisor {
 		this.cancelOwnedWorkerCleanup(client.id);
 		if (!DAEMON_COMMAND_TYPES.has(command.type)) {
 			this.write(client, failure(command.id, command.type, `Unknown daemon command: ${command.type}`));
+			return;
+		}
+		if (
+			command.type === "get_session_tree" &&
+			preParsed.protocolVersion < DAEMON_COMMAND_COMPATIBILITY.get_session_tree.minProtocol
+		) {
+			this.write(
+				client,
+				failure(
+					command.id,
+					command.type,
+					`get_session_tree requires client protocol ${DAEMON_COMMAND_COMPATIBILITY.get_session_tree.minProtocol} or newer`,
+				),
+			);
 			return;
 		}
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import { MissingSessionCwdError } from "../src/core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../src/core/session-import-errors.js";
 import {
-	buildSessionTreeFromFlatNodes,
 	DAEMON_REFINE_REQUEST_TIMEOUT_MS,
 	DaemonAgentConnection,
 } from "../src/modes/agent-connection/daemon-agent-connection.js";
@@ -2420,45 +2419,6 @@ describe("DaemonAgentConnection", () => {
 			type: "get_session_context",
 			activeSessionId: "active-1",
 		});
-	});
-
-	it("sorts rebuilt siblings by timestamp regardless of flat-array order", () => {
-		const entry = (id: string, parentId: string | null, timestamp: string) => ({
-			entry: {
-				type: "message" as const,
-				id,
-				parentId,
-				timestamp,
-				message: { role: "user" as const, content: id, timestamp: Date.parse(timestamp) },
-			},
-		});
-		const roots = buildSessionTreeFromFlatNodes([
-			entry("root", null, "2026-01-01T00:00:00.000Z"),
-			entry("newer", "root", "2026-01-03T00:00:00.000Z"),
-			entry("older", "root", "2026-01-02T00:00:00.000Z"),
-		]);
-		expect(roots[0]?.children.map((child) => child.entry.id)).toEqual(["older", "newer"]);
-	});
-
-	it("rebuilds very deep flat session trees without recursive construction", () => {
-		const flatNodes = Array.from({ length: 10_000 }, (_, index) => ({
-			entry: {
-				type: "message" as const,
-				id: `node-${index}`,
-				parentId: index === 0 ? null : `node-${index - 1}`,
-				timestamp: "2026-01-01T00:00:00.000Z",
-				message: { role: "user" as const, content: String(index), timestamp: index },
-			},
-		}));
-		expect(() => JSON.stringify({ flatNodes, leafId: "node-9999" })).not.toThrow();
-		const roots = buildSessionTreeFromFlatNodes(flatNodes);
-		let node = roots[0];
-		let depth = 0;
-		while (node) {
-			depth++;
-			node = node.children[0];
-		}
-		expect(depth).toBe(10_000);
 	});
 
 	it("loads session trees through the daemon protocol", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2438,6 +2438,24 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
+	it("sorts rebuilt siblings by timestamp regardless of flat-array order", () => {
+		const entry = (id: string, parentId: string | null, timestamp: string) => ({
+			entry: {
+				type: "message" as const,
+				id,
+				parentId,
+				timestamp,
+				message: { role: "user" as const, content: id, timestamp: Date.parse(timestamp) },
+			},
+		});
+		const roots = buildSessionTreeFromFlatNodes([
+			entry("root", null, "2026-01-01T00:00:00.000Z"),
+			entry("newer", "root", "2026-01-03T00:00:00.000Z"),
+			entry("older", "root", "2026-01-02T00:00:00.000Z"),
+		]);
+		expect(roots[0]?.children.map((child) => child.entry.id)).toEqual(["older", "newer"]);
+	});
+
 	it("rebuilds very deep flat session trees without recursive construction", () => {
 		const flatNodes = Array.from({ length: 10_000 }, (_, index) => ({
 			entry: {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { MissingSessionCwdError } from "../src/core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../src/core/session-import-errors.js";
 import {
+	buildSessionTreeFromFlatNodes,
 	DAEMON_REFINE_REQUEST_TIMEOUT_MS,
 	DaemonAgentConnection,
 } from "../src/modes/agent-connection/daemon-agent-connection.js";
@@ -216,7 +217,7 @@ class FakeDaemonClient {
 					command: command.type,
 					success: true,
 					data: {
-						tree: [
+						flatNodes: [
 							{
 								entry: {
 									type: "message",
@@ -225,7 +226,6 @@ class FakeDaemonClient {
 									timestamp: "2026-01-01T00:00:00.000Z",
 									message: { role: "user", content: "hello", timestamp: 1 },
 								},
-								children: [],
 							},
 						],
 						leafId: "user-1",
@@ -2436,6 +2436,27 @@ describe("DaemonAgentConnection", () => {
 			type: "get_session_context",
 			activeSessionId: "active-1",
 		});
+	});
+
+	it("rebuilds very deep flat session trees without recursive construction", () => {
+		const flatNodes = Array.from({ length: 10_000 }, (_, index) => ({
+			entry: {
+				type: "message" as const,
+				id: `node-${index}`,
+				parentId: index === 0 ? null : `node-${index - 1}`,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				message: { role: "user" as const, content: String(index), timestamp: index },
+			},
+		}));
+		expect(() => JSON.stringify({ flatNodes, leafId: "node-9999" })).not.toThrow();
+		const roots = buildSessionTreeFromFlatNodes(flatNodes);
+		let node = roots[0];
+		let depth = 0;
+		while (node) {
+			depth++;
+			node = node.children[0];
+		}
+		expect(depth).toBe(10_000);
 	});
 
 	it("loads session trees through the daemon protocol", async () => {

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -215,6 +215,21 @@ describe("DaemonClient", () => {
 		client.close();
 	});
 
+	it("rejects flat session-tree requests to an old daemon", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, 5);
+
+		await expect(client.request({ type: "get_session_tree", activeSessionId: "active-1" })).rejects.toThrow(
+			"does not support get_session_tree",
+		);
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
 	it("rejects session input admission clearly when an old daemon lacks the capability", async () => {
 		const client = new DaemonClient("/tmp/prime-agent.sock");
 		const connect = client.connect();

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -59,10 +59,6 @@ describe("daemon protocol helpers", () => {
 		);
 	});
 
-	it("requires protocol 6 for the flat session-tree response", () => {
-		expect(DAEMON_COMMAND_COMPATIBILITY.get_session_tree).toEqual({ minProtocol: 6 });
-	});
-
 	it("capability-gates the optional model catalog surface", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.get_model_catalog).toEqual({
 			minProtocol: 4,

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -36,7 +36,7 @@ describe("daemon protocol helpers", () => {
 	});
 
 	it("requires compatibility metadata for the heartbeat protocol surface", () => {
-		expect(DAEMON_PROTOCOL_VERSION).toBe(5);
+		expect(DAEMON_PROTOCOL_VERSION).toBe(6);
 		expect(DAEMON_SCHEMA_ID).toContain(`protocol-${DAEMON_PROTOCOL_VERSION}`);
 		expect(DAEMON_COMMAND_COMPATIBILITY.heartbeats_list).toEqual({
 			minProtocol: 3,
@@ -57,6 +57,10 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toEqual(
 			expect.arrayContaining(["heartbeat_catalog", "heartbeat_management"]),
 		);
+	});
+
+	it("requires protocol 6 for the flat session-tree response", () => {
+		expect(DAEMON_COMMAND_COMPATIBILITY.get_session_tree).toEqual({ minProtocol: 6 });
 	});
 
 	it("capability-gates the optional model catalog surface", () => {

--- a/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
-import type { DaemonCommand, DaemonResponse } from "../src/modes/daemon/daemon-protocol.js";
+import {
+	createDaemonCommandEnvelope,
+	DAEMON_COMMAND_COMPATIBILITY,
+	type DaemonCommand,
+	type DaemonResponse,
+} from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
 
@@ -56,5 +61,46 @@ describe("daemon supervisor side-question routing", () => {
 			expect.objectContaining({ command: "start_side_question", success: true }),
 			expect.objectContaining({ command: "abort_side_question", success: true }),
 		]);
+	});
+	it("rejects flat session-tree requests from an old client", async () => {
+		const handleCommand = vi.fn();
+		const write = vi.fn();
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			ready: Promise.resolve(),
+			ownership: { assertCurrent: vi.fn(async () => undefined) },
+			workers: new Map(),
+			clients: new Set(),
+			protocolClientIds: new WeakMap(),
+			mutationDrain: new MutationDrainLatch(),
+			cancelOwnedWorkerCleanup: vi.fn(),
+			handleCommand,
+			write,
+			log: vi.fn(),
+		}) as SupervisorHarness;
+		const client = { id: "old-client" } as DaemonSocketClient;
+		const command = { type: "get_session_tree", activeSessionId: "active-1" } as const;
+
+		await supervisor.handleLine(
+			client,
+			JSON.stringify(
+				createDaemonCommandEnvelope(
+					command,
+					"tree-1",
+					undefined,
+					DAEMON_COMMAND_COMPATIBILITY.get_session_tree.minProtocol - 1,
+				),
+			),
+		);
+
+		expect(handleCommand).not.toHaveBeenCalled();
+		expect(write).toHaveBeenCalledWith(
+			client,
+			expect.objectContaining({
+				id: "tree-1",
+				command: "get_session_tree",
+				success: false,
+				error: expect.stringContaining("requires client protocol 6"),
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -179,19 +179,6 @@ describe("SessionManager append and tree traversal", () => {
 		});
 	});
 
-	describe("getFlatTree", () => {
-		it("serializes a 10000-entry linear session without recursive nesting", () => {
-			const session = SessionManager.inMemory();
-			for (let index = 0; index < 10_000; index++) {
-				session.appendMessage(userMsg(String(index)));
-			}
-			const flatNodes = session.getFlatTree();
-			expect(flatNodes).toHaveLength(10_000);
-			expect(flatNodes.at(-1)?.entry.parentId).toBe(flatNodes.at(-2)?.entry.id);
-			expect(() => JSON.stringify({ flatNodes, leafId: session.getLeafId() })).not.toThrow();
-		});
-	});
-
 	describe("getTree", () => {
 		it("returns empty array for empty session", () => {
 			const session = SessionManager.inMemory();

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -179,6 +179,19 @@ describe("SessionManager append and tree traversal", () => {
 		});
 	});
 
+	describe("getFlatTree", () => {
+		it("serializes a 10000-entry linear session without recursive nesting", () => {
+			const session = SessionManager.inMemory();
+			for (let index = 0; index < 10_000; index++) {
+				session.appendMessage(userMsg(String(index)));
+			}
+			const flatNodes = session.getFlatTree();
+			expect(flatNodes).toHaveLength(10_000);
+			expect(flatNodes.at(-1)?.entry.parentId).toBe(flatNodes.at(-2)?.entry.id);
+			expect(() => JSON.stringify({ flatNodes, leafId: session.getLeafId() })).not.toThrow();
+		});
+	});
+
 	describe("getTree", () => {
 		it("returns empty array for empty session", () => {
 			const session = SessionManager.inMemory();


### PR DESCRIPTION
## Summary

- replace the recursively nested `get_session_tree` daemon response with a flat node array using the existing `entry.parentId` links
- rebuild the tree iteratively in the daemon client before opening the tree selector
- make the response intentionally protocol-incompatible (protocol 6) rather than carrying a legacy fallback

## Why

Long linear sessions can exceed JavaScript's recursion limit while the daemon serializes the nested tree. In the motivating session:

- 7,415 persisted nodes
- ~15.7 MB flat JSON response
- no graph cycles or malformed records
- the previous nested response failed in `JSON.stringify()` with `RangeError: Maximum call stack size exceeded`

The flat response has constant structural nesting depth and serializes successfully.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transfer session trees as flat nodes between daemon and client to fix deep-session serializer overflow
> - The daemon's `get_session_tree` handler now returns a flat list of nodes (`flatNodes`) instead of a nested tree, avoiding stack/serializer overflow on very deep sessions.
> - `SessionManager.getFlatTree()` is added to produce the flat list; tree reconstruction via `buildSessionTreeFromFlatNodes` is moved to the client side in `DaemonAgentConnection.getSessionTree()`.
> - The daemon protocol version is bumped from 5 to 6 (schema revision 7); `get_session_tree` now requires protocol ≥ 6, and the supervisor rejects the command with an explicit error for older clients.
> - Behavioral Change: the wire format for `get_session_tree` changes from `{ tree, leafId }` to `{ flatNodes, leafId }`; clients on protocol <6 can no longer use this command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fee7aac.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional breaking wire change for `get_session_tree` requires client and daemon on protocol 6 together; tree reconstruction logic must stay aligned with `SessionManager.getTree()` for `/tree` and branching UI.
> 
> **Overview**
> Fixes **`/tree`** and related flows failing on very deep sessions when the daemon tried to **`JSON.stringify`** a deeply nested session tree and hit a stack overflow.
> 
> **Daemon wire format:** `get_session_tree` now returns **`{ flatNodes, leafId }`** instead of a nested **`tree`**. Each flat node carries **`entry`**, optional **label** metadata, and parent links via **`entry.parentId`**. **`SessionManager.getFlatTree()`** produces that list; **`getTree()`** still builds the nested shape locally for in-process callers.
> 
> **Client:** **`DaemonAgentConnection`** requests flat nodes and rebuilds the tree with **`buildSessionTreeFromFlatNodes`** (iterative indexing and sibling sorting, matching prior **`getTree()`** ordering).
> 
> **Protocol:** Daemon protocol bumps to **6** (schema revision **7**). **`get_session_tree`** requires protocol ≥ 6; the supervisor rejects older clients with an explicit error, and the client refuses the command against protocol 5 daemons—no legacy nested fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee7aac7b3a4a82120f1a9fb210e67f67832bd83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->