### PR TITLE
fix(ai): drop Nemotron 3 Ultra from the Prime Inference catalog

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -154,8 +154,6 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"minimax/minimax-m3": { contextWindow: 524288 },
 	"moonshotai/kimi-k2-0905": { contextWindow: 98304 },
 	"nvidia/nemotron-3-super-120b-a12b": { contextWindow: 262144, maxTokens: 4096 },
-	// Preserve the existing output cap when OpenRouter leaves it unspecified.
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072, maxTokens: 16384 },
 	// Enforced window is LARGER than OpenRouter's listing.
 	"qwen/qwen3-30b-a3b-instruct-2507": { contextWindow: 262144 },
 	// OpenRouter has no max_completion_tokens for the rest of these.
@@ -206,10 +204,10 @@ const PRIME_INFERENCE_FEATURED_MODELS = new Set([
 	"z-ai/glm-5.2",
 ]);
 
-// Prime ids whose OpenRouter listing uses a different id.
-const PRIME_INFERENCE_OPENROUTER_ALIASES: Record<string, string> = {
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
-};
+// Prime ids whose OpenRouter listing uses a different id. Empty today — Prime
+// currently publishes ids that match OpenRouter's, but HF-style ids show up
+// whenever a new route is added, so the mapping stays.
+const PRIME_INFERENCE_OPENROUTER_ALIASES: Record<string, string> = {};
 
 // Conservative fallbacks for catalog models with no OpenRouter match and no
 // override above: an under-declared window degrades gracefully, an

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -31,7 +31,6 @@ describe("Prime Inference models", () => {
 				"meta-llama/llama-4-maverick",
 				"minimax/minimax-m3",
 				"moonshotai/kimi-k2.7-code",
-				"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
 				"nvidia/nemotron-3-super-120b-a12b",
 				"openai/gpt-5.4",
 				"openai/gpt-5.5",
@@ -95,14 +94,14 @@ describe("Prime Inference models", () => {
 		expect(gemini.input).toEqual(["text", "image"]);
 		expect(gemini.reasoning).toBe(true);
 
-		// The HF-style ultra id maps onto OpenRouter's short id via alias for
-		// modality/reasoning, but the gateway enforces a 131k window (measured
-		// 2026-07-08), so the curated override wins for contextWindow. OpenRouter
-		// may omit its live output cap, in which case the conservative fallback wins.
-		const ultra = getModel("prime-inference", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B");
-		expect(ultra.contextWindow).toBe(131072);
-		expect(ultra.maxTokens).toBeGreaterThan(0);
-		expect(ultra.maxTokens).toBeLessThanOrEqual(ultra.contextWindow);
+		// Modality and reasoning come from OpenRouter, but the Prime route enforces
+		// a smaller window and output cap than OpenRouter lists (1M/16k), so the
+		// curated override wins for contextWindow and maxTokens.
+		const nemotronSuper = getModel("prime-inference", "nvidia/nemotron-3-super-120b-a12b");
+		expect(nemotronSuper.reasoning).toBe(true);
+		expect(nemotronSuper.input).toEqual(["text"]);
+		expect(nemotronSuper.contextWindow).toBe(262144);
+		expect(nemotronSuper.maxTokens).toBe(4096);
 
 		const maverick = getModel("prime-inference", "meta-llama/llama-4-maverick");
 		expect(maverick.contextWindow).toBe(1048576);


### PR DESCRIPTION
Prime Inference stopped serving `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`, so the catalog regenerated at build time no longer has it and main's CI broke — `tsgo` rejected the id in the test file and two assertions failed.

- Drop the id from the catalog membership test
- Move the "borrows OpenRouter metadata" assertions onto `nvidia/nemotron-3-super-120b-a12b`, which still exercises a curated override winning over the larger published spec
- Remove the now-dead curated metadata override and OpenRouter alias for that route

Comment wording cleanups that were in #694 are split into a follow-up PR.

https://claude.ai/code/session_01PBGG2dRqCeqordQk2E5ATW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and test-only changes for a model that is no longer served; no runtime auth or request-path changes.
> 
> **Overview**
> **Removes** `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B` from Prime Inference after the route stopped appearing in the live `/models` catalog, which was breaking CI (`tsgo` and catalog membership tests).
> 
> In `generate-models.ts`, deletes the curated **context/maxTokens** override and the **OpenRouter alias** that only existed for that HF-style id; `PRIME_INFERENCE_OPENROUTER_ALIASES` is now empty with a short comment that the mapping hook stays for future id mismatches.
> 
> Tests drop the ultra id from the expected catalog list and retarget the “OpenRouter metadata + curated override wins” case to **`nvidia/nemotron-3-super-120b-a12b`** (reasoning/input from OpenRouter, 262k/4096 from overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064384361b437f696e6458f2c8c7eeec0104aa8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->