### PR TITLE
feat(coding-agent): support ACP-provided MCP servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,6 +1101,18 @@
 				}
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+			"integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1309,6 +1321,105 @@
 				"ws": "^8.18.0",
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -2150,11 +2261,57 @@
 				"addons/*"
 			]
 		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -2253,6 +2410,43 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/body-parser": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^2.0.0",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
+				"on-finished": "^2.4.1",
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/bowser": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -2315,6 +2509,44 @@
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/canvas": {
 			"version": "3.2.3",
@@ -2562,12 +2794,69 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "6.0.6",
@@ -2648,6 +2937,15 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"dev": true,
@@ -2665,6 +2963,20 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"license": "Apache-2.0",
@@ -2672,9 +2984,24 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
@@ -2683,9 +3010,17 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-errors": {
 			"version": "1.3.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -2697,6 +3032,18 @@
 			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.28.1",
@@ -2746,6 +3093,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
 		},
 		"node_modules/escodegen": {
 			"version": "2.1.0",
@@ -2801,6 +3154,36 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "1.0.0",
 			"dev": true,
@@ -2845,6 +3228,68 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.6.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+			"integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"license": "MIT"
@@ -2867,6 +3312,12 @@
 				"@types/yauzl": "^2.9.1"
 			}
 		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
 			"dev": true,
@@ -2881,6 +3332,22 @@
 			"engines": {
 				"node": ">=8.6.0"
 			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
@@ -2945,6 +3412,27 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"license": "MIT",
@@ -2953,6 +3441,24 @@
 			},
 			"engines": {
 				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -2977,7 +3483,6 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3024,6 +3529,43 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -3111,6 +3653,18 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"license": "ISC"
@@ -3122,9 +3676,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.3",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -3140,6 +3705,15 @@
 				"node": "*"
 			}
 		},
+		"node_modules/hono": {
+			"version": "4.12.32",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+			"integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "9.0.3",
 			"license": "ISC",
@@ -3148,6 +3722,26 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -3186,6 +3780,22 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"funding": [
@@ -3213,7 +3823,6 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ini": {
@@ -3234,6 +3843,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -3284,6 +3902,12 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-stream": {
 			"version": "1.1.0",
 			"dev": true,
@@ -3294,7 +3918,6 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/jiti": {
@@ -3302,6 +3925,15 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/jose": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+			"integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/json-bigint": {
@@ -3321,6 +3953,18 @@
 			"engines": {
 				"node": ">=16"
 			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
@@ -3652,6 +4296,40 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+			"integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"dev": true,
@@ -3774,6 +4452,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/netmask": {
 			"version": "2.1.1",
 			"license": "MIT",
@@ -3863,6 +4550,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/obug": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
@@ -3875,6 +4574,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/once": {
@@ -3980,6 +4691,15 @@
 			"version": "6.0.1",
 			"license": "MIT"
 		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/partial-json": {
 			"version": "0.1.7",
 			"license": "MIT"
@@ -4009,6 +4729,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/pathe": {
@@ -4054,6 +4784,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -4149,6 +4888,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/proxy-agent": {
 			"version": "6.5.0",
 			"license": "MIT",
@@ -4185,6 +4937,22 @@
 				"once": "^1.3.1"
 			}
 		},
+		"node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"dev": true,
@@ -4203,6 +4971,34 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/range-parser": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+			"integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
@@ -4243,6 +5039,15 @@
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4318,6 +5123,22 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"dev": true,
@@ -4366,6 +5187,12 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"dev": true,
@@ -4376,6 +5203,57 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "1.2.0",
@@ -4438,6 +5316,78 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/siginfo": {
@@ -4546,6 +5496,15 @@
 			"version": "0.0.2",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/std-env": {
 			"version": "4.1.0",
@@ -4786,6 +5745,15 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/token-types": {
 			"version": "6.1.2",
 			"license": "MIT",
@@ -4848,6 +5816,37 @@
 				"node": "*"
 			}
 		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/typebox": {
 			"version": "1.1.38",
 			"license": "MIT"
@@ -4887,6 +5886,15 @@
 			"version": "6.21.0",
 			"license": "MIT"
 		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"dev": true,
@@ -4901,6 +5909,15 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vite": {
@@ -5357,6 +6374,7 @@
 				"@earendil-works/pi-agent-core": "^0.7.0",
 				"@earendil-works/pi-ai": "^0.7.0",
 				"@earendil-works/pi-tui": "^0.7.0",
+				"@modelcontextprotocol/sdk": "^1.30.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added session-scoped HTTP and stdio MCP servers to ACP mode as IPython-backed integrations.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added session-scoped HTTP and stdio MCP servers to ACP mode as IPython-backed integrations.
+- Added session-scoped HTTP and stdio MCP servers to ACP mode as eagerly discovered, pre-imported IPython skills.
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -28,6 +28,20 @@ One session per connection is a deliberate limit: Prime Agent's underlying sessi
 
 Likewise `session/prompt` refuses a concurrent turn while one is running, and the working directory cannot be changed after startup — a client-supplied `cwd` that differs from the agent's real one is reported back in `_meta` rather than silently ignored.
 
+## MCP servers
+
+Prime Agent accepts streamable HTTP and stdio MCP servers from `session/new`. They are available only to that ACP process and are not written to user settings.
+
+Consistent with Prime Agent's IPython-only tool design, the servers are exposed through a temporary Python skill named `acp_mcp`:
+
+```python
+acp_mcp.list_servers()
+await acp_mcp.list_tools("task-tools")
+await acp_mcp.call_tool("task-tools", "lookup", {"query": "ACP"})
+```
+
+For server names that are valid Python identifiers, dynamic methods are also available, such as `await acp_mcp.github.search(query="ACP")`. The agent discovers tool names and schemas with `list_tools()` before calling them. HTTP headers and stdio arguments and environment variables are scoped to the client-provided server configuration.
+
 ## Streamed updates
 
 Session activity arrives as `session/update` notifications:

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -32,15 +32,13 @@ Likewise `session/prompt` refuses a concurrent turn while one is running, and th
 
 Prime Agent accepts streamable HTTP and stdio MCP servers from `session/new`. They are available only to that ACP process and are not written to user settings.
 
-Consistent with Prime Agent's IPython-only tool design, the servers are exposed through a temporary Python skill named `acp_mcp`:
+Consistent with Prime Agent's IPython-only tool design, Prime Agent discovers every server's tools while creating the session and exposes each tool as a temporary, pre-imported Python skill. Names follow the same `<server>_<tool>` normalization as `rlm-harness`:
 
 ```python
-acp_mcp.list_servers()
-await acp_mcp.list_tools("task-tools")
-await acp_mcp.call_tool("task-tools", "lookup", {"query": "ACP"})
+await task_tools_lookup(query="ACP")
 ```
 
-For server names that are valid Python identifiers, dynamic methods are also available, such as `await acp_mcp.github.search(query="ACP")`. The agent discovers tool names and schemas with `list_tools()` before calling them. HTTP headers and stdio arguments and environment variables are scoped to the client-provided server configuration.
+Each callable module has a keyword-only signature derived from the MCP tool's input schema and a docstring derived from its description, so `help(task_tools_lookup)` and `inspect.signature(task_tools_lookup)` expose the API before it is called. Session creation fails if a server cannot be reached or if two tools normalize to the same Python name. HTTP headers and stdio arguments and environment variables are scoped to the client-provided server configuration.
 
 ## Streamed updates
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -51,6 +51,7 @@
 		"@earendil-works/pi-agent-core": "^0.7.0",
 		"@earendil-works/pi-ai": "^0.7.0",
 		"@earendil-works/pi-tui": "^0.7.0",
+		"@modelcontextprotocol/sdk": "^1.30.0",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1378,6 +1378,29 @@ export class AgentSession {
 		this.agent.state.systemPrompt = this._baseSystemPrompt;
 	}
 
+	extendTemporarySkills(skillPaths: string[], source: string): void {
+		if (skillPaths.length === 0) return;
+		if (this.isStreaming) {
+			throw new Error("Cannot extend temporary skills while the agent is running");
+		}
+		const activeToolNames = this.getActiveToolNames();
+		const flagValues = this._extensionRunner.getFlagValues();
+		this._resourceLoader.extendResources({
+			skillPaths: skillPaths.map((path) => ({
+				path,
+				metadata: {
+					source,
+					scope: "temporary",
+					origin: "top-level",
+					baseDir: dirname(path),
+				},
+			})),
+		});
+		this._buildRuntime({ activeToolNames, flagValues, includeAllExtensionTools: true });
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.state.systemPrompt = this._baseSystemPrompt;
+	}
+
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
 		return this._modelRegistry;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1379,23 +1379,25 @@ export class AgentSession {
 	}
 
 	extendTemporarySkills(skillPaths: string[], source: string): void {
-		if (skillPaths.length === 0) return;
 		if (this.isStreaming) {
 			throw new Error("Cannot extend temporary skills while the agent is running");
 		}
 		const activeToolNames = this.getActiveToolNames();
 		const flagValues = this._extensionRunner.getFlagValues();
-		this._resourceLoader.extendResources({
-			skillPaths: skillPaths.map((path) => ({
-				path,
-				metadata: {
-					source,
-					scope: "temporary",
-					origin: "top-level",
-					baseDir: dirname(path),
-				},
-			})),
-		});
+		const resources = skillPaths.map((path) => ({
+			path,
+			metadata: {
+				source,
+				scope: "temporary" as const,
+				origin: "top-level" as const,
+				baseDir: dirname(path),
+			},
+		}));
+		if (this._resourceLoader.replaceSkillResources) {
+			this._resourceLoader.replaceSkillResources(resources, source);
+		} else if (resources.length > 0) {
+			this._resourceLoader.extendResources({ skillPaths: resources });
+		}
 		this._buildRuntime({ activeToolNames, flagValues, includeAllExtensionTools: true });
 		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
 		this.agent.state.systemPrompt = this._baseSystemPrompt;

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -35,6 +35,7 @@ export interface ResourceLoader {
 	getSystemPrompt(): string | undefined;
 	getAppendSystemPrompt(): string[];
 	extendResources(paths: ResourceExtensionPaths): void;
+	replaceSkillResources?(paths: Array<{ path: string; metadata: PathMetadata }>, source: string): void;
 	reload(): Promise<void>;
 }
 
@@ -331,6 +332,23 @@ export class DefaultResourceLoader implements ResourceLoader {
 			);
 			this.updateThemesFromPaths(this.lastThemePaths);
 		}
