### PR TITLE
fix(agent): discover Codex models with compatible version

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -48,6 +48,9 @@ import { buildBaseOptions } from "./simple-options.js";
 // ============================================================================
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+/** Codex CLI compatibility identity used by ChatGPT backend requests. */
+export const OPENAI_CODEX_CLIENT_VERSION = "0.144.6";
+
 const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed authenticated RLM discovery excluding OpenAI Codex models by sending a Codex-compatible discovery client version ([#639](https://github.com/PrimeIntellect-ai/prime-agent/issues/639)).
+
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -22,12 +22,13 @@ import {
 } from "@earendil-works/pi-ai";
 import { registerBuiltinMcpOAuthProviders } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import { OPENAI_CODEX_CLIENT_VERSION } from "@earendil-works/pi-ai/openai-codex-responses";
 import { existsSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -371,6 +372,8 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 		return undefined;
 	}
 }
+// OpenAI uses the Codex CLI compatibility version to select the model catalog,
+// not Prime Agent's unrelated package version.
 
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
@@ -383,7 +386,7 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	url.searchParams.set("client_version", OPENAI_CODEX_CLIENT_VERSION);
 	return url.toString();
 }
 

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -77,20 +77,21 @@ describe("ENG-4649 subagent model selection", () => {
 			provider: codexProvider,
 			models: [{ id: "parent-model" }, { id: "unsupported-model" }],
 		});
-		const fetchModels = vi.fn(
-			async () =>
-				new Response(JSON.stringify({ models: [{ slug: "parent-model" }] }), {
-					status: 200,
-					headers: { "content-type": "application/json" },
-				}),
-		);
+		const fetchModels = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const models = url.searchParams.get("client_version") === "0.144.6" ? [{ slug: "parent-model" }] : [];
+			return new Response(JSON.stringify({ models }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
 		vi.stubGlobal("fetch", fetchModels);
 		try {
 			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-1"));
 			const discovered = await harness.session.findRlmModels("", 20);
 			expect(discovered.models.map((model) => model.selector)).toEqual([`${codexProvider}/parent-model`]);
 			expect(fetchModels).toHaveBeenCalledWith(
-				expect.stringMatching(/\/codex\/models\?client_version=/),
+				expect.stringMatching(/\/codex\/models\?client_version=0\.144\.6$/),
 				expect.objectContaining({
 					headers: expect.objectContaining({ "chatgpt-account-id": "account-1" }),
 				}),


### PR DESCRIPTION
## Summary
- define the Codex compatibility identity with the Codex provider rather than model discovery
- reuse that identity when fetching the authenticated model catalog
- keep the server catalog authoritative for RLM child-model entitlement filtering
- make the regression fail when discovery uses Prime Agent's unrelated package version

Fixes #639

## Screenshots
No visual change.

## Testing
- `npm run check`
- `npm --workspace @earendil-works/pi-ai run build`
- `env -u AGENTROUTER_API_KEY -u CEREBRAS_API_KEY -u EXA_API_KEY -u FIREWORKS_API_KEY -u OPENAI_API_KEY -u OPENCODE_API_KEY -u WAFER_PASS_API_KEY -u WAFER_SERVERLESS_API_KEY -u ZHIPU_API_KEY npm --workspace @earendil-works/pi-coding-agent test -- test/suite/regressions/4649-subagent-model-selection.test.ts`
- `npm run build`

## Risk
- The shared Codex compatibility identity must be updated if OpenAI raises its compatibility floor.
- Entitlement behavior is unchanged: models absent from the returned account catalog remain unavailable.

## Notes
- A live authenticated endpoint check was not available locally because Prime Agent had no OpenAI Codex credential configured. The regression models the reported endpoint behavior by returning the catalog only for the compatible version.

## AI Review Report
- Reviewed the Codex provider, discovery consumer, and regression path together.
- Confirmed the compatibility identity has one source of truth and discovery only changes its query parameter.
- Confirmed account-catalog filtering remains authoritative.

## Security Audit
- No credential storage, token parsing, authorization headers, or logging behavior changed.
- The authenticated server response remains the source of truth for executable Codex models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a discovery query parameter; auth, headers, and entitlement filtering are unchanged. The pinned version may need manual bumps if OpenAI raises the Codex compatibility floor.
> 
> **Overview**
> **Fixes authenticated RLM discovery dropping OpenAI Codex models** by sending a Codex-compatible `client_version` on the `/codex/models` catalog request. The ChatGPT backend keys the account model list off the Codex CLI identity, not Prime Agent's release version.
> 
> The shared constant `OPENAI_CODEX_CLIENT_VERSION` (`0.144.6`) is exported from `pi-ai` and wired into `openAICodexModelsUrl` in the model registry, replacing the previous use of the agent `VERSION`. Account-catalog filtering for executable and subagent models is unchanged.
> 
> The ENG-4649 regression now stubs discovery to return models only when `client_version=0.144.6` and asserts that query string on fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a32a2e4d0717b7f63298ac1d1cd0dbf62b4a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex model discovery by sending a compatible `client_version` in the request URL
> The `/codex/models` discovery URL previously sent the agent package version as `client_version`, which caused the ChatGPT backend to exclude Codex models from the catalog. It now sends the hardcoded constant `OPENAI_CODEX_CLIENT_VERSION` (`0.144.6`) from [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/640/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc), matching the Codex CLI compatibility identity expected by the backend.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19a32a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->