### PR TITLE
feat(coding-agent): add Tavily as a built-in OAuth MCP integration

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added Tavily to the built-in OAuth MCP catalog.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/mcp/catalog.ts
+++ b/packages/ai/src/mcp/catalog.ts
@@ -8,6 +8,7 @@ export interface McpCatalogEntry {
 	server: string;
 	label: string;
 	url: string;
+	headers?: Record<string, string>;
 	oauth?: Omit<McpOAuthConfig, "server" | "url"> & { kind: "oauth" };
 }
 
@@ -23,6 +24,13 @@ export const BUILTIN_MCP_CATALOG: readonly McpCatalogEntry[] = [
 		label: "Notion",
 		url: "https://mcp.notion.com/mcp",
 		oauth: { kind: "oauth", label: "Notion" },
+	},
+	{
+		server: "tavily",
+		label: "Tavily",
+		url: "https://mcp.tavily.com/mcp",
+		headers: { "X-Client-Name": "prime-agent" },
+		oauth: { kind: "oauth", label: "Tavily" },
 	},
 ];
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added Tavily as a built-in OAuth MCP integration for web search, extraction, crawling, mapping and research.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -323,7 +323,7 @@ issues = await linear.list_issues(team="Engineering")   # tools auto-discovered 
 help(linear.list_issues)                                 # description + argument schema
 ```
 
-Built-in integrations for Linear and Notion ship disabled. **Logging in enables them**: open `/login`, switch to **MCP Connections**, pick the integration, and complete OAuth in the browser. The integration's skill then becomes visible and is auto-imported into the kernel. `/mcp` opens the same tab, while its subcommands support direct management:
+Built-in integrations for Linear, Notion, and Tavily ship disabled. **Logging in enables them**: open `/login`, switch to **MCP Connections**, pick the integration, and complete OAuth in the browser. The integration's skill then becomes visible and is auto-imported into the kernel. `/mcp` opens the same tab, while its subcommands support direct management:
 
 ```
 /mcp                 list integrations and connection status

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -30,7 +30,7 @@ credentials in `auth.json`.
 
 ## Using a built-in integration
 
-Built-in integrations (Linear, Notion) ship **disabled**. Logging in enables them:
+Built-in integrations (Linear, Notion, Tavily) ship **disabled**. Logging in enables them:
 
 - Open `/login`, switch to **MCP Connections**, pick the integration, and
   complete OAuth in the browser. `/mcp login <name>` does the same from the CLI.

--- a/packages/coding-agent/skills/tavily/SKILL.md
+++ b/packages/coding-agent/skills/tavily/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: tavily
+description: Search the web, extract pages, map and crawl sites, conduct research, and retrieve technical documentation via Tavily's official hosted MCP server. Tools are auto-discovered at runtime.
+---
+
+# Tavily
+
+Use Tavily's official hosted MCP server from the IPython kernel.
+
+## Setup
+
+Connect via `/login` → **Services** tab → **Tavily** (OAuth in the browser).
+`/mcp login tavily` does the same. Once connected, this skill is enabled
+automatically. If a call raises `NotEnabled`, the user isn't logged in — walk
+them through `/login`; don't ask them to set environment variables.
+
+## Usage
+
+The server currently provides tools for search, extraction, mapping, crawling and deep research.
+The server remains the source of truth, so discover its current tools and argument schemas before calling:
+
+```python
+import tavily
+
+# 1. Discover available tools and their schemas
+for tool in await tavily.list_tools():
+    print(tool["name"], "-", tool["description"])
+
+# 2. Inspect a tool after discovery
+help(tavily.tavily_search)
+
+# 3. Call it with arguments from its schema
+result = await tavily.tavily_search(
+    query="latest developments in AI inference",
+    max_results=5,
+    search_depth="basic",
+)
+print(result)
+```
+
+Notes:
+
+- Every call is `async` — always `await` it.
+- Results are already-parsed Python: a `dict` for structured output, a string for
+  text, or a list of content blocks otherwise. Do not call `json.loads` on them.
+- Run `list_tools()` before assuming a tool or argument exists; it also populates
+  the schemas and docstrings shown by `help()`.
+- For a tool name that is not a valid Python identifier, use
+  `await tavily.call_tool("tool-name", {"argument": "value"})`.
+- The kernel import name is `tavily`. A custom `PRIME_AGENT_KERNEL_PYTHON` that
+  already contains the `tavily-python` SDK may resolve that package instead; use
+  Prime Agent's default managed kernel environment to avoid the collision.

--- a/packages/coding-agent/skills/tavily/pyproject.toml
+++ b/packages/coding-agent/skills/tavily/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "prime-agent-skill-tavily"
+version = "0.1.0"
+description = "Tavily integration skill for Prime Agent (Tavily's official hosted MCP server)."
+requires-python = ">=3.10"
+dependencies = ["mcp", "httpx", "prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tavily"]

