### PR TITLE
fix(coding-agent): reject ctx.ui.custom() with a clear error under the daemon architecture

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -178,7 +178,16 @@ export interface ExtensionUIContext {
 	/** Set the terminal window/tab title. */
 	setTitle(title: string): void;
 
-	/** Show a custom component with keyboard focus. */
+	/**
+	 * Show a custom component with keyboard focus.
+	 *
+	 * Not supported when the extension runs under the daemon/worker
+	 * architecture: the worker process has no terminal of its own to render
+	 * or focus a custom component on, so calling this rejects with
+	 * `ExtensionCustomUiUnsupportedError`. Use `select()`, `input()`,
+	 * `confirm()`, or `editor()` instead for UI that needs to work across
+	 * both in-process and daemon sessions.
+	 */
 	custom<T>(
 		factory: (
 			tui: TUI,

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -18,6 +18,27 @@ import {
 	isDaemonDialogExtensionUiRequest,
 } from "./daemon-protocol.js";
 
+/**
+ * Thrown by the daemon-mode `ctx.ui.custom()` binding. Extensions run inside a
+ * worker process that has no terminal of its own to render or focus a custom
+ * component on - only the socket-attached client owns a terminal. Unlike
+ * `select`/`confirm`/`input`/`editor`, `custom()` has no wire-protocol path to
+ * hand rendering off to the client, so it cannot be supported here.
+ */
+export class ExtensionCustomUiUnsupportedError extends Error {
+	readonly code = "extension_custom_ui_unsupported" as const;
+
+	constructor() {
+		super(
+			"ctx.ui.custom() is not supported when the extension runs under the daemon/worker architecture: " +
+				"the worker process executing this extension does not own a terminal, so there is no way to " +
+				"render or focus a custom component here. Use ctx.ui.select(), ctx.ui.input(), ctx.ui.confirm(), " +
+				"or ctx.ui.editor() instead, which are supported across daemon and in-process sessions.",
+		);
+		this.name = "ExtensionCustomUiUnsupportedError";
+	}
+}
+
 export interface ActiveSessionBindingCallbacks {
 	broadcast: (state: ActiveSessionState, message: DaemonOutbound) => void;
 	createConnectionState?: (state: ActiveSessionState) => AgentConnectionState;
@@ -218,7 +239,7 @@ function createExtensionUIContext(
 		setHeader: () => {},
 		setTitle: (title) => emitUiRequest("setTitle", { title }),
 		async custom<T>(): Promise<T> {
-			return undefined as T;
+			throw new ExtensionCustomUiUnsupportedError();
 		},
 		pasteToEditor: (text) => emitUiRequest("setEditorText", { text }),
 		setEditorText: (text) => emitUiRequest("setEditorText", { text }),

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -148,6 +148,51 @@ describe("daemon extension binding", () => {
 		}
 	});
 
+	it("rejects ctx.ui.custom() with a clear error instead of silently swallowing the callback", async () => {
+		let customCallbackInvoked = false;
+		let caughtError: unknown;
+		const runtime = await createRuntimeForTest(
+			(pi) => {
+				pi.registerCommand("daemon-custom-ui", {
+					description: "daemon custom ui",
+					handler: async (_args, ctx) => {
+						try {
+							await ctx.ui.custom((_tui, _theme, _keybindings, done) => {
+								customCallbackInvoked = true;
+								done(undefined);
+								return { render: () => [], invalidate: () => {} };
+							});
+						} catch (error) {
+							caughtError = error;
+						}
+					},
+				});
+			},
+			["daemon custom ui reply"],
+		);
+
+		const state: ActiveSessionState = {
+			activeSessionId: "active-custom-ui",
+			runtime,
+			clients: new Set(),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "generation-custom-ui",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: () => {},
+			shutdown: () => {},
+		});
+
+		await runtime.session.prompt("/daemon-custom-ui");
+
+		expect(customCallbackInvoked).toBe(false);
+		expect(caughtError).toBeInstanceOf(Error);
+		expect((caughtError as Error).name).toBe("ExtensionCustomUiUnsupportedError");
+		expect((caughtError as Error).message).toContain("ctx.ui.custom()");
+	});
+
 	it("keeps extension replacement callbacks daemon-side and rebinds before withSession", async () => {
 		const phases: string[] = [];
 		let oldSessionFile: string | undefined;


### PR DESCRIPTION
Fixes the silent-failure half of #680.

## Problem

`ctx.ui.custom()` is a documented, typed extension API (`core/extensions/types.ts`) for showing a custom focused component. Under the daemon/worker architecture, the extension handler executing `ctx.ui.custom()` runs inside a worker process that has no terminal of its own - only the socket-attached client does. The daemon-mode `uiContext.custom()` implementation reflected that by simply returning `undefined` without ever invoking the factory callback:

```js
async custom() {
  return undefined;
}
```

That means an extension author gets no error, no log line, nothing - the callback body just silently never runs, even though `ctx.hasUI` reports `true`. See #680 for the full trace through `runner.js`, `daemon-extension-binding.js`, and `daemon-protocol.js`.

## Fix

- Adds `ExtensionCustomUiUnsupportedError`, thrown by the daemon-mode `custom()` binding instead of resolving `undefined`.
- Documents the limitation directly on `ExtensionUIContext.custom()` in `core/extensions/types.ts`, pointing extension authors at `select()`/`input()`/`confirm()`/`editor()` as daemon-compatible alternatives.
- Adds a test in `daemon-extension-binding.test.ts` confirming the factory callback is never invoked and the caller receives a catchable, named error instead of a silent no-op.

This is intentionally scoped to the "fail loudly instead of silently" fix (step 1 of the staged plan discussed in #680). It does not change behavior for any extension that already works - `select`, `confirm`, `input`, and `editor` are untouched.

## What this does not fix (follow-up work)

`ctx.ui.custom()` usage splits into two very different cases:

- **Case 1 - structured, app-drawn UI** (render rows, respond to keypresses, resolve a value, no subprocess). This is architecturally similar to `select`/`editor`: a fix would define a wire schema for the rendered content and input events, and stream frame updates/input events over the daemon socket the same way `select` streams its option list and answer. Moderate scope, reuses proven patterns.
- **Case 2 - handing the terminal to an external interactive subprocess** (e.g. `spawnSync(cmd, { stdio: "inherit" })` for something like an fzf-style picker or a full-screen curses tool). This is the architecturally hard case: the worker has no real terminal to hand off at all. Supporting it would need real PTY forwarding - allocating a pseudo-terminal on the worker (e.g. via `node-pty`), spawning the subprocess attached to it, and streaming raw bytes bidirectionally over the socket (stdin keystrokes client -> worker, stdout/stderr bytes worker -> client, resize events, raw-mode toggling), with the client temporarily suspending its own TUI to become a passthrough. This is the same class of problem SSH, tmux control mode, and `kubectl exec -it` solve - well-understood, but a real feature-sized piece of work (backpressure, encoding, terminal-mode restoration on crash, resize races), likely larger in scope than everything currently built for `select`+`confirm`+`input`+`editor` combined. Probably worth scoping as its own follow-up issue/PR rather than folding into this one.

Neither case is addressed here; this PR only makes the current no-op fail loudly and documents why, so extension authors get a fast, actionable signal instead of silently broken behavior.

## Testing

- `npm run build` (full monorepo build via `tsgo`) - clean.
- `npx biome check` - clean.
- `npx vitest run test/daemon-extension-binding.test.ts` - 3/3 pass, including the new test.
- Full pre-commit hook (`biome check --write --error-on-warnings`, `tsgo --noEmit`, installer render check, browser smoke check) - all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior change for an unsupported daemon code path; in-process and other ctx.ui methods are unchanged.
> 
> **Overview**
> Under the daemon/worker architecture, **`ctx.ui.custom()`** no longer resolves to `undefined` without running the factory callback. The daemon UI binding now throws **`ExtensionCustomUiUnsupportedError`**, with a message that points authors to **`select()`**, **`input()`**, **`confirm()`**, and **`editor()`** as supported alternatives.
> 
> **`ExtensionUIContext.custom()`** in `types.ts` is documented with the same limitation and error name so API consumers know what to expect before calling it in daemon sessions.
> 
> A **`daemon-extension-binding`** test asserts the custom UI factory is never invoked and the caller receives the named error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca60a554ea542c843399a68e8e8afe1b403f758d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject `ctx.ui.custom()` with `ExtensionCustomUiUnsupportedError` under daemon architecture
> Previously, calling `ctx.ui.custom()` in daemon mode silently returned `undefined`, which could cause confusing failures. Now it throws a new `ExtensionCustomUiUnsupportedError` with a clear message explaining that custom UI is unsupported in the daemon/worker architecture. The `ExtensionUIContext` interface in [types.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/685/files#diff-9dac4095783bbab0fe7bcb479db24a75db6cdae3bc3504d74e40cc75e44778ab) is updated with docs advising use of `select()`, `input()`, `confirm()`, or `editor()` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca60a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->