### PR TITLE
Add distinguishing JSON mode types for autonomous mode for --json mode

### DIFF
--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -11,16 +11,41 @@ Outputs all session events as JSON lines to stdout. Useful for integrating Prime
 Events are defined in [`AgentSessionEvent`](../src/core/agent-session.ts):
 
 ```typescript
+type CompactionReason = "manual" | "threshold" | "overflow" | "requested";
+
 type AgentSessionEvent =
   | AgentEvent
+  | { type: "ipython_sent_agent_message"; toolCallId: string; message: KernelSentAgentMessage }
   | { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
-  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
-  | { type: "compaction_end"; reason: "manual" | "threshold" | "overflow"; result: CompactionResult | undefined; aborted: boolean; willRetry: boolean; errorMessage?: string }
+  | { type: "compaction_start"; reason: CompactionReason; customInstructions?: string }
+  | { type: "session_info_changed"; name: string | undefined }
+  | { type: "thinking_level_changed"; level: ThinkingLevel }
+  | { type: "service_tier_changed"; serviceTier: ServiceTier }
+  | { type: "compaction_end"; reason: CompactionReason; result: CompactionResult | undefined; aborted: boolean; willRetry: boolean; errorMessage?: string; errorSeverity?: "warning" | "error"; customInstructions?: string }
   | { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
-  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | { type: "auth_stale"; provider: string; sourceTokens?: readonly AuthSourceToken[] }
+  | { type: "rlm_child_update"; child: RlmChildAgentSnapshot }
+  | { type: "recap_update"; recap: string | undefined }
+  | { type: "goal_update"; goal: GoalState }
+  | { type: "bash_start"; command: string; excludeFromContext: boolean; transient?: boolean; runId?: string }
+  | { type: "bash_output"; chunk: string }
+  | { type: "bash_end"; exitCode: number | undefined; cancelled: boolean; truncated: boolean; fullOutputPath?: string; errorMessage?: string; transient?: boolean; runId?: string }
+  | { type: "autonomous_gate_start"; command: string; attempt: number; maxRetries: number }
+  | { type: "autonomous_gate_end"; command: string; attempt: number; maxRetries: number; passed: boolean; skipped?: boolean; exitText?: string; output?: string }
+  | { type: "autonomous_continuation"; reason: "gate_failed" | "missing_terminal_evidence"; continuationsUsed: number; maxContinuations: number }
+  | { type: "autonomous_limit_reached"; reason: "maxContinuations" | "maxTurns" | "maxTokens" | "timeoutMs"; used: number; limit: number }
+  | { type: "refine_complete"; result: RefinementResult }
+  | { type: "refine_failed"; error: string };
 ```
 
-`queue_update` emits the full pending steering and follow-up queues whenever they change. `compaction_start` and `compaction_end` cover both manual and automatic compaction.
+`queue_update` emits the full pending steering and follow-up queues whenever they change. `compaction_start` and `compaction_end` cover both manual and automatic compaction; `errorSeverity` is `"warning"` for benign skips and `"error"` for real failures.
+
+`rlm_child_update` fires on every subagent state change and carries the child's full current state ([`RlmChildAgentSnapshot`](../src/core/agent-session.ts), see [rlm.md](rlm.md)). `goal_update` reports autonomous goal progress ([`GoalState`](../src/core/goals.ts), see [long-running-agents.md](long-running-agents.md)), and `recap_update` carries the summarizer's latest description of what the session is doing.
+
+The `autonomous_*` events expose the autonomous control loop (see [long-running-agents.md](long-running-agents.md)), letting a consumer tell "the agent tried and failed" apart from "a quality gate never passed" or "a budget ran out". `autonomous_gate_end` reports `skipped: true` when a gate was not rerun because the workspace is unchanged since its last failure. Gates are evaluated on both the in-session and host-driven paths, so a single cycle can emit two gate pairs — the second is normally the skipped short circuit.
+
+The `bash_*` events cover shell commands the user runs directly (`!command`), not the agent's tool calls: output arrives as `bash_output` chunks, `transient` marks side-conversation runs, and `runId` echoes the caller's id so concurrent runs can be correlated. `ipython_sent_agent_message` reports a message the kernel sent to another agent after its tool result was already recorded.
 
 Base events from [`AgentEvent`](../../agent/src/types.ts):
 
@@ -45,15 +70,15 @@ type AgentEvent =
 ## Message Types
 
 Base messages from [`packages/ai/src/types.ts`](../../ai/src/types.ts):
-- `UserMessage` (line 134)
-- `AssistantMessage` (line 140)
-- `ToolResultMessage` (line 152)
+- `UserMessage`
+- `AssistantMessage`
+- `ToolResultMessage`
 
 Extended messages from [`packages/coding-agent/src/core/messages.ts`](../src/core/messages.ts):
-- `BashExecutionMessage` (line 29)
-- `CustomMessage` (line 46)
-- `BranchSummaryMessage` (line 55)
-- `CompactionSummaryMessage` (line 62)
+- `BashExecutionMessage`
+- `CustomMessage`
+- `BranchSummaryMessage`
+- `CompactionSummaryMessage`
 
 ## Output Format
 
@@ -75,8 +100,27 @@ Followed by events as they occur:
 {"type":"agent_end","messages":[...]}
 ```
 
+Your prompt is echoed back as a `user` message pair before the assistant's, and `message_update` is only emitted for assistant messages. The final result text is never written to stdout in JSON mode, so the stream stays parseable.
+
+Not every `user` message was typed by a human: in autonomous mode, gate-failure continuation prompts are injected as ordinary `user` messages. Heartbeat, cron, and goal-context prompts are distinguishable — they arrive as `custom` messages carrying a `customType`.
+
+Extensions that fail are reported on stdout as a frame, alongside the human-readable line on stderr:
+
+```json
+{"type":"extension_error","extensionPath":"/path/ext.ts","event":"session_start","error":"..."}
+```
+
+Other diagnostics are not JSON: failure reasons and autonomous quality-gate failures are written to stderr as human-readable text only. The process exits non-zero when a run fails — a request ending in `stopReason: "error"` or `"aborted"`, a failed compaction, a failed session command, or an unmet autonomous quality gate — so the exit code is a reliable success signal without parsing the stream.
+
 ## Example
 
 ```bash
 prime-agent --mode json "List files" 2>/dev/null | jq -c 'select(.type == "message_end")'
