### PR TITLE
fix: keep codex models executable when discovery returns an empty catalog

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -978,9 +978,19 @@ export class ModelRegistry {
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
+		// An empty catalog from a successful discovery is an entitlement or
+		// client-version gate (#639), not proof that an authenticated provider
+		// has no models — filtering on it silently disabled every codex model
+		// while the models demonstrably worked, and the resulting error blamed
+		// authentication (#696). Fail open on empty and let per-request errors
+		// surface the real cause; non-empty catalogs filter as before.
+		const filterByCatalog = (ids: Set<string>): Model<Api>[] =>
+			ids.size === 0
+				? availableModels
+				: availableModels.filter((model) => model.provider !== "openai-codex" || ids.has(model.id));
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return filterByCatalog(cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1002,12 +1012,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return filterByCatalog(modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return filterByCatalog(cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/suite/regressions/696-empty-codex-catalog.test.ts
+++ b/packages/coding-agent/test/suite/regressions/696-empty-codex-catalog.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+import { clearApiKeyCache, ModelRegistry } from "../../../src/core/model-registry.js";
+
+function fakeCodexJwt(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+		"utf8",
+	).toString("base64url");
+	return `${Buffer.from("{}").toString("base64url")}.${payload}.sig`;
+}
+
+function catalogResponse(slugs: string[]): Response {
+	return new Response(JSON.stringify({ models: slugs.map((slug) => ({ slug })) }), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("issue #696 empty codex catalog must not disable the provider", () => {
+	let tempDir: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-696-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+		clearApiKeyCache();
+		vi.unstubAllGlobals();
+	});
+
+	it("keeps codex models executable when discovery succeeds with zero models", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696"));
+		const available = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		expect(available.length).toBeGreaterThan(0);
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => catalogResponse([])),
+		);
+
+		const executable = await registry.getExecutableModels();
+		const codex = executable.filter((model) => model.provider === "openai-codex");
+		expect(codex.length).toBe(available.length);
+	});
+
+	it("keeps codex models executable from a cached empty catalog", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696_cached"));
+		const fetchMock = vi.fn(async () => catalogResponse([]));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await registry.getExecutableModels();
+		const secondPass = await registry.getExecutableModels();
+		const codex = secondPass.filter((model) => model.provider === "openai-codex");
+		expect(codex.length).toBeGreaterThan(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("still filters to the catalog when discovery returns a subset", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696_subset"));
+		const available = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		expect(available.length).toBeGreaterThan(1);
+		const keep = available[0]!.id;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => catalogResponse([keep])),
+		);
+
+		const executable = await registry.getExecutableModels();
+		const codex = executable.filter((model) => model.provider === "openai-codex");
+		expect(codex.map((model) => model.id)).toEqual([keep]);
+	});
+});


### PR DESCRIPTION
Fixes #696.

## Problem

`getExecutableModels()` treats a successful discovery response with zero models the same as a real catalog: every `openai-codex` model is filtered out and the empty set is cached for 5 minutes. As #696 documents, the same credentials serve completions over `/codex/responses`, the picker still offers the model via `getAvailable()`, and the resulting subagent error blames authentication.

An empty 200 is an entitlement or client-version gate (#639), not proof that an authenticated provider has no models — and #639's fix leaves this handling latent for any account whose gate returns a subset or nothing.

## Change

`packages/coding-agent/src/core/model-registry.ts`: empty catalogs fail open — codex models stay executable and per-request errors surface the real cause. Applies to the fresh result, the fresh-cache read, and the stale-cache fallback via one `filterByCatalog` helper. Non-empty catalogs filter exactly as before; the empty result is still cached, so there is no refetch-per-call.

## Tests

`test/suite/regressions/696-empty-codex-catalog.test.ts`:

- empty catalog keeps codex models executable (fails on main)
- cached empty catalog stays fail-open, single fetch (fails on main)
- subset catalog still filters to the returned slugs (control, passes on main)

`npm run check` clean; test run from the package root per AGENTS.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Codex executable-model filtering with fail-open behavior on empty discovery; subset filtering and auth failure paths are unchanged.
> 
> **Overview**
> Fixes **#696** by changing how `getExecutableModels()` applies OpenAI Codex model discovery.
> 
> Previously, a successful discovery response with **zero** models was treated like a real catalog: every `openai-codex` entry was removed from the executable list and that empty set was cached for five minutes, while completions could still work and the UI could still show those models via `getAvailable()`.
> 
> **`filterByCatalog`** now **fails open** when the discovered ID set is empty—Codex models stay executable and any entitlement or version issue surfaces on the actual request. When discovery returns one or more slugs, filtering is unchanged. The helper is used for fresh discovery, cache hits, and stale-cache fallback.
> 
> Regression tests cover empty catalog, cached empty catalog (single fetch), and subset filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a557912a41926ce384560f49c4b7b37d486d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ModelRegistry.getExecutableModels` to keep codex models available when discovery returns an empty catalog
> When the OpenAI Codex catalog discovery returns an empty set, `getExecutableModels` previously filtered out all codex models. The fix introduces a `filterByCatalog` helper in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/717/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) that skips catalog filtering when the discovered ID set is empty, treating an empty catalog as a failed entitlement check and failing open. Non-empty catalogs still filter as before. A regression test suite in [696-empty-codex-catalog.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/717/files#diff-97a3a2438d1f3677b3ca811b481f8b168b29bc44c4406deac880d1399b07af9e) covers the empty catalog, cached empty catalog, and non-empty catalog cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a5579.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->