### PR TITLE
fix(coding-agent): preserve untouched bytes when fuzzy edit matching is used

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed fuzzy edit matching rewriting unrelated whitespace and Unicode across the whole file and omitting those changes from the reported diff ([#654](https://github.com/PrimeIntellect-ai/prime-agent/issues/654)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -120,6 +120,7 @@ function mapNormalizedBoundaryToOriginal(
 	normalizedLines: string[],
 	originalLineStarts: number[],
 	normalizedOffset: number,
+	kind: "start" | "end",
 ): number | undefined {
 	const boundary = getTextBoundary(normalizedLines, normalizedOffset);
 	if (boundary === undefined) return undefined;
@@ -127,6 +128,14 @@ function mapNormalizedBoundaryToOriginal(
 	const originalLine = originalLines[boundary.lineIndex];
 	const normalizedLine = normalizedLines[boundary.lineIndex];
 	if (!isCodePointBoundary(normalizedLine, boundary.column)) return undefined;
+
+	// Trailing whitespace adjacent to a span edge stays outside the span: a span
+	// STARTING at a normalized line end starts at the actual newline (past the
+	// line's trimmed trailing whitespace), while a span ENDING there stops before
+	// it (the earliest verified column below).
+	if (kind === "start" && boundary.column === normalizedLine.length) {
+		return originalLineStarts[boundary.lineIndex] + originalLine.length;
+	}
 
 	// Prefix comparisons must not trim: a boundary after interior whitespace
 	// (e.g. indentation) would never satisfy equality against the trimmed form.
@@ -224,12 +233,14 @@ export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResul
 		normalizedLines,
 		originalLineStarts,
 		fuzzyIndex,
+		"start",
 	);
 	const originalEnd = mapNormalizedBoundaryToOriginal(
 		originalLines,
 		normalizedLines,
 		originalLineStarts,
 		fuzzyIndex + fuzzyOldText.length,
+		"end",
 	);
 	if (
 		originalStart === undefined ||

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -32,13 +32,19 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
  * - Normalize special Unicode spaces to regular space
  */
 export function normalizeForFuzzyMatch(text: string): string {
-	return (
+	return substituteCompatibilityChars(
 		text
 			.normalize("NFKC")
 			// Strip trailing whitespace per line
 			.split("\n")
 			.map((line) => line.trimEnd())
-			.join("\n")
+			.join("\n"),
+	);
+}
+
+function substituteCompatibilityChars(text: string): string {
+	return (
+		text
 			// Smart single quotes → '
 			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")
 			// Smart double quotes → "
@@ -57,17 +63,10 @@ export function normalizeForFuzzyMatch(text: string): string {
 export interface FuzzyMatchResult {
 	/** Whether a match was found */
 	found: boolean;
-	/** The index where the match starts (in the content that should be used for replacement) */
+	/** The index where the match starts in the original content */
 	index: number;
-	/** Length of the matched text */
+	/** Length of the matched span in the original content */
 	matchLength: number;
-	/** Whether fuzzy matching was used (false = exact match) */
-	usedFuzzyMatch: boolean;
-	/**
-	 * The content to use for replacement operations.
-	 * When exact match: original content. When fuzzy match: normalized content.
-	 */
-	contentForReplacement: string;
 }
 
 export interface Edit {
@@ -87,49 +86,167 @@ export interface AppliedEditsResult {
 	newContent: string;
 }
 
+interface TextBoundary {
+	lineIndex: number;
+	column: number;
+}
+
+function getTextBoundary(lines: string[], offset: number): TextBoundary | undefined {
+	if (offset < 0) return undefined;
+
+	let lineStart = 0;
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+		const lineEnd = lineStart + lines[lineIndex].length;
+		if (offset <= lineEnd) {
+			return { lineIndex, column: offset - lineStart };
+		}
+		lineStart = lineEnd + 1;
+	}
+
+	return undefined;
+}
+
+function isCodePointBoundary(text: string, offset: number): boolean {
+	if (offset <= 0 || offset >= text.length) return true;
+	const previous = text.charCodeAt(offset - 1);
+	const next = text.charCodeAt(offset);
+	return !(previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff);
+}
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function mapNormalizedBoundaryToOriginal(
+	originalLines: string[],
+	normalizedLines: string[],
+	originalLineStarts: number[],
+	normalizedOffset: number,
+): number | undefined {
+	const boundary = getTextBoundary(normalizedLines, normalizedOffset);
+	if (boundary === undefined) return undefined;
+
+	const originalLine = originalLines[boundary.lineIndex];
+	const normalizedLine = normalizedLines[boundary.lineIndex];
+	if (!isCodePointBoundary(normalizedLine, boundary.column)) return undefined;
+
+	// Prefix comparisons must not trim: a boundary after interior whitespace
+	// (e.g. indentation) would never satisfy equality against the trimmed form.
+	const normalizedPrefix = normalizedLine.slice(0, boundary.column);
+	const matchesPrefixAt = (column: number): boolean =>
+		isCodePointBoundary(originalLine, column) &&
+		substituteCompatibilityChars(originalLine.slice(0, column).normalize("NFKC")) === normalizedPrefix;
+
+	// Fast path: when line normalization is 1:1 (no NFKC expansions), columns align.
+	if (
+		substituteCompatibilityChars(originalLine.normalize("NFKC")).length === originalLine.length &&
+		boundary.column <= originalLine.length &&
+		matchesPrefixAt(boundary.column)
+	) {
+		return originalLineStarts[boundary.lineIndex] + boundary.column;
+	}
+
+	// Linear candidate pass: accumulate normalized lengths per grapheme cluster and
+	// test the exact prefix predicate wherever the running length reaches the target.
+	// Composition happens inside a cluster, so decomposed accents accumulate exactly;
+	// only exotic cross-cluster normalization effects diverge, and those fall through.
+	let runningLength = 0;
+	let predicateAttempts = 0;
+	for (const { segment, index } of graphemeSegmenter.segment(originalLine)) {
+		if (runningLength === normalizedPrefix.length) {
+			if (matchesPrefixAt(index)) {
+				return originalLineStarts[boundary.lineIndex] + index;
+			}
+			if (++predicateAttempts >= 4) break;
+		}
+		if (runningLength > normalizedPrefix.length) break;
+		runningLength += substituteCompatibilityChars(segment.normalize("NFKC")).length;
+	}
+	if (runningLength === normalizedPrefix.length && predicateAttempts < 4 && matchesPrefixAt(originalLine.length)) {
+		return originalLineStarts[boundary.lineIndex] + originalLine.length;
+	}
+
+	// Exhaustive scan is quadratic, so it is reserved for short lines; longer lines
+	// reject the fuzzy match instead of risking a multi-second stall.
+	if (originalLine.length <= 2048) {
+		for (let scanColumn = 0; scanColumn <= originalLine.length; scanColumn++) {
+			if (matchesPrefixAt(scanColumn)) {
+				return originalLineStarts[boundary.lineIndex] + scanColumn;
+			}
+		}
+	}
+	return undefined;
+}
+
 /**
  * Find oldText in content, trying exact match first, then fuzzy match.
- * When fuzzy matching is used, the returned contentForReplacement is the
- * fuzzy-normalized version of the content (trailing whitespace stripped,
- * Unicode quotes/dashes normalized to ASCII).
+ * Returned offsets always refer to the original content, including for fuzzy
+ * matches whose normalized spans must be mapped back to original boundaries.
  */
 export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
-	// Try exact match first
 	const exactIndex = content.indexOf(oldText);
 	if (exactIndex !== -1) {
 		return {
 			found: true,
 			index: exactIndex,
 			matchLength: oldText.length,
-			usedFuzzyMatch: false,
-			contentForReplacement: content,
 		};
 	}
 
-	// Try fuzzy match - work entirely in normalized space
 	const fuzzyContent = normalizeForFuzzyMatch(content);
 	const fuzzyOldText = normalizeForFuzzyMatch(oldText);
 	const fuzzyIndex = fuzzyContent.indexOf(fuzzyOldText);
-
 	if (fuzzyIndex === -1) {
 		return {
 			found: false,
 			index: -1,
 			matchLength: 0,
-			usedFuzzyMatch: false,
-			contentForReplacement: content,
 		};
 	}
 
-	// When fuzzy matching, we work in the normalized space for replacement.
-	// This means the output will have normalized whitespace/quotes/dashes,
-	// which is acceptable since we're fixing minor formatting differences anyway.
+	const originalLines = content.split("\n");
+	const normalizedLines = originalLines.map((line) => normalizeForFuzzyMatch(line));
+	if (normalizedLines.join("\n") !== fuzzyContent) {
+		return {
+			found: false,
+			index: -1,
+			matchLength: 0,
+		};
+	}
+
+	const originalLineStarts: number[] = [];
+	let originalLineStart = 0;
+	for (const line of originalLines) {
+		originalLineStarts.push(originalLineStart);
+		originalLineStart += line.length + 1;
+	}
+
+	const originalStart = mapNormalizedBoundaryToOriginal(
+		originalLines,
+		normalizedLines,
+		originalLineStarts,
+		fuzzyIndex,
+	);
+	const originalEnd = mapNormalizedBoundaryToOriginal(
+		originalLines,
+		normalizedLines,
+		originalLineStarts,
+		fuzzyIndex + fuzzyOldText.length,
+	);
+	if (
+		originalStart === undefined ||
+		originalEnd === undefined ||
+		normalizeForFuzzyMatch(content.slice(originalStart, originalEnd)) !== fuzzyOldText
+	) {
+		return {
+			found: false,
+			index: -1,
+			matchLength: 0,
+		};
+	}
+
 	return {
 		found: true,
-		index: fuzzyIndex,
-		matchLength: fuzzyOldText.length,
-		usedFuzzyMatch: true,
-		contentForReplacement: fuzzyContent,
+		index: originalStart,
+		matchLength: originalEnd - originalStart,
 	};
 }
 
@@ -183,12 +300,11 @@ function getNoChangeError(path: string, totalEdits: number): Error {
 }
 
 /**
- * Apply one or more exact-text replacements to LF-normalized content.
+ * Apply one or more exact or fuzzy text replacements to LF-normalized content.
  *
- * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. If any edit needs
- * fuzzy matching, the operation runs in fuzzy-normalized content space to
- * preserve current single-edit behavior.
+ * All edits are matched against the same original content. Fuzzy-normalized
+ * match spans are mapped back to original offsets, then replacements are
+ * applied in reverse order so bytes outside matched spans remain unchanged.
  */
 export function applyEditsToNormalizedContent(
 	normalizedContent: string,
@@ -206,20 +322,15 @@ export function applyEditsToNormalizedContent(
 		}
 	}
 
-	const initialMatches = normalizedEdits.map((edit) => fuzzyFindText(normalizedContent, edit.oldText));
-	const baseContent = initialMatches.some((match) => match.usedFuzzyMatch)
-		? normalizeForFuzzyMatch(normalizedContent)
-		: normalizedContent;
-
 	const matchedEdits: MatchedEdit[] = [];
 	for (let i = 0; i < normalizedEdits.length; i++) {
 		const edit = normalizedEdits[i];
-		const matchResult = fuzzyFindText(baseContent, edit.oldText);
+		const matchResult = fuzzyFindText(normalizedContent, edit.oldText);
 		if (!matchResult.found) {
 			throw getNotFoundError(path, i, normalizedEdits.length);
 		}
 
-		const occurrences = countOccurrences(baseContent, edit.oldText);
+		const occurrences = countOccurrences(normalizedContent, edit.oldText);
 		if (occurrences > 1) {
 			throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
 		}
@@ -243,7 +354,7 @@ export function applyEditsToNormalizedContent(
 		}
 	}
 
-	let newContent = baseContent;
+	let newContent = normalizedContent;
 	for (let i = matchedEdits.length - 1; i >= 0; i--) {
 		const edit = matchedEdits[i];
 		newContent =
@@ -252,11 +363,11 @@ export function applyEditsToNormalizedContent(
 			newContent.substring(edit.matchIndex + edit.matchLength);
 	}
 
-	if (baseContent === newContent) {
+	if (normalizedContent === newContent) {
 		throw getNoChangeError(path, normalizedEdits.length);
 	}
 
-	return { baseContent, newContent };
+	return { baseContent: normalizedContent, newContent };
 }
 
 /**

--- a/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
@@ -309,4 +309,48 @@ describe("edit tool fuzzy byte preservation", () => {
 
 		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}end = 'r';${suffix}`);
 	});
+
+	it("keeps preceding trailing whitespace when a fuzzy match starts with a newline", async () => {
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "newline-start-fuzzy.txt");
+		const prefix = "header   ";
+		writeFileSync(testFile, `${prefix}\nfoo \u2018x\u2019;\n`);
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "\nfoo 'x';", newText: "\nfoo 'y';" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}\nfoo 'y';\n`);
+	});
+
+	it("keeps preceding trailing whitespace when a fuzzy oldText opens with a whitespace-only line", async () => {
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "ws-line-start-fuzzy.txt");
+		const prefix = "header\t ";
+		writeFileSync(testFile, `${prefix}\nbar \u201Cy\u201D;\n`);
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: '  \nbar "y";', newText: '\nbar "z";' }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}\nbar "z";\n`);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { computeEditsDiff } from "../../../src/core/tools/edit-diff.js";
+import { createEditTool } from "../../../src/index.js";
+
+const editTool = createEditTool(process.cwd());
+
+describe("edit tool fuzzy byte preservation", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `coding-agent-fuzzy-byte-test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("preserves unrelated bytes under a single fuzzy edit", async () => {
+		const testFile = join(testDir, "single-fuzzy.txt");
+		const prefix =
+			"nbsp: alpha\u00A0beta\n" +
+			"single quotes: \u2018left\u2019\n" +
+			"double quotes: \u201Cright\u201D\n" +
+			"dash: before\u2014after\n" +
+			"ligature: \uFB01le\n" +
+			"fraction: \u00BD cup\n" +
+			"trailing whitespace stays   \n";
+		const target = "console.log('x');";
+		const suffix = "\nfinal: untouched\u00A0value   \n";
+		const original = prefix + target + suffix;
+		const replacement = "console.log('y');";
+		writeFileSync(testFile, original);
+
+		await editTool.execute("fuzzy-byte-single", {
+			path: testFile,
+			edits: [{ oldText: "console.log(\u2018x\u2019);", newText: replacement }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(prefix + replacement + suffix);
+	});
+
+	it("replaces only the matched span", async () => {
+		const testFile = join(testDir, "matched-span.txt");
+		const target = "const message = \u201CHello\u201D;\n";
+		const original = `header: \u00BD and \uFB01\n${target}footer: a\u00A0b   \n`;
+		const targetIndex = original.indexOf(target);
+		const replacement = 'const message = "Goodbye";\n';
+		const expected = original.slice(0, targetIndex) + replacement + original.slice(targetIndex + target.length);
+		writeFileSync(testFile, original);
+
+		await editTool.execute("fuzzy-byte-span", {
+			path: testFile,
+			edits: [{ oldText: 'const message = "Hello";\n', newText: replacement }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(expected);
+	});
+
+	it("mixed exact and fuzzy multi-edit preserves untouched bytes", async () => {
+		const testFile = join(testDir, "mixed-multi.txt");
+		const original =
+			"decoy: \u201Cquoted\u201D \u2014 \u00BD \uFB01\n" +
+			"const exact = 1;\n" +
+			"hello\u00A0world\n" +
+			"trailing decoy   \n";
+		const expected =
+			"decoy: \u201Cquoted\u201D \u2014 \u00BD \uFB01\n" +
+			"const exact = 2;\n" +
+			"hello universe\n" +
+			"trailing decoy   \n";
+		writeFileSync(testFile, original);
+
+		await editTool.execute("fuzzy-byte-mixed", {
+			path: testFile,
+			edits: [
+				{ oldText: "const exact = 1;\n", newText: "const exact = 2;\n" },
+				{ oldText: "hello world\n", newText: "hello universe\n" },
+			],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(expected);
+	});
+
+	it("rejects a fuzzy match whose boundary falls inside an NFKC expansion", async () => {
+		const testFile = join(testDir, "nfkc-boundary.txt");
+		const original = "\u00BD cup sugar\n";
+		writeFileSync(testFile, original);
+
+		await expect(
+			editTool.execute("fuzzy-byte-nfkc-boundary", {
+				path: testFile,
+				edits: [{ oldText: "/2 cup sugar", newText: "one cup sugar" }],
+			}),
+		).rejects.toThrow(/Could not find the exact text/);
+		expect(readFileSync(testFile, "utf-8")).toBe(original);
+	});
+
+	it("consumes stripped trailing whitespace at a fuzzy match end boundary", async () => {
+		const testFile = join(testDir, "trailing-boundary.txt");
+		writeFileSync(testFile, "foo();   \nbar();\n");
+
+		await editTool.execute("fuzzy-byte-trailing-boundary", {
+			path: testFile,
+			edits: [{ oldText: "foo();\n", newText: "baz();\n" }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe("baz();\nbar();\n");
+	});
+
+	it("reported diff reflects the true original content", async () => {
+		const testFile = join(testDir, "true-original-diff.txt");
+		const unrelatedLine = "const title = \u201Cuntouched\u201D;";
+		const normalizedUnrelatedLine = 'const title = "untouched";';
+		const original = `${unrelatedLine}\nhello\u00A0world\n`;
+		writeFileSync(testFile, original);
+
+		const result = await computeEditsDiff(
+			testFile,
+			[{ oldText: "hello world\n", newText: "hello universe\n" }],
+			process.cwd(),
+		);
+
+		expect(result).not.toHaveProperty("error");
+		if ("error" in result) {
+			throw new Error(result.error);
+		}
+		expect(result.diff).toContain(unrelatedLine);
+		expect(result.diff).not.toContain(normalizedUnrelatedLine);
+		const changedLines = result.diff.split("\n").filter((line) => line.startsWith("+") || line.startsWith("-"));
+		expect(changedLines.some((line) => line.includes(unrelatedLine))).toBe(false);
+		expect(changedLines.some((line) => line.includes(normalizedUnrelatedLine))).toBe(false);
+		expect(readFileSync(testFile, "utf-8")).toBe(original);
+	});
+
+	it("exact match still takes priority and preserves bytes", async () => {
+		const testFile = join(testDir, "exact-priority.txt");
+		const target = "const exact = 'before';\n";
+		const original = `prefix: \u201Csmart\u201D \u00A0 \u00BD\n${target}suffix: \uFB01 \u2014   \n`;
+		const targetIndex = original.indexOf(target);
+		const replacement = "const exact = 'after';\n";
+		const expected = original.slice(0, targetIndex) + replacement + original.slice(targetIndex + target.length);
+		writeFileSync(testFile, original);
+
+		await editTool.execute("fuzzy-byte-exact-priority", {
+			path: testFile,
+			edits: [{ oldText: target, newText: replacement }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(expected);
+	});
+
+	it("maps a fuzzy match that starts after indentation", async () => {
+		const testFile = join(testDir, "indented-fuzzy.txt");
+		const prefix = "function outer() {\n\t";
+		const target = "console.log(\u2018x\u2019);";
+		const suffix = "\n}\n";
+		writeFileSync(testFile, prefix + target + suffix);
+
+		await editTool.execute("fuzzy-byte-indent", {
+			path: testFile,
+			edits: [{ oldText: "console.log('x');", newText: "console.log('y');" }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}console.log('y');${suffix}`);
+	});
+
+	it("maps a fuzzy match that starts after an interior space", async () => {
+		const testFile = join(testDir, "midline-fuzzy.txt");
+		const prefix = "const value = ";
+		const target = "\u2018hello\u2019;";
+		const suffix = "\nuntouched\u00A0line   \n";
+		writeFileSync(testFile, prefix + target + suffix);
+
+		await editTool.execute("fuzzy-byte-midline", {
+			path: testFile,
+			edits: [{ oldText: "'hello';", newText: "'world';" }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}'world';${suffix}`);
+	});
+
+	it("keeps trailing whitespace when a fuzzy match ends at end-of-line without a newline", async () => {
+		const testFile = join(testDir, "eol-no-newline-fuzzy.txt");
+		const target = "const x = \u2018a\u2019;";
+		const suffix = "   \nnext line\n";
+		writeFileSync(testFile, target + suffix);
+
+		await editTool.execute("fuzzy-byte-eol", {
+			path: testFile,
+			edits: [{ oldText: "const x = 'a';", newText: "const x = 'b';" }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`const x = 'b';${suffix}`);
+	});
+
+	it("maps a fuzzy match late in a long line containing a decomposed accent", async () => {
+		// Locks the linear grapheme-cluster pass: the line is far beyond the 2048-char
+		// exhaustive-scan cap, so a regression there surfaces as a spurious not-found.
+		const testFile = join(testDir, "long-nfd-fuzzy.txt");
+		const prefix = `cafe\u0301 ${"x = 1; ".repeat(1000)}`;
+		const target = "end = \u2018q\u2019;";
+		const suffix = "\nnext\u00A0line   \n";
+		writeFileSync(testFile, prefix + target + suffix);
+
+		await editTool.execute("fuzzy-byte-long-nfd", {
+			path: testFile,
+			edits: [{ oldText: "end = 'q';", newText: "end = 'r';" }],
+		});
+
+		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}end = 'r';${suffix}`);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts
@@ -1,26 +1,25 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
 import { computeEditsDiff } from "../../../src/core/tools/edit-diff.js";
 import { createEditTool } from "../../../src/index.js";
+import { createHarness, type Harness } from "../harness.js";
 
+// The tool cwd is never used: every test passes absolute paths under its harness tempDir.
 const editTool = createEditTool(process.cwd());
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	for (const harness of harnesses) harness.cleanup();
+	harnesses.length = 0;
+});
 
 describe("edit tool fuzzy byte preservation", () => {
-	let testDir: string;
-
-	beforeEach(() => {
-		testDir = join(tmpdir(), `coding-agent-fuzzy-byte-test-${Date.now()}`);
-		mkdirSync(testDir, { recursive: true });
-	});
-
-	afterEach(() => {
-		rmSync(testDir, { recursive: true, force: true });
-	});
-
 	it("preserves unrelated bytes under a single fuzzy edit", async () => {
-		const testFile = join(testDir, "single-fuzzy.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "single-fuzzy.txt");
 		const prefix =
 			"nbsp: alpha\u00A0beta\n" +
 			"single quotes: \u2018left\u2019\n" +
@@ -35,16 +34,25 @@ describe("edit tool fuzzy byte preservation", () => {
 		const replacement = "console.log('y');";
 		writeFileSync(testFile, original);
 
-		await editTool.execute("fuzzy-byte-single", {
-			path: testFile,
-			edits: [{ oldText: "console.log(\u2018x\u2019);", newText: replacement }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "console.log(\u2018x\u2019);", newText: replacement }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(prefix + replacement + suffix);
 	});
 
 	it("replaces only the matched span", async () => {
-		const testFile = join(testDir, "matched-span.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "matched-span.txt");
 		const target = "const message = \u201CHello\u201D;\n";
 		const original = `header: \u00BD and \uFB01\n${target}footer: a\u00A0b   \n`;
 		const targetIndex = original.indexOf(target);
@@ -52,16 +60,25 @@ describe("edit tool fuzzy byte preservation", () => {
 		const expected = original.slice(0, targetIndex) + replacement + original.slice(targetIndex + target.length);
 		writeFileSync(testFile, original);
 
-		await editTool.execute("fuzzy-byte-span", {
-			path: testFile,
-			edits: [{ oldText: 'const message = "Hello";\n', newText: replacement }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: 'const message = "Hello";\n', newText: replacement }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(expected);
 	});
 
 	it("mixed exact and fuzzy multi-edit preserves untouched bytes", async () => {
-		const testFile = join(testDir, "mixed-multi.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "mixed-multi.txt");
 		const original =
 			"decoy: \u201Cquoted\u201D \u2014 \u00BD \uFB01\n" +
 			"const exact = 1;\n" +
@@ -74,45 +91,79 @@ describe("edit tool fuzzy byte preservation", () => {
 			"trailing decoy   \n";
 		writeFileSync(testFile, original);
 
-		await editTool.execute("fuzzy-byte-mixed", {
-			path: testFile,
-			edits: [
-				{ oldText: "const exact = 1;\n", newText: "const exact = 2;\n" },
-				{ oldText: "hello world\n", newText: "hello universe\n" },
-			],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [
+						{ oldText: "const exact = 1;\n", newText: "const exact = 2;\n" },
+						{ oldText: "hello world\n", newText: "hello universe\n" },
+					],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(expected);
 	});
 
 	it("rejects a fuzzy match whose boundary falls inside an NFKC expansion", async () => {
-		const testFile = join(testDir, "nfkc-boundary.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "nfkc-boundary.txt");
 		const original = "\u00BD cup sugar\n";
 		writeFileSync(testFile, original);
 
-		await expect(
-			editTool.execute("fuzzy-byte-nfkc-boundary", {
-				path: testFile,
-				edits: [{ oldText: "/2 cup sugar", newText: "one cup sugar" }],
-			}),
-		).rejects.toThrow(/Could not find the exact text/);
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "/2 cup sugar", newText: "one cup sugar" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
+
+		const toolResult = harness.session.messages.find((message) => message.role === "toolResult");
+		const errorText =
+			toolResult?.content
+				.filter((part) => part.type === "text")
+				.map((part) => part.text)
+				.join("\n") ?? "";
+		expect(toolResult?.isError).toBe(true);
+		expect(errorText).toMatch(/Could not find the exact text/);
 		expect(readFileSync(testFile, "utf-8")).toBe(original);
 	});
 
 	it("consumes stripped trailing whitespace at a fuzzy match end boundary", async () => {
-		const testFile = join(testDir, "trailing-boundary.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "trailing-boundary.txt");
 		writeFileSync(testFile, "foo();   \nbar();\n");
 
-		await editTool.execute("fuzzy-byte-trailing-boundary", {
-			path: testFile,
-			edits: [{ oldText: "foo();\n", newText: "baz();\n" }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "foo();\n", newText: "baz();\n" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe("baz();\nbar();\n");
 	});
 
 	it("reported diff reflects the true original content", async () => {
-		const testFile = join(testDir, "true-original-diff.txt");
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "true-original-diff.txt");
 		const unrelatedLine = "const title = \u201Cuntouched\u201D;";
 		const normalizedUnrelatedLine = 'const title = "untouched";';
 		const original = `${unrelatedLine}\nhello\u00A0world\n`;
@@ -137,7 +188,9 @@ describe("edit tool fuzzy byte preservation", () => {
 	});
 
 	it("exact match still takes priority and preserves bytes", async () => {
-		const testFile = join(testDir, "exact-priority.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "exact-priority.txt");
 		const target = "const exact = 'before';\n";
 		const original = `prefix: \u201Csmart\u201D \u00A0 \u00BD\n${target}suffix: \uFB01 \u2014   \n`;
 		const targetIndex = original.indexOf(target);
@@ -145,71 +198,114 @@ describe("edit tool fuzzy byte preservation", () => {
 		const expected = original.slice(0, targetIndex) + replacement + original.slice(targetIndex + target.length);
 		writeFileSync(testFile, original);
 
-		await editTool.execute("fuzzy-byte-exact-priority", {
-			path: testFile,
-			edits: [{ oldText: target, newText: replacement }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: target, newText: replacement }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(expected);
 	});
 
 	it("maps a fuzzy match that starts after indentation", async () => {
-		const testFile = join(testDir, "indented-fuzzy.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "indented-fuzzy.txt");
 		const prefix = "function outer() {\n\t";
 		const target = "console.log(\u2018x\u2019);";
 		const suffix = "\n}\n";
 		writeFileSync(testFile, prefix + target + suffix);
 
-		await editTool.execute("fuzzy-byte-indent", {
-			path: testFile,
-			edits: [{ oldText: "console.log('x');", newText: "console.log('y');" }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "console.log('x');", newText: "console.log('y');" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}console.log('y');${suffix}`);
 	});
 
 	it("maps a fuzzy match that starts after an interior space", async () => {
-		const testFile = join(testDir, "midline-fuzzy.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "midline-fuzzy.txt");
 		const prefix = "const value = ";
 		const target = "\u2018hello\u2019;";
 		const suffix = "\nuntouched\u00A0line   \n";
 		writeFileSync(testFile, prefix + target + suffix);
 
-		await editTool.execute("fuzzy-byte-midline", {
-			path: testFile,
-			edits: [{ oldText: "'hello';", newText: "'world';" }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "'hello';", newText: "'world';" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}'world';${suffix}`);
 	});
 
 	it("keeps trailing whitespace when a fuzzy match ends at end-of-line without a newline", async () => {
-		const testFile = join(testDir, "eol-no-newline-fuzzy.txt");
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
+		const testFile = join(harness.tempDir, "eol-no-newline-fuzzy.txt");
 		const target = "const x = \u2018a\u2019;";
 		const suffix = "   \nnext line\n";
 		writeFileSync(testFile, target + suffix);
 
-		await editTool.execute("fuzzy-byte-eol", {
-			path: testFile,
-			edits: [{ oldText: "const x = 'a';", newText: "const x = 'b';" }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "const x = 'a';", newText: "const x = 'b';" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(`const x = 'b';${suffix}`);
 	});
 
 	it("maps a fuzzy match late in a long line containing a decomposed accent", async () => {
+		const harness = await createHarness({ tools: [editTool] });
+		harnesses.push(harness);
 		// Locks the linear grapheme-cluster pass: the line is far beyond the 2048-char
 		// exhaustive-scan cap, so a regression there surfaces as a spurious not-found.
-		const testFile = join(testDir, "long-nfd-fuzzy.txt");
+		const testFile = join(harness.tempDir, "long-nfd-fuzzy.txt");
 		const prefix = `cafe\u0301 ${"x = 1; ".repeat(1000)}`;
 		const target = "end = \u2018q\u2019;";
 		const suffix = "\nnext\u00A0line   \n";
 		writeFileSync(testFile, prefix + target + suffix);
 
-		await editTool.execute("fuzzy-byte-long-nfd", {
-			path: testFile,
-			edits: [{ oldText: "end = 'q';", newText: "end = 'r';" }],
-		});
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("edit", {
+					path: testFile,
+					edits: [{ oldText: "end = 'q';", newText: "end = 'r';" }],
+				}),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("apply the edit");
 
 		expect(readFileSync(testFile, "utf-8")).toBe(`${prefix}end = 'r';${suffix}`);
 	});


### PR DESCRIPTION
## Issue

Fuzzy edit matching found its match in a fuzzy-normalized copy of the whole file and then wrote that normalized copy back to disk. One smart quote in `oldText` was enough to strip trailing whitespace on every line, ASCII-fy quotes and dashes, and apply NFKC folds (`½` → `1/2`, `ﬁ` → `fi`) file-wide. The rendered diff was computed from the normalized base, so none of it showed up. In multi-edit mode, one fuzzy edit dragged every other edit into normalized space too.

Fixes #654.

## Fix

Fuzzy matches are still located in normalized space, but the replacement is now spliced into the original content, leaving every byte outside the matched span untouched.

- Match boundaries are mapped back to original-content offsets and verified with prefix equality. Unmappable boundaries (e.g. a match starting inside an NFKC expansion) are rejected with the normal not-found error.
- Mapping doesn't trim, so matches after indentation or interior spaces work.
- A match ending at the last visible character of a line keeps that line's trailing whitespace; including the `\n` in `oldText` consumes it, same as before.
- Multi-edit matches everything against the original content; exact and fuzzy edits mix cleanly.
- `baseContent` from `applyEditsToNormalizedContent` is always the original LF-normalized content, so diff and preview match what's written.
- Mapping is fast-path first: a 1:1 column check when NFKC doesn't change lengths, then a single-pass grapheme-cluster accumulation (handles decomposed accents); both run at any line length. The exhaustive per-column scan is quadratic, so it only runs for lines up to 2048 chars; beyond that, if neither pass can verify a boundary, the fuzzy match returns the normal retryable not-found instead of stalling. Exact matching is unaffected.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/654-fuzzy-edit-byte-preservation.test.ts`
  - 13 regressions: byte preservation (single + multi-edit), NFKC-expansion boundary rejection, trailing-whitespace semantics with/without newline and at newline-leading match starts, indented and mid-line starts, diff-matches-write, exact-match priority, and a multi-KB NFD line locking the single-pass path
- Existing edit-path suites all pass: `test/tools.test.ts` (original fuzzy tests unchanged), `test/edit-summary.test.ts`, `test/edit-tool-legacy-input.test.ts`, `test/edit-tool-no-full-redraw.test.ts`
