### PR TITLE
fix(coding-agent): drop compact stream deltas that would leave content gaps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the interactive session exiting with `Cannot read properties of null (reading 'type')` when a streamed assistant message lost a content-start frame ([#648](https://github.com/PrimeIntellect-ai/prime-agent/issues/648)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
+++ b/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
@@ -105,7 +105,9 @@ export class CompactAssistantStreamReconstructor {
 		const event = delta.assistantMessageEvent;
 		switch (event.type) {
 			case "text_start":
-				partial.content[event.contentIndex] = delta.contentStart ?? { type: "text", text: "" };
+				if (!this.setContent(partial, event.contentIndex, delta.contentStart ?? { type: "text", text: "" })) {
+					return undefined;
+				}
 				break;
 			case "text_delta": {
 				const content = partial.content[event.contentIndex];
@@ -124,7 +126,11 @@ export class CompactAssistantStreamReconstructor {
 				break;
 			}
 			case "thinking_start":
-				partial.content[event.contentIndex] = delta.contentStart ?? { type: "thinking", thinking: "" };
+				if (
+					!this.setContent(partial, event.contentIndex, delta.contentStart ?? { type: "thinking", thinking: "" })
+				) {
+					return undefined;
+				}
 				break;
 			case "thinking_delta": {
 				const content = partial.content[event.contentIndex];
@@ -146,7 +152,9 @@ export class CompactAssistantStreamReconstructor {
 				if (!delta.contentStart || delta.contentStart.type !== "toolCall") {
 					return undefined;
 				}
-				partial.content[event.contentIndex] = delta.contentStart;
+				if (!this.setContent(partial, event.contentIndex, delta.contentStart)) {
+					return undefined;
+				}
 				this.toolCallJson.set(this.toolCallKey(delta.activeSessionId, event.contentIndex), "");
 				break;
 			case "toolcall_delta": {
@@ -165,7 +173,9 @@ export class CompactAssistantStreamReconstructor {
 				break;
 			}
 			case "toolcall_end":
-				partial.content[event.contentIndex] = event.toolCall;
+				if (!this.setContent(partial, event.contentIndex, event.toolCall)) {
+					return undefined;
+				}
 				this.toolCallJson.delete(this.toolCallKey(delta.activeSessionId, event.contentIndex));
 				break;
 			case "start":
@@ -192,6 +202,23 @@ export class CompactAssistantStreamReconstructor {
 				this.toolCallJson.delete(key);
 			}
 		}
+	}
+
+	/**
+	 * Content blocks arrive addressed by absolute index. Writing past the end
+	 * leaves holes that serialize to null for clients, so a gap is treated as
+	 * lost start frames: the caller drops the delta and resyncs instead.
+	 */
+	private setContent(
+		partial: AssistantMessage,
+		contentIndex: number,
+		content: AssistantMessage["content"][number],
+	): boolean {
+		if (contentIndex < 0 || contentIndex > partial.content.length) {
+			return false;
+		}
+		partial.content[contentIndex] = content;
+		return true;
 	}
 
 	private toolCallKey(activeSessionId: string, contentIndex: number): string {

--- a/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
+++ b/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
@@ -214,7 +214,7 @@ export class CompactAssistantStreamReconstructor {
 		contentIndex: number,
 		content: AssistantMessage["content"][number],
 	): boolean {
-		if (contentIndex < 0 || contentIndex > partial.content.length) {
+		if (!Number.isInteger(contentIndex) || contentIndex < 0 || contentIndex > partial.content.length) {
 			return false;
 		}
 		partial.content[contentIndex] = content;

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -50,6 +50,29 @@ function formatInlineLoginRecoveryMessage(message: string): string | undefined {
 }
 
 /**
+ * A daemon stream that lost a content-start frame can hand over an array with
+ * gaps, which serialize to null on the wire. Rendering runs on every frame, so
+ * it drops the missing blocks instead of failing the whole TUI render pass.
+ */
+function withoutMissingBlocks(message: AssistantMessage): AssistantMessage {
+	const blocks = message.content as (AssistantMessage["content"][number] | null | undefined)[];
+	let complete = true;
+	for (let i = 0; i < blocks.length; i++) {
+		if (blocks[i] == null) {
+			complete = false;
+			break;
+		}
+	}
+	if (complete) {
+		return message;
+	}
+	return {
+		...message,
+		content: blocks.filter((block): block is AssistantMessage["content"][number] => block != null),
+	};
+}
+
+/**
  * Component that renders a complete assistant message.
  *
  * Streaming sends one updateContent() per token, so content updates are
@@ -137,7 +160,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	updateContent(message: AssistantMessage): void {
-		this.lastMessage = message;
+		this.lastMessage = withoutMissingBlocks(message);
 		this.dirty = true;
 	}
 

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -108,6 +108,20 @@ describe("AssistantMessageComponent", () => {
 		expect(raw).toContain(theme.getFgAnsi("error"));
 	});
 
+	test("renders content arrays that arrived from the daemon with gaps", () => {
+		initTheme("dark");
+
+		const gapped: AssistantMessage["content"] = [];
+		gapped[1] = { type: "text", text: "recovered" };
+		// A hole becomes null once the daemon serializes the message for clients.
+		const message = JSON.parse(JSON.stringify(createAssistantMessage(gapped))) as AssistantMessage;
+		expect(message.content[0]).toBeNull();
+
+		const rendered = stripAnsi(new AssistantMessageComponent(message).render(40).join("\n"));
+
+		expect(rendered).toContain("recovered");
+	});
+
 	test("renders collapsed multiline assistant errors as errors", () => {
 		initTheme("dark");
 

--- a/packages/coding-agent/test/compact-session-stream.test.ts
+++ b/packages/coding-agent/test/compact-session-stream.test.ts
@@ -140,6 +140,48 @@ describe("compact daemon assistant streaming", () => {
 		});
 	});
 
+	it("drops a delta that would leave a gap instead of emitting a hole", () => {
+		const reconstructor = new CompactAssistantStreamReconstructor();
+		reconstructor.observe({
+			type: "session_event",
+			activeSessionId: "active-gap",
+			event: { type: "message_start", message: assistant([]) },
+		});
+
+		// The worker is on its second block; the client never applied the first start.
+		const worker = assistant([
+			{ type: "text", text: "first" },
+			{ type: "text", text: "" },
+		]);
+		const secondStart = createCompactAssistantDelta({
+			type: "session_event",
+			activeSessionId: "active-gap",
+			event: {
+				type: "message_update",
+				message: worker,
+				assistantMessageEvent: { type: "text_start", contentIndex: 1, partial: worker },
+			},
+		});
+		expect(secondStart).toBeDefined();
+		expect(reconstructor.reconstruct(secondStart!)).toBeUndefined();
+
+		// The reconstructor stays dense, so nothing serializes to null for clients.
+		const firstStart = createCompactAssistantDelta({
+			type: "session_event",
+			activeSessionId: "active-gap",
+			event: {
+				type: "message_update",
+				message: worker,
+				assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: worker },
+			},
+		});
+		const reconstructed = reconstructor.reconstruct(firstStart!);
+		expect(reconstructed).toMatchObject({
+			event: { type: "message_update", message: { content: [{ type: "text", text: "" }] } },
+		});
+		expect(JSON.stringify(reconstructed)).not.toContain("null");
+	});
+
 	it("continues tool arguments after reconstructing from a snapshot", () => {
 		const reconstructor = new CompactAssistantStreamReconstructor();
 		reconstructor.seed(


### PR DESCRIPTION
Fixes #648.

## Problem

A streamed assistant message could reach the interactive renderer with `null` entries in `content`, which exits the CLI:

```
TypeError: Cannot read properties of null (reading 'type')
    at AssistantMessageComponent.computeSignature
    at AssistantMessageComponent.reconcile
    at AssistantMessageComponent.render
    at _TUI.doRender
    at Timeout._onTimeout
```

## Cause

`CompactAssistantStreamReconstructor.reconstruct` addressed content blocks by absolute index with no bounds check. A `*_start` frame that is not applied (missing `contentStart` on `toolcall_start`, any type mismatch returning `undefined`, or a seed shorter than the indices that follow) followed by a later start leaves a hole in `partial.content`. `daemon-supervisor` re-serializes the reconstructed message for its clients, and `JSON.stringify` turns holes into `null`. The renderer dereferences every block in `computeSignature`, `reconcile`, and `rebuild`, and `doRender()` runs from a `setTimeout` with no `uncaughtException` handler in interactive mode, so one gapped frame takes down the session.

## Change

- `compact-session-stream.ts`: `setContent` refuses writes past the end of `partial.content`, and `reconstruct` returns `undefined` for those deltas so the gap goes through the existing `scheduleCompactCatchup` resync path instead of producing a hole. Appends and in-place overwrites are unchanged.
- `assistant-message.ts`: `updateContent` drops nullish blocks so a malformed frame degrades one message instead of the process. The common path allocates nothing.

No wire or protocol change: a dropped delta takes the same client recovery path as an unparseable frame.

## Tests

- `test/compact-session-stream.test.ts`: a start frame at index 1 without index 0 is dropped, the reconstructor stays dense, and the next reconstructed message serializes without `null`.
- `test/assistant-message.test.ts`: a JSON round-tripped gapped content array renders instead of throwing. With the fix reverted, this reproduces the reported `Cannot read properties of null (reading 'type')` exactly.

`npm run check` is clean. `test/compact-session-stream.test.ts`, `test/assistant-message.test.ts`, and `test/daemon-mode.test.ts` (190 tests) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized streaming and render hardening with existing catch-up recovery; no protocol or auth changes.
> 
> **Overview**
> Fixes interactive sessions exiting with **`Cannot read properties of null (reading 'type')`** when a streamed assistant message lost a content-start frame ([#648](https://github.com/PrimeIntellect-ai/prime-agent/issues/648)).
> 
> **Compact stream reconstruction** now routes all `*_start` / `toolcall_end` writes through **`setContent`**, which only allows append or in-place updates. A delta that would skip an index (e.g. `text_start` at index 1 before index 0 exists) returns **`undefined`** instead of leaving holes that **`JSON.stringify`** turns into **`null`** for clients—matching the existing **`scheduleCompactCatchup`** path when reconstruction fails.
> 
> **TUI defense in depth:** **`AssistantMessageComponent.updateContent`** filters nullish content blocks so a malformed frame degrades one message instead of killing the render loop on **`computeSignature`**.
> 
> Tests cover gap dropping in **`compact-session-stream`** and gapped JSON round-trips in **`assistant-message`**; changelog updated under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955ae6aa6e9cb5e447f1d043ff4f5363d3f52681. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->