### PR TITLE
fix(coding-agent): fail ACP prompt turns that ended in an error

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
 - Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
+- Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
 - Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
 - Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
+- Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
 - Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
 - Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
-- Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,7 +44,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --tagsFilter kernel-heavy test/acp-kernel-features.test.ts"
+		"test:kernel": "vitest --run --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { VERSION } from "../../config.js";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
@@ -113,22 +114,74 @@ function autonomousMeta(status: AgentAutonomousStatus | undefined): Record<strin
 }
 
 /**
+ * The transcript as it stood before a turn started, recorded so the turn's own
+ * messages can be told apart from everything older.
+ *
+ * A pre-turn message *count* cannot do that job: auto-compaction can fire during
+ * a turn and rebuild `state.messages` (it filters, slices, and re-materializes
+ * persisted entries), so this turn's failure can end up at a lower index than
+ * the count taken before prompting. Membership is tracked by things a rebuild
+ * preserves instead — the message objects themselves, plus a content key for
+ * transports that hand back fresh copies (daemon RPC re-parses JSON, so identity
+ * does not survive it) and for compaction paths that re-materialize a kept
+ * message from its persisted entry with its original timestamp.
+ */
+interface TurnBoundary {
+	identities: WeakSet<object>;
+	keys: Set<string>;
+}
+
+/** Key for a kept message: compaction drops messages, it does not rewrite them. */
+function messageKey(message: unknown): string | undefined {
+	if (typeof message !== "object" || message === null) return undefined;
+	const record = message as { role?: unknown; timestamp?: unknown; stopReason?: unknown; errorMessage?: unknown };
+	if (typeof record.timestamp !== "number") return undefined;
+	return JSON.stringify([
+		record.role ?? null,
+		record.timestamp,
+		record.stopReason ?? null,
+		record.errorMessage ?? null,
+	]);
+}
+
+function turnBoundary(messages: readonly AgentMessage[]): TurnBoundary {
+	const identities = new WeakSet<object>();
+	const keys = new Set<string>();
+	for (const message of messages) {
+		if (typeof message !== "object" || message === null) continue;
+		identities.add(message);
+		const key = messageKey(message);
+		if (key) keys.add(key);
+	}
+	return { identities, keys };
+}
+
+function isPreTurn(message: unknown, boundary: TurnBoundary): boolean {
+	if (typeof message !== "object" || message === null) return false;
+	if (boundary.identities.has(message)) return true;
+	const key = messageKey(message);
+	return key !== undefined && boundary.keys.has(key);
+}
+
+/**
  * Error text from an assistant message this turn produced, when it failed.
  *
  * `promptAndWait` resolves for a failed turn just as it does for a successful
- * one, so the outcome has to be read off the transcript. Only messages appended
- * at or after `sinceIndex` are considered: scanning the whole transcript would
- * let an earlier failed turn reject a later turn that never called the model
- * (a handled slash command, say), reporting a stale error.
+ * one, so the outcome has to be read off the transcript. Only messages that were
+ * not in the transcript before the turn are considered: scanning the whole
+ * transcript would let an earlier failed turn reject a later turn that never
+ * called the model (a handled slash command, say), reporting a stale error.
  *
  * A transcript read that fails is not treated as success — that would restore
  * the silent-success behavior this exists to prevent.
  */
