### PR TITLE
fix(coding-agent): add xhigh and max to thinking level fallback list

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Changed collapsed edit and IPython tool calls to show compact per-file line-change summaries while keeping full diffs available when expanded.
 - Changed session search to rank exact name and first-message matches before prefix, substring, and stricter transcript fuzzy matches.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
+- Fixed `/effort xhigh` and `/effort max` being rejected as unknown levels when no model was active yet.
 
 ## [0.3.3] - 2026-07-23
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -753,7 +753,7 @@ interface RlmSubagentModelSelection {
 // ============================================================================
 
 /** Standard thinking levels */
-const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
+const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 /** Cap on the post-compaction kernel namespace probe so a wedged kernel can't stall recovery. */
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;


### PR DESCRIPTION
Fixes `/effort` rejecting `xhigh` and `max` as unknown thinking levels.

The no-model fallback list in `AgentSession.getAvailableThinkingLevels()` only contained `off, minimal, low, medium, high`, even though the extended levels are supported everywhere else (ai package types, `getSupportedThinkingLevels`/`clampThinkingLevel`, provider mappings, CLI args, settings, selectors, theme colors). When no model was active, `/effort xhigh` and `/effort max` failed with:

```
Unknown thinking level 'max'. Available: off, minimal, low, medium, high
```

- Added `xhigh` and `max` to the `THINKING_LEVELS` fallback in `agent-session.ts`
- `npm run check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant alignment with existing thinking-level support; no auth, persistence, or provider behavior changes.
> 
> **Overview**
> Fixes **`/effort xhigh`** and **`/effort max`** failing with an “unknown thinking level” error when no model is selected yet.
> 
> The no-model fallback in `getAvailableThinkingLevels()` only listed `off` through `high`; **`xhigh`** and **`max`** are now included in that `THINKING_LEVELS` constant so they match the rest of the stack. Changelog updated under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a158e86365edbe06c4e7470155c2d8cf8abbe454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/effort xhigh` and `/effort max` being rejected as unknown thinking levels
> Adds `xhigh` and `max` to the `THINKING_LEVELS` array in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/559/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae), which is used to validate effort levels before a model is active. Previously, these values were rejected as unknown levels at that point in the session lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a158e86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->