### PR TITLE
Count active retained subagents as running

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed self-updates to report the previous and new Prime Agent versions.
 - Changed agent messages to always use steering delivery and removed delivery-mode options from the Python, CLI, RPC, and connection APIs.
+- Fixed the subagent summary showing retained children as idle while they run follow-up work.
 
 ## [0.6.1] - 2026-08-05
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9726,7 +9726,13 @@ export class AgentSession {
 						this._emit(event);
 						return;
 					}
-					if (event.type === "message_end" && event.message.role === "assistant") {
+					if (event.type === "agent_start") {
+						activity = { kind: "waiting" };
+						emitChildUpdate();
+					} else if (event.type === "agent_end") {
+						activity = undefined;
+						emitChildUpdate();
+					} else if (event.type === "message_end" && event.message.role === "assistant") {
 						const assistant = event.message as AssistantMessage;
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -394,6 +394,7 @@ function rlmChildSnapshotForActiveSession(
 		? parent?.runtime.session.getRlmChildRunStatus(metadata.rlmChildId)
 		: undefined;
 	const status = runStatus ?? (session.isSessionActive ? "running" : "done");
+	const isActive = status === "running" || session.isSessionActive;
 	return {
 		id: metadata.rlmChildId ?? activeSession.activeSessionId,
 		parentId: parentNodeId,
@@ -407,7 +408,7 @@ function rlmChildSnapshotForActiveSession(
 		tokenCount: session._contextTokensForCurrentMessages(),
 		recap: session.getCurrentRecap(),
 		sessionDir: metadata.sessionDir ?? session.sessionManager.getSessionDir(),
-		activity: status === "running" ? { kind: session.isStreaming ? "writing" : "waiting" } : undefined,
+		activity: isActive ? { kind: session.isStreaming ? "writing" : "waiting" } : undefined,
 	};
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -349,7 +349,10 @@ function mergeSubagentSnapshot(
 		// Active updates may omit a previously known daemon session id, but a
 		// terminal update without one means the child is no longer resident.
 		activeSessionId: active ? (incoming.activeSessionId ?? previous.activeSessionId) : incoming.activeSessionId,
-		activity: active ? (incoming.activity ?? previous.activity) : undefined,
+		// A completed retained child can become active again when it receives a
+		// follow-up. Its RLM run status stays terminal, so activity must remain an
+		// independent projection of the live session state.
+		activity: active ? (incoming.activity ?? previous.activity) : incoming.activity,
 	};
 }
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1390,6 +1390,47 @@ describe("AgentSession rlm recursion", () => {
 		);
 	});
 
+	it("projects retained child follow-up turns into parent child-update activity", async () => {
+		let releaseInitial: () => void = () => {};
+		const initialGate = new Promise<void>((resolve) => {
+			releaseInitial = resolve;
+		});
+		let releaseFollowUp: () => void = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		const events: Array<{ status: string; activity?: { kind: string } }> = [];
+		const root = createSession({
+			streamFn: (_model, context) => {
+				const text = userText(context);
+				const stream = createAssistantMessageEventStream();
+				void (text === "initial" ? initialGate : followUpGate).then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`answer: ${text}`) });
+				});
+				return stream;
+			},
+		});
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") {
+				events.push({ status: event.child.status, activity: event.child.activity });
+			}
+		});
+
+		const spawned = await root.runRlmChild("initial");
+		await waitFor(() => events.some((event) => event.status === "running" && event.activity?.kind === "waiting"));
+		releaseInitial();
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		await waitFor(() => events.at(-1)?.status === "done" && events.at(-1)?.activity === undefined);
+
+		const child = root.getRlmChildSession(spawned.rlm_child_id);
+		if (!child) throw new Error("Missing retained child session");
+		const followUp = child.prompt("follow-up");
+		await waitFor(() => events.at(-1)?.status === "done" && events.at(-1)?.activity?.kind === "waiting");
+		releaseFollowUp();
+		await followUp;
+		await waitFor(() => events.at(-1)?.status === "done" && events.at(-1)?.activity === undefined);
+	});
+
 	it("lists a completed child with its parent-scoped messaging identity until disposal", async () => {
 		let daemonChildId = "";
 		const root = createSession({

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -589,6 +589,28 @@ describe("buildRlmChildSnapshots", () => {
 		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
 	});
 
+	it("keeps terminal run status while projecting a retained child's active follow-up", () => {
+		const parent = makeState({
+			activeSessionId: "parent",
+			childRunStatuses: { "sub-aaa": "done" },
+		});
+		const activeRetainedChild = makeState({
+			activeSessionId: "child",
+			isStreaming: true,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: "parent",
+				rlmChildId: "sub-aaa",
+			},
+		});
+
+		expect(buildRlmChildSnapshots("parent", [parent, activeRetainedChild])[0]).toMatchObject({
+			status: "done",
+			activity: { kind: "writing" },
+		});
+	});
+
 	it("includes in-flight assistant output in child snapshots", () => {
 		const parent = makeState({ activeSessionId: "parent" });
 		const child = makeState({

--- a/packages/coding-agent/test/subagent-summary-line.test.ts
+++ b/packages/coding-agent/test/subagent-summary-line.test.ts
@@ -113,6 +113,35 @@ describe("SubagentSummaryLine", () => {
 		expect(stripAnsi(line.render(100).join("\n"))).toContain("0 running · 1 idle · 0 inactive");
 	});
 
+	it("counts a retained completed child as running while a follow-up turn is active", () => {
+		const line = new SubagentSummaryLine();
+		const mode = Object.create(InteractiveMode.prototype) as InteractiveMode & Record<string, unknown>;
+		Object.assign(mode, {
+			subagentSnapshots: new Map<string, AgentConnectionRlmChildAgentSnapshot>(),
+			rlmNodeId: undefined,
+			heartbeatCatalog: [],
+			subagentSummaryLine: line,
+			updateScopedHeartbeats: vi.fn(),
+			updateWorkingPulse: vi.fn(),
+			syncWorkingLoader: vi.fn(),
+			updateWorkingLoaderMessage: vi.fn(),
+			ui: { requestRender: vi.fn() },
+		});
+		const update = Reflect.get(InteractiveMode.prototype, "updateSubagentSummary") as (
+			this: typeof mode,
+			value: AgentConnectionRlmChildAgentSnapshot,
+		) => void;
+
+		update.call(mode, child("worker", "done", { activeSessionId: "resident-worker" }));
+		expect(stripAnsi(line.render(100).join("\n"))).toContain("0 running · 1 idle · 0 inactive");
+
+		update.call(mode, child("worker", "done", { activeSessionId: "resident-worker", activity: { kind: "waiting" } }));
+		expect(stripAnsi(line.render(100).join("\n"))).toContain("1 running · 0 idle · 0 inactive");
+
+		update.call(mode, child("worker", "done", { activeSessionId: "resident-worker" }));
+		expect(stripAnsi(line.render(100).join("\n"))).toContain("0 running · 1 idle · 0 inactive");
+	});
+
 	it("refreshes counts when startup seeding follows an early live child update", () => {
 		const line = new SubagentSummaryLine();
 		const mode = Object.create(InteractiveMode.prototype) as InteractiveMode & Record<string, unknown>;


### PR DESCRIPTION
## What changed

The subagent summary now counts retained children as running while they are actively handling follow-up work.

Previously, a child kept its original RLM run status as `done` after its first task. If that retained child later received another message, the summary could still show it as idle even while it was running a model or tool.

The fix keeps the original run status and live activity separate:

- active follow-up work counts as running
- a resident child with no active work counts as idle
- an evicted or passive child counts as inactive

This applies to live updates, initial attachment, reconnects, and resyncs. The summary continues to count direct children only.

## Validation

- `test/daemon-session-list.test.ts`: 29 tests passed
- `test/subagent-summary-line.test.ts`: 9 tests passed
- `test/agent-session-recursion.test.ts`: 96 tests passed
- `npm run check`

## Size

| Area | Added | Removed | Net |
|---|---:|---:|---:|
| Production code | 13 | 3 | +10 |
| Tests | 92 | 0 | +92 |
| Changelog | 1 | 0 | +1 |
| **Total** | **106** | **3** | **+103** |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/status projection only; behavior is covered by new unit tests and does not change auth, persistence, or spawn semantics.
> 
> **Overview**
> Fixes the subagent summary line showing **retained children as idle** while they handle follow-up prompts after their original RLM run has already completed.
> 
> **Run status stays terminal** (`done`); **live activity** is projected separately. Parent session child updates now listen for `agent_start` / `agent_end` on retained child sessions so follow-up turns emit `activity` (waiting/writing). Daemon snapshots treat a child as active when the run tracker says running **or** the hosted session is still active, and the interactive merge no longer strips `activity` just because the RLM status is no longer `running`/`queued`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bcda34b161d7e886afa54aac0613311af6486b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Count active retained subagents as running in subagent summary
> Retained child agents can remain active (handling follow-up turns) after their run status reaches a terminal state. Previously, the subagent summary treated these children as idle because it only checked run status.
>
> - [`daemon-session-list.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/634/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21): introduces an `isActive` flag combining run status and session activity so retained children with terminal status still project their activity into snapshots.
> - [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/634/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316): stops forcibly clearing activity on non-active status, preserving activity for completed children doing follow-up work.
> - [`agent-session.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/634/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae): emits `rlm_child_update` events on `agent_start`/`agent_end` to propagate a child's active/idle state to the parent session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5bcda3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->