### PR TITLE
fix(coding-agent): dispatch socket-prefixed commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## [Unreleased]
 
-
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
 - Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
-
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.
 - Fixed daemon startup crashes hiding their exit status and daemon log until the startup timeout.
 - Documented the global `idleEvictionMinutes` daemon setting, including its default, valid values, and eviction/passivation behavior ([#621](https://github.com/PrimeIntellect-ai/prime-agent/issues/621)).
 - Fixed top-level `--help` omitting `acp` from the supported `--mode` values ([#620](https://github.com/PrimeIntellect-ai/prime-agent/issues/620)).
+- Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
+
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -147,7 +147,7 @@ async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
 
 function normalizeLeadingDaemonSocketOption(args: string[]): string[] {
 	const option = args[0];
-	if (option !== "--socket" && option !== "--daemon-socket") {
+	if (option !== "--daemon-socket") {
 		return args;
 	}
 	const socketPath = args[1];

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -34,6 +34,7 @@ export async function handlePublicCommand(args: string[]): Promise<PublicCommand
 }
 
 async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
+	args = normalizeLeadingDaemonSocketOption(args);
 	if (args[0] === "help" && isHelpCommandRequest(args.slice(1))) {
 		return printRequestedHelp(args.slice(1));
 	}
@@ -142,6 +143,19 @@ async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
 		default:
 			return continueWith(args);
 	}
+}
+
+function normalizeLeadingDaemonSocketOption(args: string[]): string[] {
+	const option = args[0];
+	if (option !== "--socket" && option !== "--daemon-socket") {
+		return args;
+	}
+	const socketPath = args[1];
+	const command = args[2];
+	if (socketPath === undefined || (command !== "stop" && command !== "rename")) {
+		return args;
+	}
+	return [command, ...args.slice(3), option, socketPath];
 }
 
 function continueWith(args: string[]): PublicCommandResult {

--- a/packages/coding-agent/test/suite/regressions/622-global-options-before-command.test.ts
+++ b/packages/coding-agent/test/suite/regressions/622-global-options-before-command.test.ts
@@ -21,23 +21,26 @@ describe("issue #622 global options before commands", () => {
 	it.each([
 		["stop", ["worker"], ["kill", "worker"]],
 		["rename", ["worker", "reviewer"], ["rename", "worker", "reviewer"]],
-	])("routes %s with the daemon socket before or after the command", async (command, operands, internalArgs) => {
-		for (const socketOption of ["--daemon-socket", "--socket"]) {
-			const socketArgs = [socketOption, "/tmp/custom-daemon.sock"];
+	])(
+		"routes %s with the documented socket option before or after the command",
+		async (command, operands, internalArgs) => {
+			const socketPath = "/tmp/custom-daemon.sock";
 
-			await expect(handlePublicCommand([...socketArgs, command, ...operands])).resolves.toMatchObject({
+			await expect(
+				handlePublicCommand(["--daemon-socket", socketPath, command, ...operands]),
+			).resolves.toMatchObject({ handled: true });
+			await expect(
+				handlePublicCommand([command, ...operands, "--daemon-socket", socketPath]),
+			).resolves.toMatchObject({ handled: true });
+			await expect(handlePublicCommand([command, ...operands, "--socket", socketPath])).resolves.toMatchObject({
 				handled: true,
 			});
-			await expect(handlePublicCommand([command, ...operands, ...socketArgs])).resolves.toMatchObject({
-				handled: true,
-			});
-		}
 
-		expect(mocks.daemonCommands).toEqual([
-			["daemon", ...internalArgs, "--daemon-socket", "/tmp/custom-daemon.sock"],
-			["daemon", ...internalArgs, "--daemon-socket", "/tmp/custom-daemon.sock"],
-			["daemon", ...internalArgs, "--socket", "/tmp/custom-daemon.sock"],
-			["daemon", ...internalArgs, "--socket", "/tmp/custom-daemon.sock"],
-		]);
-	});
+			expect(mocks.daemonCommands).toEqual([
+				["daemon", ...internalArgs, "--daemon-socket", socketPath],
+				["daemon", ...internalArgs, "--daemon-socket", socketPath],
+				["daemon", ...internalArgs, "--socket", socketPath],
+			]);
+		},
+	);
 });

--- a/packages/coding-agent/test/suite/regressions/622-global-options-before-command.test.ts
+++ b/packages/coding-agent/test/suite/regressions/622-global-options-before-command.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	daemonCommands: [] as string[][],
+}));
+
+vi.mock("../../../src/cli/daemon-command.js", () => ({
+	handleDaemonCommand: async (args: string[]) => {
+		mocks.daemonCommands.push(args);
+		return true;
+	},
+}));
+
+import { handlePublicCommand } from "../../../src/cli/public-command.js";
+
+describe("issue #622 global options before commands", () => {
+	beforeEach(() => {
+		mocks.daemonCommands.length = 0;
+	});
+
+	it.each([
+		["stop", ["worker"], ["kill", "worker"]],
+		["rename", ["worker", "reviewer"], ["rename", "worker", "reviewer"]],
+	])("routes %s with the daemon socket before or after the command", async (command, operands, internalArgs) => {
+		for (const socketOption of ["--daemon-socket", "--socket"]) {
+			const socketArgs = [socketOption, "/tmp/custom-daemon.sock"];
+
+			await expect(handlePublicCommand([...socketArgs, command, ...operands])).resolves.toMatchObject({
+				handled: true,
+			});
+			await expect(handlePublicCommand([command, ...operands, ...socketArgs])).resolves.toMatchObject({
+				handled: true,
+			});
+		}
+
+		expect(mocks.daemonCommands).toEqual([
+			["daemon", ...internalArgs, "--daemon-socket", "/tmp/custom-daemon.sock"],
+			["daemon", ...internalArgs, "--daemon-socket", "/tmp/custom-daemon.sock"],
+			["daemon", ...internalArgs, "--socket", "/tmp/custom-daemon.sock"],
+			["daemon", ...internalArgs, "--socket", "/tmp/custom-daemon.sock"],
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- normalize the documented leading `--daemon-socket` option before public-command dispatch
- preserve the existing post-command `--daemon-socket` and `--socket` forms for `stop` and `rename`
- add issue-specific regression coverage for both commands and supported option placements

Fixes #622

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/622-global-options-before-command.test.ts test/public-command.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow argv normalization for two daemon commands only; covered by regression tests with no auth or data-path changes.
> 
> **Overview**
> Fixes **#622**: when `--daemon-socket <path>` appears before `stop` or `rename`, the CLI no longer treats those words as chat prompts.
> 
> **`public-command.ts`** runs `normalizeLeadingDaemonSocketOption` at the start of public-command handling. For the pattern `--daemon-socket`, socket path, then `stop` or `rename`, it reorders argv to put the command first and the socket option at the end (same shape the existing `requireOperandCount` logic already accepts for trailing `--daemon-socket` / `--socket`). Other commands and option orderings are unchanged.
> 
> Adds a regression test for `stop` and `rename` with leading, trailing, and `--socket` forms, and an unreleased changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819c532cef99eba5c280ea7d2e39c46dc0626851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `stop` and `rename` commands being parsed as prompts when `--daemon-socket` precedes the command
> When `--daemon-socket <path>` is passed before the subcommand (e.g. `--daemon-socket /tmp/s stop`), the CLI misparsed `stop` and `rename` as prompts instead of commands. A new `normalizeLeadingDaemonSocketOption` helper in [public-command.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/627/files#diff-95293366ebc8d0605c48116d5ccf09ffd95427059bbf96225ed58b41e3411e78) detects this ordering and reorders argv to `[command, ...rest, --daemon-socket, path]` before further processing. A regression test covering leading/trailing socket options and the `--socket` alias is added in [622-global-options-before-command.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/627/files#diff-e06f704e192e3d791f5ef61fbe59b56ef2b487067f1a91f97a00f6483f90318b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 819c532.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->