### PR TITLE
fix(ai): omit service_tier for GitHub Copilot Responses models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed GitHub Copilot Responses models failing with `service_tier is not supported` by omitting `service_tier` for that provider.
+- Fixed GitHub Copilot Responses models failing with `service_tier is not supported` by omitting `service_tier` for that provider ([#645](https://github.com/PrimeIntellect-ai/prime-agent/issues/645)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed GitHub Copilot Responses models failing with `service_tier is not supported` by omitting `service_tier` for that provider.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -116,7 +116,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			stream.push({ type: "start", partial: output });
 
 			await processResponsesStream(openaiStream, output, stream, model, {
-				serviceTier: options?.serviceTier,
+				serviceTier: params.service_tier ?? undefined,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			});
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -46,6 +46,7 @@ function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCo
 	return {
 		sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
+		supportsServiceTier: model.compat?.supportsServiceTier ?? model.provider !== "github-copilot",
 	};
 }
 
@@ -244,7 +245,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		params.temperature = options?.temperature;
 	}
 
-	if (options?.serviceTier !== undefined) {
+	if (options?.serviceTier !== undefined && compat.supportsServiceTier) {
 		params.service_tier = options.serviceTier;
 	}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -332,6 +332,8 @@ export interface OpenAIResponsesCompat {
 	sendSessionIdHeader?: boolean;
 	/** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
 	supportsLongCacheRetention?: boolean;
+	/** Whether the provider accepts the `service_tier` request field. Default: true (false for GitHub Copilot). */
+	supportsServiceTier?: boolean;
 }
 
 /** Compatibility settings for Anthropic Messages-compatible APIs. */

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -165,6 +165,73 @@ describe("openai-responses provider defaults", () => {
 		},
 	);
 
+	it("omits service_tier for GitHub Copilot models", async () => {
+		const model = getModel("github-copilot", "gpt-5.6-luna");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "default",
+				onPayload: (payload) => {
+					capturedPayload = payload as Record<string, unknown>;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).toBeDefined();
+		expect(capturedPayload).not.toHaveProperty("service_tier");
+	});
+
+	it("sends service_tier for official OpenAI models", async () => {
+		const model = getModel("openai", "gpt-5.4");
+		let capturedPayload: Record<string, unknown> | undefined;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "priority",
+				onPayload: (payload) => {
+					capturedPayload = payload as Record<string, unknown>;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).toMatchObject({ service_tier: "priority" });
+	});
+
 	it("sets cache-affinity headers for official OpenAI Responses requests with a sessionId", async () => {
 		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
 

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -323,4 +323,44 @@ describe("openai-responses provider defaults", () => {
 		expect(result.usage.cost.output).toBe(model.cost.output * multiplier);
 		expect(result.usage.cost.total).toBe((model.cost.input + model.cost.output) * multiplier);
 	});
+
+	it("does not apply service-tier pricing when the tier was not sent", async () => {
+		const model = getModel("github-copilot", "gpt-5.6-luna");
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(sse, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{ apiKey: "test-key", serviceTier: "priority" },
+		);
+
+		const result = await stream.result();
+
+		expect(result.usage.cost.input).toBe(model.cost.input);
+		expect(result.usage.cost.output).toBe(model.cost.output);
+		expect(result.usage.cost.total).toBe(model.cost.input + model.cost.output);
+	});
 });


### PR DESCRIPTION
Fixes #645

## Problem

Every request to a GitHub Copilot `openai-responses` model fails:

```
Provider rejected the request (invalid_request_error, 400): service_tier is not supported
Model: gpt-5.6-luna
```

`Agent` state always carries a service tier (`serviceTier ?? "default"`), and `buildParams()` in `packages/ai/src/providers/openai-responses.ts` set `params.service_tier` whenever the option was defined. The Copilot proxy rejects that field entirely, including the value `"default"`, so the provider is unusable for those models. Copilot `anthropic-messages` models (`claude-*`) were unaffected.

## Change

- `packages/ai/src/types.ts`: added `supportsServiceTier` to `OpenAIResponsesCompat`.
- `packages/ai/src/providers/openai-responses.ts`: `getCompat()` defaults the flag to `model.provider !== "github-copilot"`, and `service_tier` is only sent when it is supported. Models can still override it via `compat`.

## Tests

`packages/ai/test/openai-responses-copilot-provider.test.ts`:

- Copilot `gpt-5.6-luna` payload has no `service_tier` even when a tier is passed.
- OpenAI `gpt-5.4` still sends `service_tier: "priority"`.

```
npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-responses-copilot-provider.test.ts
Test Files  1 passed (1)
     Tests  25 passed (25)
```

`npm run check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted provider-compat change with tests; official OpenAI and other providers still send `service_tier` by default.
> 
> **Overview**
> Fixes **GitHub Copilot** `openai-responses` calls that failed with `service_tier is not supported` because the agent always passes a tier (e.g. `"default"`) and the provider used to forward it on every request.
> 
> Adds **`supportsServiceTier`** on `OpenAIResponsesCompat`, defaulting to **`false` for `github-copilot`** and overridable per model. **`buildParams`** only sets `service_tier` when that flag is true. Stream **usage/cost** now keys off the **actual** `params.service_tier` so Copilot does not get priority/flex multipliers when the tier was dropped.
> 
> Tests cover Copilot payload omission, OpenAI still sending tiers, and base pricing when the tier is not sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945da6fde288ff645ac4f408936a3c19ca527c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `service_tier` for GitHub Copilot in OpenAI Responses provider
> GitHub Copilot's Responses API rejects requests that include `service_tier`, causing failures. This fix adds a `supportsServiceTier` compat flag (default `true`) that is set to `false` for the `github-copilot` provider, causing `service_tier` to be omitted from the request payload regardless of what the caller specifies. Service-tier pricing is also skipped when the tier was not actually sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 945da6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->