### PR TITLE
fix(ai): normalize unknown provider stop reasons

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed provider stop/status normalization across Anthropic, Google/Vertex, OpenAI Responses/Azure/Codex, and Mistral ([#707](https://github.com/PrimeIntellect-ai/prime-agent/issues/707)). Unknown values now map to `error` instead of throwing or reporting success, preserve the raw value in `stopReasonRaw`, and use the existing structured failure path.
+- Fixed new provider stop and status values being reported as successful completions ([#707](https://github.com/PrimeIntellect-ai/prime-agent/issues/707)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Anthropic, Google/Vertex, OpenAI Responses/Azure, and Mistral to map unknown provider stop/status values to `error` instead of throwing or reporting success, preserving the raw value in `stopReasonRaw` and routing through the existing `StreamFailureError` path.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed Anthropic, Google/Vertex, OpenAI Responses/Azure, and Mistral to map unknown provider stop/status values to `error` instead of throwing or reporting success, preserving the raw value in `stopReasonRaw` and routing through the existing `StreamFailureError` path.
+- Fixed provider stop/status normalization across Anthropic, Google/Vertex, OpenAI Responses/Azure/Codex, and Mistral ([#707](https://github.com/PrimeIntellect-ai/prime-agent/issues/707)). Unknown values now map to `error` instead of throwing or reporting success, preserve the raw value in `stopReasonRaw`, and use the existing structured failure path.
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1273,7 +1273,9 @@ function mapStopReason(reason: Anthropic.Messages.StopReason | string): StopReas
 		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
 			return "error";
 		default:
-			// Handle unknown stop reasons gracefully (API may add new values)
-			throw new Error(`Unhandled stop reason: ${reason}`);
+			// Unknown stop reasons must not crash a valid stream or be reported as
+			// success; map to "error" so stopReasonRaw is preserved and the stream
+			// terminates via the structured failure path (streamFailureFromStopReason).
+			return "error";
 	}
 }

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -354,10 +354,10 @@ export function mapStopReason(reason: FinishReason): StopReason {
 		case FinishReason.UNEXPECTED_TOOL_CALL:
 		case FinishReason.NO_IMAGE:
 			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// Google may add finish reasons before the SDK enum is updated. Treat
+			// those values as structured failures; callers preserve the raw reason.
+			return "error";
 	}
 }
 

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -226,7 +226,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 
 				if (candidate?.finishReason) {
 					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
+					if (output.stopReason !== "error" && output.content.some((b) => b.type === "toolCall")) {
 						output.stopReason = "toolUse";
 					}
 					if (output.stopReason === "error") {

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -209,7 +209,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 
 				if (candidate?.finishReason) {
 					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
+					if (output.stopReason !== "error" && output.content.some((b) => b.type === "toolCall")) {
 						output.stopReason = "toolUse";
 					}
 					if (output.stopReason === "error") {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -634,6 +634,8 @@ function mapChatStopReason(reason: string | null): StopReason {
 		case "error":
 			return "error";
 		default:
-			return "stop";
+			// Unknown finish reasons must not be reported as successful completion;
+			// route them through the structured failure path with stopReasonRaw preserved.
+			return "error";
 	}
 }

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils/diagnostics.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -196,6 +197,9 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 
 					if (options?.signal?.aborted) {
 						throw new Error("Request was aborted");
+					}
+					if (output.stopReason === "error") {
+						throw streamFailureFromStopReason(output.stopReasonRaw);
 					}
 					stream.push({
 						type: "done",
@@ -523,9 +527,9 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 	}
 }
 
-function normalizeCodexStatus(status: unknown): CodexResponseStatus | undefined {
+function normalizeCodexStatus(status: unknown): CodexResponseStatus | string | undefined {
 	if (typeof status !== "string") return undefined;
-	return CODEX_RESPONSE_STATUSES.has(status as CodexResponseStatus) ? (status as CodexResponseStatus) : undefined;
+	return CODEX_RESPONSE_STATUSES.has(status as CodexResponseStatus) ? (status as CodexResponseStatus) : status;
 }
 
 // ============================================================================
@@ -1197,6 +1201,8 @@ async function processWebSocketStream(
 		);
 		if (options?.signal?.aborted) {
 			keepConnection = false;
+		} else if (output.stopReason === "error") {
+			throw streamFailureFromStopReason(output.stopReasonRaw);
 		} else if (useCachedContext && entry && output.responseId) {
 			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
 				includeSystemPrompt: false,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,7 +40,7 @@ import {
 } from "../utils/diagnostics.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { streamFailureFromStopReason } from "../utils/stream-failure.js";
+import { StreamFailureError, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -301,6 +301,9 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}
+			if (output.stopReason === "error") {
+				throw streamFailureFromStopReason(output.stopReasonRaw);
+			}
 
 			stream.push({ type: "done", reason: output.stopReason as "stop" | "length" | "toolUse", message: output });
 			stream.end();
@@ -490,7 +493,7 @@ class CodexProtocolError extends Error {
 }
 
 function isCodexNonTransportError(error: unknown): boolean {
-	return error instanceof CodexApiError || error instanceof CodexProtocolError;
+	return error instanceof CodexApiError || error instanceof CodexProtocolError || error instanceof StreamFailureError;
 }
 
 async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): AsyncGenerator<ResponseStreamEvent> {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,7 +40,12 @@ import {
 } from "../utils/diagnostics.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { StreamFailureError, streamFailureFromStopReason } from "../utils/stream-failure.js";
+import {
+	formatStreamFailureMessage,
+	recordStreamFailure,
+	StreamFailureError,
+	streamFailureFromStopReason,
+} from "../utils/stream-failure.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -313,7 +318,8 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
+			output.errorMessage = formatStreamFailureMessage(error);
+			recordStreamFailure(model, output, error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -1,4 +1,3 @@
-import type OpenAI from "openai";
 import type {
 	Tool as OpenAITool,
 	ResponseCreateParamsStreaming,
@@ -540,7 +539,7 @@ export async function processResponsesStream<TApi extends Api>(
 	}
 }
 
-function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): StopReason {
+function mapStopReason(status: string | undefined): StopReason {
 	if (!status) return "stop";
 	switch (status) {
 		case "completed":

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -554,9 +554,10 @@ function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): Sto
 		case "in_progress":
 		case "queued":
 			return "stop";
-		default: {
-			const _exhaustive: never = status;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// Unknown response statuses must not crash a valid stream or be reported
+			// as success; map to "error" so stopReasonRaw is preserved and the stream
+			// terminates via the structured failure path (streamFailureFromStopReason).
+			return "error";
 	}
 }

--- a/packages/ai/test/anthropic-unknown-stop-reason.test.ts
+++ b/packages/ai/test/anthropic-unknown-stop-reason.test.ts
@@ -1,0 +1,101 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamAnthropic } from "../src/providers/anthropic.js";
+
+function createSseResponse(events: Array<{ event: string; data: string }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createFakeAnthropicClient(response: Response): Anthropic {
+	return {
+		messages: {
+			create: () => ({
+				asResponse: async () => response,
+			}),
+		},
+	} as unknown as Anthropic;
+}
+
+const model = getModel("anthropic", "claude-haiku-4-5");
+
+describe("Anthropic unknown stop reason", () => {
+	it("terminates via the structured failure path instead of crashing and preserves the raw reason", async () => {
+		// A stop reason the SDK does not know yet. The stream delivered valid content,
+		// so it must not be reported as successful completion and must not throw an
+		// unhandled "Unhandled stop reason" error that bypasses stopReasonRaw.
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_unknown",
+						usage: {
+							input_tokens: 12,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "text", text: "" },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "text_delta", text: "Hello" },
+				}),
+			},
+			{
+				event: "content_block_stop",
+				data: JSON.stringify({ type: "content_block_stop", index: 0 }),
+			},
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "content_filter_v2" },
+					usage: {
+						input_tokens: 12,
+						output_tokens: 5,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				}),
+			},
+			{
+				event: "message_stop",
+				data: JSON.stringify({ type: "message_stop" }),
+			},
+		]);
+
+		const stream = streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }] },
+			{ client: createFakeAnthropicClient(response) },
+		);
+		const result = await stream.result();
+
+		// Not reported as successful completion.
+		expect(result.stopReason).toBe("error");
+		// The raw provider value is preserved for post-mortem instead of being lost.
+		expect(result.stopReasonRaw).toBe("content_filter_v2");
+		// The structured failure path classifies the reason instead of surfacing a
+		// raw "Unhandled stop reason: ..." implementation detail.
+		expect(result.errorMessage).not.toContain("Unhandled stop reason");
+	});
+});

