### PR TITLE
fix(coding-agent): resolve kernel venv interpreter for Windows layout

### DIFF
--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -76,7 +76,7 @@ The Python side does not call providers or implement an agent loop.
 The kernel is created lazily on first IPython use. Python resolution is:
 
 1. `PRIME_AGENT_KERNEL_PYTHON`, when it can import `ipykernel`;
-2. `~/.prime/agent/kernel-venv/bin/python`, bootstrapped with `uv`; or
+2. `~/.prime/agent/kernel-venv/bin/python` (`Scripts\python.exe` on Windows), bootstrapped with `uv`; or
 3. the XDG data location when `~/.prime` is not writable.
 
 The managed environment includes Python 3.11, `ipykernel`, and `prime-agent-runtime`. A bootstrap marker detects stale environments.

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -119,6 +119,10 @@ function expandHome(filePath: string): string {
 	return filePath;
 }
 
+export function venvPython(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function fileContentHash(filePath: string): string {
 	try {
 		return `sha256:${createHash("sha256").update(readFileSync(filePath)).digest("hex")}`;
@@ -725,7 +729,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = venvPython(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +890,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = venvPython(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { venvPython } from "../src/core/kernel/bootstrap.js";
 import { KernelManager } from "../src/core/kernel/index.js";
 import { buildRlmBootstrapCode } from "../src/core/tools/ipython.js";
 
@@ -44,7 +45,7 @@ describe("IPython RLM bootstrap", () => {
 function resolveKernelPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+		venvPython(join(homedir(), ".prime", "agent", "kernel-venv")),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
 		if (!existsSync(python)) continue;

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -10,6 +10,7 @@ import {
 	getKernelVenvDir,
 	type KernelPythonSkill,
 	resolveRuntimeIdentity,
+	venvPython,
 } from "../src/core/kernel/bootstrap.js";
 
 let tempDir = "";
@@ -172,6 +173,21 @@ describe("kernel bootstrap", () => {
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
 		expect(getKernelVenvDir()).toBe(venv);
+	});
+
+	it("resolves the venv interpreter using the host platform layout", () => {
+		const originalPlatform = process.platform;
+		const setPlatform = (value: NodeJS.Platform) =>
+			Object.defineProperty(process, "platform", { value, configurable: true });
+		try {
+			setPlatform("win32");
+			expect(venvPython("C:\\venv")).toBe(join("C:\\venv", "Scripts", "python.exe"));
+
+			setPlatform("linux");
+			expect(venvPython("/venv")).toBe(join("/venv", "bin", "python"));
+		} finally {
+			setPlatform(originalPlatform);
+		}
 	});
 
 	it("bootstraps a missing venv with uv, ipykernel, prime-agent-runtime, and default extra packages", async () => {

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -3,13 +3,14 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { venvPython } from "../src/core/kernel/bootstrap.js";
 import { KernelManager } from "../src/core/kernel/index.js";
 
 /** Find a python that can launch an ipykernel and has dill, or null to skip. */
 function resolveKernelPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+		venvPython(join(homedir(), ".prime", "agent", "kernel-venv")),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
 		if (!existsSync(python)) continue;


### PR DESCRIPTION
Fixes #660.

## Problem

`bootstrapVenv` and `ensureKernelPythonUncached` both built the kernel interpreter path as `path.join(venv, "bin", "python")`. That is the POSIX venv layout; on Windows the interpreter is at `<venv>\Scripts\python.exe`. The path never exists there, so `uv pip install --python <path>` exits 2 and the kernel never starts.

Since the IPython kernel is the agent's only tool, the practical effect on Windows is an agent with no ability to read files, grep, or run commands. It still answers from context files, which makes this read as a model problem rather than a bootstrap failure.

The second site compounds it. `kernelReady(python, ...)` is checked against the same non-existent path, so it is always false on Windows: every launch falls through to `bootstrapVenv`, which calls `uv venv --seed` and recreates the directory. A venv provisioned by hand is discarded on the next run, so the failure looks intermittent when it is in fact deterministic.

## Change

- Add `venvPython(venv)`, which selects the layout from `process.platform`. This mirrors the `win32` branch already present in `findExecutable` and `ensureUv` in the same file.
- Use it at both sites.
- Update `test/ipython-bootstrap.test.ts` and `test/kernel-state-roundtrip.test.ts`, which hardcoded the POSIX candidate path and so could never locate the venv on Windows.
- Note the Windows layout in `docs/rlm-runtime.md`.

No behavior change on macOS or Linux: `venvPython` returns exactly the previous path there.

## Testing

`npm run check` passes (biome, `tsgo --noEmit`, installer render, browser smoke).

The new assertion in `test/kernel-bootstrap.test.ts` stubs `process.platform` and pins both layouts, so it exercises the Windows branch regardless of host OS:

```
npx tsx ../../node_modules/vitest/dist/cli.js --run test/kernel-bootstrap.test.ts -t "host platform layout"
Test Files  1 passed (1)
Tests  1 passed | 21 skipped (22)
```

I could not run the rest of that file meaningfully, and want to be explicit about it: its fake `uv` and fake interpreter are `#!/bin/sh` scripts, so the file is POSIX-only by construction and fails wholesale on a Windows host. I baselined instead — on the unmodified tree it is 17 failed / 4 passed, and with this change 17 failed / 5 passed. Same pre-existing failures, plus the new test. Please confirm against CI on Linux.

Verified manually on Windows 11 with prime-agent 0.7.0: with the interpreter provisioned at `Scripts\python.exe` and `PRIME_AGENT_KERNEL_PYTHON` pointed at it, the kernel starts and the agent completes a real repo search, returning a function's defining file and line number that matched an independent grep.

## Two notes

`AGENTS.md` asks for issue regressions under `test/suite/regressions/<issue>-<slug>.test.ts`. I put the assertion in `test/kernel-bootstrap.test.ts` instead, since this is a pure path unit test with no agent interaction and that directory is built around the faux-provider harness. Happy to move it if you would rather keep the convention uniform.

`venvPython` is exported so the test can call it directly, consistent with `getKernelVenvDir` and `resolveRuntimeIdentity` in the same module. If you would rather it stay private, the test can assert through `ensureKernelPython` on POSIX only, at the cost of not covering the Windows branch in CI.

## Not addressed here

Two adjacent items from the issue, left out to keep this reviewable:

- The missing-requirement error reports one group per run (`ipykernel` and runtime first, default packages second), so discovering the full set takes three launches.
- `uv venv --seed` runs before the interpreter path is validated. That is harmless once the path is correct, but it is the mechanism that destroyed a working venv.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path helper with POSIX parity; main risk is incorrect platform detection, covered by a new unit test.
> 
> **Overview**
> Fixes Windows IPython kernel bootstrap by resolving the managed venv interpreter with **`venvPython(venv)`** (`Scripts\python.exe` on `win32`, `bin/python` elsewhere) instead of always using the POSIX path.
> 
> **`bootstrapVenv`** and **`ensureKernelPythonUncached`** now pass that path into `uv pip install` and **`kernelReady`** checks, so bootstrap and reuse work when the interpreter actually lives under `Scripts`. POSIX behavior is unchanged.
> 
> Tests that locate the default kernel venv use **`venvPython`**, and **`kernel-bootstrap.test.ts`** stubs **`process.platform`** to lock both layouts. **`rlm-runtime.md`** documents the Windows path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8fac4b9726c4eb9908e4e2dcfa5dac1fb3e5348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix kernel venv interpreter path resolution for Windows in coding agent
> Adds a `venvPython` helper in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/663/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) that returns `Scripts/python.exe` on `win32` and `bin/python` otherwise. All venv interpreter references in bootstrap and resolver functions are updated to use this helper, replacing the hardcoded Unix-only path. Tests are updated to use `venvPython` instead of hardcoded paths, and a new test case asserts the correct path per platform.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8fac4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->