### PR TITLE
fix(ai): drop Nemotron 3 Ultra from the Prime Inference catalog

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -154,8 +154,6 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"minimax/minimax-m3": { contextWindow: 524288 },
 	"moonshotai/kimi-k2-0905": { contextWindow: 98304 },
 	"nvidia/nemotron-3-super-120b-a12b": { contextWindow: 262144, maxTokens: 4096 },
-	// Preserve the existing output cap when OpenRouter leaves it unspecified.
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072, maxTokens: 16384 },
 	// Enforced window is LARGER than OpenRouter's listing.
 	"qwen/qwen3-30b-a3b-instruct-2507": { contextWindow: 262144 },
 	// OpenRouter has no max_completion_tokens for the rest of these.
@@ -206,10 +204,10 @@ const PRIME_INFERENCE_FEATURED_MODELS = new Set([
 	"z-ai/glm-5.2",
 ]);
 
-// Prime ids whose OpenRouter listing uses a different id.
-const PRIME_INFERENCE_OPENROUTER_ALIASES: Record<string, string> = {
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
-};
+// Prime ids whose OpenRouter listing uses a different id. Empty today — Prime
+// currently publishes ids that match OpenRouter's, but HF-style ids show up
+// whenever a new route is added, so the mapping stays.
+const PRIME_INFERENCE_OPENROUTER_ALIASES: Record<string, string> = {};
 
 // Conservative fallbacks for catalog models with no OpenRouter match and no
 // override above: an under-declared window degrades gracefully, an

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -135,11 +135,12 @@ interface PrimeInferenceModelMetadata {
 }
 
 // The full Prime Inference catalog is registered (minus raw/duplicate variants).
