### PR TITLE
update README to remove beta installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 
 The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent.
 
-To try the latest beta built from `main`:
-
-```bash
-curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
-```
-
-Use the stable channel for normal work. Beta advances with successful builds from `main`.
-
 Start Prime Agent from the repository or directory you want it to work in:
 
 ```bash


### PR DESCRIPTION
Removed instructions for trying the latest beta version of the installer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or build impact.
> 
> **Overview**
> **Getting Started** now documents only the stable install path (`curl ... | sh`) and no longer mentions the `beta` installer flag or when to use stable vs beta.
> 
> A trailing newline was added after the License line at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d3168937068b3982c72ded6b5c86f89f4fa294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove beta installation instructions from README
> Removes the section in [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/635/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) that described how to install the latest beta via a curl command, along with the accompanying note about using the stable channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d3168.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->