### PR TITLE
fix(coding-agent): format long thinking durations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed long-running thinking timers to display hours and days instead of unbounded minutes.
+
 ## [0.4.0] - 2026-08-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3189,7 +3189,17 @@ export class InteractiveMode {
 		}
 		const minutes = Math.floor(totalSeconds / 60);
 		const seconds = totalSeconds % 60;
-		return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+		if (minutes < 60) {
+			return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+		}
+		const hours = Math.floor(minutes / 60);
+		const remainingMinutes = minutes % 60;
+		if (hours < 24) {
+			return `${hours}h ${remainingMinutes.toString().padStart(2, "0")}m ${seconds.toString().padStart(2, "0")}s`;
+		}
+		const days = Math.floor(hours / 24);
+		const remainingHours = hours % 24;
+		return `${days}d ${remainingHours.toString().padStart(2, "0")}h ${remainingMinutes.toString().padStart(2, "0")}m ${seconds.toString().padStart(2, "0")}s`;
 	}
 
 	private updateWorkingLoaderMessage(): void {

--- a/packages/coding-agent/test/working-duration.test.ts
+++ b/packages/coding-agent/test/working-duration.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+type WorkingDurationFormatter = {
+	formatWorkingElapsed(elapsedMs: number): string;
+};
+
+const formatWorkingElapsed = (InteractiveMode.prototype as unknown as WorkingDurationFormatter).formatWorkingElapsed;
+
+describe("working duration", () => {
+	test.each([
+		[59_999, "59s"],
+		[60_000, "1m 00s"],
+		[3_599_999, "59m 59s"],
+		[3_600_000, "1h 00m 00s"],
+		[86_399_999, "23h 59m 59s"],
+		[86_400_000, "1d 00h 00m 00s"],
+		[(1_543 * 60 + 49) * 1_000, "1d 01h 43m 49s"],
+	])("formats %dms as %s", (elapsedMs, expected) => {
+		expect(formatWorkingElapsed(elapsedMs)).toBe(expected);
+	});
+});


### PR DESCRIPTION
## Summary

- roll the live thinking timer over from minutes into hours and days
- preserve seconds in long-running timer output
- add regression coverage for unit boundaries and the reported 1543-minute case

## Root cause

The elapsed-time formatter handled seconds and minutes only, so every duration above one hour continued accumulating unbounded minutes.

## Impact

Long-running agent turns now show readable durations such as `1d 01h 43m 49s` instead of `1543m 49s`.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/working-duration.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatWorkingElapsed` to display hours and days for long thinking durations
> Previously, elapsed time beyond 60 minutes continued to display as unbounded minutes (e.g. `130m 45s`). The updated logic in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/579/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) adds hour and day tiers: `Hh MMm SSs` for durations ≥1h and `Dd HHh MMm SSs` for durations ≥24h. Unit tests covering boundary values are added in [`working-duration.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/579/files#diff-b76a37c20e5d05a482a87bd39837fb81c50525a8b2fac7fc81272b5727bdbc93).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0617a72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to elapsed-time strings in the TUI loader and abort messages; no auth, data, or execution logic touched.
> 
> **Overview**
> The live **thinking/working** elapsed timer in the interactive TUI no longer grows as unbounded minutes (e.g. `1543m 49s`). **`formatWorkingElapsed`** now rolls into **`Hh MMm SSs`** from one hour and **`Dd HHh MMm SSs`** from 24 hours, with the same sub-minute behavior unchanged.
> 
> A **changelog** note and **Vitest** cases cover second/minute/hour/day boundaries and the reported long-run example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0617a72a4332518a9214725c0ee37ae72b5efc0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->