### PR TITLE
fix: keep worker socket paths under the sun_path limit

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -211,9 +211,26 @@ function assertSocketLease(socketPath: string, lease: DaemonSocketPathLease): vo
 	}
 }
 
+// Longest socket filename created inside the daemon socket dir:
+// "worker-" + 12-hex descriptor key + "-" + 12-char worker id + ".sock".
+const LONGEST_SOCKET_NAME_LENGTH = 37;
+// sun_path allows 104 bytes on macOS/BSD and 108 on Linux, including the
+// terminating NUL.
+const UNIX_SOCKET_PATH_LIMIT = process.platform === "darwin" ? 103 : 107;
+
 export function defaultDaemonSocketDir(): string {
 	const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
-	return join(tmpdir(), `prime-agent-${suffix}`);
+	const dirName = `prime-agent-${suffix}`;
+	const candidate = join(tmpdir(), dirName);
+	if (process.platform !== "win32" && candidate.length + 1 + LONGEST_SOCKET_NAME_LENGTH > UNIX_SOCKET_PATH_LIMIT) {
+		// A long TMPDIR (macOS /var/folders/...) plus a long numeric uid pushes
+		// worker socket paths past the sun_path limit; bind then fails and
+		// session creation times out after 30s (#669). Fall back to /tmp — the
+		// per-uid directory name and the 0700 ownership checks in
+		// ensureDefaultDaemonSocketDir apply to it unchanged.
+		return join("/tmp", dirName);
+	}
+	return candidate;
 }
 
 function ensureDefaultDaemonSocketDir(socketPath: string): void {

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -216,7 +216,8 @@ function assertSocketLease(socketPath: string, lease: DaemonSocketPathLease): vo
 const LONGEST_SOCKET_NAME_LENGTH = 37;
 // sun_path allows 104 bytes on macOS/BSD and 108 on Linux, including the
 // terminating NUL.
-const UNIX_SOCKET_PATH_LIMIT = process.platform === "darwin" ? 103 : 107;
+const BSD_SUN_PATH_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["darwin", "freebsd", "openbsd", "netbsd"]);
+const UNIX_SOCKET_PATH_LIMIT = BSD_SUN_PATH_PLATFORMS.has(process.platform) ? 103 : 107;
 
 export function defaultDaemonSocketDir(): string {
 	const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";

--- a/packages/coding-agent/test/suite/regressions/669-socket-path-limit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/669-socket-path-limit.test.ts
@@ -1,0 +1,42 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { defaultDaemonSocketDir } from "../../../src/modes/daemon/daemon-socket.js";
+
+const LONGEST_SOCKET_NAME_LENGTH = "worker-0123456789ab-0123456789ab.sock".length;
+const UNIX_SOCKET_PATH_LIMIT = process.platform === "darwin" ? 103 : 107;
+
+describe("issue #669 worker socket path must fit the sun_path limit", () => {
+	const originalTmpdir = process.env.TMPDIR;
+
+	afterEach(() => {
+		if (originalTmpdir === undefined) {
+			delete process.env.TMPDIR;
+		} else {
+			process.env.TMPDIR = originalTmpdir;
+		}
+	});
+
+	it("falls back to /tmp when the tmpdir-based path would exceed the limit", () => {
+		// Simulate the reported shape: a long macOS /var/folders tmpdir plus a
+		// 10-digit uid. 80 chars of tmpdir guarantees overflow for any uid.
+		process.env.TMPDIR = join("/private/var/folders", "a".repeat(60));
+		const dir = defaultDaemonSocketDir();
+		expect(dir.startsWith("/tmp/prime-agent-")).toBe(true);
+		expect(dir.length + 1 + LONGEST_SOCKET_NAME_LENGTH).toBeLessThanOrEqual(UNIX_SOCKET_PATH_LIMIT);
+	});
+
+	it("keeps using the OS tmpdir when the path fits", () => {
+		process.env.TMPDIR = "/tmp";
+		const dir = defaultDaemonSocketDir();
+		expect(dir.startsWith(join(tmpdir(), "prime-agent-"))).toBe(true);
+	});
+
+	it("always yields a directory whose worker sockets fit the platform limit", () => {
+		for (const candidate of ["/tmp", join("/private/var/folders", "b".repeat(70))]) {
+			process.env.TMPDIR = candidate;
+			const dir = defaultDaemonSocketDir();
+			expect(dir.length + 1 + LONGEST_SOCKET_NAME_LENGTH).toBeLessThanOrEqual(UNIX_SOCKET_PATH_LIMIT);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/669-socket-path-limit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/669-socket-path-limit.test.ts
@@ -4,9 +4,12 @@ import { afterEach, describe, expect, it } from "vitest";
 import { defaultDaemonSocketDir } from "../../../src/modes/daemon/daemon-socket.js";
 
 const LONGEST_SOCKET_NAME_LENGTH = "worker-0123456789ab-0123456789ab.sock".length;
-const UNIX_SOCKET_PATH_LIMIT = process.platform === "darwin" ? 103 : 107;
+const BSD_SUN_PATH_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["darwin", "freebsd", "openbsd", "netbsd"]);
+const UNIX_SOCKET_PATH_LIMIT = BSD_SUN_PATH_PLATFORMS.has(process.platform) ? 103 : 107;
 
-describe("issue #669 worker socket path must fit the sun_path limit", () => {
+// The fallback under test is Unix-only: Windows named pipes have no sun_path
+// limit and defaultDaemonSocketDir never rewrites the directory there.
+describe.skipIf(process.platform === "win32")("issue #669 worker socket path must fit the sun_path limit", () => {
 	const originalTmpdir = process.env.TMPDIR;
 
 	afterEach(() => {


### PR DESCRIPTION
Fixes #669.

## Problem

`defaultDaemonSocketDir()` is `join(tmpdir(), "prime-agent-<uid>")`. On macOS `tmpdir()` resolves to a long `/var/folders/...` path, and worker sockets add `worker-<12-hex>-<12-char>.sock` (37 chars). With a 10-digit uid the full path exceeds macOS's 103 usable `sun_path` bytes — bind fails, the worker socket never exists (`ENOENT` on lstat), and session creation times out after 30s, as reported.

## Change

`packages/coding-agent/src/modes/daemon/daemon-socket.ts`: when the tmpdir-based directory cannot fit the longest socket filename within the platform limit (103 macOS/BSD, 107 Linux), fall back to `/tmp/prime-agent-<uid>`. The per-uid directory name and the 0700 ownership checks in `ensureDefaultDaemonSocketDir` apply to the fallback unchanged; a fitting `TMPDIR` keeps today's behavior, so this only engages in the overflow case the reporter worked around manually with `TMPDIR=/tmp`.

## Tests

`test/suite/regressions/669-socket-path-limit.test.ts`:

- long tmpdir falls back to `/tmp` and the resulting worker path fits the limit (fails on main)
- short tmpdir keeps the OS tmpdir location (control)
- invariant: the chosen dir plus the longest socket name always fits the platform limit (fails on main)

`npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Unix-only path selection for the daemon socket directory; security model (per-uid dir, 0700 checks) is unchanged and short tmpdirs keep prior behavior.
> 
> **Overview**
> Fixes **#669** by changing **`defaultDaemonSocketDir()`** so worker Unix socket paths stay within the platform **`sun_path`** byte limit (103 on macOS/BSD, 107 on Linux).
> 
> On non-Windows hosts it now estimates the longest worker socket name under the directory (`worker-<12-hex>-<12-char>.sock`, 37 chars). If `join(tmpdir(), prime-agent-<uid>)` plus that filename would overflow, the directory falls back to **`/tmp/prime-agent-<uid>`** instead of a long macOS `/var/folders/...` tmpdir. When the OS tmpdir already fits, behavior is unchanged; **`ensureDefaultDaemonSocketDir`** still uses the same per-uid dir name and ownership checks on whichever path is chosen.
> 
> Adds regression tests in **`669-socket-path-limit.test.ts`** (skipped on Windows) that assert the `/tmp` fallback for an artificially long **`TMPDIR`**, normal tmpdir when paths fit, and that returned dirs always leave room for the longest worker socket name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278ea1ffee9665da2f87781a3b3499011ff56d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `defaultDaemonSocketDir` to keep worker socket paths under the Unix `sun_path` limit
> Unix domain sockets have a platform-specific `sun_path` limit (104 bytes on BSD, 108 on Linux). On non-Windows platforms, `defaultDaemonSocketDir` in [daemon-socket.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/722/files#diff-59c4ea71700afcf7d09d14c5d30e2c73fd0c71b28284e8758cd8fbd4b2337dbc) now checks whether the full worker socket path (tmpdir + longest socket filename) would exceed this limit, and falls back to `/tmp/prime-agent-<uid>` if so. A regression test suite is added in [669-socket-path-limit.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/722/files#diff-edabf6a9b7ff4423700559ab689fc7c42bbd2a1fb14164d9fa3b676ccf5d51b4) to verify fallback and within-limit behavior. Behavioral Change: on systems where the OS tmpdir path is long, the daemon socket directory will now be `/tmp/prime-agent-<uid>` instead of the OS tmpdir.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 278ea1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->