### PR TITLE
fix anthropic abort model fixture

### DIFF
--- a/packages/ai/test/abort.test.ts
+++ b/packages/ai/test/abort.test.ts
@@ -156,7 +156,7 @@ describe("AI Providers Abort Tests", () => {
 	});
 
 	describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("Anthropic Provider Abort", () => {
-		const llm = getModel("anthropic", "claude-opus-4-1-20250805");
+		const llm = getModel("anthropic", "claude-opus-4-6");
 
 		it("should abort mid-stream", { retry: 3 }, async () => {
 			await testAbortSignal(llm, { thinkingEnabled: true, thinkingBudgetTokens: 2048 });


### PR DESCRIPTION
- ci regenerated the model catalog and dropped the dated anthropic opus 4.1 identifier.
- the abort integration test now uses claude opus 4.6, restoring build and release type checks.
- the unrelated heartbeat timeout passed when rerun in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only model fixture swap with no production or runtime logic changes.
> 
> **Overview**
> Updates the **Anthropic Provider Abort** integration tests to resolve the model via `getModel("anthropic", "claude-opus-4-6")` instead of the removed dated Opus 4.1 id (`claude-opus-4-1-20250805`).
> 
> This keeps abort mid-stream and immediate-abort coverage aligned with the regenerated model catalog so type checks and CI can pass again. Test behavior is unchanged aside from the fixture model id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f960015153e2848f091e37928cf0d4babb8f4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Anthropic model identifier in abort test fixture
> Updates the model ID in [abort.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/658/files#diff-d1c954dc1274bcf480461b61a93538beb4e7be5f83c345b1459682a2444cad5a) from `claude-opus-4-1-20250805` to `claude-opus-4-6` so the Anthropic abort tests reference a valid model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f96001.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->