### PR TITLE
Report versions after self-update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed self-updates to report the previous and new Prime Agent versions.
+
 ## [0.6.1] - 2026-08-05
 
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -428,6 +428,7 @@ interface SelfUpdatePlan {
 	installSpec: string;
 	packageName: string;
 	shouldRun: boolean;
+	targetVersion?: string;
 }
 
 function setSelfUpdateNoChangeExitCode(): void {
@@ -447,7 +448,7 @@ async function getSelfUpdatePlan(force: boolean): Promise<SelfUpdatePlan> {
 			packageRenameRequiresUpdate ||
 			isNewerPackageVersion(latestRelease.version, VERSION)
 		) {
-			return { installSpec, packageName, shouldRun: true };
+			return { installSpec, packageName, shouldRun: true, targetVersion: latestRelease?.version };
 		}
 	} catch {
 		return { installSpec: PACKAGE_NAME, packageName: PACKAGE_NAME, shouldRun: true };
@@ -1605,7 +1606,10 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						process.exitCode = 1;
 						return true;
 					}
-					console.log(chalk.green(`Updated ${APP_NAME}`));
+					const versionChange = selfUpdatePlan.targetVersion
+						? ` from v${VERSION} to v${selfUpdatePlan.targetVersion}`
+						: "";
+					console.log(chalk.green(`Updated ${APP_NAME}${versionChange}`));
 					if (process.env[SELF_UPDATE_INTERACTIVE_CHILD_ENV] === "1") {
 						return true;
 					}


### PR DESCRIPTION
## What changed

After a successful self-update, Prime Agent now shows both versions:

```text
Updated prime-agent from v0.6.1 to v0.6.2
```

If the target version is unavailable, it keeps the existing generic message.

## Validation

- `npm run check`

No tests were added or run, as requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only success messaging and changelog; no change to install, daemon restart, or version resolution logic beyond surfacing an already-fetched version string.
> 
> **Overview**
> Successful **`prime-agent update`** (self-update) now prints the installed version transition when the release check knows the target, e.g. `Updated prime-agent from v0.6.1 to v0.6.2`, instead of only a generic “Updated prime-agent” line.
> 
> `getSelfUpdatePlan` carries optional **`targetVersion`** from the latest release metadata; if that value is missing (e.g. release lookup failed but install still proceeds), the success message stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4bc225e127a348da454d122460b94b35f6bfa92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report previous and new versions after self-update in the coding agent CLI
> After a successful self-update, the CLI now logs `Updated <APP_NAME> from v<current> to v<target>` when the target version is known, falling back to the generic `Updated <APP_NAME>` message otherwise. Adds `targetVersion` to the `SelfUpdatePlan` interface in [package-manager-cli.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/630/files#diff-5855e8a7adb3661c9d72e9b3a139a953b900c9d3f38cc8dcf3e4dca9d205fb5f) and populates it from `latestRelease.version` in `getSelfUpdatePlan`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4bc225.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->