### PR TITLE
fix(coding-agent): advertise ACP mode in CLI help

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
+- Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -165,7 +165,7 @@ const TOP_LEVEL_OPTION_GROUPS: ReadonlyArray<{ heading: string; options: readonl
 		heading: "Run options",
 		options: [
 			["-p, --print", "Print a response and exit"],
-			["--mode <text|json|rpc|daemon>", "Select the output mode (default: text)"],
+			["--mode <text|json|rpc|acp|daemon>", "Select the output mode (default: text)"],
 			["--cwd <dir>", "Use a specific working directory"],
 			["--offline", "Disable startup network operations"],
 			["--verbose", "Force verbose startup"],

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -325,6 +325,7 @@ describe("public command routing", () => {
 		const help = formatTopLevelHelp();
 		expect(help).toContain("Options:");
 		expect(help).toContain("Run options:");
+		expect(help).toContain("--mode <text|json|rpc|acp|daemon>");
 		expect(help).toContain("Autonomous options:");
 		for (const option of [
 			"--autonomous",


### PR DESCRIPTION
## Summary

- advertise `acp` in the top-level `--mode` help values
- add regression coverage for the exact supported-mode list
- document the fix in the Unreleased changelog

Fixes #620

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/public-command.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text and test-only change; CLI mode handling is unchanged.
> 
> **Overview**
> Top-level `--help` now lists **`acp`** among valid `--mode` values (`text|json|rpc|acp|daemon`), matching runtime parsing that already accepted ACP mode.
> 
> A test asserts the exact `--mode` line in formatted help, and the Unreleased changelog notes the fix for [#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbf6eecb9fe8c2b84c8b33d8ab01b3310871c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `acp` to the `--mode` option in coding-agent CLI help
> The `--mode` flag in [command-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/625/files#diff-ba6fd689c2d87db9c6afe1cdb902b1644cb862c4434a4dbb41442f7b2ef466a8) previously omitted `acp` from its listed values. The help text is updated from `<text|json|rpc|daemon>` to `<text|json|rpc|acp|daemon>`, and the corresponding test is updated to assert the new string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dbf6ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->