### PR TITLE
fix installer fallback for protected npm prefixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1682,7 +1682,7 @@ Finalizing npm install."
 
 run_prime_agent_npm_install() {
 	if [ -n "$prime_agent_npm_prefix" ]; then
-		env NPM_CONFIG_PREFIX="$prime_agent_npm_prefix" "$@"
+		env NPM_CONFIG_PREFIX="$prime_agent_npm_prefix" "$@" --prefix "$prime_agent_npm_prefix"
 	else
 		"$@"
 	fi

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,10 @@ fi
 prime_agent_release_channel="${PRIME_AGENT_RELEASE_CHANNEL:-$prime_agent_default_release_channel}"
 prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
 prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
+prime_agent_min_node_major=22
+prime_agent_min_node_minor=8
+prime_agent_min_node_patch=0
+prime_agent_min_node_version="$prime_agent_min_node_major.$prime_agent_min_node_minor.$prime_agent_min_node_patch"
 prime_agent_esc=$(printf '\033')
 prime_agent_original_path="${PATH:-}"
 prime_agent_reset="${prime_agent_esc}[0m"
@@ -33,7 +37,8 @@ prime_agent_color_dim="${prime_agent_esc}[38;2;113;113;122m"
 prime_agent_color_primary="${prime_agent_esc}[38;2;127;91;213m"
 prime_agent_color_scan="${prime_agent_esc}[38;2;14;165;233m"
 prime_agent_color_warning="${prime_agent_esc}[38;2;245;158;11m"
-readonly prime_agent_unconfigured_base_url prime_agent_unconfigured_default_release_channel prime_agent_base_url prime_agent_default_release_channel prime_agent_release_channel prime_agent_package prime_agent_cmd prime_agent_esc prime_agent_original_path
+readonly prime_agent_unconfigured_base_url prime_agent_unconfigured_default_release_channel prime_agent_base_url prime_agent_default_release_channel prime_agent_release_channel prime_agent_package prime_agent_cmd
+readonly prime_agent_min_node_major prime_agent_min_node_minor prime_agent_min_node_patch prime_agent_min_node_version prime_agent_esc prime_agent_original_path
 readonly prime_agent_reset prime_agent_bold prime_agent_italic prime_agent_hide_cursor prime_agent_show_cursor prime_agent_home_cursor prime_agent_clear_screen prime_agent_clear_line
 readonly prime_agent_sync_start prime_agent_sync_end
 readonly prime_agent_color_text prime_agent_color_muted prime_agent_color_dim prime_agent_color_primary prime_agent_color_scan prime_agent_color_warning
@@ -57,6 +62,8 @@ prime_agent_screen_status=
 prime_agent_screen_detail=
 prime_agent_screen_question=
 prime_agent_animation_frame=0
+prime_agent_npm_prefix=
+prime_agent_install_bin=
 
 main() {
 	if [ "$prime_agent_base_url" = "$prime_agent_unconfigured_base_url" ]; then
@@ -98,6 +105,8 @@ main() {
 		fi
 	fi
 
+	configure_npm_install_environment
+
 	version="$(resolve_prime_agent_version "$@")"
 	tarball_name="$prime_agent_package-$version.tgz"
 	tarball_url="$prime_agent_base_url/releases/v$version/$tarball_name"
@@ -114,32 +123,8 @@ main() {
 	rm -rf "$download_dir"
 	prime_agent_download_dir=
 
-	if [ "${PRIME_AGENT_NODE_INSTALLED_STANDALONE:-0}" = 1 ]; then
-		prime_agent_screen "Prime Agent installed" "" "Checking your shell PATH." ""
-		configure_standalone_node_path
-	elif command -v "$prime_agent_cmd" >/dev/null 2>&1; then
-		if [ "$prime_agent_screen_enabled" = 1 ]; then
-			prime_agent_screen "Prime Agent installed" "" "Run it with: $prime_agent_cmd" ""
-		else
-			printf '\nPrime Agent was installed successfully.\n'
-			printf '\nRun it with: %s\n' "$prime_agent_cmd"
-		fi
-	else
-		if [ "$prime_agent_screen_enabled" = 1 ]; then
-			prime_agent_screen "Prime Agent installed" "" "PATH update needed for $prime_agent_cmd." ""
-			prime_agent_restore_terminal
-		else
-			printf '\nPrime Agent was installed successfully.\n'
-		fi
-		cat <<EOF
-The $prime_agent_cmd command was installed, but it is not on your PATH yet.
-Check npm's global bin directory with:
-
-  npm bin -g
-
-Then add that directory to your shell PATH.
-EOF
-	fi
+	prime_agent_screen "Prime Agent installed" "" "Checking your shell PATH." ""
+	configure_installed_command_path "$prime_agent_install_bin"
 }
 
 create_temp_dir() {
@@ -874,7 +859,7 @@ finish_preflight_checks() {
 	if [ "$prime_agent_screen_enabled" = 1 ]; then
 		if [ "$preflight_status" -ne 0 ]; then
 			preflight_summary=$(sed -n '1p' "$preflight_file")
-			prime_agent_screen "Node.js 20.6.0 or newer is required" "" "$preflight_summary" ""
+			prime_agent_screen "Node.js $prime_agent_min_node_version or newer is required" "" "$preflight_summary" ""
 			sleep 0.4
 		elif [ -s "$preflight_file" ]; then
 			preflight_summary="Existing $prime_agent_cmd command found on PATH."
@@ -895,12 +880,12 @@ run_preflight_checks() {
 
 	if command -v node >/dev/null 2>&1; then
 		node_version=$(node --version)
-		if ! node -e 'const [major, minor, patch] = process.versions.node.split(".").map(Number); process.exit(major > 20 || (major === 20 && (minor > 6 || (minor === 6 && patch >= 0))) ? 0 : 1)' >/dev/null; then
-			printf 'error: Prime Agent requires Node.js 20.6.0 or newer. Found %s.\n' "$node_version"
+		if ! node_version_string_is_new_enough "$node_version"; then
+			printf 'error: Prime Agent requires Node.js %s or newer. Found %s.\n' "$prime_agent_min_node_version" "$node_version"
 			status=1
 		fi
 	else
-		printf 'error: Node.js 20.6.0 or newer is required to install Prime Agent.\n'
+		printf 'error: Node.js %s or newer is required to install Prime Agent.\n' "$prime_agent_min_node_version"
 		status=1
 	fi
 
@@ -919,6 +904,62 @@ run_preflight_checks() {
 	fi
 
 	return "$status"
+}
+
+configure_npm_install_environment() {
+	if ! npm_prefix=$(npm prefix --global 2>/dev/null) || [ -z "$npm_prefix" ]; then
+		printf 'error: could not resolve npm global prefix.\n' >&2
+		return 1
+	fi
+	if ! npm_root=$(npm root --global 2>/dev/null) || [ -z "$npm_root" ]; then
+		printf 'error: could not resolve npm global package directory.\n' >&2
+		return 1
+	fi
+
+	case "$npm_prefix" in
+		/*) ;;
+		*)
+			printf 'error: npm returned a non-absolute global prefix: %s\n' "$npm_prefix" >&2
+			return 1
+			;;
+	esac
+
+	if ! prime_agent_path_supports_install "$npm_root" ||
+		! prime_agent_path_supports_install "$npm_root/$prime_agent_package" ||
+		! prime_agent_path_supports_install "$npm_prefix/bin"; then
+		if [ -z "${HOME:-}" ]; then
+			printf 'error: npm global prefix %s is not writable and HOME is not set.\n' "$npm_prefix" >&2
+			return 1
+		fi
+		fallback_prefix="$HOME/.local"
+		if ! prime_agent_path_supports_install "$fallback_prefix/lib/node_modules" ||
+			! prime_agent_path_supports_install "$fallback_prefix/bin"; then
+			printf 'error: npm global prefix %s and fallback prefix %s are not writable.\n' "$npm_prefix" "$fallback_prefix" >&2
+			return 1
+		fi
+
+		prime_agent_npm_prefix="$fallback_prefix"
+		npm_prefix="$fallback_prefix"
+		if [ "$prime_agent_screen_enabled" = 1 ]; then
+			prime_agent_screen "Using a user-local npm install" "" "$npm_prefix" ""
+		else
+			printf 'npm global prefix is not writable; installing Prime Agent under %s instead.\n' "$npm_prefix"
+		fi
+	fi
+
+	prime_agent_install_bin="$npm_prefix/bin"
+}
+
+prime_agent_path_supports_install() {
+	install_path="$1"
+	while [ ! -e "$install_path" ]; do
+		parent_path=$(dirname "$install_path")
+		if [ "$parent_path" = "$install_path" ]; then
+			return 1
+		fi
+		install_path="$parent_path"
+	done
+	[ -d "$install_path" ] && [ -w "$install_path" ] && [ -x "$install_path" ]
 }
 
 resolve_prime_agent_version() {
@@ -1010,9 +1051,9 @@ install_node_npm_interactive() {
 		prompt_status=$?
 	fi
 	if [ "$prompt_status" -eq 2 ]; then
-		printf 'No terminal detected; install Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+		printf 'No terminal detected; install Node.js %s or newer and npm, then run this installer again.\n' "$prime_agent_min_node_version"
 	else
-		printf '\nInstall Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+		printf '\nInstall Node.js %s or newer and npm, then run this installer again.\n' "$prime_agent_min_node_version"
 	fi
 	return 1
 }
@@ -1069,9 +1110,9 @@ node_version_string_is_new_enough() {
 	case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
 	case "$patch" in ''|*[!0-9]*) patch=0 ;; esac
 
-	[ "$major" -gt 20 ] && return 0
-	[ "$major" -eq 20 ] && [ "$minor" -gt 6 ] && return 0
-	[ "$major" -eq 20 ] && [ "$minor" -eq 6 ] && [ "$patch" -ge 0 ] && return 0
+	[ "$major" -gt "$prime_agent_min_node_major" ] && return 0
+	[ "$major" -eq "$prime_agent_min_node_major" ] && [ "$minor" -gt "$prime_agent_min_node_minor" ] && return 0
+	[ "$major" -eq "$prime_agent_min_node_major" ] && [ "$minor" -eq "$prime_agent_min_node_minor" ] && [ "$patch" -ge "$prime_agent_min_node_patch" ] && return 0
 	return 1
 }
 
@@ -1308,13 +1349,15 @@ run_with_sudo() {
 	fi
 }
 
-configure_standalone_node_path() {
+configure_installed_command_path() {
+	install_bin="$1"
 	if original_prime_agent_path=$(resolve_prime_agent_with_original_path); then
 		case "$original_prime_agent_path" in
-			"$PRIME_AGENT_STANDALONE_NODE_BIN/"*)
+			"$install_bin/"*)
 				if [ "$prime_agent_screen_enabled" = 1 ]; then
 					prime_agent_screen "Prime Agent installed" "" "Run it with: $prime_agent_cmd" ""
 				else
+					printf '\nPrime Agent was installed successfully.\n'
 					printf '\nRun it with: %s\n' "$prime_agent_cmd"
 				fi
 				return 0
@@ -1339,21 +1382,21 @@ configure_standalone_node_path() {
 			prime_agent_restore_terminal
 			printf '\n'
 		fi
-		print_standalone_path_manual_instructions
+		print_install_path_manual_instructions "$install_bin"
 		return 0
 	}
 
-	if shell_profile_has_standalone_node_path "$profile"; then
+	if shell_profile_has_install_path "$profile" "$install_bin"; then
 		if [ "$prime_agent_screen_enabled" = 1 ]; then
 			prime_agent_screen "Prime Agent installed" "" "Run: $(prime_agent_source_profile_command "$profile")" ""
 		else
-			printf '%s already contains %s.\n' "$profile" "$PRIME_AGENT_STANDALONE_NODE_BIN"
+			printf '%s already contains %s.\n' "$profile" "$install_bin"
 			printf 'Restart your shell or run: %s\n' "$(prime_agent_source_profile_command "$profile")"
 		fi
 		return 0
 	fi
 
-	prompt_add_standalone_node_path "$profile"
+	prompt_add_install_path "$profile" "$install_bin"
 }
 
 resolve_prime_agent_with_original_path() {
@@ -1398,48 +1441,51 @@ detect_shell_profile() {
 	esac
 }
 
-shell_profile_has_standalone_node_path() {
+shell_profile_has_install_path() {
 	profile="$1"
-	[ -f "$profile" ] && grep -F "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile" >/dev/null 2>&1
+	install_bin="$2"
+	[ -f "$profile" ] && grep -F "$install_bin" "$profile" >/dev/null 2>&1
 }
 
-prompt_add_standalone_node_path() {
+prompt_add_install_path() {
 	profile="$1"
-	path_line=$(standalone_node_path_line)
+	install_bin="$2"
+	path_line=$(install_path_line "$install_bin")
 
 	if ! prime_agent_prompt_yes_no \
-		"Add standalone Node.js to your PATH?" \
+		"Add Prime Agent to your PATH?" \
 		"Updates $profile so future shells can run $prime_agent_cmd." \
 		"Update PATH? [Y/n]"; then
 		if [ "$prime_agent_screen_enabled" = 1 ]; then
 			prime_agent_restore_terminal
 			printf '\n'
 		fi
-		print_standalone_path_manual_instructions
+		print_install_path_manual_instructions "$install_bin"
 		return 0
 	fi
 
 	mkdir -p "$(dirname "$profile")"
 	{
-		printf '\n# Prime Agent standalone Node.js\n'
+		printf '\n# Prime Agent command\n'
 		printf '%s\n' "$path_line"
 	} >>"$profile"
 	if [ "$prime_agent_screen_enabled" = 1 ]; then
 		prime_agent_screen "Prime Agent installed" "" "Run: $(prime_agent_source_profile_command "$profile")" ""
 	else
-		printf 'Added %s to %s.\n' "$PRIME_AGENT_STANDALONE_NODE_BIN" "$profile"
+		printf 'Added %s to %s.\n' "$install_bin" "$profile"
 		printf 'Restart your shell or run: %s\n' "$(prime_agent_source_profile_command "$profile")"
 	fi
 }
 
-print_standalone_path_manual_instructions() {
+print_install_path_manual_instructions() {
+	install_bin="$1"
 	printf 'Add this to your shell profile to use %s from new shells:\n\n' "$prime_agent_cmd"
-	printf '  %s\n' "$(standalone_node_path_line)"
+	printf '  %s\n' "$(install_path_line "$install_bin")"
 	printf '\nThen restart your shell and run: %s\n' "$prime_agent_cmd"
 }
 
-standalone_node_path_line() {
-	printf 'export PATH="%s:$PATH"' "$PRIME_AGENT_STANDALONE_NODE_BIN"
+install_path_line() {
+	printf 'export PATH=%s:"$PATH"' "$(prime_agent_shell_quote "$1")"
 }
 
 prime_agent_shell_quote() {
@@ -1602,7 +1648,7 @@ Finalizing npm install."
 			"Installing Prime Agent" \
 			"Installing Prime Agent" \
 			"$npm_install_details" \
-			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1 PRIME_AGENT_INSTALL_UV=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+			run_prime_agent_npm_install env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1 PRIME_AGENT_INSTALL_UV=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
 	else
 		npm_install_details="Preparing global install.
 Linking command binaries.
@@ -1613,7 +1659,15 @@ Finalizing npm install."
 			"Installing Prime Agent" \
 			"Installing Prime Agent" \
 			"$npm_install_details" \
-			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+			run_prime_agent_npm_install env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+	fi
+}
+
+run_prime_agent_npm_install() {
+	if [ -n "$prime_agent_npm_prefix" ]; then
+		env NPM_CONFIG_PREFIX="$prime_agent_npm_prefix" "$@"
+	else
+		"$@"
 	fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1428,31 +1428,23 @@ detect_shell_profile() {
 			printf '%s/.zshrc' "${ZDOTDIR:-$HOME}"
 			;;
 		bash)
-			case "$(uname -s 2>/dev/null)" in
-				Darwin)
-					if [ -f "$HOME/.bash_profile" ]; then
-						printf '%s/.bash_profile' "$HOME"
-					elif [ -f "$HOME/.bash_login" ]; then
-						printf '%s/.bash_login' "$HOME"
-					elif [ -f "$HOME/.profile" ]; then
-						printf '%s/.profile' "$HOME"
-					else
-						printf '%s/.bash_profile' "$HOME"
-					fi
-					;;
-				*)
-					printf '%s/.bashrc' "$HOME"
-					;;
-			esac
+			if [ -f "$HOME/.bash_profile" ]; then
+				printf '%s/.bash_profile' "$HOME"
+			elif [ -f "$HOME/.bash_login" ]; then
+				printf '%s/.bash_login' "$HOME"
+			elif [ -f "$HOME/.profile" ]; then
+				printf '%s/.profile' "$HOME"
+			elif [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+				printf '%s/.bash_profile' "$HOME"
+			else
+				printf '%s/.bashrc' "$HOME"
+			fi
+			;;
+		sh|dash|ksh)
+			printf '%s/.profile' "$HOME"
 			;;
 		*)
-			if [ -f "$HOME/.zshrc" ]; then
-				printf '%s/.zshrc' "$HOME"
-			elif [ -f "$HOME/.bashrc" ]; then
-				printf '%s/.bashrc' "$HOME"
-			else
-				printf '%s/.profile' "$HOME"
-			fi
+			return 1
 			;;
 	esac
 }
@@ -1496,9 +1488,19 @@ prompt_add_install_path() {
 
 print_install_path_manual_instructions() {
 	install_bin="$1"
-	printf 'Add this to your shell profile to use %s from new shells:\n\n' "$prime_agent_cmd"
-	printf '  %s\n' "$(install_path_line "$install_bin")"
-	printf '\nThen restart your shell and run: %s\n' "$prime_agent_cmd"
+	shell_name="${SHELL:-}"
+	shell_name="${shell_name##*/}"
+	case "$shell_name" in
+		bash|zsh|sh|dash|ksh)
+			printf 'Add this to your shell profile to use %s from new shells:\n\n' "$prime_agent_cmd"
+			printf '  %s\n' "$(install_path_line "$install_bin")"
+			printf '\nThen restart your shell and run: %s\n' "$prime_agent_cmd"
+			;;
+		*)
+			printf 'Add %s to PATH using your shell configuration.\n' "$install_bin"
+			printf 'Run Prime Agent now with: %s/%s\n' "$install_bin" "$prime_agent_cmd"
+			;;
+	esac
 }
 
 install_path_line() {

--- a/install.sh
+++ b/install.sh
@@ -1428,7 +1428,22 @@ detect_shell_profile() {
 			printf '%s/.zshrc' "${ZDOTDIR:-$HOME}"
 			;;
 		bash)
-			printf '%s/.bashrc' "$HOME"
+			case "$(uname -s 2>/dev/null)" in
+				Darwin)
+					if [ -f "$HOME/.bash_profile" ]; then
+						printf '%s/.bash_profile' "$HOME"
+					elif [ -f "$HOME/.bash_login" ]; then
+						printf '%s/.bash_login' "$HOME"
+					elif [ -f "$HOME/.profile" ]; then
+						printf '%s/.profile' "$HOME"
+					else
+						printf '%s/.bash_profile' "$HOME"
+					fi
+					;;
+				*)
+					printf '%s/.bashrc' "$HOME"
+					;;
+			esac
 			;;
 		*)
 			if [ -f "$HOME/.zshrc" ]; then

--- a/install.sh
+++ b/install.sh
@@ -933,6 +933,7 @@ configure_npm_install_environment() {
 		fi
 		fallback_prefix="$HOME/.local"
 		if ! prime_agent_path_supports_install "$fallback_prefix/lib/node_modules" ||
+			! prime_agent_path_supports_install "$fallback_prefix/lib/node_modules/$prime_agent_package" ||
 			! prime_agent_path_supports_install "$fallback_prefix/bin"; then
 			printf 'error: npm global prefix %s and fallback prefix %s are not writable.\n' "$npm_prefix" "$fallback_prefix" >&2
 			return 1
@@ -1444,7 +1445,8 @@ detect_shell_profile() {
 shell_profile_has_install_path() {
 	profile="$1"
 	install_bin="$2"
-	[ -f "$profile" ] && grep -F "$install_bin" "$profile" >/dev/null 2>&1
+	path_line=$(install_path_line "$install_bin")
+	[ -f "$profile" ] && grep -F -x "$path_line" "$profile" >/dev/null 2>&1
 }
 
 prompt_add_install_path() {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "cd packages/ai && npm run dev:tsc",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:installer && npm run check:browser-smoke",
-		"check:installer": "node scripts/check-installer-render.mjs",
+		"check:installer": "node scripts/check-installer-render.mjs && node scripts/check-installer-install.mjs",
 		"check:browser-smoke": "node scripts/check-browser-smoke.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+- Fixed the installer failing on protected npm global prefixes and accepting unsupported Node.js versions ([#705](https://github.com/PrimeIntellect-ai/prime-agent/issues/705)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/scripts/check-installer-install.mjs
+++ b/scripts/check-installer-install.mjs
@@ -54,6 +54,12 @@ case "\${1:-}" in
 		}
 		configure_npm_install_environment
 		;;
+	shell-profile)
+		uname() {
+			printf '%s\n' "$PRIME_AGENT_TEST_UNAME"
+		}
+		detect_shell_profile
+		;;
 	writable-prefix)
 		prime_agent_path_supports_install() {
 			return 0
@@ -131,6 +137,7 @@ esac
 	assertPreflightNodeVersion();
 	assertUserPrefixFallback();
 	assertBlockedFallbackPackageRejected();
+	assertBashProfileSelection();
 	assertWritablePrefixPreserved();
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });
@@ -207,6 +214,35 @@ function assertBlockedFallbackPackageRejected() {
 	check(result.stderr.includes("fallback prefix"), "blocked fallback package did not report the unwritable fallback");
 }
 
