### PR TITLE
Remove token estimates from reasoning efforts

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -21,12 +21,12 @@ const SETTINGS_SUBMENU_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 
 const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	off: "No reasoning",
-	minimal: "Very brief reasoning (~1k tokens)",
-	low: "Light reasoning (~2k tokens)",
-	medium: "Moderate reasoning (~8k tokens)",
-	high: "Deep reasoning (~16k tokens)",
-	xhigh: "Very deep reasoning (~32k tokens)",
-	max: "Maximum reasoning (unconstrained)",
+	minimal: "Very brief reasoning",
+	low: "Light reasoning",
+	medium: "Moderate reasoning",
+	high: "Deep reasoning",
+	xhigh: "Very deep reasoning",
+	max: "Maximum reasoning",
 };
 
 export interface SettingsConfig {

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -10,12 +10,12 @@ const THINKING_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 
 const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	off: "No reasoning",
-	minimal: "Very brief reasoning (~1k tokens)",
-	low: "Light reasoning (~2k tokens)",
-	medium: "Moderate reasoning (~8k tokens)",
-	high: "Deep reasoning (~16k tokens)",
-	xhigh: "Very deep reasoning (~32k tokens)",
-	max: "Maximum reasoning (unconstrained)",
+	minimal: "Very brief reasoning",
+	low: "Light reasoning",
+	medium: "Moderate reasoning",
+	high: "Deep reasoning",
+	xhigh: "Very deep reasoning",
+	max: "Maximum reasoning",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Remove approximate token counts from reasoning-effort descriptions in the settings selector.
- Remove the same estimates from the standalone thinking-level selector.
- Keep the qualitative descriptions consistent across both selectors.

## Why

Reasoning token usage varies by model and provider, so fixed estimates can be misleading.

## Impact

Reasoning-effort choices now describe relative depth without implying a specific token budget.

## Validation

- `npm run check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove token count hints from reasoning effort descriptions
> Shortens the reasoning level labels in [settings-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/564/files#diff-3aa555ecdddc2b26c6da42d9f912f582c72b61407f8846b7b4322fcd1c0f7cfa) and [thinking-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/564/files#diff-ca3cfbcbd286689bec077d9704c8aec9d4b38f5094a783716c8ab6009d383a45) by removing token count guidance and the `(unconstrained)` qualifier from the `max` level. Labels now read e.g. "Light reasoning" instead of "Light reasoning (~1k tokens)".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0d3941.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to selector descriptions; no behavior, settings persistence, or API impact.
> 
> **Overview**
> **Reasoning level labels** in the settings **Thinking level** submenu and the standalone thinking selector no longer show approximate token budgets (e.g. `~8k tokens`) or the **max** level’s `(unconstrained)` note.
> 
> Descriptions stay qualitative only—*Light reasoning*, *Deep reasoning*, etc.—so the UI does not imply fixed token usage across models and providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d3941f43e22cbd22d14958f2156248d53b07e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->