### PR TITLE
fix(coding-agent): target the merged agent-message roster API in ACP kernel test

### DIFF
--- a/packages/coding-agent/test/acp-kernel-features.test.ts
+++ b/packages/coding-agent/test/acp-kernel-features.test.ts
@@ -205,20 +205,10 @@ print(json.dumps({
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [AGENT_MESSAGE_SKILL],
 			hostHandlers: {
-				// Host request type on main is "agent_message.list"; the roster rename
-				// lives in an unmerged stack, so this branch targets main's API.
-				"agent_message.list": async () => ({
-					current: { activeSessionId: "alpha", sessionId: "session-alpha" },
-					agents: [
-						{
-							activeSessionId: "beta",
-							sessionId: "session-beta",
-							sessionName: "reviewer",
-							cwd: tempDir,
-							isStreaming: false,
-							unfinishedActionCount: 0,
-						},
-					],
+				// The family roster: parent, siblings, and children of this agent.
+				"agent_message.list_agents": async () => ({
+					current: { name: "root", id: "session-alpha", depth: 0 },
+					entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
 				}),
 				"agent_message.send": async (payload) => ({
 					id: "agentmsg-acp",
@@ -246,9 +236,9 @@ print(json.dumps({
 		const result = await manager.execute(`
 import json
 roster = await agent_message.list_agents()
-receipt = await agent_message.send("beta", "status update")
+receipt = await agent_message.send("status update", receiver_role="child", receiver_name="reviewer")
 print(json.dumps({
-    "roster": [a.get("sessionName") for a in roster["agents"]],
+    "roster": [e["name"] for e in roster["entries"]],
     "status": receipt["deliveryStatus"],
 }))
 `);


### PR DESCRIPTION
`main` is red: `test/acp-kernel-features.test.ts` fails in shard 2/3, which is also blocking the v0.6.0 release PR (#614).

## Cause

Not flaky — a real API mismatch between two PRs that were developed in parallel and merged close together.

The ACP kernel test stubbed the host request `agent_message.list` and called the positional `send(target, message)` form. #597 renamed that request to `agent_message.list_agents` and made sends role-addressed, so the bundled skill now raises:

```
RuntimeError
Cell In[3], line 2
----> 2 roster = await agent_message.list_agents()
File .../skills/agent-message/src/agent_message/__init__.py:21, in list_agents()
---> 21     return await host_request("agent_message.list_agents")
```

The test's own comment admitted the risk — "the roster rename lives in an unmerged stack, so this branch targets main's API" — and that stack has since merged. Mine, and it should have been rebased before merge.

## Fix

Stub `agent_message.list_agents` returning the family roster shape (`current` plus `entries` with `relationship`/`name`/`id`/`depth`/`status`), and send with `receiver_role="child", receiver_name="reviewer"`.

Test-only; no production code changed.

## Verification

`test/acp-kernel-features.test.ts` 4/4 pass against merged main, including the real IPython kernel. Full ACP suite 48/48. `npm run check` clean.

#614 should go green once this lands and it is rebased or re-run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only stub and assertion updates with no production code paths touched.
> 
> **Overview**
> Repairs a failing real-IPython ACP integration test that still mocked the pre-merge **agent_message** host API.
> 
> The test host stub now handles **`agent_message.list_agents`** with the family roster shape (`current` plus `entries` with relationship/name/id/depth/status), and the kernel cell calls **`list_agents()`** and **`send(..., receiver_role="child", receiver_name="reviewer")`** instead of **`list`** / positional target sends. Assertions read roster names from **`entries`**, not the old **`agents`** list.
> 
> Test-only change; no production behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ac1dacbd9c259a56e99b524f49c1c678617df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ACP kernel test to target the merged agent-message roster and send APIs
> Updates the `sends an agent-to-agent message from the kernel and surfaces it over ACP` test in [acp-kernel-features.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/615/files#diff-411dc1b69b01f554b73e1be3a5b08773594c19b3445c7acfa6b05b89a180170d) to match the new agent message API shape.
>
> - Replaces the mock handler key `agent_message.list` with `agent_message.list_agents` and updates the returned shape: `agents` array becomes `entries` with fields `{ relationship, name, id, depth, status }` and `current` now uses `{ name, id, depth }`.
> - Updates the Python snippet in the test to call `agent_message.send("status update", receiver_role="child", receiver_name="reviewer")` instead of `agent_message.send("beta", "status update")`.
> - Updates roster parsing in the Python snippet from `a.get("sessionName")` to `e["name"]` over `roster["entries"]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5ac1da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->