### PR TITLE
fix(coding-agent): render belowEditor widgets below the prompt in fullscreen

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed extension `belowEditor` widgets rendering above the prompt editor in fullscreen mode ([#697](https://github.com/PrimeIntellect-ai/prime-agent/issues/697)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6899,7 +6899,7 @@ export class InteractiveMode {
 	}
 
 	private getPromptDockComponents(): Component[] {
-		return [this.editorContainer, this.subagentSummaryLine, this.footerSlot];
+		return [this.editorContainer, this.subagentSummaryLine, this.widgetContainerBelow, this.footerSlot];
 	}
 
 	/** Enter or leave fullscreen rendering without touching the persisted setting. */
@@ -6912,7 +6912,6 @@ export class InteractiveMode {
 					this.mainViewContainer,
 					this.widgetContainerAbove,
 					...this.getPromptContextContainers(),
-					this.widgetContainerBelow,
 				],
 				dock: this.promptDock,
 				mouse: this.settingsManager.getFullscreenMouse(),


### PR DESCRIPTION
## Problem

In fullscreen mode, extension widgets registered with `placement: 'belowEditor'` render **above** the prompt editor instead of below it (#697). In non-fullscreen mode the placement is correct.

## Root cause

The placement value plumbs through correctly end to end, and non-fullscreen layout is right — `mainContainer` orders `widgetContainerBelow` after the editor. The bug is fullscreen-only, in `applyFullscreen()` (`packages/coding-agent/src/modes/interactive/interactive-mode.ts`):

```ts
this.ui.enterFullscreen({
  scroll: [ ..., this.widgetContainerBelow ],  // widget in the SCROLL region
  dock: this.promptDock,                        // editor lives in the dock
});
```

`getPromptDockComponents()` returns `[editorContainer, subagentSummaryLine, footerSlot]`, and `renderFullscreen()` (`packages/tui/src/tui.ts`) renders the entire `scroll` region above the `dock`. So `widgetContainerBelow` ends up above the editor — exactly the reported symptom.

## Fix

Move `widgetContainerBelow` out of the fullscreen `scroll` region and into the prompt dock, between `subagentSummaryLine` and `footerSlot`, so both layout paths agree.

This is safe for the non-fullscreen path:
- `promptDock` is only ever rendered as the fullscreen dock; it is never attached to the UI in non-fullscreen mode.
- `Container.addChild` (`packages/tui/src/tui.ts`) appends without reparenting, so adding `widgetContainerBelow` to `getPromptDockComponents()` does not remove it from `mainContainer`.
- `renderFullscreen()` renders only `scroll` + `dock` (never `mainContainer`), so there is no double render in fullscreen.

## Testing

- Reproduced with the in-repo `packages/coding-agent/examples/extensions/widget-placement.ts` example.
- `npm run check` passes (biome, `tsgo --noEmit`, installer render, browser smoke).

Fixes #697

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small interactive-mode layout change only; non-fullscreen `mainContainer` ordering is unchanged and the dock is fullscreen-only.
> 
> **Overview**
> Fixes **fullscreen** layout so extension widgets with `placement: 'belowEditor'` sit **under** the prompt editor, matching non-fullscreen behavior ([#697](https://github.com/PrimeIntellect-ai/prime-agent/issues/697)).
> 
> Previously `widgetContainerBelow` was in the fullscreen **scroll** stack above the dock, so below-editor widgets appeared above the editor. The container is now part of **`getPromptDockComponents()`** (after `subagentSummaryLine`, before `footerSlot`) and is no longer listed in `applyFullscreen()`’s scroll region. The unreleased changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622d313789c5b5d6f8b9dda084df7f2d57305ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `belowEditor` widgets rendering above the prompt editor in fullscreen mode
> Moves `widgetContainerBelow` from the scrollable region into the prompt dock in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/726/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316). This ensures extension `belowEditor` widgets appear below the prompt editor rather than above it when in fullscreen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 622d313.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->