### PR TITLE
fix(coding-agent): prevent overlapping daemon snapshot catch-ups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed top-level CLI help and documentation to expose autonomous mode, quality gates, and their limits.
 - Fixed compaction retaining runtime resources after an explicitly deleted subagent had a transient cleanup failure.
 - Fixed long-running thinking timers to display hours and days instead of unbounded minutes.
+- Fixed overlapping daemon snapshot catch-ups closing healthy workers and preventing new sessions from starting.
 
 ## [0.4.0] - 2026-08-01
 

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -22,6 +22,7 @@ export interface DaemonSocketClient {
 	snapshotActiveSessionIds?: Set<string>;
 	snapshotActiveSessionCounts?: Map<string, number>;
 	snapshotTransferAbortControllers?: Map<string, AbortController>;
+	snapshotTransferTails?: Map<string, Promise<void>>;
 	detachInput: () => void;
 	supportsExtensionUi: boolean;
 	capabilities: Set<DaemonClientCapability>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3913,6 +3913,16 @@ export class AgentDaemon {
 			transcript.dispose?.();
 			return;
 		}
+		client.snapshotTransferTails ??= new Map();
+		const previousTransfer = client.snapshotTransferTails.get(result.activeSessionId);
+		let finishTransfer!: () => void;
+		const transfer = new Promise<void>((resolve) => {
+			finishTransfer = resolve;
+		});
+		client.snapshotTransferTails.set(result.activeSessionId, transfer);
+		if (previousTransfer) {
+			await previousTransfer;
+		}
 		const { messages: _messages, ...snapshot } = result.snapshot;
 		const snapshotBegin: DaemonOutbound = {
 			type: "session_snapshot_begin",
@@ -4021,6 +4031,10 @@ export class AgentDaemon {
 			await deliverSnapshotFailure(streamError);
 			throw streamError;
 		} finally {
+			finishTransfer();
+			if (client.snapshotTransferTails.get(result.activeSessionId) === transfer) {
+				client.snapshotTransferTails.delete(result.activeSessionId);
+			}
 			finishClientSnapshotStreaming(client, result.activeSessionId);
 			transcript.dispose?.();
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2861,10 +2861,35 @@ export class DaemonSupervisor {
 					});
 					const loaded = attachResultFromResponse(response);
 					return this.cacheLoadedSnapshot(match.worker, activeSessionId, loaded, observedSnapshotId);
-				})().finally(() => {
-					match.worker.snapshotLoads.delete(snapshotLoadKey);
-				});
+				})();
 				match.worker.snapshotLoads.set(snapshotLoadKey, loading);
+				void loading.then(
+					async (loaded) => {
+						try {
+							const snapshotId = loaded.snapshotStream?.id;
+							const transcript = snapshotId
+								? this.snapshotGeneration(match.worker, loaded.activeSessionId, snapshotId)?.transcript
+								: undefined;
+							if (transcript && !transcript.complete) {
+								let chunkIndex = 0;
+								while (await transcript.waitForChunk(chunkIndex)) {
+									chunkIndex++;
+								}
+							}
+						} catch {
+							// Failed transfers must allow a fresh snapshot request.
+						} finally {
+							if (match.worker.snapshotLoads.get(snapshotLoadKey) === loading) {
+								match.worker.snapshotLoads.delete(snapshotLoadKey);
+							}
+						}
+					},
+					() => {
+						if (match.worker.snapshotLoads.get(snapshotLoadKey) === loading) {
+							match.worker.snapshotLoads.delete(snapshotLoadKey);
+						}
+					},
+				);
 			}
 			result = await loading;
 		}
