### PR TITLE
fix(ai): drop delisted Prime Inference Nemotron Ultra references

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -154,8 +154,6 @@ const PRIME_INFERENCE_MODEL_METADATA: Record<string, PrimeInferenceModelMetadata
 	"minimax/minimax-m3": { contextWindow: 524288 },
 	"moonshotai/kimi-k2-0905": { contextWindow: 98304 },
 	"nvidia/nemotron-3-super-120b-a12b": { contextWindow: 262144, maxTokens: 4096 },
-	// Preserve the existing output cap when OpenRouter leaves it unspecified.
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": { contextWindow: 131072, maxTokens: 16384 },
 	// Enforced window is LARGER than OpenRouter's listing.
 	"qwen/qwen3-30b-a3b-instruct-2507": { contextWindow: 262144 },
 	// OpenRouter has no max_completion_tokens for the rest of these.
@@ -208,7 +206,6 @@ const PRIME_INFERENCE_FEATURED_MODELS = new Set([
 
 // Prime ids whose OpenRouter listing uses a different id.
 const PRIME_INFERENCE_OPENROUTER_ALIASES: Record<string, string> = {
-	"nvidia/nvidia-nemotron-3-ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
 };
 
 // Conservative fallbacks for catalog models with no OpenRouter match and no

--- a/packages/ai/test/prime-inference-models.test.ts
+++ b/packages/ai/test/prime-inference-models.test.ts
@@ -31,7 +31,6 @@ describe("Prime Inference models", () => {
 				"meta-llama/llama-4-maverick",
 				"minimax/minimax-m3",
 				"moonshotai/kimi-k2.7-code",
-				"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
 				"nvidia/nemotron-3-super-120b-a12b",
 				"openai/gpt-5.4",
 				"openai/gpt-5.5",
@@ -94,15 +93,6 @@ describe("Prime Inference models", () => {
 		expect(gemini.maxTokens).toBe(65536);
 		expect(gemini.input).toEqual(["text", "image"]);
 		expect(gemini.reasoning).toBe(true);
-
-		// The HF-style ultra id maps onto OpenRouter's short id via alias for
-		// modality/reasoning, but the gateway enforces a 131k window (measured
-		// 2026-07-08), so the curated override wins for contextWindow. OpenRouter
-		// may omit its live output cap, in which case the conservative fallback wins.
-		const ultra = getModel("prime-inference", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B");
-		expect(ultra.contextWindow).toBe(131072);
-		expect(ultra.maxTokens).toBeGreaterThan(0);
-		expect(ultra.maxTokens).toBeLessThanOrEqual(ultra.contextWindow);
 
 		const maverick = getModel("prime-inference", "meta-llama/llama-4-maverick");
 		expect(maverick.contextWindow).toBe(1048576);


### PR DESCRIPTION
## Problem

CI and the Release Prime Agent workflow are red on `main` since 2026-08-05 ~22:20 UTC (first red on an unrelated commit, #637). The `packages/ai` build regenerates `src/models.generated.ts` from the **live** provider catalogs, and Prime Inference has delisted `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B` (verified against `api.pinference.ai/api/v1/models`: only the Nemotron 3 Nano/Super variants remain). The checked-in tests still reference the delisted literal, so on every fresh build:

- `tsgo --noEmit` fails with `TS2345: Argument of type '"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"' is not assignable ...` → **Build and check** job and the release workflow's **build** job fail (publish is skipped, so the beta channel has not advanced either)
- `Test (ai)` fails: the catalog-membership assertion no longer matches, and `getModel("prime-inference", <ultra id>)` returns `undefined` → `TypeError: Cannot read properties of undefined (reading 'contextWindow')`

Same failure mode as #612 (groq delisting `qwen/qwen3-32b`), one layer up.

## Fix

Drop the dead references — mirrors the #612 approach:

- `prime-inference-models.test.ts`: remove the Ultra id from the catalog-membership `arrayContaining` list and remove the Ultra block from the "borrows OpenRouter metadata" test (the Gemini/Maverick assertions keep covering that path; the Ultra was the only model exercising the HF-id → OpenRouter-short-id alias)
- `generate-models.ts`: remove the Ultra's curated metadata entry and its now-only OpenRouter alias entry (map intentionally left in place for future id mismatches)

The committed `models.generated.ts` snapshot is deliberately **not** regenerated in this PR — the build regenerates it from the live catalog, so CI and releases pick up current data regardless; keeping the diff minimal avoids conflicts with in-flight PRs. A full snapshot refresh can land as a separate chore (as with #561).

## Validation

Ran locally against the live catalog at the current `main` HEAD (c22549a37):

- `npm run build` ✅ (regenerates the catalog; Ultra no longer present)
- `npm run check` ✅ (biome + `tsgo --noEmit` + installer/browser smoke)
- `packages/ai`: `npm test` ✅ — 48 files, 315 tests passed (incl. all 10 `prime-inference-models` tests)

## Release impact

None. No version bump, no installer/release-config changes, `stable` channel pointer untouched. On merge, the Release Prime Agent workflow will simply resume its normal per-push behavior: build → publish a new beta pre-release. Production (`stable`) installs are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and generator cleanup for a delisted model id; no runtime behavior change beyond aligning with the live Prime catalog.
> 
> **Overview**
> Removes **Nemotron 3 Ultra** (`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`) from Prime Inference model generation and tests after Prime delisted it from the live catalog.
> 
> In `generate-models.ts`, the curated **context/max token** override and the **OpenRouter id alias** for that HF-style id are deleted; the alias map stays empty for future mismatches. In `prime-inference-models.test.ts`, the model is dropped from the featured-catalog membership list and the **OpenRouter metadata** assertions that only covered the alias path are removed.
> 
> No committed `models.generated.ts` refresh in this PR—the build still regenerates from the live API on CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65234b5b869e6dd43778fc7750d934ae5c681be9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove delisted Prime Inference Nemotron Ultra model from AI model registry
> Drops the `nvidia/nvidia-nemotron-3-ultra-550b-a55b` entry from the Prime Inference model metadata and OpenRouter alias maps in [generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/701/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c), and removes corresponding test assertions in [prime-inference-models.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/701/files#diff-6462d25872f543c52f27cfe6c81089527799a97772aba030f15340bd33bf77b2). The model was delisted from Prime Inference, so lookups for its context window, token limits, and OpenRouter alias will no longer resolve.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65234b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->