### PR TITLE
fix(coding-agent): allow daemon socket flags for stop and rename

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `stop` and `rename` rejecting custom daemon socket options.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -362,11 +362,22 @@ function splitOperandsAndOptions(args: string[]): { operands: string[]; options:
 }
 
 function requireOperandCount(args: string[], minimum: number, maximum: number | undefined, command: string): boolean {
-	if (args.some((arg) => arg.startsWith("-") && arg !== "--json")) {
-		fail(`Usage: ${APP_NAME} ${getCommandSpec([command])?.usage ?? command}`);
-		return false;
+	const operands: string[] = [];
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index]!;
+		if (arg === "--json") {
+			continue;
+		}
+		if (arg === "--socket" || arg === "--daemon-socket") {
+			index++;
+			continue;
+		}
+		if (arg.startsWith("-")) {
+			fail(`Usage: ${APP_NAME} ${getCommandSpec([command])?.usage ?? command}`);
+			return false;
+		}
+		operands.push(arg);
 	}
-	const operands = args.filter((arg) => arg !== "--json");
 	if (operands.length >= minimum && (maximum === undefined || operands.length <= maximum)) {
 		return true;
 	}

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -103,6 +103,24 @@ describe("public command routing", () => {
 		expect(mocks.daemonCommands).toEqual([["daemon", "list", "--all", "--json"]]);
 	});
 
+	it("forwards a custom daemon socket when stopping an agent", async () => {
+		await expect(
+			handlePublicCommand(["stop", "worker", "--daemon-socket", "/tmp/custom-daemon.sock"]),
+		).resolves.toMatchObject({ handled: true });
+		expect(mocks.daemonCommands).toEqual([
+			["daemon", "kill", "worker", "--daemon-socket", "/tmp/custom-daemon.sock"],
+		]);
+	});
+
+	it("forwards a custom daemon socket when renaming an agent", async () => {
+		await expect(
+			handlePublicCommand(["rename", "worker", "reviewer", "--daemon-socket", "/tmp/custom-daemon.sock"]),
+		).resolves.toMatchObject({ handled: true });
+		expect(mocks.daemonCommands).toEqual([
+			["daemon", "rename", "worker", "reviewer", "--daemon-socket", "/tmp/custom-daemon.sock"],
+		]);
+	});
+
 	it("separates Prime Agent updates from package updates", async () => {
 		await handlePublicCommand(["update", "--force"]);
 		await handlePublicCommand(["package", "update"]);


### PR DESCRIPTION
## What was broken

`prime-agent stop <agent>` and `prime-agent rename <old> <new>` refused to accept the `--daemon-socket` (or `--socket`) option. You got a usage error, even though the option works fine on other commands like `list`. The practical consequence: if an agent was running on anything other than the default daemon, there was no way to stop or rename it from the command line at all.

## Why it happened

Both commands count their arguments before looking at options, so the option and its value were counted as if they were extra agent names, and the count check failed.

## The fix

The argument counting now knows about the handful of options these commands support (`--json`, `--socket`, `--daemon-socket`) and skips them, counting only the real arguments. Unknown options are still rejected with the same usage errors as before.

## Testing

Two new tests prove `stop` and `rename` accept the socket option and hand it through correctly. Verified by hand on a build: before the fix the command died with a usage error, after it the request reaches the daemon as expected. Full test file passes (30/30).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI parsing change in public command routing with targeted tests; no auth, data, or daemon protocol changes.
> 
> **Overview**
> **`prime-agent stop` and `rename` no longer fail** when you pass `--daemon-socket` or `--socket`; those flags (and `--json`) are skipped during operand validation so only real agent names are counted. Unknown options still produce the same usage errors as before, and the full argv—including socket options—is still forwarded to the internal `daemon kill` / `daemon rename` handlers.
> 
> Tests cover socket forwarding for both commands; the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9db8e866646dabcf4c375d4db3ef3a3e38ad37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `stop` and `rename` commands to accept `--socket`/`--daemon-socket` flags
> The `requireOperandCount` function in [`public-command.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/603/files#diff-95293366ebc8d0605c48116d5ccf09ffd95427059bbf96225ed58b41e3411e78) was treating `--socket` and `--daemon-socket` (and their values) as invalid flags or operands, causing `stop` and `rename` to reject custom daemon socket options. The fix skips over these recognized global flags when validating operand count, matching the existing behavior for `--json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9db8e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->