### PR TITLE
fix(ai): drop the delisted groq qwen3-32b reasoning special case

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Removed the groq `qwen/qwen3-32b` reasoning-effort special case and its test; groq delisted the model, which broke CI catalog regeneration.
+
 ## [0.5.1] - 2026-08-04
 
 ## [0.5.0] - 2026-08-03

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -338,9 +338,6 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	if (isGoogleThinkingApi(model) && isGemma4Model(model.id)) {
 		mergeThinkingLevelMap(model, { off: null, minimal: "MINIMAL", low: null, medium: null, high: "HIGH" });
 	}
-	if (model.provider === "groq" && model.id === "qwen/qwen3-32b") {
-		mergeThinkingLevelMap(model, { minimal: null, low: null, medium: null, high: "default" });
-	}
 	if (
 		model.provider === "openai-codex" &&
 		supportsOpenAiXhigh(model.id) &&

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -156,34 +156,6 @@ describe("openai-completions tool_choice", () => {
 		expect("strict" in (tool ?? {})).toBe(false);
 	});
 
-	it("maps groq qwen3 reasoning levels to default reasoning_effort", async () => {
-		const model = getModel("groq", "qwen/qwen3-32b")!;
-		let payload: unknown;
-
-		await streamSimple(
-			model,
-			{
-				messages: [
-					{
-						role: "user",
-						content: "Hi",
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{
-				apiKey: "test",
-				reasoning: "medium",
-				onPayload: (params: unknown) => {
-					payload = params;
-				},
-			},
-		).result();
-
-		const params = (payload ?? mockState.lastParams) as { reasoning_effort?: string };
-		expect(params.reasoning_effort).toBe("default");
-	});
-
 	it("keeps normal reasoning_effort for groq models without compat mapping", async () => {
 		const model = getModel("groq", "openai/gpt-oss-20b")!;
 		let payload: unknown;


### PR DESCRIPTION
## Problem

CI is red on every branch: groq delisted `qwen/qwen3-32b`, so the catalog regeneration during build drops the model and the typed `getModel("groq", "qwen/qwen3-32b")` literal in `openai-completions-tool-choice.test.ts` no longer compiles.

## Fix

The `generate-models.ts` special case and its test targeted only that model, so both are removed. The committed catalog snapshot is untouched; the next regeneration drops the stale entry on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small cleanup tied to a delisted model; no changes to live streaming or reasoning logic for other groq routes.
> 
> **Overview**
> Groq delisted **`qwen/qwen3-32b`**, which broke CI: catalog regeneration no longer includes that route, and **`openai-completions-tool-choice.test.ts`** still called **`getModel("groq", "qwen/qwen3-32b")`**, so TypeScript failed.
> 
> This PR removes the only-consumer logic: the **`generate-models.ts`** block that merged a **`thinkingLevelMap`** mapping minimal/low/medium to null and high to **`default`** for that groq id, plus the test that asserted **`reasoning_effort: "default"`** for **`reasoning: "medium`**. The **[Unreleased]** changelog entry documents the fix. The committed **`models.generated.ts`** snapshot is not edited here; the next **`generate-models`** run drops the stale groq entry on its own.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84ac1871890235d0f9a8603a4b3231f4ffb9431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Groq `qwen/qwen3-32b` reasoning-effort special case due to model delisting
> Removes the conditional branch in `applyThinkingLevelMetadata` that mapped reasoning levels for the now-delisted Groq `qwen/qwen3-32b` model, along with its associated test case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d84ac18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->