+```
+
+Track a subagent fleet:
+
+```bash
+prime-agent --mode json "Investigate the build failure" 2>/dev/null \
+  | jq -r 'select(.type == "rlm_child_update") | "\(.child.label): \(.child.status)"'
 ```

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -89,6 +89,7 @@ import type { AuthSourceToken } from "./auth-storage.js";
 import {
 	type AgentAutonomousConfig,
 	type AgentAutonomousStatus,
+	type AutonomousEvent,
 	type AutonomousRuntimeState,
 	addAutonomousContinuation,
 	addAutonomousUsage,
@@ -337,6 +338,7 @@ export type AgentSessionEvent =
 			/** Echo of the caller-supplied run id, so clients correlate runs by identity. */
 			runId?: string;
 	  }
+	| AutonomousEvent
 	| { type: "refine_complete"; result: RefinementResult }
 	| { type: "refine_failed"; error: string };
 
@@ -2485,6 +2487,7 @@ export class AgentSession {
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, message, {
 			cwd: this._cwd,
 			signal: this.agent.signal,
+			onEvent: (event) => this._emit(event),
 		});
 		if (!autonomousMessage) {
 			return undefined;
@@ -2959,6 +2962,7 @@ export class AgentSession {
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, context.message, {
 			cwd: this._cwd,
 			signal,
+			onEvent: (event) => this._emit(event),
 		});
 		if (autonomousMessage && this._sessionInputArrivalEpoch !== arrivalEpoch) {
 			this._restoreAutonomousRuntimeSnapshot(autonomousSnapshot);
@@ -3877,7 +3881,10 @@ export class AgentSession {
 	}
 
 	async refreshAutonomousGates(): Promise<void> {
-		await refreshAutonomousQualityGates(this._autonomousState, { cwd: this._cwd });
+		await refreshAutonomousQualityGates(this._autonomousState, {
+			cwd: this._cwd,
+			onEvent: (event) => this._emit(event),
+		});
 	}
 
 	private async _runWithAutonomousContinuationSuppressed<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -90,9 +90,11 @@ import {
 	type AgentAutonomousConfig,
 	type AgentAutonomousStatus,
 	type AutonomousEvent,
+	type AutonomousLimitReason,
 	type AutonomousRuntimeState,
 	addAutonomousContinuation,
 	addAutonomousUsage,
+	autonomousLimitUsage,
 	autonomousStatus,
 	createAutonomousRuntimeState,
 	nextAutonomousContinuation,
@@ -2484,18 +2486,22 @@ export class AgentSession {
 		}
 		const snapshot = this._snapshotAutonomousRuntimeState();
 		const arrivalEpoch = this._sessionInputArrivalEpoch;
+		const autonomousEvents = this._bufferAutonomousEvents();
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, message, {
 			cwd: this._cwd,
 			signal: this.agent.signal,
-			onEvent: (event) => this._emit(event),
+			onEvent: autonomousEvents.onEvent,
 		});
 		if (!autonomousMessage) {
+			// No continuation, but no rollback either: the decision stands.
+			autonomousEvents.flush();
 			return undefined;
 		}
 		if (this._sessionInputArrivalEpoch !== arrivalEpoch) {
 			this._restoreAutonomousRuntimeSnapshot(snapshot);
 			return undefined;
 		}
+		autonomousEvents.flush();
 		this._queuedAutonomousThresholdContinuations.set(message, autonomousMessage);
 		this._queuedAutonomousContinuationSnapshots.set(autonomousMessage, snapshot);
 		this._postCompactionContinuationMessages.push(autonomousMessage);
@@ -2959,15 +2965,17 @@ export class AgentSession {
 			return [];
 		}
 		const autonomousSnapshot = this._snapshotAutonomousRuntimeState();
+		const autonomousEvents = this._bufferAutonomousEvents();
 		const autonomousMessage = await nextAutonomousContinuation(this._autonomousState, context.message, {
 			cwd: this._cwd,
 			signal,
-			onEvent: (event) => this._emit(event),
+			onEvent: autonomousEvents.onEvent,
 		});
 		if (autonomousMessage && this._sessionInputArrivalEpoch !== arrivalEpoch) {
 			this._restoreAutonomousRuntimeSnapshot(autonomousSnapshot);
 			return [];
 		}
+		autonomousEvents.flush();
 		return autonomousMessage ? [autonomousMessage] : [];
 	}
 
@@ -3878,6 +3886,20 @@ export class AgentSession {
 
 	recordHostAutonomousContinuation(): void {
 		addAutonomousContinuation(this._autonomousState);
+		// Host-driven continuations suppress in-session evaluation, so emit here or
+		// headless consumers never see them.
+		this._emit({
+			type: "autonomous_continuation",
+			reason: "gate_failed",
+			continuationsUsed: this._autonomousState.continuationsUsed,
+			maxContinuations: this._autonomousState.limits.maxContinuations,
+		});
+	}
+
+	/** Host-driven loops evaluate limits themselves; this reports that stop to clients. */
+	reportAutonomousLimitReached(reason: AutonomousLimitReason): void {
+		const { used, limit } = autonomousLimitUsage(this._autonomousState, reason);
+		this._emit({ type: "autonomous_limit_reached", reason, used, limit });
 	}
 
 	async refreshAutonomousGates(): Promise<void> {
@@ -3894,6 +3916,23 @@ export class AgentSession {
 		} finally {
 			this._autonomousContinuationSuppressionDepth--;
 		}
+	}
+
+	/**
+	 * Buffers autonomous events so a continuation that is rolled back (late user
+	 * input wins the arrival-epoch race) is never reported to clients. Flushing is
+	 * the caller's job, on the paths where the decision actually stands.
+	 */
+	private _bufferAutonomousEvents(): { onEvent: (event: AutonomousEvent) => void; flush: () => void } {
+		const buffered: AutonomousEvent[] = [];
+		return {
+			onEvent: (event) => buffered.push(event),
+			flush: () => {
+				for (const event of buffered.splice(0)) {
+					this._emit(event);
+				}
+			},
+		};
 	}
 
 	private _markAutonomousContinuationSuppressed(message: AgentMessage): void {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5338,6 +5338,11 @@ export class AgentSession {
 				dispatchObserver.stop();
 				endHandoffSection();
 			};
+			// Handoff commits the decision: flush before the turn so continuation and
+			// gate frames precede the turn they caused, not the one after it.
+			for (const prompt of prompts) {
+				this._flushQueuedAutonomousContinuationEvents(prompt.message);
+			}
 			const promptPromise = this.agent.prompt(messages);
 			releaseAdmission();
 			void Promise.race([promptPromise.catch(() => undefined), dispatchObserver.observed]).then(
@@ -6823,6 +6828,9 @@ export class AgentSession {
 
 		this._postCompactionContinuationScheduled = false;
 		try {
+			for (const message of continuationMessages) {
+				this._flushQueuedAutonomousContinuationEvents(message);
+			}
 			await this.agent.continue();
 			this._forgetConsumedPostCompactionContinuations(continuationMessages);
 		} catch (error) {
@@ -6845,8 +6853,6 @@ export class AgentSession {
 		for (const message of continuationMessages) {
 			if (!stillQueued.has(message)) {
 				this._queuedAutonomousContinuationSnapshots.delete(message);
-				// No snapshot left to restore from: the decision now stands.
-				this._flushQueuedAutonomousContinuationEvents(message);
 			}
 		}
 		this._postCompactionContinuationMessages = this._postCompactionContinuationMessages.filter(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1142,6 +1142,8 @@ export class AgentSession {
 	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
 	private _queuedAutonomousThresholdContinuations = new WeakMap<AssistantMessage, AgentMessage>();
 	private _queuedAutonomousContinuationSnapshots = new WeakMap<AgentMessage, AutonomousRuntimeSnapshot>();
+	/** Events for a queued continuation, held until threshold compaction commits or drops it. */
+	private _queuedAutonomousContinuationEvents = new WeakMap<AgentMessage, AutonomousEvent[]>();
 	private _pendingThresholdCompactionAutonomousMessages: AgentMessage[] = [];
 	private _pendingAutoRefineReview: { reason: AutoRefineReason; review: AutoRefineReview } | undefined;
 	private _autoRefineBranchVersion = 0;
@@ -1732,8 +1734,10 @@ export class AgentSession {
 			return false;
 		}
 		if (command.kind === "on") {
+			this._autonomousLimitReported = undefined;
 			setAutonomousEnabled(this._autonomousState, true, { cwd: this._cwd });
 		} else if (command.kind === "off") {
+			this._autonomousLimitReported = undefined;
 			setAutonomousEnabled(this._autonomousState, false);
 			this._clearQueuedAutonomousContinuations();
 		}
@@ -2501,9 +2505,11 @@ export class AgentSession {
 			this._restoreAutonomousRuntimeSnapshot(snapshot);
 			return undefined;
 		}
-		autonomousEvents.flush();
 		this._queuedAutonomousThresholdContinuations.set(message, autonomousMessage);
 		this._queuedAutonomousContinuationSnapshots.set(autonomousMessage, snapshot);
+		// A skipped or failed threshold compaction can still roll this decision back,
+		// so hold its events until the continuation is no longer rollbackable.
+		this._queuedAutonomousContinuationEvents.set(autonomousMessage, autonomousEvents.take());
 		this._postCompactionContinuationMessages.push(autonomousMessage);
 		this._pendingThresholdCompactionAutonomousMessages.push(autonomousMessage);
 		const text =
@@ -2549,6 +2555,7 @@ export class AgentSession {
 		}
 		for (const queuedMessage of queuedMessages) {
 			this._queuedAutonomousContinuationSnapshots.delete(queuedMessage);
+			this._queuedAutonomousContinuationEvents.delete(queuedMessage);
 		}
 		this._pendingThresholdCompactionAutonomousMessages = this._pendingThresholdCompactionAutonomousMessages.filter(
 			(message) => !queuedMessageSet.has(message),
@@ -3888,7 +3895,7 @@ export class AgentSession {
 		addAutonomousContinuation(this._autonomousState);
 		// Host-driven continuations suppress in-session evaluation, so emit here or
 		// headless consumers never see them.
-		this._emit({
+		this._emitAutonomousEvent({
 			type: "autonomous_continuation",
 			reason: "gate_failed",
 			continuationsUsed: this._autonomousState.continuationsUsed,
@@ -3899,13 +3906,13 @@ export class AgentSession {
 	/** Host-driven loops evaluate limits themselves; this reports that stop to clients. */
 	reportAutonomousLimitReached(reason: AutonomousLimitReason): void {
 		const { used, limit } = autonomousLimitUsage(this._autonomousState, reason);
-		this._emit({ type: "autonomous_limit_reached", reason, used, limit });
+		this._emitAutonomousEvent({ type: "autonomous_limit_reached", reason, used, limit });
 	}
 
 	async refreshAutonomousGates(): Promise<void> {
 		await refreshAutonomousQualityGates(this._autonomousState, {
 			cwd: this._cwd,
-			onEvent: (event) => this._emit(event),
+			onEvent: (event) => this._emitAutonomousEvent(event),
 		});
 	}
 
@@ -3918,21 +3925,52 @@ export class AgentSession {
 		}
 	}
 
+	/** Latches the reported limit so the in-session and host paths cannot both report one stop. */
+	private _autonomousLimitReported: AutonomousLimitReason | undefined;
+
+	/**
+	 * Single funnel for autonomous events. A run stops on a limit exactly once, but
+	 * both the in-session decision and the host loop observe that stop, so the
+	 * second report of the same limit is dropped.
+	 */
+	private _emitAutonomousEvent(event: AutonomousEvent): void {
+		if (event.type === "autonomous_limit_reached") {
+			if (this._autonomousLimitReported === event.reason) {
+				return;
+			}
+			this._autonomousLimitReported = event.reason;
+		}
+		this._emit(event);
+	}
+
 	/**
 	 * Buffers autonomous events so a continuation that is rolled back (late user
 	 * input wins the arrival-epoch race) is never reported to clients. Flushing is
 	 * the caller's job, on the paths where the decision actually stands.
 	 */
-	private _bufferAutonomousEvents(): { onEvent: (event: AutonomousEvent) => void; flush: () => void } {
+	private _bufferAutonomousEvents(): {
+		onEvent: (event: AutonomousEvent) => void;
+		flush: () => void;
+		take: () => AutonomousEvent[];
+	} {
 		const buffered: AutonomousEvent[] = [];
 		return {
 			onEvent: (event) => buffered.push(event),
 			flush: () => {
 				for (const event of buffered.splice(0)) {
-					this._emit(event);
+					this._emitAutonomousEvent(event);
 				}
 			},
+			take: () => buffered.splice(0),
 		};
+	}
+
+	/** Flushes events parked with a provisional continuation once it is no longer rollbackable. */
+	private _flushQueuedAutonomousContinuationEvents(message: AgentMessage): void {
+		for (const event of this._queuedAutonomousContinuationEvents.get(message) ?? []) {
+			this._emitAutonomousEvent(event);
+		}
+		this._queuedAutonomousContinuationEvents.delete(message);
 	}
 
 	private _markAutonomousContinuationSuppressed(message: AgentMessage): void {
@@ -6807,6 +6845,8 @@ export class AgentSession {
 		for (const message of continuationMessages) {
 			if (!stillQueued.has(message)) {
 				this._queuedAutonomousContinuationSnapshots.delete(message);
+				// No snapshot left to restore from: the decision now stands.
+				this._flushQueuedAutonomousContinuationEvents(message);
 			}
 		}
 		this._postCompactionContinuationMessages = this._postCompactionContinuationMessages.filter(

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -80,7 +80,7 @@ export interface AutonomousRuntimeState {
 export type AutonomousLimitReason = "maxContinuations" | "maxTurns" | "maxTokens" | "timeoutMs";
 export type AutonomousGateResult = "passed" | "failed" | "retry_exhausted";
 
-type AutonomousLimitState = Pick<
+export type AutonomousLimitState = Pick<
 	AgentAutonomousStatus,
 	"continuationsUsed" | "turnsUsed" | "tokensUsed" | "startedAt" | "limits"
 >;
@@ -301,6 +301,16 @@ export async function shouldAutonomouslyContinue(
 		return { shouldContinue: false, reason: "limit_reached" };
 	}
 	return { shouldContinue: true, reason: "missing_terminal_evidence" };
+}
+
+/** Used/limit pair for a binding limit, so host-driven loops can report it themselves. */
+export function autonomousLimitUsage(
+	state: AutonomousLimitState,
+	reason: AutonomousLimitReason,
+	now = Date.now(),
+): { used: number; limit: number } {
+	const [used, limit] = limitUsage(state, reason, now);
+	return { used, limit };
 }
 
 function emitLimitReached(

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -96,9 +96,49 @@ interface GitWorktreeSnapshot {
 	untrackedHash: string;
 }
 
+/** Observability for the autonomous control loop; consumed by AgentSession and forwarded to clients. */
+export type AutonomousEvent =
+	| { type: "autonomous_gate_start"; command: string; attempt: number; maxRetries: number }
+	| {
+			type: "autonomous_gate_end";
+			command: string;
+			attempt: number;
+			maxRetries: number;
+			passed: boolean;
+			/** The gate was not rerun because the workspace is unchanged since its last failure. */
+			skipped?: boolean;
+			exitText?: string;
+			output?: string;
+	  }
+	| {
+			type: "autonomous_continuation";
+			reason: "gate_failed" | "missing_terminal_evidence";
+			continuationsUsed: number;
+			maxContinuations: number;
+	  }
+	| { type: "autonomous_limit_reached"; reason: AutonomousLimitReason; used: number; limit: number };
+
 interface AutonomousOperationOptions {
 	cwd?: string;
 	signal?: AbortSignal;
+	/** Never throws: emission must not break the control loop. */
+	onEvent?: (event: AutonomousEvent) => void;
+}
+
+/** Gate work runs inside pure helpers, so a listener fault must not abort the run. */
+function emitAutonomousEvent(options: AutonomousOperationOptions, event: AutonomousEvent): void {
+	try {
+		options.onEvent?.(event);
+	} catch {
+		// A broken listener is never worth failing an autonomous run over.
+	}
+}
+
+function limitUsage(state: AutonomousLimitState, reason: AutonomousLimitReason, now: number): [number, number] {
+	if (reason === "maxContinuations") return [state.continuationsUsed, state.limits.maxContinuations];
+	if (reason === "maxTurns") return [state.turnsUsed, state.limits.maxTurns];
+	if (reason === "maxTokens") return [state.tokensUsed, state.limits.maxTokens];
+	return [state.startedAt === undefined ? 0 : Math.max(0, now - state.startedAt), state.limits.timeoutMs];
 }
 
 type GateFailure = AgentAutonomousGateFailure;
@@ -209,6 +249,14 @@ export async function nextAutonomousContinuation(
 		return undefined;
 	}
 	state.continuationsUsed++;
+	if (decision.reason === "gate_failed" || decision.reason === "missing_terminal_evidence") {
+		emitAutonomousEvent(options, {
+			type: "autonomous_continuation",
+			reason: decision.reason,
+			continuationsUsed: state.continuationsUsed,
+			maxContinuations: state.limits.maxContinuations,
+		});
+	}
 	return {
 		role: "user",
 		content: [
@@ -240,15 +288,29 @@ export async function shouldAutonomouslyContinue(
 		if (gateResult === "passed") {
 			return { shouldContinue: false, reason: "not_needed" };
 		}
-		if (gateResult === "retry_exhausted" || autonomousLimitReason(state, now)) {
+		const gateLimit = autonomousLimitReason(state, now);
+		if (gateResult === "retry_exhausted" || gateLimit) {
+			if (gateLimit) emitLimitReached(state, gateLimit, now, options);
 			return { shouldContinue: false, reason: "limit_reached" };
 		}
 		return { shouldContinue: true, reason: "gate_failed" };
 	}
-	if (autonomousLimitReason(state, now)) {
+	const limit = autonomousLimitReason(state, now);
+	if (limit) {
+		emitLimitReached(state, limit, now, options);
 		return { shouldContinue: false, reason: "limit_reached" };
 	}
 	return { shouldContinue: true, reason: "missing_terminal_evidence" };
+}
+
+function emitLimitReached(
+	state: AutonomousLimitState,
+	reason: AutonomousLimitReason,
+	now: number,
+	options: AutonomousOperationOptions,
+): void {
+	const [used, limit] = limitUsage(state, reason, now);
+	emitAutonomousEvent(options, { type: "autonomous_limit_reached", reason, used, limit });
 }
 
 export function autonomousLimitReason(
@@ -278,13 +340,14 @@ export async function refreshAutonomousQualityGates(
 	if (!state.enabled || state.gates.commands.length === 0) {
 		return undefined;
 	}
-	return await runAutonomousQualityGates(state, options.cwd, options.signal);
+	return await runAutonomousQualityGates(state, options.cwd, options.signal, options);
 }
 
 async function runAutonomousQualityGates(
 	state: AutonomousRuntimeState,
 	cwd: string | undefined,
 	signal: AbortSignal | undefined,
+	options: AutonomousOperationOptions = {},
 ): Promise<AutonomousGateResult> {
 	signal?.throwIfAborted();
 	if (!cwd) {
@@ -307,8 +370,24 @@ async function runAutonomousQualityGates(
 				output:
 					"The autonomous gate was not rerun because the workspace has not changed since this failure. Edit source files, tests, or a blocker artifact before attempting to finish again.",
 			};
+			emitAutonomousEvent(options, {
+				type: "autonomous_gate_end",
+				command,
+				attempt,
+				maxRetries: state.gates.maxRetries,
+				passed: false,
+				skipped: true,
+				exitText: state.lastGateFailure.exitText,
+				output: state.lastGateFailure.output,
+			});
 			return attempt > state.gates.maxRetries ? "retry_exhausted" : "failed";
 		}
+		emitAutonomousEvent(options, {
+			type: "autonomous_gate_start",
+			command,
+			attempt: (state.gateAttempts[command] ?? 0) + 1,
+			maxRetries: state.gates.maxRetries,
+		});
 		const result = await runChildProcess(command, [], {
 			cwd,
 			shell: true,
@@ -320,6 +399,13 @@ async function runAutonomousQualityGates(
 		const postRunSnapshot = await captureGitWorktreeSnapshot(cwd, signal);
 		signal?.throwIfAborted();
 		if (result.status === 0 && !result.error && !result.timedOut) {
+			emitAutonomousEvent(options, {
+				type: "autonomous_gate_end",
+				command,
+				attempt: (state.gateAttempts[command] ?? 0) + 1,
+				maxRetries: state.gates.maxRetries,
+				passed: true,
+			});
 			state.gateAttempts[command] = 0;
 			if (state.lastGateFailure?.command === command) {
 				state.lastGateFailure = undefined;
@@ -340,6 +426,15 @@ async function runAutonomousQualityGates(
 			),
 		};
 		state.lastGateFailureSnapshot = postRunSnapshot;
+		emitAutonomousEvent(options, {
+			type: "autonomous_gate_end",
+			command,
+			attempt,
+			maxRetries: state.gates.maxRetries,
+			passed: false,
+			exitText,
+			output: state.lastGateFailure.output,
+		});
 		return attempt > state.gates.maxRetries ? "retry_exhausted" : "failed";
 	}
 	state.lastGateFailure = undefined;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -6,7 +6,7 @@ import type {
 	AgentSessionMessageSafetyStatus,
 } from "../../core/agent-messages.js";
 import type { AuthSourceToken } from "../../core/auth-storage.js";
-import type { AgentAutonomousStatus } from "../../core/autonomous.js";
+import type { AgentAutonomousStatus, AutonomousEvent } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { ContextTreeNode } from "../../core/context-tree.js";
@@ -606,6 +606,7 @@ export type AgentConnectionSessionEvent =
 			/** Echo of the caller-supplied run id, so clients correlate runs by identity. */
 			runId?: string;
 	  }
+	| AutonomousEvent
 	| { type: "refine_complete"; result: RefinementResult }
 	| { type: "refine_failed"; error: string };
 

--- a/packages/coding-agent/src/modes/headless-completion.ts
+++ b/packages/coding-agent/src/modes/headless-completion.ts
@@ -74,10 +74,20 @@ function autonomousProgressKey(status: AgentAutonomousStatus): string {
 export async function waitForHeadlessCompletion(session: AgentSession): Promise<AgentAutonomousStatus> {
 	let lastPromptedProgressKey: string | undefined;
 	let repeatedProgressPrompts = 0;
+	let limitReported = false;
+	// The host loop evaluates limits itself, so nothing else reports them to clients.
+	const reportLimit = (current: AgentAutonomousStatus): void => {
+		if (limitReported || !current.enabled) return;
+		const reason = autonomousLimitReason(current);
+		if (!reason) return;
+		limitReported = true;
+		session.reportAutonomousLimitReached(reason);
+	};
 	while (true) {
 		await session.agent.waitForIdle();
 		const status = session.getAutonomousStatus();
 		if (!shouldContinueAutonomousGates(status) || !status.lastGateFailure) {
+			reportLimit(status);
 			return status;
 		}
 		const progressKey = autonomousProgressKey(status);
@@ -111,6 +121,7 @@ export async function waitForHeadlessCompletion(session: AgentSession): Promise<
 				if (shouldContinueAutonomousGates(postErrorStatus) && postErrorStatus.lastGateFailure) {
 					continue;
 				}
+				reportLimit(postErrorStatus);
 				return postErrorStatus;
 			}
 		}

--- a/packages/coding-agent/src/modes/headless-completion.ts
+++ b/packages/coding-agent/src/modes/headless-completion.ts
@@ -75,7 +75,8 @@ export async function waitForHeadlessCompletion(session: AgentSession): Promise<
 	let lastPromptedProgressKey: string | undefined;
 	let repeatedProgressPrompts = 0;
 	let limitReported = false;
-	// The host loop evaluates limits itself, so nothing else reports them to clients.
+	// The host loop evaluates limits itself; in-session evaluation may have already
+	// reported the same stop, so AgentSession drops the duplicate.
 	const reportLimit = (current: AgentAutonomousStatus): void => {
 		if (limitReported || !current.enabled) return;
 		const reason = autonomousLimitReason(current);

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -101,6 +101,17 @@ async function runPrintModeWithConnectionInternal(
 				writeRawStdout(`${JSON.stringify(event.event)}\n`);
 			}
 			if (event.type === "extension_error") {
+				// Also framed on stdout in json mode so consumers do not have to parse stderr prose.
+				if (mode === "json") {
+					writeRawStdout(
+						`${JSON.stringify({
+							type: "extension_error",
+							extensionPath: event.extensionPath,
+							event: event.event,
+							error: event.error,
+						})}\n`,
+					);
+				}
 				console.error(`Extension error (${event.extensionPath}): ${event.error}`);
 			}
 		});
@@ -114,27 +125,30 @@ async function runPrintModeWithConnectionInternal(
 		}
 
 		const autonomousStatus = await connection.waitForHeadlessCompletion();
-		if (mode === "text") {
-			const { primary, compactionOutcomes } = selectHeadlessTerminalResult(await connection.getMessages());
-			if (primary?.role === "assistant") {
-				if (primary.stopReason === "error" || primary.stopReason === "aborted") {
-					console.error(primary.errorMessage || `Request ${primary.stopReason}`);
-					exitCode = 1;
-				} else {
-					for (const content of primary.content) {
-						if (content.type === "text") {
-							writeRawStdout(`${content.text}\n`);
-						}
+		// Failure detection and stderr diagnostics run in both modes so a failed run
+		// is never reported as success; only the stdout result is text-mode-only,
+		// since bare text would corrupt the JSON stream.
+		const { primary, compactionOutcomes } = selectHeadlessTerminalResult(await connection.getMessages());
+		if (primary?.role === "assistant") {
+			if (primary.stopReason === "error" || primary.stopReason === "aborted") {
+				console.error(primary.errorMessage || `Request ${primary.stopReason}`);
+				exitCode = 1;
+			} else if (mode === "text") {
+				for (const content of primary.content) {
+					if (content.type === "text") {
+						writeRawStdout(`${content.text}\n`);
 					}
 				}
-			} else if (primary) {
+			}
+		} else if (primary) {
+			if (mode === "text") {
 				writeRawStdout(`${primary.content}\n`);
-				if (!primary.details.success || primary.details.severity === "error") exitCode = 1;
 			}
-			for (const outcome of compactionOutcomes) {
-				console.error(outcome.content);
-				if (outcome.details.outcome === "failed") exitCode = 1;
-			}
+			if (!primary.details.success || primary.details.severity === "error") exitCode = 1;
+		}
+		for (const outcome of compactionOutcomes) {
+			console.error(outcome.content);
+			if (outcome.details.outcome === "failed") exitCode = 1;
 		}
 
 		const autonomousLimit = autonomousLimitReason(autonomousStatus);

--- a/packages/coding-agent/test/autonomous-events.test.ts
+++ b/packages/coding-agent/test/autonomous-events.test.ts
@@ -160,6 +160,32 @@ describe("autonomous events", () => {
 		void cwd;
 	});
 
+	it("reports one stop once when both paths observe the same limit", async () => {
+		// Mirrors AgentSession._emitAutonomousEvent: the in-session decision and the
+		// host loop both see the stop, but clients get a single frame.
+		const emitted: AutonomousEvent[] = [];
+		let reported: string | undefined;
+		const funnel = (event: AutonomousEvent) => {
+			if (event.type === "autonomous_limit_reached") {
+				if (reported === event.reason) return;
+				reported = event.reason;
+			}
+			emitted.push(event);
+		};
+
+		const state = createState([]);
+		state.limits = { ...state.limits, maxContinuations: 1 };
+		state.continuationsUsed = 1;
+
+		// In-session evaluation reports the limit...
+		await nextAutonomousContinuation(state, assistantMessage(), { cwd: createCwd(), onEvent: funnel });
+		// ...then the host loop observes the same stop on exit.
+		const reason = autonomousLimitReason(state);
+		if (reason) funnel({ type: "autonomous_limit_reached", reason, ...autonomousLimitUsage(state, reason) });
+
+		expect(emitted).toEqual([{ type: "autonomous_limit_reached", reason: "maxContinuations", used: 1, limit: 1 }]);
+	});
+
 	it("does not let a throwing listener break the control loop", async () => {
 		const cwd = createCwd();
 		const state = createState(["exit 0"]);

--- a/packages/coding-agent/test/autonomous-events.test.ts
+++ b/packages/coding-agent/test/autonomous-events.test.ts
@@ -6,6 +6,9 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	type AutonomousEvent,
+	addAutonomousContinuation,
+	autonomousLimitReason,
+	autonomousLimitUsage,
 	createAutonomousRuntimeState,
 	nextAutonomousContinuation,
 	refreshAutonomousQualityGates,
@@ -126,6 +129,35 @@ describe("autonomous events", () => {
 		});
 
 		expect(events).toEqual([{ type: "autonomous_limit_reached", reason: "maxContinuations", used: 1, limit: 1 }]);
+	});
+
+	it("reports host-driven continuations and limits, which bypass in-session evaluation", async () => {
+		const cwd = createCwd();
+		const state = createState([]);
+		state.limits = { ...state.limits, maxContinuations: 2 };
+		const events: AutonomousEvent[] = [];
+
+		// Mirrors AgentSession.recordHostAutonomousContinuation + reportAutonomousLimitReached,
+		// the path waitForHeadlessCompletion drives with suppressAutonomousContinuation.
+		addAutonomousContinuation(state);
+		events.push({
+			type: "autonomous_continuation",
+			reason: "gate_failed",
+			continuationsUsed: state.continuationsUsed,
+			maxContinuations: state.limits.maxContinuations,
+		});
+		addAutonomousContinuation(state);
+		const reason = autonomousLimitReason(state);
+		expect(reason).toBe("maxContinuations");
+		if (reason) {
+			events.push({ type: "autonomous_limit_reached", reason, ...autonomousLimitUsage(state, reason) });
+		}
+
+		expect(events).toEqual([
+			{ type: "autonomous_continuation", reason: "gate_failed", continuationsUsed: 1, maxContinuations: 2 },
+			{ type: "autonomous_limit_reached", reason: "maxContinuations", used: 2, limit: 2 },
+		]);
+		void cwd;
 	});
 
 	it("does not let a throwing listener break the control loop", async () => {

--- a/packages/coding-agent/test/autonomous-events.test.ts
+++ b/packages/coding-agent/test/autonomous-events.test.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type AutonomousEvent,
+	createAutonomousRuntimeState,
+	nextAutonomousContinuation,
+	refreshAutonomousQualityGates,
+} from "../src/core/autonomous.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function createCwd(): string {
+	const root = mkdtempSync(join(tmpdir(), "prime-agent-autonomous-events-"));
+	tempRoots.push(root);
+	return root;
+}
+
+function createState(gateCommands: string[]) {
+	return createAutonomousRuntimeState({
+		enabled: true,
+		gates: { commands: gateCommands, maxRetries: 3, timeoutMs: 30_000 },
+	});
+}
+
+function assistantMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "done" }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("autonomous events", () => {
+	it("emits a start/end pair when a gate passes", async () => {
+		const cwd = createCwd();
+		const state = createState(["exit 0"]);
+		const events: AutonomousEvent[] = [];
+
+		await refreshAutonomousQualityGates(state, { cwd, onEvent: (event) => events.push(event) });
+
+		expect(events.map((event) => event.type)).toEqual(["autonomous_gate_start", "autonomous_gate_end"]);
+		expect(events[1]).toMatchObject({ command: "exit 0", passed: true, attempt: 1, maxRetries: 3 });
+	});
+
+	it("reports the failing command, attempt, and output when a gate fails", async () => {
+		const cwd = createCwd();
+		const state = createState(["echo boom >&2; exit 3"]);
+		const events: AutonomousEvent[] = [];
+
+		await refreshAutonomousQualityGates(state, { cwd, onEvent: (event) => events.push(event) });
+
+		const end = events.find((event) => event.type === "autonomous_gate_end");
+		expect(end).toMatchObject({ passed: false, attempt: 1, maxRetries: 3 });
+		expect(end && "exitText" in end ? end.exitText : "").toContain("3");
+		expect(end && "output" in end ? end.output : "").toContain("boom");
+	});
+
+	it("marks the workspace-unchanged short circuit as skipped", async () => {
+		// The short circuit compares git worktree snapshots, so it needs a real repo.
+		const cwd = createCwd();
+		execFileSync("git", ["init", "-q"], { cwd });
+		writeFileSync(join(cwd, "file.txt"), "one");
+		execFileSync("git", ["add", "-A"], { cwd });
+		execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"], { cwd });
+		const state = createState(["exit 3"]);
+
+		await refreshAutonomousQualityGates(state, { cwd });
+		const events: AutonomousEvent[] = [];
+		await refreshAutonomousQualityGates(state, { cwd, onEvent: (event) => events.push(event) });
+
+		// The rerun is short-circuited, so no gate_start is emitted for it.
+		expect(events.map((event) => event.type)).toEqual(["autonomous_gate_end"]);
+		expect(events[0]).toMatchObject({ passed: false, skipped: true, attempt: 2 });
+	});
+
+	it("emits a continuation with its reason when a gate fails", async () => {
+		const cwd = createCwd();
+		const state = createState(["exit 3"]);
+		const events: AutonomousEvent[] = [];
+
+		await nextAutonomousContinuation(state, assistantMessage(), {
+			cwd,
+			onEvent: (event) => events.push(event),
+		});
+
+		expect(events.at(-1)).toMatchObject({
+			type: "autonomous_continuation",
+			reason: "gate_failed",
+			continuationsUsed: 1,
+		});
+	});
+
+	it("emits autonomous_limit_reached with the binding limit", async () => {
+		const cwd = createCwd();
+		// No gates: the run settles on limits alone.
+		const state = createState([]);
+		state.limits = { ...state.limits, maxContinuations: 1 };
+		state.continuationsUsed = 1;
+		const events: AutonomousEvent[] = [];
+
+		await nextAutonomousContinuation(state, assistantMessage(), {
+			cwd,
+			onEvent: (event) => events.push(event),
+		});
+
+		expect(events).toEqual([{ type: "autonomous_limit_reached", reason: "maxContinuations", used: 1, limit: 1 }]);
+	});
+
+	it("does not let a throwing listener break the control loop", async () => {
+		const cwd = createCwd();
+		const state = createState(["exit 0"]);
+
+		await expect(
+			refreshAutonomousQualityGates(state, {
+				cwd,
+				onEvent: () => {
+					throw new Error("listener exploded");
+				},
+			}),
+		).resolves.toBe("passed");
+	});
+});

--- a/packages/coding-agent/test/fixtures/eng-4685-faux-refine-extension.ts
+++ b/packages/coding-agent/test/fixtures/eng-4685-faux-refine-extension.ts
@@ -4,15 +4,21 @@ import type { ExtensionAPI } from "../../src/index.js";
 /**
  * ENG-4685 faux provider extension for process-backed serialized-refine proof.
  *
- * Queues exactly three responses so the real daemon worker, model, and
- * auto-refine machinery all exercise the real code paths:
+ * Queues responses so the real daemon worker, model, and auto-refine
+ * machinery all exercise the real code paths:
  *
  *  1. Parent assistant response for the user prompt.
  *  2. Valid auto-refine review JSON (shouldRefine: true).
  *  3. Valid empty refinement-proposal JSON (edits: []).
+ *  4. Reply for the goal budget-limit continuation turn (--goal-token-budget 1
+ *     limits the goal immediately, which injects one more turn).
+ *  5. Auto-refine review declining a second refinement, so the
+ *     turnInterval: 1 cadence does not chain another proposal.
  *
  * The auto-refine review and plan both call completeSimple on the same
- * faux provider, so they consume responses 2 and 3 from the same queue.
+ * faux provider, so they consume responses from this same queue. Running the
+ * queue dry ends the run on an errored assistant turn, which JSON mode now
+ * reports as a non-zero exit.
  */
 export default function registerEng4685FauxRefineProvider(pi: ExtensionAPI): void {
 	const faux = registerFauxProvider({
@@ -34,6 +40,10 @@ export default function registerEng4685FauxRefineProvider(pi: ExtensionAPI): voi
 				expectedOutcome: "No changes",
 			}),
 		),
+		// 4 — reply for the goal budget-limit continuation turn
+		fauxAssistantMessage("Goal budget reached; stopping."),
+		// 5 — auto-refine review declining a second refinement
+		fauxAssistantMessage(JSON.stringify({ shouldRefine: false, rationale: "process-proof second review" })),
 	]);
 
 	const apiProvider = getApiProvider(faux.api);

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -7,7 +7,7 @@ import {
 	createCustomMessage,
 	createSessionSlashCommandResultMessage,
 } from "../src/core/messages.js";
-import type { SessionShutdownEvent } from "../src/index.js";
+import type { ExtensionError, SessionShutdownEvent } from "../src/index.js";
 import { selectHeadlessTerminalResult } from "../src/modes/headless-completion.js";
 import { runPrintMode } from "../src/modes/print-mode.js";
 
@@ -263,6 +263,113 @@ describe("runPrintMode", () => {
 		expect(errorSpy).toHaveBeenCalledWith("provider failure");
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("returns non-zero on assistant error in json mode without printing the result", async () => {
+		const runtimeHost = createRuntimeHost(
+			createAssistantMessage({ text: "partial", stopReason: "error", errorMessage: "provider failure" }),
+		);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "json",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(errorSpy).toHaveBeenCalledWith("provider failure");
+		// Bare result text on stdout would corrupt the JSON stream.
+		expect(output.write).not.toHaveBeenCalledWith("partial\n");
+	});
+
+	it("keeps the assistant result off stdout on success in json mode", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "json",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).not.toHaveBeenCalledWith("done\n");
+	});
+
+	it("returns non-zero for failed session command results in json mode", async () => {
+		const result = createSessionSlashCommandResultMessage("Command failed: bad arguments", {
+			command: { name: "refine", args: "rollback", text: "/refine rollback" },
+			success: false,
+			severity: "error",
+			error: "bad arguments",
+		});
+		const runtimeHost = createRuntimeHost(result);
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "json",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(output.write).not.toHaveBeenCalledWith("Command failed: bad arguments\n");
+	});
+
+	it("frames extension errors on stdout in json mode", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
+		const { session } = runtimeHost;
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		session.bindExtensions.mockImplementation(async (options: { onError?: (error: ExtensionError) => void }) => {
+			options.onError?.({ extensionPath: "/ext/foo.ts", event: "session_start", error: "boom" });
+		});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "json",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).toHaveBeenCalledWith(
+			`${JSON.stringify({
+				type: "extension_error",
+				extensionPath: "/ext/foo.ts",
+				event: "session_start",
+				error: "boom",
+			})}\n`,
+		);
+		expect(errorSpy).toHaveBeenCalledWith("Extension error (/ext/foo.ts): boom");
+	});
+
+	it("keeps extension errors off stdout in text mode", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
+		const { session } = runtimeHost;
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		session.bindExtensions.mockImplementation(async (options: { onError?: (error: ExtensionError) => void }) => {
+			options.onError?.({ extensionPath: "/ext/foo.ts", event: "session_start", error: "boom" });
+		});
+		output.write.mockClear();
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(output.write).toHaveBeenCalledWith("done\n");
+		expect(output.write).not.toHaveBeenCalledWith(expect.stringContaining('"type":"extension_error"'));
+		expect(errorSpy).toHaveBeenCalledWith("Extension error (/ext/foo.ts): boom");
+	});
+
+	it("reports a failed compaction outcome in json mode", async () => {
+		const outcome = createCompactionOutcomeMessage("Context overflow recovery failed", {
+			reason: "overflow",
+			outcome: "failed",
+		});
+		const runtimeHost = createRuntimeHost(outcome);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "json",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(errorSpy).toHaveBeenCalledWith("Context overflow recovery failed");
 	});
 
 	it("prints assistant output and reports a trailing compaction outcome", async () => {

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -37,6 +37,7 @@ type FakeSession = {
 	reload: ReturnType<typeof vi.fn>;
 	getAutonomousStatus: ReturnType<typeof vi.fn>;
 	recordHostAutonomousContinuation: ReturnType<typeof vi.fn>;
+	reportAutonomousLimitReached: ReturnType<typeof vi.fn>;
 	refreshAutonomousGates: ReturnType<typeof vi.fn>;
 };
 
@@ -106,6 +107,7 @@ function createRuntimeHost(
 		reload: vi.fn(async () => {}),
 		getAutonomousStatus: vi.fn(() => autonomousStatus),
 		recordHostAutonomousContinuation: vi.fn(),
+		reportAutonomousLimitReached: vi.fn(),
 		refreshAutonomousGates: vi.fn(),
 	};
 

--- a/packages/coding-agent/test/suite/autonomous-event-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/autonomous-event-lifecycle.test.ts
@@ -1,0 +1,84 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.js";
+
+/**
+ * Covers the wiring around autonomous events rather than their payloads: every bug
+ * in this area was an ordering or lifecycle fault, not a wrong field.
+ */
+let harness: Harness | undefined;
+
+afterEach(() => {
+	harness?.cleanup();
+	harness = undefined;
+});
+
+function eventTypes(current: Harness): string[] {
+	return current.events.map((event) => event.type);
+}
+
+describe("autonomous event lifecycle", () => {
+	it("emits gate and continuation events before the turn they cause", async () => {
+		harness = await createHarness({
+			autonomous: { enabled: true, maxContinuations: 2, gates: { commands: ["exit 3"], maxRetries: 5 } },
+		});
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("second")]);
+
+		await harness.session.prompt("go");
+		await harness.session.agent.waitForIdle();
+
+		const types = eventTypes(harness);
+		expect(types).toContain("autonomous_gate_start");
+		expect(types).toContain("autonomous_gate_end");
+		expect(types).toContain("autonomous_continuation");
+
+		// The frames must precede the continuation turn, not trail it.
+		const continuationAt = types.indexOf("autonomous_continuation");
+		const lastTurnStart = types.lastIndexOf("turn_start");
+		expect(lastTurnStart).toBeGreaterThan(-1);
+		expect(continuationAt).toBeLessThan(lastTurnStart);
+	});
+
+	it("reports a gate failure with its command and attempt", async () => {
+		harness = await createHarness({
+			autonomous: { enabled: true, maxContinuations: 1, gates: { commands: ["exit 3"], maxRetries: 5 } },
+		});
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("second")]);
+
+		await harness.session.prompt("go");
+		await harness.session.agent.waitForIdle();
+
+		const failure = harness.eventsOfType("autonomous_gate_end").find((event) => !event.passed);
+		expect(failure).toMatchObject({ command: "exit 3", passed: false, maxRetries: 5 });
+		expect(failure?.attempt).toBeGreaterThanOrEqual(1);
+	});
+
+	it("never reports the same limit twice", async () => {
+		harness = await createHarness({
+			autonomous: { enabled: true, maxContinuations: 1, gates: { commands: ["exit 3"], maxRetries: 5 } },
+		});
+		harness.setResponses([
+			fauxAssistantMessage("first"),
+			fauxAssistantMessage("second"),
+			fauxAssistantMessage("third"),
+		]);
+
+		await harness.session.prompt("go");
+		await harness.session.agent.waitForIdle();
+
+		const limits = harness.eventsOfType("autonomous_limit_reached");
+		expect(limits.length).toBeLessThanOrEqual(1);
+		const reasons = new Set(limits.map((event) => event.reason));
+		expect(reasons.size).toBe(limits.length);
+	});
+
+	it("emits nothing autonomous when the mode is off", async () => {
+		harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("done")]);
+
+		await harness.session.prompt("go");
+		await harness.session.agent.waitForIdle();
+
+		expect(eventTypes(harness).filter((type) => type.startsWith("autonomous_"))).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -2,7 +2,7 @@
  * Local test harness for the new coding-agent test suite.
  */
 
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
@@ -98,6 +98,49 @@ function createTempDir(): string {
 	const tempDir = join(tmpdir(), `pi-suite-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(tempDir, { recursive: true });
 	return tempDir;
