### PR TITLE
fix(coding-agent): use portable worker socket paths

### DIFF
--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -11,7 +11,11 @@ import {
 	DAEMON_SCHEMA_ID,
 	type DaemonRuntimeIdentity,
 } from "../modes/daemon/daemon-protocol.js";
-import { defaultDaemonSocketDir, defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
+import {
+	defaultDaemonSocketDir,
+	defaultDaemonSocketPath,
+	defaultDaemonWorkerSocketDir,
+} from "../modes/daemon/daemon-socket.js";
 import { acquireDaemonShutdownAdmission } from "../modes/daemon/daemon-supervisor-ownership.js";
 import type { DaemonWorkerDescriptor } from "../modes/daemon/daemon-worker-protocol.js";
 import { signalProcessGroupOrProcess } from "../utils/child-process.js";
@@ -880,10 +884,26 @@ function recordShutdownFailure(
 	failed.push({ socketPath, reason });
 }
 
+function normalizeWorkerSocketDirectory(directory: string): string {
+	const normalized = resolve(directory);
+	if (
+		process.platform === "darwin" &&
+		(normalized === "/tmp" ||
+			normalized.startsWith("/tmp/") ||
+			normalized === "/var" ||
+			normalized.startsWith("/var/"))
+	) {
+		return `/private${normalized}`;
+	}
+	return normalized;
+}
+
 export function isWorkerSocketPath(socketPath: string): boolean {
+	const socketDir = normalizeWorkerSocketDirectory(dirname(socketPath));
 	return (
 		process.platform !== "win32" &&
-		resolve(dirname(socketPath)) === resolve(defaultDaemonSocketDir()) &&
+		(socketDir === normalizeWorkerSocketDirectory(defaultDaemonSocketDir()) ||
+			socketDir === normalizeWorkerSocketDirectory(defaultDaemonWorkerSocketDir())) &&
 		basename(socketPath).startsWith("worker-") &&
 		basename(socketPath).endsWith(".sock")
 	);

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -41,7 +41,7 @@ export function defaultDaemonSocketPath(): string {
 }
 
 export async function acquireDaemonSocketPathLease(socketPath: string): Promise<DaemonSocketPathLease | undefined> {
-	ensureDefaultDaemonSocketDir(socketPath);
+	ensureManagedDaemonSocketDir(socketPath);
 	if (process.platform === "win32") {
 		return undefined;
 	}
@@ -60,7 +60,7 @@ export async function acquireDaemonSocketPathLease(socketPath: string): Promise<
 }
 
 export async function prepareDaemonSocketPath(socketPath: string, lease?: DaemonSocketPathLease): Promise<void> {
-	ensureDefaultDaemonSocketDir(socketPath);
+	ensureManagedDaemonSocketDir(socketPath);
 
 	if (process.platform === "win32") {
 		return;
@@ -216,25 +216,37 @@ export function defaultDaemonSocketDir(): string {
 	return join(tmpdir(), `prime-agent-${suffix}`);
 }
 
-function ensureDefaultDaemonSocketDir(socketPath: string): void {
-	if (process.platform === "win32" || dirname(socketPath) !== defaultDaemonSocketDir()) {
+export function defaultDaemonWorkerSocketDir(): string {
+	if (process.platform === "win32") {
+		return defaultDaemonSocketDir();
+	}
+	const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
+	return join("/tmp", `prime-agent-${suffix}`);
+}
+
+function ensureManagedDaemonSocketDir(socketPath: string): void {
+	const socketDir = dirname(socketPath);
+	if (
+		process.platform === "win32" ||
+		(socketDir !== defaultDaemonSocketDir() && socketDir !== defaultDaemonWorkerSocketDir())
+	) {
 		return;
 	}
 
-	if (!existsSync(defaultDaemonSocketDir())) {
-		mkdirSync(defaultDaemonSocketDir(), { recursive: true, mode: DAEMON_SOCKET_DIR_MODE });
+	if (!existsSync(socketDir)) {
+		mkdirSync(socketDir, { recursive: true, mode: DAEMON_SOCKET_DIR_MODE });
 	}
 
-	const stat = lstatSync(defaultDaemonSocketDir());
+	const stat = lstatSync(socketDir);
 	if (!stat.isDirectory()) {
-		throw new Error(`Daemon socket directory exists and is not a directory: ${defaultDaemonSocketDir()}`);
+		throw new Error(`Daemon socket directory exists and is not a directory: ${socketDir}`);
 	}
 
 	if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
-		throw new Error(`Daemon socket directory is not owned by the current user: ${defaultDaemonSocketDir()}`);
+		throw new Error(`Daemon socket directory is not owned by the current user: ${socketDir}`);
 	}
 
-	chmodSync(defaultDaemonSocketDir(), DAEMON_SOCKET_DIR_MODE);
+	chmodSync(socketDir, DAEMON_SOCKET_DIR_MODE);
 }
 
 function canConnectToUnixSocket(socketPath: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -90,8 +90,8 @@ import {
 	cleanupDaemonSocketPath,
 	type DaemonSocketIdentity,
 	type DaemonSocketPathLease,
-	defaultDaemonSocketDir,
 	defaultDaemonSocketPath,
+	defaultDaemonWorkerSocketDir,
 	getDaemonSocketIdentity,
 	prepareDaemonSocketPath,
 	restrictDaemonSocketPath,
@@ -142,6 +142,7 @@ const IDLE_EVICTION_DRAIN_TIMEOUT_MS = 5_000;
 const CHILD_PASSIVATION_PER_WORKER_CAP = 2;
 const SUPERVISOR_CONFIG_FILE_NAME = "supervisor-config";
 const WORKER_STARTUP_GATE_FD = 3;
+const PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES = 100;
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -497,12 +498,16 @@ export function idleEvictionSweepIntervalMs(idleEvictionMinutes: IdleEvictionMin
 	);
 }
 
-function workerSocketPath(supervisorSocketPath: string, workerId: string): string {
+export function workerSocketPath(supervisorSocketPath: string, workerId: string): string {
 	const key = descriptorKey(supervisorSocketPath);
 	if (process.platform === "win32") {
 		return `\\\\.\\pipe\\prime-agent-worker-${key}-${workerId.slice(0, 12)}`;
 	}
-	return join(defaultDaemonSocketDir(), `worker-${key}-${workerId.slice(0, 12)}.sock`);
+	const socketPath = join(defaultDaemonWorkerSocketDir(), `worker-${key}-${workerId.slice(0, 12)}.sock`);
+	if (Buffer.byteLength(socketPath) > PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES) {
+		throw new Error(`Generated daemon worker socket path exceeds the portable Unix limit: ${socketPath}`);
+	}
+	return socketPath;
 }
 
 function looksLikeSessionPath(selector: string): boolean {
@@ -2102,7 +2107,10 @@ export class DaemonSupervisor {
 		};
 		const workerId = existing?.descriptor.workerId ?? createActiveSessionId();
 		const rootActiveSessionId = existing?.descriptor.rootActiveSessionId ?? createActiveSessionId();
-		const socketPath = existing?.descriptor.socketPath ?? workerSocketPath(this.socketPath, workerId);
+		const socketPath =
+			existing && process.platform === "win32"
+				? existing.descriptor.socketPath
+				: workerSocketPath(this.socketPath, workerId);
 		const token = existing?.descriptor.authenticationToken ?? randomBytes(32).toString("base64url");
 		const now = new Date().toISOString();
 		const descriptorPath = existing?.descriptorPath ?? join(this.descriptorDir, `${workerId}.json`);

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -16,12 +16,17 @@ import {
 	verifyHelloSupervisorPid,
 } from "../src/cli/daemon-ps.js";
 import { getProcessStartId } from "../src/core/session-lease.js";
-import { defaultDaemonSocketDir } from "../src/modes/daemon/daemon-socket.js";
+import { defaultDaemonSocketDir, defaultDaemonWorkerSocketDir } from "../src/modes/daemon/daemon-socket.js";
 
 describe("worker socket classification", () => {
-	it.runIf(process.platform !== "win32")("recognizes only worker sockets in the default service directory", () => {
-		expect(isWorkerSocketPath(join(defaultDaemonSocketDir(), "worker-abc.sock"))).toBe(true);
-		expect(isWorkerSocketPath(join(defaultDaemonSocketDir(), "daemon.sock"))).toBe(false);
+	it.runIf(process.platform !== "win32")("recognizes worker sockets in current and legacy service directories", () => {
+		for (const directory of new Set([defaultDaemonSocketDir(), defaultDaemonWorkerSocketDir()])) {
+			expect(isWorkerSocketPath(join(directory, "worker-abc.sock"))).toBe(true);
+			expect(isWorkerSocketPath(join(directory, "daemon.sock"))).toBe(false);
+			if (process.platform === "darwin" && (directory.startsWith("/tmp/") || directory.startsWith("/var/"))) {
+				expect(isWorkerSocketPath(join(`/private${directory}`, "worker-abc.sock"))).toBe(true);
+			}
+		}
 		expect(isWorkerSocketPath("/tmp/worker-abc.sock")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/daemon-worker-socket-path.test.ts
+++ b/packages/coding-agent/test/daemon-worker-socket-path.test.ts
@@ -1,0 +1,19 @@
+import { basename, dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { defaultDaemonWorkerSocketDir } from "../src/modes/daemon/daemon-socket.js";
+import { workerSocketPath } from "../src/modes/daemon/daemon-supervisor.js";
+
+describe.runIf(process.platform !== "win32")("Unix daemon worker socket paths", () => {
+	it("uses a fixed short per-user directory within the Unix socket path limit", () => {
+		const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
+		const socketPath = workerSocketPath(
+			"/var/folders/aa/0123456789012345678901234567/T/prime-agent-4294967295/daemon.sock",
+			"01234567-89ab-cdef-0123-456789abcdef",
+		);
+
+		expect(defaultDaemonWorkerSocketDir()).toBe(join("/tmp", `prime-agent-${suffix}`));
+		expect(dirname(socketPath)).toBe(defaultDaemonWorkerSocketDir());
+		expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(100);
+		expect(Buffer.byteLength(join("/tmp", "prime-agent-4294967295", basename(socketPath)))).toBeLessThanOrEqual(100);
+	});
+});


### PR DESCRIPTION
 Worker sockets were generated under $TMPDIR, which is long by default on macOS. Combined with the per-user directory, supervisor hash, worker ID, and socket filename, paths could exceed macOS’s 103-byte Unix socket limit. The worker then failed to bind, while the client only surfaced a 30-second daemon create
 timeout. Linux usually avoids this because $TMPDIR is /tmp, but custom long temporary paths could cause the same issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where workers bind and how recovery picks socket paths; misclassification could affect shutdown/discovery, but scope is limited to daemon IPC paths with tests covering limits and classification.
> 
> **Overview**
> Daemon **worker** Unix sockets are no longer created under `$TMPDIR` (which can be very long on macOS). They now use a fixed short per-user directory at `/tmp/prime-agent-<uid>`, while the main supervisor socket stays on `$TMPDIR`.
> 
> `workerSocketPath` enforces a **100-byte** path limit and errors if generation would exceed it. Socket dir setup was generalized so both the legacy supervisor dir and the new worker dir get the same ownership/mode checks. On Unix recovery, existing workers are **not** pinned to an old long path (Windows still reuses the stored path).
> 
> `daemon ps` treats worker sockets in **both** the new worker dir and the legacy `$TMPDIR` dir as workers, with macOS `/private` normalization so discovery/shutdown still filters them correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e8cc94258d55d24552e0220fd6f5d2b7f36e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worker socket paths in the coding agent daemon to be portable across platforms
> - Introduces `defaultDaemonWorkerSocketDir` in [daemon-socket.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/687/files#diff-59c4ea71700afcf7d09d14c5d30e2c73fd0c71b28284e8758cd8fbd4b2337dbc), placing Unix worker sockets in a per-user `/tmp/prime-agent-<uid>` directory instead of the shared daemon socket directory.
> - Updates `workerSocketPath` in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/687/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) to use the new per-user directory and enforces a 100-byte path limit (`PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES`) to stay within the Unix domain socket path constraint.
> - On Unix, the supervisor now always generates a fresh worker socket path on startup/recovery rather than reusing the stored path from an existing descriptor.
> - Updates `isWorkerSocketPath` in [daemon-ps.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/687/files#diff-d26d176c2fa21f2284ca0dc614dfb273ec8abfce710655afccc3aa35628c848a) to recognize sockets in both directories, with macOS `/private/tmp` normalization.
> - Behavioral Change: existing stored worker socket paths in descriptors are ignored on Unix after this change; a new path is always generated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49e8cc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->