### PR TITLE
fix(coding-agent): say something when print mode gets no prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed print mode silently exiting when no prompt was provided through arguments or stdin.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1477,6 +1477,10 @@ export async function main(args: string[], options?: MainOptions) {
 			stdinContent,
 		);
 		time("prepareInitialMessage");
+		if (appMode !== "rpc" && !initialMessage && parsed.messages.length === 0) {
+			console.error("No prompt provided (stdin was empty); nothing to do.");
+			return;
+		}
 		initTheme(settingsManager.getTheme(), false);
 		time("initTheme");
 
@@ -1571,6 +1575,10 @@ export async function main(args: string[], options?: MainOptions) {
 		stdinContent,
 	);
 	time("prepareInitialMessage");
+	if ((appMode === "print" || appMode === "json") && !initialMessage && parsed.messages.length === 0) {
+		console.error("No prompt provided (stdin was empty); nothing to do.");
+		return;
+	}
 	initTheme(settingsManager.getTheme(), appMode === "interactive");
 	time("initTheme");
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -89,6 +89,11 @@ async function runPrintModeWithConnectionInternal(
 	}
 
 	try {
+		if (!initialMessage && messages.length === 0 && (await connection.getMessages()).length === 0) {
+			console.error("No prompt provided (stdin was empty); nothing to do.");
+			return 0;
+		}
+
 		if (mode === "json") {
 			const header = await connection.getSessionHeader();
 			if (header) {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -89,7 +89,7 @@ async function runPrintModeWithConnectionInternal(
 	}
 
 	try {
-		if (!initialMessage && messages.length === 0 && (await connection.getMessages()).length === 0) {
+		if (!initialMessage && messages.length === 0) {
 			console.error("No prompt provided (stdin was empty); nothing to do.");
 			return 0;
 		}

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -94,11 +94,6 @@ async function runPrintModeWithConnectionInternal(
 	}
 
 	try {
-		if (!initialMessage && messages.length === 0) {
-			console.error("No prompt provided (stdin was empty); nothing to do.");
-			return 0;
-		}
-
 		if (mode === "json") {
 			const header = await connection.getSessionHeader();
 			if (header) {

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -316,6 +316,35 @@ describe("ENG-4685 daemon-backed client modes", () => {
 		expect(result.stderr).toContain("No prompt provided (stdin was empty); nothing to do.");
 	}, 30_000);
 
+	it("does not replay the previous response when continuing with no prompt", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-empty-continue-"));
+		tempRoots.add(root);
+		const agentDir = join(root, "agent");
+		const socketPath = join(root, "daemon.sock");
+		daemonSockets.add(socketPath);
+		const commonArgs = [
+			"--daemon-socket",
+			socketPath,
+			"--model",
+			"faux/faux",
+			"--extension",
+			fauxExtensionPath,
+			"--no-tools",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--no-context-files",
+		];
+
+		const first = await runCli(["--print", ...commonArgs, "Say hello"], { agentDir });
+		expect(first.code).toBe(0);
+		expect(first.stdout).not.toBe("");
+
+		const resumed = await runCli(["--print", "--continue", ...commonArgs], { agentDir, stdin: "" });
+		expect(resumed).toMatchObject({ code: 0, signal: null, stdout: "" });
+		expect(resumed.stderr).toContain("No prompt provided (stdin was empty); nothing to do.");
+	}, 60_000);
+
 	it("keeps the rollback frontend fully off the daemon path", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-rollback-"));
 		tempRoots.add(root);

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -287,6 +287,35 @@ describe("ENG-4685 daemon-backed client modes", () => {
 		expect(existsSync(socketPath)).toBe(true);
 	}, 90_000);
 
+	it("warns without writing stdout when print mode receives no prompt", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-empty-print-"));
+		tempRoots.add(root);
+		const agentDir = join(root, "agent");
+		const socketPath = join(root, "daemon.sock");
+		daemonSockets.add(socketPath);
+
+		const result = await runCli(
+			[
+				"--print",
+				"--daemon-socket",
+				socketPath,
+				"--model",
+				"faux/faux",
+				"--extension",
+				fauxExtensionPath,
+				"--no-tools",
+				"--no-skills",
+				"--no-prompt-templates",
+				"--no-themes",
+				"--no-context-files",
+			],
+			{ agentDir, stdin: "" },
+		);
+
+		expect(result).toMatchObject({ code: 0, signal: null, stdout: "" });
+		expect(result.stderr).toContain("No prompt provided (stdin was empty); nothing to do.");
+	}, 30_000);
+
 	it("keeps the rollback frontend fully off the daemon path", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-agent-4685-rollback-"));
 		tempRoots.add(root);


### PR DESCRIPTION
## What was broken

Running `prime-agent -p` with nothing on stdin (for example `echo -n | prime-agent -p`) printed nothing at all and exited successfully. If a script accidentally fed an empty prompt, there was no hint that anything went wrong - it just looked like a run that produced no output.

## The fix

Print mode now writes one line to stderr - `No prompt provided (stdin was empty); nothing to do.` - and still exits with code 0. The exit code stays 0 on purpose: existing tests pin that behavior three times over, and scripts may rely on it. Stdout stays empty so pipelines are unaffected.

## Testing

New test asserts the warning appears on stderr, stdout stays empty, and the exit code stays 0. Verified by hand: before the fix, total silence; after, the warning. The three existing empty-input tests pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup guard with no model or session logic changes; behavior is additive (stderr message) while preserving exit code 0 and empty stdout.
> 
> **Overview**
> **Fixes silent success when headless runs have nothing to send.** After `prepareInitialMessage`, **print**, **json**, and daemon-backed non-RPC clients bail out early if there is neither an `initialMessage` nor CLI `messages`, instead of continuing into a no-op or replaying prior output.
> 
> The user sees **`No prompt provided (stdin was empty); nothing to do.`** on **stderr**; **stdout** stays empty and the process still exits with **code 0** so existing scripts and the empty-input regression matrix stay unchanged.
> 
> The same guard is applied on both the **daemon client** path and the **in-process** print/json path in `main.ts`. New tests cover **`--print`** with empty stdin and **`--print --continue`** after a real turn, asserting the warning and that the last assistant reply is not printed again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cad67b2c1216a5e9cfec4974d61b7feef96f2aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix print mode silently exiting when no prompt is provided
> Adds an early guard in `runPrintModeWithConnectionInternal` that detects when neither `initialMessage` nor `messages` are present. Instead of silently exiting, it now writes a warning to stderr (`No prompt provided (stdin was empty); nothing to do.`) and returns exit code 0. Two regression tests cover both `--print` with no prompt and `--print --continue` with no prompt.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #605 opened
>
> - Added early-return guards in the `main` function to validate empty prompts [3cad67b]
> - Removed empty-input validation from `runPrintModeWithConnectionInternal` function [3cad67b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3cad67b. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->