### PR TITLE
Add native Windows installation and launchers

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -237,11 +237,17 @@ jobs:
           const baseUrl = process.env.INSTALL_BASE_URL;
           if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
           const installer = fs.readFileSync("install.sh", "utf8");
+          const windowsInstaller = fs.readFileSync("install.ps1", "utf8");
           const renderInstaller = (channel) => installer
+            .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
+            .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
+          const renderWindowsInstaller = (channel) => windowsInstaller
             .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
             .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
           fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller("stable"));
           fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller("beta"));
+          fs.writeFileSync("/tmp/prime-agent-install.ps1", renderWindowsInstaller("stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.ps1", renderWindowsInstaller("beta"));
           NODE
 
       - name: Extract production release notes
@@ -296,6 +302,16 @@ jobs:
           aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
             --endpoint-url "$R2_ENDPOINT_URL" \
             --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
             --cache-control no-cache
 
       - name: Create production GitHub release
@@ -377,6 +393,16 @@ jobs:
           aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
             --endpoint-url "$R2_ENDPOINT_URL" \
             --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
             --cache-control no-cache
 
           printf 'Automated beta build from `%s` (`%s`).\n' "$DEFAULT_BRANCH" "$BUILD_REF" > /tmp/beta-release-notes.md

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Install the latest stable release on macOS or Linux:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
+On Windows, run the native PowerShell installer from PowerShell or Windows Terminal:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
 The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent.
 
 Start Prime Agent from the repository or directory you want it to work in:

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,99 @@
+$ErrorActionPreference = "Stop"
+
+$unconfiguredBaseUrl = "__PRIME_AGENT_DOWNLOAD_BASE_" + "URL__"
+$unconfiguredDefaultChannel = "__PRIME_AGENT_DEFAULT_RELEASE_" + "CHANNEL__"
+$baseUrl = "__PRIME_AGENT_DOWNLOAD_BASE_URL__"
+$defaultChannel = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"
+$packageName = "prime-agent"
+
+if ($env:PRIME_AGENT_DOWNLOAD_BASE_URL) {
+	$baseUrl = $env:PRIME_AGENT_DOWNLOAD_BASE_URL
+}
+if ($baseUrl -eq $unconfiguredBaseUrl) {
+	throw "Installer download URL is not configured. Use the installer published by the release workflow."
+}
+if ($defaultChannel -eq $unconfiguredDefaultChannel) {
+	$defaultChannel = "stable"
+}
+
+$release = if ($args.Count -gt 0) { $args[0] } elseif ($env:PRIME_AGENT_VERSION) { $env:PRIME_AGENT_VERSION } elseif ($env:PRIME_AGENT_RELEASE_CHANNEL) { $env:PRIME_AGENT_RELEASE_CHANNEL } else { $defaultChannel }
+$baseUrl = $baseUrl.TrimEnd("/")
+
+function Get-PrimeAgentVersion {
+	param([string]$Release)
+
+	if ($Release -in @("stable", "beta")) {
+		Write-Host "Resolving the $Release release..."
+		$Release = (Invoke-RestMethod -Uri "$baseUrl/$Release" -Method Get).ToString().Trim()
+	}
+
+	$version = $Release.Trim().TrimStart("v")
+	if (-not $version -or $version -notmatch "^[0-9A-Za-z.-]+$") {
+		throw "Invalid Prime Agent version: $Release"
+	}
+	return $version
+}
+
+function Assert-Command {
+	param([string]$Name, [string]$InstallMessage)
+
+	if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+		throw "$Name is required. $InstallMessage"
+	}
+}
+
+Assert-Command "node" "Install Node.js 22.8 or newer from https://nodejs.org/."
+Assert-Command "npm.cmd" "Install Node.js 22.8 or newer from https://nodejs.org/."
+
+$nodeVersion = (& node -p "process.versions.node").Trim()
+$nodeParts = $nodeVersion.Split(".")
+if ([int]$nodeParts[0] -lt 22 -or ([int]$nodeParts[0] -eq 22 -and [int]$nodeParts[1] -lt 8)) {
+	throw "Prime Agent requires Node.js 22.8 or newer; found $nodeVersion."
+}
+
+$version = Get-PrimeAgentVersion $release
+$tarballName = "$packageName-$version.tgz"
+$releaseUrl = "$baseUrl/releases/v$version"
+$tempDirectory = Join-Path ([IO.Path]::GetTempPath()) "prime-agent-$([Guid]::NewGuid().ToString('N'))"
+$tarballPath = Join-Path $tempDirectory $tarballName
+$checksumsPath = Join-Path $tempDirectory "SHA256SUMS"
+
+New-Item -ItemType Directory -Path $tempDirectory | Out-Null
+try {
+	Write-Host "Downloading Prime Agent v$version..."
+	Invoke-WebRequest -Uri "$releaseUrl/SHA256SUMS" -OutFile $checksumsPath
+	Invoke-WebRequest -Uri "$releaseUrl/$tarballName" -OutFile $tarballPath
+
+	$checksumLine = Get-Content -LiteralPath $checksumsPath | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+\*?$([regex]::Escape($tarballName))$" } | Select-Object -First 1
+	if (-not $checksumLine) {
+		throw "Checksum for $tarballName was not found in SHA256SUMS."
+	}
+	$expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+	$actualChecksum = (Get-FileHash -LiteralPath $tarballPath -Algorithm SHA256).Hash.ToLowerInvariant()
+	if ($actualChecksum -ne $expectedChecksum) {
+		throw "SHA-256 verification failed for $tarballName."
+	}
+
+	Write-Host "Installing Prime Agent globally with npm..."
+	$previousToolsBootstrap = $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL
+	$previousKernelBootstrap = $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL
+	$previousInstallUv = $env:PRIME_AGENT_INSTALL_UV
+	try {
+		$env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = "1"
+		$env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = "1"
+		$env:PRIME_AGENT_INSTALL_UV = "1"
+		& npm.cmd install -g --no-fund --no-audit --loglevel=error --progress=false $tarballPath
+		if ($LASTEXITCODE -ne 0) {
+			throw "npm install failed with exit code $LASTEXITCODE."
+		}
+	} finally {
+		$env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = $previousToolsBootstrap
+		$env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = $previousKernelBootstrap
+		$env:PRIME_AGENT_INSTALL_UV = $previousInstallUv
+	}
+} finally {
+	Remove-Item -LiteralPath $tempDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Prime Agent v$version installed successfully."
+Write-Host "Run it with: prime-agent"

--- a/install.ps1
+++ b/install.ps1
@@ -24,7 +24,7 @@ function Get-PrimeAgentVersion {
 
 	if ($Release -in @("stable", "beta")) {
 		Write-Host "Resolving the $Release release..."
-		$Release = (Invoke-RestMethod -Uri "$baseUrl/$Release" -Method Get).ToString().Trim()
+		$Release = (Invoke-RestMethod -UseBasicParsing -Uri "$baseUrl/$Release" -Method Get).ToString().Trim()
 	}
 
 	$version = $Release.Trim().TrimStart("v")
@@ -40,6 +40,13 @@ function Assert-Command {
 	if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
 		throw "$Name is required. $InstallMessage"
 	}
+}
+
+function Invoke-PrimeAgentDownload {
+	param([string]$Uri, [string]$OutFile)
+
+	$ProgressPreference = "SilentlyContinue"
+	Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $OutFile
 }
 
 Assert-Command "node" "Install Node.js 22.8 or newer from https://nodejs.org/."
@@ -61,8 +68,8 @@ $checksumsPath = Join-Path $tempDirectory "SHA256SUMS"
 New-Item -ItemType Directory -Path $tempDirectory | Out-Null
 try {
 	Write-Host "Downloading Prime Agent v$version..."
-	Invoke-WebRequest -Uri "$releaseUrl/SHA256SUMS" -OutFile $checksumsPath
-	Invoke-WebRequest -Uri "$releaseUrl/$tarballName" -OutFile $tarballPath
+	Invoke-PrimeAgentDownload -Uri "$releaseUrl/SHA256SUMS" -OutFile $checksumsPath
+	Invoke-PrimeAgentDownload -Uri "$releaseUrl/$tarballName" -OutFile $tarballPath
 
 	$checksumLine = Get-Content -LiteralPath $checksumsPath | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+\*?$([regex]::Escape($tarballName))$" } | Select-Object -First 1
 	if (-not $checksumLine) {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added native Windows PowerShell installation and source launchers.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -18,7 +18,13 @@ Run from source:
 /path/to/prime-agent/prime-agent.sh
 ```
 
-The script can be called from any directory and preserves the caller's working directory. Use that behavior to run a source checkout against a separate test project.
+On Windows, use the native launcher from PowerShell or Command Prompt:
+
+```powershell
+.\prime-agent.cmd
+```
+
+The launchers can be called from any directory and preserve the caller's working directory. Use that behavior to run a source checkout against a separate test project.
 
 ## Product and Source Names
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -1,12 +1,30 @@
 # Windows Setup
 
-Prime Agent requires a bash shell on Windows. Checked locations (in order):
+Install Prime Agent from PowerShell or Windows Terminal:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
+The installer requires Node.js 22.8 or newer. It downloads the selected release, verifies its SHA-256 checksum, installs the `prime-agent` command globally with npm, and prepares the IPython runtime. To install the current beta instead:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install-beta.ps1 | iex
+```
+
+Prime Agent launches, manages background agents, and runs its Python kernel natively on Windows. Its model-facing shell remains Bash for command compatibility. Checked Bash locations (in order):
 
 1. Custom path from `~/.prime/agent/settings.json`
 2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
 3. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
 
 For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient.
+
+After installation, open the repository or directory Prime Agent should work in and run:
+
+```powershell
+prime-agent
+```
 
 ## Custom Shell Path
 

--- a/packages/coding-agent/src/cli/subprocess-launch.ts
+++ b/packages/coding-agent/src/cli/subprocess-launch.ts
@@ -35,13 +35,28 @@ function quoteCommandArgument(value: string): string {
 	return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
-export function formatCurrentCliCommand(args: readonly string[], environment: NodeJS.ProcessEnv = process.env): string {
+function quotePowerShellArgument(value: string): string {
+	return /^[A-Za-z0-9_./:\\@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", "''")}'`;
+}
+
+function formatCommand(command: string, args: readonly string[], platform: NodeJS.Platform): string {
+	if (platform === "win32") {
+		return `& ${[command, ...args].map(quotePowerShellArgument).join(" ")}`;
+	}
+	return [command, ...args].map(quoteCommandArgument).join(" ");
+}
+
+export function formatCurrentCliCommand(
+	args: readonly string[],
+	environment: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+): string {
 	const launcherPath = environment.PRIME_AGENT_LAUNCHER_PATH;
 	if (launcherPath) {
-		return [launcherPath, ...args].map(quoteCommandArgument).join(" ");
+		return formatCommand(launcherPath, args, platform);
 	}
 	const launch = createCliSubprocessLaunchSpec(args);
-	return [launch.command, ...launch.args].map(quoteCommandArgument).join(" ");
+	return formatCommand(launch.command, launch.args, platform);
 }
 
 export function createCliSubprocessLaunchSpec(

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -344,6 +344,10 @@ export function getKernelVenvDir(): string {
 	return path.join(os.homedir(), ".prime", "agent", "kernel-venv");
 }
 
+export function getKernelVenvPython(venv: string, platform: NodeJS.Platform = process.platform): string {
+	return platform === "win32" ? path.win32.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function getXdgKernelVenvDir(): string {
 	const dataHome = process.env.XDG_DATA_HOME
 		? path.resolve(expandHome(process.env.XDG_DATA_HOME))
@@ -754,7 +758,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = getKernelVenvPython(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -915,7 +919,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = getKernelVenvPython(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -9,6 +9,7 @@ import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { getPackageDir } from "../../config.js";
+import { getShellConfig } from "../../utils/shell.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
 
 const BOOTSTRAP_SCHEMA = 8;
@@ -36,6 +37,7 @@ export const DEFAULT_RLM_EXTRA_UV_ARGS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) =>
 export const DEFAULT_RLM_EXTRA_IMPORT_NAMES = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.importName);
 export const DEFAULT_RLM_EXTRA_IMPORT_LABELS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.promptLabel);
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
+const UV_INSTALL_POWERSHELL_COMMAND = "irm https://astral.sh/uv/install.ps1 | iex";
 const REQUIRED_HARNESS_METHODS = [
 	"create_memory",
 	"update_memory",
@@ -511,6 +513,32 @@ async function findExecutable(name: string): Promise<string | null> {
 	return null;
 }
 
+export function createUvInstallLaunchSpec(
+	platform: NodeJS.Platform = process.platform,
+	environment: NodeJS.ProcessEnv = process.env,
+): { command: string; args: string[]; displayCommand: string } {
+	if (platform === "win32") {
+		const command = path.win32.join(
+			environment.SystemRoot ?? String.raw`C:\Windows`,
+			"System32",
+			"WindowsPowerShell",
+			"v1.0",
+			"powershell.exe",
+		);
+		return {
+			command,
+			args: ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", UV_INSTALL_POWERSHELL_COMMAND],
+			displayCommand: UV_INSTALL_POWERSHELL_COMMAND,
+		};
+	}
+	const { shell, args } = getShellConfig();
+	return {
+		command: shell,
+		args: [...args, UV_INSTALL_COMMAND],
+		displayCommand: UV_INSTALL_COMMAND,
+	};
+}
+
 async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 	const fromPath = await findExecutable("uv");
 	if (fromPath) return fromPath;
@@ -520,19 +548,20 @@ async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 
 	const shouldInstallUv =
 		process.env.PRIME_AGENT_INSTALL_UV === "1" || (!options.onProgress && (await confirmUvInstall()));
+	const install = createUvInstallLaunchSpec();
 	if (!shouldInstallUv) {
 		throw new Error(
-			`uv is required to set up the Python kernel. Install uv yourself: ${UV_INSTALL_COMMAND}, ` +
+			`uv is required to set up the Python kernel. Install uv yourself: ${install.displayCommand}, ` +
 				"or set PRIME_AGENT_INSTALL_UV=1 to let prime-agent run that installer.",
 		);
 	}
 
 	reportProgress(options, "› installing uv (one-time)…");
 	try {
-		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
+		await run(install.command, install.args, { stdio: options.onProgress ? "ignore" : "inherit" });
 	} catch (error) {
 		throw new Error(
-			`couldn't install uv from astral.sh; install it yourself: ${UV_INSTALL_COMMAND}, then re-run prime-agent. ${errorMessage(error)}`,
+			`couldn't install uv from astral.sh; install it yourself: ${install.displayCommand}, then re-run prime-agent. ${errorMessage(error)}`,
 		);
 	}
 

--- a/packages/coding-agent/test/kernel-bootstrap-install.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap-install.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createUvInstallLaunchSpec } from "../src/core/kernel/bootstrap.js";
+
+describe("uv bootstrap installer", () => {
+	it("uses the native PowerShell installer on Windows", () => {
+		expect(createUvInstallLaunchSpec("win32", { SystemRoot: String.raw`D:\Windows` })).toEqual({
+			command: String.raw`D:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
+			args: [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"irm https://astral.sh/uv/install.ps1 | iex",
+			],
+			displayCommand: "irm https://astral.sh/uv/install.ps1 | iex",
+		});
+	});
+});

--- a/packages/coding-agent/test/kernel-bootstrap-install.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap-install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createUvInstallLaunchSpec } from "../src/core/kernel/bootstrap.js";
+import { createUvInstallLaunchSpec, getKernelVenvPython } from "../src/core/kernel/bootstrap.js";
 
 describe("uv bootstrap installer", () => {
 	it("uses the native PowerShell installer on Windows", () => {
@@ -15,5 +15,11 @@ describe("uv bootstrap installer", () => {
 			],
 			displayCommand: "irm https://astral.sh/uv/install.ps1 | iex",
 		});
+	});
+
+	it("uses the Windows virtualenv interpreter path", () => {
+		expect(getKernelVenvPython(String.raw`D:\Users\prime\.prime\agent\kernel-venv`, "win32")).toBe(
+			String.raw`D:\Users\prime\.prime\agent\kernel-venv\Scripts\python.exe`,
+		);
 	});
 });

--- a/packages/coding-agent/test/subprocess-launch.test.ts
+++ b/packages/coding-agent/test/subprocess-launch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrentCliCommand } from "../src/cli/subprocess-launch.js";
+
+describe("formatCurrentCliCommand", () => {
+	it("formats launcher recovery commands for POSIX shells", () => {
+		expect(
+			formatCurrentCliCommand(
+				["shutdown", "--force"],
+				{ PRIME_AGENT_LAUNCHER_PATH: "/opt/Prime Agent/prime-agent.sh" },
+				"linux",
+			),
+		).toBe("'/opt/Prime Agent/prime-agent.sh' shutdown --force");
+	});
+
+	it("formats launcher recovery commands for PowerShell", () => {
+		expect(
+			formatCurrentCliCommand(
+				["shutdown", "--force"],
+				{ PRIME_AGENT_LAUNCHER_PATH: String.raw`C:\Program Files\Prime Agent\prime-agent.cmd` },
+				"win32",
+			),
+		).toBe(String.raw`& 'C:\Program Files\Prime Agent\prime-agent.cmd' shutdown --force`);
+	});
+});

--- a/prime-agent.cmd
+++ b/prime-agent.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0prime-agent.ps1" %*
+exit /b %ERRORLEVEL%

--- a/prime-agent.ps1
+++ b/prime-agent.ps1
@@ -1,0 +1,64 @@
+$ErrorActionPreference = "Stop"
+
+$launcherPath = Join-Path $PSScriptRoot "prime-agent.cmd"
+$env:PRIME_AGENT_LAUNCHER_PATH = $launcherPath
+
+try {
+	$buildId = (& git -C $PSScriptRoot describe --tags --always --dirty 2>$null)
+	if ($LASTEXITCODE -eq 0 -and $buildId) {
+		$env:PRIME_AGENT_BUILD_ID = $buildId.Trim()
+	}
+} catch {
+	# Git metadata is optional when running from a source archive.
+}
+
+$useDist = $false
+$forwardedArguments = @()
+foreach ($argument in $args) {
+	switch ($argument) {
+		"--no-env" {
+			$apiKeyNames = @(
+				"ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "OPENAI_API_KEY", "PRIME_API_KEY",
+				"GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "XAI_API_KEY",
+				"OPENROUTER_API_KEY", "ZAI_API_KEY", "MISTRAL_API_KEY", "MINIMAX_API_KEY",
+				"MINIMAX_CN_API_KEY", "AI_GATEWAY_API_KEY", "OPENCODE_API_KEY",
+				"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "HF_TOKEN",
+				"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT",
+				"GOOGLE_CLOUD_LOCATION", "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+				"AWS_SESSION_TOKEN", "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_BEARER_TOKEN_BEDROCK",
+				"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+				"AWS_WEB_IDENTITY_TOKEN_FILE", "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_BASE_URL",
+				"AZURE_OPENAI_RESOURCE_NAME"
+			)
+			foreach ($name in $apiKeyNames) {
+				Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+			}
+			Write-Host "Running Prime Agent without API keys..."
+		}
+		"--dist" {
+			$useDist = $true
+		}
+		default {
+			$forwardedArguments += $argument
+		}
+	}
+}
+
+if ($useDist) {
+	$entrypoint = Join-Path $PSScriptRoot "packages\coding-agent\dist\bundle\cli.js"
+	if (-not (Test-Path -LiteralPath $entrypoint -PathType Leaf)) {
+		Write-Error "Bundle not found at $entrypoint. Run npm run build first."
+		exit 1
+	}
+} else {
+	$tsxEntrypoint = Join-Path $PSScriptRoot "node_modules\tsx\dist\cli.mjs"
+	if (-not (Test-Path -LiteralPath $tsxEntrypoint -PathType Leaf)) {
+		Write-Error "tsx not found at $tsxEntrypoint. Run npm install from the repo root first."
+		exit 1
+	}
+	$entrypoint = $tsxEntrypoint
+	$forwardedArguments = @((Join-Path $PSScriptRoot "packages\coding-agent\src\cli.ts")) + $forwardedArguments
+}
+
+& node $entrypoint @forwardedArguments
+exit $LASTEXITCODE

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -1,9 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const installerSource = readFileSync("install.sh", "utf-8");
+const installerShell = resolveInstallerShell();
 const mainCall = '\nmain "$@"';
 const mainCallIndex = installerSource.lastIndexOf(mainCall);
 const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
@@ -164,10 +165,14 @@ if (failures.length > 0) {
 console.log("Installer render check passed.");
 
 function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
-	const result = spawnSync("sh", [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
-		detached: true,
-		encoding: "utf-8",
-	});
+	const result = spawnSync(
+		installerShell,
+		[harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)],
+		{
+			detached: true,
+			encoding: "utf-8",
+		},
+	);
 	if (result.status !== 0) {
 		failures.push(`${name}: harness exited with ${result.status ?? "unknown"}\n${result.stderr}${result.stdout}`);
 		return emptyParsedCase();
@@ -180,6 +185,16 @@ function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
 	assertScreenFrame(name, "first", parsed, initialCols, initialRows);
 	assertScreenFrame(name, "second", parsed, resizedCols, resizedRows);
 	return parsed;
+}
+
+function resolveInstallerShell() {
+	if (process.platform !== "win32") return "sh";
+
+	const candidates = [
+		process.env.ProgramFiles && join(process.env.ProgramFiles, "Git", "bin", "sh.exe"),
+		process.env["ProgramFiles(x86)"] && join(process.env["ProgramFiles(x86)"], "Git", "bin", "sh.exe"),
+	];
+	return candidates.find((candidate) => candidate && existsSync(candidate)) ?? "sh";
 }
 
 function parseRenderOutput(output) {


### PR DESCRIPTION
## Summary

- add native PowerShell and Command Prompt launchers for source checkouts
- add checksum-verified stable and beta PowerShell installers
- publish Windows installers through the existing release workflow
- document the native Windows setup and make installer validation locate Git Bash on Windows

The application, daemon, and Python runtime run natively on Windows. The model-facing command shell continues to use Bash for command compatibility and resolves Git Bash automatically.

## Validation

- `npm run check`
- `prime-agent.cmd --version`
- parsed both PowerShell scripts with the PowerShell AST parser
- exercised installer download, SHA-256 verification, and npm invocation against a local fake release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-time install and Python kernel bootstrap on Windows (download, checksum, global npm, uv install); release workflow now publishes additional install artifacts, but scope is platform/install plumbing rather than auth or data handling.
> 
> **Overview**
> **Native Windows install and dev launch** — New `install.ps1` mirrors the shell installer: resolve stable/beta, download the release tarball, verify SHA-256, and `npm install -g` with kernel/tool/uv bootstrap env vars enabled. `prime-agent.cmd` / `prime-agent.ps1` run from a source checkout (tsx or `--dist`), including `--no-env` stripping of API keys.
> 
> **Release and docs** — `build-binaries.yml` token-replaces and uploads `install.ps1` / `install-beta.ps1` to R2 with the existing shell installers. README, `windows.md`, and `development.md` document `irm … | iex` and `prime-agent.cmd`.
> 
> **Runtime fixes on Windows** — Kernel bootstrap uses `venv\Scripts\python.exe` via `getKernelVenvPython`, and optional uv install runs through PowerShell (`irm …/uv/install.ps1 | iex`) via `createUvInstallLaunchSpec`. `formatCurrentCliCommand` emits PowerShell `&` invocation with Windows-safe quoting when `platform === "win32"`. Installer render checks pick Git Bash `sh.exe` on Windows hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0df3a7139299d403df1af852d7775949f5f81be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Windows PowerShell installer and source launchers for Prime Agent
> - Adds [install.ps1](https://github.com/PrimeIntellect-ai/prime-agent/pull/732/files#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806) to install Prime Agent on Windows via `irm ... | iex`, with Node.js >= 22.8 validation, SHA-256 checksum verification, and global npm install with bootstrap flags.
> - Adds [prime-agent.ps1](https://github.com/PrimeIntellect-ai/prime-agent/pull/732/files#diff-5291d29bdf7aaa9407a985f0367b9676155a16a473b31e3c5e823c3579164728) and [prime-agent.cmd](https://github.com/PrimeIntellect-ai/prime-agent/pull/732/files#diff-2d4d12323a7737a07c94d749a958eea144c040e04e90823604368c5af7d4c9a2) as Windows source-checkout launchers with environment management and `--dist`/`--no-env` options.
> - Updates kernel bootstrap in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/732/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to use PowerShell (`irm https://astral.sh/uv/install.ps1 | iex`) for uv installation on Windows and correct `venv\Scripts\python.exe` paths.
> - Updates `formatCurrentCliCommand` in [subprocess-launch.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/732/files#diff-c05c66998f6c8e1e38e160aac581692d537a69457e7c7373915d0ae291c639fc) to produce PowerShell-style command strings (`&` with single-quoted args) on Windows.
> - Extends the release workflow to render and publish `install.ps1` and `install-beta.ps1` to the R2 bucket alongside existing Bash installers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0df3a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->