-// The /models endpoint publishes pricing only, so context/output limits and
-// modalities come from the OpenRouter catalog, which Prime routes most models
-// through. Entries here override OpenRouter where the Prime route enforces a
-// different limit (verified against the live API) or fill gaps for models
-// OpenRouter does not list or leaves incomplete.
+// Prime's /models endpoint publishes pricing only, so context/output limits and
+// modalities are read from OpenRouter's public catalog, used here purely as a
+// published spec sheet for the same upstream models — requests always go to
+// Prime's own baseUrl. Entries below override those specs where the Prime route
+// enforces a different limit (verified against the live API) or fill gaps for
+// models OpenRouter does not list or leaves incomplete.
 const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata> = {
 	// Verified 2026-07-08: these routes reject prompts above 200k tokens even
 	// though OpenRouter reports 1M. Every other Claude route accepted a >200k

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -142,14 +142,12 @@ interface PrimeInferenceModelMetadata {
 // enforces a different limit (verified against the live API) or fill gaps for
 // models OpenRouter does not list or leaves incomplete.
 const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata> = {
-	// Verified 2026-07-08: these routes reject prompts above 200k tokens even
-	// though OpenRouter reports 1M. Every other Claude route accepted a >200k
-	// prompt (opus-4.7/4.8, sonnet-4.6/5, fable-5 verified individually).
+	// These routes accept 200k, checked against the live API 2026-07-08. The
+	// other Claude routes take the full window their spec lists.
 	"anthropic/claude-sonnet-4": { contextWindow: 200000 },
 	"anthropic/claude-sonnet-4.5": { contextWindow: 200000 },
-	// Enforced windows measured against the live gateway 2026-07-08 where they
-	// are SMALLER than OpenRouter's listing — over-declaring breaks context
-	// tracking. (Measured by binary-searching the max_tokens reject boundary.)
+	// Windows confirmed against the live API 2026-07-08 where they are SMALLER
+	// than the published spec — over-declaring breaks context tracking.
 	"meta-llama/llama-3.2-1b-instruct": { contextWindow: 60000 },
 	"meta-llama/llama-3.2-3b-instruct": { contextWindow: 80000 },
 	"minimax/minimax-m3": { contextWindow: 524288 },

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -200,8 +200,8 @@ describe("Prime Inference models", () => {
 		expect(getModel("prime-inference", "anthropic/claude-sonnet-4.6").contextWindow).toBe(1000000);
 		expect(getModel("prime-inference", "anthropic/claude-sonnet-5").contextWindow).toBe(1000000);
 		expect(getModel("prime-inference", "anthropic/claude-haiku-4.5").contextWindow).toBe(200000);
-		// Empirically verified: this route rejects prompts above 200k tokens even
-		// though OpenRouter reports 1M for the upstream model.
+		// Confirmed against the live API: this route serves a 200k window, not the
+		// larger one the upstream model's published spec lists.
 		expect(getModel("prime-inference", "anthropic/claude-sonnet-4.5").contextWindow).toBe(200000);
 	});
 

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -94,9 +94,10 @@ describe("Prime Inference models", () => {
 		expect(gemini.input).toEqual(["text", "image"]);
 		expect(gemini.reasoning).toBe(true);
 
-		// Modality and reasoning come from OpenRouter, but the Prime route enforces
-		// a smaller window and output cap than OpenRouter lists (1M/16k), so the
-		// curated override wins for contextWindow and maxTokens.
+		// Modality and reasoning are read from OpenRouter's published spec for the
+		// same upstream model, but the Prime route enforces a smaller window and
+		// output cap than that spec lists (1M/16k), so the curated override wins
+		// for contextWindow and maxTokens.
 		const nemotronSuper = getModel("prime-inference", "nvidia/nemotron-3-super-120b-a12b");
 		expect(nemotronSuper.reasoning).toBe(true);
 		expect(nemotronSuper.input).toEqual(["text"]);

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -31,7 +31,6 @@ describe("Prime Inference models", () => {
 				"meta-llama/llama-4-maverick",
 				"minimax/minimax-m3",
 				"moonshotai/kimi-k2.7-code",
-				"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
 				"nvidia/nemotron-3-super-120b-a12b",
 				"openai/gpt-5.4",
 				"openai/gpt-5.5",
@@ -95,14 +94,14 @@ describe("Prime Inference models", () => {
 		expect(gemini.input).toEqual(["text", "image"]);
 		expect(gemini.reasoning).toBe(true);
 
-		// The HF-style ultra id maps onto OpenRouter's short id via alias for
-		// modality/reasoning, but the gateway enforces a 131k window (measured
-		// 2026-07-08), so the curated override wins for contextWindow. OpenRouter
-		// may omit its live output cap, in which case the conservative fallback wins.
-		const ultra = getModel("prime-inference", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B");
-		expect(ultra.contextWindow).toBe(131072);
-		expect(ultra.maxTokens).toBeGreaterThan(0);
-		expect(ultra.maxTokens).toBeLessThanOrEqual(ultra.contextWindow);
+		// Modality and reasoning come from OpenRouter, but the Prime route enforces
+		// a smaller window and output cap than OpenRouter lists (1M/16k), so the
+		// curated override wins for contextWindow and maxTokens.
+		const nemotronSuper = getModel("prime-inference", "nvidia/nemotron-3-super-120b-a12b");
+		expect(nemotronSuper.reasoning).toBe(true);
+		expect(nemotronSuper.input).toEqual(["text"]);
+		expect(nemotronSuper.contextWindow).toBe(262144);
+		expect(nemotronSuper.maxTokens).toBe(4096);
 
 		const maverick = getModel("prime-inference", "meta-llama/llama-4-maverick");
 		expect(maverick.contextWindow).toBe(1048576);


### PR DESCRIPTION
Prime Inference stopped serving `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`, so the catalog regenerated at build time no longer has it and main's CI broke — `tsgo` rejected the id in the test file and two assertions failed.

- Drop the id from the catalog membership test
- Move the "borrows OpenRouter metadata" assertions onto `nvidia/nemotron-3-super-120b-a12b`, which still exercises a curated override winning over OpenRouter's larger window
- Remove the now-dead curated metadata override and OpenRouter alias for the ultra route

Note: no `develop` branch in this repo, so this targets main.

https://claude.ai/code/session_01PBGG2dRqCeqordQk2E5ATW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and catalog-metadata cleanup only; no runtime request-path or auth changes.
> 
> **Overview**
> Removes **`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`** from the Prime Inference model set after the live catalog stopped serving it, which was breaking CI against the regenerated catalog.
> 
> In **`generate-models.ts`**, drops the curated metadata override and **OpenRouter id alias** that only existed for that ultra route, and leaves **`PRIME_INFERENCE_OPENROUTER_ALIASES`** empty with a note that it stays for future HF-style id mismatches. Comment tweaks clarify that OpenRouter is a spec sheet while traffic still goes to Prime’s base URL.
> 
> In **`prime-inference-models.test.ts`**, removes the ultra id from the catalog membership list and retargets the “borrows OpenRouter metadata / curated override wins” case to **`nvidia/nemotron-3-super-120b-a12b`** (262k context, 4096 max tokens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de39b5ada4624fd947233e320054d6daa7df05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->