### PR TITLE
Prefer attach_image for vision models; IPython as fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer `attach_image` for on-disk image analysis when the selected model accepts image input, and fall back to IPython PIL/OCR only when the model has no vision capability.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/skills/attach-image/SKILL.md
+++ b/packages/coding-agent/skills/attach-image/SKILL.md
@@ -1,49 +1,45 @@
 ---
 name: attach-image
-description: Load an on-disk image (PNG, JPEG, GIF, WebP) into the model's context as a viewable attachment so the model can directly SEE it — for screenshots, diagrams, charts, photos, or scanned pages. Use this when you need to perceive an image's visual contents. Requires a vision-capable model; errors clearly otherwise.
+description: Load an on-disk image (PNG, JPEG, GIF, WebP) into multimodal context via the pre-imported IPython callable `attach_image` (not a separate agent tool). On vision-capable models, prefer `print(await attach_image("path.png"))` when the user gives an image path or asks to analyze/see a screenshot, diagram, chart, or photo — do not use PIL/OCR instead. If the model is not vision-capable, skip this skill and fall back to IPython PIL/OCR analysis.
 ---
 
 # Attach Image
 
-Load on-disk images into the model's context as multimodal attachments. The
-image is sent to the model the same way a pasted image is, so the model can
-actually look at it.
-
-## When to use this
-
-- The user points at an image file and wants you to look at it.
-- You need to read text, a chart, a diagram, or a layout from an image.
-- A screenshot needs visual interpretation.
-
-## When NOT to use this
-
-For *programmatic* work on an image — measuring pixels, cropping, resizing,
-computing a hash, comparing files byte-by-byte — open it in the kernel with a
-library instead:
-
-```python
-from PIL import Image
-img = Image.open("diagram.png")
-print(img.size)
-```
-
-That path does not put the image in the model's context; it only lets you
-compute over it. Use `attach_image` when you need to *see* the image.
-
-## Usage
-
-Call the prepared `attach_image` import directly in the IPython kernel:
+`attach_image` is a **pre-imported Python skill** in the IPython kernel. It is
+not a standalone agent tool. Invoke it through `ipython`:
 
 ```python
 print(await attach_image("diagram.png"))
 print(await attach_image("a.png", "b.jpg"))
 ```
 
-The skill automatically resizes and compresses large images before loading them
-into context. Animated images that need compression are flattened to their first
-frame. Transparent images that need compression are composited onto a neutral
-gray background. Extremely large images are rejected by pixel count before full
-processing. The original file is left untouched.
+That loads the file into multimodal context the same way a pasted image does,
+so a vision-capable model can look at it.
 
-Supported formats: PNG, JPEG, GIF, WebP. The skill errors if a file is not a
-supported image, or if the current model is not vision-capable.
+## When to use
+
+- Current model supports images (`input` includes `image`)
+- User points at an image file and wants you to look at / analyze / describe it
+- Screenshots, diagrams, charts, UI captures, photos, scanned pages
+
+## When NOT to use (IPython fallback)
+
+If the current model is **not** vision-capable, `attach_image` raises. Do not
+retry it. Fall back to programmatic analysis in IPython:
+
+```python
+from PIL import Image
+img = Image.open("diagram.png")
+print(img.size, img.mode)
+# then OCR / crop / inspect as needed, e.g. tesseract
+```
+
+Also use PIL (not `attach_image`) for programmatic pixel work the user asked
+for explicitly — resize, crop, hash, compare bytes — even on vision models.
+
+## Rules
+
+- Vision model → prefer `await attach_image(...)` for visual understanding.
+- Non-vision model → IPython PIL/OCR fallback; say vision is unavailable.
+- Supported formats: PNG, JPEG, GIF, WebP.
+- Large images are auto-resized/compressed; originals are left untouched.

--- a/packages/coding-agent/skills/attach-image/src/attach_image/attach_image.py
+++ b/packages/coding-agent/skills/attach-image/src/attach_image/attach_image.py
@@ -240,7 +240,8 @@ async def run(*paths: str) -> str:
         model_id = info.get("id") or "the current model"
         raise RuntimeError(
             f"{model_id} does not support vision. "
-            "Tell the user to switch to a vision-capable model to load images into context."
+            "Do not retry attach_image. Fall back to IPython with PIL/OCR for analysis, "
+            "and tell the user to switch to a vision-capable model to load images into context."
         )
 
     # Validate every path before emitting anything, so a later failure never

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4286,6 +4286,7 @@ export class AgentSession {
 			rlmDepth: this._rlmDepth,
 			rlmParentAgent: this._rlmParentAgent,
 			harnessState: this._loadMergedHarnessState(),
+			supportsImageInput: this.model?.input?.includes("image"),
 		};
 		return buildSystemPrompt(this._baseSystemPromptOptions);
 	}
@@ -4302,6 +4303,13 @@ export class AgentSession {
 			return extensionPrompt;
 		}
 		return extensionPrompt.replace(baseSnapshot, () => this._baseSystemPrompt);