-async function turnFailure(connection: AgentConnection, sinceIndex: number): Promise<string | undefined> {
+async function turnFailure(connection: AgentConnection, boundary: TurnBoundary): Promise<string | undefined> {
 	const messages = await connection.getMessages();
-	for (let index = messages.length - 1; index >= sinceIndex; index--) {
+	for (let index = messages.length - 1; index >= 0; index--) {
 		const message = messages[index];
 		if (message?.role !== "assistant") continue;
+		// The newest assistant message predates the turn, so the turn appended none.
+		if (isPreTurn(message, boundary)) return undefined;
 		const assistant = message as { stopReason?: string; errorMessage?: string };
 		if (assistant.stopReason !== "error") return undefined;
 		return assistant.errorMessage || "the model request failed";
@@ -254,8 +307,10 @@ export async function runAcpModeWithConnection(
 
 			try {
 				const { text, images } = promptContent(params.prompt);
-				// Only this turn's messages may decide its outcome.
-				const priorMessageCount = (await connection.getMessages()).length;
+				// Only this turn's messages may decide its outcome, and compaction can
+				// rebuild the transcript mid-turn, so record the pre-turn messages
+				// themselves rather than how many there were.
+				const priorMessages = turnBoundary(await connection.getMessages());
 				await connection.promptAndWait(text, images.length > 0 ? { images } : undefined);
 				// Autonomous gates continue inside this same prompt turn: the turn is
 				// only over once the gate loop settles.
@@ -274,7 +329,7 @@ export async function runAcpModeWithConnection(
 				// `stopReason: "error"` with its errorMessage; ACP previously dropped
 				// that and answered end_turn with no updates at all, which reads to a
 				// client as a successful but empty turn.
-				const failure = await turnFailure(connection, priorMessageCount);
+				const failure = await turnFailure(connection, priorMessages);
 				if (failure && !abort.signal.aborted) {
 					throw new Error(`prime-agent turn failed: ${failure}`);
 				}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -112,6 +112,25 @@ function autonomousMeta(status: AgentAutonomousStatus | undefined): Record<strin
 	});
 }
 
+/**
+ * Error text from the turn's final assistant message, when it failed.
+ *
+ * `promptAndWait` resolves for a failed turn just as it does for a successful
+ * one, so the outcome has to be read off the transcript. Returns undefined when
+ * the turn ended normally.
+ */
+async function lastAssistantFailure(connection: AgentConnection): Promise<string | undefined> {
+	const messages = await connection.getMessages().catch(() => []);
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message?.role !== "assistant") continue;
+		const assistant = message as { stopReason?: string; errorMessage?: string };
+		if (assistant.stopReason !== "error") return undefined;
+		return assistant.errorMessage || "the model request failed";
+	}
+	return undefined;
+}
+
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
 	const connection = new InProcessAgentConnection(runtimeHost);
 	return runAcpModeWithConnection(connection, {
@@ -242,6 +261,15 @@ export async function runAcpModeWithConnection(
 							update: { sessionUpdate: "session_info_update", _meta: meta },
 						})
 						.catch(() => undefined);
+				}
+				// A turn that failed (provider error, auth, no usable model) must not be
+				// reported as a clean end_turn. Print mode surfaces
+				// `stopReason: "error"` with its errorMessage; ACP previously dropped
+				// that and answered end_turn with no updates at all, which reads to a
+				// client as a successful but empty turn.
+				const failure = await lastAssistantFailure(connection);
+				if (failure && !abort.signal.aborted) {
+					throw new Error(`prime-agent turn failed: ${failure}`);
 				}
 				return { stopReason: acpStopReason({ cancelled: abort.signal.aborted, autonomous: status }) };
 			} catch (error) {

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -113,15 +113,20 @@ function autonomousMeta(status: AgentAutonomousStatus | undefined): Record<strin
 }
 
 /**
- * Error text from the turn's final assistant message, when it failed.
+ * Error text from an assistant message this turn produced, when it failed.
  *
  * `promptAndWait` resolves for a failed turn just as it does for a successful
- * one, so the outcome has to be read off the transcript. Returns undefined when
- * the turn ended normally.
+ * one, so the outcome has to be read off the transcript. Only messages appended
+ * at or after `sinceIndex` are considered: scanning the whole transcript would
+ * let an earlier failed turn reject a later turn that never called the model
+ * (a handled slash command, say), reporting a stale error.
+ *
+ * A transcript read that fails is not treated as success — that would restore
+ * the silent-success behavior this exists to prevent.
  */
-async function lastAssistantFailure(connection: AgentConnection): Promise<string | undefined> {
-	const messages = await connection.getMessages().catch(() => []);
-	for (let index = messages.length - 1; index >= 0; index--) {
+async function turnFailure(connection: AgentConnection, sinceIndex: number): Promise<string | undefined> {
+	const messages = await connection.getMessages();
+	for (let index = messages.length - 1; index >= sinceIndex; index--) {
 		const message = messages[index];
 		if (message?.role !== "assistant") continue;
 		const assistant = message as { stopReason?: string; errorMessage?: string };
@@ -249,6 +254,8 @@ export async function runAcpModeWithConnection(
 
 			try {
 				const { text, images } = promptContent(params.prompt);
+				// Only this turn's messages may decide its outcome.
+				const priorMessageCount = (await connection.getMessages()).length;
 				await connection.promptAndWait(text, images.length > 0 ? { images } : undefined);
 				// Autonomous gates continue inside this same prompt turn: the turn is
 				// only over once the gate loop settles.
@@ -267,7 +274,7 @@ export async function runAcpModeWithConnection(
 				// `stopReason: "error"` with its errorMessage; ACP previously dropped
 				// that and answered end_turn with no updates at all, which reads to a
 				// client as a successful but empty turn.
-				const failure = await lastAssistantFailure(connection);
+				const failure = await turnFailure(connection, priorMessageCount);
 				if (failure && !abort.signal.aborted) {
 					throw new Error(`prime-agent turn failed: ${failure}`);
 				}

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -187,6 +187,11 @@ describe("ACP mode over a cold real CLI process", () => {
 				error !== undefined || result?.stopReason !== "end_turn",
 				`a failed turn must not report end_turn (updates=${updates}, frame=${JSON.stringify(prompt)})`,
 			).toBe(true);
+
+			// Failing loudly is only half of it: the client also has to be able to
+			// tell *why*. Assert the provider's own rejection reaches the client
+			// rather than a bare "Internal error".
+			expect(JSON.stringify(error)).toContain("unauthorized in test");
 		},
 	);
 });

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -163,7 +163,12 @@ async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
 		// daemon supervisor, a Python kernel). Close stdin so the agent sees EOF and
 		// unwinds its own children, then escalate only if it does not exit.
 		child.stdin.end();
-		const exited = new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+		// An already-dead child never emits "exit" again, so waiting on the event
+		// alone would burn the full escalation budget after a crash.
+		const alreadyExited = child.exitCode !== null || child.signalCode !== null;
+		const exited = alreadyExited
+			? Promise.resolve()
+			: new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
 		const exitedInTime = await Promise.race([
 			exited.then(() => true),
 			new Promise<boolean>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 10_000)),

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -159,7 +159,23 @@ async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
 			new Promise<void>((_, reject) => setTimeout(() => reject(new Error("ACP turn timed out")), 150_000)),
 		]);
 	} finally {
-		child.kill("SIGKILL");
+		// SIGKILL alone would strand whatever the CLI started for this socket (a
+		// daemon supervisor, a Python kernel). Close stdin so the agent sees EOF and
+		// unwinds its own children, then escalate only if it does not exit.
+		child.stdin.end();
+		const exited = new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+		const exitedInTime = await Promise.race([
+			exited.then(() => true),
+			new Promise<boolean>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 10_000)),
+		]);
+		if (!exitedInTime) {
+			child.kill("SIGTERM");
+			const stoppedInTime = await Promise.race([
+				exited.then(() => true),
+				new Promise<boolean>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 5_000)),
+			]);
+			if (!stoppedInTime) child.kill("SIGKILL");
+		}
 	}
 	return { responses, updates };
 }

