### PR TITLE
fix(coding-agent): bridge clipboard writes through Herdr

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed clipboard writes from Herdr panes reaching the foreground remote client.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -20,7 +20,7 @@ function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
 const MAX_OSC52_ENCODED_LENGTH = 100_000;
 
 function isRemoteSession(env: NodeJS.ProcessEnv = process.env): boolean {
-	return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.MOSH_CONNECTION);
+	return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.MOSH_CONNECTION || env.HERDR_ENV === "1");
 }
 
 function emitOsc52(text: string): boolean {

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -57,6 +57,7 @@ beforeEach(() => {
 	vi.stubEnv("SSH_CONNECTION", "");
 	vi.stubEnv("SSH_CLIENT", "");
 	vi.stubEnv("MOSH_CONNECTION", "");
+	vi.stubEnv("HERDR_ENV", "");
 	stdoutWrites = [];
 	nativeResolved = false;
 	mocks.clipboard.setText.mockReset();
@@ -103,6 +104,16 @@ describe("copyToClipboard", () => {
 			expect(osc52Writes()).toHaveLength(0);
 			nativeResolved = true;
 		});
+
+		await copyToClipboard("hello");
+
+		expect(nativeResolved).toBe(true);
+		expect(osc52Writes()).toHaveLength(1);
+		expect(mockedExecSync).not.toHaveBeenCalled();
+	});
+
+	test("Herdr session emits OSC 52 after native write", async () => {
+		vi.stubEnv("HERDR_ENV", "1");
 
 		await copyToClipboard("hello");
 


### PR DESCRIPTION
## Summary

Prime Agent currently treats SSH and Mosh as terminal-mediated clipboard sessions, but not Herdr panes. A Prime Agent process in a persistent Herdr server has `HERDR_ENV=1` without necessarily having an SSH marker, so a TUI selection can write only the server machine's native clipboard. The foreground `herdr --remote` client receives nothing.

Treat `HERDR_ENV=1` like the existing SSH/Mosh path. Prime Agent keeps the native-first behavior, then emits its bounded OSC 52 write. Herdr 0.8.0 validates that child clipboard message and routes it to the foreground client's clipboard. Non-Herdr local sessions are unchanged.

Reproduction coverage proves the new Herdr case fails before the predicate change (`0` OSC 52 writes) and passes after it (`1` write). The existing local test still proves native local copies do not emit OSC 52.

Validation:

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/clipboard.test.ts` (6 passed)
- `npm run check`
- GPT/Codex adversarial review: no material findings

_Generated by AI using OpenAI GPT-5.5._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow clipboard/terminal escape change with no auth or data-path impact; behavior only differs when Herdr env is set.
> 
> **Overview**
> **Herdr panes** now follow the same clipboard path as SSH/Mosh: when `HERDR_ENV=1`, `copyToClipboard` still writes to the server’s native clipboard first, then emits a bounded **OSC 52** sequence so Herdr can forward the selection to the foreground `herdr --remote` client.
> 
> `isRemoteSession` in `clipboard.ts` treats `HERDR_ENV === "1"` like the existing SSH/Mosh markers; local sessions without those env vars are unchanged. A Vitest case asserts OSC 52 after native copy in a Herdr session, and the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd4a446d69405cf76801374ac2f6b6d26b0ef2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge clipboard writes through Herdr by treating `HERDR_ENV=1` as a remote session
> When running inside a Herdr pane, clipboard writes were not reaching the foreground remote client. `isRemoteSession` in [`clipboard.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/682/files#diff-45a3d8d1b39efd61753f0f0f1bcb114f2ec5ebf38253cb7a3f3ded67c9e1f8bd) now returns `true` when `HERDR_ENV=1`, causing `copyToClipboard` to emit an OSC 52 sequence after the native write instead of using shell fallbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcd4a44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->