### PR TITLE
fix(coding-agent): reclaim stale session leases on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed session recovery on Windows being permanently blocked by a stale lease, because `renameSync` reports `EPERM`/`EACCES` for an existing target there instead of `EEXIST`/`ENOTEMPTY` ([#667](https://github.com/PrimeIntellect-ai/prime-agent/issues/667)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed session recovery on Windows being permanently blocked by a stale lease, because `renameSync` reports `EPERM`/`EACCES` for an existing target there instead of `EEXIST`/`ENOTEMPTY` ([#667](https://github.com/PrimeIntellect-ai/prime-agent/issues/667)).
+- Fixed a live session lease being reclaimed when its `owner.json` was momentarily unreadable (e.g. a briefly held handle from antivirus or the search indexer on Windows); an unreadable owner is now treated as active instead of stale ([#667](https://github.com/PrimeIntellect-ai/prime-agent/issues/667)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -49,8 +49,8 @@ export class SessionLease {
 		this.released = true;
 		try {
 			withLeaseGuard(this.directory, () => {
-				const owner = readLeaseOwner(this.directory);
-				if (owner?.token === this.token) {
+				const read = readLeaseOwner(this.directory);
+				if (read.status === "owner" && read.owner.token === this.token) {
 					rmSync(this.directory, { recursive: true, force: true });
 				}
 			});
@@ -83,9 +83,21 @@ export function canonicalSessionPath(sessionPath: string): string {
 	}
 }
 
-function readLeaseOwner(directory: string): SessionLeaseOwner | undefined {
+type LeaseOwnerRead = { status: "owner"; owner: SessionLeaseOwner } | { status: "absent" } | { status: "unreadable" };
+
+function readLeaseOwner(directory: string): LeaseOwnerRead {
+	let raw: string;
 	try {
-		const parsed = JSON.parse(readFileSync(join(directory, "owner.json"), "utf8")) as Partial<SessionLeaseOwner>;
+		raw = readFileSync(join(directory, "owner.json"), "utf8");
+	} catch (error) {
+		// A missing file means there is genuinely no owner. Any other read error (a briefly
+		// held handle from antivirus or the search indexer on Windows, EBUSY/EPERM/EACCES)
+		// means we cannot prove the lease is stale, so treat it as a live owner rather than
+		// reclaiming a possibly-active session. Mirrors isProcessAlive's EPERM handling.
+		return (error as NodeJS.ErrnoException).code === "ENOENT" ? { status: "absent" } : { status: "unreadable" };
+	}
+	try {
+		const parsed = JSON.parse(raw) as Partial<SessionLeaseOwner>;
 		if (
 			parsed.version !== 1 ||
 			typeof parsed.token !== "string" ||
@@ -93,11 +105,11 @@ function readLeaseOwner(directory: string): SessionLeaseOwner | undefined {
 			typeof parsed.sessionPath !== "string" ||
 			typeof parsed.createdAt !== "string"
 		) {
-			return undefined;
+			return { status: "absent" };
 		}
-		return parsed as SessionLeaseOwner;
+		return { status: "owner", owner: parsed as SessionLeaseOwner };
 	} catch {
-		return undefined;
+		return { status: "absent" };
 	}
 }
 
@@ -281,17 +293,27 @@ export function acquireSessionLease(
 				if (!isRenameTargetExistsError(code)) {
 					throw error;
 				}
-				const existingOwner = readLeaseOwner(directory);
-				if (existingOwner && isLeaseOwnerAlive(existingOwner)) {
-					throw new SessionAlreadyActiveError(canonicalPath, existingOwner.activeSessionId);
+				const existing = readLeaseOwner(directory);
+				if (existing.status === "unreadable") {
+					// Cannot prove the lease is stale (owner.json is present but unreadable),
+					// so assume a live owner instead of reclaiming a possibly-active session.
+					throw new SessionAlreadyActiveError(canonicalPath);
+				}
+				if (existing.status === "owner" && isLeaseOwnerAlive(existing.owner)) {
+					throw new SessionAlreadyActiveError(canonicalPath, existing.owner.activeSessionId);
 				}
 				reclaimStaleLease(directory);
 			}
 		}
 
-		const owner = existsSync(directory) ? readLeaseOwner(directory) : undefined;
-		if (owner && isLeaseOwnerAlive(owner)) {
-			throw new SessionAlreadyActiveError(canonicalPath, owner.activeSessionId);
+		if (existsSync(directory)) {
+			const read = readLeaseOwner(directory);
+			if (read.status === "unreadable") {
+				throw new SessionAlreadyActiveError(canonicalPath);
+			}
+			if (read.status === "owner" && isLeaseOwnerAlive(read.owner)) {
+				throw new SessionAlreadyActiveError(canonicalPath, read.owner.activeSessionId);
+			}
 		}
 		throw new Error(`Could not acquire session lease: ${canonicalPath}`);
 	});

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -215,6 +215,19 @@ function withLeaseGuard<T>(directory: string, action: () => T): T {
 	}
 }
 
+export function isRenameTargetExistsError(
+	code: string | undefined,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (code === "EEXIST" || code === "ENOTEMPTY") {
+		return true;
+	}
+	// Windows rejects a renameSync onto an existing non-empty directory with
+	// EPERM or EACCES instead of the POSIX EEXIST/ENOTEMPTY, so a stale lease
+	// would otherwise rethrow here and permanently block session recovery.
+	return platform === "win32" && (code === "EPERM" || code === "EACCES");
+}
+
 function reclaimStaleLease(directory: string): boolean {
 	const stalePath = `${directory}.stale-${process.pid}-${randomUUID()}`;
 	try {
@@ -265,7 +278,7 @@ export function acquireSessionLease(
 			} catch (error) {
 				rmSync(candidateDirectory, { recursive: true, force: true });
 				const code = (error as NodeJS.ErrnoException).code;
-				if (code !== "EEXIST" && code !== "ENOTEMPTY") {
+				if (!isRenameTargetExistsError(code)) {
 					throw error;
 				}
 				const existingOwner = readLeaseOwner(directory);

--- a/packages/coding-agent/test/session-lease.test.ts
+++ b/packages/coding-agent/test/session-lease.test.ts
@@ -116,6 +116,23 @@ describe("session leases", () => {
 		lease?.release();
 	});
 
+	it("does not reclaim a lease whose owner.json is present but unreadable", () => {
+		const agentDir = createTempDir();
+		const sessionPath = canonicalSessionPath(resolve(agentDir, "locked.jsonl"));
+		const key = createHash("sha256").update(sessionPath).digest("hex");
+		const lockDirectory = join(agentDir, "session-leases", `${key}.lock`);
+		mkdirSync(lockDirectory, { recursive: true });
+		// owner.json exists but cannot be read as a file (readFileSync throws EISDIR on every
+		// platform) — a deterministic stand-in for a transiently locked owner.json, which on
+		// Windows is routine (antivirus, search indexer). An unreadable owner must be treated
+		// as a live lease, not reclaimed as stale.
+		mkdirSync(join(lockDirectory, "owner.json"), { recursive: true });
+
+		expect(() => acquireSessionLease(sessionPath, agentDir, enabledEnvironment("intruder"))).toThrow(
+			SessionAlreadyActiveError,
+		);
+	});
+
 	it("reports guard contention as a coordination failure", () => {
 		const agentDir = createTempDir();
 		const sessionPath = canonicalSessionPath(join(agentDir, "session.jsonl"));

--- a/packages/coding-agent/test/suite/regressions/667-windows-stale-lease.test.ts
+++ b/packages/coding-agent/test/suite/regressions/667-windows-stale-lease.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isRenameTargetExistsError } from "../../../src/core/session-lease.js";
+
+describe("issue #667 windows stale session lease", () => {
+	it("classifies POSIX rename-target-exists codes on every platform", () => {
+		for (const platform of ["linux", "darwin", "win32"] as const) {
+			expect(isRenameTargetExistsError("EEXIST", platform)).toBe(true);
+			expect(isRenameTargetExistsError("ENOTEMPTY", platform)).toBe(true);
+		}
+	});
+
+	it("treats Windows EPERM/EACCES as a rename-target-exists so stale leases are reclaimed", () => {
+		expect(isRenameTargetExistsError("EPERM", "win32")).toBe(true);
+		expect(isRenameTargetExistsError("EACCES", "win32")).toBe(true);
+	});
+
+	it("does not swallow EPERM/EACCES on POSIX platforms", () => {
+		for (const platform of ["linux", "darwin"] as const) {
+			expect(isRenameTargetExistsError("EPERM", platform)).toBe(false);
+			expect(isRenameTargetExistsError("EACCES", platform)).toBe(false);
+		}
+	});
+
+	it("rethrows unrelated rename failures", () => {
+		for (const platform of ["linux", "darwin", "win32"] as const) {
+			expect(isRenameTargetExistsError("ENOENT", platform)).toBe(false);
+			expect(isRenameTargetExistsError("EBADF", platform)).toBe(false);
+			expect(isRenameTargetExistsError(undefined, platform)).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

On Windows, a stale session lease permanently blocks session recovery (#667). Once a lease directory is left behind by a dead owner, acquiring the session keeps failing and never reclaims it.

## Root cause

`acquireSessionLease()` (`packages/coding-agent/src/core/session-lease.ts`) claims a lease by renaming a candidate directory onto the lease directory:

```ts
try {
  renameSync(candidateDirectory, directory);
  ...
} catch (error) {
  const code = (error as NodeJS.ErrnoException).code;
  if (code !== "EEXIST" && code !== "ENOTEMPTY") {
    throw error;                 // Windows lands here
  }
  ...
  reclaimStaleLease(directory);  // never reached on Windows
}
```

`renameSync` onto an existing non-empty directory returns `EEXIST`/`ENOTEMPTY` on POSIX, but **`EPERM`/`EACCES` on Windows**. So on Windows the error is rethrown, `reclaimStaleLease()` never runs, and the stale lease persists across every retry.

## Fix

Classify `EPERM`/`EACCES` as a rename-target-exists condition on `win32`, via a small `isRenameTargetExistsError(code, platform)` helper. This mirrors the platform-specific handling already present in this file (`getProcessStartId` / `getWindowsProcessStartId`) and keeps POSIX behavior unchanged — `EPERM`/`EACCES` are only accepted on `win32`, so genuine permission failures on Linux/macOS still surface.

## Testing

- Added `test/suite/regressions/667-windows-stale-lease.test.ts` covering the code/platform matrix: POSIX codes accepted everywhere, `EPERM`/`EACCES` accepted only on `win32`, and unrelated codes (`ENOENT`, `EBADF`, `undefined`) still rethrown.
- New test plus the existing `test/session-lease.test.ts` pass.
- `npm run check` passes (biome, `tsgo --noEmit`, installer render, browser smoke).

## Note

Verified by code inspection on macOS; the `win32` runtime path itself was not exercised on a Windows host. The behavioral change is gated to `platform === "win32"`, so it cannot regress POSIX. A confirmation on a Windows box would be welcome.

Fixes #667

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-gated change to lease error handling on win32 only; POSIX behavior preserved and covered by unit tests.
> 
> **Overview**
> Fixes **session recovery on Windows** when a stale lease directory is left behind: `renameSync` onto an existing lease path now treats **`EPERM`/`EACCES` on `win32`** like POSIX **`EEXIST`/`ENOTEMPTY`**, so `acquireSessionLease` can run **`reclaimStaleLease`** instead of rethrowing and blocking forever ([#667](https://github.com/PrimeIntellect-ai/prime-agent/issues/667)).
> 
> Adds exported **`isRenameTargetExistsError(code, platform)`** in `session-lease.ts` and wires it into the lease-acquire rename catch path. **Linux/macOS** still rethrow **`EPERM`/`EACCES`**; only Windows gets the extra codes. Regression tests cover the code/platform matrix; changelog updated under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb1d3111c18a7db101655acf1dbf34bd9cbb3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale session lease reclamation on Windows in coding-agent
> - On Windows, `renameSync` raises `EPERM`/`EACCES` instead of `EEXIST`/`ENOTEMPTY` when the rename target already exists, blocking session recovery. A new `isRenameTargetExistsError` utility in [`session-lease.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/727/files#diff-74865e03a1e2d7f4025a576ca8f4c09dbc1ec7c9e2776b5d93f2691ee29e6cda) now treats these Windows-specific codes as target-exists errors.
> - `readLeaseOwner` now returns a discriminated union (`"owner"` | `"absent"` | `"unreadable"`) so callers can distinguish a missing `owner.json` from one that exists but cannot be read.
> - When `owner.json` is unreadable, `acquireSessionLease` throws `SessionAlreadyActiveError` instead of reclaiming the lease, avoiding takeover of a possibly-active session.
> - Regression tests added for `isRenameTargetExistsError` and the unreadable-owner case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c88a0e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->