### PR TITLE
fix(coding-agent): stop agents from influencing their own quality gates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed autonomous quality gates inheriting environment and PATH changes made after runtime creation.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -75,6 +75,7 @@ export interface AutonomousRuntimeState {
 	gateAttempts: Record<string, number>;
 	lastGateFailure?: GateFailure;
 	lastGateFailureSnapshot?: GitWorktreeSnapshot;
+	gateEnvironment: NodeJS.ProcessEnv;
 }
 
 export type AutonomousLimitReason = "maxContinuations" | "maxTurns" | "maxTokens" | "timeoutMs";
@@ -129,6 +130,7 @@ export function createAutonomousRuntimeState(
 		gateAttempts: {},
 		lastGateFailure: undefined,
 		lastGateFailureSnapshot: undefined,
+		gateEnvironment: { ...process.env },
 	};
 }
 
@@ -311,6 +313,7 @@ async function runAutonomousQualityGates(
 		}
 		const result = await runChildProcess(command, [], {
 			cwd,
+			env: state.gateEnvironment,
 			shell: true,
 			timeoutMs: state.gates.timeoutMs,
 			maxOutputChars: MAX_GATE_OUTPUT_CHARS,
@@ -483,6 +486,7 @@ function runChildProcess(
 	args: string[],
 	options: {
 		cwd?: string;
+		env?: NodeJS.ProcessEnv;
 		shell?: boolean;
 		timeoutMs?: number;
 		maxOutputChars?: number;
@@ -494,6 +498,7 @@ function runChildProcess(
 		const child = spawn(command, args, {
 			cwd: options.cwd,
 			detached: process.platform !== "win32",
+			env: options.env,
 			shell: options.shell === true,
 			stdio: ["ignore", "pipe", "pipe"],
 		});

--- a/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -240,6 +240,38 @@ describe("AgentSession autonomous mode", () => {
 
 		expect(getUserTexts(harness)).toEqual(["make the change"]);
 		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);
+	});
+
+	it("runs autonomous gates with the environment captured at runtime creation", async () => {
+		const originalPath = process.env.PATH;
+		const originalMarker = process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST;
+		try {
+			process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST = "captured";
+			const capturedPath = process.env.PATH;
+			const gate = `${process.execPath} -e "console.error(JSON.stringify({path:process.env.PATH,marker:process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST})); process.exit(1)"`;
+			const state = createAutonomousRuntimeState({
+				enabled: true,
+				maxContinuations: 1,
+				gates: { commands: [gate], maxRetries: 1 },
+			});
+			process.env.PATH = `/agent-controlled/bin${delimiter}${capturedPath ?? ""}`;
+			process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST = "mutated";
+
+			await nextAutonomousContinuation(state, fauxAssistantMessage("Done."), { cwd: process.cwd() });
+
+			expect(state.lastGateFailure?.output).toBe(JSON.stringify({ path: capturedPath, marker: "captured" }));
+		} finally {
+			if (originalPath === undefined) {
+				delete process.env.PATH;
+			} else {
+				process.env.PATH = originalPath;
+			}
+			if (originalMarker === undefined) {
+				delete process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST;
+			} else {
+				process.env.PRIME_AGENT_AUTONOMOUS_GATE_ENV_TEST = originalMarker;
+			}
+		}
 	});
 
 	it("feeds failing autonomous gate output back into the session", async () => {


### PR DESCRIPTION
## What was broken

In autonomous mode, the quality gate command (for example a test suite that must pass before the agent may finish) ran with whatever environment variables the process had at the moment the gate ran - including changes made while the agent was working. During testing we watched an agent defeat a gate by making it pick up a different program than intended. The gate is supposed to be the independent judge of the agent's work; the agent should not be able to change the judge's rules mid-game.

## The fix

The environment (including PATH) is captured once, when the autonomous run starts, and every gate execution uses that captured copy. Whatever the agent does to the environment afterwards, the gate does not see it. We deliberately did not restrict PATH beyond that: gates legitimately need user tools (project-local binaries, version managers, virtualenvs), so they keep the environment the user started with - just frozen.

## Testing

New test changes PATH and another variable after the run starts and confirms the gate still sees the original values. Full autonomous test file passes (23/23).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how autonomous gate subprocesses resolve PATH and env vars; intended security/isolation fix with a clear behavioral contract, but gates that relied on env updated mid-session would no longer see those updates.
> 
> **Overview**
> **Autonomous quality gates** previously inherited whatever `process.env` looked like at gate execution time, which let an agent alter PATH or other variables mid-run and change which binaries or behavior the gate saw.
> 
> This PR adds **`gateEnvironment`** on autonomous runtime state: a shallow copy of `process.env` at **`createAutonomousRuntimeState`**. Gate runs pass that snapshot into **`runChildProcess`** via a new optional **`env`** argument instead of the default live environment.
> 
> **Behavioral change:** gates keep the user’s starting environment (including project-local tools on PATH) but ignore env changes made after the autonomous runtime was created—including changes from the agent itself.
> 
> A regression test mutates PATH and a marker variable after state creation and asserts the failing gate still reports the captured values. The unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad02670161b6cc13886d930e477a0099271ab6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix autonomous quality gates to use environment captured at runtime creation
> - Agents could previously pollute quality gate execution by mutating `process.env` (e.g. PATH) after the autonomous runtime was created, causing gates to run with agent-modified environment variables.
> - `createAutonomousRuntimeState` in [autonomous.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/606/files#diff-cef9072ed18a98248d540106d118245ee4a0ffc2474a184e812f705f89245e76) now captures a shallow copy of `process.env` at creation time and stores it as `gateEnvironment`.
> - `runAutonomousQualityGates` passes this captured environment to `runChildProcess`, which now accepts an optional `env` parameter forwarded to `spawn`.
> - Behavioral Change: gate commands now always run with the environment as it existed when the runtime was created, ignoring any subsequent mutations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad02670.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->