### PR TITLE
fix: queued message rendered twice after manual compaction

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6375,7 +6375,6 @@ export class InteractiveMode {
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
-			this.recordRebuildRenderedMessages(messagesToRender);
 		}
 
 		if (options.updateFooter) {
@@ -6464,6 +6463,12 @@ export class InteractiveMode {
 		for (const [toolCallId, component] of renderedPendingTools) {
 			component.setIncludeImageDimensions(true);
 			this.pendingTools.set(toolCallId, component);
+		}
+		// Armed only after the transcript rendered fully: if the render throws
+		// partway, the in-flight message_start must still append its message
+		// rather than be swallowed by a key for a render that never completed.
+		if (options.clearChat) {
+			this.recordRebuildRenderedMessages(messagesToRender);
 		}
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -983,6 +983,13 @@ export class InteractiveMode {
 
 	// Session-owned queued messages mirrored from connection events.
 	private connectionQueue: AgentConnectionQueueState = { steering: [], followUp: [] };
+	/**
+	 * Live-event keys for user/custom messages included in the last transcript
+	 * rebuild. A queued message consumed right after compaction can be part of
+	 * the rebuild snapshot while its message_start event is still in flight;
+	 * replaying that event would render the message twice (#698).
+	 */
+	private rebuildRenderedLiveMessageKeys = new Set<string>();
 
 	// Shutdown state
 	private shutdownRequested = false;
@@ -5386,11 +5393,10 @@ export class InteractiveMode {
 			}
 
 			case "message_start":
-				if (event.message.role === "custom") {
-					this.addMessageToChat(event.message);
-					this.ui.requestRender();
-				} else if (event.message.role === "user") {
-					this.addMessageToChat(event.message);
+				if (event.message.role === "custom" || event.message.role === "user") {
+					if (!this.consumeRebuildRenderedMessage(event.message)) {
+						this.addMessageToChat(event.message);
+					}
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
 					this.startAssistantStreamingMessage(event.message);
@@ -6369,6 +6375,7 @@ export class InteractiveMode {
 
 		if (options.clearChat) {
 			this.chatContainer.clear();
+			this.recordRebuildRenderedMessages(messagesToRender);
 		}
 
 		if (options.updateFooter) {
@@ -6521,6 +6528,33 @@ export class InteractiveMode {
 				resolve(text);
 			};
 		});
+	}
+
+	private static liveTranscriptMessageKey(message: AgentMessage): string | undefined {
+		if (message.role !== "user" && message.role !== "custom") return undefined;
+		const content = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+		return `${message.role}:${message.timestamp}:${content.slice(0, 200)}`;
+	}
+
+	/** Remember which live-event-rendered messages the rebuild snapshot already covers. */
+	private recordRebuildRenderedMessages(messages: readonly AgentMessage[]): void {
+		this.rebuildRenderedLiveMessageKeys.clear();
+		for (const message of messages) {
+			const key = InteractiveMode.liveTranscriptMessageKey(message);
+			if (key !== undefined) this.rebuildRenderedLiveMessageKeys.add(key);
+		}
+	}
+
+	/**
+	 * True when the last transcript rebuild already rendered this message, so
+	 * its in-flight message_start event must not render it again (#698). Each
+	 * key is consumed once so later messages are unaffected.
+	 */
+	private consumeRebuildRenderedMessage(message: AgentMessage): boolean {
+		const key = InteractiveMode.liveTranscriptMessageKey(message);
+		if (key === undefined || !this.rebuildRenderedLiveMessageKeys.has(key)) return false;
+		this.rebuildRenderedLiveMessageKeys.delete(key);
+		return true;
 	}
 
 	private async rebuildChatFromMessages(): Promise<void> {

--- a/packages/coding-agent/test/suite/regressions/698-compaction-queued-message-duplicate.test.ts
+++ b/packages/coding-agent/test/suite/regressions/698-compaction-queued-message-duplicate.test.ts
@@ -1,0 +1,113 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import type { AgentConnectionSessionEvent } from "../../../src/modes/agent-connection/types.js";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
+
+type DedupeContext = {
+	isInitialized: boolean;
+	rebuildRenderedLiveMessageKeys: Set<string>;
+	contextUsageTokenBaseline: number;
+	agentRunFileChanges: Set<string>;
+	footer: { invalidate: () => void };
+	activityTracker: { handleEvent: (event: AgentConnectionSessionEvent) => void };
+	ui: { requestRender: () => void };
+	updateConnectionStateFromEvent: (event: AgentConnectionSessionEvent) => void;
+	prepareFeatureHintRun: (message: AgentMessage) => void;
+	setSessionHasMessages: (value: boolean) => void;
+	clearShortcutGuide: () => void;
+	renderRecap: () => void;
+	updateWorkingLoaderMessage: () => void;
+	addMessageToChat: (message: AgentMessage) => void;
+	consumeRebuildRenderedMessage: (message: AgentMessage) => boolean;
+};
+
+type DedupePrototype = {
+	handleEvent(this: DedupeContext, event: AgentConnectionSessionEvent): Promise<void>;
+	recordRebuildRenderedMessages(this: DedupeContext, messages: readonly AgentMessage[]): void;
+	consumeRebuildRenderedMessage(this: DedupeContext, message: AgentMessage): boolean;
+};
+
+const prototype = InteractiveMode.prototype as unknown as DedupePrototype;
+
+function userMessage(text: string, timestamp: number): AgentMessage {
+	return { role: "user", content: text, timestamp } as AgentMessage;
+}
+
+function createContext(rendered: string[]): DedupeContext {
+	return {
+		consumeRebuildRenderedMessage(this: DedupeContext, message: AgentMessage): boolean {
+			return prototype.consumeRebuildRenderedMessage.call(this, message);
+		},
+		isInitialized: true,
+		rebuildRenderedLiveMessageKeys: new Set<string>(),
+		contextUsageTokenBaseline: 0,
+		agentRunFileChanges: new Set<string>(),
+		footer: { invalidate: () => {} },
+		activityTracker: { handleEvent: () => {} },
+		ui: { requestRender: () => {} },
+		updateConnectionStateFromEvent: () => {},
+		prepareFeatureHintRun: () => {},
+		setSessionHasMessages: () => {},
+		clearShortcutGuide: () => {},
+		renderRecap: () => {},
+		updateWorkingLoaderMessage: () => {},
+		addMessageToChat: (message) => {
+			if (message.role === "user" && typeof message.content === "string") {
+				rendered.push(message.content);
+			}
+		},
+	};
+}
+
+function messageStart(message: AgentMessage): AgentConnectionSessionEvent {
+	return { type: "message_start", message } as AgentConnectionSessionEvent;
+}
+
+describe("issue #698 queued message is not rendered twice after /compact rebuild", () => {
+	it("skips the in-flight message_start for a message the rebuild already rendered", async () => {
+		const rendered: string[] = [];
+		const ctx = createContext(rendered);
+		const queued = userMessage("queued during compaction", 1000);
+
+		// compaction_end rebuild: snapshot already contains the consumed queued message.
+		prototype.recordRebuildRenderedMessages.call(ctx, [queued]);
+		// The in-flight message_start for the same message arrives after the rebuild.
+		await prototype.handleEvent.call(ctx, messageStart(queued));
+
+		expect(rendered).toEqual([]);
+	});
+
+	it("still renders fresh messages sent after the rebuild", async () => {
+		const rendered: string[] = [];
+		const ctx = createContext(rendered);
+		const queued = userMessage("queued during compaction", 1000);
+		const fresh = userMessage("next question", 2000);
+
+		prototype.recordRebuildRenderedMessages.call(ctx, [queued]);
+		await prototype.handleEvent.call(ctx, messageStart(queued));
+		await prototype.handleEvent.call(ctx, messageStart(fresh));
+
+		expect(rendered).toEqual(["next question"]);
+	});
+
+	it("consumes each rebuild key once, so identical later events fail open to rendering", async () => {
+		const rendered: string[] = [];
+		const ctx = createContext(rendered);
+		const queued = userMessage("queued during compaction", 1000);
+
+		prototype.recordRebuildRenderedMessages.call(ctx, [queued]);
+		await prototype.handleEvent.call(ctx, messageStart(queued));
+		await prototype.handleEvent.call(ctx, messageStart(queued));
+
+		expect(rendered).toEqual(["queued during compaction"]);
+	});
+
+	it("only records roles that live events render, and a new rebuild resets the keys", () => {
+		const ctx = createContext([]);
+		const assistant = { role: "assistant", content: [], timestamp: 1 } as unknown as AgentMessage;
+		prototype.recordRebuildRenderedMessages.call(ctx, [assistant, userMessage("a", 1)]);
+		expect(ctx.rebuildRenderedLiveMessageKeys.size).toBe(1);
+		prototype.recordRebuildRenderedMessages.call(ctx, [userMessage("b", 2)]);
+		expect(ctx.rebuildRenderedLiveMessageKeys.size).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #698.

## Problem

`compaction_end` triggers `rebuildChatFromMessages()`, which snapshots the session context over the connection and re-renders the transcript. A message queued during `/compact` is consumed into the post-compaction turn around the same time, so the snapshot can already contain the user message while its `message_start` event is still queued behind the rebuild. The rebuild renders the message once, then the replayed event calls `addMessageToChat` again — a persistent visual duplicate with a single copy in history, matching the report ("i think this is a rendering artifact and not a duplicate in the history").

## Change

`packages/coding-agent/src/modes/interactive/interactive-mode.ts`: transcript rebuilds (`renderSessionContext` with `clearChat`) now record a key — role, timestamp, content prefix — for each user/custom message they render. A `message_start` arriving for an already-rendered message consumes the key and skips the second render. Keys are one-shot and reset on the next rebuild, so fresh messages, repeated sends, and every other event path are unaffected; if no rebuild raced the event, the lookup misses and rendering proceeds as before.

## Tests

`test/suite/regressions/698-compaction-queued-message-duplicate.test.ts` (4 tests, all fail on main): the raced `message_start` is skipped after a rebuild that contains the message; fresh messages after the rebuild still render; keys are consumed once (fail open); only live-event-rendered roles are recorded and rebuilds reset the set.

Neighbor suites (`interactive-mode-effort-command`, `agent-session-compaction`, `working-duration`): 24/24. `npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to interactive chat rendering deduplication for user/custom message_start events; no session history or auth changes.
> 
> **Overview**
> Fixes **#698**, where a user message queued during `/compact` could appear twice in the chat even though history only stored it once.
> 
> After a **clear-chat transcript rebuild** (e.g. on `compaction_end`), `InteractiveMode` now records one-shot keys for each **user/custom** message in the rebuilt snapshot. If a still-queued `message_start` for the same message arrives afterward, it is skipped instead of calling `addMessageToChat` again. Keys are recorded only after the rebuild render finishes, and each key is consumed once so later messages still render normally.
> 
> Adds regression tests in `698-compaction-queued-message-duplicate.test.ts` for the race, post-rebuild fresh messages, one-shot consumption, and rebuild resets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a368ffda9af676b68fd799b56eeba02fd8059b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix queued user/custom messages rendering twice after manual compaction in `InteractiveMode`
> When a transcript rebuild (compaction) occurs, in-flight `message_start` events for user/custom messages that were already rendered during the rebuild would render again on arrival. This fix introduces deduplication by tracking keys (role + timestamp + content prefix) for messages rendered during a rebuild and skipping matching live events once.
>
> - Adds `rebuildRenderedLiveMessageKeys` set to [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/730/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to record messages included in the last rebuild.
> - Adds `liveTranscriptMessageKey`, `recordRebuildRenderedMessages`, and `consumeRebuildRenderedMessage` helpers to generate and consume deduplication keys.
> - Keys are consumed at most once, so identical subsequent events still render correctly.
> - Adds regression tests in [`698-compaction-queued-message-duplicate.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/730/files#diff-ba5e1a66d751a9d743a31bb41e585faae3932a027aec9ddffec3c1f2a332ba61) covering all deduplication cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6a368f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->