### PR TITLE
fix(coding-agent): handle Ctrl+C cleanly in print mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed SIGINT in print mode leaving the session active until liveness reclaim.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -77,11 +77,16 @@ async function runPrintModeWithConnectionInternal(
 		await connection.dispose();
 	};
 
-	for (const signal of ["SIGTERM", ...(process.platform === "win32" ? [] : ["SIGHUP"])] as NodeJS.Signals[]) {
+	for (const signal of [
+		"SIGINT",
+		"SIGTERM",
+		...(process.platform === "win32" ? [] : ["SIGHUP"]),
+	] as NodeJS.Signals[]) {
 		const handler = () => {
 			killTrackedDetachedChildren();
 			void disposeConnection().finally(() => {
-				process.exit(signal === "SIGHUP" ? 129 : 143);
+				const exitCode = signal === "SIGINT" ? 130 : signal === "SIGHUP" ? 129 : 143;
+				process.exit(exitCode);
 			});
 		};
 		process.on(signal, handler);

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -16,6 +16,9 @@ vi.mock("../src/core/output-guard.js", () => ({
 	writeRawStdout: output.write,
 	flushRawStdout: output.flush,
 }));
+vi.mock("../src/utils/shell.js", () => ({
+	killTrackedDetachedChildren: vi.fn(),
+}));
 
 type EmitEvent = SessionShutdownEvent;
 
@@ -143,6 +146,36 @@ describe("runPrintMode", () => {
 		expect(session.promptAndWait).toHaveBeenCalledWith("Say done", { images });
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("disposes the connection before exiting on SIGINT", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
+		const { session } = runtimeHost;
+		let resolvePrompt: (() => void) | undefined;
+		session.promptAndWait.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolvePrompt = resolve;
+				}),
+		);
+		const onSpy = vi.spyOn(process, "on");
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as typeof process.exit);
+
+		const runPromise = runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+			initialMessage: "Wait",
+		});
+		await vi.waitFor(() => expect(session.promptAndWait).toHaveBeenCalled());
+		const handler = onSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1];
+		if (typeof handler !== "function") throw new Error("SIGINT handler was not registered");
+
+		handler();
+
+		await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(130));
+		expect(runtimeHost.dispose).toHaveBeenCalledTimes(1);
+		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+		resolvePrompt?.();
+		await expect(runPromise).resolves.toBe(0);
 	});
 
 	it("prints successful session command results in text mode", async () => {


### PR DESCRIPTION
## What was broken

When you run `prime-agent -p "..."` and press Ctrl+C, the process did not go through its normal shutdown routine. Print mode had cleanup handlers for other termination signals, but Ctrl+C - the one people actually press - was missing from the list. That meant the connection was not closed properly and the session could be left registered as active until the system noticed the process was gone.

## The fix

Ctrl+C now triggers the same cleanup as the other signals, and the process exits with the conventional code for it (130).

## Honest caveat

While verifying this, we could not reproduce the original "session is already active" complaint on current main anymore - recovery has since become fast enough that a follow-up `-p -c` works within a few seconds either way. So this is a correctness/consistency fix more than a visible behavior change. We also noticed that if a tool is mid-run, shutdown waits for it before exiting - that affects all termination signals equally, predates this change, and is not touched here.

## Testing

New test confirms Ctrl+C closes the connection, announces the shutdown, and exits with code 130. Full print-mode test file passes (22/22).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to print-mode signal handling and tests; aligns SIGINT with existing shutdown behavior without touching auth, daemon protocol, or core agent logic.
> 
> **Overview**
> **Print mode** (`prime-agent -p`) now treats **Ctrl+C (SIGINT)** like the other termination signals: it kills tracked detached children, **disposes the connection** (including `session_shutdown`), and exits with code **130**.
> 
> Previously only `SIGTERM` and `SIGHUP` ran that path, so interrupting a headless run could leave the session registered as active until liveness reclaim. A regression test covers dispose + shutdown on SIGINT; the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ab2858ac35060774531b40f397869a3f33ab22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle SIGINT cleanly in coding-agent print mode by disposing the connection and exiting with code 130
> Previously, pressing Ctrl+C in print mode left the session active until liveness reclaim. Now, a SIGINT handler in [`print-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/604/files#diff-0f7fbdf4b1fbdf54ab294c2c2e5f09f81ad26ad663eae418e6406768271f6379) kills tracked detached children, disposes the `AgentConnection`, and exits with code 130. SIGHUP exits with 129 and SIGTERM exits with 143.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1ab285.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->