### PR TITLE
fix(coding-agent): derive refine output budgets from the model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/refine` failing with an opaque JSON parse error when the refiner exceeded a fixed 4096-token output cap; output budgets now derive from the selected model, and a truncated reply reports the exhausted budget directly.
+
 ## [0.5.0] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -184,6 +184,26 @@ Return JSON only:
   "instructions": "optional concise instructions for /refine if shouldRefine is true"
 }`;
 
+/**
+ * Output budgets are derived from the selected model instead of fixed literals.
+ * /refine input scales with harness size (entry overview, refinement history, and
+ * the trajectory slice), so a constant output cap silently truncates exactly the
+ * large multi-edit proposals that matter most. Math.min keeps small models honest.
+ */
+const REFINEMENT_MAX_OUTPUT_TOKENS = 32_000;
+const AUTO_REFINE_REVIEW_MAX_OUTPUT_TOKENS = 4_096;
+
+const TRUNCATED_JSON_ERROR =
+	"the model stopped before completing its JSON object. This usually means the output budget was exhausted; retry with a smaller request.";
+
+function refinementMaxOutputTokens(model: Model<any>): number {
+	return Math.min(model.maxTokens, REFINEMENT_MAX_OUTPUT_TOKENS);
+}
+
+function autoRefineReviewMaxOutputTokens(model: Model<any>): number {
+	return Math.min(model.maxTokens, AUTO_REFINE_REVIEW_MAX_OUTPUT_TOKENS);
+}
+
 function now(): string {
 	return new Date().toISOString();
 }
@@ -550,10 +570,19 @@ function extractJsonObject(text: string): unknown {
 	if (fenced) {
 		return JSON.parse(fenced[1].trim());
 	}
+	// Brace slicing recovers JSON wrapped in prose. On a reply truncated inside the
+	// edits array it would otherwise slice to an earlier edit's closing brace and
+	// hand back a fragment whose JSON.parse error describes the fragment, not the
+	// truncation. Only accept a slice that actually parses.
 	const start = trimmed.indexOf("{");
 	const end = trimmed.lastIndexOf("}");
 	if (start !== -1 && end > start) {
-		return JSON.parse(trimmed.slice(start, end + 1));
+		const sliced = trimmed.slice(start, end + 1);
+		try {
+			return JSON.parse(sliced);
+		} catch {
+			throw new Error(TRUNCATED_JSON_ERROR);
+		}
 	}
 	throw new Error("Refiner did not return a JSON object");
 }
@@ -844,11 +873,14 @@ export async function planRefinement(
 			systemPrompt: REFINEMENT_SYSTEM_PROMPT,
 			messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() }],
 		},
-		{ maxTokens: 4096, signal, apiKey, headers },
+		{ maxTokens: refinementMaxOutputTokens(model), signal, apiKey, headers },
 	);
 
 	if (response.stopReason === "error") {
 		throw new Error(`Refinement failed: ${response.errorMessage || "Unknown error"}`);
+	}
+	if (response.stopReason === "length") {
+		throw new Error(`Refinement failed: ${TRUNCATED_JSON_ERROR}`);
 	}
 
 	const text = response.content
@@ -907,10 +939,13 @@ ${conversationText}
 			systemPrompt: AUTO_REFINE_REVIEW_SYSTEM_PROMPT,
 			messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() }],
 		},
-		{ maxTokens: 1024, signal, apiKey, headers },
+		{ maxTokens: autoRefineReviewMaxOutputTokens(model), signal, apiKey, headers },
 	);
 	if (response.stopReason === "error") {
 		throw new Error(`Auto-refine review failed: ${response.errorMessage || "Unknown error"}`);
+	}
+	if (response.stopReason === "length") {
+		throw new Error(`Auto-refine review failed: ${TRUNCATED_JSON_ERROR}`);
 	}
 	const text = response.content
 		.filter((content): content is { type: "text"; text: string } => content.type === "text")

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -561,28 +561,71 @@ function historyForPrompt(history: RefinementResult[]): string {
 		.join("\n\n");
 }
 
