### PR TITLE
feat(coding-agent): add Windows PowerShell installer

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Production release tag to create or update (e.g., v0.0.1)'
+        description: "Production release tag to create or update (e.g., v0.0.1)"
         required: true
         type: string
 
@@ -136,8 +136,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -236,12 +236,15 @@ jobs:
           const fs = require("node:fs");
           const baseUrl = process.env.INSTALL_BASE_URL;
           if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
-          const installer = fs.readFileSync("install.sh", "utf8");
-          const renderInstaller = (channel) => installer
+          const shellInstaller = fs.readFileSync("install.sh", "utf8");
+          const powershellInstaller = fs.readFileSync("install.ps1", "utf8");
+          const renderInstaller = (installer, channel) => installer
             .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
             .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
-          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller("stable"));
-          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller("beta"));
+          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller(shellInstaller, "stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller(shellInstaller, "beta"));
+          fs.writeFileSync("/tmp/prime-agent-install.ps1", renderInstaller(powershellInstaller, "stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.ps1", renderInstaller(powershellInstaller, "beta"));
           NODE
 
       - name: Extract production release notes
@@ -296,6 +299,16 @@ jobs:
           aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
             --endpoint-url "$R2_ENDPOINT_URL" \
             --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type 'text/plain; charset=utf-8' \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type 'text/plain; charset=utf-8' \
             --cache-control no-cache
 
       - name: Create production GitHub release
@@ -379,6 +392,16 @@ jobs:
             --content-type text/x-shellscript \
             --cache-control no-cache
 
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type 'text/plain; charset=utf-8' \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type 'text/plain; charset=utf-8' \
+            --cache-control no-cache
+
           printf 'Automated beta build from `%s` (`%s`).\n' "$DEFAULT_BRANCH" "$BUILD_REF" > /tmp/beta-release-notes.md
 
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/beta" >/dev/null 2>&1; then
@@ -409,4 +432,4 @@ jobs:
           fi
 
           gh release upload beta "$BETA_DIR"/* --clobber
-          echo "Beta installer: ${R2_PUBLIC_BASE_URL%/}/install-beta.sh"
+          echo "Beta installers: ${R2_PUBLIC_BASE_URL%/}/install-beta.sh and ${R2_PUBLIC_BASE_URL%/}/install-beta.ps1"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 On Windows, run from PowerShell:
 
 ```powershell
-irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+& ([scriptblock]::Create((irm https://app.primeintellect.ai/prime-agent/install.ps1)))
 ```
 
 The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent. Windows also requires Git Bash, Cygwin, MSYS2, or WSL; the PowerShell installer can install Git for Windows when needed.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Install the latest stable release on macOS or Linux:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
-The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent.
+On Windows, run from PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
+The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent. Windows also requires Git Bash, Cygwin, MSYS2, or WSL; the PowerShell installer can install Git for Windows when needed.
 
 Start Prime Agent from the repository or directory you want it to work in:
 
@@ -78,7 +84,8 @@ prime-agent shutdown [--force]       # Stop every agent, worker, and background 
 ```
 
 ## Built for Long-Running Work
-Prime Agent is built for long-running work, especially for evaluations in research. These features are available in the TUI, and when run autonomously. 
+
+Prime Agent is built for long-running work, especially for evaluations in research. These features are available in the TUI, and when run autonomously.
 
 - **Continual Harness:** `/refine` can persist focused, reviewable lessons as supplemental prompts, memories, reusable skill descriptions, or subagent specifications, with recorded refinement history. It does not replace packaging and reviewing new executable skills.
 - **Direct agent-to-agent communication:** running agents and retained subagents can discover one another, exchange messages, and steer active work.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,864 @@
+#Requires -Version 5.1
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$unconfiguredBaseUrl = "__PRIME_AGENT_DOWNLOAD_BASE" + "_URL__"
+$unconfiguredDefaultChannel = "__PRIME_AGENT_DEFAULT_RELEASE_" + "CHANNEL__"
+$configuredBaseUrl = "__PRIME_AGENT_DOWNLOAD_BASE_URL__"
+$configuredDefaultChannel = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"
+
+$baseUrl = if ($env:PRIME_AGENT_DOWNLOAD_BASE_URL) { $env:PRIME_AGENT_DOWNLOAD_BASE_URL } else { $configuredBaseUrl }
+$baseUrl = $baseUrl.TrimEnd("/")
+if ($baseUrl -eq $unconfiguredBaseUrl) {
+    throw "Installer download URL is not configured. Set PRIME_AGENT_DOWNLOAD_BASE_URL or use published installer."
+}
+
+$defaultChannel = if ($configuredDefaultChannel -eq $unconfiguredDefaultChannel) { "stable" } else { $configuredDefaultChannel }
+$releaseChannel = if ($env:PRIME_AGENT_RELEASE_CHANNEL) { $env:PRIME_AGENT_RELEASE_CHANNEL } else { $defaultChannel }
+$packageName = if ($env:PRIME_AGENT_PACKAGE) { $env:PRIME_AGENT_PACKAGE } else { "prime-agent" }
+$commandName = if ($env:PRIME_AGENT_CMD) { $env:PRIME_AGENT_CMD } else { "prime-agent" }
+$minimumNodeVersion = [version]"22.8.0"
+$ProgressPreference = "SilentlyContinue"
+
+$escape = [char]27
+$reset = "$escape[0m"
+$bold = "$escape[1m"
+$hideCursor = "$escape[?25l"
+$showCursor = "$escape[?25h"
+$homeCursor = "$escape[H"
+$clearScreen = "$escape[2J$escape[H"
+$clearLine = "$escape[K"
+$syncStart = "$escape[?2026h"
+$syncEnd = "$escape[?2026l"
+$colorText = "$escape[38;2;244;244;245m"
+$colorMuted = "$escape[38;2;161;161;170m"
+$colorDim = "$escape[38;2;113;113;122m"
+$colorPrimary = "$escape[38;2;127;91;213m"
+$colorScan = "$escape[38;2;14;165;233m"
+$colorWarning = "$escape[38;2;245;158;11m"
+
+$script:InstallerScreenEnabled = $false
+$script:InstallerScreenFrame = 0
+$script:InstallerScreenCols = 80
+$script:InstallerScreenRows = 24
+$script:InstallerScreenDrawn = $false
+$script:InstallerScreenLastCols = 0
+$script:InstallerScreenLastRows = 0
+$script:InstallerScreenLayoutReady = $false
+$script:InstallerScreenLayoutShowLogo = $false
+$script:InstallerScreenLayoutLabWidth = 0
+$script:InstallerScreenRenderLabWidth = 0
+$script:InstallerScreenCompact = $false
+$script:InstallerScreenTitle = ""
+$script:InstallerScreenDetail = ""
+$script:InstallerScreenQuestion = ""
+$script:InstallerAnimationFrame = 0
+$script:InstallerDownloadDir = $null
+$script:InstallerOriginalOutputEncoding = $null
+
+function Write-InstallerMessage {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Message)
+
+    Write-Information $Message -InformationAction Continue
+}
+
+function Write-InstallerTerminal {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "", Justification = "Installer TUI requires direct terminal control.")]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Text)
+
+    [Console]::Write($Text)
+}
+
+function Test-InstallerScreenAvailable {
+    if ($env:PRIME_AGENT_INSTALLER_PLAIN -eq "1") { return $false }
+    if ($env:TERM -eq "dumb") { return $false }
+    try {
+        if ([Console]::IsOutputRedirected) { return $false }
+    }
+    catch {
+        Write-Verbose "Could not inspect console redirection."
+    }
+
+    try {
+        if (-not $Host.UI.SupportsVirtualTerminal -and -not $env:WT_SESSION) { return $false }
+    }
+    catch {
+        if (-not $env:WT_SESSION) { return $false }
+    }
+    return $true
+}
+
+function Initialize-InstallerScreen {
+    $script:InstallerScreenEnabled = Test-InstallerScreenAvailable
+    if ($script:InstallerScreenEnabled) {
+        try {
+            $script:InstallerOriginalOutputEncoding = [Console]::OutputEncoding
+            [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+        }
+        catch {
+            Write-Verbose "Could not enable UTF-8 terminal output."
+        }
+    }
+}
+
+function Restore-InstallerTerminal {
+    if ($script:InstallerScreenEnabled) {
+        Write-InstallerTerminal "$reset$showCursor"
+    }
+    if ($script:InstallerOriginalOutputEncoding) {
+        try {
+            [Console]::OutputEncoding = $script:InstallerOriginalOutputEncoding
+        }
+        catch {
+            Write-Verbose "Could not restore terminal output encoding."
+        }
+        $script:InstallerOriginalOutputEncoding = $null
+    }
+}
+
+function Read-InstallerTerminalSize {
+    $cols = 80
+    $rows = 24
+    try {
+        $size = $Host.UI.RawUI.WindowSize
+        if ($size.Width -gt 0) { $cols = $size.Width }
+        if ($size.Height -gt 0) { $rows = $size.Height }
+    }
+    catch {
+        Write-Verbose "Could not read terminal dimensions."
+    }
+    $script:InstallerScreenCols = [math]::Max($cols, 1)
+    $script:InstallerScreenRows = [math]::Max($rows, 1)
+}
+
+function Get-IntegerQuotient {
+    param(
+        [Parameter(Mandatory)][int]$Dividend,
+        [Parameter(Mandatory)][int]$Divisor
+    )
+
+    return [int][math]::Truncate($Dividend / $Divisor)
+}
+
+function Test-InstallerTerminalSupportsLogo {
+    return $script:InstallerScreenRows -ge 22 -and $script:InstallerScreenCols -ge 42
+}
+
+function Get-InstallerLabWidth {
+    param([Parameter(Mandatory)][int]$Cols)
+
+    $width = $Cols - 6
+    $width = [math]::Min($width, 78)
+    $width = [math]::Max($width, 42)
+    $maxSafeWidth = [math]::Max($Cols - 1, 1)
+    $width = [math]::Min($width, $maxSafeWidth)
+    return [math]::Max($width, 32)
+}
+
+function Initialize-InstallerScreenLayout {
+    if ($script:InstallerScreenLayoutReady) { return }
+
+    $script:InstallerScreenLayoutReady = $true
+    $script:InstallerScreenLayoutShowLogo = $false
+    $script:InstallerScreenLayoutLabWidth = 0
+    $script:InstallerScreenRenderLabWidth = 0
+    if (Test-InstallerTerminalSupportsLogo) {
+        $script:InstallerScreenLayoutShowLogo = $true
+        $script:InstallerScreenLayoutLabWidth = Get-InstallerLabWidth $script:InstallerScreenCols
+    }
+}
+
+function Select-InstallerScreenLayoutMode {
+    $script:InstallerScreenCompact = $false
+    $script:InstallerScreenRenderLabWidth = 0
+    if (-not $script:InstallerScreenLayoutShowLogo) { return }
+    if ($script:InstallerScreenRows -lt 17) {
+        $script:InstallerScreenCompact = $true
+        return
+    }
+
+    $maxSafeWidth = $script:InstallerScreenCols - 1
+    if ($maxSafeWidth -lt 32) {
+        $script:InstallerScreenCompact = $true
+        return
+    }
+    $script:InstallerScreenRenderLabWidth = [math]::Min($script:InstallerScreenLayoutLabWidth, $maxSafeWidth)
+}
+
+function Test-InstallerLogoVisible {
+    return $script:InstallerScreenLayoutShowLogo -and
+    -not $script:InstallerScreenCompact -and
+    $script:InstallerScreenRenderLabWidth -ge 32
+}
+
+function Get-InstallerLogoLine {
+    param([Parameter(Mandatory)][int]$Row)
+
+    switch ($Row) {
+        2 { return "                          ▄▄███▀" }
+        3 { return "    ▄▄▄▄▄              ▄█████▀" }
+        4 { return "    ██████▄         ▄██████▀" }
+        5 { return "   ▄███▀███▄     ▄███▀▄██▀" }
+        6 { return "   ███ ▄████▄▄▄████▀▄▄██" }
+        7 { return "  ▀██  ▀█████████▀▀▀▀▀▀" }
+        8 { return "  ▄██   ██████▀▀ ▄███" }
+        9 { return " █████    ▀█▄▄▄█████▀" }
+        10 { return "███████▄  ████████▀" }
+        11 { return "▀███▀▀    █████▀" }
+        default { return "" }
+    }
+}
+
+function Get-InstallerLabCell {
+    param(
+        [Parameter(Mandatory)][int]$X,
+        [Parameter(Mandatory)][int]$Y,
+        [Parameter(Mandatory)][int]$Width
+    )
+
+    $height = 14
+    $frame = $script:InstallerScreenFrame
+    $char = " "
+    $style = ""
+    $hash = ($X * 37 + $Y * 53 + $frame * 11 + $X * $Y * 3) % 101
+    if ($hash -lt 3) {
+        $char = "·"
+        $style = $colorDim
+    }
+
+    $centerX = Get-IntegerQuotient ($Width * 36) 100
+    $centerY = Get-IntegerQuotient ($height * 54) 100
+    $dx = [math]::Abs($X - $centerX)
+    $dy = [math]::Abs($Y - $centerY)
+    $contour = $dx + $dy * 4 + (Get-IntegerQuotient $X 6) - $frame
+    $contourMod = (($contour % 24) + 24) % 24
+    if ($X -lt (Get-IntegerQuotient ($Width * 82) 100) -and $contourMod -eq 12) {
+        $char = if ((($X + $Y) % 5) -eq 0) { "╌" } else { "·" }
+        $style = $colorDim
+    }
+
+    $horizonY = Get-IntegerQuotient ($height * 58) 100
+    if ($Y -eq $horizonY -and ($X % 2) -eq 0 -and (($X + $frame) % 13) -lt 2) {
+        $char = "─"
+        $style = if ($X -gt (Get-IntegerQuotient ($Width * 60) 100)) { $colorPrimary } else { $colorDim }
+    }
+
+    $scanStart = Get-IntegerQuotient $Width 2
+    if ($X -ge $scanStart) {
+        $scanOffset = $X - $scanStart
+        if (($scanOffset % 5) -eq 0) {
+            $scanIndex = Get-IntegerQuotient $scanOffset 5
+            $scanTop = 1 + (($scanIndex + (Get-IntegerQuotient $frame 3)) % 3)
+            $scanBottom = $height - 2 - (($scanIndex * 2 + (Get-IntegerQuotient $frame 4)) % 3)
+            if ($Y -ge $scanTop -and $Y -le $scanBottom -and (($Y + $scanIndex + $frame) % 6) -ne 0) {
+                $char = if ((($scanIndex + $Y) % 4) -eq 0) { "┃" } else { "╎" }
+                $style = $colorScan
+            }
+        }
+    }
+
+    for ($traceIndex = 0; $traceIndex -lt 3; $traceIndex += 1) {
+        $base = switch ($traceIndex) {
+            0 { Get-IntegerQuotient ($height * 30) 100 }
+            1 { Get-IntegerQuotient ($height * 49) 100 }
+            default { Get-IntegerQuotient ($height * 72) 100 }
+        }
+        $wave = ($X * 2 + $frame + $traceIndex * 7) % 16
+        if ($wave -gt 7) { $wave = 15 - $wave }
+        $traceY = $base + (Get-IntegerQuotient ($wave - 3) 2)
+        if ($Y -eq $traceY) {
+            if ((($X + $frame + $traceIndex * 13) % 41) -eq 0) {
+                $char = "◆"
+                $style = $colorWarning
+            }
+            elseif ((($X + $frame) % 12) -eq 0) {
+                $char = "•"
+                $style = $colorPrimary
+            }
+            else {
+                $char = "·"
+                $style = $colorPrimary
+            }
+        }
+    }
+    return [pscustomobject]@{ Char = $char; Style = $style }
+}
+
+function Get-InstallerLabBackgroundRange {
+    param(
+        [Parameter(Mandatory)][int]$Row,
+        [Parameter(Mandatory)][int]$Start,
+        [Parameter(Mandatory)][int]$End,
+        [Parameter(Mandatory)][int]$Width
+    )
+
+    $activeStyle = ""
+    $line = [Text.StringBuilder]::new()
+    for ($x = $Start; $x -lt $End; $x += 1) {
+        $cell = Get-InstallerLabCell -X $x -Y $Row -Width $Width
+        if ($cell.Style -ne $activeStyle) {
+            if ($activeStyle) { [void]$line.Append($reset) }
+            if ($cell.Style) { [void]$line.Append($cell.Style) }
+            $activeStyle = $cell.Style
+        }
+        [void]$line.Append($cell.Char)
+    }
+    if ($activeStyle) { [void]$line.Append($reset) }
+    return $line.ToString()
+}
+
+function Get-InstallerLabLine {
+    param([Parameter(Mandatory)][int]$Row)
+
+    $width = $script:InstallerScreenRenderLabWidth
+    $logoLine = Get-InstallerLogoLine $Row
+    if ($logoLine) {
+        $logoStart = Get-IntegerQuotient ($width - 32) 2
+        $logoEnd = $logoStart + 32
+        $left = Get-InstallerLabBackgroundRange -Row $Row -Start 0 -End $logoStart -Width $width
+        $right = Get-InstallerLabBackgroundRange -Row $Row -Start $logoEnd -End $width -Width $width
+        return "$left$colorText$logoLine$reset$right"
+    }
+    return Get-InstallerLabBackgroundRange -Row $Row -Start 0 -End $width -Width $width
+}
+
+function Get-InstallerFittedText {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [Parameter(Mandatory)][int]$MaxWidth
+    )
+
+    if ($Text.Length -le $MaxWidth) { return $Text }
+    if ($MaxWidth -le 3) { return $Text.Substring(0, $MaxWidth) }
+    return "$($Text.Substring(0, $MaxWidth - 3))..."
+}
+
+function Get-InstallerPrimaryText {
+    if (-not $script:InstallerScreenQuestion) { return $script:InstallerScreenTitle }
+    if ($script:InstallerScreenQuestion -like "*[Y/n]*") {
+        return "$($script:InstallerScreenTitle) [Y/n] >"
+    }
+    return "$($script:InstallerScreenTitle) $($script:InstallerScreenQuestion)"
+}
+
+function Get-InstallerStyledTitle {
+    param([Parameter(Mandatory)][string]$Title)
+
+    if ($Title.Contains("Prime Agent")) {
+        return "$bold$colorPrimary$($Title.Replace('Prime Agent', "${bold}${colorPrimary}PRIME Agent${reset}${bold}${colorPrimary}"))$reset"
+    }
+    return "$bold$colorPrimary$Title$reset"
+}
+
+function Get-InstallerContentHeight {
+    return 2 + $(if (Test-InstallerLogoVisible) { 15 } else { 0 })
+}
+
+function Get-InstallerContentLine {
+    param([Parameter(Mandatory)][int]$Index)
+
+    if (Test-InstallerLogoVisible) {
+        if ($Index -ge 0 -and $Index -le 13) {
+            return [pscustomobject]@{ Text = Get-InstallerLabLine $Index; Width = $script:InstallerScreenRenderLabWidth }
+        }
+        if ($Index -eq 14) { return [pscustomobject]@{ Text = ""; Width = 0 } }
+        $Index -= 15
+    }
+    if ($Index -lt 0) { return $null }
+
+    $maxWidth = [math]::Max($script:InstallerScreenCols - 4, 1)
+    if ($Index -eq 0) {
+        if ($script:InstallerScreenQuestion) {
+            $text = Get-InstallerFittedText -Text (Get-InstallerPrimaryText) -MaxWidth $maxWidth
+            return [pscustomobject]@{ Text = "$bold$colorText$text$reset"; Width = $text.Length }
+        }
+        $text = Get-InstallerFittedText -Text $script:InstallerScreenTitle -MaxWidth $maxWidth
+        return [pscustomobject]@{ Text = Get-InstallerStyledTitle $text; Width = $text.Length }
+    }
+    if ($Index -eq 1) {
+        if ($script:InstallerScreenQuestion) {
+            $text = Get-InstallerFittedText -Text "Press Enter to continue; type n to cancel." -MaxWidth $maxWidth
+            return [pscustomobject]@{ Text = "$colorMuted$text$reset"; Width = $text.Length }
+        }
+        if ($script:InstallerScreenDetail) {
+            $text = Get-InstallerFittedText -Text $script:InstallerScreenDetail -MaxWidth $maxWidth
+            return [pscustomobject]@{ Text = "$colorMuted$text$reset"; Width = $text.Length }
+        }
+        return [pscustomobject]@{ Text = ""; Width = 0 }
+    }
+    return $null
+}
+
+function Get-InstallerCenteredLine {
+    param([AllowNull()][object]$Content)
+
+    if (-not $Content) {
+        $left = Get-IntegerQuotient $script:InstallerScreenCols 2
+        return "$(' ' * $left)$clearLine"
+    }
+    $left = [math]::Max((Get-IntegerQuotient ($script:InstallerScreenCols - $Content.Width) 2), 0)
+    return "$(' ' * $left)$($Content.Text)$clearLine"
+}
+
+function Get-InstallerScreenFrameText {
+    $contentHeight = Get-InstallerContentHeight
+    $top = [math]::Max((Get-IntegerQuotient ($script:InstallerScreenRows - $contentHeight) 2), 0)
+    $lines = [Collections.Generic.List[string]]::new()
+    for ($y = 0; $y -lt $script:InstallerScreenRows; $y += 1) {
+        $content = Get-InstallerContentLine ($y - $top)
+        $lines.Add((Get-InstallerCenteredLine $content))
+    }
+    return $lines -join "`n"
+}
+
+function Show-InstallerScreen {
+    param(
+        [Parameter(Mandatory)][string]$Title,
+        [AllowEmptyString()][string]$Detail = "",
+        [AllowEmptyString()][string]$Question = ""
+    )
+
+    if (-not $script:InstallerScreenEnabled) { return }
+    $script:InstallerScreenTitle = $Title
+    $script:InstallerScreenDetail = $Detail
+    $script:InstallerScreenQuestion = $Question
+    $script:InstallerScreenFrame += 1
+    Read-InstallerTerminalSize
+    Initialize-InstallerScreenLayout
+    Select-InstallerScreenLayoutMode
+
+    $resized = $script:InstallerScreenCols -ne $script:InstallerScreenLastCols -or
+    $script:InstallerScreenRows -ne $script:InstallerScreenLastRows
+    $prefix = if (-not $script:InstallerScreenDrawn -or $resized) {
+        $script:InstallerScreenDrawn = $true
+        $script:InstallerScreenLastCols = $script:InstallerScreenCols
+        $script:InstallerScreenLastRows = $script:InstallerScreenRows
+        "$reset$clearScreen$hideCursor"
+    }
+    else {
+        "$reset$homeCursor$hideCursor"
+    }
+    Write-InstallerTerminal "$syncStart$prefix$(Get-InstallerScreenFrameText)$syncEnd"
+}
+
+function Show-InstallerPromptCursor {
+    if (-not $script:InstallerScreenEnabled) { return }
+    $maxWidth = [math]::Max($script:InstallerScreenCols - 4, 1)
+    $promptText = Get-InstallerFittedText -Text (Get-InstallerPrimaryText) -MaxWidth $maxWidth
+    $contentHeight = Get-InstallerContentHeight
+    $top = [math]::Max((Get-IntegerQuotient ($script:InstallerScreenRows - $contentHeight) 2), 0)
+    $promptIndex = if (Test-InstallerLogoVisible) { 15 } else { 0 }
+    $row = $top + $promptIndex + 1
+    $col = (Get-IntegerQuotient ($script:InstallerScreenCols - $promptText.Length) 2) + $promptText.Length + 2
+    $col = [math]::Max([math]::Min($col, $script:InstallerScreenCols), 1)
+    Write-InstallerTerminal "$reset$showCursor$escape[$row;${col}H"
+}
+
+function Confirm-PrimeAgentAction {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [AllowEmptyString()][string]$Detail = ""
+    )
+
+    if ($script:InstallerScreenEnabled -and -not [Console]::IsInputRedirected) {
+        Show-InstallerScreen -Title $Message -Detail $Detail -Question "[Y/n]"
+        Show-InstallerPromptCursor
+        $answer = [Console]::ReadLine()
+    }
+    else {
+        $answer = Read-Host "$Message [Y/n]"
+    }
+    return $answer -notmatch "^(n|no)$"
+}
+
+function Get-InstallerPulse {
+    switch ($script:InstallerScreenFrame % 4) {
+        0 { return "." }
+        1 { return ".." }
+        2 { return "..." }
+        default { return "" }
+    }
+}
+
+function Get-InstallerAnimationDetail {
+    param([Parameter(Mandatory)][string[]]$Details)
+
+    if ($Details.Count -eq 0) { return "" }
+    $frame = [math]::Max($script:InstallerAnimationFrame, 1)
+    $index = [math]::Min((Get-IntegerQuotient ($frame - 1) 24), $Details.Count - 1)
+    return $Details[$index]
+}
+
+function ConvertTo-NativeArgument {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Argument)
+
+    if ($Argument -notmatch '[\s"]') { return $Argument }
+    $escaped = [regex]::Replace($Argument, '(\\*)"', '$1$1\"')
+    $escaped = [regex]::Replace($escaped, '(\\+)$', '$1$1')
+    return "`"$escaped`""
+}
+
+function Invoke-InstallerNativeCommand {
+    param(
+        [Parameter(Mandatory)][string]$Title,
+        [Parameter(Mandatory)][string]$Status,
+        [Parameter(Mandatory)][string[]]$Details,
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    if (-not $script:InstallerScreenEnabled) {
+        Write-InstallerMessage "$Status..."
+        & $FilePath @Arguments 2>&1 | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "$Status failed with exit code $LASTEXITCODE." }
+        return
+    }
+
+    $argumentLine = ($Arguments | ForEach-Object { ConvertTo-NativeArgument $_ }) -join " "
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    if ([IO.Path]::GetExtension($FilePath) -in @(".cmd", ".bat")) {
+        $commandLine = "$(ConvertTo-NativeArgument $FilePath) $argumentLine"
+        $startInfo.FileName = $env:ComSpec
+        $startInfo.Arguments = "/d /s /c `"$commandLine`""
+    }
+    else {
+        $startInfo.FileName = $FilePath
+        $startInfo.Arguments = $argumentLine
+    }
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        [void]$process.Start()
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $script:InstallerAnimationFrame = 0
+        while (-not $process.WaitForExit(180)) {
+            $script:InstallerAnimationFrame += 1
+            Show-InstallerScreen -Title "$Title$(Get-InstallerPulse)" -Detail (Get-InstallerAnimationDetail $Details)
+        }
+        $process.WaitForExit()
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        if ($process.ExitCode -ne 0) {
+            Restore-InstallerTerminal
+            if ($stdout) { [Console]::Error.Write($stdout) }
+            if ($stderr) { [Console]::Error.Write($stderr) }
+            throw "$Status failed with exit code $($process.ExitCode)."
+        }
+    }
+    finally {
+        if (-not $process.HasExited) {
+            try { $process.Kill() } catch { Write-Verbose "Could not stop interrupted installer child process." }
+        }
+        $process.Dispose()
+    }
+}
+
+function Invoke-InstallerDownload {
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [Parameter(Mandatory)][string]$OutFile,
+        [Parameter(Mandatory)][string]$Title,
+        [Parameter(Mandatory)][string]$Status,
+        [Parameter(Mandatory)][string]$Detail
+    )
+
+    if (-not $script:InstallerScreenEnabled) {
+        Write-InstallerMessage "$Status..."
+        Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
+        return
+    }
+
+    Add-Type -AssemblyName System.Net.Http
+    $client = [Net.Http.HttpClient]::new()
+    try {
+        $task = $client.GetByteArrayAsync($Uri)
+        while (-not $task.Wait(180)) {
+            Show-InstallerScreen -Title "$Title$(Get-InstallerPulse)" -Detail $Detail
+        }
+        [IO.File]::WriteAllBytes($OutFile, $task.GetAwaiter().GetResult())
+    }
+    finally {
+        $client.Dispose()
+    }
+}
+
+function Get-PrimeAgentCommand {
+    param([Parameter(Mandatory)][string[]]$Names)
+
+    foreach ($name in $Names) {
+        $command = Get-Command $name -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($command) { return $command.Source }
+    }
+    return $null
+}
+
+function Install-WithWinget {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $winget = Get-PrimeAgentCommand @("winget.exe", "winget")
+    if (-not $winget) { throw "$Name is required. Install it manually because winget is unavailable." }
+
+    $details = @(
+        "Using winget.",
+        "Resolving packages.",
+        "Downloading $Name.",
+        "Installing $Name.",
+        "Refreshing your PATH."
+    )
+    Invoke-InstallerNativeCommand -Title "Installing $Name" -Status "Installing $Name" -Details $details `
+        -FilePath $winget -Arguments @("install", "--id", $Id, "--exact", "--accept-package-agreements", "--accept-source-agreements")
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = @($machinePath, $userPath) -join ";"
+}
+
+function Get-NodeCommand {
+    $node = Get-PrimeAgentCommand @("node.exe", "node")
+    if (-not $node) { return $null }
+    $versionText = (& $node --version).Trim().TrimStart("v")
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $version = $null
+    if (-not [version]::TryParse($versionText, [ref]$version)) { return $null }
+    if ($version -lt $minimumNodeVersion) { return $null }
+    return $node
+}
+
+function Initialize-NodeAndNpm {
+    $node = Get-NodeCommand
+    $npm = Get-PrimeAgentCommand @("npm.cmd", "npm")
+    if ($node -and $npm) { return $npm }
+
+    if (-not (Confirm-PrimeAgentAction -Message "Install Node.js and npm with winget?" -Detail "Required before Prime Agent can be installed.")) {
+        throw "Prime Agent requires Node.js $minimumNodeVersion or newer and npm."
+    }
+    Install-WithWinget -Id "OpenJS.NodeJS.LTS" -Name "Node.js LTS"
+    $node = Get-NodeCommand
+    $npm = Get-PrimeAgentCommand @("npm.cmd", "npm")
+    if (-not $node -or -not $npm) {
+        throw "Node.js installation completed, but Node.js $minimumNodeVersion or newer and npm are unavailable. Restart PowerShell and run installer again."
+    }
+    return $npm
+}
+
+function Find-Bash {
+    $settingsPath = Join-Path $HOME ".prime\agent\settings.json"
+    if (Test-Path -LiteralPath $settingsPath -PathType Leaf) {
+        try {
+            $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+            if ($settings.shellPath -and (Test-Path -LiteralPath $settings.shellPath -PathType Leaf)) {
+                return [string]$settings.shellPath
+            }
+        }
+        catch {
+            Write-Verbose "Ignoring invalid Prime Agent settings while locating bash."
+        }
+    }
+    $gitBash = Join-Path $env:ProgramFiles "Git\bin\bash.exe"
+    if (Test-Path -LiteralPath $gitBash -PathType Leaf) { return $gitBash }
+    return Get-PrimeAgentCommand @("bash.exe", "bash")
+}
+
+function Initialize-Bash {
+    if (Find-Bash) { return }
+    if (-not (Confirm-PrimeAgentAction -Message "Install Git for Windows with winget?" -Detail "Prime Agent requires Git Bash or another bash shell.")) {
+        throw "Prime Agent requires Git Bash, Cygwin, MSYS2, or WSL on Windows."
+    }
+    Install-WithWinget -Id "Git.Git" -Name "Git for Windows"
+    if (-not (Find-Bash)) {
+        throw "Git installation completed, but bash.exe was not found. Restart PowerShell and run installer again."
+    }
+}
+
+function ConvertTo-PrimeAgentVersion {
+    param([Parameter(Mandatory)][string]$Version)
+
+    $normalized = $Version.Trim().TrimStart("v")
+    if ($normalized -notmatch "^[0-9A-Za-z.-]+$") { throw "Invalid Prime Agent version: $Version" }
+    return $normalized
+}
+
+function Resolve-PrimeAgentVersion {
+    param([string]$RequestedRelease)
+
+    if ($RequestedRelease -and $RequestedRelease -notin @("stable", "beta")) {
+        return ConvertTo-PrimeAgentVersion $RequestedRelease
+    }
+    $channel = if ($RequestedRelease) { $RequestedRelease } else { $releaseChannel }
+    if ($channel -notin @("stable", "beta")) { throw "Invalid Prime Agent release channel: $channel" }
+    if ($env:PRIME_AGENT_VERSION) { return ConvertTo-PrimeAgentVersion $env:PRIME_AGENT_VERSION }
+
+    $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("prime-agent-channel-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+    try {
+        $channelPath = Join-Path $tempDir $channel
+        Invoke-InstallerDownload -Uri "$baseUrl/$channel" -OutFile $channelPath -Title "Resolving latest release" `
+            -Status "Resolving latest release" -Detail "Checking the $channel release channel."
+        return ConvertTo-PrimeAgentVersion (Get-Content -LiteralPath $channelPath -Raw)
+    }
+    finally {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-PrimeAgentChecksum {
+    param(
+        [Parameter(Mandatory)][string]$ChecksumsPath,
+        [Parameter(Mandatory)][string]$TarballPath
+    )
+
+    $tarballName = Split-Path $TarballPath -Leaf
+    $escapedName = [regex]::Escape($tarballName)
+    $checksumLine = Get-Content -LiteralPath $ChecksumsPath | Where-Object {
+        $_ -match "^([0-9A-Fa-f]{64})\s+\*?$escapedName$"
+    } | Select-Object -First 1
+    if (-not $checksumLine) { throw "Checksum for $tarballName was not found." }
+
+    $expected = ([regex]::Match($checksumLine, "^[0-9A-Fa-f]{64}")).Value.ToUpperInvariant()
+    $stream = [IO.File]::OpenRead($TarballPath)
+    try {
+        $sha256 = [Security.Cryptography.SHA256]::Create()
+        try {
+            $actual = [BitConverter]::ToString($sha256.ComputeHash($stream)).Replace("-", "")
+        }
+        finally {
+            $sha256.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+    if ($actual -ne $expected) { throw "Checksum verification failed for $tarballName." }
+}
+
+function Install-PrimeAgentPackage {
+    param(
+        [Parameter(Mandatory)][string]$Npm,
+        [Parameter(Mandatory)][string]$TarballPath,
+        [Parameter(Mandatory)][bool]$BootstrapKernel
+    )
+
+    $previousTools = $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL
+    $previousKernel = $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL
+    $previousUv = $env:PRIME_AGENT_INSTALL_UV
+    try {
+        $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = "1"
+        if ($BootstrapKernel) {
+            $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = "1"
+            $env:PRIME_AGENT_INSTALL_UV = "1"
+        }
+        $details = @(
+            "Preparing global install.",
+            "Linking command binaries.",
+            "Installing runtime packages.",
+            "Preloading search tools.",
+            $(if ($BootstrapKernel) { "Preparing IPython kernel." } else { "Finalizing npm install." }),
+            "Finalizing npm install."
+        )
+        $arguments = @("install", "-g", "--no-fund", "--no-audit", "--loglevel=error", "--progress=false", $TarballPath)
+        Invoke-InstallerNativeCommand -Title "Installing Prime Agent" -Status "Installing Prime Agent" `
+            -Details $details -FilePath $Npm -Arguments $arguments
+    }
+    finally {
+        $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = $previousTools
+        $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = $previousKernel
+        $env:PRIME_AGENT_INSTALL_UV = $previousUv
+    }
+}
+
+function Invoke-PrimeAgentInstaller {
+    param([object[]]$RequestedArguments = @())
+
+    if ($env:OS -ne "Windows_NT") { throw "install.ps1 supports Windows only." }
+    if ($RequestedArguments.Count -gt 1) { throw "Usage: install.ps1 [stable|beta|version]" }
+
+    Initialize-InstallerScreen
+    if ($script:InstallerScreenEnabled) {
+        Show-InstallerScreen -Title "Installing Prime Agent"
+    }
+    else {
+        Write-InstallerMessage ""
+        Write-InstallerMessage "  Installing Prime Agent"
+        Write-InstallerMessage "  npm global install"
+        Write-InstallerMessage ""
+    }
+
+    Show-InstallerScreen -Title "Checking Node.js and npm"
+    $npmCommand = Initialize-NodeAndNpm
+    Initialize-Bash
+    Show-InstallerScreen -Title "Environment ready" -Detail "Node.js, npm, and bash are available."
+
+    $requestedRelease = if ($RequestedArguments.Count -eq 1) { [string]$RequestedArguments[0] } else { $null }
+    $version = Resolve-PrimeAgentVersion $requestedRelease
+    $tarballName = "$packageName-$version.tgz"
+    $releaseUrl = "$baseUrl/releases/v$version"
+
+    if (-not (Confirm-PrimeAgentAction -Message "Install Prime Agent v$version globally with npm?" `
+                -Detail "Downloads the verified release and runs npm install -g.")) {
+        Show-InstallerScreen -Title "Installation cancelled" -Detail "No changes were made."
+        if (-not $script:InstallerScreenEnabled) { Write-InstallerMessage "Installation cancelled." }
+        return
+    }
+
+    $bootstrapKernel = if ($env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL -eq "1") {
+        $true
+    }
+    elseif ($env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL -eq "0") {
+        $false
+    }
+    else {
+        Confirm-PrimeAgentAction -Message "Prepare IPython runtime now?" `
+            -Detail "Installs uv, Python 3.11, ipykernel, and Prime Agent runtime."
+    }
+
+    $script:InstallerDownloadDir = Join-Path ([IO.Path]::GetTempPath()) ("prime-agent-install-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $script:InstallerDownloadDir | Out-Null
+    $checksumsPath = Join-Path $script:InstallerDownloadDir "SHA256SUMS"
+    $tarballPath = Join-Path $script:InstallerDownloadDir $tarballName
+
+    Invoke-InstallerDownload -Uri "$releaseUrl/SHA256SUMS" -OutFile $checksumsPath -Title "Downloading checksums" `
+        -Status "Downloading release checksums" -Detail "Prime Agent v$version"
+    Invoke-InstallerDownload -Uri "$releaseUrl/$tarballName" -OutFile $tarballPath -Title "Downloading Prime Agent" `
+        -Status "Downloading Prime Agent v$version" -Detail "Fetching the verified package."
+    Show-InstallerScreen -Title "Verifying download" -Detail "Checking SHA-256."
+    Assert-PrimeAgentChecksum -ChecksumsPath $checksumsPath -TarballPath $tarballPath
+    Install-PrimeAgentPackage -Npm $npmCommand -TarballPath $tarballPath -BootstrapKernel $bootstrapKernel
+
+    Remove-Item -LiteralPath $script:InstallerDownloadDir -Recurse -Force
+    $script:InstallerDownloadDir = $null
+    if (Get-Command $commandName -ErrorAction SilentlyContinue) {
+        Show-InstallerScreen -Title "Prime Agent installed" -Detail "Run it with: $commandName"
+        if (-not $script:InstallerScreenEnabled) {
+            Write-InstallerMessage ""
+            Write-InstallerMessage "Prime Agent v$version installed."
+            Write-InstallerMessage "Run it with: $commandName"
+        }
+    }
+    else {
+        Show-InstallerScreen -Title "Prime Agent installed" -Detail "Restart PowerShell, then run: $commandName"
+        if (-not $script:InstallerScreenEnabled) {
+            Write-InstallerMessage "Prime Agent v$version installed, but $commandName is not on PATH yet."
+            Write-InstallerMessage "Restart PowerShell, then run: $commandName"
+        }
+    }
+}
+
+try {
+    Invoke-PrimeAgentInstaller -RequestedArguments @($args)
+}
+finally {
+    if ($script:InstallerDownloadDir -and (Test-Path -LiteralPath $script:InstallerDownloadDir)) {
+        Remove-Item -LiteralPath $script:InstallerDownloadDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Restore-InstallerTerminal
+}
+
+

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
@@ -867,5 +867,6 @@ finally {
     }
     Restore-InstallerTerminal
 }
+
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
@@ -508,12 +508,8 @@ function Invoke-InstallerNativeCommand {
         [Parameter(Mandatory)][string[]]$Arguments
     )
 
-    if (-not $script:InstallerScreenEnabled) {
-        Write-InstallerMessage "$Status..."
-        & $FilePath @Arguments 2>&1 | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw "$Status failed with exit code $LASTEXITCODE." }
-        return
-    }
+    $plainMode = -not $script:InstallerScreenEnabled
+    if ($plainMode) { Write-InstallerMessage "$Status..." }
 
     $argumentLine = ($Arguments | ForEach-Object { ConvertTo-NativeArgument $_ }) -join " "
     $startInfo = [Diagnostics.ProcessStartInfo]::new()
@@ -537,17 +533,28 @@ function Invoke-InstallerNativeCommand {
         $stdoutTask = $process.StandardOutput.ReadToEndAsync()
         $stderrTask = $process.StandardError.ReadToEndAsync()
         $script:InstallerAnimationFrame = 0
-        while (-not $process.WaitForExit(180)) {
-            $script:InstallerAnimationFrame += 1
-            Show-InstallerScreen -Title "$Title$(Get-InstallerPulse)" -Detail (Get-InstallerAnimationDetail $Details)
+        if ($plainMode) {
+            $process.WaitForExit()
         }
-        $process.WaitForExit()
+        else {
+            while (-not $process.WaitForExit(180)) {
+                $script:InstallerAnimationFrame += 1
+                Show-InstallerScreen -Title "$Title$(Get-InstallerPulse)" -Detail (Get-InstallerAnimationDetail $Details)
+            }
+            $process.WaitForExit()
+        }
         $stdout = $stdoutTask.GetAwaiter().GetResult()
         $stderr = $stderrTask.GetAwaiter().GetResult()
-        if ($process.ExitCode -ne 0) {
-            Restore-InstallerTerminal
-            if ($stdout) { [Console]::Error.Write($stdout) }
+        if ($plainMode) {
+            if ($stdout) { [Console]::Out.Write($stdout) }
             if ($stderr) { [Console]::Error.Write($stderr) }
+        }
+        if ($process.ExitCode -ne 0) {
+            if (-not $plainMode) {
+                Restore-InstallerTerminal
+                if ($stdout) { [Console]::Error.Write($stdout) }
+                if ($stderr) { [Console]::Error.Write($stderr) }
+            }
             throw "$Status failed with exit code $($process.ExitCode)."
         }
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "cd packages/ai && npm run dev:tsc",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:installer && npm run check:browser-smoke",
-		"check:installer": "node scripts/check-installer-render.mjs",
+		"check:installer": "node scripts/check-installer-render.mjs && node scripts/check-windows-installer.mjs",
 		"check:browser-smoke": "node scripts/check-browser-smoke.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a PowerShell installer for verified Prime Agent releases on Windows.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes
@@ -134,7 +136,7 @@
 - Unified Agents View and session resume into one searchable Running/Idle/Inactive session view with live heartbeat badges.
 - Changed selection cursors from `→` to `›` across model selectors, scoped-models, and the theme default for consistency with tree and user-message selectors.
 - Changed the queued follow-up hint connector from `↳` to `╰─` to match the tool-execution continuation connector.
-- Changed `/context` tree connectors from `├ `/`└ ` to `├─ `/`└─ ` to match the tree selector and session picker.
+- Changed `/context` tree connectors from `├`/`└` to `├─`/`└─` to match the tree selector and session picker.
 - Changed the IPython cell queued marker from `▸` to `◇` to match the subagent and context-tree status icons.
 - Changed slash-command autocomplete to separate argument hints and resource provenance, show only the selected command description, and summarize hidden results directionally.
 - Fixed cancelled extension commands remaining alive when spawned processes ignored SIGTERM ([#458](https://github.com/PrimeIntellect-ai/prime-agent/pull/458) by [@snimu](https://github.com/snimu)).
@@ -144,7 +146,6 @@
 - Changed `/refine` to run planning in the background so the conversation is not blocked during the LLM pass ([#497](https://github.com/PrimeIntellect-ai/prime-agent/pull/497) by [@sethkarten](https://github.com/sethkarten)).
 - Added serialized headless refinement and `--goal` / `--goal-token-budget` for seeding durable session goals ([#514](https://github.com/PrimeIntellect-ai/prime-agent/pull/514) by [@sethkarten](https://github.com/sethkarten)).
 - Added multi-turn `/btw` side conversations with transient in-pane bash commands ([#512](https://github.com/PrimeIntellect-ai/prime-agent/pull/512) by [@ilijalichkovski](https://github.com/ilijalichkovski)).
-
 
 ## [0.3.2] - 2026-07-20
 

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -13,7 +13,7 @@ curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 On Windows, run from PowerShell:
 
 ```powershell
-irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+& ([scriptblock]::Create((irm https://app.primeintellect.ai/prime-agent/install.ps1)))
 ```
 
 Then run it in a project directory:

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -10,6 +10,12 @@ Install the latest stable release on Linux or macOS:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
+On Windows, run from PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
 Then run it in a project directory:
 
 ```bash

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -10,13 +10,23 @@ Install the latest stable release on Linux or macOS:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
+On Windows, run from PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
 To try the latest beta built from `main`:
 
 ```bash
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
-Both commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install-beta.ps1 | iex
+```
+
+These commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
 
 Then start Prime Agent in the project directory you want it to work on:
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -13,7 +13,7 @@ curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 On Windows, run from PowerShell:
 
 ```powershell
-irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+& ([scriptblock]::Create((irm https://app.primeintellect.ai/prime-agent/install.ps1)))
 ```
 
 To try the latest beta built from `main`:
@@ -23,7 +23,7 @@ curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
 ```powershell
-irm https://app.primeintellect.ai/prime-agent/install-beta.ps1 | iex
+& ([scriptblock]::Create((irm https://app.primeintellect.ai/prime-agent/install-beta.ps1)))
 ```
 
 These commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -1,5 +1,13 @@
 # Windows Setup
 
+Install the latest stable release from PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
+The installer verifies the release checksum, installs Prime Agent with npm, and can install Node.js LTS and Git for Windows through `winget` when needed.
+
 Prime Agent requires a bash shell on Windows. Checked locations (in order):
 
 1. Custom path from `~/.prime/agent/settings.json`

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -3,7 +3,7 @@
 Install the latest stable release from PowerShell:
 
 ```powershell
-irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+& ([scriptblock]::Create((irm https://app.primeintellect.ai/prime-agent/install.ps1)))
 ```
 
 The installer verifies the release checksum, installs Prime Agent with npm, and can install Node.js LTS and Git for Windows through `winget` when needed.

--- a/scripts/check-windows-installer.mjs
+++ b/scripts/check-windows-installer.mjs
@@ -5,7 +5,8 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 
-const source = readFileSync("install.ps1", "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+const rawSource = readFileSync("install.ps1", "utf8");
+const source = rawSource.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
 const shellSource = readFileSync("install.sh", "utf8");
 const baseUrlPlaceholder = "__PRIME_AGENT_DOWNLOAD_BASE_URL__";
 const channelPlaceholder = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__";
@@ -16,6 +17,7 @@ const shellMainCallIndex = shellSource.lastIndexOf(shellMainCall);
 const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const failures = [];
 
+check(!rawSource.startsWith("\uFEFF"), "installer must not start with a UTF-8 BOM");
 check(source.includes(baseUrlPlaceholder), "missing download base URL placeholder");
 check(source.includes(channelPlaceholder), "missing default release channel placeholder");
 check(source.includes("Security.Cryptography.SHA256"), "installer must verify downloads with SHA-256");
@@ -275,15 +277,12 @@ async function runEndToEndCheck(command) {
 			const renderedInstaller = source
 				.replaceAll(baseUrlPlaceholder, testBaseUrl)
 				.replaceAll(channelPlaceholder, "stable");
-			writeFileSync(
-				installerPath,
-				Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(renderedInstaller)]),
-			);
+			writeFileSync(installerPath, renderedInstaller);
 			const wrapperPath = join(tempDir, "invoke-installer.ps1");
 			const escapedInstallerPath = installerPath.replaceAll("'", "''");
 			const wrapper = `$beforeErrorActionPreference = $ErrorActionPreference
 $beforeProgressPreference = $ProgressPreference
-$installer = Get-Content -LiteralPath '${escapedInstallerPath}' -Raw
+$installer = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes('${escapedInstallerPath}'))
 & ([scriptblock]::Create($installer))
 if ($ErrorActionPreference -ne $beforeErrorActionPreference) { throw "Installer changed ErrorActionPreference." }
 if ($ProgressPreference -ne $beforeProgressPreference) { throw "Installer changed ProgressPreference." }

--- a/scripts/check-windows-installer.mjs
+++ b/scripts/check-windows-installer.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 
-const source = readFileSync("install.ps1", "utf8").replace(/^\uFEFF/, "");
+const source = readFileSync("install.ps1", "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
 const shellSource = readFileSync("install.sh", "utf8");
 const baseUrlPlaceholder = "__PRIME_AGENT_DOWNLOAD_BASE_URL__";
 const channelPlaceholder = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__";
@@ -279,6 +279,18 @@ async function runEndToEndCheck(command) {
 				installerPath,
 				Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(renderedInstaller)]),
 			);
+			const wrapperPath = join(tempDir, "invoke-installer.ps1");
+			const escapedInstallerPath = installerPath.replaceAll("'", "''");
+			const wrapper = `$beforeErrorActionPreference = $ErrorActionPreference
+$beforeProgressPreference = $ProgressPreference
+$installer = Get-Content -LiteralPath '${escapedInstallerPath}' -Raw
+& ([scriptblock]::Create($installer))
+if ($ErrorActionPreference -ne $beforeErrorActionPreference) { throw "Installer changed ErrorActionPreference." }
+if ($ProgressPreference -ne $beforeProgressPreference) { throw "Installer changed ProgressPreference." }
+if (Get-Command Invoke-PrimeAgentInstaller -CommandType Function -ErrorAction SilentlyContinue) { throw "Installer functions leaked into caller scope." }
+try { $null = $primeAgentUndefinedStrictModeProbe } catch { throw "Installer enabled strict mode in caller scope." }
+`;
+			writeFileSync(wrapperPath, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(wrapper)]));
 			const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
 			const env = {
 				...process.env,
@@ -292,7 +304,7 @@ async function runEndToEndCheck(command) {
 			delete env.PRIME_AGENT_DOWNLOAD_BASE_URL;
 			delete env.PRIME_AGENT_RELEASE_CHANNEL;
 			delete env.PRIME_AGENT_VERSION;
-			const result = await run(command, ["-NoProfile", "-File", installerPath], env, "y\n");
+			const result = await run(command, ["-NoProfile", "-File", wrapperPath], env, "y\n");
 			check(result.code === 0, `installer execution exited with ${result.code}\n${result.stderr}${result.stdout}`);
 			if (result.code === 0) {
 				check(!result.stdout.includes("\u001b[?2026h"), "redirected installer must not emit terminal control sequences");
@@ -300,7 +312,8 @@ async function runEndToEndCheck(command) {
 				check(npmInvocation.includes("install -g"), `installer did not run npm install -g: ${npmInvocation}`);
 				check(npmInvocation.includes(tarballName), `installer did not pass downloaded tarball to npm: ${npmInvocation}`);
 				check(npmInvocation.includes("TOOLS=1"), `installer did not bootstrap required tools: ${npmInvocation}`);
-				check(npmInvocation.includes("KERNEL="), `installer unexpectedly bootstrapped kernel: ${npmInvocation}`);
+				check(/(?:^|[|\r\n])KERNEL=0(?:\r?\n|$)/.test(npmInvocation), `installer unexpectedly bootstrapped kernel: ${npmInvocation}`);
+				check(result.stderr.includes("simulated npm stderr"), "plain installer must preserve successful native stderr output");
 			}
 		} finally {
 			await new Promise((resolve) => server.close(resolve));
@@ -315,7 +328,7 @@ function writeFakeCommands(binDir, npmLog) {
 		writeFileSync(join(binDir, "node.cmd"), "@echo off\r\necho v22.8.0\r\n");
 		writeFileSync(
 			join(binDir, "npm.cmd"),
-			`@echo off\r\n>"${npmLog}" echo %*\r\n>>"${npmLog}" echo TOOLS=%PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL%\r\n>>"${npmLog}" echo KERNEL=%PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL%\r\n`,
+			`@echo off\r\n>"${npmLog}" echo %*\r\n>>"${npmLog}" echo TOOLS=%PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL%\r\n>>"${npmLog}" echo KERNEL=%PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL%\r\n>&2 echo simulated npm stderr\r\n`,
 		);
 		return;
 	}
@@ -325,7 +338,7 @@ function writeFakeCommands(binDir, npmLog) {
 	writeFileSync(nodePath, "#!/bin/sh\nprintf 'v22.8.0\\n'\n");
 	writeFileSync(
 		npmPath,
-		`#!/bin/sh\nprintf '%s|TOOLS=%s|KERNEL=%s\\n' "$*" "$PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL" "$PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL" > "${npmLog}"\n`,
+		`#!/bin/sh\nprintf '%s|TOOLS=%s|KERNEL=%s\\n' "$*" "$PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL" "$PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL" > "${npmLog}"\nprintf 'simulated npm stderr\\n' >&2\n`,
 	);
 	chmodSync(nodePath, 0o755);
 	chmodSync(npmPath, 0o755);

--- a/scripts/check-windows-installer.mjs
+++ b/scripts/check-windows-installer.mjs
@@ -1,0 +1,351 @@
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+
+const source = readFileSync("install.ps1", "utf8").replace(/^\uFEFF/, "");
+const shellSource = readFileSync("install.sh", "utf8");
+const baseUrlPlaceholder = "__PRIME_AGENT_DOWNLOAD_BASE_URL__";
+const channelPlaceholder = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__";
+const mainCall = "\ntry {\n";
+const mainCallIndex = source.lastIndexOf(mainCall);
+const shellMainCall = '\nmain "$@"';
+const shellMainCallIndex = shellSource.lastIndexOf(shellMainCall);
+const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const failures = [];
+
+check(source.includes(baseUrlPlaceholder), "missing download base URL placeholder");
+check(source.includes(channelPlaceholder), "missing default release channel placeholder");
+check(source.includes("Security.Cryptography.SHA256"), "installer must verify downloads with SHA-256");
+check(source.includes('OpenJS.NodeJS.LTS'), "installer must offer Node.js installation");
+check(source.includes('Git.Git'), "installer must offer Git Bash installation");
+check(source.includes("▄▄███▀"), "installer must include Prime Agent logo");
+check(source.includes("$syncStart"), "installer must use synchronized terminal updates");
+check(mainCallIndex !== -1, "could not find final installer invocation");
+check(shellMainCallIndex !== -1, "could not find final shell installer invocation");
+
+const exampleBaseUrl = ["https:", "", "downloads.example.test"].join("/");
+for (const channel of ["stable", "beta"]) {
+	const rendered = source.replaceAll(baseUrlPlaceholder, exampleBaseUrl).replaceAll(channelPlaceholder, channel);
+	check(!rendered.includes(baseUrlPlaceholder), `${channel} render retained base URL placeholder`);
+	check(!rendered.includes(channelPlaceholder), `${channel} render retained channel placeholder`);
+}
+
+const shellReferenceFrame = getShellReferenceFrame();
+const powershellCommands = findPowerShellCommands();
+if (powershellCommands.length > 0) {
+	for (const command of powershellCommands) {
+		await runRenderCheck(command);
+		await runEndToEndCheck(command);
+	}
+} else {
+	process.stdout.write("PowerShell unavailable; skipped Windows installer execution check.\n");
+}
+
+if (failures.length > 0) {
+	process.stderr.write(`${["Windows installer check failed:", ...failures.map((failure) => `- ${failure}`)].join("\n")}\n`);
+	process.exit(1);
+}
+
+process.stdout.write("Windows installer check passed.\n");
+
+function getShellReferenceFrame() {
+	if (shellMainCallIndex === -1) return undefined;
+	const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-shell-render-"));
+	const harnessPath = join(tempDir, "render.sh");
+	const harness = `${shellSource.slice(0, shellMainCallIndex)}
+
+prime_agent_screen_cols=100
+prime_agent_screen_rows=30
+prime_agent_screen_layout_ready=0
+prime_agent_screen_layout_show_logo=0
+prime_agent_screen_layout_lab_width=0
+prime_agent_screen_render_lab_width=0
+prime_agent_screen_compact=0
+prime_agent_screen_frame=1
+prime_agent_screen_title="Installing Prime Agent"
+prime_agent_screen_detail="Fetching the verified package."
+prime_agent_screen_question=
+prime_agent_init_screen_layout
+prime_agent_refresh_screen_layout_mode
+prime_agent_render_screen
+`;
+	try {
+		writeFileSync(harnessPath, harness);
+		const result = spawnSync("sh", [harnessPath], { encoding: "utf8" });
+		check(result.status === 0, `shell render harness exited with ${result.status}\n${result.stderr}${result.stdout}`);
+		if (result.status !== 0) return undefined;
+		return result.stdout.replace(ansiPattern, "").replace(/\n$/, "");
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function findPowerShellCommands() {
+	return ["pwsh", "powershell"].filter((command) => {
+		const result = spawnSync(command, ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"], {
+			encoding: "utf8",
+		});
+		return result.status === 0;
+	});
+}
+
+async function runRenderCheck(command) {
+	if (mainCallIndex === -1) return;
+	const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-windows-render-"));
+	const harnessPath = join(tempDir, "render.ps1");
+	const harness = `${source.slice(0, mainCallIndex)}
+
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Text.UTF8Encoding]::new($false)
+
+function Get-TestRender {
+	param(
+		[int]$InitialCols,
+		[int]$InitialRows,
+		[int]$ResizedCols,
+		[int]$ResizedRows
+	)
+
+	$script:InstallerScreenLayoutReady = $false
+	$script:InstallerScreenLayoutShowLogo = $false
+	$script:InstallerScreenLayoutLabWidth = 0
+	$script:InstallerScreenRenderLabWidth = 0
+	$script:InstallerScreenCompact = $false
+	$script:InstallerScreenFrame = 1
+	$script:InstallerScreenTitle = "Installing Prime Agent"
+	$script:InstallerScreenDetail = "Fetching the verified package."
+	$script:InstallerScreenQuestion = ""
+	$script:InstallerScreenCols = $InitialCols
+	$script:InstallerScreenRows = $InitialRows
+	Initialize-InstallerScreenLayout
+	Select-InstallerScreenLayoutMode
+	$firstFrame = Get-InstallerScreenFrameText
+	$firstLines = $firstFrame -split "\n"
+	$first = [pscustomobject]@{
+		visible = Test-InstallerLogoVisible
+		compact = $script:InstallerScreenCompact
+		labWidth = $script:InstallerScreenLayoutLabWidth
+		renderLabWidth = $script:InstallerScreenRenderLabWidth
+		lineCount = $firstLines.Count
+		maxWidth = ($firstLines | ForEach-Object { [regex]::Replace($_, "\\x1b\\[[0-?]*[ -/]*[@-~]", "").Length } | Measure-Object -Maximum).Maximum
+		containsLogo = $firstFrame.Contains("▄")
+		plainFrame = [regex]::Replace($firstFrame, "\\x1b\\[[0-?]*[ -/]*[@-~]", "")
+	}
+
+	$script:InstallerScreenFrame = 2
+	$script:InstallerScreenCols = $ResizedCols
+	$script:InstallerScreenRows = $ResizedRows
+	Select-InstallerScreenLayoutMode
+	$secondFrame = Get-InstallerScreenFrameText
+	$secondLines = $secondFrame -split "\n"
+	$second = [pscustomobject]@{
+		visible = Test-InstallerLogoVisible
+		compact = $script:InstallerScreenCompact
+		labWidth = $script:InstallerScreenLayoutLabWidth
+		renderLabWidth = $script:InstallerScreenRenderLabWidth
+		lineCount = $secondLines.Count
+		maxWidth = ($secondLines | ForEach-Object { [regex]::Replace($_, "\\x1b\\[[0-?]*[ -/]*[@-~]", "").Length } | Measure-Object -Maximum).Maximum
+		containsLogo = $secondFrame.Contains("▄")
+	}
+	return [pscustomobject]@{ first = $first; second = $second }
+}
+
+$details = @("Preparing global install.", "Linking command binaries.", "Finalizing npm install.")
+$progress = foreach ($frame in @(1, 24, 25, 48, 49, 200)) {
+	$script:InstallerAnimationFrame = $frame
+	Get-InstallerAnimationDetail $details
+}
+$script:InstallerScreenEnabled = $true
+$script:TestAnimationCalls = 0
+function Show-InstallerScreen {
+	param([string]$Title, [string]$Detail = "", [string]$Question = "")
+	$script:TestAnimationCalls += 1
+}
+function Restore-InstallerTerminal {}
+Invoke-InstallerNativeCommand -Title "Testing animation" -Status "Testing animation" -Details $details \`
+	-FilePath '${command.replaceAll("'", "''")}' -Arguments @("-NoProfile", "-Command", "Start-Sleep -Milliseconds 400")
+
+$result = [pscustomobject]@{
+	stable = Get-TestRender 100 30 90 30
+	expanded = Get-TestRender 60 24 120 32
+	noLogo = Get-TestRender 41 24 100 30
+	compactWidth = Get-TestRender 100 30 32 24
+	compactRows = Get-TestRender 100 30 100 10
+	progress = $progress
+	animationCalls = $script:TestAnimationCalls
+}
+[Console]::Out.WriteLine(($result | ConvertTo-Json -Depth 6 -Compress))
+`;
+
+	try {
+		writeFileSync(harnessPath, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(harness)]));
+		const env = {
+			...process.env,
+			PRIME_AGENT_DOWNLOAD_BASE_URL: exampleBaseUrl,
+		};
+		const result = await run(command, ["-NoProfile", "-File", harnessPath], env);
+		check(result.code === 0, `render harness exited with ${result.code}\n${result.stderr}${result.stdout}`);
+		if (result.code !== 0) return;
+		const render = JSON.parse(result.stdout.trim());
+		check(render.stable.first.visible, "large Windows render must show logo");
+		check(render.stable.second.visible, "safe Windows resize must retain logo");
+		check(render.stable.first.containsLogo, "large Windows render must contain logo glyphs");
+		check(render.stable.first.labWidth === render.stable.second.labWidth, "Windows logo width must remain stable after resize");
+		check(render.stable.first.lineCount === 30, "large Windows render must fill terminal rows");
+		check(render.stable.first.maxWidth <= 99, "large Windows render must fit terminal width");
+		if (shellReferenceFrame) {
+			const windowsLines = render.stable.first.plainFrame.split("\n");
+			const shellLines = shellReferenceFrame.split("\n");
+			const mismatch = windowsLines.findIndex((line, index) => line !== shellLines[index]);
+			check(
+				mismatch === -1 && windowsLines.length === shellLines.length,
+				`Windows and shell installer frames must match; first mismatch line ${mismatch + 1}: ${JSON.stringify(windowsLines[mismatch])} != ${JSON.stringify(shellLines[mismatch])}`,
+			);
+		}
+		check(render.expanded.first.labWidth === render.expanded.second.labWidth, "Windows logo width must not grow after expansion");
+		check(!render.noLogo.first.visible && !render.noLogo.second.visible, "small initial Windows terminal must remain text-only");
+		check(render.compactWidth.second.compact && !render.compactWidth.second.visible, "severe Windows width shrink must hide logo");
+		check(render.compactRows.second.compact && !render.compactRows.second.visible, "short Windows terminal must hide logo");
+		check(render.animationCalls > 0, "Windows native command animation must redraw while child runs");
+		check(
+			JSON.stringify(render.progress) ===
+				JSON.stringify([
+					"Preparing global install.",
+					"Preparing global install.",
+					"Linking command binaries.",
+					"Linking command binaries.",
+					"Finalizing npm install.",
+					"Finalizing npm install.",
+				]),
+			"Windows progress details must advance deterministically",
+		);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+async function runEndToEndCheck(command) {
+	const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-windows-installer-"));
+	const binDir = join(tempDir, "bin");
+	const npmLog = join(tempDir, "npm.log");
+	const shellPath = join(tempDir, "bash.exe");
+	const version = "1.2.3";
+	const tarballName = `prime-agent-${version}.tgz`;
+	const tarball = Buffer.from("prime-agent-test-tarball");
+	const checksum = createHash("sha256").update(tarball).digest("hex");
+
+	try {
+		mkdirSync(binDir, { recursive: true });
+		writeFileSync(shellPath, "test shell");
+		writeFakeCommands(binDir, npmLog);
+		const settingsDir = join(tempDir, ".prime", "agent");
+		mkdirSync(settingsDir, { recursive: true });
+		writeFileSync(join(settingsDir, "settings.json"), `${JSON.stringify({ shellPath })}\n`);
+
+		const server = createServer((request, response) => {
+			response.setHeader("Content-Type", "text/plain; charset=utf-8");
+			switch (request.url) {
+				case "/stable":
+					response.end(`v${version}\n`);
+					break;
+				case `/releases/v${version}/SHA256SUMS`:
+					response.end(`${checksum}  ${tarballName}\n`);
+					break;
+				case `/releases/v${version}/${tarballName}`:
+					response.end(tarball);
+					break;
+				default:
+					response.statusCode = 404;
+					response.end("not found");
+			}
+		});
+		await new Promise((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		try {
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("test server did not expose a TCP port");
+			const testBaseUrl = `http://127.0.0.1:${address.port}`;
+			const installerPath = join(tempDir, "install.ps1");
+			const renderedInstaller = source
+				.replaceAll(baseUrlPlaceholder, testBaseUrl)
+				.replaceAll(channelPlaceholder, "stable");
+			writeFileSync(
+				installerPath,
+				Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(renderedInstaller)]),
+			);
+			const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+			const env = {
+				...process.env,
+				HOME: tempDir,
+				OS: "Windows_NT",
+				PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL: "0",
+				PRIME_AGENT_TEST_NPM_LOG: npmLog,
+				USERPROFILE: tempDir,
+				[pathKey]: `${binDir}${delimiter}${process.env[pathKey] ?? ""}`,
+			};
+			delete env.PRIME_AGENT_DOWNLOAD_BASE_URL;
+			delete env.PRIME_AGENT_RELEASE_CHANNEL;
+			delete env.PRIME_AGENT_VERSION;
+			const result = await run(command, ["-NoProfile", "-File", installerPath], env, "y\n");
+			check(result.code === 0, `installer execution exited with ${result.code}\n${result.stderr}${result.stdout}`);
+			if (result.code === 0) {
+				check(!result.stdout.includes("\u001b[?2026h"), "redirected installer must not emit terminal control sequences");
+				const npmInvocation = readFileSync(npmLog, "utf8");
+				check(npmInvocation.includes("install -g"), `installer did not run npm install -g: ${npmInvocation}`);
+				check(npmInvocation.includes(tarballName), `installer did not pass downloaded tarball to npm: ${npmInvocation}`);
+				check(npmInvocation.includes("TOOLS=1"), `installer did not bootstrap required tools: ${npmInvocation}`);
+				check(npmInvocation.includes("KERNEL="), `installer unexpectedly bootstrapped kernel: ${npmInvocation}`);
+			}
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function writeFakeCommands(binDir, npmLog) {
+	if (process.platform === "win32") {
+		writeFileSync(join(binDir, "node.cmd"), "@echo off\r\necho v22.8.0\r\n");
+		writeFileSync(
+			join(binDir, "npm.cmd"),
+			`@echo off\r\n>"${npmLog}" echo %*\r\n>>"${npmLog}" echo TOOLS=%PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL%\r\n>>"${npmLog}" echo KERNEL=%PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL%\r\n`,
+		);
+		return;
+	}
+
+	const nodePath = join(binDir, "node");
+	const npmPath = join(binDir, "npm");
+	writeFileSync(nodePath, "#!/bin/sh\nprintf 'v22.8.0\\n'\n");
+	writeFileSync(
+		npmPath,
+		`#!/bin/sh\nprintf '%s|TOOLS=%s|KERNEL=%s\\n' "$*" "$PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL" "$PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL" > "${npmLog}"\n`,
+	);
+	chmodSync(nodePath, 0o755);
+	chmodSync(npmPath, 0o755);
+}
+
+function run(command, args, env, input) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { env, stdio: ["pipe", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => (stdout += chunk));
+		child.stderr.on("data", (chunk) => (stderr += chunk));
+		child.stdin.end(input ?? "");
+		child.once("error", reject);
+		child.once("close", (code) => resolve({ code, stdout, stderr }));
+	});
+}
+
+function check(condition, message) {
+	if (!condition) failures.push(message);
+}


### PR DESCRIPTION
## Summary

Adds an official PowerShell installer for Windows with the same verified stable/beta release flow and terminal experience as `install.sh`.

Windows users can install Prime Agent with:

```powershell
irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
```

## Change

- Add `install.ps1` with Node.js/npm and bash preflight checks.
- Offer Node.js LTS and Git for Windows installation through `winget` when required.
- Resolve stable, beta, or explicit versions and verify downloaded release tarballs with SHA-256.
- Port the responsive Prime Agent splash, progress animation, prompts, compact layout, and terminal restoration from `install.sh`.
- Publish stable and beta PowerShell installers through the existing R2 release workflow.
- Document Windows installation and add an unreleased changelog entry.

The existing shell installer and macOS/Linux release flow are unchanged.

## Regression coverage

The installer check runs the real PowerShell functions with controlled HTTP responses and fake Node/npm executables. It verifies:

- PowerShell 5.1 and PowerShell 7 compatibility.
- Stable and beta installer rendering.
- Exact visual frame parity with `install.sh`.
- Responsive and compact terminal layouts.
- SHA-256 verification and npm installation arguments.
- Bash discovery through existing Prime Agent settings.
- Plain output when terminal control sequences are unavailable.

## Validation

- `npm run check`
- `npm run check:installer`
- `Invoke-ScriptAnalyzer -Path ./install.ps1 -Severity Warning,Error`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production release publish path and runs privileged global installs (npm/winget) on user machines, though behavior is isolated to Windows and covered by installer regression tests.
> 
> **Overview**
> Adds a **Windows PowerShell installer** (`install.ps1`) that mirrors the verified **stable/beta** release flow from `install.sh`: channel resolution, tarball download, **SHA-256** checks, and **global npm install**, with optional **Node.js LTS**, **Git for Windows**, and IPython runtime setup via **winget**.
> 
> The **release workflow** now renders and uploads `install.ps1` / `install-beta.ps1` to R2 next to the shell installers. **CI** gains `scripts/check-windows-installer.mjs` (wired into `check:installer`) for render parity with `install.sh`, layout checks, and a mocked end-to-end install path. **README** and coding-agent docs document the PowerShell one-liners and Windows bash requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94430315147501d0019144999f7c6f60dc91d82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Windows PowerShell installer for Prime Agent
> - Adds [install.ps1](https://github.com/PrimeIntellect-ai/prime-agent/pull/716/files#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806), a PowerShell installer that downloads and verifies SHA-256 checksums before running `npm install -g` on the versioned tarball.
> - The installer detects or installs prerequisites (Node.js LTS and Git for Windows) via `winget`, and renders a TUI when the terminal supports ANSI sequences.
> - The CI release workflow in [build-binaries.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/716/files#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2e) now publishes `install.ps1` and `install-beta.ps1` to the R2 bucket alongside the existing shell installers.
> - Adds [scripts/check-windows-installer.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/716/files#diff-843a92d7316b3a13efad53e2b011e02b09f882478cedc0321203237a5615020e) for automated validation of rendering and end-to-end execution, integrated into `npm run check:installer`.
> - Updates README and docs with Windows installation instructions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9443031.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->