+}
+
+const REMOVABLE_RACE_CODES = new Set(["EBUSY", "EEXIST", "ENOTEMPTY", "EPERM"]);
+
+function sleepSync(milliseconds: number): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function describeRemainingEntries(path: string): string {
+	try {
+		const entries = readdirSync(path, { recursive: true }) as string[];
+		const listed = entries.slice(0, 20).join(", ");
+		return entries.length > 20 ? `${listed}, … (${entries.length} entries)` : listed;
+	} catch {
+		return "unreadable";
+	}
+}
+
+/**
+ * Remove a temp directory that spawned fixture processes may still be writing into.
+ *
+ * `rmSync` enumerates a directory's children once and then only retries the final
+ * `rmdir`, so a registry write that lands after that enumeration fails the removal
+ * no matter how large `maxRetries` is. Re-run the whole removal instead, so every
+ * attempt re-enumerates, until the directory is gone or the deadline passes.
+ */
+function removeTempDir(path: string, timeoutMs = 30_000): void {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			rmSync(path, { recursive: true, force: true, maxRetries: 2, retryDelay: 25 });
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (!code || !REMOVABLE_RACE_CODES.has(code) || Date.now() >= deadline) {
+				throw new Error(
+					`Failed to remove ${path} (${code ?? "unknown"}); remaining: ${describeRemainingEntries(path)}`,
+					{ cause: error },
+				);
+			}
+			sleepSync(25);
+		}
+	}
 }
 
 export async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
