### PR TITLE
fix(coding-agent): bootstrap IPython kernel venv with the Windows interpreter path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed IPython kernel bootstrap failing on Windows by selecting the venv interpreter at `Scripts\python.exe` instead of the POSIX `bin\python` layout.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -76,7 +76,8 @@ The Python side does not call providers or implement an agent loop.
 The kernel is created lazily on first IPython use. Python resolution is:
 
 1. `PRIME_AGENT_KERNEL_PYTHON`, when it can import `ipykernel`;
-2. `~/.prime/agent/kernel-venv/bin/python`, bootstrapped with `uv`; or
+2. the managed venv at `~/.prime/agent/kernel-venv` (interpreter at `bin/python` on
+   POSIX, `Scripts/python.exe` on Windows), bootstrapped with `uv`; or
 3. the XDG data location when `~/.prime` is not writable.
 
 The managed environment includes Python 3.11, `ipykernel`, and `prime-agent-runtime`. A bootstrap marker detects stale environments.

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -342,6 +342,11 @@ export function getKernelVenvDir(): string {
 	return path.join(os.homedir(), ".prime", "agent", "kernel-venv");
 }
 
+function kernelVenvPython(venv: string): string {
+	// The venv interpreter lives under Scripts/ on Windows and bin/ elsewhere.
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function getXdgKernelVenvDir(): string {
 	const dataHome = process.env.XDG_DATA_HOME
 		? path.resolve(expandHome(process.env.XDG_DATA_HOME))
@@ -725,7 +730,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = kernelVenvPython(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +891,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = kernelVenvPython(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_RLM_EXTRA_IMPORT_NAMES,
@@ -98,13 +98,15 @@ function writeFakePython(filePath: string, importableModules: readonly string[])
 	);
 }
 
-function installFakeUv(): string {
+function installFakeUv(win32 = false): string {
 	const binDir = join(tempDir, "bin");
 	mkdirSync(binDir, { recursive: true });
 	const logPath = join(tempDir, "uv.log");
 	const extraImportCases = DEFAULT_RLM_EXTRA_IMPORT_NAMES.map((moduleName) => `    "import ${moduleName}") exit 0 ;;`);
+	const venvBin = win32 ? "Scripts" : "bin";
+	const venvPython = win32 ? "python.exe" : "python";
 	process.env.UV_LOG = logPath;
-	process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
+	process.env.PATH = `${binDir}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`;
 	writeExecutable(
 		join(binDir, "uv"),
 		[
@@ -116,8 +118,8 @@ function installFakeUv(): string {
 			"fi",
 			'if [ "$1" = "venv" ]; then',
 			'  venv="$2"',
-			'  mkdir -p "$venv/bin"',
-			"  cat > \"$venv/bin/python\" <<'PY'",
+			`  mkdir -p "$venv/${venvBin}"`,
+			`  cat > "$venv/${venvBin}/${venvPython}" <<'PY'`,
 			"#!/bin/sh",
 			'if [ "$1" = "-c" ]; then',
 			'  case "$2" in',
@@ -129,7 +131,7 @@ function installFakeUv(): string {
 			"fi",
 			"exit 0",
 			"PY",
-			'  chmod +x "$venv/bin/python"',
+			`  chmod +x "$venv/${venvBin}/${venvPython}"`,
 			"  exit 0",
 			"fi",
 			'if [ "$1" = "pip" ]; then',
@@ -200,6 +202,26 @@ describe("kernel bootstrap", () => {
 			extraUvArgs: DEFAULT_RLM_EXTRA_UV_ARGS,
 			pythonSkills: [],
 		});
+		expect(version.runtime).toMatch(/^sha256:/);
+	});
+
+	it("bootstraps a missing venv with the Windows venv layout on win32", async () => {
+		const logPath = installFakeUv(true);
+		const venv = join(tempDir, "kernel-venv");
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32" });
+
+		try {
+			await expect(ensureKernelPython()).resolves.toBe(join(venv, "Scripts", "python.exe"));
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+		}
+
+		const log = readFileSync(logPath, "utf8");
+		expect(log).toContain(`venv ${venv} --python 3.11 --seed`);
+		expect(log).toContain("pip install --python");
+		const version = JSON.parse(readFileSync(join(venv, ".bootstrap-version"), "utf8"));
 		expect(version.runtime).toMatch(/^sha256:/);
 	});
 


### PR DESCRIPTION
﻿## Summary

Fixes IPython kernel bootstrap on Windows. The kernel bootstrapper hardcoded the POSIX venv interpreter path (`venv/bin/python`) in both `bootstrapVenv` and the resolution path in `ensureKernelPythonUncached`. On Windows a uv-created venv places the interpreter at `venv/Scripts/python.exe`, so `uv pip install --python <venv>/bin/python ...` failed with exit code 2 and the IPython tool could never start.

## Change

- Added a small `kernelVenvPython(venv)` helper that selects `Scripts\python.exe` on `win32` and `bin\python` elsewhere (mirroring the existing `process.platform === "win32"` pattern already used in this file).
- Used it in both places that need the venv interpreter path.
- Added a win32-layout test to `kernel-bootstrap.test.ts` (the fake uv now supports a Windows-style venv shape).
- Updated `docs/rlm-runtime.md` and a changelog entry.

The POSIX path is unchanged, so existing Linux/CI behavior is preserved (the helper returns `bin/python` when `process.platform` is not `win32`; existing tests assert that path and stay green).

## Testing

- `npm run check` pre-commit hook: biome + `tsgo --noEmit` pass.
- Manually verified the Windows path on a real Windows host: a patched install rebuilt the managed venv with the `Scripts\python.exe` layout, installed `ipykernel` + `prime-agent-runtime` + default packages, and a launched IPython kernel executed `print(6*7)` correctly.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix IPython kernel venv bootstrap to use `Scripts/python.exe` on Windows
> The venv interpreter path was hardcoded to the POSIX `bin/python` layout, causing bootstrap failures on Windows. A new `kernelVenvPython` helper in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/695/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) resolves to `venv/Scripts/python.exe` on `win32` and `venv/bin/python` otherwise. This path is now used consistently across pip installs, skill sync, and the `ensureKernelPython` readiness check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93eb5a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to kernel venv path resolution on Windows; POSIX paths are unchanged and covered by existing tests plus a new win32-layout test.
> 
> **Overview**
> **Fixes IPython kernel bootstrap on Windows** by resolving the managed venv interpreter through a new `kernelVenvPython()` helper instead of hardcoding POSIX `bin/python`.
> 
> Previously, `bootstrapVenv` and `ensureKernelPython` always pointed `uv pip install --python` at `venv/bin/python`, which does not exist on Windows (`Scripts\python.exe`). Bootstrap could fail before the kernel could start.
> 
> The helper picks `Scripts\python.exe` when `process.platform === "win32"` and `bin/python` otherwise; POSIX behavior is unchanged. Docs and changelog note the dual layout; tests cover the Windows path via a fake `uv` that creates a `Scripts` venv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93eb5a2b7fd85ad8d1d6d951bafe29713112c924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->