+	}
+
+	replaceSkillResources(paths: Array<{ path: string; metadata: PathMetadata }>, source: string): void {
+		const skillPaths = this.normalizeExtensionPaths(paths);
+		this.lastSkillPaths = this.lastSkillPaths.filter((path) => {
+			if (this.extensionSkillSourceInfos.get(path)?.source !== source) return true;
+			this.extensionSkillSourceInfos.delete(path);
+			return false;
+		});
+		for (const entry of skillPaths) {
+			this.extensionSkillSourceInfos.set(entry.path, createSourceInfo(entry.path, entry.metadata));
+		}
+		this.lastSkillPaths = this.mergePaths(
+			this.lastSkillPaths,
+			skillPaths.map((entry) => entry.path),
+		);
+		this.updateSkillsFromPaths(this.lastSkillPaths);
 	}
 
 	async reload(): Promise<void> {

--- a/packages/coding-agent/src/modes/acp/acp-mcp.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mcp.ts
@@ -1,0 +1,158 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { McpServer } from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
+import type { AgentSession } from "../../core/agent-session.js";
+
+type AcpMcpServerConfig =
+	| { type: "http"; url: string; headers: Record<string, string> }
+	| { type: "stdio"; command: string; args: string[]; env: Record<string, string> };
+
+function resolveServers(servers: readonly McpServer[]): Record<string, AcpMcpServerConfig> {
+	const resolved = Object.create(null) as Record<string, AcpMcpServerConfig>;
+	for (const server of servers) {
+		if (Object.hasOwn(resolved, server.name)) {
+			throw RequestError.invalidParams({ reason: `duplicate MCP server name: ${server.name}` });
+		}
+		if (!server.name) {
+			throw RequestError.invalidParams({ reason: "MCP server names must not be empty" });
+		}
+		if ("command" in server) {
+			if (!server.command) {
+				throw RequestError.invalidParams({ reason: `MCP server ${server.name} has no stdio command` });
+			}
+			resolved[server.name] = {
+				type: "stdio",
+				command: server.command,
+				args: [...server.args],
+				env: Object.fromEntries(server.env.map((entry) => [entry.name, entry.value])),
+			};
+			continue;
+		}
+		if (server.type === "http") {
+			if (!server.url) {
+				throw RequestError.invalidParams({ reason: `MCP server ${server.name} has no HTTP URL` });
+			}
+			resolved[server.name] = {
+				type: "http",
+				url: server.url,
+				headers: Object.fromEntries(server.headers.map((header) => [header.name, header.value])),
+			};
+			continue;
+		}
+		throw RequestError.invalidParams({
+			reason: `MCP server ${server.name} uses unsupported ${server.type} transport`,
+		});
+	}
+	return resolved;
+}
+
+function pythonModule(config: Record<string, AcpMcpServerConfig>): string {
+	const encoded = JSON.stringify(JSON.stringify(config));
+	return `"""MCP servers supplied by the ACP client for this session."""
+
+import json
+
+from rlm import AcpMcpIntegration
+
+_CONFIG = json.loads(${encoded})
+_SERVERS = {name: AcpMcpIntegration(name, spec) for name, spec in _CONFIG.items()}
+
+
+def list_servers():
+    return sorted(_SERVERS)
+
+
+def server(name):
+    try:
+        return _SERVERS[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown ACP MCP server {name!r}; available: {list_servers()}") from exc
+
+
+async def list_tools(name):
+    return await server(name).list_tools()
+
+
+async def call_tool(name, tool, arguments=None):
+    return await server(name).call_tool(tool, arguments or {})
+
+
+def __getattr__(name):
+    if name.startswith("_"):
+        raise AttributeError(name)
+    try:
+        return _SERVERS[name]
+    except KeyError as exc:
+        raise AttributeError(name) from exc
+`;
+}
+
+function skillMarkdown(names: string[]): string {
+	const listed = names.map((name) => JSON.stringify(name)).join(", ");
+	const summary = names.map((name) => JSON.stringify(name)).join(", ");
+	const description = `Use MCP tools supplied by the ACP client: ${summary}`.slice(0, 1024);
+	return `---
+name: acp-mcp
+description: ${JSON.stringify(description)}
+---
+
+# ACP MCP servers
+
+The ACP client supplied these MCP servers for this session: ${listed}.
+
+Use them from IPython through the pre-imported \`acp_mcp\` module:
+
+\`\`\`python
+acp_mcp.list_servers()
+await acp_mcp.list_tools("server-name")
+await acp_mcp.call_tool("server-name", "tool-name", {"argument": "value"})
+\`\`\`
+
+When a server name is a valid Python identifier, its tools are also available as
+dynamic async methods, for example \`await acp_mcp.github.search(query="ACP")\`.
+Call \`list_tools\` before choosing a tool or arguments; do not guess its schema.
+`;
+}
+
+const PYPROJECT = `[project]
+name = "prime-agent-acp-mcp"
+version = "0.0.0"
+requires-python = ">=3.10"
+dependencies = ["mcp>=1.28,<2", "httpx>=0.27,<1"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/acp_mcp"]
+`;
+
+export class AcpMcpSkillInstaller {
+	private root: string | undefined;
+
+	constructor(private readonly session: AgentSession) {}
+
+	configure(servers: readonly McpServer[]): void {
+		if (servers.length === 0) return;
+		const config = resolveServers(servers);
+		this.root ??= mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-"));
+		const skillDir = join(this.root, "acp-mcp");
+		const packageDir = join(skillDir, "src", "acp_mcp");
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(join(skillDir, "SKILL.md"), skillMarkdown(Object.keys(config)), { encoding: "utf-8", mode: 0o600 });
+		writeFileSync(join(skillDir, "pyproject.toml"), PYPROJECT, { encoding: "utf-8", mode: 0o600 });
+		writeFileSync(join(packageDir, "__init__.py"), pythonModule(config), { encoding: "utf-8", mode: 0o600 });
+		const source = `acp:${createHash("sha256").update(JSON.stringify(config)).digest("hex").slice(0, 12)}`;
+		this.session.extendTemporarySkills([join(skillDir, "SKILL.md")], source);
+	}
+
+	dispose(): void {
+		if (!this.root) return;
+		rmSync(this.root, { recursive: true, force: true });
+		this.root = undefined;
+	}
+}

--- a/packages/coding-agent/src/modes/acp/acp-mcp.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mcp.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { McpServer } from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
-import type { AgentSession } from "../../core/agent-session.js";
+
+interface TemporarySkillHost {
+	extendTemporarySkills(skillPaths: string[], source: string): Promise<void> | void;
+}
 
 type AcpMcpServerConfig =
 	| { type: "http"; url: string; headers: Record<string, string> }
@@ -134,9 +137,9 @@ packages = ["src/acp_mcp"]
 export class AcpMcpSkillInstaller {
 	private root: string | undefined;
 
-	constructor(private readonly session: AgentSession) {}
+	constructor(private readonly host: TemporarySkillHost) {}
 
-	configure(servers: readonly McpServer[]): void {
+	async configure(servers: readonly McpServer[]): Promise<void> {
 		if (servers.length === 0) return;
 		const config = resolveServers(servers);
 		this.root ??= mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-"));
@@ -147,7 +150,7 @@ export class AcpMcpSkillInstaller {
 		writeFileSync(join(skillDir, "pyproject.toml"), PYPROJECT, { encoding: "utf-8", mode: 0o600 });
 		writeFileSync(join(packageDir, "__init__.py"), pythonModule(config), { encoding: "utf-8", mode: 0o600 });
 		const source = `acp:${createHash("sha256").update(JSON.stringify(config)).digest("hex").slice(0, 12)}`;
-		this.session.extendTemporarySkills([join(skillDir, "SKILL.md")], source);
+		await this.host.extendTemporarySkills([join(skillDir, "SKILL.md")], source);
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/src/modes/acp/acp-mcp.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mcp.ts
@@ -4,14 +4,29 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { McpServer } from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 interface TemporarySkillHost {
 	extendTemporarySkills(skillPaths: string[], source: string): Promise<void> | void;
+	getSkillNames?(): Promise<string[]>;
 }
 
 type AcpMcpServerConfig =
 	| { type: "http"; url: string; headers: Record<string, string> }
 	| { type: "stdio"; command: string; args: string[]; env: Record<string, string> };
+
+type AcpMcpTool = Pick<Tool, "name" | "description" | "inputSchema">;
+type DiscoverTools = (server: string, config: AcpMcpServerConfig, cwd: string) => Promise<AcpMcpTool[]>;
+
+interface DiscoveredSkill {
+	server: string;
+	config: AcpMcpServerConfig;
+	tool: AcpMcpTool;
+	importName: string;
+}
 
 function resolveServers(servers: readonly McpServer[]): Record<string, AcpMcpServerConfig> {
 	const resolved = Object.create(null) as Record<string, AcpMcpServerConfig>;
@@ -52,76 +67,96 @@ function resolveServers(servers: readonly McpServer[]): Record<string, AcpMcpSer
 	return resolved;
 }
 
-function pythonModule(config: Record<string, AcpMcpServerConfig>): string {
-	const encoded = JSON.stringify(JSON.stringify(config));
-	return `"""MCP servers supplied by the ACP client for this session."""
+function errorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+async function discoverServerTools(server: string, config: AcpMcpServerConfig, cwd: string): Promise<AcpMcpTool[]> {
+	const client = new Client({ name: "prime-agent-acp", version: "1.0.0" });
+	try {
+		const transport =
+			config.type === "http"
+				? new StreamableHTTPClientTransport(new URL(config.url), {
+						requestInit: { headers: config.headers },
+					})
+				: new StdioClientTransport({
+						command: config.command,
+						args: config.args,
+						env: { ...getDefaultEnvironment(), ...config.env },
+						cwd,
+					});
+		await client.connect(transport);
+		const result = await client.listTools();
+		return result.tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			inputSchema: tool.inputSchema,
+		}));
+	} catch (error) {
+		throw RequestError.invalidParams({
+			reason: `failed to discover tools from MCP server ${server}: ${errorText(error)}`,
+		});
+	} finally {
+		await client.close().catch(() => undefined);
+	}
+}
+
+function skillImportName(server: string, tool: string): string {
+	const normalized = `${server}_${tool}`.replace(/\W/g, "_");
+	return /^\d/.test(normalized) ? `_${normalized}` : normalized;
+}
+
+function skillDirectoryName(importName: string): string {
+	return importName.replaceAll("_", "-");
+}
+
+function pythonModule(server: string, config: AcpMcpServerConfig, tool: AcpMcpTool): string {
+	const encodedConfig = JSON.stringify(JSON.stringify(config));
+	const encodedTool = JSON.stringify(JSON.stringify(tool));
+	return `"""ACP MCP tool generated for this session."""
 
 import json
 
-from rlm import AcpMcpIntegration
+from rlm import make_acp_mcp_skill
 
-_CONFIG = json.loads(${encoded})
-_SERVERS = {name: AcpMcpIntegration(name, spec) for name, spec in _CONFIG.items()}
-
-
-def list_servers():
-    return sorted(_SERVERS)
-
-
-def server(name):
-    try:
-        return _SERVERS[name]
-    except KeyError as exc:
-        raise KeyError(f"Unknown ACP MCP server {name!r}; available: {list_servers()}") from exc
-
-
-async def list_tools(name):
-    return await server(name).list_tools()
-
-
-async def call_tool(name, tool, arguments=None):
-    return await server(name).call_tool(tool, arguments or {})
-
-
-def __getattr__(name):
-    if name.startswith("_"):
-        raise AttributeError(name)
-    try:
-        return _SERVERS[name]
-    except KeyError as exc:
-        raise AttributeError(name) from exc
+run = make_acp_mcp_skill(
+    ${JSON.stringify(server)},
+    json.loads(${encodedConfig}),
+    json.loads(${encodedTool}),
+)
 `;
 }
 
-function skillMarkdown(names: string[]): string {
-	const listed = names.map((name) => JSON.stringify(name)).join(", ");
-	const summary = names.map((name) => JSON.stringify(name)).join(", ");
-	const description = `Use MCP tools supplied by the ACP client: ${summary}`.slice(0, 1024);
+function skillMarkdown(skill: DiscoveredSkill): string {
+	const summary = skill.tool.description?.split("\n", 1)[0] || `Call ${skill.tool.name} on ${skill.server}.`;
+	const description = `MCP tool ${skill.server}/${skill.tool.name}: ${summary}`.slice(0, 1024);
+	const skillName = skillDirectoryName(skill.importName);
 	return `---
-name: acp-mcp
+name: ${JSON.stringify(skillName)}
 description: ${JSON.stringify(description)}
 ---
 
-# ACP MCP servers
+# ${skill.importName}
 
-The ACP client supplied these MCP servers for this session: ${listed}.
-
-Use them from IPython through the pre-imported \`acp_mcp\` module:
+This session-scoped skill calls MCP tool ${JSON.stringify(skill.tool.name)} on server
+${JSON.stringify(skill.server)}. It is pre-imported in IPython and callable directly:
 
 \`\`\`python
-acp_mcp.list_servers()
-await acp_mcp.list_tools("server-name")
-await acp_mcp.call_tool("server-name", "tool-name", {"argument": "value"})
+await ${skill.importName}(...)
 \`\`\`
 
-When a server name is a valid Python identifier, its tools are also available as
-dynamic async methods, for example \`await acp_mcp.github.search(query="ACP")\`.
-Call \`list_tools\` before choosing a tool or arguments; do not guess its schema.
+Use \`help(${skill.importName})\` or \`inspect.signature(${skill.importName})\` for its
+description and schema-derived keyword arguments.
 `;
 }
 
-const PYPROJECT = `[project]
-name = "prime-agent-acp-mcp"
+function pyproject(skill: DiscoveredSkill): string {
+	const digest = createHash("sha256")
+		.update(JSON.stringify([skill.server, skill.config, skill.tool]))
+		.digest("hex")
+		.slice(0, 16);
+	return `[project]
+name = "prime-agent-acp-mcp-${digest}"
 version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = ["mcp>=1.28,<2", "httpx>=0.27,<1"]
@@ -131,31 +166,83 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/acp_mcp"]
+packages = ["src/${skill.importName}"]
 `;
+}
 
 export class AcpMcpSkillInstaller {
 	private root: string | undefined;
+	private installedSkillNames = new Set<string>();
 
-	constructor(private readonly host: TemporarySkillHost) {}
+	constructor(
+		private readonly host: TemporarySkillHost,
+		private readonly discoverTools: DiscoverTools = discoverServerTools,
+	) {}
 
-	async configure(servers: readonly McpServer[]): Promise<void> {
-		if (servers.length === 0) return;
+	async configure(servers: readonly McpServer[], cwd: string): Promise<void> {
 		const config = resolveServers(servers);
-		this.root ??= mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-"));
-		const skillDir = join(this.root, "acp-mcp");
-		const packageDir = join(skillDir, "src", "acp_mcp");
-		mkdirSync(packageDir, { recursive: true });
-		writeFileSync(join(skillDir, "SKILL.md"), skillMarkdown(Object.keys(config)), { encoding: "utf-8", mode: 0o600 });
-		writeFileSync(join(skillDir, "pyproject.toml"), PYPROJECT, { encoding: "utf-8", mode: 0o600 });
-		writeFileSync(join(packageDir, "__init__.py"), pythonModule(config), { encoding: "utf-8", mode: 0o600 });
-		const source = `acp:${createHash("sha256").update(JSON.stringify(config)).digest("hex").slice(0, 12)}`;
-		await this.host.extendTemporarySkills([join(skillDir, "SKILL.md")], source);
+		const discovered: DiscoveredSkill[] = [];
+		const names = new Map<string, { server: string; tool: string }>();
+		for (const [server, spec] of Object.entries(config)) {
+			const tools = await this.discoverTools(server, spec, cwd);
+			for (const tool of tools) {
+				if (!tool.name) {
+					throw RequestError.invalidParams({ reason: `MCP server ${server} returned a tool with an empty name` });
+				}
+				const importName = skillImportName(server, tool.name);
+				const prior = names.get(importName);
+				if (prior) {
+					throw RequestError.invalidParams({
+						reason:
+							`MCP tools ${prior.server}/${prior.tool} and ${server}/${tool.name} ` +
+							`normalize to the same Python skill ${importName}`,
+					});
+				}
+				names.set(importName, { server, tool: tool.name });
+				discovered.push({ server, config: spec, tool, importName });
+			}
+		}
+
+		const existingSkillNames = new Set((await this.host.getSkillNames?.()) ?? []);
+		for (const installedName of this.installedSkillNames) existingSkillNames.delete(installedName);
+		for (const skill of discovered) {
+			const skillName = skillDirectoryName(skill.importName);
+			if (existingSkillNames.has(skillName)) {
+				throw RequestError.invalidParams({
+					reason: `MCP tool ${skill.server}/${skill.tool.name} conflicts with existing skill ${skillName}`,
+				});
+			}
+		}
+		const nextRoot = discovered.length > 0 ? mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-")) : undefined;
+		const skillPaths: string[] = [];
+		for (const skill of discovered) {
+			const skillDir = join(nextRoot!, skillDirectoryName(skill.importName));
+			const packageDir = join(skillDir, "src", skill.importName);
+			mkdirSync(packageDir, { recursive: true });
+			const skillPath = join(skillDir, "SKILL.md");
+			writeFileSync(skillPath, skillMarkdown(skill), { encoding: "utf-8", mode: 0o600 });
+			writeFileSync(join(skillDir, "pyproject.toml"), pyproject(skill), { encoding: "utf-8", mode: 0o600 });
+			writeFileSync(join(packageDir, "__init__.py"), pythonModule(skill.server, skill.config, skill.tool), {
+				encoding: "utf-8",
+				mode: 0o600,
+			});
+			skillPaths.push(skillPath);
+		}
+		try {
+			await this.host.extendTemporarySkills(skillPaths, "acp:mcp");
+		} catch (error) {
+			if (nextRoot) rmSync(nextRoot, { recursive: true, force: true });
+			throw error;
+		}
+		if (this.root) rmSync(this.root, { recursive: true, force: true });
+		this.root = nextRoot;
+		this.installedSkillNames = new Set(discovered.map((skill) => skillDirectoryName(skill.importName)));
 	}
 
 	dispose(): void {
 		if (!this.root) return;
 		rmSync(this.root, { recursive: true, force: true });
 		this.root = undefined;
+		this.installedSkillNames.clear();
 	}
 }

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -89,7 +89,7 @@ export interface AcpModeOptions {
 	/** Bind headless extensions once the connection is live (in-process mode). */
 	bindHeadlessExtensions?: () => Promise<void>;
 	/** Install the MCP servers supplied when the ACP session is created. */
-	configureMcpServers?: (servers: readonly acp.McpServer[]) => Promise<void> | void;
+	configureMcpServers?: (servers: readonly acp.McpServer[], cwd: string) => Promise<void> | void;
 	/**
 	 * Transport override. Defaults to NDJSON over stdio; tests supply an
 	 * in-memory stream pair so the protocol runs without a subprocess.
@@ -248,9 +248,11 @@ export async function runAcpModeWithConnection(
 	const mcp = connection.extendTemporarySkills
 		? new AcpMcpSkillInstaller({
 				extendTemporarySkills: (skillPaths, source) => connection.extendTemporarySkills!(skillPaths, source),
+				getSkillNames: async () => (await connection.getResourceSnapshot()).skills.map((skill) => skill.name),
 			})
 		: undefined;
-	const configureMcpServers = options.configureMcpServers ?? (mcp ? (servers) => mcp.configure(servers) : undefined);
+	const configureMcpServers =
+		options.configureMcpServers ?? (mcp ? (servers, cwd) => mcp.configure(servers, cwd) : undefined);
 
 	// One ACP connection drives one AgentConnection, whose newSession() replaces
 	// the live session rather than creating a parallel one. Tracking a single
@@ -293,25 +295,23 @@ export async function runAcpModeWithConnection(
 				await options.bindHeadlessExtensions?.();
 				bound = true;
 			}
-			if (params.mcpServers.length > 0) {
-				if (!configureMcpServers) {
-					throw acp.RequestError.invalidParams({ reason: "MCP servers are unavailable in this ACP host" });
-				}
-				await configureMcpServers(params.mcpServers);
+			const requestedCwd = params.cwd;
+			const actualCwd = await connection
+				.getState()
+				.then((state) => state.cwd)
+				.catch(() => undefined);
+			if (params.mcpServers.length > 0 && !configureMcpServers) {
+				throw acp.RequestError.invalidParams({ reason: "MCP servers are unavailable in this ACP host" });
 			}
+			await configureMcpServers?.(params.mcpServers, actualCwd ?? requestedCwd);
 			// prime-agent's cwd is fixed at startup by the session it was launched
 			// with, so a client-supplied cwd cannot be adopted after the fact.
 			// Report the real cwd back in `_meta` rather than failing the request or
 			// letting the client assume a directory the agent is not using.
-			const requestedCwd = params.cwd;
 			let cwdMismatch: { requested: string; actual: string } | undefined;
 			if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
-				const actual = await connection
-					.getState()
-					.then((state) => state.cwd)
-					.catch(() => undefined);
-				if (actual && !sameCwd(requestedCwd, actual)) {
-					cwdMismatch = { requested: requestedCwd, actual };
+				if (actualCwd && !sameCwd(requestedCwd, actualCwd)) {
+					cwdMismatch = { requested: requestedCwd, actual: actualCwd };
 				}
 			}
 			const sessionId = randomUUID();

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -232,15 +232,9 @@ async function turnFailure(connection: AgentConnection, boundary: TurnBoundary):
 
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
 	const connection = new InProcessAgentConnection(runtimeHost);
-	const mcp = new AcpMcpSkillInstaller(runtimeHost.session);
-	try {
-		return await runAcpModeWithConnection(connection, {
-			bindHeadlessExtensions: () => connection.bindHeadlessExtensions({}),
-			configureMcpServers: (servers) => mcp.configure(servers),
-		});
-	} finally {
-		mcp.dispose();
-	}
+	return runAcpModeWithConnection(connection, {
+		bindHeadlessExtensions: () => connection.bindHeadlessExtensions({}),
+	});
 }
 
 export async function runAcpModeWithConnection(
@@ -251,6 +245,12 @@ export async function runAcpModeWithConnection(
 	if (options.ownStdout !== false && !options.stream) {
 		takeOverStdout();
 	}
+	const mcp = connection.extendTemporarySkills
+		? new AcpMcpSkillInstaller({
+				extendTemporarySkills: (skillPaths, source) => connection.extendTemporarySkills!(skillPaths, source),
+			})
+		: undefined;
+	const configureMcpServers = options.configureMcpServers ?? (mcp ? (servers) => mcp.configure(servers) : undefined);
 
 	// One ACP connection drives one AgentConnection, whose newSession() replaces
 	// the live session rather than creating a parallel one. Tracking a single
@@ -287,17 +287,17 @@ export async function runAcpModeWithConnection(
 				);
 			}
 			const params = ctx.params as acp.NewSessionRequest;
-			if (params.mcpServers.length > 0) {
-				if (!options.configureMcpServers) {
-					throw acp.RequestError.invalidParams({ reason: "MCP servers are unavailable in this ACP host" });
-				}
-				await options.configureMcpServers(params.mcpServers);
-			}
 			if (!bound) {
 				// Only latch after a successful bind: a rejected bind must not leave
 				// extensions permanently unavailable for the rest of the process.
 				await options.bindHeadlessExtensions?.();
 				bound = true;
+			}
+			if (params.mcpServers.length > 0) {
+				if (!configureMcpServers) {
+					throw acp.RequestError.invalidParams({ reason: "MCP servers are unavailable in this ACP host" });
+				}
+				await configureMcpServers(params.mcpServers);
 			}
 			// prime-agent's cwd is fixed at startup by the session it was launched
 			// with, so a client-supplied cwd cannot be adopted after the fact.
@@ -437,6 +437,7 @@ export async function runAcpModeWithConnection(
 	session?.unsubscribe?.();
 	session = undefined;
 	await connection.dispose().catch(() => undefined);
+	mcp?.dispose();
 	// Only the real stdio entrypoint owns the process; a caller-supplied transport
 	// (tests, embedding) must never have its host exited from under it.
 	if (options.stream) return undefined as never;

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -13,6 +13,7 @@ import { InProcessAgentConnection } from "../agent-connection/in-process-agent-c
 import type { AgentConnection } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
 import { type AcpEventMappingState, acpUpdatesForSessionEvent } from "./acp-events.js";
+import { AcpMcpSkillInstaller } from "./acp-mcp.js";
 import { primeAgentMeta } from "./acp-meta.js";
 import { type AcpStopReason, acpStopReason } from "./acp-stop-reason.js";
 
@@ -87,6 +88,8 @@ function sameCwd(left: string, right: string): boolean {
 export interface AcpModeOptions {
 	/** Bind headless extensions once the connection is live (in-process mode). */
 	bindHeadlessExtensions?: () => Promise<void>;
+	/** Install the MCP servers supplied when the ACP session is created. */
+	configureMcpServers?: (servers: readonly acp.McpServer[]) => Promise<void> | void;
 	/**
 	 * Transport override. Defaults to NDJSON over stdio; tests supply an
 	 * in-memory stream pair so the protocol runs without a subprocess.
@@ -229,9 +232,15 @@ async function turnFailure(connection: AgentConnection, boundary: TurnBoundary):
 
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
 	const connection = new InProcessAgentConnection(runtimeHost);
-	return runAcpModeWithConnection(connection, {
-		bindHeadlessExtensions: () => connection.bindHeadlessExtensions({}),
-	});
+	const mcp = new AcpMcpSkillInstaller(runtimeHost.session);
+	try {
+		return await runAcpModeWithConnection(connection, {
+			bindHeadlessExtensions: () => connection.bindHeadlessExtensions({}),
+			configureMcpServers: (servers) => mcp.configure(servers),
+		});
+	} finally {
+		mcp.dispose();
+	}
 }
 
 export async function runAcpModeWithConnection(
@@ -260,6 +269,7 @@ export async function runAcpModeWithConnection(
 			agentCapabilities: {
 				loadSession: false,
 				promptCapabilities: { image: true, embeddedContext: true },
+				mcpCapabilities: { http: true },
 				// Advertise close so a client knows it can release the session (and
 				// the single-session slot) instead of dropping the connection.
 				sessionCapabilities: { close: {} },
@@ -270,23 +280,30 @@ export async function runAcpModeWithConnection(
 			_meta: primeAgentMeta({}),
 		}))
 		.onRequest("session/new", async (ctx: any) => {
-			if (!bound) {
-				// Only latch after a successful bind: a rejected bind must not leave
-				// extensions permanently unavailable for the rest of the process.
-				await options.bindHeadlessExtensions?.();
-				bound = true;
-			}
 			if (session) {
 				throw new Error(
 					"prime-agent ACP mode hosts one session per connection; " +
 						"start another prime-agent process for a second session",
 				);
 			}
+			const params = ctx.params as acp.NewSessionRequest;
+			if (params.mcpServers.length > 0) {
+				if (!options.configureMcpServers) {
+					throw acp.RequestError.invalidParams({ reason: "MCP servers are unavailable in this ACP host" });
+				}
+				await options.configureMcpServers(params.mcpServers);
+			}
+			if (!bound) {
+				// Only latch after a successful bind: a rejected bind must not leave
+				// extensions permanently unavailable for the rest of the process.
+				await options.bindHeadlessExtensions?.();
+				bound = true;
+			}
 			// prime-agent's cwd is fixed at startup by the session it was launched
 			// with, so a client-supplied cwd cannot be adopted after the fact.
 			// Report the real cwd back in `_meta` rather than failing the request or
 			// letting the client assume a directory the agent is not using.
-			const requestedCwd = (ctx.params as { cwd?: unknown } | undefined)?.cwd;
+			const requestedCwd = params.cwd;
 			let cwdMismatch: { requested: string; actual: string } | undefined;
 			if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
 				const actual = await connection

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -450,6 +450,15 @@ export class DaemonAgentConnection implements AgentConnection {
 		});
 	}
 
+	async extendTemporarySkills(skillPaths: string[], source: string): Promise<void> {
+		await this.requestOk({
+			type: "extend_temporary_skills",
+			activeSessionId: this.activeSessionId,
+			skillPaths,
+			source,
+		});
+	}
+
 	async getAvailableModels(): Promise<AgentConnectionModel[]> {
 		const data = await this.requestData<{ models: AgentConnectionModel[] }>({
 			type: "get_available_models",

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -103,6 +103,10 @@ export class InProcessAgentConnection implements AgentConnection {
 		await this.bindCurrentSessionExtensions();
 	}
 
+	async extendTemporarySkills(skillPaths: string[], source: string): Promise<void> {
+		this.runtimeHost.session.extendTemporarySkills(skillPaths, source);
+	}
+
 	subscribe(listener: AgentConnectionEventListener): () => void {
 		this.listeners.add(listener);
 		return () => {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -673,6 +673,8 @@ export interface AgentConnection {
 	getToolDefinition(name: string): Promise<AgentConnectionToolDefinition | undefined>;
 	setSessionEntryLabel(entryId: string, label: string | undefined): Promise<void>;
 	respondToExtensionUiRequest(requestId: string, response: AgentConnectionExtensionUiResponse): Promise<void>;
+	/** Attach process-local Python skills before a headless session starts streaming. */
+	extendTemporarySkills?(skillPaths: string[], source: string): Promise<void>;
 
 	prompt(message: string, options?: AgentConnectionPromptOptions): Promise<void>;
 	promptAndWait(message: string, options?: AgentConnectionPromptOptions): Promise<void>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -277,6 +277,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_context_tree",
 	"get_commands",
 	"get_resource_snapshot",
+	"extend_temporary_skills",
 	"get_model_catalog",
 	"get_available_models",
 	"get_queue",
@@ -4155,6 +4156,14 @@ export class AgentDaemon {
 					"get_resource_snapshot",
 					createAgentConnectionResourceSnapshot(state.runtime.session),
 				);
+			}
+
+			case "extend_temporary_skills": {
+				const state = this.getSessionState(command.activeSessionId);
+				await withClientEnv(state.clientEnv, async () =>
+					state.runtime.session.extendTemporarySkills(command.skillPaths, command.source),
+				);
+				return success(command.id, "extend_temporary_skills");
 			}
 
 			case "get_available_models": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -57,7 +57,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 12 publishes idle-residency metadata on session summary rows.
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 export const DAEMON_SCHEMA_REVISION = 13;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-13-816309b1cd50";
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-13-a013caa216af";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -502,6 +502,13 @@ export type DaemonCommand =
 	| { id?: string; type: "get_context_tree"; activeSessionId: string }
 	| { id?: string; type: "get_commands"; activeSessionId: string }
 	| { id?: string; type: "get_resource_snapshot"; activeSessionId: string }
+	| {
+			id?: string;
+			type: "extend_temporary_skills";
+			activeSessionId: string;
+			skillPaths: string[];
+			source: string;
+	  }
 	| { id?: string; type: "get_model_catalog"; activeSessionId: string }
 	| { id?: string; type: "get_available_models"; activeSessionId: string }
 	| { id?: string; type: "get_queue"; activeSessionId: string }
@@ -675,6 +682,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	get_context_tree: LEGACY_DAEMON_COMMAND,
 	get_commands: LEGACY_DAEMON_COMMAND,
 	get_resource_snapshot: LEGACY_DAEMON_COMMAND,
+	extend_temporary_skills: CURRENT_DAEMON_COMMAND,
 	get_model_catalog: { minProtocol: 7, capability: "model_catalog" },
 	get_available_models: LEGACY_DAEMON_COMMAND,
 	get_queue: LEGACY_DAEMON_COMMAND,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -187,6 +187,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"get_context_tree",
 	"get_commands",
 	"get_resource_snapshot",
+	"extend_temporary_skills",
 	"get_model_catalog",
 	"get_available_models",
 	"get_queue",

--- a/packages/coding-agent/test/acp-mcp.test.ts
+++ b/packages/coding-agent/test/acp-mcp.test.ts
@@ -1,6 +1,9 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { once } from "node:events";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import * as acp from "@agentclientprotocol/sdk";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.js";
@@ -19,15 +22,84 @@ function runtimeHostFor(session: unknown): AgentSessionRuntime {
 	} as unknown as AgentSessionRuntime;
 }
 
+async function startHttpMcpServer(): Promise<{
+	url: string;
+	authorization: () => string | undefined;
+	close: () => Promise<void>;
+}> {
+	let authorization: string | undefined;
+	const server = createServer(async (request, response) => {
+		authorization = request.headers.authorization;
+		if (request.method === "DELETE") {
+			response.writeHead(200).end();
+			return;
+		}
+		if (request.method !== "POST") {
+			response.writeHead(405).end();
+			return;
+		}
+		const chunks: Buffer[] = [];
+		for await (const chunk of request) {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		}
+		const message = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
+			jsonrpc: "2.0";
+			id?: string | number;
+			method: string;
+			params?: { protocolVersion?: string };
+		};
+		if (message.id === undefined) {
+			response.writeHead(202).end();
+			return;
+		}
+		const result =
+			message.method === "initialize"
+				? {
+						protocolVersion: message.params?.protocolVersion ?? "2025-06-18",
+						capabilities: { tools: {} },
+						serverInfo: { name: "test-tools", version: "1.0.0" },
+					}
+				: {
+						tools: [
+							{
+								name: "lookup",
+								description: "Look up a task by query.",
+								inputSchema: {
+									type: "object",
+									properties: { query: { type: "string" }, limit: { type: "integer" } },
+									required: ["query"],
+								},
+							},
+						],
+					};
+		response.writeHead(200, { "Content-Type": "application/json" });
+		response.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
+	});
+	server.listen(0, "127.0.0.1");
+	await once(server, "listening");
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("test MCP server did not bind TCP");
+	return {
+		url: `http://127.0.0.1:${address.port}/mcp`,
+		authorization: () => authorization,
+		close: async () => {
+			server.close();
+			await once(server, "close");
+		},
+	};
+}
+
 describe("ACP MCP servers", () => {
-	it("advertises HTTP support and configures session/new servers", async () => {
+	it("advertises HTTP support and configures session/new servers in the agent cwd", async () => {
 		const harness = await createHarness();
 		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
-		const extendTemporarySkills = vi.spyOn(connection, "extendTemporarySkills");
+		const agentCwd = (await connection.getState()).cwd;
+		const configureMcpServers = vi.fn();
 		const toAgent = new TransformStream<Uint8Array, Uint8Array>();
 		const toClient = new TransformStream<Uint8Array, Uint8Array>();
 		const modeDone = runAcpModeWithConnection(connection, {
 			stream: acp.ndJsonStream(toClient.writable, toAgent.readable),
+			configureMcpServers,
 		});
 		const handle = acp
 			.client({ name: "mcp-test-client" })
@@ -45,11 +117,14 @@ describe("ACP MCP servers", () => {
 			url: "http://127.0.0.1:8000/mcp",
 			headers: [{ name: "Authorization", value: "Bearer task" }],
 		};
-		await handle.agent.request("session/new", {
+		const firstSession = await handle.agent.request("session/new", {
 			cwd: harness.tempDir,
 			mcpServers: [server],
 		});
-		expect(extendTemporarySkills).toHaveBeenCalledOnce();
+		expect(configureMcpServers).toHaveBeenCalledWith([server], agentCwd);
+		await handle.agent.request("session/close", { sessionId: firstSession.sessionId });
+		await handle.agent.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		expect(configureMcpServers).toHaveBeenLastCalledWith([], agentCwd);
 
 		handle.close();
 		await toAgent.writable.close().catch(() => undefined);
@@ -57,8 +132,173 @@ describe("ACP MCP servers", () => {
 		harness.cleanup();
 	}, 30_000);
 
+	it("eagerly discovers HTTP tools and writes one Python skill per tool", async () => {
+		const mcp = await startHttpMcpServer();
+		const extendTemporarySkills = vi.fn();
+		const installer = new AcpMcpSkillInstaller({ extendTemporarySkills });
+		try {
+			await installer.configure(
+				[
+					{
+						type: "http",
+						name: "task-tools",
+						url: mcp.url,
+						headers: [{ name: "Authorization", value: "Bearer task" }],
+					},
+				],
+				process.cwd(),
+			);
+
+			expect(mcp.authorization()).toBe("Bearer task");
+			expect(extendTemporarySkills).toHaveBeenCalledOnce();
+			const [skillPaths] = extendTemporarySkills.mock.calls[0] as [string[], string];
+			expect(skillPaths).toHaveLength(1);
+			const skillDir = dirname(skillPaths[0]);
+			expect(basename(skillDir)).toBe("task-tools-lookup");
+			const skill = readFileSync(skillPaths[0], "utf-8");
+			expect(skill).toContain("await task_tools_lookup(...)");
+			const source = readFileSync(join(skillDir, "src", "task_tools_lookup", "__init__.py"), "utf-8");
+			expect(source).toContain("make_acp_mcp_skill");
+			expect(source).toContain("Look up a task by query.");
+			expect(source).toContain("Bearer task");
+		} finally {
+			installer.dispose();
+			await mcp.close();
+		}
+	});
+
+	it("eagerly discovers stdio tools in the session cwd and environment", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-stdio-test-"));
+		const extendTemporarySkills = vi.fn();
+		const installer = new AcpMcpSkillInstaller({ extendTemporarySkills });
+		const fixture = fileURLToPath(new URL("./fixtures/acp-mcp-stdio-server.mjs", import.meta.url));
+		try {
+			await installer.configure(
+				[
+					{
+						name: "local-tools",
+						command: process.execPath,
+						args: [fixture],
+						env: [{ name: "TASK_MARKER", value: "stdio" }],
+					},
+				],
+				root,
+			);
+
+			const [skillPaths] = extendTemporarySkills.mock.calls[0] as [string[], string];
+			expect(skillPaths).toHaveLength(1);
+			expect(basename(dirname(skillPaths[0]))).toBe("local-tools-env-stdio");
+			const skill = readFileSync(skillPaths[0], "utf-8");
+			expect(skill).toContain(`Discovered in ${realpathSync(root)}`);
+			const source = readFileSync(
+				join(dirname(skillPaths[0]), "src", "local_tools_env_stdio", "__init__.py"),
+				"utf-8",
+			);
+			expect(source).toContain("TASK_MARKER");
+			expect(source).toContain("stdio");
+		} finally {
+			installer.dispose();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects MCP tools whose RLM-style Python names collide", async () => {
+		const extendTemporarySkills = vi.fn();
+		const installer = new AcpMcpSkillInstaller({ extendTemporarySkills }, async (server) => [
+			{
+				name: server === "a" ? "b-c" : "c",
+				description: "collision",
+				inputSchema: { type: "object" },
+			},
+		]);
+		await expect(
+			installer.configure(
+				[
+					{ type: "http", name: "a", url: "https://a.test/mcp", headers: [] },
+					{ type: "http", name: "a-b", url: "https://b.test/mcp", headers: [] },
+				],
+				process.cwd(),
+			),
+		).rejects.toMatchObject({
+			data: { reason: expect.stringContaining("normalize to the same Python skill a_b_c") },
+		});
+		expect(extendTemporarySkills).not.toHaveBeenCalled();
+		installer.dispose();
+	});
+
+	it("rejects an MCP tool that conflicts with an installed Python skill", async () => {
+		const extendTemporarySkills = vi.fn();
+		const installer = new AcpMcpSkillInstaller(
+			{
+				extendTemporarySkills,
+				getSkillNames: async () => ["task-tools-lookup"],
+			},
+			async () => [
+				{
+					name: "lookup",
+					description: "collision",
+					inputSchema: { type: "object" },
+				},
+			],
+		);
+		await expect(
+			installer.configure(
+				[{ type: "http", name: "task-tools", url: "https://tools.test/mcp", headers: [] }],
+				process.cwd(),
+			),
+		).rejects.toMatchObject({
+			data: { reason: "MCP tool task-tools/lookup conflicts with existing skill task-tools-lookup" },
+		});
+		expect(extendTemporarySkills).not.toHaveBeenCalled();
+		installer.dispose();
+	});
+
+	it("replaces MCP skills when a new ACP session supplies a different server set", async () => {
+		const resourceRoot = mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-replace-test-"));
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: resourceRoot,
+			agentDir: resourceRoot,
+			bundledSkillsDir: null,
+		});
+		await resourceLoader.reload();
+		const harness = await createHarness({ resourceLoader });
+		const installer = new AcpMcpSkillInstaller(harness.session, async (server) => [
+			{
+				name: "lookup",
+				description: `Look up data from ${server}.`,
+				inputSchema: { type: "object" },
+			},
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		try {
+			await installer.configure(
+				[{ type: "http", name: "first", url: "https://first.test/mcp", headers: [] }],
+				harness.tempDir,
+			);
+			expect((await connection.getResourceSnapshot()).skills.map((skill) => skill.name)).toContain("first-lookup");
+
+			await installer.configure(
+				[{ type: "http", name: "second", url: "https://second.test/mcp", headers: [] }],
+				harness.tempDir,
+			);
+			const replaced = (await connection.getResourceSnapshot()).skills.map((skill) => skill.name);
+			expect(replaced).not.toContain("first-lookup");
+			expect(replaced).toContain("second-lookup");
+
+			await installer.configure([], harness.tempDir);
+			expect((await connection.getResourceSnapshot()).skills.map((skill) => skill.name)).not.toContain(
+				"second-lookup",
+			);
+		} finally {
+			installer.dispose();
+			await connection.dispose();
+			harness.cleanup();
+			rmSync(resourceRoot, { recursive: true, force: true });
+		}
+	});
+
 	it(
-		"installs HTTP and stdio servers as one temporary Python skill",
+		"pre-imports eagerly discovered MCP tools with RLM-style signatures",
 		{ tags: ["kernel-heavy"], timeout: 180_000 },
 		async () => {
 			const resourceRoot = mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-test-"));
@@ -69,51 +309,84 @@ describe("ACP MCP servers", () => {
 			});
 			await resourceLoader.reload();
 			const harness = await createHarness({ resourceLoader });
-			const installer = new AcpMcpSkillInstaller(harness.session);
+			const discoverTools = vi.fn(async (server: string) => [
+				{
+					name: server === "remote-tools" ? "lookup" : "run_job",
+					description: server === "remote-tools" ? "Look up a task." : "Run a local job.",
+					inputSchema:
+						server === "remote-tools"
+							? {
+									type: "object" as const,
+									properties: { query: { type: "string" }, limit: { type: "integer" } },
+									required: ["query"],
+								}
+							: { type: "object" as const },
+				},
+			]);
+			const installer = new AcpMcpSkillInstaller(harness.session, discoverTools);
 			try {
-				await installer.configure([
-					{
-						type: "http",
-						name: "remote-tools",
-						url: "https://tools.example/mcp",
-						headers: [{ name: "X-Task", value: "one" }],
-					},
-					{
-						name: "local-tools",
-						command: "/usr/bin/tool-server",
-						args: ["--stdio"],
-						env: [{ name: "TASK", value: "two" }],
-					},
-				]);
+				await installer.configure(
+					[
+						{
+							type: "http",
+							name: "remote-tools",
+							url: "https://tools.example/mcp",
+							headers: [{ name: "X-Task", value: "one" }],
+						},
+						{
+							name: "local-tools",
+							command: "/usr/bin/tool-server",
+							args: ["--stdio"],
+							env: [{ name: "TASK", value: "two" }],
+						},
+					],
+					resourceRoot,
+				);
 
 				const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
 				const resources = await connection.getResourceSnapshot();
-				const skill = resources.skills.find((candidate) => candidate.name === "acp-mcp");
-				expect(skill).toBeDefined();
-				expect(harness.session.systemPrompt).toContain("remote-tools");
-				expect(harness.session.systemPrompt).toContain("local-tools");
+				const remoteSkill = resources.skills.find((candidate) => candidate.name === "remote-tools-lookup");
+				const localSkill = resources.skills.find((candidate) => candidate.name === "local-tools-run-job");
+				expect(remoteSkill).toBeDefined();
+				expect(localSkill).toBeDefined();
+				expect(harness.session.systemPrompt).toContain("remote_tools_lookup");
+				expect(harness.session.systemPrompt).toContain("local_tools_run_job");
 
-				const source = readFileSync(join(dirname(skill!.filePath), "src", "acp_mcp", "__init__.py"), "utf-8");
+				const source = readFileSync(
+					join(dirname(remoteSkill!.filePath), "src", "remote_tools_lookup", "__init__.py"),
+					"utf-8",
+				);
 				expect(source).toContain("https://tools.example/mcp");
 				expect(source).toContain("X-Task");
-				expect(source).toContain("/usr/bin/tool-server");
-				expect(source).toContain("TASK");
-				const pyproject = readFileSync(join(dirname(skill!.filePath), "pyproject.toml"), "utf-8");
+				const localSource = readFileSync(
+					join(dirname(localSkill!.filePath), "src", "local_tools_run_job", "__init__.py"),
+					"utf-8",
+				);
+				expect(localSource).toContain("/usr/bin/tool-server");
+				expect(localSource).toContain("TASK");
+				const pyproject = readFileSync(join(dirname(remoteSkill!.filePath), "pyproject.toml"), "utf-8");
 				expect(pyproject).not.toContain("prime-agent-runtime");
 
 				const ipython = harness.session.agent.state.tools.find((tool) => tool.name === "ipython");
 				expect(ipython).toBeDefined();
 				const imported = await ipython!.execute("acp-mcp-import", {
-					code: "print(acp_mcp.list_servers())",
+					code: [
+						"import inspect",
+						"print(remote_tools_lookup.__name__)",
+						"print(inspect.signature(remote_tools_lookup))",
+						"print(remote_tools_lookup.__doc__)",
+					].join("\n"),
 				});
 				const output = imported.content
 					.filter((item): item is { type: "text"; text: string } => item.type === "text")
 					.map((item) => item.text)
 					.join("");
-				expect(output).toContain("local-tools");
-				expect(output).toContain("remote-tools");
+				expect(output).toContain("remote_tools_lookup");
+				expect(output).toContain("query: str");
+				expect(output).toContain("limit: int = None");
+				expect(output).toContain("Look up a task.");
 
-				const skillDirectory = dirname(skill!.filePath);
+				const skillDirectory = dirname(remoteSkill!.filePath);
 				await harness.session.disposeAsync();
 				installer.dispose();
 				expect(existsSync(skillDirectory)).toBe(false);

--- a/packages/coding-agent/test/acp-mcp.test.ts
+++ b/packages/coding-agent/test/acp-mcp.test.ts
@@ -1,0 +1,129 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import * as acp from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.js";
+import { DefaultResourceLoader } from "../src/core/resource-loader.js";
+import { AcpMcpSkillInstaller } from "../src/modes/acp/acp-mcp.js";
+import { runAcpModeWithConnection } from "../src/modes/acp/acp-mode.js";
+import { InProcessAgentConnection } from "../src/modes/agent-connection/in-process-agent-connection.js";
+import { createHarness } from "./suite/harness.js";
+
+function runtimeHostFor(session: unknown): AgentSessionRuntime {
+	return {
+		session,
+		setRebindSession() {},
+		setBeforeSessionInvalidate() {},
+		async dispose() {},
+	} as unknown as AgentSessionRuntime;
+}
+
+describe("ACP MCP servers", () => {
+	it("advertises HTTP support and configures session/new servers", async () => {
+		const harness = await createHarness();
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+		const toClient = new TransformStream<Uint8Array, Uint8Array>();
+		const configureMcpServers = vi.fn();
+		const modeDone = runAcpModeWithConnection(connection, {
+			stream: acp.ndJsonStream(toClient.writable, toAgent.readable),
+			configureMcpServers,
+		});
+		const handle = acp
+			.client({ name: "mcp-test-client" })
+			.connect(acp.ndJsonStream(toAgent.writable, toClient.readable));
+
+		const initialized = await handle.agent.request("initialize", {
+			protocolVersion: acp.PROTOCOL_VERSION,
+			clientCapabilities: {},
+		});
+		expect(initialized.agentCapabilities?.mcpCapabilities?.http).toBe(true);
+
+		const server: acp.McpServer = {
+			type: "http",
+			name: "task-tools",
+			url: "http://127.0.0.1:8000/mcp",
+			headers: [{ name: "Authorization", value: "Bearer task" }],
+		};
+		await handle.agent.request("session/new", {
+			cwd: harness.tempDir,
+			mcpServers: [server],
+		});
+		expect(configureMcpServers).toHaveBeenCalledWith([server]);
+
+		handle.close();
+		await toAgent.writable.close().catch(() => undefined);
+		await modeDone;
+		harness.cleanup();
+	}, 30_000);
+
+	it(
+		"installs HTTP and stdio servers as one temporary Python skill",
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
+		async () => {
+			const resourceRoot = mkdtempSync(join(tmpdir(), "prime-agent-acp-mcp-test-"));
+			const resourceLoader = new DefaultResourceLoader({
+				cwd: resourceRoot,
+				agentDir: resourceRoot,
+				bundledSkillsDir: null,
+			});
+			await resourceLoader.reload();
+			const harness = await createHarness({ resourceLoader });
+			const installer = new AcpMcpSkillInstaller(harness.session);
+			try {
+				installer.configure([
+					{
+						type: "http",
+						name: "remote-tools",
+						url: "https://tools.example/mcp",
+						headers: [{ name: "X-Task", value: "one" }],
+					},
+					{
+						name: "local-tools",
+						command: "/usr/bin/tool-server",
+						args: ["--stdio"],
+						env: [{ name: "TASK", value: "two" }],
+					},
+				]);
+
+				const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+				const resources = await connection.getResourceSnapshot();
+				const skill = resources.skills.find((candidate) => candidate.name === "acp-mcp");
+				expect(skill).toBeDefined();
+				expect(harness.session.systemPrompt).toContain("remote-tools");
+				expect(harness.session.systemPrompt).toContain("local-tools");
+
+				const source = readFileSync(join(dirname(skill!.filePath), "src", "acp_mcp", "__init__.py"), "utf-8");
+				expect(source).toContain("https://tools.example/mcp");
+				expect(source).toContain("X-Task");
+				expect(source).toContain("/usr/bin/tool-server");
+				expect(source).toContain("TASK");
+				const pyproject = readFileSync(join(dirname(skill!.filePath), "pyproject.toml"), "utf-8");
+				expect(pyproject).not.toContain("prime-agent-runtime");
+
+				const ipython = harness.session.agent.state.tools.find((tool) => tool.name === "ipython");
+				expect(ipython).toBeDefined();
+				const imported = await ipython!.execute("acp-mcp-import", {
+					code: "print(acp_mcp.list_servers())",
+				});
+				const output = imported.content
+					.filter((item): item is { type: "text"; text: string } => item.type === "text")
+					.map((item) => item.text)
+					.join("");
+				expect(output).toContain("local-tools");
+				expect(output).toContain("remote-tools");
+
+				const skillDirectory = dirname(skill!.filePath);
+				await harness.session.disposeAsync();
+				installer.dispose();
+				expect(existsSync(skillDirectory)).toBe(false);
+			} finally {
+				await harness.session.disposeAsync();
+				installer.dispose();
+				harness.cleanup();
+				rmSync(resourceRoot, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/packages/coding-agent/test/acp-mcp.test.ts
+++ b/packages/coding-agent/test/acp-mcp.test.ts
@@ -23,12 +23,11 @@ describe("ACP MCP servers", () => {
 	it("advertises HTTP support and configures session/new servers", async () => {
 		const harness = await createHarness();
 		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const extendTemporarySkills = vi.spyOn(connection, "extendTemporarySkills");
 		const toAgent = new TransformStream<Uint8Array, Uint8Array>();
 		const toClient = new TransformStream<Uint8Array, Uint8Array>();
-		const configureMcpServers = vi.fn();
 		const modeDone = runAcpModeWithConnection(connection, {
 			stream: acp.ndJsonStream(toClient.writable, toAgent.readable),
-			configureMcpServers,
 		});
 		const handle = acp
 			.client({ name: "mcp-test-client" })
@@ -50,7 +49,7 @@ describe("ACP MCP servers", () => {
 			cwd: harness.tempDir,
 			mcpServers: [server],
 		});
-		expect(configureMcpServers).toHaveBeenCalledWith([server]);
+		expect(extendTemporarySkills).toHaveBeenCalledOnce();
 
 		handle.close();
 		await toAgent.writable.close().catch(() => undefined);
@@ -72,7 +71,7 @@ describe("ACP MCP servers", () => {
 			const harness = await createHarness({ resourceLoader });
 			const installer = new AcpMcpSkillInstaller(harness.session);
 			try {
-				installer.configure([
+				await installer.configure([
 					{
 						type: "http",
 						name: "remote-tools",

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -180,6 +180,8 @@ class FakeDaemonClient {
 						},
 					},
 				};
+			case "extend_temporary_skills":
+				return { type: "response", command: command.type, success: true };
 			case "get_model_catalog":
 				return {
 					type: "response",
@@ -2308,6 +2310,21 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests[1]).toMatchObject({
 			type: "get_resource_snapshot",
 			activeSessionId: "active-1",
+		});
+	});
+
+	it("extends temporary skills through the daemon protocol", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		await connection.attach();
+
+		await connection.extendTemporarySkills(["/tmp/acp-mcp/SKILL.md"], "acp:test");
+
+		expect(fakeClient.requests[1]).toMatchObject({
+			type: "extend_temporary_skills",
+			activeSessionId: "active-1",
+			skillPaths: ["/tmp/acp-mcp/SKILL.md"],
+			source: "acp:test",
 		});
 	});
 

--- a/packages/coding-agent/test/fixtures/acp-mcp-stdio-server.mjs
+++ b/packages/coding-agent/test/fixtures/acp-mcp-stdio-server.mjs
@@ -1,0 +1,20 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+	{ name: "acp-mcp-stdio-fixture", version: "1.0.0" },
+	{ capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+	tools: [
+		{
+			name: `env_${process.env.TASK_MARKER ?? "missing"}`,
+			description: `Discovered in ${process.cwd()}`,
+			inputSchema: { type: "object", properties: {} },
+		},
+	],
+}));
+
+await server.connect(new StdioServerTransport());

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -313,6 +313,7 @@ class _CallableModule(types.ModuleType):
 sys.modules[__name__].__class__ = _CallableModule
 
 __all__ = [
+    "AcpMcpIntegration",
     "HarnessEntry",
     "HarnessScope",
     "HarnessState",
@@ -335,7 +336,7 @@ __all__ = [
 
 # Lazily re-export the MCP base class. Kept lazy so `import rlm` never requires
 # the optional `mcp` SDK — only integration packages that subclass it do.
-_LAZY_MCP = {"McpIntegration", "McpToolError", "NotEnabled"}
+_LAZY_MCP = {"AcpMcpIntegration", "McpIntegration", "McpToolError", "NotEnabled"}
 
 
 def __getattr__(name: str) -> Any:  # noqa: D401 - module-level lazy attr hook

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -330,13 +330,20 @@ __all__ = [
     "harness",
     "host_request",
     "list_subagents",
+    "make_acp_mcp_skill",
     "rlm",
     "run",
 ]
 
 # Lazily re-export the MCP base class. Kept lazy so `import rlm` never requires
 # the optional `mcp` SDK — only integration packages that subclass it do.
-_LAZY_MCP = {"AcpMcpIntegration", "McpIntegration", "McpToolError", "NotEnabled"}
+_LAZY_MCP = {
+    "AcpMcpIntegration",
+    "McpIntegration",
+    "McpToolError",
+    "NotEnabled",
+    "make_acp_mcp_skill",
+}
 
 
 def __getattr__(name: str) -> Any:  # noqa: D401 - module-level lazy attr hook

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from . import host_request
 
-__all__ = ["McpIntegration", "McpToolError", "NotEnabled"]
+__all__ = ["AcpMcpIntegration", "McpIntegration", "McpToolError", "NotEnabled"]
 
 # Stored access tokens are treated as expired this many seconds early so a token
 # never dies mid-request. Mirrors the host's refresh buffer.
@@ -107,6 +107,36 @@ def _resolve_streamable_http():
     raise ImportError(
         "the installed `mcp` SDK exposes no streamable-HTTP client; upgrade `mcp`"
     )
+
+
+async def _open_http_session(
+    stack: AsyncExitStack, url: str, headers: dict[str, str]
+):
+    """Open and initialize one streamable-HTTP MCP session."""
+    import inspect  # noqa: PLC0415
+
+    from mcp import ClientSession  # noqa: PLC0415
+
+    transport = _resolve_streamable_http()
+    params = inspect.signature(transport).parameters
+    if "headers" in params:
+        cm = transport(url, headers=headers or None)
+    elif "http_client" in params:
+        import httpx  # noqa: PLC0415
+
+        client = await stack.enter_async_context(
+            httpx.AsyncClient(headers=headers or None)
+        )
+        cm = transport(url, http_client=client)
+    else:
+        raise RuntimeError(
+            f"unsupported mcp streamable-HTTP client signature: {tuple(params)}"
+        )
+
+    read, write, *_ = await stack.enter_async_context(cm)
+    session = await stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+    return session
 
 
 class McpIntegration:
@@ -210,38 +240,15 @@ class McpIntegration:
         streamable HTTP with a Bearer token from auth.json. The URL comes from the
         host (mcpServers override) when available, else ``self.url``.
         """
-        import inspect  # noqa: PLC0415
-
-        from mcp import ClientSession  # noqa: PLC0415
-
         url, extra_headers = await self._resolve_config()
         if not url:
             raise ValueError(
                 f"{type(self).__name__} must set `url` or override `_open_session`"
             )
         token = await self._resolve_token()
-        transport = _resolve_streamable_http()
         # Extra configured headers first, Authorization last so it always wins.
         auth_header = {**extra_headers, "Authorization": f"Bearer {token}"}
-
-        # SDK signatures vary: some take headers=, others only http_client=.
-        params = inspect.signature(transport).parameters
-        if "headers" in params:
-            cm = transport(url, headers=auth_header)
-        elif "http_client" in params:
-            import httpx  # noqa: PLC0415
-
-            client = await stack.enter_async_context(httpx.AsyncClient(headers=auth_header))
-            cm = transport(url, http_client=client)
-        else:
-            raise RuntimeError(
-                f"unsupported mcp streamable-HTTP client signature: {tuple(params)}"
-            )
-
-        read, write, *_ = await stack.enter_async_context(cm)
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        return session
+        return await _open_http_session(stack, url, auth_header)
 
     # -- tools --------------------------------------------------------------
 
@@ -301,6 +308,71 @@ class McpIntegration:
             desc = self._tools[name].get("description") or ""
             _call.__doc__ = f"{desc}\n\nArguments (JSON Schema):\n{json.dumps(schema, indent=2)}"
         return _call
+
+
+class AcpMcpIntegration(McpIntegration):
+    """An unauthenticated MCP integration supplied by an ACP client.
+
+    ACP owns the complete transport configuration, including HTTP headers or a
+    stdio child environment. It must not inherit Prime Agent's user OAuth state.
+    """
+
+    def __init__(self, server: str, config: dict[str, Any]) -> None:
+        self.server = server
+        self._acp_config = dict(config)
+        super().__init__()
+
+    async def _open_session(self, stack: AsyncExitStack):
+        transport = self._acp_config.get("type")
+        if transport == "http":
+            url = self._acp_config.get("url")
+            headers = self._acp_config.get("headers", {})
+            if not isinstance(url, str) or not url:
+                raise ValueError(f"ACP MCP server {self.server!r} has no HTTP URL")
+            if not isinstance(headers, dict) or not all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in headers.items()
+            ):
+                raise ValueError(
+                    f"ACP MCP server {self.server!r} has invalid HTTP headers"
+                )
+            return await _open_http_session(stack, url, headers)
+
+        if transport == "stdio":
+            from mcp import ClientSession, StdioServerParameters  # noqa: PLC0415
+            from mcp.client.stdio import stdio_client  # noqa: PLC0415
+
+            command = self._acp_config.get("command")
+            args = self._acp_config.get("args", [])
+            env = self._acp_config.get("env", {})
+            if not isinstance(command, str) or not command:
+                raise ValueError(
+                    f"ACP MCP server {self.server!r} has no stdio command"
+                )
+            if not isinstance(args, list) or not all(
+                isinstance(value, str) for value in args
+            ):
+                raise ValueError(
+                    f"ACP MCP server {self.server!r} has invalid stdio arguments"
+                )
+            if not isinstance(env, dict) or not all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in env.items()
+            ):
+                raise ValueError(
+                    f"ACP MCP server {self.server!r} has invalid stdio environment"
+                )
+            streams = stdio_client(
+                StdioServerParameters(command=command, args=args, env=env)
+            )
+            read, write = await stack.enter_async_context(streams)
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+            return session
+
+        raise ValueError(
+            f"ACP MCP server {self.server!r} uses unsupported transport {transport!r}"
+        )
 
 
 def _parse_result(result: Any) -> Any:

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -17,6 +17,7 @@ and re-reads. Interactive login runs host-side, never here.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import os
 import time
@@ -26,7 +27,13 @@ from typing import Any
 
 from . import host_request
 
-__all__ = ["AcpMcpIntegration", "McpIntegration", "McpToolError", "NotEnabled"]
+__all__ = [
+    "AcpMcpIntegration",
+    "McpIntegration",
+    "McpToolError",
+    "NotEnabled",
+    "make_acp_mcp_skill",
+]
 
 # Stored access tokens are treated as expired this many seconds early so a token
 # never dies mid-request. Mirrors the host's refresh buffer.
@@ -373,6 +380,79 @@ class AcpMcpIntegration(McpIntegration):
         raise ValueError(
             f"ACP MCP server {self.server!r} uses unsupported transport {transport!r}"
         )
+
+
+_JSON_TO_PYTHON = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def _mcp_tool_signature(schema: dict[str, Any]) -> inspect.Signature:
+    """Build the keyword-only Python signature used by rlm-harness MCP skills."""
+    properties = schema.get("properties", {})
+    required = set(schema.get("required", []))
+    if not isinstance(properties, dict):
+        properties = {}
+    parameters = []
+    for name, raw_property in properties.items():
+        if not isinstance(name, str) or not name.isidentifier():
+            continue
+        property_schema = raw_property if isinstance(raw_property, dict) else {}
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=(
+                    inspect.Parameter.empty if name in required else None
+                ),
+                annotation=_JSON_TO_PYTHON.get(
+                    property_schema.get("type"), inspect.Parameter.empty
+                ),
+            )
+        )
+    parameters.sort(
+        key=lambda parameter: parameter.default is not inspect.Parameter.empty
+    )
+    return inspect.Signature(parameters)
+
+
+def make_acp_mcp_skill(
+    server: str,
+    config: dict[str, Any],
+    tool: dict[str, Any],
+):
+    """Create one eagerly-discovered, callable ACP MCP skill.
+
+    The generated package assigns this function to ``run``. Prime Agent then
+    pre-imports and wraps the module, matching rlm-harness's
+    ``await <server>_<tool>(...)`` contract.
+    """
+    tool_name = tool.get("name")
+    if not isinstance(tool_name, str) or not tool_name:
+        raise ValueError("ACP MCP tool metadata has no non-empty name")
+    description = tool.get("description")
+    schema = tool.get("inputSchema")
+    if not isinstance(schema, dict):
+        schema = {}
+    integration = AcpMcpIntegration(server, config)
+
+    async def run(**kwargs: Any) -> Any:
+        return await integration.call_tool(tool_name, kwargs)
+
+    run.__name__ = tool_name
+    run.__qualname__ = tool_name
+    run.__signature__ = _mcp_tool_signature(schema)  # type: ignore[attr-defined]
+    run.__doc__ = (
+        description
+        if isinstance(description, str) and description
+        else f"MCP tool {tool_name!r} from server {server!r}."
+    )
+    return run
 
 
 def _parse_result(result: Any) -> Any:

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 from rlm import mcp_base
-from rlm.mcp_base import McpIntegration, McpToolError, NotEnabled
+from rlm.mcp_base import AcpMcpIntegration, McpIntegration, McpToolError, NotEnabled
 
 
 def _run(coro):
@@ -268,6 +268,87 @@ class McpIntegrationTest(unittest.TestCase):
             url, headers = _run(_Integration()._resolve_config())
             self.assertEqual(url, _Integration.url)
             self.assertEqual(headers, {})
+
+    def test_acp_http_server_uses_client_configuration_without_auth(self):
+        captured = {}
+        session = _FakeSession(
+            tools=[],
+            result=type("R", (), {"structuredContent": {"ok": True}})(),
+        )
+
+        async def fake_open(stack, url, headers):
+            captured.update(url=url, headers=headers)
+            return session
+
+        integration = AcpMcpIntegration(
+            "task-tools",
+            {
+                "type": "http",
+                "url": "https://tools.example/mcp",
+                "headers": {"Authorization": "Bearer task", "X-Test": "1"},
+            },
+        )
+        with mock.patch.object(mcp_base, "_open_http_session", fake_open):
+            result = _run(integration.call_tool("lookup", {"query": "ACP"}))
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(captured["url"], "https://tools.example/mcp")
+        self.assertEqual(
+            captured["headers"],
+            {"Authorization": "Bearer task", "X-Test": "1"},
+        )
+        self.assertEqual(session.calls, [("lookup", {"query": "ACP"})])
+
+    def test_acp_stdio_server_uses_client_process_configuration(self):
+        captured = {}
+
+        class _Streams:
+            async def __aenter__(self):
+                return ("read", "write")
+
+            async def __aexit__(self, *args):
+                return False
+
+        session = mock.MagicMock()
+        session.initialize = mock.AsyncMock()
+        session.call_tool = mock.AsyncMock(
+            return_value=type(
+                "R", (), {"content": [], "structuredContent": {"ok": True}}
+            )()
+        )
+
+        def fake_stdio_client(params):
+            captured["params"] = params
+            return _Streams()
+
+        session_cm = mock.MagicMock()
+        session_cm.__aenter__ = mock.AsyncMock(return_value=session)
+        session_cm.__aexit__ = mock.AsyncMock(return_value=False)
+        integration = AcpMcpIntegration(
+            "task-tools",
+            {
+                "type": "stdio",
+                "command": "/usr/bin/tool-server",
+                "args": ["--stdio"],
+                "env": {"TASK": "one"},
+            },
+        )
+        with mock.patch("mcp.client.stdio.stdio_client", fake_stdio_client), mock.patch(
+            "mcp.ClientSession", return_value=session_cm
+        ):
+            result = _run(integration.call_tool("lookup", {"query": "ACP"}))
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(captured["params"].command, "/usr/bin/tool-server")
+        self.assertEqual(captured["params"].args, ["--stdio"])
+        self.assertEqual(captured["params"].env, {"TASK": "one"})
+        session.initialize.assert_awaited_once_with()
+        session.call_tool.assert_awaited_once_with("lookup", {"query": "ACP"})
+
+    def test_acp_server_rejects_unsupported_transport(self):
+        integration = AcpMcpIntegration("task-tools", {"type": "sse"})
+        with self.assertRaisesRegex(ValueError, "unsupported transport"):
+            _run(integration._open_session(AsyncExitStack()))
 
 
 if __name__ == "__main__":

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import tempfile
 import time
@@ -10,7 +11,13 @@ from pathlib import Path
 from unittest import mock
 
 from rlm import mcp_base
-from rlm.mcp_base import AcpMcpIntegration, McpIntegration, McpToolError, NotEnabled
+from rlm.mcp_base import (
+    AcpMcpIntegration,
+    McpIntegration,
+    McpToolError,
+    NotEnabled,
+    make_acp_mcp_skill,
+)
 
 
 def _run(coro):
@@ -349,6 +356,40 @@ class McpIntegrationTest(unittest.TestCase):
         integration = AcpMcpIntegration("task-tools", {"type": "sse"})
         with self.assertRaisesRegex(ValueError, "unsupported transport"):
             _run(integration._open_session(AsyncExitStack()))
+
+    def test_acp_generated_skill_has_rlm_signature_and_fixed_tool(self):
+        tool = {
+            "name": "lookup",
+            "description": "Look up a task.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                    "not-valid": {"type": "boolean"},
+                },
+                "required": ["query"],
+            },
+        }
+        run = make_acp_mcp_skill(
+            "task-tools",
+            {"type": "http", "url": "https://tools.example/mcp", "headers": {}},
+            tool,
+        )
+        self.assertEqual(
+            str(inspect.signature(run)), "(*, query: str, limit: int = None)"
+        )
+        self.assertEqual(run.__doc__, "Look up a task.")
+
+        with mock.patch.object(
+            AcpMcpIntegration,
+            "call_tool",
+            mock.AsyncMock(return_value={"ok": True}),
+        ) as call_tool:
+            result = _run(run(query="ACP", limit=2))
+
+        self.assertEqual(result, {"ok": True})
+        call_tool.assert_awaited_once_with("lookup", {"query": "ACP", "limit": 2})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- consume streamable HTTP and stdio MCP servers supplied in `session/new`
- expose those servers as a temporary, pre-imported `acp_mcp` Python skill in the persistent IPython kernel
- advertise ACP HTTP MCP support while rejecting unsupported transports and duplicate or invalid server definitions
- keep client headers, commands, arguments, and environment session-scoped without modifying Prime Agent user settings
- clean up the generated skill when the ACP process exits

## Why

Prime Agent's ACP mode previously ignored `mcpServers`. ACP clients such as verifiers could therefore start a tool-bearing task successfully while the model silently had none of its task tools.

Prime Agent intentionally uses IPython-backed skills instead of adding model-facing native tools. This change follows the same boundary as the RLM ACP implementation: standard ACP MCP configuration is accepted at session creation and materialized as programmatic tools inside the kernel.

## Validation

- `npm run check`
- ACP protocol and regression suites: 29 passed
- real IPython kernel skill install/import test: passed
- `prime-agent-runtime` MCP suite: 20 passed, including HTTP header isolation and stdio process configuration


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ACP-provided MCP server support to the coding agent
> - ACP `session/new` requests can now include `mcpServers` (streamable HTTP or stdio); the `initialize` response advertises `mcpCapabilities.http = true`.
> - When MCP servers are provided, [`AcpMcpSkillInstaller`](https://github.com/PrimeIntellect-ai/prime-agent/pull/644/files#diff-adeb53679069ec30c9344904eaad667c0d8c9fbe5e293361b1f18a38c7c85ba6) writes a temporary Python skill (`acp_mcp`) to disk, installs it into the session via the new `AgentSession.extendTemporarySkills` method, and removes it on session teardown.
> - [`AcpMcpIntegration`](https://github.com/PrimeIntellect-ai/prime-agent/pull/644/files#diff-3e0a705745bc6d6096fecf5672e6173e25ee363911b2fc0ff065fa59f0117524) is added to the Python runtime, supporting both HTTP (with client-supplied headers) and stdio (with client-supplied command/args/env) transports without injecting auth.
> - Server configs are validated and normalized at `session/new` time; duplicate names, missing required fields, or unsupported transports fail with `invalid-params`.
> - Risk: `extendTemporarySkills` rebuilds the tool runtime and system prompt before streaming; calling it after streaming starts throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b7f9161. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->