### PR TITLE
Make agent messages steer-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ prime-agent shutdown [--force]       # Stop every agent, worker, and background 
 Prime Agent is built for long-running work, especially for evaluations in research. These features are available in the TUI, and when run autonomously. 
 
 - **Continual Harness:** `/refine` can persist focused, reviewable lessons as supplemental prompts, memories, reusable skill descriptions, or subagent specifications, with recorded refinement history. It does not replace packaging and reviewing new executable skills.
-- **Direct agent-to-agent communication:** running agents and retained subagents can discover one another, exchange messages, steer active work, or queue follow-ups.
+- **Direct agent-to-agent communication:** running agents and retained subagents can discover one another, exchange messages, and steer active work.
 - **Daemon-backed continuity:** active sessions, IPython state, schedules, and subagents keep running when the terminal detaches and can be reattached later.
 - **Heartbeats and schedules:** `/heartbeat`, `rlm_heartbeat`, and `prime-agent schedule` can re-enter a session periodically or at a specific time.
 - **Persistent goals:** `/goal` keeps an objective and its progress active across turns until it is completed, paused, or cleared.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed agent messages to always use steering delivery and removed delivery-mode options from the Python, CLI, RPC, and connection APIs.
+
 ## [0.6.1] - 2026-08-05
 
 - Added reverse tab navigation to the `/login` configuration menu and moved the model scope shortcut to `Alt+S`.

--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -20,7 +20,6 @@ if child is not None:
         "Please inspect the latest result.",
         receiver_role="child",
         receiver_name=child.session_name,