@@ -223,8 +266,9 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 			fauxProvider.unregister();
 			if (existsSync(tempDir)) {
 				// Spawned fixture processes may still be flushing their final registry
-				// writes; retry briefly instead of failing the suite on ENOTEMPTY.
-				rmSync(tempDir, { recursive: true, force: true, maxRetries: 40, retryDelay: 50 });
+				// writes, so re-enumerate on every attempt instead of failing the suite
+				// on the ENOTEMPTY that a single late write would otherwise cause.
+				removeTempDir(tempDir);
 			}
 		},
 	};


### PR DESCRIPTION
Cleaning up some behavior for the `--json` mode flag, which will be used later for setting up ACP. Also used in the harbor agent.

Also updated the original Pi docs to reflect these changes.

- JSON mode exited 0 on failure — detection sat inside print-mode's `mode === "text"` branch. Only stdout writes stay text-only now. Upstream pi-mono has the same bug; intentional divergence.
- New frame `{"type":"extension_error","extensionPath":…,"event":…,"error":…}`, previously only prose on stderr.
- New autonomous events, separating task failure from gate failure and budget exhaustion:
      autonomous_gate_start    { command, attempt, maxRetries }
      autonomous_gate_end      { command, attempt, maxRetries, passed, skipped?, exitText?, output? }
      autonomous_continuation  { reason, continuationsUsed, maxContinuations }
      autonomous_limit_reached { reason, used, limit }
  Emitted via an optional `onEvent` on the existing options bag — no signature or protocol changes. One cycle emits two gate pairs (in-session + host paths); not deduped.
