### PR TITLE
docs(coding-agent): document idle eviction setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
+
 ## [0.6.0] - 2026-08-04
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -166,6 +166,14 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 
 Normally the package manager's global modules location is queried using `root -g`. As a special case, if the first element of `npmCommand` is `"bun"`, the modules location will instead be queried with `pm bin -g`.
 
+### Daemon
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `idleEvictionMinutes` | number or `"off"` | `90` | Idle threshold in minutes for whole-tree worker eviction and individual idle-child passivation; `"off"` disables both. |
+
+`idleEvictionMinutes` is a global daemon policy and is read only from `~/.prime/agent/settings.json`. Set it to a positive number to configure the idle threshold.
+
 ### Sessions
 
 | Setting | Type | Default | Description |


### PR DESCRIPTION
## Summary

- document the global `idleEvictionMinutes` daemon setting
- describe its `90` minute default, positive-number values, and `"off"` behavior
- clarify that it controls whole-tree worker eviction and idle-child passivation

Fixes #621

## Testing

- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Documents the existing global daemon setting **`idleEvictionMinutes`** in user-facing docs (fixes #621).
> 
> **`docs/settings.md`** adds a **Daemon** section: type `number | "off"`, default **90**, meaning idle minutes before whole-tree worker eviction and per-child passivation; `"off"` disables both. It notes the value is read only from **`~/.prime/agent/settings.json`**, not project overrides.
> 
> **`CHANGELOG.md`** records the documentation under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db9f0053ac18c8e4f2363dc65fda4a8210b5476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `idleEvictionMinutes` daemon setting in coding-agent docs
> Adds a new 'Daemon' section to [settings.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/626/files#diff-fab1566cd80cf0a84c29db9db081b306b113186245fa2356e42a14f9c3b6b552) documenting the `idleEvictionMinutes` global setting (type `number | "off"`, default `90`). Describes its role in whole-tree worker eviction and idle-child passivation, and notes it is read only from `~/.prime/agent/settings.json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c4fe7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->