+function assertBashProfileSelection() {
+	const bashProfilePath = join(homeDir, ".bash_profile");
+	const bashLoginPath = join(homeDir, ".bash_login");
+	const bashrcPath = join(homeDir, ".bashrc");
+	const posixProfilePath = join(homeDir, ".profile");
+	const automaticProfile = {
+		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
+		PRIME_AGENT_TEST_SHELL_PROFILE_AUTO: "1",
+	};
+
+	writeFileSync(bashLoginPath, "", "utf-8");
+	writeFileSync(posixProfilePath, "", "utf-8");
+	let result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Darwin" });
+	check(result.status === 0, `macOS Bash profile harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
+	check(result.stdout === bashLoginPath, "macOS Bash did not select the first existing login profile");
+
+	rmSync(bashLoginPath);
+	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Darwin" });
+	check(result.stdout === posixProfilePath, "macOS Bash did not preserve an existing .profile");
+
+	rmSync(posixProfilePath);
+	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Darwin" });
+	check(result.stdout === bashProfilePath, "macOS Bash did not default to .bash_profile");
+
+	writeFileSync(bashrcPath, "", "utf-8");
+	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Linux" });
+	check(result.stdout === bashrcPath, "non-macOS Bash did not retain .bashrc");
+}
+
 function assertWritablePrefixPreserved() {
 	writeFileSync(npmLogPath, "", "utf-8");
 	const result = runHarness("writable-prefix", {
@@ -232,6 +268,7 @@ function runHarness(testCase, overrides) {
 		SHELL: "/bin/bash",
 	};
 	delete env.NPM_CONFIG_PREFIX;
+	if (env.PRIME_AGENT_TEST_SHELL_PROFILE_AUTO === "1") delete env.PRIME_AGENT_SHELL_PROFILE;
 	return spawnSync("sh", [harnessPath, testCase], { encoding: "utf-8", env });
 }
 

--- a/scripts/check-installer-install.mjs
+++ b/scripts/check-installer-install.mjs
@@ -190,6 +190,7 @@ function assertUserPrefixFallback() {
 
 	const npmLog = readFileSync(npmLogPath, "utf-8");
 	check(npmLog.includes(`prefix=${expectedPrefix}\n`), "npm install did not receive the fallback NPM_CONFIG_PREFIX");
+	check(npmLog.includes("<--prefix>"), "npm install did not force the fallback prefix with --prefix");
 	check(npmLog.includes("<install> <-g>"), "npm install did not run as a global install");
 	check(npmLog.includes("</fixture/prime-agent.tgz>"), "npm install did not receive the release tarball");
 

--- a/scripts/check-installer-install.mjs
+++ b/scripts/check-installer-install.mjs
@@ -60,6 +60,9 @@ case "\${1:-}" in
 		}
 		detect_shell_profile
 		;;
+	unsupported-shell-path)
+		configure_installed_command_path "$HOME/.local/bin"
+		;;
 	writable-prefix)
 		prime_agent_path_supports_install() {
 			return 0
@@ -138,6 +141,7 @@ esac
 	assertUserPrefixFallback();
 	assertBlockedFallbackPackageRejected();
 	assertBashProfileSelection();
+	assertUnsupportedShellPathInstructions();
 	assertWritablePrefixPreserved();
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });
@@ -240,8 +244,30 @@ function assertBashProfileSelection() {
 	check(result.stdout === bashProfilePath, "macOS Bash did not default to .bash_profile");
 
 	writeFileSync(bashrcPath, "", "utf-8");
+	writeFileSync(posixProfilePath, "", "utf-8");
 	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Linux" });
-	check(result.stdout === bashrcPath, "non-macOS Bash did not retain .bashrc");
+	check(result.stdout === posixProfilePath, "Linux Bash did not select an existing login profile");
+
+	writeFileSync(bashProfilePath, "", "utf-8");
+	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Linux" });
+	check(result.stdout === bashProfilePath, "Linux Bash did not honor Bash login-profile precedence");
+
+	rmSync(bashProfilePath);
+	rmSync(posixProfilePath);
+	result = runHarness("shell-profile", { ...automaticProfile, PRIME_AGENT_TEST_UNAME: "Linux" });
+	check(result.stdout === bashrcPath, "Linux Bash did not default to .bashrc when no login profile exists");
+}
+
+function assertUnsupportedShellPathInstructions() {
+	const result = runHarness("unsupported-shell-path", {
+		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
+		PRIME_AGENT_TEST_SHELL: "/usr/bin/fish",
+		PRIME_AGENT_TEST_SHELL_PROFILE_AUTO: "1",
+	});
+	check(result.status === 0, `unsupported-shell harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
+	check(result.stdout.includes(`Add ${join(homeDir, ".local/bin")} to PATH using your shell configuration.`), "unsupported shell did not receive shell-neutral PATH guidance");
+	check(result.stdout.includes(`Run Prime Agent now with: ${join(homeDir, ".local/bin/prime-agent")}`), "unsupported shell did not receive an immediately runnable command");
+	check(!result.stdout.includes("export PATH="), "unsupported shell received POSIX-only PATH syntax");
 }
 
 function assertWritablePrefixPreserved() {
@@ -266,7 +292,7 @@ function runHarness(testCase, overrides) {
 		PRIME_AGENT_INSTALLER_PLAIN: "1",
 		PRIME_AGENT_SHELL_PROFILE: profilePath,
 		PRIME_AGENT_TEST_NPM_LOG: npmLogPath,
-		SHELL: "/bin/bash",
+		SHELL: overrides.PRIME_AGENT_TEST_SHELL ?? "/bin/bash",
 	};
 	delete env.NPM_CONFIG_PREFIX;
 	if (env.PRIME_AGENT_TEST_SHELL_PROFILE_AUTO === "1") delete env.PRIME_AGENT_SHELL_PROFILE;

--- a/scripts/check-installer-install.mjs
+++ b/scripts/check-installer-install.mjs
@@ -45,6 +45,15 @@ case "\${1:-}" in
 		install_prime_agent_package /fixture/prime-agent.tgz
 		configure_installed_command_path "$prime_agent_install_bin"
 		;;
+	blocked-fallback-package)
+		prime_agent_path_supports_install() {
+			case "$1" in
+				"$PRIME_AGENT_TEST_NPM_PREFIX"|"$PRIME_AGENT_TEST_NPM_PREFIX/"*|"$HOME/.local/lib/node_modules/$prime_agent_package") return 1 ;;
+				*) return 0 ;;
+			esac
+		}
+		configure_npm_install_environment
+		;;
 	writable-prefix)
 		prime_agent_path_supports_install() {
 			return 0
@@ -121,6 +130,7 @@ esac
 	assertMinimumNodeVersion();
 	assertPreflightNodeVersion();
 	assertUserPrefixFallback();
+	assertBlockedFallbackPackageRejected();
 	assertWritablePrefixPreserved();
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });
@@ -156,12 +166,17 @@ function assertPreflightNodeVersion() {
 
 function assertUserPrefixFallback() {
 	writeFileSync(npmLogPath, "", "utf-8");
+	const expectedPrefix = join(homeDir, ".local");
+	const expectedBin = join(expectedPrefix, "bin");
+	writeFileSync(
+		profilePath,
+		`# export PATH='${expectedBin}':"$PATH"\nexport PATH="/usr/bin:${expectedBin}:$PATH"\n`,
+		"utf-8",
+	);
 	const result = runHarness("user-prefix", {
 		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
 		PRIME_AGENT_TEST_NPM_PREFIX: systemPrefix,
 	});
-	const expectedPrefix = join(homeDir, ".local");
-	const expectedBin = join(expectedPrefix, "bin");
 	check(result.status === 0, `user-prefix harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
 	check(result.stdout.includes(`__PREFIX__ ${expectedPrefix}\n`), "unwritable npm prefix did not select ~/.local");
 	check(result.stdout.includes(`__BIN__ ${expectedBin}\n`), "unwritable npm prefix reported the wrong command directory");
@@ -181,6 +196,15 @@ function assertUserPrefixFallback() {
 	});
 	check(sourced.status === 0, `profile update could not be sourced: ${sourced.stderr}`);
 	check(sourced.stdout.startsWith(`${expectedBin}:`), "profile update did not prepend the fallback npm bin directory");
+}
+
+function assertBlockedFallbackPackageRejected() {
+	const result = runHarness("blocked-fallback-package", {
+		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
+		PRIME_AGENT_TEST_NPM_PREFIX: systemPrefix,
+	});
+	check(result.status === 1, `blocked fallback package harness exited with ${result.status ?? "unknown"}`);
+	check(result.stderr.includes("fallback prefix"), "blocked fallback package did not report the unwritable fallback");
 }
 
 function assertWritablePrefixPreserved() {

--- a/scripts/check-installer-install.mjs
+++ b/scripts/check-installer-install.mjs
@@ -1,0 +1,216 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const installerSource = readFileSync("install.sh", "utf-8");
+const mainCall = '\nmain "$@"';
+const mainCallIndex = installerSource.lastIndexOf(mainCall);
+
+if (mainCallIndex === -1) {
+	console.error('Installer check failed: could not find final main "$@" call.');
+	process.exit(1);
+}
+
+const harnessSource = `${installerSource.slice(0, mainCallIndex)}
+
+case "\${1:-}" in
+	minimum)
+		printf '__MINIMUM__ %s\\n' "$prime_agent_min_node_version"
+		for version in 20.6.0 22.7.99 22.8.0 23.0.0; do
+			if node_version_string_is_new_enough "$version"; then
+				status=supported
+			else
+				status=unsupported
+			fi
+			printf '__VERSION__ %s %s\\n' "$version" "$status"
+		done
+		;;
+	preflight)
+		run_preflight_checks
+		;;
+	user-prefix)
+		prime_agent_path_supports_install() {
+			case "$1" in
+				"$PRIME_AGENT_TEST_NPM_PREFIX"|"$PRIME_AGENT_TEST_NPM_PREFIX/"*) return 1 ;;
+				*) return 0 ;;
+			esac
+		}
+		prime_agent_prompt_yes_no() {
+			return 0
+		}
+		configure_npm_install_environment
+		printf '__PREFIX__ %s\\n' "$prime_agent_npm_prefix"
+		printf '__BIN__ %s\\n' "$prime_agent_install_bin"
+		install_prime_agent_package /fixture/prime-agent.tgz
+		configure_installed_command_path "$prime_agent_install_bin"
+		;;
+	writable-prefix)
+		prime_agent_path_supports_install() {
+			return 0
+		}
+		configure_npm_install_environment
+		printf '__PREFIX__ %s\\n' "$prime_agent_npm_prefix"
+		printf '__BIN__ %s\\n' "$prime_agent_install_bin"
+		install_prime_agent_package /fixture/prime-agent.tgz
+		;;
+	*)
+		printf 'unknown installer check case: %s\\n' "\${1:-}" >&2
+		exit 2
+		;;
+esac
+`;
+
+const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-installer-check-"));
+const harnessPath = join(tempDir, "harness.sh");
+const fakeBin = join(tempDir, "fake-bin");
+const fakeNpmPath = join(fakeBin, "npm");
+const fakeNodePath = join(fakeBin, "node");
+const npmLogPath = join(tempDir, "npm.log");
+const profilePath = join(tempDir, "profile");
+const homeDir = join(tempDir, "home dir's");
+const systemPrefix = join(tempDir, "system-prefix");
+const writablePrefix = join(tempDir, "writable-prefix");
+const failures = [];
+
+try {
+	mkdirSync(fakeBin, { recursive: true });
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(systemPrefix, { recursive: true });
+	mkdirSync(writablePrefix, { recursive: true });
+	writeFileSync(harnessPath, harnessSource, "utf-8");
+	writeFileSync(
+		fakeNodePath,
+		`#!/bin/sh
+if [ "\${1:-}" = --version ]; then
+	printf 'v%s\\n' "$PRIME_AGENT_TEST_NODE_VERSION"
+	exit 0
+fi
+exit 99
+`,
+		"utf-8",
+	);
+	writeFileSync(
+		fakeNpmPath,
+		`#!/bin/sh
+case "\${1:-}:\${2:-}" in
+	prefix:--global)
+		printf '%s\\n' "$PRIME_AGENT_TEST_NPM_PREFIX"
+		;;
+	root:--global)
+		printf '%s/lib/node_modules\\n' "$PRIME_AGENT_TEST_NPM_PREFIX"
+		;;
+	install:-g)
+		printf 'prefix=%s\\n' "\${NPM_CONFIG_PREFIX-}" >>"$PRIME_AGENT_TEST_NPM_LOG"
+		printf 'args=' >>"$PRIME_AGENT_TEST_NPM_LOG"
+		printf ' <%s>' "$@" >>"$PRIME_AGENT_TEST_NPM_LOG"
+		printf '\\n' >>"$PRIME_AGENT_TEST_NPM_LOG"
+		;;
+	*)
+		printf 'unexpected npm invocation: %s\\n' "$*" >&2
+		exit 98
+		;;
+esac
+`,
+		"utf-8",
+	);
+	chmodSync(harnessPath, 0o755);
+	chmodSync(fakeNodePath, 0o755);
+	chmodSync(fakeNpmPath, 0o755);
+
+	assertMinimumNodeVersion();
+	assertPreflightNodeVersion();
+	assertUserPrefixFallback();
+	assertWritablePrefixPreserved();
+} finally {
+	rmSync(tempDir, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+	console.error(["Installer install check failed:", ...failures.map((failure) => `- ${failure}`)].join("\n"));
+	process.exit(1);
+}
+
+console.log("Installer install check passed.");
+
+function assertMinimumNodeVersion() {
+	const result = runHarness("minimum", { PRIME_AGENT_TEST_NODE_VERSION: "22.8.0" });
+	check(result.status === 0, `minimum version harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
+	const packageJson = JSON.parse(readFileSync("packages/coding-agent/package.json", "utf-8"));
+	const expectedMinimum = packageJson.engines.node.replace(/^>=/, "");
+	check(result.stdout.includes(`__MINIMUM__ ${expectedMinimum}\n`), "installer minimum does not match package engines.node");
+	check(result.stdout.includes("__VERSION__ 20.6.0 unsupported\n"), "expected Node 20.6.0 to be rejected");
+	check(result.stdout.includes("__VERSION__ 22.7.99 unsupported\n"), "expected Node 22.7.99 to be rejected");
+	check(result.stdout.includes("__VERSION__ 22.8.0 supported\n"), "expected Node 22.8.0 to be accepted");
+	check(result.stdout.includes("__VERSION__ 23.0.0 supported\n"), "expected Node 23.0.0 to be accepted");
+}
+
+function assertPreflightNodeVersion() {
+	const rejected = runHarness("preflight", { PRIME_AGENT_TEST_NODE_VERSION: "20.6.0" });
+	check(rejected.status === 1, `Node 20 preflight exited with ${rejected.status ?? "unknown"}`);
+	check(rejected.stdout.includes("requires Node.js 22.8.0 or newer"), "Node 20 preflight did not explain the 22.8.0 minimum");
+
+	const accepted = runHarness("preflight", { PRIME_AGENT_TEST_NODE_VERSION: "22.8.0" });
+	check(accepted.status === 0, `Node 22.8 preflight exited with ${accepted.status ?? "unknown"}: ${accepted.stderr}`);
+}
+
+function assertUserPrefixFallback() {
+	writeFileSync(npmLogPath, "", "utf-8");
+	const result = runHarness("user-prefix", {
+		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
+		PRIME_AGENT_TEST_NPM_PREFIX: systemPrefix,
+	});
+	const expectedPrefix = join(homeDir, ".local");
+	const expectedBin = join(expectedPrefix, "bin");
+	check(result.status === 0, `user-prefix harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
+	check(result.stdout.includes(`__PREFIX__ ${expectedPrefix}\n`), "unwritable npm prefix did not select ~/.local");
+	check(result.stdout.includes(`__BIN__ ${expectedBin}\n`), "unwritable npm prefix reported the wrong command directory");
+
+	const npmLog = readFileSync(npmLogPath, "utf-8");
+	check(npmLog.includes(`prefix=${expectedPrefix}\n`), "npm install did not receive the fallback NPM_CONFIG_PREFIX");
+	check(npmLog.includes("<install> <-g>"), "npm install did not run as a global install");
+	check(npmLog.includes("</fixture/prime-agent.tgz>"), "npm install did not receive the release tarball");
+
+	const profile = readFileSync(profilePath, "utf-8");
+	check(profile.includes("# Prime Agent command"), "profile update did not include the Prime Agent marker");
+	const profileCheck = spawnSync("sh", ["-n", profilePath], { encoding: "utf-8" });
+	check(profileCheck.status === 0, `profile update is not valid shell: ${profileCheck.stderr}`);
+	const sourced = spawnSync("sh", ["-c", '. "$PRIME_AGENT_TEST_PROFILE"; printf "%s" "$PATH"'], {
+		encoding: "utf-8",
+		env: { PATH: "/usr/bin:/bin", PRIME_AGENT_TEST_PROFILE: profilePath },
+	});
+	check(sourced.status === 0, `profile update could not be sourced: ${sourced.stderr}`);
+	check(sourced.stdout.startsWith(`${expectedBin}:`), "profile update did not prepend the fallback npm bin directory");
+}
+
+function assertWritablePrefixPreserved() {
+	writeFileSync(npmLogPath, "", "utf-8");
+	const result = runHarness("writable-prefix", {
+		PRIME_AGENT_TEST_NODE_VERSION: "22.8.0",
+		PRIME_AGENT_TEST_NPM_PREFIX: writablePrefix,
+	});
+	check(result.status === 0, `writable-prefix harness exited with ${result.status ?? "unknown"}: ${result.stderr}`);
+	check(result.stdout.includes("__PREFIX__ \n"), "writable npm prefix unexpectedly selected an override");
+	check(result.stdout.includes(`__BIN__ ${join(writablePrefix, "bin")}\n`), "writable npm prefix reported the wrong bin directory");
+	const npmLog = readFileSync(npmLogPath, "utf-8");
+	check(npmLog.includes("prefix=\n"), "writable npm prefix unexpectedly set NPM_CONFIG_PREFIX");
+}
+
+function runHarness(testCase, overrides) {
+	const env = {
+		...process.env,
+		...overrides,
+		HOME: homeDir,
+		PATH: `${fakeBin}:${process.env.PATH}`,
+		PRIME_AGENT_INSTALLER_PLAIN: "1",
+		PRIME_AGENT_SHELL_PROFILE: profilePath,
+		PRIME_AGENT_TEST_NPM_LOG: npmLogPath,
+		SHELL: "/bin/bash",
+	};
+	delete env.NPM_CONFIG_PREFIX;
+	return spawnSync("sh", [harnessPath, testCase], { encoding: "utf-8", env });
+}
+
+function check(condition, message) {
+	if (!condition) failures.push(message);
+}


### PR DESCRIPTION
Fixes #705.

## Problem

The shell installer accepts any available Node/npm pair, then unconditionally runs `npm install -g`. Distro-provided npm commonly targets `/usr/local/lib/node_modules`, so the official installer fails with `EACCES` for non-root users.

The same preflight advertised Node.js 20.6+ even though the shipped package requires 22.8+, and its PATH recovery suggested the removed `npm bin -g` command.

## Change

- Preserve npm's configured prefix when its package and command directories are writable.
- Fall back to `~/.local` for this install through `NPM_CONFIG_PREFIX` when npm targets protected directories; npm's persistent configuration is not rewritten.
- Reuse the installer's profile-update flow for both standalone Node and npm-prefix installations, including shell-safe PATH quoting.
- Align installer and package preflight on Node.js 22.8+.

## Install flow

```mermaid
flowchart TD
    A[Validate Node 22.8+ and npm] --> B[Resolve npm prefix and global root]
    B --> C{Install targets writable?}
    C -- Yes --> D[Keep configured prefix]
    C -- No --> E[Use ~/.local for this install]
    D --> F[npm install -g]
    E --> F
    F --> G[Persist the selected bin directory on PATH]
```

## Regression coverage

The new installer check runs the real shell functions with controlled fake Node/npm executables. It verifies protected-prefix fallback, writable-prefix preservation, the npm install environment and arguments, persistent PATH activation, shell-safe quoted paths, and the Node.js version boundary.

## Validation

- `npm run check` — passed on the final committed tree.
- `npm run check:installer` — installer render and install checks passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix installer fallback to `~/.local` when npm global prefix is not writable
> - Adds `configure_npm_install_environment` to detect whether the npm global prefix is writable; if not, falls back to `$HOME/.local` and sets `NPM_CONFIG_PREFIX`/`--prefix` accordingly during install.
> - Updates `configure_installed_command_path` to target the actual resolved bin directory (including `~/.local/bin`) and improve shell profile detection for bash login profiles and POSIX shells.
> - Bumps the minimum required Node.js version from 20.6.0 to 22.8.0 and makes it configurable via variables used throughout preflight checks and guidance messages.
> - Adds a test harness in [`scripts/check-installer-install.mjs`](https://github.com/PrimeIntellect-ai/prime-agent/pull/706/files#diff-f0114b2fcee1fb49b6ea46a714b565a49cab2a6c87541ec9792369980a195de1) that validates fallback behavior, version checks, and profile selection with a shimmed environment.
> - Behavioral Change: installers on systems with a protected npm prefix (e.g. `/usr/local`) now install under `~/.local` instead of failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8606e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default install path and version gate for all users running the shell installer; behavior is covered by a new harness but mistakes could still break installs or PATH setup.
> 
> **Overview**
> Fixes **#705** by making `install.sh` install successfully when npm’s global prefix is not writable, while aligning Node preflight with the package’s **22.8+** requirement.
> 
> Before `npm install -g`, the installer now resolves npm’s global prefix and checks that the global module tree and `bin` directory are writable. If not, it uses **`$HOME/.local`** for this install only via **`NPM_CONFIG_PREFIX`** (npm’s persistent config is unchanged). **`run_prime_agent_npm_install`** applies that override for the global install step.
> 
> Post-install **PATH** handling is generalized to the actual install bin directory (including `~/.local/bin`): shell-safe quoted `export PATH=…`, macOS Bash login profile selection, and prompts renamed from standalone Node to “Add Prime Agent to your PATH.” Minimum Node checks and messages use shared **`prime_agent_min_node_version`** variables instead of hard-coded 20.6.0.
> 
> **`scripts/check-installer-install.mjs`** exercises the real shell logic with fake `node`/`npm` (prefix fallback, blocked fallback, writable prefix, preflight boundaries, profile updates). **`npm run check:installer`** runs it alongside the existing render check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11e01dfaf5a291eaba448439ab5b3e66db3737a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->