### PR TITLE
fix(coding-agent): hide console windows for background child processes

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -692,6 +692,7 @@ async function runStart(parsed: ParsedDaemonClientCommand): Promise<void> {
 		...sessionArgs.daemonArgs.filter((arg) => arg !== "--background" && arg !== "-d"),
 	];
 	const child = spawn(process.execPath, daemonArgs, {
+		windowsHide: true,
 		cwd: sessionArgs.config?.cwd ?? process.cwd(),
 		detached: true,
 		env: process.env,

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -372,6 +372,7 @@ async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promi
 		process.execPath,
 		[...process.execArgv, entrypoint, "--mode", "daemon", "--daemon-socket", socketPath],
 		{
+			windowsHide: true,
 			cwd: spawnCwd ?? process.cwd(),
 			detached: true,
 			env,

--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -548,6 +548,7 @@ export async function launchDaemonUpdateRestartCoordinator(
 		...(originActiveSessionId ? [DAEMON_UPDATE_RESTART_ORIGIN_FLAG, originActiveSessionId] : []),
 	]);
 	const child = spawn(launch.command, launch.args, {
+		windowsHide: true,
 		cwd: options.cwd ?? process.cwd(),
 		detached: true,
 		env: coordinatorEnvironment(agentDir),

--- a/packages/coding-agent/src/cli/owned-session-worker.ts
+++ b/packages/coding-agent/src/cli/owned-session-worker.ts
@@ -344,6 +344,7 @@ export async function runOwnedSessionWorkerFrontend(
 			? ["inherit", "inherit", "inherit", "ipc"]
 			: [bridgeStdin ? "pipe" : "inherit", "pipe", "pipe", "ipc"];
 		const child = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: process.cwd(),
 			detached: process.platform !== "win32",
 			env: {

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -200,6 +200,8 @@ function readCommandOutput(
 	const result = spawnSync(command, args, {
 		encoding: "utf-8",
 		stdio: ["ignore", "pipe", "pipe"],
+		// Without windowsHide, console child processes get a visible window on Windows.
+		windowsHide: true,
 		shell: shouldUseWindowsShell(command),
 	});
 	if (result.status === 0) return result.stdout.trim() || undefined;

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -492,6 +492,7 @@ function runChildProcess(
 	options.signal?.throwIfAborted();
 	return new Promise((resolve) => {
 		const child = spawn(command, args, {
+			windowsHide: true,
 			cwd: options.cwd,
 			detached: process.platform !== "win32",
 			shell: options.shell === true,

--- a/packages/coding-agent/src/core/exec.ts
+++ b/packages/coding-agent/src/core/exec.ts
@@ -59,6 +59,7 @@ export async function execCommand(
 ): Promise<ExecResult> {
 	return new Promise((resolve) => {
 		const proc = spawn(command, args, {
+			windowsHide: true,
 			cwd,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -10,6 +10,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
 		cwd: repoDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		windowsHide: true,
 	});
 	const branch = result.status === 0 ? result.stdout.trim() : "";
 	return branch || null;
@@ -24,6 +25,7 @@ function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
 			{
 				cwd: repoDir,
 				encoding: "utf8",
+				windowsHide: true,
 			},
 			(error: ExecFileException | null, stdout: string) => {
 				if (error) {

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -374,6 +374,7 @@ async function resolveWritableKernelVenvDir(): Promise<string> {
 function run(command: string, args: string[], options: { stdio?: "ignore" | "inherit" } = {}): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, args, {
+			windowsHide: true,
 			env: process.env,
 			stdio: options.stdio ?? "ignore",
 		});

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -173,6 +173,7 @@ class ForkServer {
 				// The template only imports; its own cwd/env are irrelevant since each
 				// forked child applies the per-kernel cwd/env itself. Inherit the daemon's.
 				const proc = spawn(this.params.python, ["-c", FORK_SERVER_SCRIPT, socketPath], {
+					windowsHide: true,
 					env: this.launchEnv,
 					stdio: ["ignore", "ignore", "pipe"],
 				});

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -645,6 +645,7 @@ export class KernelManager {
 
 		if (!forked) {
 			const kernel = spawn(python, ["-m", "ipykernel_launcher", "-f", connection.path], {
+				windowsHide: true,
 				cwd: this.options.cwd,
 				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
 				stdio: ["ignore", "pipe", "pipe"],

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2379,6 +2379,7 @@ export class DefaultPackageManager implements PackageManager {
 
 	private spawnCommand(command: string, args: string[], options?: { cwd?: string }): ChildProcess {
 		return spawn(command, args, {
+			windowsHide: true,
 			cwd: options?.cwd,
 			stdio: isStdoutTakenOver() ? ["ignore", 2, 2] : "inherit",
 			shell: shouldUseWindowsShell(command),
@@ -2393,6 +2394,7 @@ export class DefaultPackageManager implements PackageManager {
 	): ChildProcessByStdio<null, Readable, Readable> {
 		const baseEnv = getEnv();
 		return spawn(command, args, {
+			windowsHide: true,
 			cwd: options?.cwd,
 			stdio: ["ignore", "pipe", "pipe"],
 			shell: shouldUseWindowsShell(command),
@@ -2464,6 +2466,7 @@ export class DefaultPackageManager implements PackageManager {
 			encoding: "utf-8",
 			shell: shouldUseWindowsShell(command),
 			env: getEnv(),
+			windowsHide: true,
 		});
 		if (result.error || result.status !== 0) {
 			throw new Error(

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -58,6 +58,7 @@ function executeWithDefaultShell(command: string): string | undefined {
 			encoding: "utf-8",
 			timeout: 10000,
 			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
 		});
 		return output.trim() || undefined;
 	} catch {

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -25,7 +25,7 @@ async function deleteSessionArtifacts(sessionPath: string): Promise<void> {
 /** Remove the session `.jsonl`, trying the `trash` CLI first, then falling back to unlink. */
 async function removeSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
-	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8", windowsHide: true });
 
 	const getTrashErrorHint = (): string | null => {
 		const parts: string[] = [];

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -116,6 +116,8 @@ function runProcessQuery(command: string, args: string[]): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		// Without windowsHide, powershell.exe gets a visible terminal window on Windows.
+		windowsHide: true,
 	});
 }
 

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -73,6 +73,7 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 					return;
 				}
 				const child = spawn(shell, [...args, command], {
+					windowsHide: true,
 					cwd,
 					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -393,6 +393,7 @@ export class DaemonCatalogClient {
 	private async spawnCatalog(): Promise<void> {
 		const launch = createCliSubprocessLaunchSpec(["--version"]);
 		const child = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: process.cwd(),
 			env: createCliSubprocessEnv({ ...process.env, [DAEMON_CATALOG_ROLE_ENV]: "1" }),
 			stdio: ["ignore", "ignore", "ignore", "ipc"],

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -816,6 +816,7 @@ export class AgentDaemon {
 			delete environment[SESSION_LEASES_ENABLED_ENV];
 			delete environment[SESSION_LEASE_OWNER_ID_ENV];
 			const child = spawn(launch.command, launch.args, {
+				windowsHide: true,
 				cwd: this.options.defaultSessionConfig.cwd ?? process.cwd(),
 				detached: true,
 				env: environment,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2113,6 +2113,7 @@ export class DaemonSupervisor {
 		const launch = createCliSubprocessLaunchSpec(["--mode", "daemon", "--daemon-socket", socketPath]);
 		await this.assertRecoveryAllowed();
 		const child: ChildProcess = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: createCommand.config?.cwd ?? process.cwd(),
 			detached: true,
 			env: createCliSubprocessEnv({
@@ -4848,6 +4849,7 @@ export class DaemonSupervisor {
 			delete environment[SESSION_LEASES_ENABLED_ENV];
 			delete environment[SESSION_LEASE_OWNER_ID_ENV];
 			const replacement = spawn(launch.command, launch.args, {
+				windowsHide: true,
 				cwd: this.defaultSessionConfig.cwd ?? process.cwd(),
 				detached: true,
 				env: environment,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8714,7 +8714,7 @@ export class InteractiveMode {
 
 		try {
 			const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
-				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile]);
+				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile], { windowsHide: true });
 				let stdout = "";
 				let stderr = "";
 				proc.stdout?.on("data", (data) => {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -104,6 +104,7 @@ export class RpcClient {
 		}
 
 		this.process = spawn("node", [cliPath, ...args], {
+			windowsHide: true,
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -464,6 +464,7 @@ async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
 		await new Promise<void>((resolve, reject) => {
 			// Windows package managers are commonly .cmd shims. Use the shell so Node can execute them.
 			const child = spawn(step.command, step.args, {
+				windowsHide: true,
 				stdio: "inherit",
 				shell: shouldUseWindowsShell(step.command),
 			});

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -98,6 +98,7 @@ function runCommand(
 		timeout: timeoutMs,
 		maxBuffer: maxBufferBytes,
 		env: options?.env,
+		windowsHide: true,
 	});
 
 	if (result.error) {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -69,7 +69,7 @@ export async function copyToClipboard(text: string): Promise<void> {
 				execSync("pbcopy", options);
 				copied = true;
 			} else if (p === "win32") {
-				execSync("clip", options);
+				execSync("clip", { ...options, windowsHide: true });
 				copied = true;
 			} else {
 				// Linux. Try Termux, Wayland, or X11 clipboard tools.

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -253,6 +253,7 @@ function runGit(cwd: string, args: string[]): string | null {
 		cwd,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		windowsHide: true,
 	});
 	if (result.status !== 0 || typeof result.stdout !== "string") return null;
 	return result.stdout.trim() || null;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -16,7 +16,7 @@ function findBashOnPath(): string | null {
 	if (process.platform === "win32") {
 		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
 		try {
-			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000 });
+			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 			if (result.status === 0 && result.stdout) {
 				const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 				if (firstMatch && existsSync(firstMatch)) {
@@ -31,7 +31,7 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000 });
+		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 		if (result.status === 0 && result.stdout) {
 			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 			if (firstMatch) {
@@ -192,6 +192,7 @@ export function killProcessTree(pid: number): void {
 		// Use taskkill on Windows to kill process tree
 		try {
 			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+				windowsHide: true,
 				stdio: "ignore",
 				detached: true,
 			});

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -100,7 +100,7 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check that a command both launches and reports a successful version.
 function commandWorks(cmd: string): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS });
+		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS, windowsHide: true });
 		return !result.error && result.status === 0;
 	} catch {
 		return false;
@@ -224,7 +224,10 @@ async function downloadTool(tool: ManagedTool): Promise<string> {
 
 	try {
 		if (assetName.endsWith(".tar.gz")) {
-			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], { stdio: "pipe" });
+			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], {
+				stdio: "pipe",
+				windowsHide: true,
+			});
 			if (extractResult.error || extractResult.status !== 0) {
 				const errMsg = extractResult.error?.message ?? extractResult.stderr?.toString().trim() ?? "unknown error";
 				throw new Error(`Failed to extract ${assetName}: ${errMsg}`);


### PR DESCRIPTION
## Problem

On Windows, `spawn`/`spawnSync`/`execFileSync` calls without `windowsHide: true` give every console child process its own visible console window. When Windows Terminal is the default terminal, each of those windows opens as a new WT window that flashes on screen and closes immediately.

Users see bursts of terminal windows flashing during normal agent use: at startup (node --version checks, tools --version checks), while typing in chat (powershell.exe process-identity checks in `session-lease.ts`), and in the footer (git branch), shell/tool exec, clipboard and daemon subprocess spawns.

## Fix

Add `windowsHide: true` to all background spawn/spawnSync/execFile/execFileSync/execSync call sites in `packages/coding-agent/src` (27 files, +39/-7). The flag is a no-op on POSIX, so this is safe cross-platform.

Interactive windows that the user is meant to see are intentionally untouched: `extension-editor.ts`, `login-dialog.ts`, update/relaunch paths that inherit the parent console (`stdio: "inherit"`).

## Reproduction

Windows 10/11 with Windows Terminal set as the default terminal application:
1. Run `prime-agent` from a terminal.
2. Start typing a message.
3. A burst of Windows Terminal windows opens and closes within a second.

Confirmed fixed after applying all call-site changes; reverting only the `session-lease.ts` change makes the windows come back, so the fix is needed across all background spawns, not just one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only UX change via a standard Node spawn option; no auth, data, or protocol changes, and interactive console paths were left untouched.
> 
> **Overview**
> Fixes **flashing Windows Terminal windows** during normal agent use by setting **`windowsHide: true`** on background `spawn` / `spawnSync` / `execFile` / `execSync` call sites across `packages/coding-agent/src` (daemon launch, workers, git/footer checks, bash/exec, kernel bootstrap, clipboard, package manager, etc.).
> 
> On Windows, console children without this flag get a visible console; with WT as the default terminal that shows up as brief new windows at startup, while typing (e.g. `powershell.exe` in session lease checks), and during tool/git subprocess work. The flag is a **no-op on POSIX**, so behavior elsewhere is unchanged.
> 
> **Intentionally not changed:** flows where the user is meant to see a console (e.g. extension editor, login dialog, inherited `stdio: "inherit"` update/relaunch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e07abaae49258e5f9d288919e5cbb59f6bc84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide console windows for all background child processes in the coding agent on Windows
> Adds `windowsHide: true` to every `spawn`, `spawnSync`, `execSync`, `execFile`, and `execFileSync` call across the coding agent package so that background processes do not create visible console windows on Windows. Affected sites include daemon launch, session workers, kernel management, package manager commands, git utilities, clipboard helpers, and the RPC client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7e07ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->