### PR TITLE
fix(ai): use current Anthropic model in abort test

### DIFF
--- a/packages/ai/test/abort.test.ts
+++ b/packages/ai/test/abort.test.ts
@@ -156,7 +156,7 @@ describe("AI Providers Abort Tests", () => {
 	});
 
 	describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("Anthropic Provider Abort", () => {
-		const llm = getModel("anthropic", "claude-opus-4-1-20250805");
+		const llm = getModel("anthropic", "claude-sonnet-4-6");
 
 		it("should abort mid-stream", { retry: 3 }, async () => {
 			await testAbortSignal(llm, { thinkingEnabled: true, thinkingBudgetTokens: 2048 });


### PR DESCRIPTION
## Summary

- Replace the removed dated Claude Opus 4.1 model in the Anthropic abort test with Claude Sonnet 4.6.

## Root cause

The AI package build regenerates the model catalog from models.dev. The live catalog no longer includes `claude-opus-4-1-20250805`, so the subsequent TypeScript check fails even though the checked-in catalog still contains it. Claude Sonnet 4.6 is already used for Anthropic OAuth coverage and is guaranteed by the model generator fallback.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/abort.test.ts` (skipped without provider credentials; import and compilation succeeded)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only model ID change with no production or runtime impact.
> 
> **Overview**
> Updates the Anthropic provider abort integration test to use **`claude-sonnet-4-6`** instead of **`claude-opus-4-1-20250805`**, which is no longer in the regenerated models.dev catalog and was breaking TypeScript checks during the AI package build.
> 
> Test behavior is unchanged: the same mid-stream and immediate-abort cases still run with thinking enabled when `ANTHROPIC_OAUTH_TOKEN` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce5ef78aae5fa2d8c116a3c0ae3c5e7dbd30525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Anthropic model identifier to `claude-sonnet-4-6` in abort tests
> Updates the model used in [abort.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/659/files#diff-d1c954dc1274bcf480461b61a93538beb4e7be5f83c345b1459682a2444cad5a) from `claude-opus-4-1-20250805` to `claude-sonnet-4-6` to match a current available model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ce5ef7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->