### PR TITLE
fix(coding-agent): echo salvaged command id in daemon parse failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed daemon parse rejections dropping the command id, which left older clients waiting for a timeout instead of seeing the protocol error.
 - Changed large daemon session loads to stream JSONL history and avoid retaining a second full-file copy in memory.
 - Changed the agents view to render explicit session names in bold and the "(no messages)" placeholder in italics.
 - Fixed the blank line between the recap and the working hint so they render directly above each other.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -149,6 +149,7 @@ import {
 	isDaemonCommandEnvelope,
 	isDaemonDialogExtensionUiRequest,
 	isDaemonMutatingCommand,
+	salvageDaemonCommandId,
 	success,
 	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
@@ -2660,7 +2661,7 @@ export class AgentDaemon {
 			}
 			command = parsed as DaemonCommand;
 		} catch (error) {
-			this.write(client, failure(undefined, "parse", error, serializeDaemonError(error)));
+			this.write(client, failure(salvageDaemonCommandId(line), "parse", error, serializeDaemonError(error)));
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -967,16 +967,17 @@ export function isDaemonCommandEnvelope(value: unknown): value is DaemonCommandE
 /**
  * Best-effort id salvage for rejected command lines, so parse failures reach
  * the sender as correlatable responses instead of client-side timeouts.
- * Deliberately ignores protocol-version validity: clients on rejected
- * protocol versions still correlate responses by id.
+ * Deliberately ignores everything but the id itself: whatever made the line
+ * unparseable (rejected protocol version, missing or invalid type), the
+ * sender still correlates the failure by id.
  */
 export function salvageDaemonCommandId(line: string): string | undefined {
 	try {
-		const candidate = JSON.parse(line) as { type?: unknown; id?: unknown };
+		const candidate = JSON.parse(line) as { id?: unknown };
 		if (!candidate || typeof candidate !== "object") {
 			return undefined;
 		}
-		return typeof candidate.type === "string" && typeof candidate.id === "string" ? candidate.id : undefined;
+		return typeof candidate.id === "string" ? candidate.id : undefined;
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -964,6 +964,24 @@ export function isDaemonCommandEnvelope(value: unknown): value is DaemonCommandE
 	);
 }
 
+/**
+ * Best-effort id salvage for rejected command lines, so parse failures reach
+ * the sender as correlatable responses instead of client-side timeouts.
+ * Deliberately ignores protocol-version validity: clients on rejected
+ * protocol versions still correlate responses by id.
+ */
+export function salvageDaemonCommandId(line: string): string | undefined {
+	try {
+		const candidate = JSON.parse(line) as { type?: unknown; id?: unknown };
+		if (!candidate || typeof candidate !== "object") {
+			return undefined;
+		}
+		return typeof candidate.type === "string" && typeof candidate.id === "string" ? candidate.id : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 const READ_ONLY_DAEMON_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
 	"ack_result",
 	"list",

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -61,6 +61,7 @@ import {
 	failure,
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
+	salvageDaemonCommandId,
 	success,
 	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
@@ -1064,7 +1065,7 @@ export class DaemonSupervisor {
 		try {
 			preParsed = this.parseCommandAndRegisterPromptAdmission(client, line);
 		} catch (error) {
-			this.write(client, failure(undefined, "parse", error));
+			this.write(client, failure(salvageDaemonCommandId(line), "parse", error));
 			return;
 		}
 		const command = preParsed.command;

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -216,14 +216,15 @@ describe("daemon protocol helpers", () => {
 		});
 	});
 
-	it("salvages command ids from rejected lines regardless of protocol validity", () => {
+	it("salvages command ids from rejected lines regardless of shape validity", () => {
 		const oldEnvelope = JSON.stringify(
 			createDaemonCommandEnvelope({ type: "list" } as DaemonCommand, "list-1", "old-client", 6),
 		);
 		expect(salvageDaemonCommandId(oldEnvelope)).toBe("list-1");
 		expect(salvageDaemonCommandId(JSON.stringify({ type: "list", id: "bare-1" }))).toBe("bare-1");
+		expect(salvageDaemonCommandId(JSON.stringify({ type: null, id: "typeless-1" }))).toBe("typeless-1");
+		expect(salvageDaemonCommandId(JSON.stringify({ id: "no-type" }))).toBe("no-type");
 		expect(salvageDaemonCommandId(JSON.stringify({ type: "command", id: 7 }))).toBeUndefined();
-		expect(salvageDaemonCommandId(JSON.stringify({ id: "no-type" }))).toBeUndefined();
 		expect(salvageDaemonCommandId(JSON.stringify("command"))).toBeUndefined();
 		expect(salvageDaemonCommandId("{ not json")).toBeUndefined();
 	});

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -18,6 +18,7 @@ import {
 	type DaemonOutbound,
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
+	salvageDaemonCommandId,
 } from "../src/modes/daemon/daemon-protocol.js";
 
 describe("daemon protocol helpers", () => {
@@ -213,5 +214,17 @@ describe("daemon protocol helpers", () => {
 			fromCursor: { generation: "old", sequence: 5 },
 			toCursor: { generation: "new", sequence: 0 },
 		});
+	});
+
+	it("salvages command ids from rejected lines regardless of protocol validity", () => {
+		const oldEnvelope = JSON.stringify(
+			createDaemonCommandEnvelope({ type: "list" } as DaemonCommand, "list-1", "old-client", 6),
+		);
+		expect(salvageDaemonCommandId(oldEnvelope)).toBe("list-1");
+		expect(salvageDaemonCommandId(JSON.stringify({ type: "list", id: "bare-1" }))).toBe("bare-1");
+		expect(salvageDaemonCommandId(JSON.stringify({ type: "command", id: 7 }))).toBeUndefined();
+		expect(salvageDaemonCommandId(JSON.stringify({ id: "no-type" }))).toBeUndefined();
+		expect(salvageDaemonCommandId(JSON.stringify("command"))).toBeUndefined();
+		expect(salvageDaemonCommandId("{ not json")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-side-question.test.ts
@@ -115,6 +115,7 @@ describe("daemon supervisor side-question routing", () => {
 		expect(write).toHaveBeenCalledWith(
 			client,
 			expect.objectContaining({
+				id: "state-1",
 				command: "parse",
 				success: false,
 				error: expect.stringContaining("require protocol 7"),
@@ -166,6 +167,7 @@ describe("daemon supervisor side-question routing", () => {
 			await expect(messages).resolves.toEqual([
 				expect.objectContaining({ type: "daemon_hello" }),
 				expect.objectContaining({
+					id: "state-1",
 					type: "response",
 					command: "parse",
 					success: false,


### PR DESCRIPTION
## Summary

Sandbox validation for the v0.5.0 release (#591) found that a v0.4.0 client talking to a protocol-7 daemon hangs for 30s with a generic timeout instead of surfacing the protocol rejection.

The daemon does reply promptly with `Daemon commands require protocol 7 or newer`, but the parse-failure path writes `failure(undefined, "parse", ...)`. Old clients only resolve pending requests by response id (`daemon-client.ts` ignores id-less responses), so the rejection is never correlated and the request waits out its full timeout.

## Change

- `salvageDaemonCommandId(line)` in `daemon-protocol.ts`: best-effort id extraction from the raw line, deliberately ignoring protocol-version validity, returning `undefined` for malformed JSON or missing/non-string ids.
- Both parse-failure paths (`daemon-supervisor.ts` `handleLine` and `daemon-mode.ts` `handleLine`) echo the salvaged id instead of `undefined`.

No wire-shape change: `id` is already an optional `DaemonResponse` field that all released clients correlate on. No protocol or schema bump needed.

## Tests

- `daemon-protocol.test.ts`: unit coverage for the salvage helper (v6 envelope, bare command, non-string id, missing type, non-object, malformed JSON).
- `daemon-supervisor-side-question.test.ts`: the two existing protocol-6 rejection tests now assert the echoed id.

With this, a 0.4.0 client hitting a 0.5.0 daemon sees the protocol error in milliseconds instead of a 30s timeout, making the 0.5.0 changelog's "rejected cleanly at connect" true in both directions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix on error paths only; no change to successful command handling or protocol version.
> 
> **Overview**
> Fixes a compatibility gap where **daemon parse failures** (e.g. protocol-6 clients on a protocol-7 daemon) were answered promptly but with **no command `id`**, so older clients ignored the response and **timed out** instead of showing the protocol error.
> 
> Adds **`salvageDaemonCommandId`** to best-effort read a string `id` from the raw JSON line even when the command is otherwise invalid. **`AgentDaemon.handleLine`** and **`DaemonSupervisor.handleLine`** now pass that id into `failure(..., "parse", ...)` instead of `undefined`. No wire or schema bump—`id` was already optional on responses.
> 
> Tests cover the helper and assert echoed ids on existing protocol-6 rejection scenarios; changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ee7ab7d37a4ea8eee72d48e416a85f9a2ee64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Echo salvaged command id in daemon parse failure responses
> When a daemon socket line fails JSON parsing, the failure response previously dropped the command id. Now both `AgentDaemon.handleLine` and `DaemonSupervisor.handleLine` call the new `salvageDaemonCommandId` utility to best-effort extract the `id` field from the raw line and include it in the failure response when recoverable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15ee7ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->