### PR TITLE
fix(coding-agent): keep selection highlight visible against matching terminal backgrounds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Changed session search to rank exact name and first-message matches before prefix, substring, and stricter transcript fuzzy matches.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 - Fixed `/effort xhigh` and `/effort max` being rejected as unknown levels when no model was active yet.
+- Fixed selected rows in the agents view, child agent panel, and selectors being nearly invisible on terminals whose background closely matches the `selectedBg` theme color; the selection highlight now adapts to keep a minimum contrast against the detected terminal background.
 - Fixed startup blocking on a private Prime Inference model authorization request; the authorization is now cached next to `models.json` and stale entries refresh in the background.
 
 ## [0.3.3] - 2026-07-23

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2377,7 +2377,7 @@ export class AgentsViewMode implements Component, Focusable {
 		if (code) {
 			return theme.bg("toolPanelBg", padded);
 		}
-		return selected ? theme.bg("selectedBg", padded) : padded;
+		return selected ? theme.getSelectionBackgroundColor()(padded) : padded;
 	}
 
 	private isPendingDeleteRow(row: AgentsViewRow): boolean {

--- a/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/child-agent-inspector.ts
@@ -586,7 +586,7 @@ export class ChildAgentSummaryComponent implements Component, Focusable {
 		const truncated = this.truncate(line, contentWidth);
 		const paddedContent = truncated + " ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
 		const padded = `${" ".repeat(this.paddingX)}${paddedContent}${" ".repeat(this.paddingX)}`;
-		return selected ? theme.bg("selectedBg", padded) : padded;
+		return selected ? theme.getSelectionBackgroundColor()(padded) : padded;
 	}
 
 	private truncate(line: string, width: number): string {

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -383,9 +383,7 @@ export class MenuRow implements Component, FullWidthMenuComponent {
 	}
 
 	private rowLine(text: string, width: number, selected: boolean): string {
-		const background = selected
-			? (content: string) => theme.bg("selectedBg", content)
-			: theme.getEditorBackgroundColor();
+		const background = selected ? theme.getSelectionBackgroundColor() : theme.getEditorBackgroundColor();
 		return paddedBackgroundLine(text, width, ROW_PADDING_X, background);
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -692,7 +692,7 @@ class TreeList implements Component {
 
 			let line = cursor + theme.fg("dim", prefix) + foldMarker + pathMarker + label + labelTimestamp + content;
 			if (isSelected) {
-				line = theme.bg("selectedBg", line);
+				line = theme.getSelectionBackgroundColor()(line);
 			}
 			lines.push(truncateToWidth(line, width));
 		}

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -188,6 +188,10 @@ type ColorMode = "truecolor" | "256color";
 const ADAPTIVE_LIGHT_BG_ACCENT: Rgb = { r: 0, g: 95, b: 135 };
 const SURFACE_MIN_LUMINANCE_DELTA = 12;
 const SURFACE_CONTRAST_ALPHA = 0.08;
+// Selection rows must stand out clearly, much more than passive surfaces.
+const SELECTION_MIN_LUMINANCE_DELTA = 28;
+const SELECTION_MAX_BLEND_ALPHA = 0.5;
+const SELECTION_BLEND_STEP = 0.05;
 const BLACK: Rgb = { r: 0, g: 0, b: 0 };
 const WHITE: Rgb = { r: 255, g: 255, b: 255 };
 const CUBE_VALUES = [0, 95, 135, 175, 215, 255] as const;
@@ -418,6 +422,80 @@ export class Theme {
 
 	getPopupBackgroundColor(): (str: string) => string {
 		return this.surfaceBackgroundColor("toolPanelBg");
+	}
+
+	getSelectionBackgroundColor(): (str: string) => string {
+		const terminalBg = getDefaultTerminalColors()?.background;
+		const selectedBgValue = this.bgColorValues.get("selectedBg");
+		// Basic ANSI colors (0-15) are terminal-defined; their rendered color is
+		// unknown, so no reliable contrast computation (or blend base) exists.
+		if (!terminalBg || (typeof selectedBgValue === "number" && selectedBgValue < 16)) {
+			return (str: string) => this.bg("selectedBg", str);
+		}
+		// An empty selectedBg renders as the terminal background itself; blend
+		// from there so the selection still gets an explicit contrasting color.
+		const selectionRgb = colorValueToRgb(selectedBgValue) ?? terminalBg;
+
+		// Compare against what actually renders: on 256-color terminals the
+		// palette quantization can erase the contrast of the configured value,
+		// and gives the blends a quantized baseline to beat.
+		const terminalLuminance = luminance(terminalBg);
+		const renderedSelection = colorValueToRgb(bestAnsiColor(selectionRgb, this.mode)) ?? selectionRgb;
+		const selectionLuminance = luminance(renderedSelection);
+		const delta = Math.abs(selectionLuminance - terminalLuminance);
+		if (delta >= SELECTION_MIN_LUMINANCE_DELTA) {
+			return (str: string) => this.bg("selectedBg", str);
+		}
+
+		// Blend away from the terminal background toward the endpoint on the
+		// selection's side of it. When that direction cannot reach the minimum
+		// delta (e.g. the selection already sits at the endpoint), fall back to
+		// the opposite endpoint, which requires crossing the background.
+		const endpoints = selectionLuminance >= terminalLuminance ? [WHITE, BLACK] : [BLACK, WHITE];
+		let bestColor: string | number | undefined;
+		let bestDelta = delta;
+		for (const top of endpoints) {
+			const spread = luminance(top) - selectionLuminance;
+			if (spread === 0) {
+				continue;
+			}
+			const targetLuminance = terminalLuminance + Math.sign(spread) * SELECTION_MIN_LUMINANCE_DELTA;
+			const baseAlpha = Math.min(SELECTION_MAX_BLEND_ALPHA, (targetLuminance - selectionLuminance) / spread);
+			// Quantize before evaluating: on 256-color terminals the palette
+			// rounding can otherwise erase the delta the blend was chosen for.
+			// If the direct hit undershoots, keep stepping toward the cap —
+			// a stronger blend may quantize to a palette color that passes.
+			const alphas: number[] = [];
+			for (let alpha = baseAlpha; alpha < SELECTION_MAX_BLEND_ALPHA; alpha += SELECTION_BLEND_STEP) {
+				alphas.push(alpha);
+			}
+			alphas.push(SELECTION_MAX_BLEND_ALPHA);
+			for (const alpha of alphas) {
+				const adjustedColor = bestAnsiColor(blendColor(top, selectionRgb, alpha), this.mode);
+				const adjustedRgb = colorValueToRgb(adjustedColor);
+				if (adjustedColor === "" || !adjustedRgb) {
+					continue;
+				}
+				const resultDelta = Math.abs(luminance(adjustedRgb) - terminalLuminance);
+				if (resultDelta >= SELECTION_MIN_LUMINANCE_DELTA - 1) {
+					bestColor = adjustedColor;
+					bestDelta = resultDelta;
+					break;
+				}
+				if (resultDelta > bestDelta) {
+					bestColor = adjustedColor;
+					bestDelta = resultDelta;
+				}
+			}
+			if (bestColor !== undefined && bestDelta >= SELECTION_MIN_LUMINANCE_DELTA - 1) {
+				break;
+			}
+		}
+		if (bestColor === undefined) {
+			return (str: string) => this.bg("selectedBg", str);
+		}
+		const ansi = bgAnsi(bestColor, this.mode);
+		return (str: string) => `${ansi}${str}\x1b[49m`;
 	}
 
 	private surfaceBackgroundColor(color: ThemeBg): (str: string) => string {

--- a/packages/coding-agent/test/theme-adaptive.test.ts
+++ b/packages/coding-agent/test/theme-adaptive.test.ts
@@ -1,6 +1,26 @@
 import { clearDefaultTerminalColors, setDefaultTerminalColors } from "@earendil-works/pi-tui";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getEditorTheme, initTheme, theme } from "../src/modes/interactive/theme/theme.js";
+import { getEditorTheme, initTheme, setThemeInstance, Theme, theme } from "../src/modes/interactive/theme/theme.js";
+
+function ansi256IndexToRgb(index: number): { r: number; g: number; b: number } {
+	if (index >= 232) {
+		const v = 8 + (index - 232) * 10;
+		return { r: v, g: v, b: v };
+	}
+	const cube = [0, 95, 135, 175, 215, 255];
+	const n = index - 16;
+	return { r: cube[Math.floor(n / 36)]!, g: cube[Math.floor((n % 36) / 6)]!, b: cube[n % 6]! };
+}
+
+function luminanceRgb(color: { r: number; g: number; b: number }): number {
+	return 0.299 * color.r + 0.587 * color.g + 0.114 * color.b;
+}
+
+function extractRgbLuminance(rendered: string): number {
+	const match = /48;2;(\d+);(\d+);(\d+)m/.exec(rendered);
+	if (!match) throw new Error(`Expected truecolor background escape, got: ${JSON.stringify(rendered)}`);
+	return 0.299 * Number(match[1]) + 0.587 * Number(match[2]) + 0.114 * Number(match[3]);
+}
 
 describe("adaptive TUI theme colors", () => {
 	let previousColorTerm: string | undefined;
@@ -71,6 +91,220 @@ describe("adaptive TUI theme colors", () => {
 
 		expect(editorTheme.backgroundColor?.("x")).toBe(theme.bg("userMessageBg", "x"));
 		expect(editorTheme.borderColor("x")).toBe(theme.fg("borderMuted", "x"));
+	});
+
+	it("keeps the theme selection background when the terminal background is unknown", () => {
+		expect(theme.getSelectionBackgroundColor()("x")).toBe(theme.bg("selectedBg", "x"));
+	});
+
+	it("keeps the theme selection background on clearly different terminal backgrounds", () => {
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 0, g: 0, b: 0 },
+		});
+
+		expect(theme.getSelectionBackgroundColor()("x")).toBe(theme.bg("selectedBg", "x"));
+	});
+
+	it("strengthens the selection background when it nearly matches the terminal background", () => {
+		setDefaultTerminalColors({
+			foreground: { r: 235, g: 219, b: 178 },
+			background: { r: 29, g: 32, b: 33 },
+		});
+
+		const selection = theme.getSelectionBackgroundColor()("x");
+		expect(selection).not.toBe(theme.bg("selectedBg", "x"));
+		expect(selection).toMatch(/\x1b\[48;2;\d+;\d+;\d+mx\x1b\[49m/);
+	});
+
+	it("darkens a selection background that is darker than a dark terminal background", () => {
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 60, g: 60, b: 60 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		// Selection luminance 34.5 against a terminal luminance of 60 has delta 25.5;
+		// blending darker reaches the minimum without crossing the background.
+		expect(Math.abs(extractRgbLuminance(rendered) - 60)).toBeGreaterThanOrEqual(27.5);
+		expect(extractRgbLuminance(rendered)).toBeLessThan(34.5);
+	});
+
+	it("lightens a selection background that is brighter than a light terminal background", () => {
+		initTheme("light");
+		setDefaultTerminalColors({
+			foreground: { r: 0, g: 0, b: 0 },
+			background: { r: 200, g: 200, b: 200 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		// light theme selectedBg #d0d0e0 has luminance ~209.7, terminal has 200.
+		expect(extractRgbLuminance(rendered)).toBeGreaterThan(209.7);
+		expect(Math.abs(extractRgbLuminance(rendered) - 200)).toBeGreaterThanOrEqual(27.5);
+	});
+
+	it("crosses the background when the selection sits at the blend endpoint", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: "#000000" } as ConstructorParameters<typeof Theme>[1],
+				"truecolor",
+			),
+		);
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 1, g: 1, b: 1 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		// Blending toward black cannot change a black selection, so it must blend
+		// upward across the background to reach the minimum contrast.
+		expect(Math.abs(extractRgbLuminance(rendered) - 1)).toBeGreaterThanOrEqual(27.5);
+
+		initTheme("prime");
+	});
+
+	it("falls back across the background when the same-side blend is capped", () => {
+		// Prime selectedBg (#222226, luminance ~34.5) is slightly darker than this
+		// terminal background; blending darker is capped at 0.5 and cannot reach 28,
+		// so the highlight must cross upward instead.
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 35, g: 35, b: 35 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		expect(Math.abs(extractRgbLuminance(rendered) - 35)).toBeGreaterThanOrEqual(27.5);
+	});
+
+	it("keeps contrast after 256-color quantization", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: "#e93e4d" } as ConstructorParameters<typeof Theme>[1],
+				"256color",
+			),
+		);
+		// #e93e4d (luminance 114.9) on #2ca649 (luminance 118.9): the pre-quantized
+		// blend is fine, but naive quantization lands on #af5f5f, matching the
+		// terminal background exactly.
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 44, g: 166, b: 73 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		const match = /48;5;(\d+)m/.exec(rendered);
+		if (!match) throw new Error(`Expected 256-color background escape, got: ${JSON.stringify(rendered)}`);
+		const quantized = ansi256IndexToRgb(Number(match[1]));
+		expect(Math.abs(luminanceRgb(quantized) - 118.9)).toBeGreaterThanOrEqual(27.5);
+
+		initTheme("prime");
+	});
+
+	it("searches stronger blends when 256-color quantization undershoots", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: "#2f4d50" } as ConstructorParameters<typeof Theme>[1],
+				"256color",
+			),
+		);
+		// #2f4d50 (luminance 68.4) on #751dce (luminance 75.5): both exact-target
+		// blends quantize far below the threshold; a stronger blend toward white
+		// quantizes to #87afaf and clears it.
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 117, g: 29, b: 206 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		const match = /48;5;(\d+)m/.exec(rendered);
+		if (!match) throw new Error(`Expected 256-color background escape, got: ${JSON.stringify(rendered)}`);
+		expect(Math.abs(luminanceRgb(ansi256IndexToRgb(Number(match[1]))) - 75.5)).toBeGreaterThanOrEqual(27.5);
+
+		initTheme("prime");
+	});
+
+	it("adapts when 256-color quantization erases the configured contrast", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: "#e82d6a" } as ConstructorParameters<typeof Theme>[1],
+				"256color",
+			),
+		);
+		// #e82d6a (luminance ~108) on #d6005d (luminance ~74.6): raw delta 33 passes,
+		// but the selection quantizes to #d7005f which nearly matches the terminal.
+		setDefaultTerminalColors({
+			foreground: { r: 255, g: 255, b: 255 },
+			background: { r: 214, g: 0, b: 93 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		const match = /48;5;(\d+)m/.exec(rendered);
+		if (!match) throw new Error(`Expected 256-color background escape, got: ${JSON.stringify(rendered)}`);
+		expect(Math.abs(luminanceRgb(ansi256IndexToRgb(Number(match[1]))) - 74.6)).toBeGreaterThanOrEqual(27.5);
+
+		initTheme("prime");
+	});
+
+	it("leaves terminal-defined basic ANSI selection colors alone", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: 0 } as ConstructorParameters<typeof Theme>[1],
+				"256color",
+			),
+		);
+		setDefaultTerminalColors({
+			foreground: { r: 235, g: 219, b: 178 },
+			background: { r: 29, g: 32, b: 33 },
+		});
+
+		expect(theme.getSelectionBackgroundColor()("x")).toBe(theme.bg("selectedBg", "x"));
+
+		initTheme("prime");
+	});
+
+	it("derives a contrasting selection when selectedBg uses the terminal default", () => {
+		setThemeInstance(
+			new Theme(
+				{} as ConstructorParameters<typeof Theme>[0],
+				{ selectedBg: "" } as ConstructorParameters<typeof Theme>[1],
+				"256color",
+			),
+		);
+		setDefaultTerminalColors({
+			foreground: { r: 235, g: 219, b: 178 },
+			background: { r: 29, g: 32, b: 33 },
+		});
+
+		const rendered = theme.getSelectionBackgroundColor()("x");
+		expect(rendered).not.toBe(theme.bg("selectedBg", "x"));
+		const match = /48;5;(\d+)m/.exec(rendered);
+		if (!match) throw new Error(`Expected 256-color background escape, got: ${JSON.stringify(rendered)}`);
+		// Terminal background luminance is 31.2; the derived highlight must clear it.
+		expect(Math.abs(luminanceRgb(ansi256IndexToRgb(Number(match[1]))) - 31.2)).toBeGreaterThanOrEqual(27.5);
+
+		initTheme("prime");
+	});
+
+	it("darkens a light selection background that nearly matches a light terminal background", () => {
+		initTheme("light");
+		setDefaultTerminalColors({
+			foreground: { r: 0, g: 0, b: 0 },
+			background: { r: 210, g: 210, b: 220 },
+		});
+
+		const selection = theme.getSelectionBackgroundColor()("x");
+		expect(selection).not.toBe(theme.bg("selectedBg", "x"));
+		expect(selection).toMatch(/\x1b\[48;2;\d+;\d+;\d+mx\x1b\[49m/);
 	});
 
 	it("uses COLORFGBG for automatic default theme selection when OSC colors are unavailable", () => {


### PR DESCRIPTION
## Problem

Selected rows (agents view, child agent panel, menu panel, tree selector, session selector) use a fixed `selectedBg` theme color. When the terminal background is close to that color, the selection highlight is nearly invisible. Concrete case: the `prime` theme ships `selectedBg: #222226` (luminance ~34), which against a Ghostty Gruvbox Dark Hard background `#1d2021` (luminance ~31) has a contrast delta of ~3.

The existing surface adaptation (minimum luminance delta for editor/popup backgrounds) is not applied to selection rows, and its delta of 12 is too weak for a selection indicator anyway.

## Fix

`Theme.getSelectionBackgroundColor()`: when the terminal background is known (OSC 10/11 probe) and the luminance delta against `selectedBg` is below 28, the highlight is blended toward white (or black on light terminals) by just enough alpha (capped at 0.5) to reach that minimum. Falls back to the plain theme color when the background can't be detected (e.g. tmux) or the delta is already sufficient, so well-contrasted setups render unchanged.

Adapted highlights use the detected terminal palette, consistent with how `getEditorBackgroundColor()`/`getPopupBackgroundColor()` already adapt passive surfaces.

## Testing

- New cases in `theme-adaptive.test.ts`: unknown background, sufficient contrast, dark terminal bg matching `selectedBg` (adapted), light terminal bg matching light-theme `selectedBg` (adapted).
- Existing selector/agent-list tests still pass.
- Verified against the installed 0.3.3 bundle: with a `#1d2021` terminal background the selection row renders `rgb(59,59,62)` instead of `rgb(34,34,38)`; unchanged for black or unknown backgrounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only selection styling with fallbacks to the original theme token; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Fixes **nearly invisible list selection** when the terminal background is close to the theme's `selectedBg` (e.g. prime `#222226` on Gruvbox `#1d2021`).
> 
> Adds **`Theme.getSelectionBackgroundColor()`**, which compares luminance against the detected terminal background (OSC probe). If contrast is below a **28** luminance delta, it blends toward white or black (capped alpha, with fallbacks when the same-side blend cannot reach the threshold) and accounts for **256-color quantization** so palette rounding does not erase the highlight. When the background is unknown or `selectedBg` is a basic ANSI index, behavior stays **`selectedBg` unchanged**.
> 
> **Agents view**, **child agent panel**, **menu panel**, and **tree selector** now use this helper instead of a fixed `selectedBg` background. Changelog and **`theme-adaptive.test.ts`** cover contrast, light/dark terminals, empty `selectedBg`, and quantization edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa39d1c9dcf013acef87a1d953bf41fc915eb0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix selection highlight visibility against matching terminal backgrounds in coding agent UI
> - Adds `Theme.getSelectionBackgroundColor()` in [theme.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/562/files#diff-cfeb6df930e2178ee2bad20d06795540093a317adcd9ed03e9b70bf39c667c53), which returns an adaptive background function that blends the configured `selectedBg` toward black or white until a minimum luminance delta versus the terminal background is met.
> - Replaces direct `theme.bg("selectedBg", ...)` calls in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/562/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10), [child-agent-inspector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/562/files#diff-c6e80ba5fe28e36eaaf2f0d66307dec3db0481b56d24b214c31d2530d49517a1), [menu-panel.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/562/files#diff-22f82f8366fad943dc6e7f231f4645c864e17b89b5228a1453cc21e1a57a329c), and [tree-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/562/files#diff-eb3a2b5ed9743a3bf5f855316bb3f508141b0d28028ed4cc246be17d04a77fa6) with the new adaptive method.
> - Falls back to the configured `selectedBg` unchanged when the terminal background is unknown or when `selectedBg` is a basic ANSI color (indices 0–15).
> - Behavioral Change: selection highlight color may now differ from the configured `selectedBg` in truecolor and 256-color terminals when the background is too similar to the selection color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efa39d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->