### PR TITLE
fix: codex model discovery sends prime-agent version as client_version

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -27,7 +27,7 @@ import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -372,6 +372,14 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+/**
+ * The ChatGPT backend gates the Codex model catalog by Codex CLI version, not
+ * ours: sending prime-agent's own package version (0.x) reads as an ancient
+ * client and returns an empty catalog, which hides every openai-codex model
+ * from discovery and subagent spawns (#702). Pin a verified Codex CLI version.
+ */
+const OPENAI_CODEX_CLIENT_VERSION = "0.146.1";
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -383,7 +391,7 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	url.searchParams.set("client_version", OPENAI_CODEX_CLIENT_VERSION);
 	return url.toString();
 }
 

--- a/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { VERSION } from "../../../src/config.js";
+import { createHarness } from "../harness.js";
+
+const codexProvider = "openai-codex";
+
+function openAICodexToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("issue #702 codex model discovery must not send prime-agent's version as client_version", () => {
+	it("pins a Codex CLI client_version instead of the package VERSION", async () => {
+		const harness = await createHarness({
+			provider: codexProvider,
+			models: [{ id: "parent-model" }],
+		});
+		const fetchModels = vi.fn(
+			async (_input: string | URL | Request, _init?: RequestInit) =>
+				new Response(JSON.stringify({ models: [{ slug: "parent-model" }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-1"));
+			const discovered = await harness.session.findRlmModels("parent model", 20);
+			expect(discovered.models.map((model) => model.selector)).toContain(`${codexProvider}/parent-model`);
+
+			const codexCalls = fetchModels.mock.calls.filter((call) => String(call[0]).includes("/codex/models"));
+			expect(codexCalls.length).toBeGreaterThan(0);
+			const requestedUrl = new URL(String(codexCalls[0]![0]));
+			const clientVersion = requestedUrl.searchParams.get("client_version");
+			// The backend gates the catalog by Codex CLI version; prime-agent's
+			// own version reads as an ancient client and yields an empty catalog.
+			expect(clientVersion).not.toBe(VERSION);
+			expect(clientVersion).toMatch(/^0\.1\d\d\.\d+$/);
+		} finally {
+			vi.unstubAllGlobals();
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #702.

## Problem

`openAICodexModelsUrl()` (`packages/coding-agent/src/core/model-registry.ts:386`) passed prime-agent's own package `VERSION` as the `client_version` query parameter. The ChatGPT backend gates the Codex model catalog by Codex CLI version, so `0.7.0` reads as an ancient client and returns `{"models": []}`. The empty catalog filters every `openai-codex` model out of `getAvailable()`, `findRlmModels`, and subagent spawns, producing the misleading "unavailable, unauthenticated, or expired" error with fresh auth — exactly as diagnosed in the report.

## Change

Pin a verified Codex CLI version (`OPENAI_CODEX_CLIENT_VERSION = "0.146.1"`, confirmed by the reporter to restore the full 9-model catalog with the same bearer token) instead of our own version, with a comment explaining why the package version must not be used. `VERSION` import dropped from model-registry (now unused there).

Complementary to #717, which fail-opens when discovery legitimately returns empty; this PR makes discovery return the real catalog in the first place. The report's optional suggestion (distinct error for discovery-empty vs auth failure) is left out to keep the change minimal.

## Tests

`test/suite/regressions/702-codex-client-version.test.ts`: stubs fetch, drives `findRlmModels` through the harness, and asserts the `/codex/models` request's `client_version` is not the package `VERSION` and matches a Codex CLI version shape. Fails on main (`expected '0.7.0' not to be '0.7.0'`).

Neighbor suites (`4649-subagent-model-selection`, `model-registry`, `696-empty-codex-catalog`): 85/85. Note: two 4649 tests fail on unmodified main when `DEEPSEEK_API_KEY`/`OPENROUTER_API_KEY`/`HF_TOKEN` are set in the environment (provider availability leaks into discovery); all green with those unset, before and after this change. `npm run check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Codex catalog discovery query params plus a regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes **#702** by stopping `openAICodexModelsUrl` from sending prime-agent’s package `VERSION` as the `client_version` query param on `/codex/models` requests. The ChatGPT backend treats that as an outdated Codex CLI client and returns an empty catalog, which made every `openai-codex` model disappear from discovery, `getAvailable()`, and subagent flows despite valid auth.
> 
> The URL builder now uses a pinned **`OPENAI_CODEX_CLIENT_VERSION` (`0.146.1`)** with an inline comment explaining why the app version must not be used; the unused `VERSION` import is removed from `model-registry.ts`.
> 
> Adds regression test **`702-codex-client-version.test.ts`**, which stubs `fetch`, runs `findRlmModels`, and asserts `client_version` is not the package version and matches a Codex CLI-style semver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5392c285d4d34f805dfc64c79ca4a7354d889dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex model discovery to send a pinned Codex CLI version as `client_version`
> The Codex model discovery URL was sending the package `VERSION` as `client_version`, but the OpenAI Codex endpoint gates on a specific Codex CLI version. [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/731/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) now uses a hardcoded constant `OPENAI_CODEX_CLIENT_VERSION` (`0.146.1`) instead. A regression test verifies the pinned version is sent and differs from the package `VERSION`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5392c28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->