### PR TITLE
Open reasoning selector for bare /effort

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `/new` support for an optional stable session name and initial prompt.
 - Changed collapsed edit and IPython tool calls to show compact per-file line-change summaries while keeping full diffs available when expanded.
+- Changed bare `/effort` to open a selector for the current model's supported reasoning levels.
 - Changed session search to rank exact name and first-message matches before prefix, substring, and stricter transcript fuzzy matches.
 - Fixed daemon startup failing when an interrupted supervisor left an empty ownership directory.
 - Fixed `/effort xhigh` and `/effort max` being rejected as unknown levels when no model was active yet.

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -38,7 +38,7 @@ interface BuiltinSlashCommandAlias {
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
-	{ name: "effort", description: "Set reasoning/thinking level", argumentHint: "[level]", takesArgument: true },
+	{ name: "effort", description: "Select reasoning/thinking level (opens selector UI)", argumentHint: "[level]" },
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -200,6 +200,7 @@ import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SideQuestionComponent } from "./components/side-question.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
+import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
 import {
 	selectLatestToolExpandHint,
 	ToolExecutionComponent,
@@ -7774,7 +7775,7 @@ export class InteractiveMode {
 		}
 		const requested = arg.trim().toLowerCase();
 		if (!requested) {
-			this.showStatus(`Thinking level: ${this.connectionState?.thinkingLevel} (type a level: ${levels.join(", ")})`);
+			this.showThinkingSelector(levels);
 			return;
 		}
 		if (!levels.includes(requested as ThinkingLevel)) {
@@ -7782,6 +7783,29 @@ export class InteractiveMode {
 			return;
 		}
 		this.applyThinkingLevel(requested as ThinkingLevel);
+	}
+
+	private showThinkingSelector(levels: ThinkingLevel[] = this.getAvailableThinkingLevels()): void {
+		const currentLevel = this.connectionState?.thinkingLevel ?? levels[0];
+		if (!currentLevel) {
+			this.showStatus("Current model does not support thinking");
+			return;
+		}
+		this.showSelector((done) => {
+			const selector = new ThinkingSelectorComponent(
+				currentLevel,
+				levels,
+				(level) => {
+					done();
+					this.applyThinkingLevel(level);
+				},
+				() => {
+					done();
+					this.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector.getSelectList() };
+		});
 	}
 
 	private applyThinkingLevel(level: ThinkingLevel): void {

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -1,7 +1,8 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
-import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import type { AutocompleteItem, Component } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { ThinkingSelectorComponent } from "../src/modes/interactive/components/thinking-selector.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
@@ -18,12 +19,16 @@ type EffortCommandContext = {
 	updateEditorBorderColor: () => void;
 	getAvailableThinkingLevels: () => ThinkingLevel[];
 	applyThinkingLevel: (level: ThinkingLevel) => void;
+	showThinkingSelector: (levels?: ThinkingLevel[]) => void;
+	showSelector: (create: (done: () => void) => { component: Component; focus: Component }) => void;
+	ui: { requestRender: () => void };
 };
 
 type InteractiveModePrototype = {
 	getAvailableThinkingLevels(this: EffortCommandContext): ThinkingLevel[];
 	getThinkingLevelCompletions(this: EffortCommandContext, prefix: string): AutocompleteItem[] | null;
 	handleEffortCommand(this: EffortCommandContext, arg: string): void;
+	showThinkingSelector(this: EffortCommandContext, levels?: ThinkingLevel[]): void;
 	applyThinkingLevel(this: EffortCommandContext, level: ThinkingLevel): void;
 };
 
@@ -109,6 +114,9 @@ function makeContext(overrides: Partial<EffortCommandContext> = {}): EffortComma
 		updateEditorBorderColor: vi.fn(),
 		getAvailableThinkingLevels: () => interactiveModePrototype.getAvailableThinkingLevels.call(context),
 		applyThinkingLevel: (level) => interactiveModePrototype.applyThinkingLevel.call(context, level),
+		showThinkingSelector: (levels) => interactiveModePrototype.showThinkingSelector.call(context, levels),
+		showSelector: vi.fn(),
+		ui: { requestRender: vi.fn() },
 		...overrides,
 	};
 	return context;
@@ -173,15 +181,26 @@ describe("InteractiveMode /effort", () => {
 			);
 		});
 
-		it("shows the current level and choices when called without an argument", () => {
-			const context = makeContext();
+		it("opens the thinking-level selector when called without an argument", () => {
+			let selector: ThinkingSelectorComponent | undefined;
+			const done = vi.fn();
+			const context = makeContext({
+				showSelector: (create) => {
+					selector = create(done).component as ThinkingSelectorComponent;
+				},
+			});
 
 			interactiveModePrototype.handleEffortCommand.call(context, "");
 
 			expect(context.agentConnection.setThinkingLevel).not.toHaveBeenCalled();
-			expect(context.showStatus).toHaveBeenCalledWith(
-				"Thinking level: medium (type a level: off, low, medium, high)",
-			);
+			expect(selector).toBeInstanceOf(ThinkingSelectorComponent);
+			expect(selector?.getSelectList().getSelectedItem()?.value).toBe("medium");
+
+			selector?.getSelectList().setSelectedIndex(3);
+			selector?.getSelectList().onSelect?.(selector.getSelectList().getSelectedItem()!);
+
+			expect(done).toHaveBeenCalledOnce();
+			expect(context.agentConnection.setThinkingLevel).toHaveBeenCalledWith("high");
 		});
 
 		it("reports when the model does not support thinking", () => {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -28,7 +28,7 @@ describe("built-in slash commands", () => {
 
 	test("exposes /effort for selecting the thinking level", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
-			description: "Set reasoning/thinking level",
+			description: "Select reasoning/thinking level (opens selector UI)",
 			argumentHint: "[level]",
 			aliases: ["thinking"],
 		});
@@ -63,12 +63,9 @@ describe("built-in slash commands", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "goal")).toMatchObject({
 			takesArgument: true,
 		});
-		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "effort")).toMatchObject({
-			takesArgument: true,
-		});
 		expect(builtinSlashCommandTakesArgument("goal")).toBe(true);
-		expect(builtinSlashCommandTakesArgument("effort")).toBe(true);
-		expect(builtinSlashCommandTakesArgument("thinking")).toBe(true);
+		expect(builtinSlashCommandTakesArgument("effort")).toBe(false);
+		expect(builtinSlashCommandTakesArgument("thinking")).toBe(false);
 		expect(builtinSlashCommandTakesArgument("heartbeat")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("mcp")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("new")).toBe(true);


### PR DESCRIPTION
## Summary

- open the existing thinking-level selector when `/effort` is submitted without an argument
- keep `/effort <level>` and argument autocomplete as direct shortcuts
- submit `/effort` immediately from slash-command autocomplete, matching `/model`
- add command and selector regression coverage

## Why

Reasoning effort is a model-supported enum, but bare `/effort` only printed the current value and required the user to type a level. The selector makes the available values discoverable and prevents invalid input.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-effort-command.test.ts test/slash-commands.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive UX and slash-command metadata only; reasoning level application path is unchanged aside from the no-argument entry point.
> 
> **Overview**
> Bare **`/effort`** (and **`/thinking`**) now opens the **thinking-level selector** instead of printing the current level and asking users to type a value. **`/effort <level>`** still applies a level directly, and level **argument autocomplete** remains for shortcuts.
> 
> Slash-command metadata is aligned with **`/model`**: **`/effort`** is no longer treated as an argument-required command, so choosing it from autocomplete can **submit immediately** and launch the selector. Help text now describes that it **opens the selector UI**.
> 
> Regression tests cover selector open/selection and updated **`takesArgument`** expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbc44bc0385ebdcb8d43dff79003b92d2795e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open a reasoning level selector UI when `/effort` is invoked without an argument
> Previously, bare `/effort` printed available thinking levels in the status bar. Now it opens a `ThinkingSelectorComponent` UI picker initialized with the current level and the model's supported levels. Selecting a level calls `applyThinkingLevel`; cancelling dismisses the selector. The `effort` command metadata is updated to set `takesArgument: false` in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/563/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cbc44b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->