### PR TITLE
fix(coding-agent): canonicalize ACP cwd comparison

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `stop` and `rename` becoming prompts when `--daemon-socket` precedes the command ([#622](https://github.com/PrimeIntellect-ai/prime-agent/issues/622)).
 - Fixed subagent terminal notices arriving as anonymous follow-up prompts instead of attributed agent messages, so a parent can now tell which child reported completion, failure, or cancellation, and a busy parent is steered at the next turn boundary rather than waiting to go idle ([#617](https://github.com/PrimeIntellect-ai/prime-agent/issues/617)).
 - Fixed ACP mode reporting a failed turn as a clean `end_turn`. A provider error, expired auth, or unusable model left `session/prompt` resolving with no updates at all, which reads to a client as a successful but empty turn; the turn now fails with the underlying error instead.
+- Fixed ACP cwd mismatch metadata treating symlink aliases such as macOS `/var` and `/private/var` as different directories ([#623](https://github.com/PrimeIntellect-ai/prime-agent/issues/623)).
 
 ## [0.6.0] - 2026-08-04
 

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { realpathSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
@@ -62,6 +62,23 @@ function canonicalCwd(path: string): string {
 		canonical = resolved;
 	}
 	return normalizeWindowsDriveLetter(canonical);
+}
+
+function sameCwd(left: string, right: string): boolean {
+	const canonicalLeft = canonicalCwd(left);
+	const canonicalRight = canonicalCwd(right);
+	if (canonicalLeft === canonicalRight) return true;
+
+	try {
+		const leftStat = statSync(canonicalLeft, { bigint: true });
+		const rightStat = statSync(canonicalRight, { bigint: true });
+		const leftIdentityMissing = leftStat.dev === 0n && leftStat.ino === 0n;
+		const rightIdentityMissing = rightStat.dev === 0n && rightStat.ino === 0n;
+		if (leftIdentityMissing || rightIdentityMissing) return false;
+		return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino;
+	} catch {
+		return false;
+	}
 }
 
 export interface AcpModeOptions {
@@ -273,7 +290,7 @@ export async function runAcpModeWithConnection(
 					.getState()
 					.then((state) => state.cwd)
 					.catch(() => undefined);
-				if (actual && canonicalCwd(requestedCwd) !== canonicalCwd(actual)) {
+				if (actual && !sameCwd(requestedCwd, actual)) {
 					cwdMismatch = { requested: requestedCwd, actual };
 				}
 			}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -47,6 +47,11 @@ function rawStdoutSink(): WritableStream<Uint8Array> {
 	});
 }
 
+function normalizeWindowsDriveLetter(path: string): string {
+	if (process.platform !== "win32" || !/^[A-Z]:/i.test(path)) return path;
+	return path.slice(0, 1).toLowerCase() + path.slice(1);
+}
+
 function canonicalCwd(path: string): string {
 	const resolved = resolve(path);
 	let canonical: string;
@@ -56,7 +61,7 @@ function canonicalCwd(path: string): string {
 		// Preserve the previous lexical comparison when a path is missing or inaccessible.
 		canonical = resolved;
 	}
-	return process.platform === "win32" ? canonical.toLowerCase() : canonical;
+	return normalizeWindowsDriveLetter(canonical);
 }
 
 export interface AcpModeOptions {

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
@@ -44,6 +45,18 @@ function rawStdoutSink(): WritableStream<Uint8Array> {
 			writeRawStdout(typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true }));
 		},
 	});
+}
+
+function canonicalCwd(path: string): string {
+	const resolved = resolve(path);
+	let canonical: string;
+	try {
+		canonical = realpathSync(resolved);
+	} catch {
+		// Preserve the previous lexical comparison when a path is missing or inaccessible.
+		canonical = resolved;
+	}
+	return process.platform === "win32" ? canonical.toLowerCase() : canonical;
 }
 
 export interface AcpModeOptions {
@@ -255,7 +268,7 @@ export async function runAcpModeWithConnection(
 					.getState()
 					.then((state) => state.cwd)
 					.catch(() => undefined);
-				if (actual && resolve(requestedCwd) !== resolve(actual)) {
+				if (actual && canonicalCwd(requestedCwd) !== canonicalCwd(actual)) {
 					cwdMismatch = { requested: requestedCwd, actual };
 				}
 			}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -72,8 +72,11 @@ function sameCwd(left: string, right: string): boolean {
 	try {
 		const leftStat = statSync(canonicalLeft, { bigint: true });
 		const rightStat = statSync(canonicalRight, { bigint: true });
-		const leftIdentityMissing = leftStat.dev === 0n && leftStat.ino === 0n;
-		const rightIdentityMissing = rightStat.dev === 0n && rightStat.ino === 0n;
+		// Either half being zero makes the pair untrustworthy: Windows path-based
+		// stat can report dev 0 with a real ino, and comparing ino alone would match
+		// distinct directories on different volumes, since file IDs are volume-local.
+		const leftIdentityMissing = leftStat.dev === 0n || leftStat.ino === 0n;
+		const rightIdentityMissing = rightStat.dev === 0n || rightStat.ino === 0n;
 		if (leftIdentityMissing || rightIdentityMissing) return false;
 		return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino;
 	} catch {

--- a/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
+++ b/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
@@ -92,6 +92,11 @@ describe("#623 ACP canonical cwd comparison", () => {
 		"uses filesystem identity when realpath preserves different component casing",
 		async () => {
 			if (!caseVariantCwd) throw new Error("Expected a case-only cwd variant");
+			const originalStat = statSync(process.cwd(), { bigint: true });
+			const variantStat = statSync(caseVariantCwd, { bigint: true });
+			expect(realpathSync(caseVariantCwd)).not.toBe(realpathSync(process.cwd()));
+			expect([variantStat.dev, variantStat.ino]).toEqual([originalStat.dev, originalStat.ino]);
+
 			const harness = await createHarness();
 			harnesses.push(harness);
 

--- a/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
+++ b/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as acp from "@agentclientprotocol/sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.js";
+import { PRIME_AGENT_META_NAMESPACE } from "../../../src/modes/acp/acp-meta.js";
+import { runAcpModeWithConnection } from "../../../src/modes/acp/index.js";
+import { InProcessAgentConnection } from "../../../src/modes/agent-connection/in-process-agent-connection.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function runtimeHostFor(session: unknown): AgentSessionRuntime {
+	return {
+		session,
+		setRebindSession() {},
+		setBeforeSessionInvalidate() {},
+		async dispose() {},
+	} as unknown as AgentSessionRuntime;
+}
+
+async function newAcpSession(harness: Harness, cwd: string) {
+	const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+	const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+	const toClient = new TransformStream<Uint8Array, Uint8Array>();
+	void runAcpModeWithConnection(connection, {
+		stream: acp.ndJsonStream(toClient.writable, toAgent.readable),
+	});
+	const handle = acp.client({ name: "cwd-regression" }).connect(acp.ndJsonStream(toAgent.writable, toClient.readable));
+	await handle.agent.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+	return handle.agent.request("session/new", { cwd, mcpServers: [] });
+}
+
+function cwdMeta(created: { _meta?: Record<string, unknown> | null }): unknown {
+	return (created._meta?.[PRIME_AGENT_META_NAMESPACE] as { cwd?: unknown } | undefined)?.cwd;
+}
+
+const harnesses: Harness[] = [];
+const directories: string[] = [];
+
+afterEach(() => {
+	for (const directory of directories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	for (const harness of harnesses.splice(0)) {
+		harness.cleanup();
+	}
+});
+
+describe("#623 ACP canonical cwd comparison", () => {
+	it("does not report a mismatch for paths resolving to the same directory", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const aliasRoot = mkdtempSync(join(tmpdir(), "prime-agent-acp-cwd-"));
+		directories.push(aliasRoot);
+		const alias = join(aliasRoot, "alias");
+		symlinkSync(process.cwd(), alias, process.platform === "win32" ? "junction" : "dir");
+
+		// macOS exposes /var as /private/var; a portable symlink exercises the
+		// same distinction between a displayed path and its canonical path.
+		const created = await newAcpSession(harness, alias);
+
+		expect(created.sessionId).toBeTruthy();
+		expect(cwdMeta(created)).toBeUndefined();
+	}, 30_000);
+
+	it("preserves mismatch metadata when canonicalization falls back", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const requested = join(harness.tempDir, "missing");
+
+		const created = await newAcpSession(harness, requested);
+
+		expect(created.sessionId).toBeTruthy();
+		expect(cwdMeta(created)).toEqual({ requested, actual: process.cwd() });
+	}, 30_000);
+});

--- a/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
+++ b/packages/coding-agent/test/suite/regressions/623-acp-canonical-cwd.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
@@ -34,6 +34,31 @@ function cwdMeta(created: { _meta?: Record<string, unknown> | null }): unknown {
 	return (created._meta?.[PRIME_AGENT_META_NAMESPACE] as { cwd?: unknown } | undefined)?.cwd;
 }
 
+function findExistingCaseVariant(path: string): string | undefined {
+	const originalStat = statSync(path, { bigint: true });
+	for (let index = 0; index < path.length; index++) {
+		const character = path[index];
+		if (!character || !/[A-Z]/i.test(character)) continue;
+		const toggled = character === character.toLowerCase() ? character.toUpperCase() : character.toLowerCase();
+		const candidate = path.slice(0, index) + toggled + path.slice(index + 1);
+		if (!existsSync(candidate)) continue;
+		try {
+			const candidateStat = statSync(candidate, { bigint: true });
+			if (
+				realpathSync(candidate) !== realpathSync(path) &&
+				originalStat.dev === candidateStat.dev &&
+				originalStat.ino === candidateStat.ino
+			) {
+				return candidate;
+			}
+		} catch {
+			// Try the next component when this spelling cannot be inspected.
+		}
+	}
+	return undefined;
+}
+
+const caseVariantCwd = findExistingCaseVariant(process.cwd());
 const harnesses: Harness[] = [];
 const directories: string[] = [];
 
@@ -62,6 +87,21 @@ describe("#623 ACP canonical cwd comparison", () => {
 		expect(created.sessionId).toBeTruthy();
 		expect(cwdMeta(created)).toBeUndefined();
 	}, 30_000);
+
+	it.runIf(caseVariantCwd !== undefined)(
+		"uses filesystem identity when realpath preserves different component casing",
+		async () => {
+			if (!caseVariantCwd) throw new Error("Expected a case-only cwd variant");
+			const harness = await createHarness();
+			harnesses.push(harness);
+
+			const created = await newAcpSession(harness, caseVariantCwd);
+
+			expect(created.sessionId).toBeTruthy();
+			expect(cwdMeta(created)).toBeUndefined();
+		},
+		30_000,
+	);
 
 	it("preserves mismatch metadata when canonicalization falls back", async () => {
 		const harness = await createHarness();


### PR DESCRIPTION
## Summary

- compare requested and actual ACP cwd values using canonical paths and filesystem identity
- preserve lexical fallback behavior when a path is missing or inaccessible
- preserve genuine mismatches on case-sensitive Windows directories
- add portable symlink, case-only identity, and fallback regression coverage

Fixes #623

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/623-acp-canonical-cwd.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to ACP session metadata comparison with conservative stat fallbacks; no auth, data, or session behavior changes beyond fewer false-positive cwd warnings.
> 
> **Overview**
> **ACP `session/new` cwd mismatch detection** no longer uses plain `resolve()` string equality. It now uses **`sameCwd()`**, which canonicalizes with `realpathSync`, normalizes Windows drive letters, and when strings still differ compares **`stat` dev/ino** so symlink aliases (e.g. macOS `/var` vs `/private/var`) count as the same directory.
> 
> Missing or inaccessible paths still fall back to lexical comparison so real mismatches keep **`_meta` cwd** metadata. **CHANGELOG** and regression tests cover symlinks, case-only path identity, and the fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2655f4bca0c4473c71962b13bdf1094f143b5572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ACP cwd mismatch detection for symlink aliases and drive-letter variants
> Replaces the simple `resolve()` string comparison for cwd in `session/new` handling with a `sameCwd()` function that canonicalizes paths via `realpathSync` before comparing. If the canonical strings differ, it falls back to a `stat`-based identity check (dev/ino) to catch symlink aliases like macOS `/var` vs `/private/var`. A Windows drive-letter normalizer ensures `C:` and `c:` are treated as equal.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #628 opened
>
> - Changed `acp-mode.sameCwd` utility to treat filesystem identity as missing when either `dev` or `ino` is `0n` [2655f4b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e57414.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->