### PR TITLE
fix: doctor flags a daemon whose cached spawn paths are gone

### DIFF
--- a/packages/coding-agent/src/cli/daemon-ps-format.ts
+++ b/packages/coding-agent/src/cli/daemon-ps-format.ts
@@ -38,6 +38,8 @@ function colorStatus(status: DaemonStatus, value: string): string {
 			return chalk.green(value);
 		case "stale":
 			return chalk.yellow(value);
+		case "broken-runtime":
+			return chalk.red(value);
 		case "unreachable":
 			return chalk.red(value);
 		case "orphan-file":

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -36,7 +36,7 @@ import { promptYesNo } from "./daemon-stop-confirm.js";
  * older build (a new protocol command would not).
  */
 
-export type DaemonStatus = "current" | "stale" | "unreachable" | "orphan-file";
+export type DaemonStatus = "current" | "stale" | "broken-runtime" | "unreachable" | "orphan-file";
 
 export interface DiscoveredDaemonProcess {
 	pid: number;
@@ -62,9 +62,10 @@ export interface DaemonInfo {
 
 const STATUS_ORDER: Record<DaemonStatus, number> = {
 	current: 0,
-	stale: 1,
-	unreachable: 2,
-	"orphan-file": 3,
+	"broken-runtime": 1,
+	stale: 2,
+	unreachable: 3,
+	"orphan-file": 4,
 };
 const SHUTDOWN_QUIET_PERIOD_MS = 1000;
 const SHUTDOWN_CONVERGENCE_TIMEOUT_MS = 10_000;
@@ -318,6 +319,31 @@ function classifyReachable(probe: ProbeResult): DaemonStatus {
 	return "stale";
 }
 
+/**
+ * A reachable daemon spawns every session worker with its own cached
+ * `process.execPath` and entrypoint (see createCliSubprocessLaunchSpec). When
+ * either path was removed from disk after the daemon started — a Homebrew
+ * Node upgrade deletes the old Cellar binary — the daemon still answers
+ * status queries while every worker spawn fails with ENOENT (#704). Surface
+ * that as "broken-runtime" instead of reporting the daemon healthy.
+ */
+export function classifyRuntimeHealth(
+	status: DaemonStatus,
+	runtime: { executablePath?: string; entrypointPath?: string } | undefined,
+	pathExists: (path: string) => boolean = existsSync,
+): DaemonStatus {
+	if (status !== "current" && status !== "stale") {
+		return status;
+	}
+	const spawnPaths = [runtime?.executablePath, runtime?.entrypointPath].filter(
+		(path): path is string => typeof path === "string" && path.length > 0,
+	);
+	if (spawnPaths.length === 0) {
+		return status;
+	}
+	return spawnPaths.every((path) => pathExists(path)) ? status : "broken-runtime";
+}
+
 export function verifyHelloSupervisorPid(
 	pid: number | undefined,
 	expectedProcessStartId: string | undefined,
@@ -368,7 +394,7 @@ export async function discoverDaemons(): Promise<DaemonInfo[]> {
 			const pid = proc?.pid ?? verifyHelloSupervisorPid(probe.supervisorPid, probe.supervisorProcessStartId);
 			const hasTrackedWorkers = workerSockets.has(socketPath);
 			const status: DaemonStatus = probe.reachable
-				? classifyReachable(probe)
+				? classifyRuntimeHealth(classifyReachable(probe), probe.runtime)
 				: proc || hasTrackedWorkers
 					? "unreachable"
 					: "orphan-file";

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -327,6 +327,16 @@ function classifyReachable(probe: ProbeResult): DaemonStatus {
  * status queries while every worker spawn fails with ENOENT (#704). Surface
  * that as "broken-runtime" instead of reporting the daemon healthy.
  */
+/**
+ * A daemon compiled as a Bun binary reports process.argv[1] as a path inside
+ * Bun's virtual filesystem, which never exists on disk; worker spawns skip the
+ * entrypoint entirely for those builds (createCliSubprocessLaunchSpec), so its
+ * absence must not count as a broken runtime. Markers match isBunBinary.
+ */
+function isBunVirtualEntrypoint(path: string): boolean {
+	return path.includes("$bunfs") || path.includes("~BUN") || path.includes("%7EBUN");
+}
+
 export function classifyRuntimeHealth(
 	status: DaemonStatus,
 	runtime: { executablePath?: string; entrypointPath?: string } | undefined,
@@ -335,7 +345,11 @@ export function classifyRuntimeHealth(
 	if (status !== "current" && status !== "stale") {
 		return status;
 	}
-	const spawnPaths = [runtime?.executablePath, runtime?.entrypointPath].filter(
+	const entrypointPath =
+		runtime?.entrypointPath !== undefined && isBunVirtualEntrypoint(runtime.entrypointPath)
+			? undefined
+			: runtime?.entrypointPath;
+	const spawnPaths = [runtime?.executablePath, entrypointPath].filter(
 		(path): path is string => typeof path === "string" && path.length > 0,
 	);
 	if (spawnPaths.length === 0) {

--- a/packages/coding-agent/test/suite/regressions/704-doctor-stale-node-path.test.ts
+++ b/packages/coding-agent/test/suite/regressions/704-doctor-stale-node-path.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { classifyRuntimeHealth, type DaemonInfo, sortDaemons } from "../../../src/cli/daemon-ps.js";
+
+const missing = () => false;
+const present = () => true;
+
+describe("issue #704 doctor must flag a daemon whose spawn paths are gone", () => {
+	it("reports broken-runtime when the cached node binary was removed", () => {
+		const status = classifyRuntimeHealth(
+			"current",
+			{ executablePath: "/opt/homebrew/Cellar/node/26.6.0/bin/node", entrypointPath: "/opt/homebrew/lib/cli.js" },
+			(path) => path !== "/opt/homebrew/Cellar/node/26.6.0/bin/node",
+		);
+		expect(status).toBe("broken-runtime");
+	});
+
+	it("reports broken-runtime when the entrypoint was removed", () => {
+		const status = classifyRuntimeHealth(
+			"current",
+			{ executablePath: process.execPath, entrypointPath: "/gone/cli.js" },
+			(path) => path === process.execPath,
+		);
+		expect(status).toBe("broken-runtime");
+	});
+
+	it("keeps current when both spawn paths exist", () => {
+		expect(
+			classifyRuntimeHealth("current", { executablePath: "/usr/bin/node", entrypointPath: "/x/cli.js" }, present),
+		).toBe("current");
+	});
+
+	it("does not reclassify daemons without runtime identity or unreachable ones", () => {
+		expect(classifyRuntimeHealth("stale", undefined, missing)).toBe("stale");
+		expect(classifyRuntimeHealth("unreachable", { executablePath: "/gone" }, missing)).toBe("unreachable");
+		expect(classifyRuntimeHealth("orphan-file", { executablePath: "/gone" }, missing)).toBe("orphan-file");
+	});
+
+	it("sorts broken-runtime daemons between current and stale", () => {
+		const daemon = (status: DaemonInfo["status"], socketPath: string): DaemonInfo => ({
+			socketPath,
+			status,
+			isDefault: false,
+		});
+		const sorted = sortDaemons([daemon("stale", "/b"), daemon("broken-runtime", "/c"), daemon("current", "/a")]);
+		expect(sorted.map((info) => info.status)).toEqual(["current", "broken-runtime", "stale"]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/704-doctor-stale-node-path.test.ts
+++ b/packages/coding-agent/test/suite/regressions/704-doctor-stale-node-path.test.ts
@@ -23,6 +23,26 @@ describe("issue #704 doctor must flag a daemon whose spawn paths are gone", () =
 		expect(status).toBe("broken-runtime");
 	});
 
+	it("does not flag a bun-binary daemon whose virtual entrypoint never exists on disk", () => {
+		const bunPaths = ["/$bunfs/root/prime-agent", "/private/tmp/~BUN/cli.js", "/x/%7EBUN/cli.js"];
+		for (const entrypointPath of bunPaths) {
+			const status = classifyRuntimeHealth(
+				"current",
+				{ executablePath: "/usr/local/bin/prime-agent", entrypointPath },
+				(path) => path === "/usr/local/bin/prime-agent",
+			);
+			expect(status).toBe("current");
+		}
+		// The executable itself must still exist even for bun binaries.
+		expect(
+			classifyRuntimeHealth(
+				"current",
+				{ executablePath: "/gone/prime-agent", entrypointPath: "/$bunfs/root/x" },
+				missing,
+			),
+		).toBe("broken-runtime");
+	});
+
 	it("keeps current when both spawn paths exist", () => {
 		expect(
 			classifyRuntimeHealth("current", { executablePath: "/usr/bin/node", entrypointPath: "/x/cli.js" }, present),


### PR DESCRIPTION
Fixes #704.

## Problem

A daemon spawns every session worker with its own cached `process.execPath` and entrypoint (`createCliSubprocessLaunchSpec`, subprocess-launch.ts:47). When a Homebrew Node upgrade removes the old Cellar binary, the daemon keeps answering status queries, `doctor` reports it `current`, and every worker spawn fails with `spawn ... ENOENT` — the silent failure described in #704.

## Change

The `daemon_hello` runtime identity already carries `executablePath` and `entrypointPath`; doctor just never checked them. `packages/coding-agent/src/cli/daemon-ps.ts` adds `classifyRuntimeHealth()`: a reachable daemon whose spawn paths no longer exist on disk is reported as `broken-runtime` (red in the table, sorted between `current` and `stale`). Daemons that did not report a runtime identity, and unreachable/orphan states, are untouched.

Reap semantics are unchanged: a sessionless `broken-runtime` daemon falls through to `shutdown` in `planReap`, so `doctor --fix` performs exactly the documented workaround (`prime-agent shutdown` + fresh daemon); one with live sessions is skipped, since its existing workers still function.

## Tests

`test/suite/regressions/704-doctor-stale-node-path.test.ts` (5 tests): removed node binary and removed entrypoint each classify as `broken-runtime` (fail on main — the type does not exist), healthy paths stay `current`, missing-identity/unreachable/orphan pass through, sort order pinned.

Existing `daemon-ps`, `daemon-ps-format`, `public-command` suites: 60/60. `npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI daemon status classification and display; no protocol, auth, or reap behavior changes beyond existing shutdown paths for idle daemons.
> 
> **Overview**
> **Doctor / daemon discovery** now downgrades reachable daemons that still answer probes but can no longer spawn workers because their cached Node binary or CLI entrypoint was removed (e.g. after a Homebrew Node upgrade). Those daemons are reported as **`broken-runtime`** instead of **`current`**, using `executablePath` and `entrypointPath` from `daemon_hello` runtime identity.
> 
> Bun-compiled daemons ignore virtual entrypoint paths that never exist on disk; unreachable and orphan statuses are unchanged. The status sorts between `current` and `stale` and renders in red in the daemon list table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52748a197be2e490bbb56450cb850c707e1ab02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `doctor` to flag daemons whose cached spawn paths no longer exist on disk
> - Adds a `classifyRuntimeHealth` function in [`daemon-ps.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/723/files#diff-d26d176c2fa21f2284ca0dc614dfb273ec8abfce710655afccc3aa35628c848a) that checks whether a reachable daemon's `executablePath` and `entrypointPath` still exist on disk, reclassifying the daemon as `"broken-runtime"` if either is missing.
> - Bun virtual entrypoints (paths containing `$bunfs`, `~BUN`, or `%7EBUN`) are excluded from the missing-path check.
> - `"broken-runtime"` is inserted into the sort order between `"current"` and `"stale"`, and rendered in red in the `ps` output.
> - A regression test suite is added in [`704-doctor-stale-node-path.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/723/files#diff-3adff2477f278ee2437b639b133bd7994e7551a7f7328592c4392ca9ecf2341b) covering classification, exclusions, status preservation, and sort order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a52748a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->