### PR TITLE
fix(coding-agent): don't let leftover junk files block daemon startup forever

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed daemon startup failing permanently when an interrupted supervisor owner directory contained only stray files.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -623,7 +623,8 @@ function readOwnerRecordForScope(
 		return owner;
 	}
 	const scope = readOwnerScope(directory);
-	if (!scope && readdirSync(directory).length === 0) {
+	const entries = !scope ? readdirSync(directory) : [];
+	if (!scope && !entries.includes("owner.json") && !entries.includes("scope.json")) {
 		const abandonedDirectory = `${directory}.abandoned-${randomUUID()}`;
 		renameSync(directory, abandonedDirectory);
 		rmSync(abandonedDirectory, { recursive: true, force: true });

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -924,6 +924,26 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		await owner.release();
 	});
 
+	it("reclaims owner directories containing only stray files", async () => {
+		const paths = await createPaths();
+		const abandonedDirectory = join(paths.registryDir, "abandoned-owner.owner");
+		mkdirSync(abandonedDirectory, { recursive: true });
+		writeFileSync(join(abandonedDirectory, ".DS_Store"), "stray");
+
+		const owner = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "healthy-owner",
+			registryDir: paths.registryDir,
+			socketPath: paths.socketPath,
+		});
+
+		expect(existsSync(abandonedDirectory)).toBe(false);
+		expect(owner.record.generation).toBe("healthy-owner");
+		await owner.release();
+	});
+
 	it("persists a fence when immutable scope proves a corrupt owner is unrelated", async () => {
 		const paths = await createPaths();
 		const targetOwner = await acquireDaemonSupervisorOwnership({


### PR DESCRIPTION
## What was broken

The daemon keeps small bookkeeping folders that say "a daemon is running here". On macOS these live in a temp area the OS cleans up by file age - and the cleaner sometimes deletes the files inside a folder but leaves the folder itself behind, possibly with junk like `.DS_Store` in it. A previous fix (#532) taught startup to remove such a leftover folder if it was completely empty. But if the folder contained any stray file, startup still treated it as a corrupted record and refused to start - permanently, on every attempt, until someone deleted the folder by hand. A user hit exactly this and had to debug it themselves.

## The fix

Startup now checks for the two files that actually make up a claim (`owner.json` and `scope.json`). If neither exists, the folder cannot belong to a live daemon, no matter what else is lying around in it - so it is cleaned up and startup proceeds. If a claim file is present but unreadable, startup still refuses to run, exactly as before: that case is deliberately conservative (an existing test pins it) because a present-but-unreadable claim could in principle belong to a live daemon from another version.

## Testing

New test: a claim folder containing only a `.DS_Store` gets cleaned up and startup succeeds. Verified end to end on a build: before the fix the daemon process died with "Invalid daemon supervisor owner record"; after it, the daemon starts and the junk folder is gone. The existing test that pins the conservative corrupt-file behavior passes unchanged. (One unrelated test in the same file fails on this machine even on clean main - pre-existing local issue.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to abandoned-directory detection during ownership acquisition; conservative handling when claim files are present is unchanged.
> 
> **Overview**
> **Daemon startup** no longer gets stuck forever when a leftover supervisor owner folder has junk (e.g. `.DS_Store`) but no real claim files.
> 
> `readOwnerRecordForScope` used to treat only **completely empty** directories as abandoned. Folders with any stray file were treated as corrupt and blocked every startup with `Invalid daemon supervisor owner record`. The reclaim path now treats a directory as abandoned when it has **no** `scope.json` and **neither** `owner.json` nor `scope.json` on disk—other files are ignored. If either claim file exists but is unreadable, behavior is unchanged (still fail closed).
> 
> Adds a regression test for a `.DS_Store`-only owner directory and an unreleased changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d715d31eeaef77d80252b3198841ac75ec66351a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon startup blocked by stray files in supervisor owner directories
> Previously, `readOwnerRecordForScope` only reclaimed an owner directory if it was completely empty. If an interrupted startup left behind stray files (e.g. `.DS_Store`), the directory would not be reclaimed and daemon startup would fail permanently.
>
> - Updates the abandonment check in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/607/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) to consider a directory abandoned when it lacks both `owner.json` and `scope.json`, regardless of other files present.
> - Abandoned directories are renamed with an `.abandoned-<uuid>` suffix and deleted, allowing ownership acquisition to proceed.
> - Adds a regression test covering the stray-files case using `.DS_Store` as the stray file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d715d31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->