--- a/packages/coding-agent/test/acp-cold-cli.test.ts
+++ b/packages/coding-agent/test/acp-cold-cli.test.ts
@@ -1,0 +1,192 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.js";
+
+/**
+ * Cold real-CLI ACP coverage.
+ *
+ * Every other ACP test drives an in-process session with a faux provider already
+ * wired up. That is exactly why a failed turn could report `end_turn` with no
+ * updates: the failure mode only appears when a real `--mode acp` process talks
+ * to a provider that rejects it. This spawns the real CLI over real stdio and
+ * points it at a local server that answers 401.
+ */
+
+const cliPath = resolve(__dirname, "../src/cli.ts");
+const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
+
+const tempDirs: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) {
+		await new Promise<void>((done) => server.close(() => done()));
+	}
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/** A provider endpoint that always rejects, so the turn fails for a real reason. */
+async function startRejectingProvider(): Promise<string> {
+	const server = createServer((_req, res) => {
+		res.writeHead(401, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ error: { message: "unauthorized in test" } }));
+	});
+	servers.push(server);
+	await new Promise<void>((done) => server.listen(0, "127.0.0.1", () => done()));
+	const address = server.address();
+	const port = typeof address === "object" && address ? address.port : 0;
+	return `http://127.0.0.1:${port}/v1`;
+}
+
+interface AcpResult {
+	responses: Record<string, unknown>[];
+	updates: number;
+}
+
+async function driveAcpTurn(baseUrl: string): Promise<AcpResult> {
+	const tempRoot = mkdtempSync(join(tmpdir(), "pi-acp-cold-"));
+	tempDirs.push(tempRoot);
+	const agentDir = join(tempRoot, "agent");
+	const projectDir = join(tempRoot, "project");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(projectDir, { recursive: true });
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				intercept: {
+					baseUrl,
+					api: "openai-completions",
+					apiKey: "test-key",
+					models: [{ id: "cold/test-model", reasoning: false, input: ["text"] }],
+				},
+			},
+		}),
+		"utf-8",
+	);
+
+	const child = spawn(
+		process.execPath,
+		[
+			tsxPath,
+			cliPath,
+			"--mode",
+			"acp",
+			"--provider",
+			"intercept",
+			"--model",
+			"cold/test-model",
+			"--no-session",
+			"--offline",
+			"--daemon-socket",
+			join(tempRoot, "d.sock"),
+		],
+		{
+			cwd: projectDir,
+			env: {
+				...process.env,
+				[ENV_AGENT_DIR]: agentDir,
+				HOME: agentDir,
+				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		},
+	);
+
+	const responses: Record<string, unknown>[] = [];
+	let updates = 0;
+	let buffer = "";
+
+	const send = (payload: unknown) => child.stdin.write(`${JSON.stringify(payload)}\n`);
+
+	const done = new Promise<void>((resolveDone) => {
+		child.stdout.on("data", (chunk) => {
+			buffer += chunk.toString();
+			// ACP frames are newline delimited; keep any partial trailing line.
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? "";
+			for (const line of lines) {
+				if (!line.trim().startsWith("{")) continue;
+				let frame: Record<string, unknown>;
+				try {
+					frame = JSON.parse(line) as Record<string, unknown>;
+				} catch {
+					continue;
+				}
+				if (frame.method === "session/update") {
+					updates++;
+					continue;
+				}
+				responses.push(frame);
+				if (frame.id === 1) {
+					send({
+						jsonrpc: "2.0",
+						id: 2,
+						method: "session/new",
+						params: { cwd: projectDir, mcpServers: [] },
+					});
+				} else if (frame.id === 2) {
+					const sessionId = (frame.result as { sessionId?: string } | undefined)?.sessionId;
+					send({
+						jsonrpc: "2.0",
+						id: 3,
+						method: "session/prompt",
+						params: { sessionId, prompt: [{ type: "text", text: "say hi" }] },
+					});
+				} else if (frame.id === 3) {
+					resolveDone();
+				}
+			}
+		});
+	});
+
+	send({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: { protocolVersion: 1, clientCapabilities: {} },
+	});
+
+	try {
+		await Promise.race([
+			done,
+			new Promise<void>((_, reject) => setTimeout(() => reject(new Error("ACP turn timed out")), 150_000)),
+		]);
+	} finally {
+		child.kill("SIGKILL");
+	}
+	return { responses, updates };
+}
+
+describe("ACP mode over a cold real CLI process", () => {
+	it(
+		"reports a provider failure instead of a silent end_turn",
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
+		async () => {
+			const baseUrl = await startRejectingProvider();
+			const { responses, updates } = await driveAcpTurn(baseUrl);
+
+			const initialize = responses.find((frame) => frame.id === 1);
+			expect(initialize, "the real CLI must answer initialize on stdout").toBeDefined();
+
+			const prompt = responses.find((frame) => frame.id === 3);
+			expect(prompt, "session/prompt must answer").toBeDefined();
+
+			// The provider rejected, so the turn must not claim a clean completion.
+			// Before this was fixed the answer was {stopReason: "end_turn"} with
+			// updates === 0, which a client reads as a successful empty turn.
+			const result = (prompt as { result?: { stopReason?: string } }).result;
+			const error = (prompt as { error?: unknown }).error;
+			expect(
+				error !== undefined || result?.stopReason !== "end_turn",
+				`a failed turn must not report end_turn (updates=${updates}, frame=${JSON.stringify(prompt)})`,
+			).toBe(true);
+		},
+	);
+});