+	}
+
+	/** Rebuild base system prompt after a model change so modality guidance stays current. */
+	private _rebuildSystemPromptAfterModelChange(): void {
+		const oldBase = this._baseSystemPrompt;
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.state.systemPrompt = this._refreshExtensionSystemPrompt(this.agent.state.systemPrompt, oldBase);
 	}
 
 	private _finishSubmissionNormalization(
@@ -6607,6 +6615,8 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 		this._clampServiceTierForModel(serviceTier);
 
+		this._rebuildSystemPromptAfterModelChange();
+
 		const emitPromise = this._queueModelSelectEmit(model, previousModel, "set");
 		if (this._shouldWaitForModelSelectEmit(options)) {
 			await emitPromise;
@@ -6685,6 +6695,8 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 		this._clampServiceTierForModel(serviceTier);
 
+		this._rebuildSystemPromptAfterModelChange();
+
 		const emitPromise = this._queueModelSelectEmit(next.model, currentModel, "cycle");
 		if (this._shouldWaitForModelSelectEmit(options)) {
 			await emitPromise;
@@ -6724,6 +6736,8 @@ export class AgentSession {
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 		this._clampServiceTierForModel(serviceTier);
+
+		this._rebuildSystemPromptAfterModelChange();
 
 		const emitPromise = this._queueModelSelectEmit(nextModel, currentModel, "cycle");
 		if (this._shouldWaitForModelSelectEmit(options)) {
@@ -8320,6 +8334,7 @@ export class AgentSession {
 		}
 
 		this.agent.state.model = refreshedModel;
+		this._rebuildSystemPromptAfterModelChange();
 	}
 
 	private _bindExtensionCore(runner: ExtensionRunner): void {

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -9,6 +9,8 @@ export interface RlmPromptOptions {
 	depth?: number;
 	parentAgent?: string;
 	activeTools?: string[];
+	/** Whether the current model accepts image input (`input` includes `"image"`). */
+	supportsImageInput?: boolean;
 }
 
 const IPYTHON_CONTROL_PROMPT = [
@@ -55,6 +57,23 @@ export function buildChildAgentDoctrine(options: ChildAgentDoctrineOptions): str
 		);
 	}
 	return lines.join("\n");
+}
+
+/** Prefer model vision via attach_image; fall back to IPython/PIL/OCR only when needed. */
+export function buildAttachImageGuidance(supportsImageInput?: boolean): string[] {
+	if (supportsImageInput === true) {
+		return [
+			'For visual understanding of on-disk images (screenshots, diagrams, charts, photos, PNG/JPEG/GIF/WebP paths), use the pre-imported `attach_image` skill — it is not a separate agent tool. Call it through IPython: `print(await attach_image("path.png"))`. That loads the file into multimodal context so you can see it. Do not use PIL, OpenCV, tesseract, or OCR as a substitute for seeing the image when the goal is visual understanding. Use PIL only for programmatic pixel work the user explicitly asked for (resize, crop, hash, measure).',
+		];
+	}
+	if (supportsImageInput === false) {
+		return [
+			"The current model does not accept image input, so `attach_image` will fail. For on-disk image analysis, use IPython as the fallback: open the file with PIL and use OCR (e.g. tesseract) / cropping / pixel inspection as needed. Tell the user briefly that vision is unavailable on this model and suggest switching to a vision-capable model when accuracy matters.",
+		];
+	}
+	return [
+		'For visual understanding of on-disk images (screenshots, diagrams, charts, photos, PNG/JPEG/GIF/WebP paths): when the current model accepts image input, use the pre-imported `attach_image` skill through IPython — `print(await attach_image("path.png"))` — so the model can see the file. Do not use PIL/OCR as a substitute for vision on a vision-capable model. If the model does not support vision (or `attach_image` errors), fall back to IPython with PIL/OCR and tell the user vision is unavailable.',
+	];
 }
 
 export function buildRlmPrompt(options: RlmPromptOptions): string {
@@ -107,6 +126,9 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			skillLines.push(
 				"For targeted existing-file edits, prefer the pre-imported async `edit` skill from IPython: `old = '''...'''; new = '''...'''; await edit(path=\"pkg/file.py\", old_str=old, new_str=new)`. Use exact old/new strings; if the text contains triple double quotes, use triple single-quoted variables or build `old`/`new` from inspected file slices.",
 			);
+		}
+		if (hasIpython && installedSkills.includes("attach_image")) {
+			skillLines.push(...buildAttachImageGuidance(options.supportsImageInput));
 		}
 	}
 	if (skillLines.length > 0) {

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -33,6 +33,8 @@ export interface BuildSystemPromptOptions {
 	rlmParentAgent?: string;
 	/** Global harness state to inject as compact persistent context. */
 	harnessState?: HarnessState;
+	/** Whether the current model accepts image input (`input` includes `"image"`). */
+	supportsImageInput?: boolean;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -121,6 +123,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		allowRecursion,
 		depth: options.rlmDepth,
 		parentAgent: options.rlmParentAgent,
+		supportsImageInput: options.supportsImageInput,
 	});
 
 	// Appended AFTER the trained buildRlmPrompt prefix, and before the harness-state

--- a/packages/coding-agent/test/kernel-attach-image-skill.test.ts
+++ b/packages/coding-agent/test/kernel-attach-image-skill.test.ts
@@ -231,7 +231,8 @@ except RuntimeError as error:
 		expect(result.status).toBe("ok");
 		expect(result.stdout.trim()).toBe(
 			"RuntimeError: openai/gpt-oss-120b does not support vision. " +
-				"Tell the user to switch to a vision-capable model to load images into context.",
+				"Do not retry attach_image. Fall back to IPython with PIL/OCR for analysis, " +
+				"and tell the user to switch to a vision-capable model to load images into context.",
 		);
 		expect(result.attachments).toBeUndefined();
 	});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -255,6 +255,56 @@ describe("buildRlmPrompt", () => {
 
 		expect(withoutEdit).not.toContain("await edit(path=");
 	});
