### PR TITLE
refresh Prime Agent README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Prime Agent: A Self-Improving RLM Agent
   </a>
 </p>
 
-Prime Agent is an open-source coding and research agent for work that takes longer than one chat window. It is designed around two core abstractions:
+Prime Agent is an open-source coding and research agent for general and long-running work. It is designed around two core abstractions:
 
-- The **[Recursive Language Model (RLM)](https://www.primeintellect.ai/blog/rlm)** treats context and subagent delegation as variables and function calls inside a persistent REPL.
+- The **[Recursive Language Model (RLM)](https://www.primeintellect.ai/blog/rlm)** treats context as variables (*prompt-as-a-variable*) and tools like recursive subagents as function calls (*programmatic tool /sub-agent calling*) inside a persistent REPL.
 - The **[Continual Harness](https://arxiv.org/abs/2605.09998)** stores supplemental prompts, memories, skill descriptions, and reusable subagent specifications as durable state that Prime Agent can refine through small, evidence-backed updates, local to the session by default.
 
 Prime Agent combines a persistent Python control environment with durable harness state, so useful working context and reusable operating patterns can outlive a single chat window.
@@ -43,7 +43,7 @@ Prime Agent combines a persistent Python control environment with durable harnes
 - **Agents communicate directly:** running agents can exchange messages and orchestrate one another without routing everything through the user.
 - **Long tasks keep moving:** automatic compaction, persistent goals, heartbeats, schedules, autonomous mode, and retained subagents preserve progress across turns and terminal sessions.
 
-## Quickstart
+## Getting Started
 
 Install the latest stable release on macOS or Linux:
 
@@ -86,6 +86,7 @@ prime-agent shutdown [--force]       # Stop every agent, worker, and background 
 ```
 
 ## Built for Long-Running Work
+Prime Agent is built for long-running work, especially for evaluations in research. These features are available in the TUI, and when run autonomously. 
 
 - **Continual Harness:** `/refine` can persist focused, reviewable lessons as supplemental prompts, memories, reusable skill descriptions, or subagent specifications, with recorded refinement history. It does not replace packaging and reviewing new executable skills.
 - **Direct agent-to-agent communication:** running agents and retained subagents can discover one another, exchange messages, steer active work, or queue follow-ups.
@@ -105,3 +106,11 @@ prime-agent shutdown [--force]       # Stop every agent, worker, and background 
 - [Provider setup](packages/coding-agent/docs/providers.md) — subscription and API-key providers
 - [Architecture overview](packages/coding-agent/docs/architecture.md) — daemon, worker, kernel, and persistence boundaries
 - [Development](packages/coding-agent/docs/development.md) — build and run from source
+
+## Acknowledgements
+
+Our agent and TUI is built on top of [`pi`](https://github.com/earendil-works/pi). We thank the authors of `pi` for their valuable work.
+
+## License
+
+Prime Agent is fully open source and released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 </p>
 
 <h3 align="center">
-Prime Agent: RLM-native Coding and Research Harness
+Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
+  <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a> &bull;
   <a href="https://github.com/badlogic/pi-mono">pi-mono</a>
@@ -27,48 +28,58 @@ Prime Agent: RLM-native Coding and Research Harness
   </a>
 </p>
 
-Prime Agent is a coding and research agent built for long-running tasks.
+Prime Agent is an open-source coding and research agent for work that takes longer than one chat window. It is designed around two core abstractions:
 
-Most agents are optimized for short, single-threaded sessions. As tasks grow, logs and tool output lead to context rot, compaction drops useful details, and one model becomes the bottleneck. Their skills are simply markdown instructions, and sessions require a client to remain open.
+- The **[Recursive Language Model (RLM)](https://www.primeintellect.ai/blog/rlm)** treats context and subagent delegation as variables and function calls inside a persistent REPL.
+- The **[Continual Harness](https://arxiv.org/abs/2605.09998)** stores supplemental prompts, memories, skill descriptions, and reusable subagent specifications as durable state that Prime Agent can refine through small, evidence-backed updates, local to the session by default.
 
-Prime Agent combines a [Recursive Language Model (RLM)](https://www.primeintellect.ai/blog/rlm) runtime with durable background processes:
+Prime Agent combines a persistent Python control environment with durable harness state, so useful working context and reusable operating patterns can outlive a single chat window.
 
-- **Everything is programmatic:** persistent IPython is the only built-in model tool; file operations, shell commands, tool use, and context management happen through code.
-- **Subagents are built in:** `rlm(...)` spawns real child agents from Python for parallel or background work and returns their results programmatically.
+- **Everything is programmatic:** persistent IPython is the built-in model tool; file operations, shell commands, tool use, subagents, and context management happen through code.
+- **Subagents are built in:** `rlm(...)` spawns real child agents for parallel or background work and returns their results programmatically.
+- **The harness can improve:** `/refine` reviews the current trajectory and can apply small, evidence-backed updates to supplemental harness state. It never rewrites the immutable base system prompt, and recorded snapshots support rollback.
 - **Skills are executable:** skills are importable Python packages, and the built-in skill creator can turn recurring workflows into project or personal skills.
 - **Sessions run in the background:** daemon-backed agents keep running when the terminal disconnects and can be reattached later.
 - **Agents communicate directly:** running agents can exchange messages and orchestrate one another without routing everything through the user.
-- **Long tasks keep moving:** automatic compaction, persistent goals, heartbeats, cron schedules, autonomous mode, and retained subagents preserve progress across turns and terminal sessions.
+- **Long tasks keep moving:** automatic compaction, persistent goals, heartbeats, schedules, autonomous mode, and retained subagents preserve progress across turns and terminal sessions.
 
-## Getting Started
+## Quickstart
 
-Install the latest stable release:
+Install the latest stable release on macOS or Linux:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
-Install the latest beta built from `main`:
+The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent.
+
+To try the latest beta built from `main`:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install-beta.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
-Stable advances when a version bump lands on `main`; beta advances on every commit to `main`.
+Use the stable channel for normal work. Beta advances with successful builds from `main`.
 
-Then start Prime Agent:
+Start Prime Agent from the repository or directory you want it to work in:
 
 ```bash
+cd /path/to/project
 prime-agent
 ```
 
-Public releases are currently installed from versioned release artifacts through these installer scripts. The repository still contains inherited npm workspace identifiers for source compatibility; they are not the user-facing Prime Agent install path.
+On first launch, run `/login` to choose a subscription or API-key provider. Prime Agent works in the current directory and can run commands and modify files there. Use a disposable clone, clean worktree, or another checkpoint you can inspect and restore.
 
-Other useful commands:
+> [!WARNING]
+> Prime Agent executes model-generated Python and project commands with your user permissions. Its worker and kernel processes improve lifecycle isolation and recovery; they are **not** a security sandbox. Review changes and use trusted repositories, instructions, skills, and extensions only. Run untrusted code or instructions in an external sandbox or restricted environment.
+
+Useful commands:
 
 ```bash
-prime-agent agents                   # Search running, idle, and inactive sessions
-prime-agent --resume <path|id>       # Resume a specific session
+prime-agent agents                   # Browse running, idle, and saved sessions
+prime-agent attach <agent>           # Reattach to a running session
+prime-agent --resume <path|id>       # Resume a saved session
+prime-agent status                   # Inspect background service state
 prime-agent doctor [--fix]           # Inspect or repair background services
 prime-agent update [--force]         # Update Prime Agent
 prime-agent shutdown [--force]       # Stop every agent, worker, and background service
@@ -76,19 +87,21 @@ prime-agent shutdown [--force]       # Stop every agent, worker, and background 
 
 ## Built for Long-Running Work
 
+- **Continual Harness:** `/refine` can persist focused, reviewable lessons as supplemental prompts, memories, reusable skill descriptions, or subagent specifications, with recorded refinement history. It does not replace packaging and reviewing new executable skills.
 - **Direct agent-to-agent communication:** running agents and retained subagents can discover one another, exchange messages, steer active work, or queue follow-ups.
 - **Daemon-backed continuity:** active sessions, IPython state, schedules, and subagents keep running when the terminal detaches and can be reattached later.
 - **Heartbeats and schedules:** `/heartbeat`, `rlm_heartbeat`, and `prime-agent schedule` can re-enter a session periodically or at a specific time.
 - **Persistent goals:** `/goal` keeps an objective and its progress active across turns until it is completed, paused, or cleared.
-- **Bounded autonomous mode:** `/autonomous` continues working until its quality gates pass or a configured turn, token, or time limit is reached.
+- **Bounded autonomous mode:** `/autonomous` continues within configured turn, token, and time budgets and can run user-defined quality gates. A passed gate checks only what that gate verifies; reaching a limit does not imply task success.
 
 ## Documentation
 
-- [Documentation index](packages/coding-agent/docs/index.md)
-- [Architecture overview](packages/coding-agent/docs/architecture.md)
-- [Quickstart](packages/coding-agent/docs/quickstart.md)
-- [RLM programming model](packages/coding-agent/docs/rlm.md)
-- [Long-running and background agents](packages/coding-agent/docs/long-running-agents.md)
-- [Usage and CLI reference](packages/coding-agent/docs/usage.md)
-- [Provider setup](packages/coding-agent/docs/providers.md)
-- [Development](packages/coding-agent/docs/development.md)
+- [Quickstart](packages/coding-agent/docs/quickstart.md) — install, authenticate, and run a first session
+- [Usage and CLI reference](packages/coding-agent/docs/usage.md) — commands, sessions, autonomous limits, and output modes
+- [Long-running and background agents](packages/coding-agent/docs/long-running-agents.md) — detach and reattach, goals, heartbeats, and schedules
+- [RLM programming model](packages/coding-agent/docs/rlm.md) — persistent IPython, subagents, skills, and the trust model
+- [JSON mode](packages/coding-agent/docs/json.md) and [RPC mode](packages/coding-agent/docs/rpc.md) — headless automation and integrations
+- [Skills](packages/coding-agent/docs/skills.md) — install and create reusable capabilities
+- [Provider setup](packages/coding-agent/docs/providers.md) — subscription and API-key providers
+- [Architecture overview](packages/coding-agent/docs/architecture.md) — daemon, worker, kernel, and persistence boundaries
+- [Development](packages/coding-agent/docs/development.md) — build and run from source

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -43,13 +43,13 @@ Prime Agent began as a hard fork of [pi-mono](https://github.com/badlogic/pi-mon
 ## Quick Start
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 To install the beta built from the latest commit on `main`:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install-beta.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
 Authenticate with an API key:

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -7,7 +7,7 @@ Prime Agent is an RLM-native coding and research harness built around a persiste
 Install the latest stable release on Linux or macOS:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 Then run it in a project directory:

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -7,16 +7,16 @@ This page gets you from install to a useful first Prime Agent session.
 Install the latest stable release on Linux or macOS:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
 To try the latest beta built from `main`:
 
 ```bash
-curl -fsSL https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install-beta.sh | sh
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
-Both installers fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
+Both commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
 
 Then start Prime Agent in the project directory you want it to work on:
 


### PR DESCRIPTION
## Summary

- switches the public quickstart to the canonical `app.primeintellect.ai` installer endpoint, including beta-channel invocation through the same script
- aligns the README positioning with Prime Agent's RLM and Continual Harness architecture while keeping refinement scope and the immutable base-prompt boundary explicit
- adds practical first-run authentication, working-directory, and security guidance
- improves session-management commands and documentation navigation for headless modes, skills, providers, and architecture

## Validation

- public stable installer returned HTTP 200 for the exact documented `curl` command
- downloaded installer passed `sh -n`; source inspection confirmed `beta` is a supported positional channel
- all relative README links resolve in the worktree
- `git diff --check`
- `npm run check`

## Scope

Documentation-only across the top-level README, package README, documentation index, and quickstart. The launch-blog framing informed the concise product description; evolving benchmark results and unpublished media are intentionally not duplicated here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to user-facing docs; no runtime, auth, or install script code is modified in this PR.
> 
> **Overview**
> **Documentation-only** refresh of the top-level README and aligned install instructions in `packages/coding-agent/README.md`, `docs/index.md`, and `docs/quickstart.md`.
> 
> Public install commands now point at `https://app.primeintellect.ai/prime-agent/install.sh`, with beta via `sh -s -- beta` instead of a separate `install-beta.sh` URL on the old R2 host. Getting Started adds installer behavior (checksum, IPython prep), `/login`, working-directory guidance, and a **security warning** that execution is not sandboxed.
> 
> The root README reframes the product around **RLM** and **Continual Harness**, documents **`/refine`** (supplemental harness state, immutable base prompt, rollback), tightens autonomous-mode wording, and expands CLI examples (`attach`, `status`). Documentation links are reorganized with short blurbs; **Acknowledgements** (`pi`) and **License** sections are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab8d342f163c985f19af55415592087a77e0838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh Prime Agent README with updated install URLs and documentation
> - Updates install script URLs across [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/610/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [packages/coding-agent/README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/610/files#diff-b28d42a35be05803ac5e2fb345eca35f4a26a730b783c0447e5b5204b6e1211f), [docs/index.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/610/files#diff-218d46321638f6fc86d50aefd277a2551b50e631d37a957a72e9abac03aa1d8c), and [quickstart.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/610/files#diff-23cbacf5e20c0132ac6466ddd518211157234350e0735c29513c748000eee03e) to use `https://app.primeintellect.ai/prime-agent/install.sh`, with beta channel via `sh -s -- beta`.
> - Rewrites the introduction to emphasize the RLM and Continual Harness abstractions, and documents the `/refine` command for persisting supplemental prompts, memories, skills, and specs.
> - Adds CLI command descriptions for `attach <agent>` and `status`, and updates `resume` description.
> - Adds a warning about executing model-generated Python and commands without sandbox guarantees.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #610 opened
>
> - Updated product positioning to emphasize general and long-running work capabilities [2ab8d34]
> - Expanded the 'Built for Long-Running Work' section with additional context about availability and use cases [2ab8d34]
> - Renamed the 'Quickstart' section header to 'Getting Started' [2ab8d34]
> - Added 'Acknowledgements' section crediting the `pi` project [2ab8d34]
> - Added 'License' section documenting MIT License [2ab8d34]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 089027b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->