### PR TITLE
fix(coding-agent): run ACP kernel tests in their own CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
             package: packages/coding-agent
             command: npm run test:process
             install_uv: true
+          - name: coding-agent kernel
+            package: packages/coding-agent
+            command: npm run test:kernel
+            install_uv: true
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -43,7 +43,8 @@
 		"test:process-stress": "vitest --run --tagsFilter process-stress test/daemon-supervisor-process.test.ts",
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
-		"bundle": "node scripts/bundle.mjs"
+		"bundle": "node scripts/bundle.mjs",
+		"test:kernel": "vitest --run --tagsFilter kernel-heavy test/acp-kernel-features.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/test/acp-kernel-features.test.ts
+++ b/packages/coding-agent/test/acp-kernel-features.test.ts
@@ -59,7 +59,7 @@ describe("ACP mode over a real IPython kernel", () => {
 
 	it(
 		"keeps IPython state across cells and represents each cell as an ACP execute call",
-		{ tags: ["kernel-heavy"] },
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
 		async () => {
 			// Every provisioner in this file requests the same skill set: the kernel venv
 			// is shared, and a skill-less kernel here can leave a later skill-dependent
@@ -86,7 +86,7 @@ describe("ACP mode over a real IPython kernel", () => {
 
 	it(
 		"runs continual-harness CRUD in the kernel and can represent the result over ACP",
-		{ tags: ["kernel-heavy"] },
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
 		async () => {
 			provisioner = new IpythonKernelProvisioner(tempDir, {
 				pythonSkills: [AGENT_MESSAGE_SKILL],
@@ -161,7 +161,7 @@ print(json.dumps({
 
 	it(
 		"exposes rlm depth and subagent APIs to the kernel behind the ACP front end",
-		{ tags: ["kernel-heavy"] },
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
 		async () => {
 			provisioner = new IpythonKernelProvisioner(tempDir, {
 				pythonSkills: [AGENT_MESSAGE_SKILL],
@@ -215,7 +215,7 @@ print(json.dumps({
 
 	it(
 		"sends an agent-to-agent message from the kernel and surfaces it over ACP",
-		{ tags: ["kernel-heavy"] },
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
 		async () => {
 			provisioner = new IpythonKernelProvisioner(tempDir, {
 				pythonSkills: [AGENT_MESSAGE_SKILL],

--- a/packages/coding-agent/test/acp-kernel-features.test.ts
+++ b/packages/coding-agent/test/acp-kernel-features.test.ts
@@ -57,37 +57,44 @@ describe("ACP mode over a real IPython kernel", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("keeps IPython state across cells and represents each cell as an ACP execute call", async () => {
-		// Every provisioner in this file requests the same skill set: the kernel venv
-		// is shared, and a skill-less kernel here can leave a later skill-dependent
-		// test with an unsynced venv when files run concurrently.
-		provisioner = new IpythonKernelProvisioner(tempDir, { pythonSkills: [AGENT_MESSAGE_SKILL] });
-		const manager: KernelManager = await provisioner.ensure();
+	it(
+		"keeps IPython state across cells and represents each cell as an ACP execute call",
+		{ tags: ["kernel-heavy"] },
+		async () => {
+			// Every provisioner in this file requests the same skill set: the kernel venv
+			// is shared, and a skill-less kernel here can leave a later skill-dependent
+			// test with an unsynced venv when files run concurrently.
+			provisioner = new IpythonKernelProvisioner(tempDir, { pythonSkills: [AGENT_MESSAGE_SKILL] });
+			const manager: KernelManager = await provisioner.ensure();
 
-		const first = await manager.execute("acp_state = 41\nprint('set')");
-		expect(first.status).toBe("ok");
-		// Persistence is the whole point of the kernel: a second cell must see it.
-		const second = await manager.execute("print(acp_state + 1)");
-		expect(second.status).toBe("ok");
-		expect(second.stdout.trim()).toBe("42");
+			const first = await manager.execute("acp_state = 41\nprint('set')");
+			expect(first.status).toBe("ok");
+			// Persistence is the whole point of the kernel: a second cell must see it.
+			const second = await manager.execute("print(acp_state + 1)");
+			expect(second.status).toBe("ok");
+			expect(second.stdout.trim()).toBe("42");
 
-		const updates = acpUpdatesForSessionEvent(toolEndEvent("cell-2", second.stdout));
-		expect(updates[0]).toMatchObject({
-			sessionUpdate: "tool_call_update",
-			toolCallId: "cell-2",
-			status: "completed",
-		});
-		expect(JSON.stringify(updates[0]?.content)).toContain("42");
-	}, 180_000);
+			const updates = acpUpdatesForSessionEvent(toolEndEvent("cell-2", second.stdout));
+			expect(updates[0]).toMatchObject({
+				sessionUpdate: "tool_call_update",
+				toolCallId: "cell-2",
+				status: "completed",
+			});
+			expect(JSON.stringify(updates[0]?.content)).toContain("42");
+		},
+	);
 
-	it("runs continual-harness CRUD in the kernel and can represent the result over ACP", async () => {
-		provisioner = new IpythonKernelProvisioner(tempDir, {
-			pythonSkills: [AGENT_MESSAGE_SKILL],
-			env: { RLM_GLOBAL_HARNESS_STATE_DIR: join(tempDir, "harness") },
-		});
-		const manager = await provisioner.ensure();
+	it(
+		"runs continual-harness CRUD in the kernel and can represent the result over ACP",
+		{ tags: ["kernel-heavy"] },
+		async () => {
+			provisioner = new IpythonKernelProvisioner(tempDir, {
+				pythonSkills: [AGENT_MESSAGE_SKILL],
+				env: { RLM_GLOBAL_HARNESS_STATE_DIR: join(tempDir, "harness") },
+			});
+			const manager = await provisioner.ensure();
 
-		const allKinds = await manager.execute(`
+			const allKinds = await manager.execute(`
 import json
 mem = rlm.harness.create_memory(title="m", content="memory content", global_=True)
 note = rlm.harness.create_prompt_note(title="n", content="prompt note content", global_=True)
@@ -104,15 +111,15 @@ print(json.dumps({
     "skill_ref": skill.reference.get("import"),
 }, sort_keys=True))
 `);
-		expect(allKinds.status, why(allKinds)).toBe("ok");
-		// Every editable harness kind, not just memory: skills additionally require
-		// a python reference and an argument contract.
-		expect(JSON.parse(allKinds.stdout.trim())).toMatchObject({
-			kinds: ["memory", "prompt", "skill", "subagent"],
-			skill_ref: "pkg.mod",
-		});
+			expect(allKinds.status, why(allKinds)).toBe("ok");
+			// Every editable harness kind, not just memory: skills additionally require
+			// a python reference and an argument contract.
+			expect(JSON.parse(allKinds.stdout.trim())).toMatchObject({
+				kinds: ["memory", "prompt", "skill", "subagent"],
+				skill_ref: "pkg.mod",
+			});
 
-		const result = await manager.execute(`
+			const result = await manager.execute(`
 import json
 entry = rlm.harness.create_memory(
     title="ACP verification memory",
@@ -131,58 +138,62 @@ print(json.dumps({
     "after": after.title if after else None,
 }, sort_keys=True))
 `);
-		expect(result.status, why(result)).toBe("ok");
-		const payload = JSON.parse(result.stdout.trim());
-		expect(payload.found).toBe("ACP verification memory");
-		expect(payload.listed).toContain(payload.created);
-		expect(payload.deleted).toBe(true);
-		expect(payload.after).toBeNull();
+			expect(result.status, why(result)).toBe("ok");
+			const payload = JSON.parse(result.stdout.trim());
+			expect(payload.found).toBe("ACP verification memory");
+			expect(payload.listed).toContain(payload.created);
+			expect(payload.deleted).toBe(true);
+			expect(payload.after).toBeNull();
 
-		// A refinement outcome for that CRUD is expressible as namespaced metadata.
-		const refined = acpUpdatesForSessionEvent({
-			type: "refine_complete",
-			result: {
-				summary: "persisted ACP verification memory",
-				appliedEdits: [{ applied: true, action: "create", kind: "memory", id: payload.created }],
-			},
-		} as AgentConnectionSessionEvent);
-		expect(refined[0]?._meta).toMatchObject({
-			[PRIME_AGENT_META_NAMESPACE]: { refinement: { status: "complete" } },
-		});
-	}, 180_000);
+			// A refinement outcome for that CRUD is expressible as namespaced metadata.
+			const refined = acpUpdatesForSessionEvent({
+				type: "refine_complete",
+				result: {
+					summary: "persisted ACP verification memory",
+					appliedEdits: [{ applied: true, action: "create", kind: "memory", id: payload.created }],
+				},
+			} as AgentConnectionSessionEvent);
+			expect(refined[0]?._meta).toMatchObject({
+				[PRIME_AGENT_META_NAMESPACE]: { refinement: { status: "complete" } },
+			});
+		},
+	);
 
-	it("exposes rlm depth and subagent APIs to the kernel behind the ACP front end", async () => {
-		provisioner = new IpythonKernelProvisioner(tempDir, {
-			pythonSkills: [AGENT_MESSAGE_SKILL],
-			env: { RLM_DEPTH: "0", RLM_MAX_DEPTH: "1" },
-			hostHandlers: {
-				"rlm.list_subagents": async () => ({
-					subagents: [
-						{
-							rlm_child_id: "child-1",
-							active_session_id: "active-1",
+	it(
+		"exposes rlm depth and subagent APIs to the kernel behind the ACP front end",
+		{ tags: ["kernel-heavy"] },
+		async () => {
+			provisioner = new IpythonKernelProvisioner(tempDir, {
+				pythonSkills: [AGENT_MESSAGE_SKILL],
+				env: { RLM_DEPTH: "0", RLM_MAX_DEPTH: "1" },
+				hostHandlers: {
+					"rlm.list_subagents": async () => ({
+						subagents: [
+							{
+								rlm_child_id: "child-1",
+								active_session_id: "active-1",
+								session_id: "session-1",
+								session_name: "reviewer",
+								session_dir: tempDir,
+								status: "completed",
+							},
+						],
+					}),
+					"rlm.delete_subagent": async (payload) => ({
+						subagent: {
+							rlm_child_id: String(payload.target),
+							active_session_id: null,
 							session_id: "session-1",
 							session_name: "reviewer",
 							session_dir: tempDir,
 							status: "completed",
 						},
-					],
-				}),
-				"rlm.delete_subagent": async (payload) => ({
-					subagent: {
-						rlm_child_id: String(payload.target),
-						active_session_id: null,
-						session_id: "session-1",
-						session_name: "reviewer",
-						session_dir: tempDir,
-						status: "completed",
-					},
-				}),
-			},
-		});
-		const manager = await provisioner.ensure();
+					}),
+				},
+			});
+			const manager = await provisioner.ensure();
 
-		const result = await manager.execute(`
+			const result = await manager.execute(`
 import json, os
 children = await rlm.list_subagents()
 removed = await rlm.delete_subagent(children[0])
@@ -193,47 +204,53 @@ print(json.dumps({
     "removed": removed.session_name,
 }, sort_keys=True))
 `);
-		expect(result.status, why(result)).toBe("ok");
-		const payload = JSON.parse(result.stdout.trim());
-		expect(payload.names).toEqual(["reviewer"]);
-		expect(payload.removed).toBe("reviewer");
-		expect(payload.depth).toBe("0");
-		expect(payload.max_depth).toBe("1");
-	}, 180_000);
+			expect(result.status, why(result)).toBe("ok");
+			const payload = JSON.parse(result.stdout.trim());
+			expect(payload.names).toEqual(["reviewer"]);
+			expect(payload.removed).toBe("reviewer");
+			expect(payload.depth).toBe("0");
+			expect(payload.max_depth).toBe("1");
+		},
+	);
 
-	it("sends an agent-to-agent message from the kernel and surfaces it over ACP", async () => {
-		provisioner = new IpythonKernelProvisioner(tempDir, {
-			pythonSkills: [AGENT_MESSAGE_SKILL],
-			hostHandlers: {
-				// The family roster: parent, siblings, and children of this agent.
-				"agent_message.list_agents": async () => ({
-					current: { name: "root", id: "session-alpha", depth: 0 },
-					entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
-				}),
-				"agent_message.send": async (payload) => ({
-					id: "agentmsg-acp",
-					source: "agent_message",
-					target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "reviewer" },
-					message: payload.message,
-					deliveryStatus: "queued",
-					queuedAt: "2026-08-04T00:00:00.000Z",
-					deliveryMode: payload.mode ?? "auto",
-				}),
-			},
-		});
-		const manager = await provisioner.ensure();
+	it(
+		"sends an agent-to-agent message from the kernel and surfaces it over ACP",
+		{ tags: ["kernel-heavy"] },
+		async () => {
+			provisioner = new IpythonKernelProvisioner(tempDir, {
+				pythonSkills: [AGENT_MESSAGE_SKILL],
+				hostHandlers: {
+					// The family roster: parent, siblings, and children of this agent.
+					"agent_message.list_agents": async () => ({
+						current: { name: "root", id: "session-alpha", depth: 0 },
+						entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
+					}),
+					"agent_message.send": async (payload) => ({
+						id: "agentmsg-acp",
+						source: "agent_message",
+						target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "reviewer" },
+						message: payload.message,
+						deliveryStatus: "queued",
+						queuedAt: "2026-08-04T00:00:00.000Z",
+						deliveryMode: payload.mode ?? "auto",
+					}),
+				},
+			});
+			const manager = await provisioner.ensure();
 
-		// The kernel venv is shared across test files. If a concurrently running
-		// file rebuilt it without this skill, say so plainly rather than failing
-		// later with an opaque AttributeError on the stub object.
-		const available = await manager.execute("import json; print(json.dumps({'kind': type(agent_message).__name__}))");
-		expect(available.status, why(available)).toBe("ok");
-		expect(
-			JSON.parse(available.stdout.trim()).kind,
-			"agent_message skill was not installed into the shared kernel venv",
-		).not.toBe("_PrimeAgentUnavailableSkill");
+			// The kernel venv is shared across test files. If a concurrently running
+			// file rebuilt it without this skill, say so plainly rather than failing
+			// later with an opaque AttributeError on the stub object.
+			const available = await manager.execute(
+				"import json; print(json.dumps({'kind': type(agent_message).__name__}))",
+			);
+			expect(available.status, why(available)).toBe("ok");
+			expect(
+				JSON.parse(available.stdout.trim()).kind,
+				"agent_message skill was not installed into the shared kernel venv",
+			).not.toBe("_PrimeAgentUnavailableSkill");
 
-		const result = await manager.execute(`
+			const result = await manager.execute(`
 import json
 roster = await agent_message.list_agents()
 receipt = await agent_message.send("status update", receiver_role="child", receiver_name="reviewer")
@@ -242,22 +259,23 @@ print(json.dumps({
     "status": receipt["deliveryStatus"],
 }))
 `);
-		expect(result.status, why(result)).toBe("ok");
-		const payload = JSON.parse(result.stdout.trim());
-		expect(payload.roster).toEqual(["reviewer"]);
-		expect(payload.status).toBe("queued");
+			expect(result.status, why(result)).toBe("ok");
+			const payload = JSON.parse(result.stdout.trim());
+			expect(payload.roster).toEqual(["reviewer"]);
+			expect(payload.status).toBe("queued");
 
-		// The kernel reports the send; ACP carries it as namespaced metadata.
-		const sentMessages = result.sentAgentMessages ?? [];
-		expect(sentMessages.length).toBeGreaterThan(0);
-		const sent = sentMessages[0];
-		const updates = acpUpdatesForSessionEvent({
-			type: "ipython_sent_agent_message",
-			toolCallId: "cell-msg",
-			message: sent,
-		} as AgentConnectionSessionEvent);
-		expect(updates[0]?._meta).toMatchObject({
-			[PRIME_AGENT_META_NAMESPACE]: { agentMessage: { toolCallId: "cell-msg", deliveryStatus: "queued" } },
-		});
-	}, 180_000);
+			// The kernel reports the send; ACP carries it as namespaced metadata.
+			const sentMessages = result.sentAgentMessages ?? [];
+			expect(sentMessages.length).toBeGreaterThan(0);
+			const sent = sentMessages[0];
+			const updates = acpUpdatesForSessionEvent({
+				type: "ipython_sent_agent_message",
+				toolCallId: "cell-msg",
+				message: sent,
+			} as AgentConnectionSessionEvent);
+			expect(updates[0]?._meta).toMatchObject({
+				[PRIME_AGENT_META_NAMESPACE]: { agentMessage: { toolCallId: "cell-msg", deliveryStatus: "queued" } },
+			});
+		},
+	);
 });

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -17,8 +17,15 @@ export default defineConfig({
 				name: "process-stress",
 				description: "Slow real-process stress and wall-clock scheduling coverage",
 			},
+			{
+				name: "kernel-heavy",
+				description: "Boots a real IPython kernel and syncs skills into the shared venv",
+			},
 		],
-		tagsFilter: ["!process-stress"],
+		// Kernel-heavy tests are excluded from the default sharded run: several files
+		// booting real kernels in one shard starve the neighbouring kernel tests that
+		// rely on the 30s default timeout. `test:kernel` runs them on their own.
+		tagsFilter: ["!process-stress", "!kernel-heavy"],
 		server: {
 			deps: {
 				external: [/@silvia-odwyer\/photon-node/],


### PR DESCRIPTION
`main` has been red since the ACP merge (#613), which also blocks the v0.6.0 release PR (#614). This fixes the cause.

## Diagnosis

Not a logic bug. A *different* kernel skill test times out at 30s on each run — `kernel-rlm-heartbeat-skill` on main, `kernel-goal-skill` on #614. That varying-victim pattern is contention.

Every kernel test boots a real IPython kernel and may sync skills into a shared venv. Measured locally on a cold venv, interleaved:

| | time |
|---|---|
| goal / heartbeat / agent-message, **without** the ACP file | 11–14s each |
| same, **with** the ACP file | 12–15s each |
| all of them after CI's `bootstrap-cli.ts` pre-warm | 5–8s each |

So those files were already running at roughly half the 30s budget before ACP existed. The ACP file adds a fourth kernel-booting file to the same shard, and on a loaded runner that is enough to push one neighbour over. The ACP tests themselves never fail, because they carry explicit 180s timeouts — the tests that break are the ones relying on the repo default.

## Fix

Tag the four ACP kernel tests `kernel-heavy`, exclude that tag from the default sharded run, and add a `coding-agent kernel` job that runs them.

They keep their 180s budget and still run on every PR — this is segregation, not deletion. It mirrors how `process-stress` already separates heavy real-process coverage.

## Verification

- dedicated job: 4/4 pass
- default run: correctly skips them, so they cannot crowd a shard
- previously failing `kernel-goal-skill`, `kernel-rlm-heartbeat-skill`, and `kernel-agent-message-skill`: pass on a cold venv
- remaining ACP suite: 44/44
- `npm run check` clean

## Wrong turn worth recording

My first theory was that the ACP tests thrashed the venv by requesting different skill sets. I implemented that fix and measured it: timings were **identical**, and a baseline without the ACP file showed the same 11–14s. The theory was wrong, so I reverted it rather than shipping a plausible-looking no-op.

## ACP against merged main

Separately confirmed ACP still works with #583–#597 merged: full suite 48/48, and the real CLI answers `initialize` on stdout with zero protocol frames on stderr.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI wiring only; no runtime or product behavior changes.
> 
> **Overview**
> Addresses flaky CI timeouts by **segregating** real IPython kernel tests in `acp-kernel-features.test.ts` from the default sharded `test:ci` run, instead of removing coverage.
> 
> The four ACP kernel integration tests are tagged **`kernel-heavy`** (with **180s** per-test timeouts kept on each case). Default Vitest runs now exclude both `process-stress` and **`kernel-heavy`** via `tagsFilter`, so those tests no longer compete with other kernel tests that rely on the **30s** default timeout on a shared venv.
> 
> A new **`test:kernel`** script runs only the tagged tests in that file, and CI adds a **`coding-agent kernel`** matrix job that runs it (with `uv`), mirroring the existing process-smoke split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dbdfe3acf4159aef616a65c87d97105096a19e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run coding-agent ACP kernel tests in a dedicated CI job
> - Adds a `test:kernel` npm script in `packages/coding-agent` that runs `vitest` filtered to the `kernel-heavy` tag against [acp-kernel-features.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/616/files#diff-411dc1b69b01f554b73e1be3a5b08773594c19b3445c7acfa6b05b89a180170d).
> - Tags each test in that file as `kernel-heavy` with a 180s timeout, and excludes `kernel-heavy` from the default sharded vitest run in [vitest.config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/616/files#diff-bde9d899eecf81df61ac3e23b7661d244fa4c650c879157d49d0577ad9063862).
> - Adds a `coding-agent kernel` matrix entry in [ci.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/616/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs `npm run test:kernel` with `install_uv: true`, so the kernel tests boot a real IPython environment in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4dbdfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->