### PR TITLE
fix(coding-agent): tolerate unsupported directory fsync

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed daemon command recovery compaction on platforms without directory fsync support ([#666](https://github.com/PrimeIntellect-ai/prime-agent/issues/666)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -206,11 +206,15 @@ export class CommandRecoveryJournal {
 			closeSync(descriptor);
 		}
 		renameSync(tempPath, this.path);
-		const directoryDescriptor = openSync(dirname(this.path), "r");
 		try {
-			fsyncSync(directoryDescriptor);
-		} finally {
-			closeSync(directoryDescriptor);
+			const directoryDescriptor = openSync(dirname(this.path), "r");
+			try {
+				fsyncSync(directoryDescriptor);
+			} finally {
+				closeSync(directoryDescriptor);
+			}
+		} catch {
+			// Directory fsync is unavailable on some platforms; the atomic rename still protects readers.
 		}
 		this.recordCount = records.length;
 	}


### PR DESCRIPTION
Fixes #666

## Summary

Make command journal compaction tolerate platforms that do not support `fsync` on directory handles.

## Root cause

`CommandRecoveryJournal.compact()` atomically renames the temporary journal and then calls `fsyncSync()` on the containing directory. On Windows, Node maps this to `FlushFileBuffers()` on a directory handle and returns `EPERM`. The exception escapes `acknowledge()`, so every daemon command acknowledgment logs an error and can leave the daemon unable to create or authenticate workers.

## Change

- Keep the temporary file `fsync` and atomic `renameSync`.
- Treat the post-rename directory `fsync` as best effort, matching the existing `cron-jobs` persistence path.
- Document the fix in the coding-agent changelog.

## Validation

- On Windows, the existing command journal test failed before the change: 5 passed, 1 failed at the directory `fsync`.
- The same test passes after the change: 6 passed.
- `npm run check` passes: Biome, TypeScript, installer render, and browser smoke checks.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CommandRecoveryJournal` to tolerate platforms without directory fsync support
> On some platforms, fsyncing a directory after an atomic rename is unsupported and throws. The directory open/fsync/close in [command-recovery-journal.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/670/files#diff-ad9ad93f7564a34f4c838495026b460ad85292338ab337c5cdca8f48161ecd3a) is now wrapped in a try/catch that swallows errors from missing directory fsync support. The atomic rename still occurs, so journal writes and compaction proceed normally on all platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e728af6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized durability tweak on an already-best-effort directory fsync; temp file fsync and atomic rename are unchanged.
> 
> **Overview**
> **Command recovery journal compaction** no longer fails when the OS rejects `fsync` on the journal directory (notably Windows `EPERM`). After the temp-file fsync and atomic `renameSync`, directory fsync is **best-effort** inside a try/catch—the same pattern as cron job persistence—so `acknowledge()` and compaction complete instead of surfacing errors that could break daemon command acknowledgment and worker auth.
> 
> The unreleased changelog notes the fix for [#666](https://github.com/PrimeIntellect-ai/prime-agent/issues/666).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e728af6d97969f388e8056b27b7d94b1fa454ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->