--- a/packages/ai/test/google-unknown-stop-reason.test.ts
+++ b/packages/ai/test/google-unknown-stop-reason.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { mapStopReason } from "../src/providers/google-shared.js";
+
+describe("Google unknown finish reasons", () => {
+	it("maps future finish reasons to structured failure instead of throwing", () => {
+		const futureReason = "FUTURE_FINISH_REASON" as unknown as Parameters<typeof mapStopReason>[0];
+
+		expect(mapStopReason(futureReason)).toBe("error");
+	});
+});

--- a/packages/ai/test/google-vertex-api-key-resolution.test.ts
+++ b/packages/ai/test/google-vertex-api-key-resolution.test.ts
@@ -2,12 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const googleGenAiMock = vi.hoisted(() => ({
 	constructorCalls: [] as Array<Record<string, unknown>>,
+	streamChunks: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("@google/genai", () => {
 	class GoogleGenAI {
 		models = {
 			generateContentStream: async function* () {
+				if (googleGenAiMock.streamChunks.length > 0) {
+					yield* googleGenAiMock.streamChunks;
+					return;
+				}
 				yield {
 					responseId: "vertex-response-id",
 					candidates: [
@@ -32,6 +37,25 @@ vi.mock("@google/genai", () => {
 
 	return {
 		GoogleGenAI,
+		FinishReason: {
+			STOP: "STOP",
+			MAX_TOKENS: "MAX_TOKENS",
+			BLOCKLIST: "BLOCKLIST",
+			PROHIBITED_CONTENT: "PROHIBITED_CONTENT",
+			SPII: "SPII",
+			SAFETY: "SAFETY",
+			IMAGE_SAFETY: "IMAGE_SAFETY",
+			IMAGE_PROHIBITED_CONTENT: "IMAGE_PROHIBITED_CONTENT",
+			IMAGE_RECITATION: "IMAGE_RECITATION",
+			IMAGE_OTHER: "IMAGE_OTHER",
+			RECITATION: "RECITATION",
+			FINISH_REASON_UNSPECIFIED: "FINISH_REASON_UNSPECIFIED",
+			OTHER: "OTHER",
+			LANGUAGE: "LANGUAGE",
+			MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+			UNEXPECTED_TOOL_CALL: "UNEXPECTED_TOOL_CALL",
+			NO_IMAGE: "NO_IMAGE",
+		},
 		ResourceScope: {
 			COLLECTION: "COLLECTION",
 		},
@@ -58,6 +82,7 @@ const originalGoogleCloudApiKey = process.env.GOOGLE_CLOUD_API_KEY;
 
 beforeEach(() => {
 	googleGenAiMock.constructorCalls.length = 0;
+	googleGenAiMock.streamChunks.length = 0;
 	delete process.env.GOOGLE_CLOUD_API_KEY;
 });
 
@@ -219,5 +244,23 @@ describe("google-vertex api key resolution", () => {
 				apiVersion: "",
 			},
 		});
+	});
+
+	it("keeps an unknown finish reason as an error when a tool call is present", async () => {
+		googleGenAiMock.streamChunks.push({
+			candidates: [
+				{
+					content: { parts: [{ functionCall: { name: "lookup", args: {} } }] },
+					finishReason: "FUTURE_FINISH_REASON",
+				},
+			],
+		});
+
+		const result = await streamGoogleVertex(model, context, {
+			apiKey: "AIzaSyExampleRealisticLookingApiKey123456",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.stopReasonRaw).toBe("FUTURE_FINISH_REASON");
 	});
 });

--- a/packages/ai/test/mistral-unknown-stop-reason.test.ts
+++ b/packages/ai/test/mistral-unknown-stop-reason.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import type { Context } from "../src/types.js";
+
+const mistralMock = vi.hoisted(() => ({
+	streamYields: [] as Array<{ data: Record<string, unknown> }>,
+}));
+
+vi.mock("@mistralai/mistralai", () => {
+	class Mistral {
+		chat = {
+			stream: async function* () {
+				for (const event of mistralMock.streamYields) {
+					yield event;
+				}
+			},
+		};
+	}
+	return { Mistral };
+});
+
+import { streamMistral } from "../src/providers/mistral.js";
+
+const model = getModel("mistral", "mistral-small-latest");
+const context: Context = {
+	messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+};
+
+describe("Mistral unknown stop reason", () => {
+	it("does not report an unknown finish reason as successful completion", async () => {
+		// An unknown finish reason must not be collapsed into "stop" (success).
+		// It must route through the structured failure path with the raw value preserved.
+		mistralMock.streamYields = [
+			{
+				data: {
+					id: "mistral-unknown",
+					choices: [
+						{
+							index: 0,
+							finishReason: "model_faulted",
+							delta: { content: "Hello" },
+						},
+					],
+				},
+			},
+		];
+
+		const stream = streamMistral(model, context, { apiKey: "fake-key" });
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.stopReasonRaw).toBe("model_faulted");
+		expect(result.errorMessage).not.toContain("Unhandled");
+	});
+
+	it("still reports a normal stop as successful completion", async () => {
+		mistralMock.streamYields = [
+			{
+				data: {
+					id: "mistral-stop",
+					choices: [
+						{
+							index: 0,
+							finishReason: "stop",
+							delta: { content: "Hello" },
+						},
+					],
+				},
+			},
+		];
+
+		const stream = streamMistral(model, context, { apiKey: "fake-key" });
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.stopReasonRaw).toBeUndefined();
+	});
+
+	it("keeps an absent finish reason as a successful default", async () => {
+		mistralMock.streamYields = [
+			{
+				data: {
+					id: "mistral-no-finish-reason",
+					choices: [
+						{
+							index: 0,
+							finishReason: null,
+							delta: { content: "Hello" },
+						},
+					],
+				},
+			},
+		];
+
+		const stream = streamMistral(model, context, { apiKey: "fake-key" });
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.stopReasonRaw).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -352,10 +352,20 @@ describe("openai-codex streaming", () => {
 			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
 		};
 
-		const result = await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result();
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" });
+		let sawDone = false;
+		let sawError = false;
+		for await (const event of streamResult) {
+			if (event.type === "done") sawDone = true;
+			if (event.type === "error") {
+				sawError = true;
+				expect(event.error.stopReason).toBe("error");
+				expect(event.error.stopReasonRaw).toBe("quarantined");
+			}
+		}
 
-		expect(result.stopReason).toBe("error");
-		expect(result.stopReasonRaw).toBe("quarantined");
+		expect(sawDone).toBe(false);
+		expect(sawError).toBe(true);
 	});
 
 	it("sets session_id/x-client-request-id headers and prompt_cache_key when sessionId is provided", async () => {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -34,13 +34,7 @@ function mockToken(): string {
 	return `aaa.${payload}.bbb`;
 }
 
-function buildSSEPayload({
-	status,
-	includeDone = false,
-}: {
-	status: "completed" | "incomplete";
-	includeDone?: boolean;
-}): string {
+function buildSSEPayload({ status, includeDone = false }: { status: string; includeDone?: boolean }): string {
 	const terminalType = status === "incomplete" ? "response.incomplete" : "response.completed";
 	const events = [
 		`data: ${JSON.stringify({
@@ -309,6 +303,59 @@ describe("openai-codex streaming", () => {
 
 		expect(result.content.find((c) => c.type === "text")?.text).toBe("Hello");
 		expect(result.stopReason).toBe("length");
+	});
+
+	it("routes an unknown response status through the structured failure path", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "quarantined" });
+		const responseStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(responseStream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.stopReasonRaw).toBe("quarantined");
 	});
 
 	it("sets session_id/x-client-request-id headers and prompt_cache_key when sessionId is provided", async () => {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -361,6 +361,9 @@ describe("openai-codex streaming", () => {
 				sawError = true;
 				expect(event.error.stopReason).toBe("error");
 				expect(event.error.stopReasonRaw).toBe("quarantined");
+				expect(event.error.diagnostics).toEqual(
+					expect.arrayContaining([expect.objectContaining({ type: "provider_stream_failure" })]),
+				);
 			}
 		}
 

--- a/packages/ai/test/openai-responses-unknown-status.test.ts
+++ b/packages/ai/test/openai-responses-unknown-status.test.ts
@@ -1,0 +1,69 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, Model } from "../src/types.js";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.js";
+
+const model: Model<"openai-responses"> = {
+	id: "gpt-5-mini",
+	name: "GPT-5 Mini",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+function createOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function* completedWithStatus(status: string): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.completed",
+		sequence_number: 1,
+		response: {
+			id: "resp_unknown",
+			status: status as never,
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				total_tokens: 2,
+				input_tokens_details: { cached_tokens: 0 },
+			},
+		},
+	} as unknown as ResponseStreamEvent;
+}
+
+describe("OpenAI Responses unknown status", () => {
+	it("maps an unknown response status to error and preserves the raw status", async () => {
+		const output = createOutput();
+		const stream = new AssistantMessageEventStream();
+
+		// A status the SDK enum does not list yet. Must not crash the processor and
+		// must not be reported as successful completion; the raw value is preserved.
+		await processResponsesStream(completedWithStatus("quarantined"), output, stream, model);
+
+		expect(output.stopReason).toBe("error");
+		expect(output.stopReasonRaw).toBe("quarantined");
+	});
+});


### PR DESCRIPTION
Closes #707

## Summary

Unknown terminal values from Anthropic, Mistral, and the shared OpenAI Responses path now use the existing structured provider-failure flow instead of crashing or being reported as successful completion.

```text
upstream stop/status value
            |
            v
provider mapper -- unknown --> stopReason: "error" + stopReasonRaw
                                      |
                                      v
                         StreamFailureError classification
```

This covers Anthropic, Mistral, and OpenAI Responses (including Azure and Codex users of the shared implementation). Known stop values and Mistral's null finish-reason behavior are unchanged.

The change is intentionally limited to the follow-up handling after [#313](https://github.com/PrimeIntellect-ai/prime-agent/pull/313); it does not duplicate the existing `StreamFailureError` infrastructure.

## Tests

- Added synthetic unknown-value tests for Anthropic `message_delta.stop_reason`.
- Added synthetic unknown-value tests for OpenAI Responses `response.completed.status`.
- Added synthetic unknown-value and known/null behavior tests for Mistral `finish_reason`.
- Ran the four focused provider suites: 4 files, 32 tests passed.
- Commit hook ran `npm run check`, including type checking, installer rendering, and browser smoke checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change across core streaming providers: unknown terminal reasons now end as errors instead of success or hard crashes; Mistral unknown finish reasons no longer map to stop. Low risk for known enum values; medium due to breadth of provider touchpoints.
> 
> **Overview**
> Fixes [#707](https://github.com/PrimeIntellect-ai/prime-agent/issues/707) by routing **unrecognized** terminal stop/finish/status values through the existing structured failure path (`stopReason: "error"`, `stopReasonRaw`, `streamFailureFromStopReason`) instead of throwing or treating the stream as a successful completion.
> 
> **Anthropic, Google (`google-shared`), Mistral, and OpenAI Responses** mappers now return `"error"` for unknown values (replacing throws or Mistral’s previous default to `"stop"`). **Google** and **Google Vertex** no longer promote `"toolUse"` when the mapped reason is already `"error"` (e.g. unknown finish reason with a tool call in the same chunk).
> 
> **OpenAI Codex** wires the same path: after SSE/WebSocket processing it throws `streamFailureFromStopReason` when `stopReason === "error"`, uses `formatStreamFailureMessage` / `recordStreamFailure` on catch, treats `StreamFailureError` as non-transport, and preserves unknown Codex response statuses via `normalizeCodexStatus` so `stopReasonRaw` is set downstream.
> 
> Tests cover synthetic unknown values for Anthropic, Mistral, OpenAI Responses, Codex SSE, Google mapping, and Vertex tool-call + unknown finish reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb738bd6e37f8c06c4003bcbcb0fae33efaf31e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unknown provider stop reasons to emit structured errors instead of successful completions
> - Unknown stop/finish reasons from Anthropic, Google, Mistral, and OpenAI providers previously either threw unhandled errors or were silently treated as successful completions. They now map to `stopReason="error"` and preserve the raw value in `stopReasonRaw`.
> - Google and Vertex stream handlers no longer reclassify an error stop reason as `toolUse` when a tool call is present.
> - The OpenAI Codex Responses stream now throws a structured `StreamFailureError` (via `streamFailureFromStopReason`) when `stopReason` is `error`, recording diagnostics instead of emitting a `done` event.
> - `normalizeCodexStatus` in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/708/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) now returns unknown status strings verbatim instead of `undefined`.
> - Behavioral Change: streams that previously completed successfully with unrecognized stop reasons will now surface as errors with `stopReason="error"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb738bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->