### PR TITLE
Fix OpenAI Codex model discovery for RLM subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 - Fixed `retry_worker` cancelling its own recovery when a stopped session worker left a saved stop marker behind, leaving the session stuck at "Session worker is not connected".
+- Fixed RLM model discovery omitting OpenAI Codex GPT-5.6 models ([#718](https://github.com/PrimeIntellect-ai/prime-agent/pull/718) by [@nickadminroot](https://github.com/nickadminroot)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -27,7 +27,7 @@ import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -372,6 +372,10 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+// Codex model discovery gates its catalog by Codex CLI semver, not the Prime Agent version.
+// 0.144.0 is the first catalog version that advertises GPT-5.6 models.
+const OPENAI_CODEX_DISCOVERY_CLIENT_VERSION = "0.144.0";
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -383,7 +387,7 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	url.searchParams.set("client_version", OPENAI_CODEX_DISCOVERY_CLIENT_VERSION);
 	return url.toString();
 }
 

--- a/packages/coding-agent/test/suite/regressions/639-codex-discovery-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/639-codex-discovery-client-version.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+function openAICodexToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("#639 OpenAI Codex model discovery", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("sends a Codex client version that advertises GPT-5.6 models", async () => {
+		harness = await createHarness({
+			provider: "openai-codex",
+			models: [{ id: "gpt-5.6-luna" }],
+		});
+		const fetchModels = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input);
+			expect(url.searchParams.get("client_version")).toBe("0.144.0");
+			return new Response(JSON.stringify({ models: [{ slug: "gpt-5.6-luna" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchModels);
+		harness.authStorage.setRuntimeApiKey("openai-codex", openAICodexToken("account-1"));
+
+		await expect(harness.session.findRlmModels("luna", 8)).resolves.toMatchObject({
+			models: [{ selector: "openai-codex/gpt-5.6-luna" }],
+		});
+		expect(fetchModels).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

- use a dedicated Codex-compatible client version for OpenAI Codex model discovery
- restore GPT-5.6 Luna, Sol, and Terra to the executable RLM model catalog
- add a regression test for the discovery URL and Luna visibility

Fixes #639.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/639-codex-discovery-client-version.test.ts`
- `npm run check`
- live Codex catalog request with `client_version=0.144.0` returned Luna, Sol, and Terra

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the Codex discovery query parameter plus a regression test; no auth, inference, or data-path changes.
> 
> **Overview**
> **Fixes RLM/subagent model discovery** for OpenAI Codex when GPT-5.6 models (e.g. Luna, Sol, Terra) were missing from the executable catalog.
> 
> OpenAI Codex’s `/models` endpoint filters the catalog by **`client_version`**, and it expects a **Codex CLI semver**, not Prime Agent’s app version. The discovery URL now sends **`client_version=0.144.0`** (documented as the first catalog version that advertises GPT-5.6) instead of the agent `VERSION`.
> 
> A regression test asserts the discovery `fetch` uses `0.144.0` and that `findRlmModels` can surface a matching Codex model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5daa5962d23f667e3b8ea528dcae456b45e7e8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenAI Codex model discovery by pinning `client_version` to `0.144.0`
> The Codex catalog gates GPT-5.6 model availability by the Codex CLI semver passed as `client_version` in the discovery URL. Previously, the agent's own version was used, which caused GPT-5.6 models to be omitted from RLM model discovery. The fix pins `client_version` to `0.144.0` (the first catalog version advertising GPT-5.6) in [`model-registry.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/718/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453). A regression test in [`639-codex-discovery-client-version.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/718/files#diff-adddcd71c58569b0caed0cdb2e7f93bb529ea974d25c29ffc7e5cd1310c33cfe) verifies the correct version is sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 091c2f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->