### PR TITLE
fix(coding-agent): remove blank line between recap and working hint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed large daemon session loads to stream JSONL history and avoid retaining a second full-file copy in memory.
+- Fixed the blank line between the recap and the working hint so they render directly above each other.
 - Changed subagent guidance to retain reusable children and delete completed direct children once they are no longer needed.
 - Changed top-level CLI help and documentation to expose autonomous mode, quality gates, and their limits.
 - Fixed compaction retaining runtime resources after an explicitly deleted subagent had a transient cleanup failure.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3281,6 +3281,7 @@ export class InteractiveMode {
 		}
 		this.featureHintComponent = new FeatureHintComponent(this.currentFeatureHint);
 		this.featureHintContainer.addChild(this.featureHintComponent);
+		this.renderRecap();
 		this.featureHintAnimationTimer = setInterval(() => {
 			this.featureHintComponent?.advance();
 			this.ui.requestRender();
@@ -3301,6 +3302,7 @@ export class InteractiveMode {
 		if (this.featureHintComponent) {
 			this.featureHintContainer.removeChild(this.featureHintComponent);
 			this.featureHintComponent = undefined;
+			this.renderRecap();
 		}
 	}
 
@@ -3594,7 +3596,7 @@ export class InteractiveMode {
 		if (recap) {
 			this.recapContainer.addChild(new TruncatedText(theme.fg("dim", `Recap: ${recap}`), 1, 0));
 		}
-		if (recap || showChanges) {
+		if ((recap || showChanges) && !this.featureHintComponent) {
 			this.recapContainer.addChild(new Spacer(1));
 		}
 		this.ui.requestRender();


### PR DESCRIPTION
## What

Removes the blank line between the `Recap:` line and the animated `Hint:` line while both are visible, so they sit directly above each other.

<img width="996" height="624" alt="image" src="https://github.com/user-attachments/assets/c625ae3e-f2ca-423c-a2ed-2f87ac4244eb" />

## Why

`renderRecap()` always appended a trailing `Spacer(1)`, and the feature hint (which renders in the next container) brings its own trailing blank line, producing a two-line gap.

## How

- The recap's trailing spacer is suppressed while a `featureHintComponent` is visible.
- `showFeatureHint()` and `clearFeatureHintPresentation()` call `renderRecap()` so the spacer re-syncs at the two moments the hint toggles (recap and hint otherwise update on independent triggers, and the spacer would go stale).

+3/-1 in `interactive-mode.ts`. `npm run check` passes; `interactive-mode-feature-hints`, `4741-hint-placement`, and `4533-preserve-recap` suites pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only layout change in interactive mode with no impact on sessions, auth, or data handling.
> 
> **Overview**
> Fixes **extra vertical gap** between the recap block and the animated working **Hint** in the interactive TUI.
> 
> `renderRecap()` no longer appends its trailing `Spacer(1)` while `featureHintComponent` is shown—the hint container already supplies spacing, so both lines sit directly adjacent. **`showFeatureHint()`** and **`clearFeatureHintPresentation()`** re-call `renderRecap()` when the hint toggles so spacer state stays correct even though recap and hints update on different triggers.
> 
> Changelog notes the fix under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613ddb907dd4e0c375246e66981111dc3acbdf57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove blank line between recap and working hint in interactive mode
> When a feature hint is present, `InteractiveMode.renderRecap` no longer inserts a spacer between the recap/change summary and the hint, so they render directly adjacent. `renderRecap` is also called immediately when a feature hint is shown or cleared to keep spacing consistent without waiting for the next render cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 613ddb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->