### PR TITLE
fix(coding-agent): disable ANSI colors in IPython tracebacks

### DIFF
--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -26,6 +26,7 @@ import asyncio
 import os as _prime_agent_os
 
 _prime_agent_os.environ["NO_COLOR"] = "1"
+get_ipython().colors = "nocolor"
 
 try:
     import nest_asyncio as _prime_agent_nest_asyncio


### PR DESCRIPTION
## Summary

- Set IPython's color mode to `nocolor` during kernel bootstrap.

## Why

IPython ignores `NO_COLOR` for its own traceback formatter, so uncaught Python exceptions included ANSI escape sequences in model-visible output. Setting `get_ipython().colors = "nocolor"` removes that noise while retaining `NO_COLOR=1` for subprocesses.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/ipython-bootstrap.test.ts`
- `npm run check`
- Fresh source kernel: `print(get_ipython().colors)` returned `nocolor`; `1 / 0` returned a traceback with no ANSI escape characters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single bootstrap line in the IPython runtime setup; no auth, data, or execution-path changes beyond cleaner error text.
> 
> **Overview**
> IPython kernel bootstrap now sets **`get_ipython().colors = "nocolor"`** alongside the existing **`NO_COLOR=1`** env var.
> 
> **`NO_COLOR`** already kept **`%%bash`** and subprocess output plain, but IPython’s own traceback formatter still emitted ANSI escapes on uncaught Python exceptions—noise in model-visible tool output. Forcing **`nocolor`** on the active IPython shell strips those sequences from tracebacks while leaving subprocess behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9efbcf6e03811a4cfdcc1bfcfeaf9a543b28c1aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable ANSI colors in IPython tracebacks by setting color mode to `nocolor`
> Sets `get_ipython().colors = "nocolor"` at module import time in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/566/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d), complementing the existing `NO_COLOR` environment variable. This ensures IPython tracebacks and outputs are stripped of ANSI escape codes for the duration of the session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9efbcf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->