### PR TITLE
fix(coding-agent): isolate kernel state tests

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,7 +44,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts"
+		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-state-roundtrip.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -22,7 +22,7 @@ function resolveKernelPython(): string | null {
 const python = resolveKernelPython();
 const describeIfKernel = python ? describe : describe.skip;
 
-describeIfKernel("kernel state snapshot round-trip (real kernel)", () => {
+describeIfKernel("kernel state snapshot round-trip (real kernel)", { tags: ["kernel-heavy"] }, () => {
 	let dir = "";
 	let snapshotPath = "";
 	let manifestPath = "";


### PR DESCRIPTION
## Summary

- Mark the real-kernel state round-trip suite as `kernel-heavy` so normal coding-agent shards exclude it.
- Run the suite in the dedicated kernel job.
- Serialize kernel test files to prevent concurrent mutation of the shared kernel virtual environment.

## Root cause

The round-trip suite was running alongside roughly 100 files in the normal shard and timing out while kernel processes competed for resources. Moving it into the dedicated job initially exposed a second race: kernel test files ran concurrently while one rebuilt `~/.prime/agent/kernel-venv`, causing other files to fail with `spawn .../bin/python ENOENT`. Serial file execution removes that shared-resource race.

## Validation

- Focused round-trip suite with `kernel-heavy`: 6 passed
- `npm run test:kernel`: 3 files and 11 tests passed
- Normal filter: round-trip suite skipped
- `npm run check`

Stacked on #659.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate kernel state tests in coding-agent by adding file-level parallelism control and tags
> - Updates the `test:kernel` script in [package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/661/files#diff-8539bf3a7fb8b77848c0018f167f04fac756a980228bd467182af459cd8c5674) to run with `--no-file-parallelism` and explicitly includes `kernel-state-roundtrip.test.ts` to prevent interference between kernel tests.
> - Tags the `kernel state snapshot round-trip` suite with `kernel-heavy` in [kernel-state-roundtrip.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/661/files#diff-0384e2afc0ba33cb48d0c8ec3a51a50c408444c4f9ae6418bf6ca83864801e68) to enable targeted filtering.
> - Removes the `nvidia/nvidia-nemotron-3-ultra-550b-a55b` curated override and alias from [generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/661/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c), and updates related tests to no longer expect that model in the catalog.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed4c218.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI test orchestration and catalog metadata/comments; the removed Nemotron Ultra override could shift context limits for that model id if it remains in the live catalog.
> 
> **Overview**
> **Kernel CI:** The real-kernel **state snapshot round-trip** suite is tagged `kernel-heavy`, added to `test:kernel`, and that script now runs with **`--no-file-parallelism`** so kernel-heavy files do not race on the shared `kernel-venv`.
> 
> **Prime Inference (`generate-models.ts`):** Drops the curated override and OpenRouter alias for **`nvidia/nvidia-nemotron-3-ultra-550b-a55b`** (alias map is empty with a note that IDs match OpenRouter today). Comments around OpenRouter-as-spec-sheet and API-verified limits are tightened; tests now assert **nemotron-3-super** override behavior instead of the HF-style ultra id, and the featured-model list no longer expects the ultra entry.
> 
> **AI tests:** Anthropic abort coverage switches from **`claude-sonnet-4-6`** to **`claude-opus-4-6`** (still with thinking options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4c21890f7b9f47a5666139f9ad1feb10724109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->