+
+	test("prefers attach_image on vision models and IPython fallback without vision", () => {
+		const withVision = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["attach_image"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+			supportsImageInput: true,
+		});
+
+		expect(withVision).toContain('print(await attach_image("path.png"))');
+		expect(withVision).toContain("Do not use PIL, OpenCV, tesseract, or OCR as a substitute");
+		expect(withVision).not.toContain("The current model does not accept image input");
+
+		const withoutVision = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["attach_image"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+			supportsImageInput: false,
+		});
+
+		expect(withoutVision).toContain("The current model does not accept image input");
+		expect(withoutVision).toContain("use IPython as the fallback");
+		expect(withoutVision).not.toContain('print(await attach_image("path.png"))');
+
+		const unknownCapability = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["attach_image"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+		});
+
+		expect(unknownCapability).toContain('print(await attach_image("path.png"))');
+		expect(unknownCapability).toContain("fall back to IPython with PIL/OCR");
+
+		const withoutSkill = buildRlmPrompt({
+			cwd: "/repo",
+			messagesPath: "/repo/.pi/sessions/session.jsonl",
+			installedSkills: ["websearch"],
+			activeTools: ["ipython"],
+			allowRecursion: false,
+			supportsImageInput: true,
+		});
+
+		expect(withoutSkill).not.toContain("attach_image");
+	});
 });
 
 describe("buildSystemPrompt", () => {


### PR DESCRIPTION
## Summary

- When `attach_image` is installed, the RLM prompt now steers on-disk image analysis by model capability: vision models use `await attach_image(...)`; non-vision models fall back to IPython PIL/OCR
- Rebuild the system prompt on model switch/cycle so that guidance stays in sync with `model.input`
- Strengthen the `attach-image` skill docs and non-vision error message so models stop treating OCR as the default path

Fixes #728

## Test plan

- [x] `npm run check`
- [x] `npx tsx ../../node_modules/vitest/dist/cli.js --run test/system-prompt.test.ts test/kernel-attach-image-skill.test.ts`
- [x] Manually: vision model + image path → first tool call is `print(await attach_image(...))`
- [x] Manually: non-vision model + image path → PIL/OCR fallback, no attach_image retry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and documentation steering only; behavior of `attach_image` itself is unchanged aside from a clearer error message.
> 
> **Overview**
> Steers on-disk image work by whether the **active model accepts image input**: vision models are told to use IPython `print(await attach_image("path.png"))` for visual understanding and to avoid PIL/OCR as a substitute; non-vision models get explicit **PIL/OCR fallback** guidance and are told not to retry `attach_image`.
> 
> **System prompt stays in sync with the model** via `supportsImageInput` (from `model.input` including `"image"`) and `_rebuildSystemPromptAfterModelChange()` on set/cycle/refresh paths. RLM prompt adds `buildAttachImageGuidance()` when the `attach_image` skill is installed.
> 
> The **attach-image skill** docs and the non-vision `RuntimeError` message now match that policy (no retry; fall back to PIL/OCR). Tests cover prompt variants and the updated error string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0c960cab47d2bce291fbc02fc8d5250fcf2ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer `attach_image` for vision models with IPython PIL/OCR fallback in system prompts
> - The RLM system prompt now includes adaptive `attach_image` guidance based on whether the active model accepts image input: prefer `attach_image` on vision-capable models, fall back to IPython PIL/OCR when the model lacks vision support.
> - `AgentSession` rebuilds the base system prompt after any model change (via `setModel`, `cycleModel`, `cycleScopedModels`, or `_refreshModel`) so guidance stays in sync with the current model's capabilities.
> - The `attach_image` error message on non-vision models now explicitly instructs the agent not to retry and to use IPython PIL/OCR as a fallback.
> - `BuildSystemPromptOptions` and `RlmPromptOptions` gain an optional `supportsImageInput` boolean, populated from `model.input.includes('image')`.
> - Behavioral Change: agents running on vision-capable models will now receive explicit instructions to call `attach_image` directly rather than routing through IPython PIL/OCR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b0c960.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->