### PR TITLE
fix: wait for scheduled post-compaction continuation before reporting idle

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1253,6 +1253,7 @@ export class AgentSession {
 	private _turnIntervalAutoRefinePending = false;
 	private _postCompactionContinuationScheduled = false;
 	private _postCompactionContinuationTimer: ReturnType<typeof setTimeout> | undefined;
+	private _postCompactionContinuationWaiters = new Set<() => void>();
 	private _postCompactionContinuationMessages: AgentMessage[] = [];
 	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
 	private _queuedAutonomousThresholdContinuations = new WeakMap<AssistantMessage, AgentMessage>();
@@ -6426,6 +6427,16 @@ export class AgentSession {
 			await this.agent.waitForIdle();
 			const agentEventQueue = this._agentEventQueue;
 			await agentEventQueue;
+			// A scheduled post-compaction continuation is pending session work
+			// that lives only in a timer — none of the checks below see it, so
+			// headless/print completion would tear the session down before the
+			// continuation fires and silently truncate the run (#674). Wait for
+			// the continuation to run or be cancelled; if it starts a turn, the
+			// next loop iteration observes the streaming state as usual.
+			if (this._postCompactionContinuationScheduled) {
+				await new Promise<void>((resolve) => this._postCompactionContinuationWaiters.add(resolve));
+				continue;
+			}
 			if (
 				pump === this._sessionInputPump &&
 				agentEventQueue === this._agentEventQueue &&
@@ -7180,6 +7191,15 @@ export class AgentSession {
 		}
 		this._postCompactionContinuationScheduled = false;
 		this._scheduledPostCompactionContinuationMessages = [];
+		this._notifyPostCompactionContinuationWaiters();
+	}
+
+	private _notifyPostCompactionContinuationWaiters(): void {
+		const waiters = [...this._postCompactionContinuationWaiters];
+		this._postCompactionContinuationWaiters.clear();
+		for (const waiter of waiters) {
+			waiter();
+		}
 	}
 
 	private _discardPendingAutoRefine(options: { cancelPostCompactionContinue?: boolean } = {}): void {
@@ -7291,6 +7311,18 @@ export class AgentSession {
 	}
 
 	private async _runScheduledPostCompactionContinue(): Promise<void> {
+		try {
+			await this._runScheduledPostCompactionContinueInner();
+		} finally {
+			// Wake waitForIdle waiters on every exit path. If the run
+			// rescheduled itself, the flag is set again and the waiter loop
+			// re-arms; if it started a turn, the streaming state keeps
+			// waitForIdle looping as usual.
+			this._notifyPostCompactionContinuationWaiters();
+		}
+	}
+
+	private async _runScheduledPostCompactionContinueInner(): Promise<void> {
 		await this._waitForRefineIdle();
 		if (!this._postCompactionContinuationScheduled) {
 			return;

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -978,9 +978,19 @@ export class ModelRegistry {
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
+		// An empty catalog from a successful discovery is an entitlement or
+		// client-version gate (#639), not proof that an authenticated provider
+		// has no models — filtering on it silently disabled every codex model
+		// while the models demonstrably worked, and the resulting error blamed
+		// authentication (#696). Fail open on empty and let per-request errors
+		// surface the real cause; non-empty catalogs filter as before.
+		const filterByCatalog = (ids: Set<string>): Model<Api>[] =>
+			ids.size === 0
+				? availableModels
+				: availableModels.filter((model) => model.provider !== "openai-codex" || ids.has(model.id));
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return filterByCatalog(cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1002,12 +1012,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return filterByCatalog(modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return filterByCatalog(cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1003,6 +1003,10 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.getFollowUpMessages()).toHaveLength(1);
 
 		await harness.session.prompt("/autonomous off");
+		// waitForIdle now waits for a scheduled post-compaction continuation
+		// (#674); under fake timers its 100ms timer must be advanced or the
+		// wait would (correctly) never resolve.
+		await vi.advanceTimersByTimeAsync(150);
 		await harness.session.waitForIdle();
 		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);

--- a/packages/coding-agent/test/suite/regressions/674-headless-compaction-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/674-headless-compaction-continuation.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+type SessionContinuationInternals = {
+	_schedulePostCompactionContinue(): void;
+	_cancelPostCompactionContinue(): void;
+	_postCompactionContinuationScheduled: boolean;
+};
+
+describe("issue #674 headless completion must not race the post-compaction continuation", () => {
+	let harness: Harness;
+
+	beforeEach(async () => {
+		harness = await createHarness();
+	});
+
+	afterEach(() => {
+		harness.cleanup();
+	});
+
+	it("waitForIdle waits for a scheduled continuation instead of resolving into teardown", async () => {
+		const internals = harness.session as unknown as SessionContinuationInternals;
+		const continueSpy = vi.spyOn(harness.session.agent, "continue").mockResolvedValue(undefined as never);
+
+		internals._schedulePostCompactionContinue();
+		expect(internals._postCompactionContinuationScheduled).toBe(true);
+
+		await harness.session.waitForIdle();
+
+		// The 100ms continuation timer is pending session work: completion must
+		// observe it, not resolve while it is still scheduled (which is how
+		// print mode tore the session down mid-run).
+		expect(internals._postCompactionContinuationScheduled).toBe(false);
+		expect(continueSpy).toHaveBeenCalled();
+	});
+
+	it("waitForIdle resolves when a scheduled continuation is cancelled", async () => {
+		const internals = harness.session as unknown as SessionContinuationInternals;
+		internals._schedulePostCompactionContinue();
+
+		const idle = harness.session.waitForIdle();
+		internals._cancelPostCompactionContinue();
+
+		await expect(
+			Promise.race([idle.then(() => "idle"), new Promise((resolve) => setTimeout(() => resolve("timeout"), 2_000))]),
+		).resolves.toBe("idle");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/696-empty-codex-catalog.test.ts
+++ b/packages/coding-agent/test/suite/regressions/696-empty-codex-catalog.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+import { clearApiKeyCache, ModelRegistry } from "../../../src/core/model-registry.js";
+
+function fakeCodexJwt(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+		"utf8",
+	).toString("base64url");
+	return `${Buffer.from("{}").toString("base64url")}.${payload}.sig`;
+}
+
+function catalogResponse(slugs: string[]): Response {
+	return new Response(JSON.stringify({ models: slugs.map((slug) => ({ slug })) }), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("issue #696 empty codex catalog must not disable the provider", () => {
+	let tempDir: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-696-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+		clearApiKeyCache();
+		vi.unstubAllGlobals();
+	});
+
+	it("keeps codex models executable when discovery succeeds with zero models", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696"));
+		const available = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		expect(available.length).toBeGreaterThan(0);
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => catalogResponse([])),
+		);
+
+		const executable = await registry.getExecutableModels();
+		const codex = executable.filter((model) => model.provider === "openai-codex");
+		expect(codex.length).toBe(available.length);
+	});
+
+	it("keeps codex models executable from a cached empty catalog", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696_cached"));
+		const fetchMock = vi.fn(async () => catalogResponse([]));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await registry.getExecutableModels();
+		const secondPass = await registry.getExecutableModels();
+		const codex = secondPass.filter((model) => model.provider === "openai-codex");
+		expect(codex.length).toBeGreaterThan(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("still filters to the catalog when discovery returns a subset", async () => {
+		const registry = ModelRegistry.inMemory(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", fakeCodexJwt("acct_696_subset"));
+		const available = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		expect(available.length).toBeGreaterThan(1);
+		const keep = available[0]!.id;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => catalogResponse([keep])),
+		);
+
+		const executable = await registry.getExecutableModels();
+		const codex = executable.filter((model) => model.provider === "openai-codex");
+		expect(codex.map((model) => model.id)).toEqual([keep]);
+	});
+});


### PR DESCRIPTION
Fixes #674.

## Problem

The post-compaction continuation is deferred through a 100ms `setTimeout`. `waitForIdle()` checks queued actions, the input pump, streaming state, and unfinished actions — none of which see a pending continuation timer. `waitForHeadlessCompletion()` resolves through that gap, print mode tears the session down, and the scheduled continuation is killed. From outside the run looks finished: exit 0, empty stderr, no marker — exactly the truncation reported in #674 (compaction_end at T, zero-token `aborted` turn 0.25s later).

## Change

`packages/coding-agent/src/core/agent-session.ts`:

- `waitForIdle()` waits while `_postCompactionContinuationScheduled` is set. If the continuation starts a turn, the next loop iteration observes the streaming state as before.
- Waiters are woken on every continuation exit path: the scheduled run (wrapped in try/finally), reschedule (waiter re-arms against the new timer), cancel, and dispose — so the wait cannot outlive the continuation.

One existing fake-timers test awaited `waitForIdle()` with a continuation scheduled; it now advances the 100ms timer first, since the wait is the point of this change.

## Tests

`test/suite/regressions/674-headless-compaction-continuation.test.ts`:

- `waitForIdle` resolves only after the scheduled continuation ran (fails on main: resolves with the timer still pending)
- cancellation releases the wait (control against deadlock)

`agent-session-compaction.test.ts` suite: 34/34. `npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session idle/completion timing (affects headless exit) and model availability logic for OpenAI Codex; behavior is intentional but touches run lifecycle and provider selection.
> 
> **Overview**
> Fixes **headless/print runs ending early** (#674) by treating the deferred post-compaction continuation (100ms timer) as session work in `waitForIdle()`. When `_postCompactionContinuationScheduled` is set, the idle loop waits on waiter callbacks that are released when the continuation runs (try/finally), reschedules, or is cancelled—so completion no longer tears the session down before `agent.continue` fires.
> 
> Separately fixes **OpenAI Codex models disappearing** (#696): `getExecutableModels()` used to filter Codex entries against discovery catalog IDs, so a **successful but empty** catalog removed every Codex model and surfaced misleading auth errors. Empty catalogs now **fail open** (keep configured Codex models); non-empty catalogs still filter to the returned subset.
> 
> Regression tests cover continuation wait/cancel behavior and empty vs subset Codex catalogs; an existing compaction test advances fake timers before `waitForIdle` under the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 414eb580f4671e146fea9fd61effb89138413134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `waitForIdle` to wait for scheduled post-compaction continuation before reporting idle
> - `AgentSession.waitForIdle` previously returned before a scheduled post-compaction continuation timer had fired, causing premature session teardown. It now blocks until the continuation either runs or is cancelled.
> - A new `_postCompactionContinuationWaiters` set tracks resolvers; `_cancelPostCompactionContinue` and `_runScheduledPostCompactionContinue` both call `_notifyPostCompactionContinuationWaiters` to unblock waiters on every exit path.
> - Fixes a separate bug where an empty OpenAI Codex model catalog returned by a successful discovery request would disable all codex models; empty catalogs are now treated as unfiltered.
> - Regression tests added for both fixes in [674-headless-compaction-continuation.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/721/files#diff-38cb2313e648eeecc82412001b5cc56a51efe16c52137bf4be892e9a607b78b5) and [696-empty-codex-catalog.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/721/files#diff-97a3a2438d1f3677b3ca811b481f8b168b29bc44c4406deac880d1399b07af9e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 414eb58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->