- No existing event changed shape or ordering. `docs/json.md` now covers all 18 session events (was 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches autonomous control-loop observability and headless exit semantics; behavior changes for JSON consumers (no result text on stdout, non-zero on failures) but is covered by new tests.
> 
> **Overview**
> **JSON mode** is tightened for headless/ACP consumers: failure handling (assistant errors, failed session commands, compaction, autonomous gates) now sets a non-zero exit code in both text and JSON modes, while **assistant result text stays off stdout in JSON** so the line stream stays valid. **`extension_error`** is emitted as a JSON frame on stdout in JSON mode (stderr prose is unchanged).
> 
> **Autonomous mode** gains structured **`autonomous_*` session events** (gate start/end with `skipped` for unchanged-workspace short circuits, continuations, limit reached) via an optional `onEvent` on existing autonomous options—wired through `AgentSession`, agent-connection, and headless completion. **`AgentSession`** funnels emissions (dedupes duplicate limit reports across in-session vs host paths), buffers events when continuations can roll back (threshold compaction / arrival-epoch races), and flushes them before the turn they trigger. **`docs/json.md`** documents the full session event surface and JSON-mode semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c13e7b7dd94e0b0e3b5a5cfd09a977e00bea937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add autonomous lifecycle events to `--json` mode output
> - Introduces an `AutonomousEvent` union (`autonomous_gate_start/end`, `autonomous_continuation`, `autonomous_limit_reached`) emitted during autonomous loop execution, enabling downstream consumers to observe gate evaluation and continuation decisions.
> - Routes autonomous events through a single `_emitAutonomousEvent` funnel with de-duplication for `autonomous_limit_reached` to prevent duplicate frames from concurrent in-session and host paths.
> - Buffers autonomous events during speculative continuation decisions and flushes them only when the decision is committed, ensuring event ordering (autonomous frames precede the turn they caused).
> - JSON mode now frames extension errors on stdout as structured JSON and suppresses bare assistant text output; exit codes are non-zero on assistant error, failed compaction, or unmet autonomous gates.
> - Adds new test suites covering gate start/end, continuation reasons, limit de-duplication, listener fault tolerance, and event lifecycle ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c13e7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->