### PR TITLE
feat(coding-agent): style agents view titles by source

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed large daemon session loads to stream JSONL history and avoid retaining a second full-file copy in memory.
+- Changed the agents view to render explicit session names in bold and the "(no messages)" placeholder in italics.
 - Changed subagent guidance to retain reusable children and delete completed direct children once they are no longer needed.
 - Changed top-level CLI help and documentation to expose autonomous mode, quality gates, and their limits.
 - Fixed compaction retaining runtime resources after an explicitly deleted subagent had a transient cleanup failure.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2334,7 +2334,7 @@ export class AgentsViewMode implements Component, Focusable {
 			? this.getPendingDeleteTitle()
 			: pendingKill
 				? `${keyText("app.agents.delete")} again to stop`
-				: row.title;
+				: styleRowTitle(row);
 		// Append the background summary as a dim suffix on the same line, e.g.
 		// "fix auth · Refactoring token validation". Hidden during delete/stop
 		// confirmations so the warning text stands alone.
@@ -2377,7 +2377,13 @@ export class AgentsViewMode implements Component, Focusable {
 		if (code) {
 			return theme.bg("toolPanelBg", padded);
 		}
-		return selected ? theme.getSelectionBackgroundColor()(padded) : padded;
+		if (!selected) {
+			return padded;
+		}
+		// Truncating styled cells embeds full \x1b[0m resets; re-open the
+		// selection background after each so the highlight spans the whole row.
+		const applySelectionBg = theme.getSelectionBackgroundColor();
+		return padded.split("\x1b[0m").map(applySelectionBg).join("\x1b[0m");
 	}
 
 	private isPendingDeleteRow(row: AgentsViewRow): boolean {
@@ -2575,6 +2581,18 @@ function rowHasSpawnCode(row: AgentsViewRow): boolean {
 
 function isRunningSessionSummary(summary: SessionSummary): boolean {
 	return summary.activity === "working";
+}
+
+// Explicit session names read bold so they stand out from fallback titles
+// (first prompt, cwd, ids); the "(no messages)" placeholder reads italic.
+function styleRowTitle(row: AgentsViewRow): string {
+	if (row.summary.sessionName?.replace(/\s+/g, " ").trim()) {
+		return theme.bold(row.title);
+	}
+	if (row.title === "(no messages)") {
+		return theme.italic(row.title);
+	}
+	return row.title;
 }
 
 function formatTableCell(value: string, width: number): string {


### PR DESCRIPTION
## What

In the agents view, session titles that come from an explicit session name render **bold**, and the `(no messages)` placeholder renders in *italics*. Fallback titles (first prompt, cwd basename, ids) stay plain.

<img width="775" height="768" alt="image" src="https://github.com/user-attachments/assets/fa8ffa59-0695-4b1c-bc53-ac47828d40d0" />


## Why

Named agents should be visually distinguishable from sessions whose row title is merely the first prompt or a summary, and the empty-session placeholder should read as a placeholder.

## How

A small `styleRowTitle()` in `AgentsViewMode.renderRow`: bold when `row.summary.sessionName` is non-blank (same whitespace normalization as `getSessionTitle`, so a whitespace-only name is not bolded), italic for the `(no messages)` placeholder emitted by the session catalog. Delete/stop confirmation titles are unaffected.

+13/-1 in `agents-view-mode.ts`. `npm run check` passes; `agents-view-state` suite passes unchanged.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only presentation in agents-view rendering with no auth, data, or protocol changes.
> 
> **Overview**
> **Agents view** session list titles are now styled by how the label was derived: rows with a non-blank `sessionName` render **bold**, and the `(no messages)` placeholder renders in *italics*; fallback titles (first prompt, cwd, ids) stay plain. Delete/stop confirmation copy is unchanged.
> 
> Selected rows with bold/italic titles no longer show gaps in the highlight—`finalizeRenderedLine` reapplies the selection background after embedded `\x1b[0m` resets from width truncation.
> 
> Changelog updated under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c284fca9185c576eacaf4c0397aadc7296d712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Style agents view row titles by source in bold or italics
> - Adds `styleRowTitle` helper in [agents-view-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/582/files#diff-116f4364505fa125d57532296cde69f9a73543363de3d3cd48bd4f48b2ee6e10) to apply bold to rows with an explicit session name and italics to the `(no messages)` placeholder.
> - Fixes selection background rendering to reapply the highlight across embedded ANSI reset sequences, so selected rows display a continuous background color.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0c284f.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->