### PR TITLE
fix(coding-agent): declare argument hints for name, model, export, and import

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added missing argument hints to /name, /model, /export, and /import in autocomplete.
+
 - Fixed `stop` and `rename` rejecting custom daemon socket options.
 - Fixed SIGINT in print mode leaving the session active until liveness reclaim.
 - Fixed daemon startup failing permanently when an interrupted supervisor owner directory contained only stray files.

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -86,12 +86,22 @@ interface BuiltinSlashCommandAlias {
 
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
-	{ name: "model", description: "Select model (opens selector UI)" },
+	{ name: "model", description: "Select model (opens selector UI)", argumentHint: "[search]", takesArgument: true },
 	{ name: "effort", description: "Select reasoning/thinking level (opens selector UI)", argumentHint: "[level]" },
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
-	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import and resume a session from a JSONL file" },
+	{
+		name: "export",
+		description: "Export session (HTML default, or specify path: .html/.jsonl)",
+		argumentHint: "[path]",
+		takesArgument: true,
+	},
+	{
+		name: "import",
+		description: "Import and resume a session from a JSONL file",
+		argumentHint: "<path.jsonl>",
+		takesArgument: true,
+	},
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{
@@ -100,7 +110,12 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 		argumentHint: "<question>",
 		takesArgument: true,
 	},
-	{ name: "name", description: "Set session display name" },
+	{
+		name: "name",
+		description: "Set or show the session display name",
+		argumentHint: "[name]",
+		takesArgument: true,
+	},
 	{ name: "session", description: "Show session info" },
 	{ name: "system-prompt", description: "Show the exact system prompt sent to the model" },
 	{ name: "logs", description: "Show where daemon and client logs are saved" },

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -64,6 +64,17 @@ describe("built-in slash commands", () => {
 	});
 
 	test("marks argument commands as taking a free-form argument", () => {
+		for (const [name, argumentHint] of [
+			["model", "[search]"],
+			["export", "[path]"],
+			["import", "<path.jsonl>"],
+			["name", "[name]"],
+		] as const) {
+			expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === name)).toMatchObject({
+				argumentHint,
+				takesArgument: true,
+			});
+		}
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "goal")).toMatchObject({
 			takesArgument: true,
 		});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -92,7 +92,9 @@ describe("slash command aliases", () => {
 			aliases: ["usage"],
 		});
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "name")).toMatchObject({
-			description: "Set session display name",
+			description: "Set or show the session display name",
+			argumentHint: "[name]",
+			takesArgument: true,
 			aliases: ["rename"],
 		});
 	});


### PR DESCRIPTION
## What was broken

Four slash commands accept arguments in their handlers but never declared them, so the autocomplete popup showed them as bare names with no hint that they take anything:

- `/name <name>` sets the session name (shows the current one when called without an argument) - the description also did not mention the argument
- `/model [search]` prefilters the model selector
- `/export [path]` picks the output file (`.html` or `.jsonl`)
- `/import <path.jsonl>` requires the file to import

They were also not marked as argument commands, so the editor did not apply command-token styling while typing arguments after them.

## The fix

Declared `argumentHint` and `takesArgument` for all four in the builtin command list, and reworded /name's description to "Set or show the session display name". Data-only change; no rendering logic touched.

## Example

Before:

<img width="437" height="121" alt="image" src="https://github.com/user-attachments/assets/c8e33ecd-3e94-40d4-964c-551c81880e4c" />

After:

<img width="437" height="121" alt="image" src="https://github.com/user-attachments/assets/ca291876-29ed-4397-993d-63d5b5848c5a" />

## Testing

Existing slash-command test extended to pin /name's hint and argument flag (17/17 pass). Verified in the TUI that the popup now shows `name [name]`, `model [search]`, `export [path]`, and `import <path.jsonl>`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only updates to builtin slash-command metadata and tests; no execution or security paths changed.
> 
> **Overview**
> **Autocomplete and editor styling** for four built-in slash commands that already accepted arguments but were listed without metadata.
> 
> `/model`, `/export`, `/import`, and `/name` now declare `argumentHint` (`[search]`, `[path]`, `<path.jsonl>`, `[name]`) and `takesArgument: true` in `CANONICAL_BUILTIN_SLASH_COMMANDS`, so the popup shows expected syntax and the editor can treat trailing text as command arguments. `/name`'s description is updated to **"Set or show the session display name"**.
> 
> Tests pin the new hints and flags; the changelog notes the fix. No handler or rendering logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c6397269c0333c2393ef548dc6271d2ad7ef6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add argument hints to `/name`, `/model`, `/export`, and `/import` slash commands
> Adds `argumentHint` and `takesArgument` metadata to the `/name`, `/model`, `/export`, and `/import` entries in `CANONICAL_BUILTIN_SLASH_COMMANDS` so autocomplete surfaces argument hints for these commands. Also updates the `/name` description to "Set or show the session display name".
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #609 opened
>
> - Added test assertions verifying that `model`, `export`, `import`, and `name` slash commands have correct `argumentHint` values and `takesArgument` set to `true` [65c6397]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f9f5d3.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->