--- a/packages/coding-agent/test/suite/acp-features.test.ts
+++ b/packages/coding-agent/test/suite/acp-features.test.ts
@@ -602,6 +602,30 @@ describe("ACP mode preserves prime-agent features", () => {
 		harness.cleanup();
 	}, 30_000);
 
+	it("does not let an earlier failed turn reject a later one", async () => {
+		const harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." })]);
+		const fixture = await connectAcp(harness);
+
+		// First turn fails and must be reported as a failure.
+		await expect(
+			fixture.agent.request("session/prompt", {
+				sessionId: fixture.sessionId,
+				prompt: [{ type: "text", text: "first" }],
+			}),
+		).rejects.toThrow();
+
+		// A slash command is handled without calling the model, so it appends no
+		// assistant message. Scanning the whole transcript would surface the earlier
+		// turn's error and wrongly reject this one.
+		const second = await fixture.agent.request("session/prompt", {
+			sessionId: fixture.sessionId,
+			prompt: [{ type: "text", text: "/compact" }],
+		});
+		expect(second.stopReason).toBe("end_turn");
+		harness.cleanup();
+	}, 30_000);
+
 	it("advertises prime-agent capabilities without polluting the ACP object root", async () => {
 		const harness = await createHarness();
 		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));

--- a/packages/coding-agent/test/suite/acp-features.test.ts
+++ b/packages/coding-agent/test/suite/acp-features.test.ts
@@ -353,11 +353,14 @@ describe("ACP mode preserves prime-agent features", () => {
 		harness.setResponses([fauxAssistantMessage("working on it")]);
 		const fixture = await connectAcp(harness);
 
-		await fixture.agent.request("session/prompt", {
-			sessionId: fixture.sessionId,
-			prompt: [{ type: "text", text: "start" }],
-		});
+		// A seeded goal keeps requesting continuations, so this turn eventually
+		// exhausts the faux queue and fails. The assertion is that goal state
+		// reaches the client, which happens on the first turn either way.
+		const turn = fixture.agent
+			.request("session/prompt", { sessionId: fixture.sessionId, prompt: [{ type: "text", text: "start" }] })
+			.catch(() => undefined);
 		await waitFor(() => fixture.metaOf("goal").length > 0);
+		await turn;
 
 		const goals = fixture.metaOf("goal");
 		expect(goals.length, "goal state must reach the ACP client").toBeGreaterThan(0);
@@ -580,6 +583,22 @@ describe("ACP mode preserves prime-agent features", () => {
 
 		expect(fixture.updates.length, "inbound agent messages must produce ACP updates").toBeGreaterThan(0);
 		expect(streamedText()).toContain("acknowledged the sibling");
+		harness.cleanup();
+	}, 30_000);
+
+	it("fails the prompt turn instead of reporting end_turn when the model errors", async () => {
+		const harness = await createHarness();
+		// A provider failure is the shape verifiers hit in a container: the turn
+		// resolves, streams nothing, and previously answered a clean end_turn.
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." })]);
+		const fixture = await connectAcp(harness);
+
+		await expect(
+			fixture.agent.request("session/prompt", {
+				sessionId: fixture.sessionId,
+				prompt: [{ type: "text", text: "say hi" }],
+			}),
+		).rejects.toThrow();
 		harness.cleanup();
 	}, 30_000);
 

--- a/packages/coding-agent/test/suite/acp-features.test.ts
+++ b/packages/coding-agent/test/suite/acp-features.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.js";
@@ -50,8 +51,8 @@ async function waitFor(predicate: () => boolean, timeoutMs = 15_000): Promise<vo
 	throw new Error("timed out waiting for the expected ACP updates");
 }
 
-async function connectAcp(harness: Harness): Promise<AcpFixture> {
-	const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+async function connectAcp(harness: Harness, existing?: InProcessAgentConnection): Promise<AcpFixture> {
+	const connection = existing ?? new InProcessAgentConnection(runtimeHostFor(harness.session));
 	const toAgent = new TransformStream<Uint8Array, Uint8Array>();
 	const toClient = new TransformStream<Uint8Array, Uint8Array>();
 	const updates: any[] = [];
@@ -101,6 +102,46 @@ const ipythonTool = {
 		return { content: [{ type: "text" as const, text: "42" }], details: { code } };
 	},
 };
+
+/**
+ * Wrap a connection so a transcript rebuild runs mid-turn, right after
+ * `promptAndWait` resolves and before the ACP handler inspects the outcome.
+ *
+ * Auto-compaction does exactly this to `state.messages`: it drops older messages
+ * and re-materializes the ones it keeps (`buildSessionContext`, and the filters
+ * and slices around it), so a message the turn appended can end up at a lower
+ * index than the pre-turn message count. Driving a real compaction needs a
+ * token-overflow response from the provider, so the rebuild is simulated here;
+ * what matters is its shape, which is asserted in each test.
+ */
+function withMidTurnRebuild(
+	harness: Harness,
+	rebuild: (messages: AgentMessage[]) => AgentMessage[] | undefined,
+): { connection: InProcessAgentConnection; arm: () => void } {
+	const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+	const promptAndWait = connection.promptAndWait.bind(connection) as (...args: any[]) => Promise<any>;
+	let armed = false;
+	(connection as any).promptAndWait = async (...args: any[]) => {
+		const result = await promptAndWait(...args);
+		if (armed) {
+			armed = false;
+			const rebuilt = rebuild(harness.session.state.messages);
+			if (rebuilt) harness.session.state.messages = rebuilt;
+		}
+		return result;
+	};
+	return {
+		connection,
+		arm: () => {
+			armed = true;
+		},
+	};
+}
+
+/** Copy messages the way a rebuild from persisted entries does: new objects, same fields. */
+function rematerialize(messages: AgentMessage[]): AgentMessage[] {
+	return JSON.parse(JSON.stringify(messages));
+}
 
 describe("ACP mode preserves prime-agent features", () => {
 	it("streams IPython execution as an execute tool call with its cell source", async () => {
@@ -623,6 +664,86 @@ describe("ACP mode preserves prime-agent features", () => {
 			prompt: [{ type: "text", text: "/compact" }],
 		});
 		expect(second.stopReason).toBe("end_turn");
+		harness.cleanup();
+	}, 30_000);
+
+	it("reports a failure that a mid-turn transcript rebuild moved below the pre-turn message count", async () => {
+		const harness = await createHarness();
+		harness.setResponses([
+			fauxAssistantMessage("first turn done"),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." }),
+		]);
+		let rebuiltLength = 0;
+		const { connection, arm } = withMidTurnRebuild(harness, (messages) => {
+			// Keep only the tail, as compaction does: this turn's error message keeps
+			// its content but moves to a much lower index.
+			const rebuilt = rematerialize(messages.slice(-2));
+			rebuiltLength = rebuilt.length;
+			return rebuilt;
+		});
+		const fixture = await connectAcp(harness, connection);
+
+		const first = await fixture.agent.request("session/prompt", {
+			sessionId: fixture.sessionId,
+			prompt: [{ type: "text", text: "first" }],
+		});
+		expect(first.stopReason).toBe("end_turn");
+
+		const priorMessageCount = harness.session.state.messages.length;
+		expect(priorMessageCount, "the first turn must leave messages behind to compact away").toBeGreaterThan(1);
+		arm();
+
+		const failure = await fixture.agent
+			.request("session/prompt", {
+				sessionId: fixture.sessionId,
+				prompt: [{ type: "text", text: "second" }],
+			})
+			.then(
+				(result: unknown) => ({ resolved: result }),
+				(error: unknown) => ({ error }),
+			);
+		expect(
+			"error" in failure,
+			`a failed turn must not report a clean stop reason (got ${JSON.stringify(failure)})`,
+		).toBe(true);
+		// The client must be told the turn failed, not handed a bare protocol error.
+		expect(JSON.stringify(failure)).toContain("prime-agent turn failed");
+
+		// The point of the test: a pre-turn count watermark would have skipped the
+		// failure, because after the rebuild it sits below that count.
+		expect(rebuiltLength, "the rebuild must shorten the transcript").toBeLessThanOrEqual(priorMessageCount);
+		expect(rebuiltLength - 1, "the failure must land below the pre-turn count").toBeLessThan(priorMessageCount);
+		harness.cleanup();
+	}, 30_000);
+
+	it("does not mistake a rebuilt copy of an earlier failure for this turn's failure", async () => {
+		const harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." })]);
+		let rebuiltIdentities = false;
+		const { connection, arm } = withMidTurnRebuild(harness, (messages) => {
+			const rebuilt = rematerialize(messages);
+			rebuiltIdentities = rebuilt.every((message, index) => message !== messages[index]);
+			return rebuilt;
+		});
+		const fixture = await connectAcp(harness, connection);
+
+		await expect(
+			fixture.agent.request("session/prompt", {
+				sessionId: fixture.sessionId,
+				prompt: [{ type: "text", text: "first" }],
+			}),
+		).rejects.toThrow();
+
+		// A rebuild replaces every kept message with a fresh object, so object
+		// identity alone cannot tell the earlier failure from a new one. The turn
+		// below appends no assistant message and must still end cleanly.
+		arm();
+		const handled = await fixture.agent.request("session/prompt", {
+			sessionId: fixture.sessionId,
+			prompt: [{ type: "text", text: "/compact" }],
+		});
+		expect(handled.stopReason).toBe("end_turn");
+		expect(rebuiltIdentities, "the rebuild must replace the message objects").toBe(true);
 		harness.cleanup();
 	}, 30_000);
 


### PR DESCRIPTION
Found by running prime-agent as a real verifiers v1 harness. ACP mode reported a **failed** turn as a clean `end_turn`.

## Symptom

Driving prime-agent 0.6.0 over ACP inside the verifiers docker runtime (`python:3.11-slim`):

```
initialize      -> correct response
session/new     -> real sessionId
session/prompt  -> {"stopReason":"end_turn"}   <- zero session/update, empty stderr
```

verifiers surfaces it as `ACP agent produced no visible reply (stop_reason=end_turn, tool_statuses=[])`, with `calls=0` and `usage=None`. A silent no-op that looks like success.

## Cause

The clean isolation: same container, same `models.json`, same unreachable endpoint, two modes.

| mode | result |
|---|---|
| `--mode json` | `stopReason: "error"`, `errorMessage: "Connection error."` — **surfaced** |
| `--mode acp` | `stopReason: "end_turn"`, no updates, empty stderr — **swallowed** |

So the model call fails identically; only ACP hides it. `promptAndWait` resolves for a failed turn exactly as for a successful one, and the `session/prompt` handler returned `end_turn` uncondititionally without ever inspecting the outcome. Any provider error, expired auth, or unusable model therefore reads to a client as a successful empty turn.

`prime-agent model list` inside the container correctly lists the `intercept` provider, so this is not a config-resolution problem.

## Fix

Read the turn's final assistant message; if it ended in `error`, fail the prompt with the provider's own message instead of answering `end_turn`.

## Tests

Regression test drives a faux error response through a live ACP client. **Verified it fails without this change** and passes with it, rather than assuming green means covered.

It also caught a pre-existing test that was only passing because this failure was invisible: a seeded goal keeps requesting continuations, so it exhausts the faux response queue and the turn ends in an error. I confirmed that by queuing four responses and watching all four get consumed. That test now asserts what it actually cares about — goal state reaching the client — without depending on the turn succeeding.

45 ACP tests pass, `npm run check` clean.

## Coverage gap worth naming

The 97 existing ACP tests all run with a faux provider pre-wired and a warm in-process session, so none of them exercise a turn whose model call fails. That is why this shipped. This PR closes the specific case; a cold real-CLI turn in CI would be stronger still, but tsx cannot transform TypeScript in a Linux container using the host's darwin esbuild, and building `dist/` is disallowed by AGENTS.md without explicit sign-off. The verifiers eval itself is the real end-to-end check, and I will re-run it against a release containing this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP client-visible behavior for failed turns (errors instead of `end_turn`) and adds subtle transcript-boundary logic that must stay correct under compaction; scope is limited to ACP prompt handling with broad test coverage.
> 
> **Overview**
> **ACP failed model turns no longer look like empty successes.** After `promptAndWait` and autonomous completion, the handler inspects assistant messages added this turn; if the newest one has `stopReason: "error"`, it throws with the provider `errorMessage` instead of returning `stopReason: "end_turn"` with no updates.
> 
> **Turn boundaries use message identity plus content keys** (role, timestamp, stop reason, error text) so a pre-turn message count is not used—auto-compaction and daemon re-parsing can shorten or replace the transcript mid-turn without skipping the failure or blaming an older error on a later slash-command turn.
> 
> **Tests:** in-process cases for model errors, stale errors on follow-up turns, and simulated mid-turn rebuilds; a **cold real CLI** test (`acp-cold-cli.test.ts`, wired into `test:kernel`) hits a 401 provider and expects the rejection text on the JSON-RPC error. Changelog documents the fix; one goal-state test no longer assumes the prompt turn succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977fbe0744ec541c218fee45178ba1ea343cf39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ACP prompt turns that ended in an error to be reported as failures
> - Previously, when an ACP turn ended with `stopReason === 'error'` (e.g. a provider/auth failure), the session/prompt handler returned a clean `end_turn` with no updates instead of propagating the error.
> - Adds a `turnFailure` utility in [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/624/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae) that scans the newest assistant messages for the current turn and throws if an error stop reason is detected.
> - Introduces `TurnBoundary` tracking using object identity and content-derived keys to correctly identify pre-turn messages even after transcript compaction or rebuild.
> - Adds a new integration test in [acp-cold-cli.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/624/files#diff-7c4df9f2b45094e5bb4c676d72042d3d8db0bac3af2e87a0eafe2e8e4488a78a) that spawns the real CLI against a 401-returning server and asserts the error is surfaced.
> - Behavioral Change: `session/prompt` now rejects with an error instead of returning `end_turn` when the provider signals a failure.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #624 opened
>
> - Replaced unconditional SIGKILL termination with staged shutdown in `driveAcpTurn` test helper [a1bc8b7]
> - Added pre-exit detection in `driveAcpTurn` test helper function's cleanup logic [977fbe0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc12b59.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->