-        mode="auto",
     )
     # Keep the child until this follow-up finishes so its result remains observable.
 ```
@@ -32,23 +31,21 @@ if child is not None:
   for the current agent's parent, siblings, and children. It includes inactive
   family members and sorts parent, siblings by name, then children by name; it
   does not expose a global daemon session list.
-- `await agent_message.send(message, receiver_role="parent" | "sibling" | "child", receiver_name=None, mode="auto")` — sends one direct
+- `await agent_message.send(message, receiver_role="parent" | "sibling" | "child", receiver_name=None)` — sends one direct
   text message to an active session. Sending to an idle completed subagent
   starts an ordinary follow-up turn in that same child session and context.
   The child remains available only until its parent session closes. The daemon
   resolves `receiver_role` within the current agent family; `receiver_name` is
   required for siblings and children and omitted for the unique parent.
-  `send("all", message)` broadcasts only to the
-  family roster and returns `{receipts: [...]}` in roster order; successful entries
-  are ordinary receipts and failed entries contain the target id and a short `error`.
-  One failed delivery does not reject successful deliveries. `mode` is
-  `"auto"`, `"follow_up"`, or `"steer"`. In `auto` mode, messages to busy sessions are queued as steering
-  messages so the target sees them during the active run; use `"follow_up"` for
-  intentionally delayed delivery. Returns a receipt with a `deliveryStatus`
-  field: `"delivered"` means the message reached an idle target's context;
-  `"queued"` means it was accepted and will deliver when the target's current
-  work allows (`send` does not block waiting for that). Delivered receipts
-  carry `deliveredAt`, queued receipts carry `queuedAt`.
+  `send("all", message)` broadcasts only to the family roster and returns
+  `{receipts: [...]}` in roster order; successful entries are ordinary receipts
+  and failed entries contain the target id and a short `error`. One failed delivery
+  does not reject successful deliveries. Messages always use steering delivery so
+  a busy target sees them during its active run. Returns a receipt with a
+  `deliveryStatus` field: `"delivered"` means the message reached an idle target's
+  context; `"queued"` means a steering message was accepted and will deliver when
+  the target's current work allows (`send` does not block waiting for that).
+  Delivered receipts carry `deliveredAt`, queued receipts carry `queuedAt`.
 
 ## Safety
 

--- a/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
+++ b/packages/coding-agent/skills/agent-message/src/agent_message/__init__.py
@@ -11,7 +11,6 @@ from typing import Any, Literal
 from IPython.display import display
 from rlm import host_request
 
-MessageMode = Literal["auto", "follow_up", "steer"]
 ReceiverRole = Literal["parent", "sibling", "child"]
 _MESSAGE_DISPLAY_MIME = "application/vnd.prime-agent.agent-message+json"
 
@@ -27,7 +26,6 @@ async def send(
     *,
     receiver_role: ReceiverRole | str | None = None,
     receiver_name: str | None = None,
-    mode: MessageMode = "auto",
 ) -> dict[str, Any]:
     """Send one direct role-addressed message or broadcast to ``"all"``."""
     roles = ("parent", "sibling", "child")
@@ -42,7 +40,6 @@ async def send(
         payload: dict[str, Any] = {
             "target": "all",
             "message": broadcast_message,
-            "mode": mode,
         }
     else:
         if receiver_role not in roles:
@@ -58,10 +55,7 @@ async def send(
             "message": message,
             "receiver_role": receiver_role,
             "receiver_name": receiver_name,
-            "mode": mode,
         }
-    if mode not in ("auto", "follow_up", "steer"):
-        raise ValueError('mode must be "auto", "follow_up", or "steer"')
     receipt = await host_request("agent_message.send", payload)
     receipts = receipt.get("receipts") if isinstance(receipt, dict) else None
     if isinstance(receipts, list):

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -43,7 +43,7 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 	},
 	{
 		path: ["send"],
-		usage: "send [--from <agent>] [--steer|--follow-up] <agent> <message>",
+		usage: "send [--from <agent>] <agent> <message>",
 		summary: "Send a message to an agent",
 		options: [
 			"--from <agent>  Identify the sending agent",

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -899,7 +899,6 @@ async function runSend(client: DaemonClient, args: string[], json: boolean): Pro
 		type: "send_message",
 		targetActiveSessionId: parsed.targetActiveSessionId,
 		fromActiveSessionId: parsed.fromActiveSessionId,
-		deliveryMode: parsed.deliveryMode,
 		message: parsed.message,
 	});
 	const data = requireSuccess(response);
@@ -918,13 +917,11 @@ async function runSend(client: DaemonClient, args: string[], json: boolean): Pro
 interface ParsedSendArgs {
 	targetActiveSessionId: string;
 	fromActiveSessionId?: string;
-	deliveryMode?: "auto" | "steer" | "follow_up";
 	message: string;
 }
 
 function parseSendArgs(args: string[]): ParsedSendArgs {
 	let fromActiveSessionId: string | undefined;
-	let deliveryMode: "auto" | "steer" | "follow_up" | undefined;
 	let targetActiveSessionId: string | undefined;
 	let explicitMessage: string | undefined;
 	const messageParts: string[] = [];
@@ -943,27 +940,6 @@ function parseSendArgs(args: string[]): ParsedSendArgs {
 			}
 			fromActiveSessionId = value;
 			index++;
-			continue;
-		}
-		if (parseOptions && arg === "--steer") {
-			if (deliveryMode !== undefined) {
-				throw new Error("Only one send delivery mode may be specified: --steer or --follow-up");
-			}
-			deliveryMode = "steer";
-			continue;
-		}
-		if (parseOptions && arg === "--follow-up") {
-			if (deliveryMode !== undefined) {
-				throw new Error("Only one send delivery mode may be specified: --steer or --follow-up");
-			}
-			deliveryMode = "follow_up";
-			continue;
-		}
-		if (parseOptions && arg === "--auto") {
-			if (deliveryMode !== undefined) {
-				throw new Error("Only one send delivery mode may be specified: --steer or --follow-up");
-			}
-			deliveryMode = "auto";
 			continue;
 		}
 		if (parseOptions && arg === "--message") {
@@ -990,20 +966,15 @@ function parseSendArgs(args: string[]): ParsedSendArgs {
 	}
 
 	if (explicitMessage !== undefined && messageParts.length > 0) {
-		throw new Error(
-			"Usage: prime-agent send [--from <agent>] [--steer|--follow-up] <agent> [--message <message>|<message>]",
-		);
+		throw new Error("Usage: prime-agent send [--from <agent>] <agent> [--message <message>|<message>]");
 	}
 	const message = (explicitMessage ?? messageParts.join(" ")).trim();
 	if (!targetActiveSessionId || !message) {
-		throw new Error(
-			"Usage: prime-agent send [--from <agent>] [--steer|--follow-up] <agent> [--message <message>|<message>]",
-		);
+		throw new Error("Usage: prime-agent send [--from <agent>] <agent> [--message <message>|<message>]");
 	}
 	return {
 		targetActiveSessionId,
 		fromActiveSessionId,
-		deliveryMode,
 		message,
 	};
 }

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -14,6 +14,7 @@ export const DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION = 20;
 export const DEFAULT_AGENT_MESSAGE_RATE_LIMIT_CAPACITY = 3;
 export const DEFAULT_AGENT_MESSAGE_RATE_LIMIT_REFILL_MS = 1000;
 
+/** Legacy daemon wire input accepted and ignored for compatibility. */
 export type AgentSessionMessageDeliveryMode = "auto" | "steer" | "follow_up";
 export type AgentSessionMessageDeliveryStatus = "delivered" | "queued";
 export type AgentSessionMessageRuntimeKind = "top-level" | "subagent";
@@ -116,7 +117,6 @@ export interface AgentSessionMessagePayload {
 	/** Sender relationship from the receiver's point of view. */
 	fromRelationship?: AgentFamilyRelationship;
 	target: AgentSessionMessageEndpoint;
-	deliveryMode: AgentSessionMessageDeliveryMode;
 }
 
 export interface AgentSessionMessageDetails {
@@ -145,13 +145,12 @@ export interface AgentSessionMessageReceipt {
 	deliveredAt?: string;
 	/** Present when deliveryStatus is "queued": the message waits behind the target's current work. */
 	queuedAt?: string;
-	deliveryMode: AgentSessionMessageDeliveryMode;
+	deliveryMode?: "steer";
 }
 
 export interface AgentSessionMessageSendInput {
 	target: string;
 	message: string;
-	deliveryMode?: AgentSessionMessageDeliveryMode;
 	receiverRole?: AgentFamilyRelationship;
 }
 
@@ -343,16 +342,6 @@ export function normalizeAgentSessionMessage(message: string, maxChars = DEFAULT
 	return trimmed;
 }
 
-export function normalizeAgentSessionMessageDeliveryMode(value: unknown): AgentSessionMessageDeliveryMode | undefined {
-	if (value === undefined || value === null) {
-		return undefined;
-	}
-	if (value === "auto" || value === "steer" || value === "follow_up") {
-		return value;
-	}
-	throw new Error('agent_message.send mode must be "auto", "steer", or "follow_up"');
-}
-
 export function assertDirectAgentMessageTarget(target: string): string {
 	const normalized = target.trim();
 	if (!normalized) {
@@ -373,23 +362,6 @@ export function assertAgentMessageQueueCapacity(
 			`Target session has too many pending messages: ${unfinishedActionCount} unfinished, limit is ${maxPending}`,
 		);
 	}
-}
-
-export function resolveAgentSessionMessageStreamingBehavior(
-	isTargetStreaming: boolean,
-	deliveryMode: AgentSessionMessageDeliveryMode | undefined,
-): "steer" | "followUp" | undefined {
-	const mode = deliveryMode ?? "auto";
-	if (!isTargetStreaming) {
-		return undefined;
-	}
-	if (mode === "steer") {
-		return "steer";
-	}
-	if (mode === "follow_up") {
-		return "followUp";
-	}
-	return "steer";
 }
 
 export function parseAgentSessionMessagePromptId(text: string): string | undefined {
@@ -478,7 +450,7 @@ export function createAgentSessionMessageReceipt(
 		message: payload.message,
 		deliveryStatus: status,
 		...(status === "delivered" ? { deliveredAt: at } : { queuedAt: at }),
-		deliveryMode: payload.deliveryMode,
+		deliveryMode: "steer",
 	};
 }
 
@@ -579,7 +551,6 @@ export function createAgentMessageHostHandlers(
 						controller.sendAgentMessage({
 							target: entry.id,
 							message: payload.message as string,
-							deliveryMode: normalizeAgentSessionMessageDeliveryMode(payload.mode),
 							receiverRole: entry.relationship,
 						}),
 					),
@@ -629,7 +600,6 @@ export function createAgentMessageHostHandlers(
 			return (await controller.sendAgentMessage({
 				target,
 				message: payload.message,
-				deliveryMode: normalizeAgentSessionMessageDeliveryMode(payload.mode),
 				receiverRole: payload.receiver_role as AgentFamilyRelationship,
 			})) as unknown as Record<string, unknown>;
 		},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -68,7 +68,6 @@ import {
 	formatAgentSessionNameUnavailable,
 	isAgentSessionMessage,
 	normalizeAgentSessionMessage,
-	normalizeAgentSessionMessageDeliveryMode,
 	parseAgentSessionMessagePromptId,
 } from "./agent-messages.js";
 import {
@@ -3075,11 +3074,9 @@ export class AgentSession {
 				if (typeof payload.message !== "string") {
 					throw new Error("agent_message.send message must be a string");
 				}
-				const deliveryMode = normalizeAgentSessionMessageDeliveryMode(payload.mode);
 				return this._agentMessageController.sendAgentMessage({
 					target: assertDirectAgentMessageTarget(payload.target),
 					message: normalizeAgentSessionMessage(payload.message),
-					...(deliveryMode ? { deliveryMode } : {}),
 				});
 			}
 			default:
@@ -8716,7 +8713,6 @@ export class AgentSession {
 						const receipt = (await this.handleAgentMessageHostRequest("agent_message.send", {
 							target: input.target,
 							message: input.message,
-							mode: input.deliveryMode,
 						})) as AgentSessionMessageReceipt;
 						if (this._rlmDepth > 0) {
 							let addressedParent = input.receiverRole === "parent";
@@ -9694,9 +9690,6 @@ export class AgentSession {
 			const childController = childSession?._agentMessageController;
 			if (childController) {
 				try {
-					// deliveryMode is deliberately omitted: the "auto" default steers into
-					// a busy parent, whereas "follow_up" parks a child's last signal in the
-					// when-run-idle lane, which drains only once the steer lane empties.
 					await childController.sendAgentMessage({
 						target: this.sessionId,
 						message: message.content as string,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai";
 import { appendRotatingLog, getAgentLogPath, getDaemonLogPath } from "../../config.js";
-import type {
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageReceipt,
-	AgentSessionMessageSafetyStatus,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionEvent } from "../../core/agent-session.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
@@ -644,17 +640,12 @@ export class DaemonAgentConnection implements AgentConnection {
 		return data.heartbeat ?? undefined;
 	}
 
-	async sendAgentMessage(
-		targetActiveSessionId: string,
-		message: string,
-		deliveryMode?: AgentSessionMessageDeliveryMode,
-	): Promise<AgentSessionMessageReceipt> {
+	async sendAgentMessage(targetActiveSessionId: string, message: string): Promise<AgentSessionMessageReceipt> {
 		return this.requestData<AgentSessionMessageReceipt>({
 			type: "send_message",
 			targetActiveSessionId,
 			message,
 			fromActiveSessionId: this.activeSessionId,
-			deliveryMode,
 		});
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -1,11 +1,7 @@
 import { resolve } from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai";
-import type {
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageReceipt,
-	AgentSessionMessageSafetyStatus,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
@@ -242,11 +238,7 @@ export class InProcessAgentConnection implements AgentConnection {
 		throw new Error("Heartbeats require daemon mode");
 	}
 
-	async sendAgentMessage(
-		_targetActiveSessionId: string,
-		_message: string,
-		_deliveryMode?: AgentSessionMessageDeliveryMode,
-	): Promise<AgentSessionMessageReceipt> {
+	async sendAgentMessage(_targetActiveSessionId: string, _message: string): Promise<AgentSessionMessageReceipt> {
 		throw new Error("Agent messaging requires daemon mode");
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -1,10 +1,6 @@
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, ImageContent, Model, ServiceTier, TextContent, Transport, Usage } from "@earendil-works/pi-ai";
-import type {
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageReceipt,
-	AgentSessionMessageSafetyStatus,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AuthSourceToken } from "../../core/auth-storage.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
@@ -665,11 +661,7 @@ export interface AgentConnection {
 		deliveryMode?: AgentHeartbeatDeliveryMode,
 	): Promise<AgentCronJob>;
 	updateHeartbeat(action: AgentHeartbeatUpdateAction): Promise<AgentCronJob | undefined>;
-	sendAgentMessage(
-		targetActiveSessionId: string,
-		message: string,
-		deliveryMode?: AgentSessionMessageDeliveryMode,
-	): Promise<AgentSessionMessageReceipt>;
+	sendAgentMessage(targetActiveSessionId: string, message: string): Promise<AgentSessionMessageReceipt>;
 	getAgentMessageStatus(): Promise<AgentSessionMessageSafetyStatus>;
 	pauseAgentMessages(): Promise<AgentSessionMessageSafetyStatus>;
 	resumeAgentMessages(): Promise<AgentSessionMessageSafetyStatus>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -63,7 +63,6 @@ import {
 	formatAgentSessionNameUnavailable,
 	isAgentSessionMessagePrompt,
 	normalizeAgentSessionMessage,
-	resolveAgentSessionMessageStreamingBehavior,
 	sessionNameReservationKey,
 } from "../../core/agent-messages.js";
 import {
@@ -2839,7 +2838,6 @@ export class AgentDaemon {
 					targetSelector: input.target,
 					message: input.message,
 					fromState: requireCurrentState(),
-					deliveryMode: input.deliveryMode,
 					origin: "agent",
 				}),
 		};
@@ -3380,7 +3378,6 @@ export class AgentDaemon {
 						message: command.message,
 						sender: command.sender,
 						senderKey: command.sender.activeSessionId ?? `client:${command.sender.clientId}`,
-						deliveryMode: command.deliveryMode,
 						origin: "agent",
 					});
 					this.writeWorkerSuccess(client, command, receipt);
@@ -3945,7 +3942,6 @@ export class AgentDaemon {
 					fromState,
 					clientId: client.id,
 					senderKey: this.createCliAgentMessageSenderKey(),
-					deliveryMode: command.deliveryMode,
 					origin: command.agentOrigin === true ? "agent" : "cli",
 				});
 				return success(command.id, "send_message", receipt);
@@ -5343,7 +5339,6 @@ export class AgentDaemon {
 		sender?: AgentSessionMessageSender;
 		clientId?: string;
 		senderKey?: string;
-		deliveryMode?: AgentSessionMessagePayload["deliveryMode"];
 		origin: "agent" | "cli";
 	}): Promise<AgentSessionMessageReceipt> {
 		if (this.agentMessagesPaused) {
@@ -5386,12 +5381,7 @@ export class AgentDaemon {
 						} else if (this.options.worker && options.fromState) {
 							// The supervisor can resolve and wake a saved worker even when it is no longer
 							// present in this worker's resident peer snapshot.
-							return this.sendRemoteAgentSessionMessage(
-								options.fromState,
-								targetSelector,
-								message,
-								options.deliveryMode,
-							);
+							return this.sendRemoteAgentSessionMessage(options.fromState, targetSelector, message);
 						} else {
 							throw error;
 						}
@@ -5423,7 +5413,6 @@ export class AgentDaemon {
 				this.createAgentSessionMessageSender(options.fromState, options.clientId ?? options.origin),
 			fromRelationship: this.agentMessageRelationship(options.fromState, targetState),
 			target: this.createAgentSessionMessageEndpoint(targetState),
-			deliveryMode: options.deliveryMode ?? "auto",
 		};
 		try {
 			const { status } = await this.withAgentMessageTargetLock(targetState.activeSessionId, async () => {
@@ -5455,7 +5444,6 @@ export class AgentDaemon {
 		fromState: ActiveSessionState,
 		targetSelector: string,
 		message: string,
-		deliveryMode?: AgentSessionMessagePayload["deliveryMode"],
 	): Promise<AgentSessionMessageReceipt> {
 		const supervisorSocketPath = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
 		if (!supervisorSocketPath) {
@@ -5476,7 +5464,6 @@ export class AgentDaemon {
 						message,
 						fromActiveSessionId: fromState.activeSessionId,
 						agentOrigin: true,
-						deliveryMode,
 					},
 					30_000,
 				);
@@ -5521,9 +5508,7 @@ export class AgentDaemon {
 			session.isRetrying ||
 			session.isBashRunning ||
 			session.unfinishedActionCount > 0;
-		const streamingBehavior =
-			resolveAgentSessionMessageStreamingBehavior(shouldQueue, payload.deliveryMode) ??
-			(payload.deliveryMode === "follow_up" ? "followUp" : "steer");
+		const streamingBehavior = "steer";
 		const message = createAgentSessionMessage(payload);
 		const prompt = message.content;
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1845,7 +1845,6 @@ export class DaemonSupervisor {
 							runtimeKind: source.summary.runtimeKind ?? "top-level",
 							clientId: client.id,
 						},
-						deliveryMode: command.deliveryMode,
 					},
 					WORKER_REQUEST_TIMEOUT_MS,
 				);

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -7,11 +7,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent } from "@earendil-works/pi-ai";
-import type {
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageReceipt,
-	AgentSessionMessageSafetyStatus,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type {
@@ -437,16 +433,11 @@ export class RpcClient {
 		return this.getData<{ messages: AgentMessage[] }>(response).messages;
 	}
 
-	async sendAgentMessage(
-		targetActiveSessionId: string,
-		message: string,
-		deliveryMode?: AgentSessionMessageDeliveryMode,
-	): Promise<AgentSessionMessageReceipt> {
+	async sendAgentMessage(targetActiveSessionId: string, message: string): Promise<AgentSessionMessageReceipt> {
 		const response = await this.send({
 			type: "send_message",
 			targetActiveSessionId,
 			message,
-			deliveryMode,
 		});
 		return this.getData(response);
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -338,7 +338,7 @@ async function runRpcModeWithConnectionInternal(
 				return success(
 					id,
 					command.type,
-					await connection.sendAgentMessage(command.targetActiveSessionId, command.message, command.deliveryMode),
+					await connection.sendAgentMessage(command.targetActiveSessionId, command.message),
 				);
 			case "agent_messages_status":
 				return success(id, command.type, await connection.getAgentMessageStatus());

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,11 +7,7 @@
 
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model } from "@earendil-works/pi-ai";
-import type {
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageReceipt,
-	AgentSessionMessageSafetyStatus,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type {
@@ -84,7 +80,6 @@ export type RpcCommand =
 			type: "send_message";
 			targetActiveSessionId: string;
 			message: string;
-			deliveryMode?: AgentSessionMessageDeliveryMode;
 	  }
 	| { id?: string; type: "agent_messages_status" }
 	| { id?: string; type: "agent_messages_pause" }

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -12,7 +12,6 @@ import {
 	createAgentSessionMessageReceipt,
 	normalizeAgentSessionMessage,
 	parseAgentSessionMessagePromptId,
-	resolveAgentSessionMessageStreamingBehavior,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
 
@@ -22,7 +21,6 @@ describe("agent session bus", () => {
 			id: "agentmsg-1",
 			source: AGENT_MESSAGE_SOURCE,
 			message: "Use the latest benchmark notes.",
-			deliveryMode: "auto",
 			from: {
 				activeSessionId: "planner",
 				sessionId: "session-planner",
@@ -53,7 +51,6 @@ describe("agent session bus", () => {
 				id: "agentmsg-2",
 				source: AGENT_MESSAGE_SOURCE,
 				message: "hello",
-				deliveryMode: "auto",
 				from: { clientId: "client-only" },
 				target: {
 					activeSessionId: "worker",
@@ -68,7 +65,6 @@ describe("agent session bus", () => {
 			id: "agentmsg_canonical",
 			source: AGENT_MESSAGE_SOURCE,
 			message: "hello",
-			deliveryMode: "auto",
 			from: {
 				activeSessionId: "source\nMessage id: agentmsg_spoofed",
 				sessionId: "session-source",
@@ -104,7 +100,6 @@ describe("agent session bus", () => {
 			id: "agentmsg_canonical",
 			source: AGENT_MESSAGE_SOURCE,
 			message: "hello",
-			deliveryMode: "auto",
 			from: {
 				activeSessionId: "source, session victim",
 				sessionId: "session-source",
@@ -121,20 +116,12 @@ describe("agent session bus", () => {
 		expect(prompt).toContain("To: Worker active spoof, active worker, session session-worker");
 	});
 
-	it("uses steering delivery by default only when the target is streaming", () => {
-		expect(resolveAgentSessionMessageStreamingBehavior(false, "auto")).toBeUndefined();
-		expect(resolveAgentSessionMessageStreamingBehavior(true, "auto")).toBe("steer");
-		expect(resolveAgentSessionMessageStreamingBehavior(true, "follow_up")).toBe("followUp");
-		expect(resolveAgentSessionMessageStreamingBehavior(true, "steer")).toBe("steer");
-	});
-
 	it("normalizes messages and creates receipts", () => {
 		const message = normalizeAgentSessionMessage("  hello from another session  ");
 		const payload = {
 			id: "agentmsg-3",
 			source: AGENT_MESSAGE_SOURCE,
 			message,
-			deliveryMode: "follow_up",
 			target: {
 				activeSessionId: "target",
 				sessionId: "session-target",
@@ -154,7 +141,7 @@ describe("agent session bus", () => {
 			message: "hello from another session",
 			deliveryStatus: "delivered",
 			deliveredAt: "2026-06-15T12:00:00.000Z",
-			deliveryMode: "follow_up",
+			deliveryMode: "steer",
 		});
 		expect(createAgentSessionMessageReceipt(payload, "queued", "2026-06-15T12:00:00.000Z")).toMatchObject({
 			deliveryStatus: "queued",
@@ -181,7 +168,6 @@ describe("agent session bus", () => {
 			message: input.message,
 			deliveryStatus: "delivered" as const,
 			deliveredAt: new Date(0).toISOString(),
-			deliveryMode: "auto" as const,
 		}));
 		const handlers = createAgentMessageHostHandlers({
 			roster: () => ({
@@ -203,7 +189,6 @@ describe("agent session bus", () => {
 		expect(sendAgentMessage).toHaveBeenLastCalledWith({
 			target: "sibling",
 			message: "hello",
-			deliveryMode: undefined,
 			receiverRole: "sibling",
 		});
 
@@ -255,7 +240,6 @@ describe("agent session bus", () => {
 				message: input.message,
 				deliveryStatus: "delivered" as const,
 				deliveredAt: new Date(0).toISOString(),
-				deliveryMode: "auto" as const,
 			};
 		});
 		const handlers = createAgentMessageHostHandlers({

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -726,7 +726,6 @@ describe("AgentSession rlm recursion", () => {
 			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
 			message: "done",
 			deliveryStatus: "delivered" as const,
-			deliveryMode: "auto" as const,
 		}));
 		const child = createSession({
 			depth: 1,
@@ -765,7 +764,6 @@ describe("AgentSession rlm recursion", () => {
 			target: { activeSessionId: "child-active", sessionId: input.target },
 			message: input.message,
 			deliveryStatus: "delivered" as const,
-			deliveryMode: "auto" as const,
 		}));
 		const roster = vi.fn(() => ({
 			current: { name: "root", id: root.sessionId, depth: 0 },
@@ -833,7 +831,6 @@ describe("AgentSession rlm recursion", () => {
 			target: { activeSessionId: "child-active", sessionId: input.target },
 			message: input.message,
 			deliveryStatus: "delivered" as const,
-			deliveryMode: "auto" as const,
 		}));
 		const root = createSession({
 			agentMessageController: {
@@ -921,7 +918,6 @@ describe("AgentSession rlm recursion", () => {
 			target: { activeSessionId: "healthy-active", sessionId: input.target },
 			message: input.message,
 			deliveryStatus: "delivered" as const,
-			deliveryMode: "auto" as const,
 		}));
 		const root = createSession({
 			agentMessageController: {
@@ -1029,7 +1025,6 @@ describe("AgentSession rlm recursion", () => {
 			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
 			message: "status",
 			deliveryStatus: "delivered" as const,
-			deliveryMode: "auto" as const,
 		}));
 		const child = createSession({
 			depth: 1,
@@ -1092,7 +1087,6 @@ describe("AgentSession rlm recursion", () => {
 				targetSelector: string;
 				message: string;
 				fromState: ActiveSessionState;
-				deliveryMode?: "auto" | "steer" | "follow_up";
 				origin: "agent";
 			}): Promise<unknown>;
 		};
@@ -1112,7 +1106,6 @@ describe("AgentSession rlm recursion", () => {
 			targetSelector: childState.activeSessionId,
 			message: "continue",
 			fromState: parentState,
-			deliveryMode: "steer",
 			origin: "agent",
 		});
 		const steer = findLastMessage(child.messages, isAgentSessionMessage);
@@ -1129,7 +1122,6 @@ describe("AgentSession rlm recursion", () => {
 			message: "new task",
 			fromRelationship: "parent",
 			target: { activeSessionId: "child-active", sessionId: child.sessionId },
-			deliveryMode: "auto",
 		});
 
 		await child.acceptAgentMessagePrompt(message.content as string, { customMessage: message });
@@ -1146,7 +1138,6 @@ describe("AgentSession rlm recursion", () => {
 			message: "continue",
 			fromRelationship: "parent",
 			target: { activeSessionId: "child-active", sessionId: child.sessionId },
-			deliveryMode: "follow_up",
 		});
 
 		await child.queueAgentMessagePrompt(message.content as string, "followUp", message);
@@ -1266,7 +1257,6 @@ describe("AgentSession rlm recursion", () => {
 					target: { activeSessionId: "parent-active", sessionId: "parent-session" },
 					message: "done",
 					deliveryStatus: "delivered",
-					deliveryMode: "auto",
 				}),
 			},
 		});
@@ -1280,7 +1270,6 @@ describe("AgentSession rlm recursion", () => {
 				message: "continue cleanup",
 				fromRelationship: "parent",
 				target: { activeSessionId: "child-active", sessionId: child.sessionId },
-				deliveryMode: "follow_up",
 			});
 			await child.queueAgentMessagePrompt(followUp.content as string, "followUp", followUp);
 			expect(child.repliedToParentSinceTask).toBe(false);

--- a/packages/coding-agent/test/daemon-command.test.ts
+++ b/packages/coding-agent/test/daemon-command.test.ts
@@ -282,31 +282,6 @@ describe("daemon command", () => {
 		});
 	});
 
-	it("honors send delivery-mode flags after the target", async () => {
-		await expect(
-			handleDaemonCommand([
-				"daemon",
-				"--socket",
-				"/tmp/prime-agent.sock",
-				"send",
-				"worker",
-				"--steer",
-				"stop",
-				"and",
-				"re-plan",
-			]),
-		).resolves.toBe(true);
-
-		const client = daemonClientMock.instances[0];
-		expect(client?.requests[0]).toEqual({
-			type: "send_message",
-			targetActiveSessionId: "worker",
-			fromActiveSessionId: undefined,
-			deliveryMode: "steer",
-			message: "stop and re-plan",
-		});
-	});
-
 	it("rejects unknown send options instead of folding them into the message", async () => {
 		await expect(
 			handleDaemonCommand(["daemon", "--socket", "/tmp/prime-agent.sock", "send", "worker", "--bogus", "hello"]),
@@ -327,7 +302,6 @@ describe("daemon command", () => {
 				"--socket",
 				"/tmp/prime-agent.sock",
 				"send",
-				"--follow-up",
 				"worker",
 				"--",
 				"--from",
@@ -341,7 +315,6 @@ describe("daemon command", () => {
 			type: "send_message",
 			targetActiveSessionId: "worker",
 			fromActiveSessionId: undefined,
-			deliveryMode: "follow_up",
 			message: "--from literal --steer",
 		});
 	});
@@ -366,28 +339,6 @@ describe("daemon command", () => {
 			targetActiveSessionId: "--target-like",
 			message: "--from literal",
 		});
-	});
-
-	it("rejects conflicting send delivery modes", async () => {
-		await expect(
-			handleDaemonCommand([
-				"daemon",
-				"--socket",
-				"/tmp/prime-agent.sock",
-				"send",
-				"--steer",
-				"--follow-up",
-				"worker",
-				"hello",
-			]),
-		).resolves.toBe(true);
-
-		expect(daemonClientMock.instances[0]?.requests).toEqual([]);
-		expect(
-			consoleErrorMessages.some(
-				(message) => typeof message === "string" && message.includes("Only one send delivery mode"),
-			),
-		).toBe(true);
 	});
 
 	it("rejects extra agent-messages status arguments", async () => {
@@ -423,7 +374,6 @@ describe("daemon command", () => {
 			type: "send_message",
 			targetActiveSessionId: "worker",
 			fromActiveSessionId: "planner",
-			deliveryMode: undefined,
 			message: "please keep --from literal --steer",
 		});
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1385,12 +1385,7 @@ describe("daemon mode helpers", () => {
 				origin: "agent",
 			}),
 		).resolves.toEqual(receipt);
-		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(
-			source,
-			remoteSelector,
-			"continue remotely",
-			undefined,
-		);
+		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, remoteSelector, "continue remotely");
 	});
 
 	it("routes nonresident agent-message targets through the supervisor wake path", async () => {
@@ -1436,7 +1431,7 @@ describe("daemon mode helpers", () => {
 				origin: "agent",
 			}),
 		).rejects.toThrow("Unknown active session: deleted-child");
-		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "deleted-child", "continue", undefined);
+		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "deleted-child", "continue");
 	});
 
 	it("rejects invalid nonresident agent messages before remote fallback", async () => {
@@ -1731,7 +1726,6 @@ describe("daemon mode helpers", () => {
 				targetSelector: string;
 				message: string;
 				fromState?: ActiveSessionState;
-				deliveryMode?: "auto" | "steer" | "follow_up";
 				origin: "agent" | "cli";
 			}): Promise<unknown>;
 		};
@@ -1750,21 +1744,50 @@ describe("daemon mode helpers", () => {
 			target: { activeSessionId: targetState.activeSessionId },
 		});
 		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({ streamingBehavior: "steer" });
+	});
 
-		acceptAgentMessagePrompt.mockClear();
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "please continue later",
-				fromState,
-				deliveryMode: "follow_up",
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({
-			deliveryStatus: "queued",
-			target: { activeSessionId: targetState.activeSessionId },
+	it("ignores a legacy follow-up mode and always steers agent messages", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
 		});
-		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({ streamingBehavior: "followUp" });
+		const targetState = makeState("target");
+		const queueAgentMessagePrompt = vi.fn(async () => true);
+		targetState.runtime = {
+			...targetState.runtime,
+			cwd: "/tmp",
+			session: {
+				sessionId: "session-target",
+				sessionName: "Target",
+				isStreaming: true,
+				isCompacting: false,
+				isRetrying: false,
+				isBashRunning: false,
+				unfinishedActionCount: 0,
+				queueAgentMessagePrompt,
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+		};
+		internals.sessions.set(targetState.activeSessionId, targetState);
+
+		const response = await internals.handleCommand(makeClient("legacy-client", targetState.activeSessionId), {
+			type: "send_message",
+			targetActiveSessionId: targetState.activeSessionId,
+			message: "do not defer",
+			deliveryMode: "follow_up",
+		});
+
+		expect(response).toMatchObject({ data: { deliveryStatus: "queued", deliveryMode: "steer" } });
+		expect(queueAgentMessagePrompt).toHaveBeenCalledWith(
+			expect.stringContaining("do not defer"),
+			"steer",
+			expect.objectContaining({ customType: "agent_message" }),
+		);
 	});
 
 	it("rate limits agent messages per sender and target pair", async () => {

--- a/packages/coding-agent/test/fire-and-forget-protocol.test.ts
+++ b/packages/coding-agent/test/fire-and-forget-protocol.test.ts
@@ -12,7 +12,6 @@ describe("fire-and-forget agent protocol", () => {
 			from: { activeSessionId: "active-child", sessionId: "child-id", sessionName: "worker" },
 			fromRelationship: "child",
 			target: endpoint,
-			deliveryMode: "auto",
 		});
 		expect(prompt).toContain("[from child:worker]");
 		expect(parseAgentSessionMessagePromptId(prompt)).toBe("agentmsg_reply");
@@ -30,7 +29,6 @@ describe("fire-and-forget agent protocol", () => {
 			},
 			fromRelationship: "sibling",
 			target: endpoint,
-			deliveryMode: "auto",
 		});
 
 		expect(prompt.startsWith("[from sibling:worker from parent]\n")).toBe(true);
@@ -46,7 +44,6 @@ describe("fire-and-forget agent protocol", () => {
 			from: { activeSessionId: "active-child", sessionId: "child-id", sessionName: "child\nextra" },
 			fromRelationship: "child",
 			target: endpoint,
-			deliveryMode: "auto",
 		});
 
 		expect(prompt.startsWith("[from child:child extra]\nAgent-to-agent message received.")).toBe(true);
@@ -60,7 +57,6 @@ describe("fire-and-forget agent protocol", () => {
 			message: "continue",
 			fromRelationship: "parent",
 			target: endpoint,
-			deliveryMode: "auto",
 		});
 		expect(prompt.startsWith("[from parent]\n")).toBe(true);
 	});

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -62,7 +62,6 @@ describe("agent-message skill over the kernel host bridge", () => {
 						message: payload.message,
 						deliveryStatus: "queued",
 						queuedAt: "2026-06-16T00:00:00.000Z",
-						deliveryMode: payload.mode,
 					};
 				},
 			},
@@ -73,7 +72,7 @@ describe("agent-message skill over the kernel host bridge", () => {
 import json
 agents = await agent_message.list_agents()
 receipt = await agent_message.send(
-    "hello beta", receiver_role="sibling", receiver_name="beta", mode="follow_up"
+    "hello beta", receiver_role="sibling", receiver_name="beta"
 )
 print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 `);