+/**
+ * Whether a JSON candidate ends mid-value: an unterminated string, or unclosed
+ * objects/arrays. A reply cut off by an exhausted output budget is incomplete in
+ * this sense, while a complete-but-malformed reply is balanced. Brace slicing can
+ * also produce a balanced fragment, so callers treat "balanced" as malformed.
+ */
+function isIncompleteJson(candidate: string): boolean {
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (const char of candidate) {
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (inString) {
+			if (char === "\\") escaped = true;
+			else if (char === '"') inString = false;
+			continue;
+		}
+		if (char === '"') inString = true;
+		else if (char === "{" || char === "[") depth++;
+		else if (char === "}" || char === "]") depth--;
+	}
+	return inString || depth > 0;
+}
+
+function parseJsonCandidate(candidate: string): unknown {
+	try {
+		return JSON.parse(candidate);
+	} catch (error) {
+		// A truncated reply and a malformed one both fail here, and JSON.parse
+		// describes the fragment rather than the cause. Name the cause instead.
+		if (isIncompleteJson(candidate)) {
+			throw new Error(TRUNCATED_JSON_ERROR);
+		}
+		throw new Error(`the model did not return valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
 function extractJsonObject(text: string): unknown {
 	const trimmed = text.trim();
 	if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-		return JSON.parse(trimmed);
+		// A reply truncated after a nested closing brace still looks well-formed
+		// here, so this path needs the same diagnosis as the slicing fallback.
+		return parseJsonCandidate(trimmed);
 	}
 	const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
 	if (fenced) {
-		return JSON.parse(fenced[1].trim());
+		return parseJsonCandidate(fenced[1].trim());
 	}
 	// Brace slicing recovers JSON wrapped in prose. On a reply truncated inside the
-	// edits array it would otherwise slice to an earlier edit's closing brace and
-	// hand back a fragment whose JSON.parse error describes the fragment, not the
-	// truncation. Only accept a slice that actually parses.
+	// edits array it slices to an earlier edit's closing brace, so a failure here
+	// is diagnosed against the original text rather than the balanced fragment.
 	const start = trimmed.indexOf("{");
 	const end = trimmed.lastIndexOf("}");
 	if (start !== -1 && end > start) {
-		const sliced = trimmed.slice(start, end + 1);
 		try {
-			return JSON.parse(sliced);
+			return JSON.parse(trimmed.slice(start, end + 1));
 		} catch {
-			throw new Error(TRUNCATED_JSON_ERROR);
+			return parseJsonCandidate(trimmed.slice(start));
 		}
+	}
+	if (isIncompleteJson(trimmed)) {
+		throw new Error(TRUNCATED_JSON_ERROR);
 	}
 	throw new Error("Refiner did not return a JSON object");
 }

--- a/packages/coding-agent/test/refinement.test.ts
+++ b/packages/coding-agent/test/refinement.test.ts
@@ -1030,8 +1030,9 @@ describe("harness refinement", () => {
 				"During a local refinement, global entries are read-only context: never propose update or delete edits for them",
 			),
 		});
+		// Budget is derived from the model (8192) rather than a fixed literal.
 		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
-			maxTokens: 4096,
+			maxTokens: 8192,
 			apiKey: "api-key",
 			headers: { "x-test-header": "1" },
 		});
@@ -1044,6 +1045,51 @@ describe("harness refinement", () => {
 		});
 		expect(state.entries.memory.native_validation.content).toBe(
 			"Run validation through the target project environment.",
+		);
+	});
+
+	it("caps the refinement output budget by the model's own maxTokens", async () => {
+		const state = loadHarnessState(makeTempDir());
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(JSON.stringify({ summary: "s", rationale: "r", expectedOutcome: "o", edits: [] })),
+		);
+		// A large model must receive the policy ceiling, not its full output width.
+		const wideModel = { ...createRefineModel(false), maxTokens: 128_000 };
+
+		await refineHarness([], state, [], wideModel, "api-key", {});
+
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({ maxTokens: 32_000 });
+	});
+
+	it("reports an exhausted output budget instead of a JSON parse error", async () => {
+		const state = loadHarnessState(makeTempDir());
+		// A reply truncated inside the edits array: brace slicing would otherwise
+		// recover a fragment and surface an opaque JSON.parse message.
+		const truncated = `{
+  "summary": "s",
+  "rationale": "r",
+  "expectedOutcome": "o",
+  "edits": [
+    { "action": "create", "kind": "memory", "id": "a", "title": "t", "content": "first" },
+    { "action": "create", "kind": "memory", "id": "b", "title": "t2", "content": "second`;
+		completeSimpleMock.mockResolvedValueOnce({ ...assistantText(truncated), stopReason: "length" });
+
+		await expect(refineHarness([], state, [], createRefineModel(false), "api-key", {})).rejects.toThrow(
+			/output budget was exhausted/,
+		);
+	});
+
+	it("rejects a truncated proposal that never reports a length stop reason", async () => {
+		const state = loadHarnessState(makeTempDir());
+		const truncated = `{
+  "summary": "s",
+  "edits": [
+    { "action": "create", "kind": "memory", "id": "a", "title": "t", "content": "first" },
+    { "action": "create", "kind": "memory", "id": "b", "title": "t2", "content": "second`;
+		completeSimpleMock.mockResolvedValueOnce(assistantText(truncated));
+
+		await expect(refineHarness([], state, [], createRefineModel(false), "api-key", {})).rejects.toThrow(
+			/stopped before completing its JSON object/,
 		);
 	});
 

--- a/packages/coding-agent/test/refinement.test.ts
+++ b/packages/coding-agent/test/refinement.test.ts
@@ -1093,6 +1093,32 @@ describe("harness refinement", () => {
 		);
 	});
 
+	it("reports truncation when a JSON-only reply is cut after a nested closing brace", async () => {
+		const state = loadHarnessState(makeTempDir());
+		// Ends on "}" so it takes the startsWith/endsWith fast path rather than
+		// the brace-slicing fallback, but is still an incomplete object.
+		const truncated = `{
+  "summary": "s",
+  "edits": [
+    { "action": "create", "kind": "memory", "id": "a", "title": "t", "content": "first" }`;
+		completeSimpleMock.mockResolvedValueOnce(assistantText(truncated));
+
+		await expect(refineHarness([], state, [], createRefineModel(false), "api-key", {})).rejects.toThrow(
+			/stopped before completing its JSON object/,
+		);
+	});
+
+	it("reports malformed JSON as invalid rather than as an exhausted budget", async () => {
+		const state = loadHarnessState(makeTempDir());
+		// Complete and balanced, but not valid JSON: this is a model formatting
+		// failure, not a truncation, and must not blame the output budget.
+		completeSimpleMock.mockResolvedValueOnce(assistantText('Here is the result: {"edits": [oops]}'));
+
+		await expect(refineHarness([], state, [], createRefineModel(false), "api-key", {})).rejects.toThrow(
+			/did not return valid JSON/,
+		);
+	});
+
 	it("rolls back created, updated, and deleted entries from refinement history", async () => {
 		const state = loadHarnessState(makeTempDir());
 		seedEntry(state, "memory", "kept_memory");


### PR DESCRIPTION
`/refine` failed with:

```
Error: Refinement failed: Expected ',' or ']' after array element in JSON at position 8741 (line 31 column 6)
```

## Cause

`planRefinement` builds its request from four blocks and then caps the reply at a fixed 4096 tokens:

| Block | Bound | Measured on a real harness (59 entries, 51 refinements) |
|---|---|---|
| system prompt | fixed | ~1,188 tok |
| `<current_harness_state>` | 40 entries/kind, 240 chars each | ~5,691 tok |
| `<refinement_history>` | last 20 records | ~207 tok |
| `<conversation>` | `.slice(-80_000)` chars | ~20,000 tok |

That is ~27k tokens of input against a 4,096-token output cap, a 6.6:1 ratio. Every input block grows with harness size; the output cap was a constant chosen when the harness was empty.

Reconstructing per-edit JSON from real entries: median 202 tok, p90 347 tok, max 737 tok. Typical proposals carry 1-3 edits and fit comfortably. Large ones do not: 5 max-sized edits land at ~3.9k, 8 at ~6.1k. The cap does not bite on routine refinements, only on the consequential multi-edit ones.

Two things then turned truncation into an unreadable error:

1. `stopReason === "length"` was never checked. Only `"error"` was handled, so a truncated-but-successful reply went straight to parsing.
2. `extractJsonObject`'s brace-slicing fallback is meant to recover JSON wrapped in prose. On a reply truncated inside the `edits` array it slices to the *previous* edit's closing brace, producing a fragment that is genuinely invalid JSON. The reported parse error describes that fragment, not the truncation.

## Changes

- Derive both budgets from the model: `min(model.maxTokens, 32_000)` for the proposal, `min(model.maxTokens, 4_096)` for the auto-refine review. 32k is ~5x the realistic worst case and ~25% of a 128k-output model. `maxTokens` is a ceiling, not a reservation, so unused budget costs nothing.
- Throw a clear error on `stopReason === "length"` at both call sites.
- Make `extractJsonObject` validate its brace-sliced candidate instead of returning a fragment that cannot parse.

## Tests

`test/refinement.test.ts`, 57 passed. Three new cases: the budget is capped by the model's own `maxTokens`; a truncated reply reporting `length` produces the budget error; a truncated reply that never reports `length` is rejected by the parser rather than surfacing a fragment error. One existing assertion moved from the `4096` literal to the model-derived `8192`.

`npm run check` passes.

## Not included

This fixes the output side only. The input side has a related problem worth a separate change: the 40-entry cap is already reached at 40 memories, and the 240-char truncation hides ~62% of entry content from the refiner, which is how near-duplicate entries get created. The better fix is an index-style overview plus direct harness lookups during refinement rather than a larger one-shot dump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to refinement LLM calls and JSON parsing; behavior change is larger output budgets on capable models and clearer errors on truncation, with no auth or data-path impact.
> 
> **Overview**
> Fixes `/refine` failures where large harness proposals hit a **fixed 4096-token output cap** and surfaced misleading `JSON.parse` errors instead of explaining truncation.
> 
> **Output budgets** in `planRefinement` and auto-refine review now use `min(model.maxTokens, ceiling)` — **32k** for refinement proposals and **4k** for the review gate — replacing hardcoded **4096** and **1024**.
> 
> **Truncation handling** treats `stopReason === "length"` as an explicit exhausted-budget error at both LLM call sites. **`extractJsonObject`** gains incomplete-JSON detection (`isIncompleteJson`, `parseJsonCandidate`) so cut-off replies and brace-slicing artifacts report budget exhaustion or invalid JSON distinctly, not opaque parse failures on partial objects.
> 
> Tests cover model-derived caps, the 32k ceiling on wide models, length stop reason, silent truncation, and malformed vs truncated JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae16e3085ff2fd888ac29fc5be566680c34d9f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/refine` output budget to derive from model capacity instead of fixed 4096-token cap
> - Replaces the hardcoded 4096-token output limit in `planRefinement` with a model-derived cap (up to 32000 tokens), and the 1024-token limit in auto-refine review with a model-derived cap (up to 4096 tokens), both in [refinement.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/598/files#diff-17b614d876315ad8ac0165562a8f07a5c4ada3b28928eb02d90f6b93a96ea91d).
> - Adds `isIncompleteJson` and `parseJsonCandidate` helpers to distinguish truncated JSON from malformed JSON, so truncation now surfaces a clear "exhausted budget" error instead of an opaque parse failure.
> - Adds a `stopReason === 'length'` check in both refine paths to throw an explicit truncation error before attempting to parse the response.
> - Behavioral Change: models with fewer than 32000 max tokens will now use their actual limit; replies that previously failed silently with a JSON parse error will now throw a descriptive truncation message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae16e30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->