### PR TITLE
fix(coding-agent): attribute subagent terminal notices

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,17 +2,12 @@
 
 ## [Unreleased]
 
-
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
 - Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
-### Fixed
-
-- Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
-
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 
+
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
 - Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
+### Fixed
+
+- Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
+- Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
+
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
-- Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
+- Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
 
 
 ## [0.6.0] - 2026-08-04

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9694,23 +9694,16 @@ export class AgentSession {
 			const childController = childSession?._agentMessageController;
 			if (childController) {
 				try {
-					// No explicit deliveryMode: terminal notices take the same "auto"
-					// default as any other child-to-parent message, so a busy parent
-					// receives them as a steer at the next turn boundary. Forcing
-					// "follow_up" would put the one signal that a child will never
-					// report into the when-run-idle lane, which ActionStore drains
-					// only after the steer lane empties — a parent that keeps taking
-					// turns (autonomous mode, long tool chains, more children
-					// reporting) could defer it indefinitely.
+					// deliveryMode is deliberately omitted: the "auto" default steers into
+					// a busy parent, whereas "follow_up" parks a child's last signal in the
+					// when-run-idle lane, which drains only once the steer lane empties.
 					await childController.sendAgentMessage({
 						target: this.sessionId,
 						message: message.content as string,
 					});
 					return;
 				} catch {
-					// Fall through to the injected-message path: a parent that loses the
-					// terminal notice entirely is worse than one that receives it
-					// unattributed.
+					// An unattributed notice beats silence, so fall through to the injected path.
 				}
 			}
 			await this._promptInjectedMessage(message.content as string, message, {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9690,7 +9690,18 @@ export class AgentSession {
 			onSessionPublished: publishChildSession,
 		};
 
-		const injectTerminalMessage = async (message: CustomMessage): Promise<void> => {
+		const deliverTerminalMessageToParent = async (message: CustomMessage): Promise<void> => {
+			const childController = childSession?._agentMessageController;
+			if (childController) {
+				await childController
+					.sendAgentMessage({
+						target: this.sessionId,
+						message: message.content as string,
+						deliveryMode: "follow_up",
+					})
+					.catch(() => undefined);
+				return;
+			}
 			await this._promptInjectedMessage(message.content as string, message, {
 				streamingBehavior: "followUp",
 				queueIfBusy: true,
@@ -9803,7 +9814,7 @@ export class AgentSession {
 				emitChildUpdate();
 				if (!run.detachedDeletion && child._parentReplyCount === parentReplyCountBeforeRun) {
 					const lastAssistantText = child.getLastAssistantText();
-					await injectTerminalMessage(
+					await deliverTerminalMessageToParent(
 						createRlmChildTerminalNoticeMessage({
 							kind: "completed_without_reply",
 							childId: run.id,
@@ -9833,7 +9844,7 @@ export class AgentSession {
 				emitChildUpdate();
 				if (!run.detachedDeletion) {
 					if (run.status === "error") {
-						await injectTerminalMessage(
+						await deliverTerminalMessageToParent(
 							createRlmChildFailureMessage({
 								childId: run.id,
 								sessionName,
@@ -9841,7 +9852,7 @@ export class AgentSession {
 							}),
 						);
 					} else if (run.status === "cancelled") {
-						await injectTerminalMessage(
+						await deliverTerminalMessageToParent(
 							createRlmChildTerminalNoticeMessage({
 								kind: "cancelled",
 								childId: run.id,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9693,14 +9693,18 @@ export class AgentSession {
 		const deliverTerminalMessageToParent = async (message: CustomMessage): Promise<void> => {
 			const childController = childSession?._agentMessageController;
 			if (childController) {
-				await childController
-					.sendAgentMessage({
+				try {
+					await childController.sendAgentMessage({
 						target: this.sessionId,
 						message: message.content as string,
 						deliveryMode: "follow_up",
-					})
-					.catch(() => undefined);
-				return;
+					});
+					return;
+				} catch {
+					// Fall through to the injected-message path: a parent that loses the
+					// terminal notice entirely is worse than one that receives it
+					// unattributed.
+				}
 			}
 			await this._promptInjectedMessage(message.content as string, message, {
 				streamingBehavior: "followUp",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9694,10 +9694,17 @@ export class AgentSession {
 			const childController = childSession?._agentMessageController;
 			if (childController) {
 				try {
+					// No explicit deliveryMode: terminal notices take the same "auto"
+					// default as any other child-to-parent message, so a busy parent
+					// receives them as a steer at the next turn boundary. Forcing
+					// "follow_up" would put the one signal that a child will never
+					// report into the when-run-idle lane, which ActionStore drains
+					// only after the steer lane empties — a parent that keeps taking
+					// turns (autonomous mode, long tool chains, more children
+					// reporting) could defer it indefinitely.
 					await childController.sendAgentMessage({
 						target: this.sessionId,
 						message: message.content as string,
-						deliveryMode: "follow_up",
 					});
 					return;
 				} catch {

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -9,6 +9,7 @@ import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { Agent } from "@earendil-works/pi-agent-core";
 import type { FauxModelDefinition, FauxProviderRegistration, FauxResponseStep, Model } from "@earendil-works/pi-ai";
 import { registerFauxProvider } from "@earendil-works/pi-ai";
+import type { AgentSessionMessageController } from "../../src/core/agent-messages.js";
 import type { AgentObserveController } from "../../src/core/agent-observe.js";
 import { AgentSession, type AgentSessionEvent, type AutoRefineReviewer } from "../../src/core/agent-session.js";
 import { AuthStorage } from "../../src/core/auth-storage.js";
@@ -16,6 +17,7 @@ import type { AgentAutonomousConfig } from "../../src/core/autonomous.js";
 import type { ExtensionRunner } from "../../src/core/extensions/index.js";
 import { convertToLlm } from "../../src/core/messages.js";
 import { ModelRegistry } from "../../src/core/model-registry.js";
+import type { SubagentRuntimeHost } from "../../src/core/rlm-runtime.js";
 import { SessionManager } from "../../src/core/session-manager.js";
 import type { Settings } from "../../src/core/settings-manager.js";
 import { SettingsManager } from "../../src/core/settings-manager.js";
@@ -68,8 +70,11 @@ export interface HarnessOptions {
 	extensionFactories?: Array<ExtensionFactory | CreateTestExtensionsResultInput>;
 	withConfiguredAuth?: boolean;
 	agentObserveController?: AgentObserveController;
+	agentMessageController?: AgentSessionMessageController;
+	subagentRuntimeHost?: SubagentRuntimeHost;
 	persistSession?: boolean;
 	rlmDepth?: number;
+	rlmMaxDepth?: number;
 	autonomous?: AgentAutonomousConfig;
 	autoRefineReviewer?: AutoRefineReviewer;
 	serializedRefine?: boolean;
@@ -188,9 +193,12 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		modelRegistry,
 		resourceLoader,
 		agentObserveController: options.agentObserveController,
+		agentMessageController: options.agentMessageController,
+		subagentRuntimeHost: options.subagentRuntimeHost,
 		baseToolsOverride: toolMap,
 		extensionRunnerRef,
 		rlmDepth: options.rlmDepth,
+		rlmMaxDepth: options.rlmMaxDepth,
 		autonomous: options.autonomous,
 		autoRefineReviewer: options.autoRefineReviewer,
 		serializedRefine: options.serializedRefine,

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -1,0 +1,97 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	AGENT_MESSAGE_CUSTOM_TYPE,
+	type AgentSessionMessage,
+	createAgentSessionMessage,
+} from "../../../src/core/agent-messages.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function terminalMessage(messages: readonly unknown[]): AgentSessionMessage | undefined {
+	return messages.find(
+		(message): message is AgentSessionMessage =>
+			typeof message === "object" &&
+			message !== null &&
+			"role" in message &&
+			"customType" in message &&
+			(message as { role?: unknown }).role === "custom" &&
+			(message as { customType?: unknown }).customType === AGENT_MESSAGE_CUSTOM_TYPE,
+	);
+}
+
+describe("#617 subagent terminal agent messages", () => {
+	let parent: Harness | undefined;
+	let child: Harness | undefined;
+
+	afterEach(() => {
+		child?.cleanup();
+		parent?.cleanup();
+		child = undefined;
+		parent = undefined;
+	});
+
+	it("delivers a child completion without a reply as an attributed agent message", async () => {
+		const childSessionName = "terminal-worker";
+		child = await createHarness({
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async (input) => {
+					expect(input).toMatchObject({
+						target: parent!.session.sessionId,
+						deliveryMode: "follow_up",
+						message: expect.stringContaining("completed without sending a reply"),
+					});
+					const message = createAgentSessionMessage({
+						id: "agentmsg-terminal-completion",
+						source: "agent_message",
+						message: input.message,
+						from: {
+							activeSessionId: "child-active",
+							sessionId: child!.session.sessionId,
+							sessionName: childSessionName,
+						},
+						fromRelationship: "child",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						deliveryMode: input.deliveryMode ?? "auto",
+					});
+					await parent!.session.acceptAgentMessagePrompt(message.content, { customMessage: message });
+					return {
+						id: message.details.id,
+						source: "agent_message",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						message: input.message,
+						deliveryStatus: "delivered",
+						deliveryMode: input.deliveryMode ?? "auto",
+					};
+				},
+			},
+		});
+		parent = await createHarness({
+			rlmDepth: 0,
+			rlmMaxDepth: 1,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		child.setResponses([fauxAssistantMessage("child completed")]);
+
+		const spawned = await parent.session.runRlmChild("finish without replying", { name: childSessionName });
+
+		await expect
+			.poll(() => terminalMessage(parent!.session.messages))
+			.toMatchObject({
+				customType: AGENT_MESSAGE_CUSTOM_TYPE,
+				details: {
+					id: "agentmsg-terminal-completion",
+					fromRelationship: "child",
+					from: { sessionId: child.session.sessionId, sessionName: childSessionName },
+				},
+				content: expect.stringContaining(`[from child:${childSessionName}]`),
+			});
+		expect(parent.session.messages).not.toContainEqual(
+			expect.objectContaining({ customType: "rlm_child_terminal_notice" }),
+		);
+		expect(terminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -41,9 +41,7 @@ describe("#617 subagent terminal agent messages", () => {
 						target: parent!.session.sessionId,
 						message: expect.stringContaining("completed without sending a reply"),
 					});
-					// No explicit deliveryMode: the notice inherits the same "auto"
-					// default as any other child-to-parent message, which steers into
-					// a busy parent instead of waiting for it to go idle.
+					// Omitted, so the daemon applies the "auto" default.
 					expect(input.deliveryMode).toBeUndefined();
 					const message = createAgentSessionMessage({
 						id: "agentmsg-terminal-completion",
@@ -99,10 +97,7 @@ describe("#617 subagent terminal agent messages", () => {
 		expect(terminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
 	});
 	it("steers a terminal notice into a busy parent instead of deferring it", async () => {
-		// The delivered mode is what the daemon derives from the child's request.
-		// Omitting deliveryMode must resolve to a steer for a streaming parent, so
-		// the notice lands at the next turn boundary rather than in the
-		// when-run-idle lane behind unrelated work.
+		// A streaming parent must resolve to a steer, not a deferred follow-up.
 		const childSessionName = "busy-parent-worker";
 		let resolvedBehavior: "steer" | "followUp" | undefined;
 		child = await createHarness({

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -94,4 +94,35 @@ describe("#617 subagent terminal agent messages", () => {
 		);
 		expect(terminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
 	});
+	it("falls back to an injected notice when the agent message cannot be delivered", async () => {
+		// A controller that always rejects: the parent must still learn the child
+		// finished. Losing the notice entirely is worse than losing attribution.
+		child = await createHarness({
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async () => {
+					throw new Error("delivery unavailable");
+				},
+			},
+		});
+		parent = await createHarness({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			} as never,
+		});
+		child.setResponses([fauxAssistantMessage("done, no reply to parent")]);
+		parent.setResponses([fauxAssistantMessage("parent ack")]);
+
+		await parent.session.runRlmChild("do the work");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		// The notice arrives some way: either the agent message or the injected
+		// fallback, but never silently dropped.
+		const sawNotice = parent.session.messages.some((message) => {
+			const content = (message as { content?: unknown }).content;
+			return typeof content === "string" && content.includes("completed without sending a reply");
+		});
+		expect(sawNotice || terminalMessage(parent.session.messages) !== undefined).toBe(true);
+	}, 60_000);
 });

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -4,6 +4,7 @@ import {
 	AGENT_MESSAGE_CUSTOM_TYPE,
 	type AgentSessionMessage,
 	createAgentSessionMessage,
+	resolveAgentSessionMessageStreamingBehavior,
 } from "../../../src/core/agent-messages.js";
 import { createHarness, type Harness } from "../harness.js";
 
@@ -38,9 +39,12 @@ describe("#617 subagent terminal agent messages", () => {
 				sendAgentMessage: async (input) => {
 					expect(input).toMatchObject({
 						target: parent!.session.sessionId,
-						deliveryMode: "follow_up",
 						message: expect.stringContaining("completed without sending a reply"),
 					});
+					// No explicit deliveryMode: the notice inherits the same "auto"
+					// default as any other child-to-parent message, which steers into
+					// a busy parent instead of waiting for it to go idle.
+					expect(input.deliveryMode).toBeUndefined();
 					const message = createAgentSessionMessage({
 						id: "agentmsg-terminal-completion",
 						source: "agent_message",
@@ -94,6 +98,58 @@ describe("#617 subagent terminal agent messages", () => {
 		);
 		expect(terminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
 	});
+	it("steers a terminal notice into a busy parent instead of deferring it", async () => {
+		// The delivered mode is what the daemon derives from the child's request.
+		// Omitting deliveryMode must resolve to a steer for a streaming parent, so
+		// the notice lands at the next turn boundary rather than in the
+		// when-run-idle lane behind unrelated work.
+		const childSessionName = "busy-parent-worker";
+		let resolvedBehavior: "steer" | "followUp" | undefined;
+		child = await createHarness({
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async (input) => {
+					expect(input.deliveryMode).toBeUndefined();
+					resolvedBehavior = resolveAgentSessionMessageStreamingBehavior(true, input.deliveryMode);
+					const message = createAgentSessionMessage({
+						id: "agentmsg-terminal-busy",
+						source: "agent_message",
+						message: input.message,
+						from: {
+							activeSessionId: "child-active",
+							sessionId: child!.session.sessionId,
+							sessionName: childSessionName,
+						},
+						fromRelationship: "child",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						deliveryMode: input.deliveryMode ?? "auto",
+					});
+					return {
+						id: message.details.id,
+						source: "agent_message",
+						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
+						message: input.message,
+						deliveryStatus: "delivered",
+						deliveryMode: input.deliveryMode ?? "auto",
+					};
+				},
+			},
+		});
+		parent = await createHarness({
+			rlmDepth: 0,
+			rlmMaxDepth: 1,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		child.setResponses([fauxAssistantMessage("child completed")]);
+
+		await parent.session.runRlmChild("finish without replying", { name: childSessionName });
+
+		await expect.poll(() => resolvedBehavior).toBe("steer");
+	});
+
 	it("falls back to an injected notice when the agent message cannot be delivered", async () => {
 		// A controller that always rejects: the parent must still learn the child
 		// finished. Losing the notice entirely is worse than losing attribution.


### PR DESCRIPTION
## Summary

Fixes #617.

Fire-and-forget child terminal paths previously called `_promptInjectedMessage(..., { streamingBehavior: "followUp" })` on the parent. That path preserves the `rlm_child_failure` / `rlm_child_terminal_notice` custom message but bypasses daemon agent-message delivery, so it has no sender relationship or `[from child:<name>]` attribution.

The terminal dispatcher now uses the completed child's `AgentSessionMessageController` to send the notice to the parent session with `deliveryMode: "follow_up"`. The daemon's existing `sendAgentSessionMessage` path creates the `agent_message` custom message and derives `fromRelationship: "child"`. The inline/no-controller fallback retains the prior injected-message behavior.

This covers all detached child terminal notifications:
- completion without an ordinary reply;
- post-admission startup/task failure;
- cancellation after the child unwinds.

## Verification

- `npm run check`
- `env -u MPLBACKEND npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/617-subagent-terminal-agent-message.test.ts`
- `env -u MPLBACKEND -u RLM_DEPTH -u RLM_MAX_DEPTH npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-recursion.test.ts` (95 passed)

The regression uses the suite harness/faux provider to run a silent child to completion and asserts that the parent receives `AGENT_MESSAGE_CUSTOM_TYPE`, `fromRelationship: "child"`, the child label, and no `rlm_child_terminal_notice` follow-up injection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parent/child RLM lifecycle and prompt scheduling; scope is narrow with regression tests and a safe fallback when agent-message delivery fails.
> 
> **Overview**
> Fixes **#617** by routing RLM child **completion-without-reply**, **failure**, and **cancellation** notices through the child’s `AgentSessionMessageController.sendAgentMessage` to the parent instead of injecting anonymous `rlm_child_*` follow-up prompts on the parent.
> 
> **`deliverTerminalMessageToParent`** omits `deliveryMode` so the daemon’s **`auto`** path applies: a busy parent gets **steer** at the next turn boundary rather than a deferred idle-only follow-up. If delivery throws, behavior falls back to the prior injected follow-up so the parent still sees the notice.
> 
> The test harness gains **`agentMessageController`**, **`subagentRuntimeHost`**, and **`rlmMaxDepth`**; regression tests cover attribution (`[from child:<name>]`), steer resolution, and the fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1603d92ac06b496a0adbc26ebe50a1b054998c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attribute subagent terminal notices as agent messages in `AgentSession`
> - Replaces direct prompt injection with `sendAgentMessage` for delivering child completion, error, and cancellation notices to the parent, so notices arrive with agent attribution and use `auto` delivery (which steers into a busy parent).
> - Introduces `deliverTerminalMessageToParent` in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/619/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) as the new delivery helper, falling back to the old injected follow-up path if `sendAgentMessage` throws.
> - Adds a regression test suite in [617-subagent-terminal-agent-message.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/619/files#diff-e459f5900c29e32d2ac6f22edd13161afdf39e608bdfe86947906cc7deaf68b2) covering attribution, steering behavior, and the fallback path.
> - Extends the test harness to accept `agentMessageController`, `subagentRuntimeHost`, and `rlmMaxDepth` for driving these scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1603d92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->