### PR TITLE
fix: rank configured providers first in model selector search

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -326,10 +326,14 @@ export class ModelSelectorComponent extends Container implements Focusable {
 				query,
 				({ id, provider }) => `${id} ${provider} ${provider}/${id} ${provider} ${id}`,
 			);
+			// Configured providers outrank raw match quality: the unfiltered
+			// list already sorts signed-in providers first (sortModels), and a
+			// query must not surface a provider the user cannot run above one
+			// they are logged into (#653).
 			scored.sort(
 				(a, b) =>
-					a.score - b.score ||
 					Number(this.isProviderConfigured(b.item)) - Number(this.isProviderConfigured(a.item)) ||
+					a.score - b.score ||
 					this.recentRankOf(a.item) - this.recentRankOf(b.item),
 			);
 			this.filteredModels = scored.map((r) => r.item);

--- a/packages/coding-agent/test/suite/regressions/653-search-configured-provider-priority.test.ts
+++ b/packages/coding-agent/test/suite/regressions/653-search-configured-provider-priority.test.ts
@@ -1,0 +1,70 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../../../src/core/keybindings.js";
+import { ModelSelectorComponent } from "../../../src/modes/interactive/components/model-selector.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function createFakeTui(): TUI {
+	return {
+		requestRender: () => {},
+	} as unknown as TUI;
+}
+
+type SelectorInternals = {
+	filteredModels: Array<{ provider: string; id: string }>;
+};
+
+describe("issue #653 search must rank configured providers first", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("ranks a configured provider's model above a closer match from an unconfigured provider", async () => {
+		const harness = await createHarness({
+			models: [{ id: "kimi-k2-thinking", name: "Kimi K2 Thinking", reasoning: true }],
+		});
+		harnesses.push(harness);
+		const configured = harness.getModel("kimi-k2-thinking")!;
+		// "k2" scores strictly better for kimi/k2 than for faux/kimi-k2-thinking,
+		// so score-first ordering surfaces the provider the user cannot run.
+		const unconfigured: Model<typeof configured.api> = {
+			...configured,
+			id: "k2",
+			name: "K2",
+			provider: "kimi",
+		};
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			undefined,
+			harness.session.modelRegistry,
+			[],
+			() => {},
+			() => {},
+			"k2",
+			{
+				availableModels: [unconfigured, configured],
+				configuredProviders: new Set([configured.provider]),
+			},
+		);
+
+		const internals = selector as unknown as SelectorInternals;
+		const order = internals.filteredModels.map((item) => `${item.provider}/${item.id}`);
+		expect(order[0]).toBe(`${configured.provider}/${configured.id}`);
+		expect(order).toContain("kimi/k2");
+	});
+});


### PR DESCRIPTION
Fixes #653.

## Problem

The unfiltered model list sorts signed-in providers first (`sortModels`), and the selector's hint says "Signed-in providers first." — but the search path sorts by raw fuzzy score before configured-provider status (`filterModels`). A query whose text matches an unconfigured provider's model more tightly surfaces junk the user cannot run above the provider they are logged into, which is the screenshot in #653.

## Change

`packages/coding-agent/src/modes/interactive/components/model-selector.ts`: flip the search tiebreak to configured provider, then match score, then recency — making search consistent with browse and with the component's own hint. One-line reorder.

The second observation in the issue (signed-in state not visible per row) is a display addition, not touched here.

## Tests

`test/suite/regressions/653-search-configured-provider-priority.test.ts`: an unconfigured provider's `k2` scores strictly better than the configured `kimi-k2-thinking` for the query `k2` (score probe: -24.9 vs -4.4), so score-first ordering puts the unrunnable model on top — fails on main, passes with the fix.

Neighbor suites (`model-selector-actions`, `selector-search-reset`, `3217-scoped-model-order`): 14/14. `npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small comparator reorder in interactive UI only; behavior change is intentional and covered by a regression test.
> 
> **Overview**
> Fixes **#653** by aligning model search ranking with the unfiltered list and the “Signed-in providers first” hint.
> 
> In `filterModels`, search results are now sorted by **configured/signed-in provider** before fuzzy match score, then recency. Previously, a tighter text match on an unconfigured provider could appear above a runnable model from a provider the user is logged into.
> 
> Adds regression test `653-search-configured-provider-priority.test.ts` where query `k2` would rank `kimi/k2` above the configured `kimi-k2-thinking` under score-first ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f26bec8e755afbf0af1d2cf79a0ac9eac2426793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rank configured providers first in model selector search results
> Updates `ModelSelectorComponent.filterModels` to sort by configured-provider status before fuzzy match score, with recent-rank as a final tiebreaker. Previously, an unconfigured provider's model could appear first if it had a closer textual match. Adds a regression test in [653-search-configured-provider-priority.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/724/files#diff-9d6e02c33a84fd9b2cfd775d84804e11dde43d475c223820a1ed66bcf10f4ee6) to verify this ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f26bec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->