@@ -89,7 +88,6 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 			source: "agent_message",
 			message: "hello beta",
 			deliveryStatus: "queued",
-			deliveryMode: "follow_up",
 		});
 		expect(result.sentAgentMessages).toEqual([
 			{
@@ -111,7 +109,6 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 				message: "hello beta",
 				receiver_role: "sibling",
 				receiver_name: "beta",
-				mode: "follow_up",
 			},
 		});
 		expect(requests[1].payload).not.toHaveProperty("from");
@@ -206,7 +203,7 @@ except TypeError as error:
 		);
 	});
 
-	it("validates mode before sending to the host", async () => {
+	it("does not expose a queueable delivery mode", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
 			hostHandlers: {
@@ -220,11 +217,11 @@ except TypeError as error:
 		const result = await manager.execute(`
 try:
     await agent_message.send("hello", receiver_role="sibling", receiver_name="beta", mode="broadcast")
-except ValueError as error:
-    print(f"ValueError: {error}")
+except TypeError as error:
+    print(f"TypeError: {error}")
 `);
 		expect(result.status).toBe("ok");
-		expect(result.stdout.trim()).toBe('ValueError: mode must be "auto", "follow_up", or "steer"');
+		expect(result.stdout.trim()).toContain("TypeError: send() got an unexpected keyword argument 'mode'");
 	});
 
 	it("captures sent messages from detached tasks after the cell is idle", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1979,7 +1979,6 @@ describe("AgentSession queue characterization", () => {
 			id: "agentmsg_same_object",
 			source: AGENT_MESSAGE_SOURCE,
 			message: "same object",
-			deliveryMode: "follow_up" as const,
 			target: { activeSessionId: "worker-active", sessionId: "worker-session" },
 		};
 		const message = createAgentSessionMessage(payload);

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -30,7 +30,6 @@ function createPayload(message: string): AgentSessionMessagePayload {
 		id: "agentmsg_4531",
 		source: AGENT_MESSAGE_SOURCE,
 		message,
-		deliveryMode: "auto",
 		from: {
 			activeSessionId: "planner-active",
 			sessionId: "planner-session",

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -4,7 +4,6 @@ import {
 	AGENT_MESSAGE_CUSTOM_TYPE,
 	type AgentSessionMessage,
 	createAgentSessionMessage,
-	resolveAgentSessionMessageStreamingBehavior,
 } from "../../../src/core/agent-messages.js";
 import { createHarness, type Harness } from "../harness.js";
 
@@ -41,8 +40,6 @@ describe("#617 subagent terminal agent messages", () => {
 						target: parent!.session.sessionId,
 						message: expect.stringContaining("completed without sending a reply"),
 					});
-					// Omitted, so the daemon applies the "auto" default.
-					expect(input.deliveryMode).toBeUndefined();
 					const message = createAgentSessionMessage({
 						id: "agentmsg-terminal-completion",
 						source: "agent_message",
@@ -54,7 +51,6 @@ describe("#617 subagent terminal agent messages", () => {
 						},
 						fromRelationship: "child",
 						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
-						deliveryMode: input.deliveryMode ?? "auto",
 					});
 					await parent!.session.acceptAgentMessagePrompt(message.content, { customMessage: message });
 					return {
@@ -63,7 +59,6 @@ describe("#617 subagent terminal agent messages", () => {
 						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
 						message: input.message,
 						deliveryStatus: "delivered",
-						deliveryMode: input.deliveryMode ?? "auto",
 					};
 				},
 			},
@@ -96,55 +91,6 @@ describe("#617 subagent terminal agent messages", () => {
 		);
 		expect(terminalMessage(parent.session.messages)?.content).toContain(spawned.rlm_child_id);
 	});
-	it("steers a terminal notice into a busy parent instead of deferring it", async () => {
-		// A streaming parent must resolve to a steer, not a deferred follow-up.
-		const childSessionName = "busy-parent-worker";
-		let resolvedBehavior: "steer" | "followUp" | undefined;
-		child = await createHarness({
-			agentMessageController: {
-				listAgents: () => ({ agents: [] }),
-				sendAgentMessage: async (input) => {
-					expect(input.deliveryMode).toBeUndefined();
-					resolvedBehavior = resolveAgentSessionMessageStreamingBehavior(true, input.deliveryMode);
-					const message = createAgentSessionMessage({
-						id: "agentmsg-terminal-busy",
-						source: "agent_message",
-						message: input.message,
-						from: {
-							activeSessionId: "child-active",
-							sessionId: child!.session.sessionId,
-							sessionName: childSessionName,
-						},
-						fromRelationship: "child",
-						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
-						deliveryMode: input.deliveryMode ?? "auto",
-					});
-					return {
-						id: message.details.id,
-						source: "agent_message",
-						target: { activeSessionId: "parent-active", sessionId: parent!.session.sessionId },
-						message: input.message,
-						deliveryStatus: "delivered",
-						deliveryMode: input.deliveryMode ?? "auto",
-					};
-				},
-			},
-		});
-		parent = await createHarness({
-			rlmDepth: 0,
-			rlmMaxDepth: 1,
-			subagentRuntimeHost: {
-				createRlmSubagentRuntime: async () => ({ session: child!.session }),
-				deleteRlmSubagentRuntime: async () => {},
-			},
-		});
-		child.setResponses([fauxAssistantMessage("child completed")]);
-
-		await parent.session.runRlmChild("finish without replying", { name: childSessionName });
-
-		await expect.poll(() => resolvedBehavior).toBe("steer");
-	});
-
 	it("falls back to an injected notice when the agent message cannot be delivered", async () => {
 		// A controller that always rejects: the parent must still learn the child
 		// finished. Losing the notice entirely is worse than losing attribution.

--- a/prime-agent-runtime/test/test_agent_message_skill.py
+++ b/prime-agent-runtime/test/test_agent_message_skill.py
@@ -11,7 +11,7 @@ SKILL = Path(__file__).parents[2] / "packages/coding-agent/skills/agent-message/
 
 
 class AgentMessageSkillTest(unittest.TestCase):
-    def test_roled_parent_and_legacy_forms(self) -> None:
+    def test_roled_parent_and_broadcast_forms(self) -> None:
         spec = importlib.util.spec_from_file_location("agent_message_test", SKILL)
         assert spec and spec.loader
         module = importlib.util.module_from_spec(spec)
@@ -19,9 +19,9 @@ class AgentMessageSkillTest(unittest.TestCase):
         host = AsyncMock(return_value={"deliveryStatus": "queued"})
         with patch.object(module, "host_request", host), patch.object(module, "_emit_sent_message"):
             asyncio.run(module.send("done", receiver_role="parent"))
-            asyncio.run(module.send("child-id", "follow up"))
+            asyncio.run(module.send("all", "follow up"))
         self.assertEqual(host.await_args_list[0].args[1]["receiver_role"], "parent")
-        self.assertEqual(host.await_args_list[1].args[1]["target"], "child-id")
+        self.assertEqual(host.await_args_list[1].args[1]["target"], "all")
 
     def test_roled_selector_validation(self) -> None:
         spec = importlib.util.spec_from_file_location("agent_message_validation", SKILL)
@@ -32,6 +32,8 @@ class AgentMessageSkillTest(unittest.TestCase):
             asyncio.run(module.send("hello", receiver_role="child"))
         with self.assertRaisesRegex(ValueError, "omitted"):
             asyncio.run(module.send("hello", receiver_role="parent", receiver_name="x"))
+        with self.assertRaisesRegex(TypeError, "unexpected keyword argument 'mode'"):
+            asyncio.run(module.send("hello", receiver_role="parent", mode="follow_up"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Agent messages can no longer be queued behind the recipient's current work. Every agent message is delivered as steering input.

This removes the delivery-mode option from:

- the Python `agent_message.send` API
- CLI flags and help
- TypeScript host and controller APIs
- `AgentConnection`
- RPC APIs

This avoids a deadlock where one agent waits for a reply that is queued behind the work waiting for that reply.

## Compatibility

The existing optional daemon `deliveryMode` field is still accepted for compatibility, but a new daemon ignores it and always steers. This means an older client cannot request queued `follow_up` delivery from a new daemon.

New clients omit the field. Older daemons already interpret an omitted mode as `auto`, which steers messages to busy agents. The wire format is unchanged, so no protocol or schema bump is needed.

## Size

| Area | Added | Removed | Net |
|---|---:|---:|---:|
| Production code | 18 | 145 | -127 |
| Tests | 55 | 170 | -115 |
| Docs and changelog | 13 | 14 | -1 |
| **Total** | **86** | **329** | **-243** |

## Validation

- `npm run check`
- 9 changed coding-agent test files: 457 tests passed
- `uv run python -m unittest test/test_agent_message_skill.py`: 2 tests passed
- focused daemon test run: 190 tests passed
