### PR TITLE
fix(coding-agent): surface seeded --goal objective to the model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed daemon parse rejections dropping the command id, which left older clients waiting for a timeout instead of seeing the protocol error.
+- Fixed `--goal` sessions never showing the objective to the model, which made seeded goals invisible to first turns and continuations.
 - Changed large daemon session loads to stream JSONL history and avoid retaining a second full-file copy in memory.
 - Changed the agents view to render explicit session names in bold and the "(no messages)" placeholder in italics.
 - Fixed the blank line between the recap and the working hint so they render directly above each other.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1625,6 +1625,9 @@ export class AgentSession {
 	}
 
 	private _clearQueuedGoalContexts(): void {
+		this._pendingNextTurnMessages = this._pendingNextTurnMessages.filter(
+			(message) => message.customType !== GOAL_CONTEXT_CUSTOM_TYPE,
+		);
 		this.agent.removeQueuedMessages(
 			(message) => message.role === "custom" && message.customType === GOAL_CONTEXT_CUSTOM_TYPE,
 		);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1248,13 +1248,8 @@ export class AgentSession {
 		// or restart/rehydration of a session that already has messages or a goal.
 		if (this._rlmDepth === 0 && config.initialGoal && this._isBranchSeedable()) {
 			this._goalState = this._startGoal(config.initialGoal.objective, config.initialGoal.tokenBudget);
-			// The goal-context message is the only way the model learns a goal
-			// exists (there is no goal block in the system prompt). The slash
-			// command injects it via _runOrQueueGoalContext; CLI seeding runs
-			// mid-construction where no action can be admitted yet, so ride the
-			// next-turn context bucket instead: delivered with the first turn,
-			// persisted into the transcript, and therefore visible to
-			// continuations of the session.
+			// Goal context is the model's only source of goal visibility; action
+			// admission is unavailable mid-construction, so ride the next turn.
 			this._pendingNextTurnMessages.push(createGoalContextMessage(this._goalState, "continuation"));
 		}
 		this._restoreLateIpythonSentAgentMessages();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1248,6 +1248,14 @@ export class AgentSession {
 		// or restart/rehydration of a session that already has messages or a goal.
 		if (this._rlmDepth === 0 && config.initialGoal && this._isBranchSeedable()) {
 			this._goalState = this._startGoal(config.initialGoal.objective, config.initialGoal.tokenBudget);
+			// The goal-context message is the only way the model learns a goal
+			// exists (there is no goal block in the system prompt). The slash
+			// command injects it via _runOrQueueGoalContext; CLI seeding runs
+			// mid-construction where no action can be admitted yet, so ride the
+			// next-turn context bucket instead: delivered with the first turn,
+			// persisted into the transcript, and therefore visible to
+			// continuations of the session.
+			this._pendingNextTurnMessages.push(createGoalContextMessage(this._goalState, "continuation"));
 		}
 		this._restoreLateIpythonSentAgentMessages();
 		if (this._goalState.status === "active") {

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -917,6 +917,20 @@ describe("initial goal seeding from config", () => {
 		expect(currentAgentContext(harness).messages).toContain(messages[firstContextIndex]);
 	});
 
+	it("drops the seeded goal context when the goal is cleared before the first prompt", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			initialGoal: { objective: "Write tests", tokenBudget: 50000 },
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([fauxAssistantMessage("ack")]);
+		await harness.session.prompt("/goal clear");
+		expect(harness.session.goalState.status).toBe("idle");
+		await harness.session.prompt("hello");
+		expect(goalContextMessages(harness)).toHaveLength(0);
+	});
+
 	it("does not seed initialGoal for subagent sessions (rlmDepth > 0)", async () => {
 		const harness = await createHarness({
 			persistSession: true,

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -903,10 +903,7 @@ describe("initial goal seeding from config", () => {
 		const goalEntry = branch.find((e) => e.type === "custom" && e.customType === GOAL_STATE_CUSTOM_TYPE);
 		expect(goalEntry).toBeDefined();
 
-		// The first turn must carry the goal context to the model; seeding
-		// without it left the goal invisible (active state, silent model).
-		// Later contexts may follow from the goal continuation loop; the
-		// seeded one must precede the first assistant reply.
+		// The seeded goal context must reach the model before its first reply.
 		harness.setResponses([fauxAssistantMessage("ack")]);
 		await harness.session.prompt("hello");
 		const messages = harness.session.messages;

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -902,6 +902,22 @@ describe("initial goal seeding from config", () => {
 		const branch = harness.sessionManager.getBranch();
 		const goalEntry = branch.find((e) => e.type === "custom" && e.customType === GOAL_STATE_CUSTOM_TYPE);
 		expect(goalEntry).toBeDefined();
+
+		// The first turn must carry the goal context to the model; seeding
+		// without it left the goal invisible (active state, silent model).
+		// Later contexts may follow from the goal continuation loop; the
+		// seeded one must precede the first assistant reply.
+		harness.setResponses([fauxAssistantMessage("ack")]);
+		await harness.session.prompt("hello");
+		const messages = harness.session.messages;
+		const firstContextIndex = messages.findIndex(
+			(message) => message.role === "custom" && message.customType === "goal_context",
+		);
+		const firstAssistantIndex = messages.findIndex((message) => message.role === "assistant");
+		expect(firstContextIndex).toBeGreaterThanOrEqual(0);
+		expect(firstContextIndex).toBeLessThan(firstAssistantIndex);
+		expect(getMessageText(messages[firstContextIndex])).toContain("Write tests");
+		expect(currentAgentContext(harness).messages).toContain(messages[firstContextIndex]);
 	});
 
 	it("does not seed initialGoal for subagent sessions (rlmDepth > 0)", async () => {


### PR DESCRIPTION
## Summary

Headless testing during the v0.5.0 release validation found that `-p --goal "x" "prompt"` runs with an active goal the model knows nothing about: a follow-up `-p -c "Is there an active goal?"` answers No.

Root cause: the model's only source of goal visibility is the `goal_context` message (there is no goal block in the system prompt). `/goal` injects it via `_runOrQueueGoalContext` after `_startGoal`. CLI `--goal` seeding in the `AgentSession` constructor calls only `_startGoal` - state is persisted, accounting runs, budget limits fire, the interactive footer shows the goal - but no context message is ever injected, so the model never sees the objective on the first turn or any continuation.

## Change

Constructor seeding now pushes the same `goal_context` message (kind `continuation`, same as first-time `/goal`) into `_pendingNextTurnMessages`, the existing next-turn context bucket already used from the constructor by `_restoreLateIpythonSentAgentMessages`. It is construction-safe (no action admission mid-constructor), delivered with the first turn under the turn's execution policy, and persisted to the transcript as a `custom_message` entry - which is what makes the goal visible to `-c` continuations too (verified against a reopened session file).

One line of behavior plus a comment; no changes to `/goal`, goal continuation, or budget paths.

## Tests

Extended the existing `seeds an active goal from initialGoal config` suite test: after the first prompt, a `goal_context` message containing the objective must appear before the first assistant message and be part of the agent context. Verified the assertion fails without the fix. Full goal suite passes (42), `npm run check` clean.

## Note

Flagged as high-priority pre-work for the recursive-agent-harness plan: its PR 3 copies the goal persistence/seeding pattern for `/rlm-max-depth`, so the pattern should be correct before it is cloned (see `features/bug-reports/headless-cli-issues.md` #7).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `--goal` sessions to surface the seeded objective to the model
> - When an `initialGoal` seeds a top-level `AgentSession`, a `goal_context` message is now pushed to `_pendingNextTurnMessages` so the model sees the objective before the first assistant reply.
> - `_clearQueuedGoalContexts` is extended to also filter pending goal context messages from `_pendingNextTurnMessages`, so clearing a goal before the first prompt prevents delivery.
> - Tests in [agent-session-goal.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/593/files#diff-f831cdd3806262a4b6e6b6cb82279e590e00695be22ea012ba4b216eb4b5df59) verify ordering, content, inclusion in `currentAgentContext`, and the cleared-goal case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3287807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow goal-seeding and queue-cleanup change with targeted tests; no auth, persistence, or scheduling core changes.
> 
> **Overview**
> **Fixes `--goal` sessions where the model never saw the objective.** Goal state was persisted and shown in the UI, but unlike `/goal`, CLI seeding did not inject the `goal_context` custom message the model relies on.
> 
> After `_startGoal` in the constructor, the same `goal_context` message used elsewhere (`continuation` kind) is pushed onto `_pendingNextTurnMessages` so it ships with the first turn and lands in the transcript for `-c` continuations. **`_clearQueuedGoalContexts`** now drops those pending messages too when the goal is cleared before the first prompt.
> 
> Tests assert the objective appears in context before the first assistant reply and that clearing the goal removes pending goal context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3287807eb345d343b1aca14c94f5b3923b03cd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->