@@ -3641,6 +3666,8 @@ export class DaemonSupervisor {
 	}
 
 	private invalidateWorkerSnapshot(worker: ResidentWorker, activeSessionId: string, transcriptChanged = true): void {
+		worker.snapshotLoads.delete(`${activeSessionId}:chunked`);
+		worker.snapshotLoads.delete(`${activeSessionId}:full`);
 		worker.snapshotCache.delete(activeSessionId);
 		if (!transcriptChanged) {
 			return;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2843,6 +2843,7 @@ export class DaemonSupervisor {
 		}
 		if (!result) {
 			const snapshotLoadKey = `${activeSessionId}:${client.capabilities.has("chunked_snapshot") ? "chunked" : "full"}`;
+			let retryInvalidatedLoad = true;
 			while (!result) {
 				let loading = match.worker.snapshotLoads.get(snapshotLoadKey);
 				if (!loading) {
@@ -2864,7 +2865,7 @@ export class DaemonSupervisor {
 						});
 						const loaded = attachResultFromResponse(response);
 						if (match.worker.snapshotLoads.get(snapshotLoadKey) !== loading) {
-							throw new SnapshotLoadInvalidatedError();
+							throw new SnapshotLoadInvalidatedError("Session snapshot changed during attach");
 						}
 						return this.cacheLoadedSnapshot(match.worker, activeSessionId, loaded, observedSnapshotId);
 					})();
@@ -2903,6 +2904,10 @@ export class DaemonSupervisor {
 					if (!(error instanceof SnapshotLoadInvalidatedError)) {
 						throw error;
 					}
+					if (!retryInvalidatedLoad) {
+						throw error;
+					}
+					retryInvalidatedLoad = false;
 				}
 			}
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -296,6 +296,8 @@ class SupervisorRecoveryCancelledError extends Error {
 	readonly code = "supervisor_recovery_cancelled" as const;
 }
 
+class SnapshotLoadInvalidatedError extends Error {}
+
 function isSupervisorGenerationStale(error: unknown): boolean {
 	return (
 		typeof error === "object" &&
@@ -2841,57 +2843,68 @@ export class DaemonSupervisor {
 		}
 		if (!result) {
 			const snapshotLoadKey = `${activeSessionId}:${client.capabilities.has("chunked_snapshot") ? "chunked" : "full"}`;
-			let loading = match.worker.snapshotLoads.get(snapshotLoadKey);
-			if (!loading) {
-				const observedSnapshotId =
-					match.worker.transcriptCaches.get(activeSessionId)?.snapshotId ??
-					match.worker.snapshotCache.get(activeSessionId)?.snapshotStream?.id;
-				loading = (async () => {
-					if (!match.worker.client) {
-						throw new Error("Session worker is not connected");
-					}
-					const response = await match.worker.client.request({
-						type: "attach",
-						activeSessionId,
-						capabilities: client.capabilities.has("chunked_snapshot")
-							? ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"]
-							: ["attach_snapshot", "event_sequence", "slim_attach"],
-						supportsExtensionUi: false,
-						env: command.env ?? collectDaemonClientEnv(),
-					});
-					const loaded = attachResultFromResponse(response);
-					return this.cacheLoadedSnapshot(match.worker, activeSessionId, loaded, observedSnapshotId);
-				})();
-				match.worker.snapshotLoads.set(snapshotLoadKey, loading);
-				void loading.then(
-					async (loaded) => {
-						try {
-							const snapshotId = loaded.snapshotStream?.id;
-							const transcript = snapshotId
-								? this.snapshotGeneration(match.worker, loaded.activeSessionId, snapshotId)?.transcript
-								: undefined;
-							if (transcript && !transcript.complete) {
-								let chunkIndex = 0;
-								while (await transcript.waitForChunk(chunkIndex)) {
-									chunkIndex++;
+			while (!result) {
+				let loading = match.worker.snapshotLoads.get(snapshotLoadKey);
+				if (!loading) {
+					const observedSnapshotId =
+						match.worker.transcriptCaches.get(activeSessionId)?.snapshotId ??
+						match.worker.snapshotCache.get(activeSessionId)?.snapshotStream?.id;
+					loading = (async () => {
+						if (!match.worker.client) {
+							throw new Error("Session worker is not connected");
+						}
+						const response = await match.worker.client.request({
+							type: "attach",
+							activeSessionId,
+							capabilities: client.capabilities.has("chunked_snapshot")
+								? ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"]
+								: ["attach_snapshot", "event_sequence", "slim_attach"],
+							supportsExtensionUi: false,
+							env: command.env ?? collectDaemonClientEnv(),
+						});
+						const loaded = attachResultFromResponse(response);
+						if (match.worker.snapshotLoads.get(snapshotLoadKey) !== loading) {
+							throw new SnapshotLoadInvalidatedError();
+						}
+						return this.cacheLoadedSnapshot(match.worker, activeSessionId, loaded, observedSnapshotId);
+					})();
+					match.worker.snapshotLoads.set(snapshotLoadKey, loading);
+					void loading.then(
+						async (loaded) => {
+							try {
+								const snapshotId = loaded.snapshotStream?.id;
+								const transcript = snapshotId
+									? this.snapshotGeneration(match.worker, loaded.activeSessionId, snapshotId)?.transcript
+									: undefined;
+								if (transcript && !transcript.complete) {
+									let chunkIndex = 0;
+									while (await transcript.waitForChunk(chunkIndex)) {
+										chunkIndex++;
+									}
+								}
+							} catch {
+								// Failed transfers must allow a fresh snapshot request.
+							} finally {
+								if (match.worker.snapshotLoads.get(snapshotLoadKey) === loading) {
+									match.worker.snapshotLoads.delete(snapshotLoadKey);
 								}
 							}
-						} catch {
-							// Failed transfers must allow a fresh snapshot request.
-						} finally {
+						},
+						() => {
 							if (match.worker.snapshotLoads.get(snapshotLoadKey) === loading) {
 								match.worker.snapshotLoads.delete(snapshotLoadKey);
 							}
-						}
-					},
-					() => {
-						if (match.worker.snapshotLoads.get(snapshotLoadKey) === loading) {
-							match.worker.snapshotLoads.delete(snapshotLoadKey);
-						}
-					},
-				);
+						},
+					);
+				}
+				try {
+					result = await loading;
+				} catch (error) {
+					if (!(error instanceof SnapshotLoadInvalidatedError)) {
+						throw error;
+					}
+				}
 			}
-			result = await loading;
 		}
 		const wasAttached = client.attachedActiveSessionIds.has(activeSessionId);
 		let transcript: SnapshotTranscriptCache | undefined;
@@ -3666,12 +3679,12 @@ export class DaemonSupervisor {
 	}
 
 	private invalidateWorkerSnapshot(worker: ResidentWorker, activeSessionId: string, transcriptChanged = true): void {
-		worker.snapshotLoads.delete(`${activeSessionId}:chunked`);
-		worker.snapshotLoads.delete(`${activeSessionId}:full`);
 		worker.snapshotCache.delete(activeSessionId);
 		if (!transcriptChanged) {
 			return;
 		}
+		worker.snapshotLoads.delete(`${activeSessionId}:chunked`);
+		worker.snapshotLoads.delete(`${activeSessionId}:full`);
 		const transcript = worker.transcriptCaches.get(activeSessionId);
 		if (transcript) {
 			this.retireWorkerSnapshotCache(worker, activeSessionId, transcript);


### PR DESCRIPTION
## Issue

Starting a new session can fail with `Daemon worker client closed` when two snapshot catch-ups for the same session overlap. The supervisor can see the second transfer start before the first one finishes and treat the healthy worker as broken. An invalidated snapshot could also remain available for another attachment to reuse.

## Fix

Snapshot transfers are now queued per client and session, so one transfer finishes before the next starts. A shared snapshot load remains available until all of its chunks arrive, and invalidating that snapshot removes the shared load so the next attachment requests a current copy.

## Validation

- `npm run check`

No test files are changed in this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix overlapping daemon snapshot catch-ups closing healthy workers
> - Serializes snapshot transfers per client/session using a `snapshotTransferTails` promise chain in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/580/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450), preventing concurrent streams for the same session from interfering.
> - Adds a `SnapshotLoadInvalidatedError` in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/580/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) to signal stale snapshot loads during attach, triggering a single retry instead of failing.
> - Invalidating a worker snapshot now also clears any in-flight `snapshotLoads` entries, allowing fresh loads to proceed immediately.
> - Transcript chunks are awaited before a snapshot load is considered complete, preventing premature cleanup.
> - Risk: The retry-once logic for invalidated loads means a second concurrent invalidation during attach will still fail rather than retry again.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e6b7c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon snapshot attach/catch-up and worker invalidation paths that gate session startup; behavior is localized but timing-sensitive under concurrent clients.
> 
> **Overview**
> Fixes a race where **overlapping snapshot catch-ups** for the same client/session could make the supervisor treat a healthy worker as broken (`Daemon worker client closed`) and block **new session starts**.
> 
> **Daemon mode** now **serializes snapshot transfers** per client and `activeSessionId` via `snapshotTransferTails`: each transfer waits on the previous tail promise before streaming, and the tail map is cleared in `finally`.
> 
> **Supervisor** snapshot loading is **invalidation-aware**: if the in-flight `snapshotLoads` entry is replaced mid-attach, it throws `SnapshotLoadInvalidatedError` and **retries once**; shared loads stay registered until chunked transcripts finish (or fail), and **`invalidateWorkerSnapshot`** clears both `chunked` and `full` load keys so stale snapshots are not reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6b7c083b452cc75ecbc416948f036251e6402e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->