--- a/packages/coding-agent/skills/tavily/src/tavily/__init__.py
+++ b/packages/coding-agent/skills/tavily/src/tavily/__init__.py
@@ -1,0 +1,31 @@
+"""Tavily integration: tools auto-discovered from Tavily's official MCP server.
+
+Usage in the kernel:
+
+    import tavily
+    results = await tavily.tavily_search(query="latest AI news")
+"""
+
+from __future__ import annotations
+
+from rlm import McpIntegration
+
+__all__ = ["Tavily", "tavily"]
+
+
+class Tavily(McpIntegration):
+    server = "tavily"
+    url = "https://mcp.tavily.com/mcp"
+
+
+tavily = Tavily()
+
+# Don't forward names the kernel bootstrap probes (e.g. `run`) or it wraps the
+# module as a callable skill and breaks `await tavily.<tool>()` dispatch.
+_RESERVED = {"run", "__wrapped__", "__call__"}
+
+
+def __getattr__(name: str):
+    if name.startswith("_") or name in _RESERVED:
+        raise AttributeError(name)
+    return getattr(tavily, name)

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -67,6 +67,7 @@ export class McpManager {
 				label: entry.label,
 				url: entry.url,
 				usesOAuth: entry.oauth?.kind === "oauth",
+				headers: entry.headers,
 			});
 		}
 		for (const [server, config] of Object.entries(this.getUserServers() ?? {})) {

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -28,6 +28,7 @@ describe("McpManager", () => {
 		const overrides = manager.getDisabledBuiltinSkillOverrides();
 		expect(overrides).toContain("-linear/SKILL.md");
 		expect(overrides).toContain("-notion/SKILL.md");
+		expect(overrides).toContain("-tavily/SKILL.md");
 	});
 
 	it("enables an integration once credentials are stored", () => {
@@ -41,6 +42,7 @@ describe("McpManager", () => {
 		const overrides = manager.getDisabledBuiltinSkillOverrides();
 		expect(overrides).not.toContain("-linear/SKILL.md");
 		expect(overrides).toContain("-notion/SKILL.md");
+		expect(overrides).toContain("-tavily/SKILL.md");
 
 		const status = manager.listStatus().find((s) => s.server === "linear");
 		expect(status?.enabled).toBe(true);
@@ -50,6 +52,7 @@ describe("McpManager", () => {
 		new McpManager({ authStorage });
 		expect(getOAuthProvider("mcp:linear")).toBeDefined();
 		expect(getOAuthProvider("mcp:notion")).toBeDefined();
+		expect(getOAuthProvider("mcp:tavily")).toBeDefined();
 	});
 
 	it("keeps MCP providers registered after ModelRegistry.refresh() resets the registry", () => {
@@ -58,6 +61,7 @@ describe("McpManager", () => {
 		registry.refresh(); // calls resetOAuthProviders(); must re-add MCP providers
 		expect(getOAuthProvider("mcp:linear")).toBeDefined();
 		expect(getOAuthProvider("mcp:notion")).toBeDefined();
+		expect(getOAuthProvider("mcp:tavily")).toBeDefined();
 	});
 
 	it("re-registers user-declared OAuth servers after ModelRegistry.refresh via the reset hook", () => {
@@ -110,6 +114,10 @@ describe("McpManager", () => {
 			headers: { "X-Extra": "1" },
 		});
 		expect(await handlers["mcp.config"]({ server: "notion" })).toEqual({ url: "https://mcp.notion.com/mcp" });
+		expect(await handlers["mcp.config"]({ server: "tavily" })).toEqual({
+			url: "https://mcp.tavily.com/mcp",
+			headers: { "X-Client-Name": "prime-agent" },
+		});
 	});
 
 	it("does not treat an oauth override of a catalog name as authed via the official stored cred", () => {


### PR DESCRIPTION
- Adds Tavily as an MCP server to expand web capabilities in the harness
- This PR does not touch the `websearch()` skill that uses Serper currently

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive built-in MCP catalog entry and skill gating; no auth or payment logic changes beyond existing OAuth MCP patterns.
> 
> **Overview**
> **Adds Tavily** as a third built-in OAuth MCP integration (alongside Linear and Notion) so agents can use Tavily’s hosted MCP for web search, extraction, crawling, mapping, and research after `/login` or `/mcp login tavily`.
> 
> The `packages/ai` catalog gains an optional **`headers`** field on entries; Tavily uses `X-Client-Name: prime-agent`. **`McpManager`** forwards catalog headers into resolved integrations and exposes them via **`mcp.config`** for the kernel. A new bundled skill at `skills/tavily/` (`McpIntegration` + `SKILL.md`) mirrors the existing Linear/Notion pattern, with tests covering disable-until-auth, OAuth provider registration, and Tavily config headers. README and MCP docs list Tavily; changelogs are updated. This does **not** change the Serper-based **`websearch`** skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3396f917b6825df9b0ae72d69ff636cf0177feca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Tavily as a built-in OAuth MCP integration in the coding agent
> - Adds a `tavily` entry to `BUILTIN_MCP_CATALOG` in [catalog.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/672/files#diff-17d479dc7eccc6d1826e2da1daad0cad0c9829fe8066ea848132d2a25cf9363f) with OAuth config and a static `X-Client-Name: prime-agent` header.
> - Introduces a new `McpCatalogEntry.headers` field and wires it through `McpManager.resolveIntegrations` so per-server headers reach host handlers.
> - Adds a new Python skill package at [packages/coding-agent/skills/tavily](https://github.com/PrimeIntellect-ai/prime-agent/pull/672/files#diff-3a0359f907220dfe46f16a3cd40b3e258527c9fb71caa2ec67e0c9066f8cefe3) exposing a `tavily` module with auto-discovered tools callable as `await tavily.<tool>(...)`.
> - Tavily ships disabled by default alongside Linear and Notion; tests cover OAuth registration, persistence across registry refresh, and headers passthrough.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3396f91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->