### PR TITLE
fix(coding-agent): preserve extension statuses across daemon sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 - Fixed `retry_worker` cancelling its own recovery when a stopped session worker left a saved stop marker behind, leaving the session stuck at "Session worker is not connected".
 - Fixed extension status updates racing session replacement redraws.
+- Fixed extension statuses disappearing until their next refresh after attaching to or replacing a session.
 - Fixed the interactive footer dropping extension status text such as Codex usage.
 
 ## [0.7.0] - 2026-08-05

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 - Fixed `retry_worker` cancelling its own recovery when a stopped session worker left a saved stop marker behind, leaving the session stuck at "Session worker is not connected".
+- Fixed extension status updates racing session replacement redraws.
 - Fixed the interactive footer dropping extension status text such as Codex usage.
 
 ## [0.7.0] - 2026-08-05

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 - Fixed `retry_worker` cancelling its own recovery when a stopped session worker left a saved stop marker behind, leaving the session stuck at "Session worker is not connected".
+- Fixed the interactive footer dropping extension status text such as Codex usage.
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -87,6 +87,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	private rebindSession?: (session: AgentSession) => Promise<void>;
 	private readonly sessionReplacedListeners = new Set<(session: AgentSession) => void | Promise<void>>();
 	private runtimeEnvScope?: <T>(fn: () => Promise<T>) => Promise<T>;
+	private beforeSessionReplace?: () => void;
+	private sessionReplaceFailed?: () => void;
 	private beforeSessionInvalidate?: () => void;
 	private subagentRuntimeHost?: SubagentRuntimeHost;
 	private subagentRuntimes = new Map<string, AgentSessionRuntime>();
@@ -167,6 +169,16 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	setSubagentRuntimeHost(host?: SubagentRuntimeHost): void {
 		this.subagentRuntimeHost = host;
 		this.bindRuntimeHost();
+	}
+
+	/** Run synchronously before a session replacement starts its teardown. */
+	setBeforeSessionReplace(beforeSessionReplace?: () => void): void {
+		this.beforeSessionReplace = beforeSessionReplace;
+	}
+
+	/** Run when replacement teardown or runtime creation fails before rebinding. */
+	setSessionReplaceFailed(sessionReplaceFailed?: () => void): void {
+		this.sessionReplaceFailed = sessionReplaceFailed;
 	}
 
 	/**
@@ -275,6 +287,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		try {
 			result = await build();
 		} catch (error) {
+			this.sessionReplaceFailed?.();
 			this.releaseUncommittedLease(lease);
 			throw error;
 		}
@@ -288,8 +301,10 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		lease: SessionLease | undefined,
 	): Promise<void> {
 		try {
+			this.beforeSessionReplace?.();
 			await this.teardownCurrent(reason, targetSessionFile);
 		} catch (error) {
+			this.sessionReplaceFailed?.();
 			this.releaseUncommittedLease(lease);
 			throw error;
 		}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -221,6 +221,8 @@ export class DaemonAgentConnection implements AgentConnection {
 	private terminalCloseEmitted = false;
 	private updateReconnectPromise?: Promise<void>;
 	private readonly activeSideQuestionIds = new Set<string>();
+	private readonly extensionStatusKeys = new Map<string, Set<string>>();
+	private readonly extensionStatuses = new Map<string, Map<string, string>>();
 	private readonly snapshotAssemblies = new Map<string, DaemonSnapshotAssembly>();
 	private readonly completedSnapshots = new Map<string, DaemonSessionSnapshot>();
 	private readonly pendingReattachActiveSessionIds = new Set<string>();
@@ -1135,7 +1137,7 @@ export class DaemonAgentConnection implements AgentConnection {
 				capabilities: [
 					"attach_snapshot",
 					"event_sequence",
-					...(supportsExtensionUi ? (["extension_ui"] as const) : []),
+					...(supportsExtensionUi ? (["extension_ui", "extension_status_snapshot"] as const) : []),
 					"slim_attach",
 					"chunked_snapshot",
 					...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
@@ -1180,6 +1182,12 @@ export class DaemonAgentConnection implements AgentConnection {
 			throw error;
 		} finally {
 			this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
+			for (const activeSessionId of this.extensionStatusKeys.keys()) {
+				if (activeSessionId !== this.activeSessionId) this.extensionStatusKeys.delete(activeSessionId);
+			}
+			for (const activeSessionId of this.extensionStatuses.keys()) {
+				if (activeSessionId !== this.activeSessionId) this.extensionStatuses.delete(activeSessionId);
+			}
 		}
 	}
 
@@ -1314,6 +1322,8 @@ export class DaemonAgentConnection implements AgentConnection {
 			this.client.close();
 		}
 		this.rejectSnapshotAssemblies(new Error("Daemon connection disposed during snapshot transfer"));
+		this.extensionStatusKeys.clear();
+		this.extensionStatuses.clear();
 	}
 
 	async promoteToResident(): Promise<void> {
@@ -1524,6 +1534,16 @@ export class DaemonAgentConnection implements AgentConnection {
 			return;
 		}
 		if (message.type === "extension_ui_request") {
+			if (message.method === "setStatus" && typeof message.payload.statusKey === "string") {
+				const statusKey = message.payload.statusKey;
+				const keys = this.extensionStatusKeys.get(message.activeSessionId) ?? new Set<string>();
+				const statuses = this.extensionStatuses.get(message.activeSessionId) ?? new Map<string, string>();
+				keys.add(statusKey);
+				if (typeof message.payload.statusText === "string") statuses.set(statusKey, message.payload.statusText);
+				else statuses.delete(statusKey);
+				this.extensionStatusKeys.set(message.activeSessionId, keys);
+				this.extensionStatuses.set(message.activeSessionId, statuses);
+			}
 			await this.emit({
 				type: "extension_ui_request",
 				request: {
@@ -1755,6 +1775,23 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 	}
 
+	private async replayRecoveredExtensionStatuses(activeSessionId: string): Promise<void> {
+		if (this.options.supportsExtensionUi !== false) return;
+		const keys = this.extensionStatusKeys.get(activeSessionId);
+		if (!keys?.size) return;
+		const statuses = this.extensionStatuses.get(activeSessionId) ?? new Map<string, string>();
+		for (const statusKey of keys) {
+			await this.emit({
+				type: "extension_ui_request",
+				request: {
+					id: randomUUID(),
+					method: "setStatus",
+					payload: { statusKey, statusText: statuses.get(statusKey) },
+				},
+			});
+		}
+	}
+
 	private async recoverFailedSnapshot(purpose: "replacement" | "resync", snapshotError: Error): Promise<void> {
 		this.latestSnapshotIsFresh = false;
 		if (purpose === "replacement") {
@@ -1772,6 +1809,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			} else {
 				await this.emit({ type: "session_resynced", snapshot });
 			}
+			await this.replayRecoveredExtensionStatuses(this.activeSessionId);
 		} catch (recoveryError) {
 			if (this.disposed) {
 				return;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -302,7 +302,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			capabilities: [
 				"attach_snapshot",
 				"event_sequence",
-				...(supportsExtensionUi ? (["extension_ui"] as const) : []),
+				...(supportsExtensionUi ? (["extension_ui", "extension_status_snapshot"] as const) : []),
 				"slim_attach",
 				"chunked_snapshot",
 				...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -345,6 +345,8 @@ export interface AgentConnectionState {
 	contextUsage: SessionStats["contextUsage"];
 	/** One-line recap of the agent's recent work, shown above the prompt. */
 	recap?: string;
+	/** Last daemon extension statuses, restored when attaching or replacing a session. */
+	extensionStatuses?: Record<string, string>;
 }
 
 export interface AgentConnectionSlashCommand {

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -38,6 +38,8 @@ export interface ActiveSessionState {
 	/** Attach snapshots in flight: reserved for passivation busyness, but not yet event recipients. */
 	pendingAttaches: number;
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
+	/** Last passive extension statuses, replayed in attach and replacement snapshots. */
+	extensionStatuses?: Map<string, string>;
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
 	unsubscribe?: () => void;

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -29,6 +29,10 @@ export interface DaemonSocketClient {
 	supportsExtensionUi: boolean;
 	capabilities: Set<DaemonClientCapability>;
 	capabilitiesByActiveSessionId?: Map<string, Set<DaemonClientCapability>>;
+	/** Status keys observed by legacy clients, retained as tombstones for resync clears. */
+	extensionStatusKeysByActiveSessionId?: Map<string, Set<string>>;
+	/** Legacy status updates observed during snapshot transfer, replayed after it closes. */
+	pendingExtensionStatusReplayActiveSessionIds?: Set<string>;
 }
 
 export interface ActiveSessionState {

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { AgentSession } from "../../core/agent-session.js";
 import type {
 	ExtensionCommandContextActions,
 	ExtensionUIContext,
@@ -18,11 +19,6 @@ import {
 	isDaemonDialogExtensionUiRequest,
 } from "./daemon-protocol.js";
 
-export interface ActiveSessionBindingOptions {
-	/** Defer fire-and-forget UI requests until the replacement snapshot is broadcast. */
-	deferPassiveExtensionUi?: boolean;
-}
-
 export interface ActiveSessionBindingCallbacks {
 	broadcast: (state: ActiveSessionState, message: DaemonOutbound) => void;
 	createConnectionState?: (state: ActiveSessionState) => AgentConnectionState;
@@ -32,6 +28,16 @@ export interface ActiveSessionBindingCallbacks {
 }
 
 type BroadcastSessionEvent = Extract<DaemonOutbound, { type: "session_event" }>["event"];
+type ExtensionUiRequest = Extract<DaemonOutbound, { type: "extension_ui_request" }>;
+
+interface ExtensionUiBindingState {
+	replacementsInProgress: number;
+	staleSessions: WeakSet<AgentSession>;
+}
+
+interface DeferredExtensionUiRequests {
+	messages: ExtensionUiRequest[];
+}
 
 /**
  * message_update events carry the full partial assistant message twice: once
@@ -54,19 +60,38 @@ function slimSessionEventForWire(event: BroadcastSessionEvent): BroadcastSession
 export async function bindActiveSessionState(
 	state: ActiveSessionState,
 	callbacks: ActiveSessionBindingCallbacks,
-	options: ActiveSessionBindingOptions = {},
-): Promise<DaemonOutbound[]> {
+): Promise<void> {
+	state.extensionStatuses ??= new Map();
+	await bindSession(state, callbacks, { replacementsInProgress: 0, staleSessions: new WeakSet() }, false);
+}
+
+async function bindSession(
+	state: ActiveSessionState,
+	callbacks: ActiveSessionBindingCallbacks,
+	uiState: ExtensionUiBindingState,
+	deferPassiveExtensionUi: boolean,
+): Promise<DeferredExtensionUiRequests> {
 	const session = state.runtime.session;
-	const deferredExtensionUiRequests: DaemonOutbound[] = [];
+	state.extensionStatuses ??= new Map();
+	const statuses = state.extensionStatuses;
+	const deferred: DeferredExtensionUiRequests = { messages: [] };
 	let binding = true;
 	const broadcastExtensionUi: ActiveSessionBindingCallbacks["broadcast"] = (targetState, message) => {
+		if (message.type !== "extension_ui_request") {
+			callbacks.broadcast(targetState, message);
+			return;
+		}
+		const passive = !isDaemonDialogExtensionUiRequest(message.method);
 		if (
-			options.deferPassiveExtensionUi &&
-			binding &&
-			message.type === "extension_ui_request" &&
-			!isDaemonDialogExtensionUiRequest(message.method)
+			uiState.replacementsInProgress > 0 ||
+			uiState.staleSessions.has(session) ||
+			targetState.runtime.session !== session
 		) {
-			deferredExtensionUiRequests.push(message);
+			return;
+		}
+		if (passive) recordExtensionStatus(message, statuses);
+		if (deferPassiveExtensionUi && binding && passive) {
+			if (message.method !== "setStatus") deferred.messages.push(message);
 			return;
 		}
 		callbacks.broadcast(targetState, message);
@@ -79,6 +104,13 @@ export async function bindActiveSessionState(
 
 	state.unsubscribe?.();
 	state.runtime.setSubagentRuntimeHost(callbacks.subagentRuntimeHost);
+	state.runtime.setBeforeSessionReplace(() => {
+		uiState.replacementsInProgress += 1;
+		uiState.staleSessions.add(session);
+	});
+	state.runtime.setSessionReplaceFailed(() => {
+		uiState.replacementsInProgress = Math.max(0, uiState.replacementsInProgress - 1);
+	});
 	state.unsubscribe = session.subscribe((event) => {
 		callbacks.broadcast(state, {
 			type: "session_event",
@@ -88,27 +120,31 @@ export async function bindActiveSessionState(
 	});
 
 	state.runtime.setRebindSession(async () => {
-		const deferredRequests = await bindActiveSessionState(state, callbacks, {
-			deferPassiveExtensionUi: true,
-		});
+		uiState.replacementsInProgress = Math.max(0, uiState.replacementsInProgress - 1);
+		const replacementUi = await bindSession(state, callbacks, uiState, true);
 		callbacks.sessionReplaced?.(state);
+		const connectionState =
+			callbacks.createConnectionState?.(state) ?? createAgentConnectionState(state.runtime, state.activeSessionId);
+		connectionState.extensionStatuses = Object.fromEntries(statuses);
 		callbacks.broadcast(state, {
 			type: "session_replaced",
 			activeSessionId: state.activeSessionId,
-			state:
-				callbacks.createConnectionState?.(state) ??
-				createAgentConnectionState(state.runtime, state.activeSessionId),
+			state: connectionState,
 			messages: state.runtime.session.messages,
 		});
-		// A replacement resets the client footer before rebinding the session.
-		// Send passive extension UI updates only after that reset and snapshot.
-		for (const message of deferredRequests) callbacks.broadcast(state, message);
+		// The snapshot restores statuses atomically with the replacement render.
+		// Deliver other passive UI updates only after that reset and snapshot.
+		for (const message of replacementUi.messages) callbacks.broadcast(state, message);
 	});
 
 	await session.bindExtensions({
 		uiContext: createExtensionUIContext(
 			state,
-			options.deferPassiveExtensionUi ? broadcastExtensionUi : callbacks.broadcast,
+			broadcastExtensionUi,
+			() =>
+				uiState.replacementsInProgress === 0 &&
+				!uiState.staleSessions.has(session) &&
+				state.runtime.session === session,
 		),
 		commandContextActions: createCommandContextActions(state),
 		shutdownHandler: callbacks.shutdown,
@@ -124,7 +160,16 @@ export async function bindActiveSessionState(
 	});
 	binding = false;
 
-	return deferredExtensionUiRequests;
+	return deferred;
+}
+
+function recordExtensionStatus(message: ExtensionUiRequest, statuses: Map<string, string>): void {
+	if (message.method !== "setStatus") return;
+	const statusKey = message.payload.statusKey;
+	if (typeof statusKey !== "string") return;
+	const statusText = message.payload.statusText;
+	if (typeof statusText === "string") statuses.set(statusKey, statusText);
+	else statuses.delete(statusKey);
 }
 
 function createCommandContextActions(state: ActiveSessionState): ExtensionCommandContextActions {
@@ -156,8 +201,10 @@ function createCommandContextActions(state: ActiveSessionState): ExtensionComman
 function createExtensionUIContext(
 	state: ActiveSessionState,
 	broadcast: ActiveSessionBindingCallbacks["broadcast"],
+	isActive: () => boolean,
 ): ExtensionUIContext {
-	const emitUiRequest = (method: string, payload: Record<string, unknown>): string => {
+	const emitUiRequest = (method: string, payload: Record<string, unknown>): string | undefined => {
+		if (!isActive()) return undefined;
 		const id = randomUUID();
 		broadcast(state, {
 			type: "extension_ui_request",
@@ -176,6 +223,7 @@ function createExtensionUIContext(
 		fallback: T,
 		resolveResponse: (response: DaemonExtensionUIResponse) => T,
 	): Promise<T> => {
+		if (!isActive()) return Promise.resolve(fallback);
 		if (opts?.signal?.aborted) {
 			return Promise.resolve(fallback);
 		}
@@ -183,6 +231,7 @@ function createExtensionUIContext(
 			return Promise.resolve(fallback);
 		}
 		const requestId = emitUiRequest(method, payload);
+		if (!requestId) return Promise.resolve(fallback);
 		return new Promise((resolveDialog) => {
 			let timeoutId: ReturnType<typeof setTimeout> | undefined;
 			const cleanup = () => {

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -18,6 +18,11 @@ import {
 	isDaemonDialogExtensionUiRequest,
 } from "./daemon-protocol.js";
 
+export interface ActiveSessionBindingOptions {
+	/** Defer fire-and-forget UI requests until the replacement snapshot is broadcast. */
+	deferPassiveExtensionUi?: boolean;
+}
+
 export interface ActiveSessionBindingCallbacks {
 	broadcast: (state: ActiveSessionState, message: DaemonOutbound) => void;
 	createConnectionState?: (state: ActiveSessionState) => AgentConnectionState;
@@ -49,8 +54,23 @@ function slimSessionEventForWire(event: BroadcastSessionEvent): BroadcastSession
 export async function bindActiveSessionState(
 	state: ActiveSessionState,
 	callbacks: ActiveSessionBindingCallbacks,
-): Promise<void> {
+	options: ActiveSessionBindingOptions = {},
+): Promise<DaemonOutbound[]> {
 	const session = state.runtime.session;
+	const deferredExtensionUiRequests: DaemonOutbound[] = [];
+	let binding = true;
+	const broadcastExtensionUi: ActiveSessionBindingCallbacks["broadcast"] = (targetState, message) => {
+		if (
+			options.deferPassiveExtensionUi &&
+			binding &&
+			message.type === "extension_ui_request" &&
+			!isDaemonDialogExtensionUiRequest(message.method)
+		) {
+			deferredExtensionUiRequests.push(message);
+			return;
+		}
+		callbacks.broadcast(targetState, message);
+	};
 
 	session.setExecEnvProvider(() => execEnvForSession(state.clientEnv));
 	// Every runtime rebuild (new/switch/fork/import, subagent spawn) re-loads
@@ -68,7 +88,9 @@ export async function bindActiveSessionState(
 	});
 
 	state.runtime.setRebindSession(async () => {
-		await bindActiveSessionState(state, callbacks);
+		const deferredRequests = await bindActiveSessionState(state, callbacks, {
+			deferPassiveExtensionUi: true,
+		});
 		callbacks.sessionReplaced?.(state);
 		callbacks.broadcast(state, {
 			type: "session_replaced",
@@ -78,10 +100,16 @@ export async function bindActiveSessionState(
 				createAgentConnectionState(state.runtime, state.activeSessionId),
 			messages: state.runtime.session.messages,
 		});
+		// A replacement resets the client footer before rebinding the session.
+		// Send passive extension UI updates only after that reset and snapshot.
+		for (const message of deferredRequests) callbacks.broadcast(state, message);
 	});
 
 	await session.bindExtensions({
-		uiContext: createExtensionUIContext(state, callbacks.broadcast),
+		uiContext: createExtensionUIContext(
+			state,
+			options.deferPassiveExtensionUi ? broadcastExtensionUi : callbacks.broadcast,
+		),
 		commandContextActions: createCommandContextActions(state),
 		shutdownHandler: callbacks.shutdown,
 		onError: (error) => {
@@ -94,6 +122,9 @@ export async function bindActiveSessionState(
 			});
 		},
 	});
+	binding = false;
+
+	return deferredExtensionUiRequests;
 }
 
 function createCommandContextActions(state: ActiveSessionState): ExtensionCommandContextActions {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4120,7 +4120,7 @@ export class AgentDaemon {
 
 			case "get_connection_state": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(command.id, "get_connection_state", this.createConnectionState(state));
+				return success(command.id, "get_connection_state", this.createConnectionState(state, client));
 			}
 
 			case "get_messages": {
@@ -4550,7 +4550,7 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		command: Extract<DaemonCommand, { type: "attach" }>,
 	): Promise<DaemonAttachResult> {
-		const snapshot = await this.createSessionSnapshot(state);
+		const snapshot = await this.createSessionSnapshot(state, client);
 		const replay =
 			command.resumeCursor?.activeSessionId && command.resumeCursor.activeSessionId !== state.activeSessionId
 				? {
@@ -4589,7 +4589,10 @@ export class AgentDaemon {
 		};
 	}
 
-	private async createSessionSnapshot(state: ActiveSessionState): Promise<DaemonSessionSnapshot> {
+	private async createSessionSnapshot(
+		state: ActiveSessionState,
+		client: DaemonSocketClient,
+	): Promise<DaemonSessionSnapshot> {
 		const metadata = state.runtime.metadata;
 		const parent =
 			metadata.parentActiveSessionId || metadata.parentSessionId || metadata.rlmParentNodeId || metadata.rlmChildId
@@ -4611,7 +4614,7 @@ export class AgentDaemon {
 			children = await this.buildRlmChildSnapshotsWithPassiveRlmSubagents(state);
 		}
 		session = state.runtime.session;
-		const connectionState = this.createConnectionState(state);
+		const connectionState = this.createConnectionState(state, client);
 		return {
 			activeSessionId: state.activeSessionId,
 			summary: summaryForActiveSession(state),
@@ -4764,6 +4767,8 @@ export class AgentDaemon {
 				purpose,
 				transferSignal,
 			);
+			const snapshotState = this.sessions.get(result.activeSessionId);
+			if (snapshotState) this.replayExtensionStatusesToClient(client, snapshotState);
 		} catch (error) {
 			if (transferSignal.aborted) {
 				await deliverSnapshotFailure(new Error(`Snapshot ${stream.id} was aborted`));
@@ -4852,8 +4857,14 @@ export class AgentDaemon {
 		});
 	}
 
-	private createConnectionState(state: ActiveSessionState): ReturnType<typeof createAgentConnectionState> {
+	private createConnectionState(
+		state: ActiveSessionState,
+		client?: DaemonSocketClient,
+	): ReturnType<typeof createAgentConnectionState> {
 		const connectionState = createAgentConnectionState(state.runtime, state.activeSessionId);
+		if (!client || daemonClientSupportsExtensionStatusSnapshot(client, state.activeSessionId)) {
+			connectionState.extensionStatuses = Object.fromEntries(state.extensionStatuses ?? []);
+		}
 		connectionState.heartbeat = this.cronStore.getLatestHeartbeat(state.activeSessionId) ?? null;
 		if (state.summaryState?.summary) {
 			connectionState.recap = state.summaryState.summary;
@@ -6116,6 +6127,17 @@ export class AgentDaemon {
 		return cascadeError;
 	}
 
+	private replayExtensionStatusesToClient(client: DaemonSocketClient, state: ActiveSessionState): void {
+		if (
+			client.socket.destroyed ||
+			!client.attachedActiveSessionIds.has(state.activeSessionId) ||
+			daemonClientSupportsExtensionStatusSnapshot(client, state.activeSessionId)
+		) {
+			return;
+		}
+		for (const message of createExtensionStatusReplay(state)) this.write(client, message);
+	}
+
 	private broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void {
 		if (message.type === "session_event") {
 			const eventType = message.event.type;
@@ -6139,14 +6161,16 @@ export class AgentDaemon {
 		this.stampRlmChildActiveSessionId(message);
 		const sequencedMessage = this.addSessionEventMeta(state, message);
 		let serialized: string | undefined;
+		let serializedWithoutExtensionStatuses: string | undefined;
 		for (const client of state.clients) {
 			if (!shouldSendDaemonOutboundToClient(client, sequencedMessage)) {
 				continue;
 			}
+			const messageForClient = daemonOutboundForClient(client, sequencedMessage);
 			if (sequencedMessage.type === "session_closed") {
 				client.catchupActiveSessionIds?.delete(state.activeSessionId);
 				client.catchupPurposes?.delete(state.activeSessionId);
-				this.write(client, sequencedMessage);
+				this.write(client, messageForClient);
 				continue;
 			}
 			if (client.snapshotActiveSessionIds?.has(state.activeSessionId)) {
@@ -6170,14 +6194,24 @@ export class AgentDaemon {
 				client.transport === "private-framed" &&
 				daemonClientCapabilitiesForSession(client, state.activeSessionId).has("chunked_snapshot")
 			) {
-				this.beginReplacementSnapshot(client, state, sequencedMessage);
+				this.beginReplacementSnapshot(
+					client,
+					state,
+					messageForClient as Extract<DaemonOutbound, { type: "session_replaced" }>,
+				);
 				continue;
 			}
 			if (client.transport === "private-framed") {
-				this.write(client, sequencedMessage);
+				this.write(client, messageForClient);
+			} else if (messageForClient === sequencedMessage) {
+				serialized ??= serializeJsonLine(messageForClient);
+				this.writeSerialized(client, serialized, messageForClient);
 			} else {
-				serialized ??= serializeJsonLine(sequencedMessage);
-				this.writeSerialized(client, serialized, sequencedMessage);
+				serializedWithoutExtensionStatuses ??= serializeJsonLine(messageForClient);
+				this.writeSerialized(client, serializedWithoutExtensionStatuses, messageForClient);
+			}
+			if (sequencedMessage.type === "session_replaced") {
+				this.replayExtensionStatusesToClient(client, state);
 			}
 		}
 	}
@@ -6685,6 +6719,37 @@ function daemonClientCapabilitiesForSession(
 
 function daemonClientSupportsExtensionUi(client: DaemonSocketClient, activeSessionId: string): boolean {
 	return client.capabilitiesByActiveSessionId?.get(activeSessionId)?.has("extension_ui") ?? client.supportsExtensionUi;
+}
+
+export function daemonClientSupportsExtensionStatusSnapshot(
+	client: DaemonSocketClient,
+	activeSessionId: string,
+): boolean {
+	return daemonClientCapabilitiesForSession(client, activeSessionId).has("extension_status_snapshot");
+}
+
+export function daemonOutboundForClient<T extends DaemonOutbound>(client: DaemonSocketClient, message: T): T {
+	if (
+		message.type !== "session_replaced" ||
+		message.state.extensionStatuses === undefined ||
+		daemonClientSupportsExtensionStatusSnapshot(client, message.activeSessionId)
+	) {
+		return message;
+	}
+	const { extensionStatuses: _extensionStatuses, ...state } = message.state;
+	return { ...message, state } as T;
+}
+
+export function createExtensionStatusReplay(
+	state: ActiveSessionState,
+): Array<Extract<DaemonOutbound, { type: "extension_ui_request" }>> {
+	return [...(state.extensionStatuses ?? [])].map(([statusKey, statusText]) => ({
+		type: "extension_ui_request",
+		activeSessionId: state.activeSessionId,
+		id: randomUUID(),
+		method: "setStatus",
+		payload: { statusKey, statusText },
+	}));
 }
 
 export function markClientSnapshotStreaming(client: DaemonSocketClient, activeSessionId: string): AbortSignal {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3647,6 +3647,9 @@ export class AgentDaemon {
 						lastEventSequence: result.lastEventSequence,
 					});
 				}
+				// Legacy clients reset extension UI while attaching and need the
+				// ordered status replay after the inline attach payload.
+				this.replayExtensionStatusesToClient(client, state);
 				return success(command.id, "attach", result);
 			}
 
@@ -4655,6 +4658,10 @@ export class AgentDaemon {
 		const transferSignal = signal ?? markClientSnapshotStreaming(client, result.activeSessionId);
 		if (client.socket.destroyed) {
 			finishClientSnapshotStreaming(client, result.activeSessionId);
+			if (client.pendingExtensionStatusReplayActiveSessionIds?.delete(result.activeSessionId)) {
+				const latestState = this.sessions.get(result.activeSessionId);
+				if (latestState) this.replayExtensionStatusesToClient(client, latestState);
+			}
 			transcript.dispose?.();
 			return;
 		}
@@ -4783,6 +4790,10 @@ export class AgentDaemon {
 				client.snapshotTransferTails.delete(result.activeSessionId);
 			}
 			finishClientSnapshotStreaming(client, result.activeSessionId);
+			if (client.pendingExtensionStatusReplayActiveSessionIds?.delete(result.activeSessionId)) {
+				const latestState = this.sessions.get(result.activeSessionId);
+				if (latestState) this.replayExtensionStatusesToClient(client, latestState);
+			}
 			transcript.dispose?.();
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {
 				void this.catchUpBackpressuredClient(client).catch((error) =>
@@ -6088,6 +6099,7 @@ export class AgentDaemon {
 		this.broadcastToSession(state, { type: "session_closed", activeSessionId: state.activeSessionId, reason });
 		for (const client of state.clients) {
 			client.attachedActiveSessionIds.delete(state.activeSessionId);
+			client.extensionStatusKeysByActiveSessionId?.delete(state.activeSessionId);
 			removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 		}
 		state.clients.clear();
@@ -6127,6 +6139,16 @@ export class AgentDaemon {
 		return cascadeError;
 	}
 
+	private noteDeliveredExtensionStatus(client: DaemonSocketClient, message: DaemonOutbound): void {
+		if (message.type !== "extension_ui_request" || message.method !== "setStatus") return;
+		const statusKey = message.payload.statusKey;
+		if (typeof statusKey !== "string") return;
+		client.extensionStatusKeysByActiveSessionId ??= new Map();
+		const knownKeys = client.extensionStatusKeysByActiveSessionId.get(message.activeSessionId) ?? new Set<string>();
+		knownKeys.add(statusKey);
+		client.extensionStatusKeysByActiveSessionId.set(message.activeSessionId, knownKeys);
+	}
+
 	private replayExtensionStatusesToClient(client: DaemonSocketClient, state: ActiveSessionState): void {
 		if (
 			client.socket.destroyed ||
@@ -6135,7 +6157,13 @@ export class AgentDaemon {
 		) {
 			return;
 		}
-		for (const message of createExtensionStatusReplay(state)) this.write(client, message);
+		client.extensionStatusKeysByActiveSessionId ??= new Map();
+		const knownKeys = client.extensionStatusKeysByActiveSessionId.get(state.activeSessionId) ?? new Set<string>();
+		for (const message of createExtensionStatusReplay(state, knownKeys)) {
+			this.write(client, message);
+			knownKeys.add(message.payload.statusKey as string);
+		}
+		client.extensionStatusKeysByActiveSessionId.set(state.activeSessionId, knownKeys);
 	}
 
 	private broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void {
@@ -6173,12 +6201,21 @@ export class AgentDaemon {
 				this.write(client, messageForClient);
 				continue;
 			}
+			const legacyStatusUpdate =
+				messageForClient.type === "extension_ui_request" &&
+				messageForClient.method === "setStatus" &&
+				!daemonClientSupportsExtensionStatusSnapshot(client, state.activeSessionId);
 			if (client.snapshotActiveSessionIds?.has(state.activeSessionId)) {
-				this.queueClientCatchup(
-					client,
-					state.activeSessionId,
-					sequencedMessage.type === "session_replaced" ? "replacement" : "resync",
-				);
+				if (!legacyStatusUpdate) {
+					this.queueClientCatchup(
+						client,
+						state.activeSessionId,
+						sequencedMessage.type === "session_replaced" ? "replacement" : "resync",
+					);
+				} else {
+					client.pendingExtensionStatusReplayActiveSessionIds ??= new Set();
+					client.pendingExtensionStatusReplayActiveSessionIds.add(state.activeSessionId);
+				}
 				continue;
 			}
 			if (client.backpressured === true) {
@@ -6210,6 +6247,7 @@ export class AgentDaemon {
 				serializedWithoutExtensionStatuses ??= serializeJsonLine(messageForClient);
 				this.writeSerialized(client, serializedWithoutExtensionStatuses, messageForClient);
 			}
+			this.noteDeliveredExtensionStatus(client, messageForClient);
 			if (sequencedMessage.type === "session_replaced") {
 				this.replayExtensionStatusesToClient(client, state);
 			}
@@ -6229,6 +6267,7 @@ export class AgentDaemon {
 			this.log(`could not prepare replacement snapshot: ${String(error)}`);
 			if (!client.socket.destroyed && this.sessions.get(state.activeSessionId) === state) {
 				this.write(client, message);
+				this.replayExtensionStatusesToClient(client, state);
 			}
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {
 				void this.catchUpBackpressuredClient(client).catch((catchupError) =>
@@ -6475,6 +6514,7 @@ export class AgentDaemon {
 					}
 					return "retry-later";
 				}
+				this.replayExtensionStatusesToClient(client, state);
 			} catch (error) {
 				for (const remaining of pending.slice(index)) {
 					this.queueClientCatchup(client, remaining.activeSessionId, remaining.purpose);
@@ -6685,6 +6725,7 @@ export function getChildActiveSessionStates(
 export function detachClientFromActiveSession(client: DaemonSocketClient, state: ActiveSessionState): void {
 	state.clients.delete(client);
 	client.attachedActiveSessionIds.delete(state.activeSessionId);
+	client.extensionStatusKeysByActiveSessionId?.delete(state.activeSessionId);
 	removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 	if (state.clients.size === 0) {
 		cancelPendingExtensionUiRequests(state);
@@ -6729,27 +6770,48 @@ export function daemonClientSupportsExtensionStatusSnapshot(
 }
 
 export function daemonOutboundForClient<T extends DaemonOutbound>(client: DaemonSocketClient, message: T): T {
-	if (
-		message.type !== "session_replaced" ||
-		message.state.extensionStatuses === undefined ||
-		daemonClientSupportsExtensionStatusSnapshot(client, message.activeSessionId)
-	) {
+	const activeSessionId = "activeSessionId" in message ? message.activeSessionId : undefined;
+	if (activeSessionId === undefined || daemonClientSupportsExtensionStatusSnapshot(client, activeSessionId)) {
 		return message;
 	}
-	const { extensionStatuses: _extensionStatuses, ...state } = message.state;
-	return { ...message, state } as T;
+	if (message.type === "session_replaced" && message.state.extensionStatuses !== undefined) {
+		const { extensionStatuses: _extensionStatuses, ...state } = message.state;
+		return { ...message, state } as T;
+	}
+	if (message.type === "session_resynced" && message.snapshot.state.extensionStatuses !== undefined) {
+		const { extensionStatuses: _extensionStatuses, ...state } = message.snapshot.state;
+		return { ...message, snapshot: { ...message.snapshot, state } } as T;
+	}
+	return message;
 }
 
 export function createExtensionStatusReplay(
 	state: ActiveSessionState,
+	knownKeys?: ReadonlySet<string>,
 ): Array<Extract<DaemonOutbound, { type: "extension_ui_request" }>> {
-	return [...(state.extensionStatuses ?? [])].map(([statusKey, statusText]) => ({
-		type: "extension_ui_request",
-		activeSessionId: state.activeSessionId,
-		id: randomUUID(),
-		method: "setStatus",
-		payload: { statusKey, statusText },
-	}));
+	const statuses = state.extensionStatuses ?? new Map<string, string>();
+	const messages: Array<Extract<DaemonOutbound, { type: "extension_ui_request" }>> = [];
+	for (const statusKey of knownKeys ?? []) {
+		if (!statuses.has(statusKey)) {
+			messages.push({
+				type: "extension_ui_request",
+				activeSessionId: state.activeSessionId,
+				id: randomUUID(),
+				method: "setStatus",
+				payload: { statusKey, statusText: undefined },
+			});
+		}
+	}
+	for (const [statusKey, statusText] of statuses) {
+		messages.push({
+			type: "extension_ui_request",
+			activeSessionId: state.activeSessionId,
+			id: randomUUID(),
+			method: "setStatus",
+			payload: { statusKey, statusText },
+		});
+	}
+	return messages;
 }
 
 export function markClientSnapshotStreaming(client: DaemonSocketClient, activeSessionId: string): AbortSignal {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -57,6 +57,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 12 publishes idle-residency metadata on session summary rows.
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
+// Revision 14 adds capability-gated extension statuses to connection state snapshots.
 export const DAEMON_SCHEMA_REVISION = 14;
 export const DAEMON_SCHEMA_ID = "protocol-7-schema-14-816309b1cd50";
 
@@ -74,6 +75,7 @@ export type DaemonClientCapability =
 	| "attach_snapshot"
 	| "event_sequence"
 	| "extension_ui"
+	| "extension_status_snapshot"
 	| "slim_attach"
 	| "chunked_snapshot"
 	| "client_owned_sessions";
@@ -119,6 +121,7 @@ export const DAEMON_SUPPORTED_CLIENT_CAPABILITIES: readonly DaemonClientCapabili
 	"attach_snapshot",
 	"event_sequence",
 	"extension_ui",
+	"extension_status_snapshot",
 	"slim_attach",
 	"chunked_snapshot",
 	"client_owned_sessions",

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -72,6 +72,7 @@ import {
 	type DaemonUpdateRestartManifest,
 	failure,
 	isDaemonCommandEnvelope,
+	isDaemonDialogExtensionUiRequest,
 	isDaemonMutatingCommand,
 	salvageDaemonCommandId,
 	success,
@@ -254,6 +255,8 @@ interface ResidentWorker {
 	transcriptCaches: Map<string, SnapshotTranscriptCache>;
 	snapshotGenerations: Map<string, Map<string, SnapshotTranscriptGeneration>>;
 	snapshotLoads: Map<string, Promise<DaemonAttachResult>>;
+	/** Passive status deltas observed while worker snapshots are loading or validating. */
+	extensionStatusOverlays: Map<string, Map<string, string | undefined>>;
 	recovery?: Promise<void>;
 	deferredRecovery?: Promise<void>;
 	intentionalStop: boolean;
@@ -301,6 +304,8 @@ interface WorkerMatch {
 
 interface WorkerAttachData {
 	result: DaemonAttachResult;
+	/** Authoritative worker state retained for legacy status replay. */
+	extensionStatuses?: Record<string, string>;
 	worker: ResidentWorker;
 	transcript?: SnapshotTranscriptCache;
 	releaseTranscript?: () => void;
@@ -934,6 +939,7 @@ export class DaemonSupervisor {
 					transcriptCaches: new Map(),
 					snapshotGenerations: new Map(),
 					snapshotLoads: new Map(),
+					extensionStatusOverlays: new Map(),
 					intentionalStop: descriptor.stopRequestedAt !== undefined,
 					stopRevision: 0,
 				});
@@ -1051,6 +1057,7 @@ export class DaemonSupervisor {
 			this.cancelWaitingPromptAdmissionsForClient(client);
 			for (const activeSessionId of [...client.attachedActiveSessionIds]) {
 				client.attachedActiveSessionIds.delete(activeSessionId);
+				client.extensionStatusKeysByActiveSessionId?.delete(activeSessionId);
 				void this.syncWorkerExtensionUi(activeSessionId);
 			}
 			this.scheduleOwnedWorkerCleanupForClient(this.protocolClientId(client));
@@ -1455,6 +1462,7 @@ export class DaemonSupervisor {
 							streamedResult,
 							transcript,
 							"attach",
+							attached.extensionStatuses,
 							attached.releaseTranscript,
 						).catch((error) =>
 							this.log(
@@ -1467,7 +1475,10 @@ export class DaemonSupervisor {
 					}
 					return undefined;
 				}
-				return success(command.id, "attach", attached.result);
+				const response = success(command.id, "attach", attached.result);
+				this.write(client, response);
+				this.replayExtensionStatusesToClient(client, attached.result.activeSessionId, attached.extensionStatuses);
+				return undefined;
 			}
 			case "reattach": {
 				const target = await this.findWorkerForClient(client, command.targetActiveSessionId);
@@ -1498,6 +1509,7 @@ export class DaemonSupervisor {
 							streamedResult,
 							transcript,
 							"replacement",
+							attached.extensionStatuses,
 							releaseTranscript,
 							releaseSnapshotReservation,
 						);
@@ -1508,6 +1520,7 @@ export class DaemonSupervisor {
 						return undefined;
 					}
 					this.write(client, success(command.id, command.type, attached.result));
+					this.replayExtensionStatusesToClient(client, targetActiveSessionId, attached.extensionStatuses);
 					this.detachClient(client, command.activeSessionId);
 					releaseSnapshotReservation();
 					return undefined;
@@ -1888,7 +1901,12 @@ export class DaemonSupervisor {
 				(match.summary.activeSessionId ?? match.summary.id) === match.worker.descriptor.rootActiveSessionId;
 			if (!isRootKill) {
 				const forward = async () => {
-					const response = await this.forwardToWorker(match.worker, resolvedCommand);
+					const response = await this.forwardToWorker(
+						match.worker,
+						resolvedCommand,
+						WORKER_REQUEST_TIMEOUT_MS,
+						client,
+					);
 					if (admission && response.success) admission.status = "owned";
 					return response;
 				};
@@ -1904,7 +1922,7 @@ export class DaemonSupervisor {
 			this.persistWorkerStopTombstone(match.worker, true);
 			let response: DaemonResponse;
 			try {
-				response = await this.forwardToWorker(match.worker, resolvedCommand);
+				response = await this.forwardToWorker(match.worker, resolvedCommand, WORKER_REQUEST_TIMEOUT_MS, client);
 			} finally {
 				await this.stopWorker(match.worker, true, false, true);
 			}
@@ -2189,6 +2207,7 @@ export class DaemonSupervisor {
 				transcriptCaches: new Map(),
 				snapshotGenerations: new Map(),
 				snapshotLoads: new Map(),
+				extensionStatusOverlays: new Map(),
 				intentionalStop: false,
 				stopRevision: 0,
 				launchEnv,
@@ -2364,8 +2383,15 @@ export class DaemonSupervisor {
 			type: "worker_subscribe",
 			activeSessionId,
 			capabilities: supportsExtensionUi
-				? ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"]
-				: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
+				? [
+						"attach_snapshot",
+						"event_sequence",
+						"extension_ui",
+						"extension_status_snapshot",
+						"slim_attach",
+						"chunked_snapshot",
+					]
+				: ["attach_snapshot", "event_sequence", "extension_status_snapshot", "slim_attach", "chunked_snapshot"],
 			supportsExtensionUi,
 		});
 		if (!response.success) {
@@ -2706,6 +2732,7 @@ export class DaemonSupervisor {
 	}
 
 	private async recoverWorker(worker: ResidentWorker): Promise<void> {
+		worker.extensionStatusOverlays?.clear();
 		if (this.isWorkerRecoveryCancelled(worker)) {
 			return;
 		}
@@ -3124,6 +3151,130 @@ export class DaemonSupervisor {
 		};
 	}
 
+	private publicOutboundForClient(client: DaemonSocketClient, message: DaemonOutbound): DaemonOutbound {
+		if (client.capabilities.has("extension_status_snapshot")) return message;
+		if (message.type === "session_replaced" && message.state.extensionStatuses !== undefined) {
+			const { extensionStatuses: _extensionStatuses, ...state } = message.state;
+			return { ...message, state };
+		}
+		if (message.type === "session_resynced" && message.snapshot.state.extensionStatuses !== undefined) {
+			const { extensionStatuses: _extensionStatuses, ...state } = message.snapshot.state;
+			return { ...message, snapshot: { ...message.snapshot, state } };
+		}
+		return message;
+	}
+
+	private applyExtensionStatusOverlay(
+		worker: ResidentWorker,
+		activeSessionId: string,
+		result: DaemonAttachResult,
+	): DaemonAttachResult {
+		if (!worker.extensionStatusOverlays) worker.extensionStatusOverlays = new Map();
+		const overlays = worker.extensionStatusOverlays;
+		const overlay = overlays.get(activeSessionId);
+		if (!overlay || !result.snapshot.state) return result;
+		const statuses = Object.assign(
+			Object.create(null) as Record<string, string>,
+			result.snapshot.state.extensionStatuses ?? {},
+		);
+		for (const [statusKey, statusText] of overlay) {
+			if (statusText === undefined) delete statuses[statusKey];
+			else statuses[statusKey] = statusText;
+		}
+		return {
+			...result,
+			snapshot: { ...result.snapshot, state: { ...result.snapshot.state, extensionStatuses: statuses } },
+		};
+	}
+
+	private updateCachedExtensionStatus(
+		worker: ResidentWorker,
+		activeSessionId: string,
+		message: DaemonOutbound | undefined,
+	): void {
+		if (message?.type !== "extension_ui_request" || message.method !== "setStatus") return;
+		const statusKey = message.payload.statusKey;
+		if (typeof statusKey !== "string") return;
+		if (!worker.extensionStatusOverlays) worker.extensionStatusOverlays = new Map();
+		const overlays = worker.extensionStatusOverlays;
+		const overlay = overlays.get(activeSessionId) ?? new Map<string, string | undefined>();
+		overlay.set(statusKey, typeof message.payload.statusText === "string" ? message.payload.statusText : undefined);
+		overlays.set(activeSessionId, overlay);
+		const cached = worker.snapshotCache.get(activeSessionId);
+		if (cached)
+			worker.snapshotCache.set(activeSessionId, this.applyExtensionStatusOverlay(worker, activeSessionId, cached));
+	}
+
+	private extensionStatusesForOutbound(message: DaemonOutbound | undefined): Record<string, string> | undefined {
+		if (!message) return undefined;
+		if (message.type === "session_replaced") return message.state.extensionStatuses;
+		if (message.type === "session_resynced") return message.snapshot.state.extensionStatuses;
+		return undefined;
+	}
+
+	private publicAttachResultForClient(client: DaemonSocketClient, result: DaemonAttachResult): DaemonAttachResult {
+		if (client.capabilities.has("extension_status_snapshot") || !result.snapshot.state) return result;
+		const stripState = <T extends { extensionStatuses?: Record<string, string> }>(state: T): T => {
+			if (state.extensionStatuses === undefined) return state;
+			const { extensionStatuses: _extensionStatuses, ...withoutStatuses } = state;
+			return withoutStatuses as T;
+		};
+		return {
+			...result,
+			snapshot: { ...result.snapshot, state: stripState(result.snapshot.state) },
+		};
+	}
+
+	private replayExtensionStatusesToClient(
+		client: DaemonSocketClient,
+		activeSessionId: string,
+		statuses: Record<string, string> | undefined,
+	): void {
+		if (
+			!client.socket ||
+			client.socket.destroyed ||
+			!client.attachedActiveSessionIds.has(activeSessionId) ||
+			client.capabilities.has("extension_status_snapshot")
+		) {
+			return;
+		}
+		client.extensionStatusKeysByActiveSessionId ??= new Map();
+		const knownKeys = client.extensionStatusKeysByActiveSessionId.get(activeSessionId) ?? new Set<string>();
+		const current = statuses ?? {};
+		for (const statusKey of knownKeys) {
+			if (!Object.hasOwn(current, statusKey)) {
+				this.write(client, {
+					type: "extension_ui_request",
+					activeSessionId,
+					id: randomUUID(),
+					method: "setStatus",
+					payload: { statusKey, statusText: undefined },
+				});
+			}
+		}
+		for (const [statusKey, statusText] of Object.entries(current)) {
+			this.write(client, {
+				type: "extension_ui_request",
+				activeSessionId,
+				id: randomUUID(),
+				method: "setStatus",
+				payload: { statusKey, statusText },
+			});
+			knownKeys.add(statusKey);
+		}
+		client.extensionStatusKeysByActiveSessionId.set(activeSessionId, knownKeys);
+	}
+
+	private noteDeliveredExtensionStatus(client: DaemonSocketClient, message: DaemonOutbound): void {
+		if (message.type !== "extension_ui_request" || message.method !== "setStatus") return;
+		const statusKey = message.payload.statusKey;
+		if (typeof statusKey !== "string") return;
+		client.extensionStatusKeysByActiveSessionId ??= new Map();
+		const knownKeys = client.extensionStatusKeysByActiveSessionId.get(message.activeSessionId) ?? new Set<string>();
+		knownKeys.add(statusKey);
+		client.extensionStatusKeysByActiveSessionId.set(message.activeSessionId, knownKeys);
+	}
+
 	private publicSummary(worker: ResidentWorker, summary: SessionSummary): SessionSummary {
 		const activeSessionId = summary.activeSessionId ?? summary.id;
 		return {
@@ -3234,6 +3385,7 @@ export class DaemonSupervisor {
 		worker: ResidentWorker,
 		command: DaemonCommand,
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
+		publicClient?: DaemonSocketClient,
 	): Promise<DaemonResponse> {
 		if (!worker.client || worker.descriptor.lifecycle !== "ready") {
 			throw new Error(`Session worker is ${worker.descriptor.lifecycle}`);
@@ -3241,6 +3393,17 @@ export class DaemonSupervisor {
 		const response = await worker.client.request(withoutCommandId(command), timeoutMs);
 		if (command.type === "get_state" && response.success && isSessionSummary(response.data)) {
 			return { ...response, id: command.id, data: this.publicSummary(worker, response.data) };
+		}
+		if (
+			command.type === "get_connection_state" &&
+			publicClient &&
+			!publicClient.capabilities.has("extension_status_snapshot") &&
+			response.success &&
+			response.data &&
+			typeof response.data === "object"
+		) {
+			const { extensionStatuses: _extensionStatuses, ...state } = response.data as Record<string, unknown>;
+			return { ...response, id: command.id, data: state };
 		}
 		if (command.type === "rename" && response.success && isSessionSummary(response.data)) {
 			await this.refreshWorkerSummaries(worker);
@@ -3316,8 +3479,14 @@ export class DaemonSupervisor {
 							type: "attach",
 							activeSessionId,
 							capabilities: client.capabilities.has("chunked_snapshot")
-								? ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"]
-								: ["attach_snapshot", "event_sequence", "slim_attach"],
+								? [
+										"attach_snapshot",
+										"event_sequence",
+										"extension_status_snapshot",
+										"slim_attach",
+										"chunked_snapshot",
+									]
+								: ["attach_snapshot", "event_sequence", "extension_status_snapshot", "slim_attach"],
 							supportsExtensionUi: false,
 							env: command.env ?? collectDaemonClientEnv(),
 						});
@@ -3398,12 +3567,12 @@ export class DaemonSupervisor {
 					}
 				}
 			}
-			const publicResult: DaemonAttachResult = {
+			const publicResult: DaemonAttachResult = this.publicAttachResultForClient(client, {
 				...result,
 				state: result.state ? publicSummary : undefined,
 				snapshot: { ...result.snapshot, summary: publicSummary },
 				client: { id: client.id, capabilities: [...client.capabilities] },
-			};
+			});
 			if (publicResult.state && publicResult.messages) {
 				this.write(client, {
 					type: "session_attached",
@@ -3416,7 +3585,13 @@ export class DaemonSupervisor {
 				});
 			}
 			void this.syncWorkerExtensionUi(activeSessionId);
-			return { result: publicResult, worker: match.worker, transcript, releaseTranscript };
+			return {
+				result: publicResult,
+				extensionStatuses: result.snapshot.state?.extensionStatuses,
+				worker: match.worker,
+				transcript,
+				releaseTranscript,
+			};
 		} catch (error) {
 			releaseTranscript?.();
 			if (!wasAttached) {
@@ -3440,6 +3615,9 @@ export class DaemonSupervisor {
 		loaded: DaemonAttachResult,
 		observedSnapshotId: string | undefined,
 	): DaemonAttachResult {
+		const reconcile = (candidate: DaemonAttachResult): DaemonAttachResult =>
+			this.applyExtensionStatusOverlay(worker, activeSessionId, candidate);
+		loaded = reconcile(loaded);
 		const currentTranscript = worker.transcriptCaches.get(activeSessionId);
 		const currentGeneration = this.currentSnapshotGeneration(worker, activeSessionId);
 		const currentResult = currentGeneration?.result ?? worker.snapshotCache.get(activeSessionId);
@@ -3447,9 +3625,11 @@ export class DaemonSupervisor {
 		const loadedSnapshotId = loaded.snapshotStream?.id;
 		if (!loaded.snapshotStream) {
 			if (currentSnapshotId && currentSnapshotId !== observedSnapshotId) {
+				worker.extensionStatusOverlays.delete(activeSessionId);
 				return loaded;
 			}
 			worker.snapshotCache.set(activeSessionId, loaded);
+			worker.extensionStatusOverlays.delete(activeSessionId);
 			return loaded;
 		}
 		if (
@@ -3458,7 +3638,9 @@ export class DaemonSupervisor {
 			(currentSnapshotId !== observedSnapshotId ||
 				(currentResult?.lastEventSequence ?? -1) > loaded.lastEventSequence)
 		) {
-			return currentResult ?? loaded;
+			const selected = this.applyExtensionStatusOverlay(worker, activeSessionId, currentResult ?? loaded);
+			worker.extensionStatusOverlays.delete(activeSessionId);
+			return selected;
 		}
 		let transcript = currentTranscript;
 		if (transcript && transcript.snapshotId !== loaded.snapshotStream.id) {
@@ -3492,6 +3674,7 @@ export class DaemonSupervisor {
 		}
 		worker.transcriptCaches.set(activeSessionId, transcript);
 		worker.snapshotCache.set(activeSessionId, loaded);
+		worker.extensionStatusOverlays.delete(activeSessionId);
 		return loaded;
 	}
 
@@ -3558,6 +3741,7 @@ export class DaemonSupervisor {
 		result: DaemonAttachResult,
 		transcript: SnapshotTranscriptCache,
 		purpose: "attach" | "replacement" | "resync" = "attach",
+		extensionStatuses?: Record<string, string>,
 		retainedTranscriptRelease?: () => void,
 		releaseSnapshotReservation = this.reserveSnapshotStream(client, result.activeSessionId),
 	): Promise<void> {
@@ -3609,6 +3793,11 @@ export class DaemonSupervisor {
 				lastEventSequence: result.lastEventSequence,
 				lastEventCursor: result.lastEventCursor,
 			});
+			const latestResult =
+				worker.snapshotCache.get(result.activeSessionId) ??
+				this.applyExtensionStatusOverlay(worker, result.activeSessionId, result);
+			const latestExtensionStatuses = latestResult.snapshot.state?.extensionStatuses ?? extensionStatuses;
+			this.replayExtensionStatusesToClient(client, result.activeSessionId, latestExtensionStatuses);
 		} catch (error) {
 			const streamError = error instanceof Error ? error : new Error(String(error));
 			if (!client.socket.destroyed) {
@@ -3630,6 +3819,16 @@ export class DaemonSupervisor {
 		} finally {
 			releaseSnapshotReservation();
 			releaseTranscript();
+			if (client.pendingExtensionStatusReplayActiveSessionIds?.delete(result.activeSessionId)) {
+				const latestResult =
+					worker.snapshotCache.get(result.activeSessionId) ??
+					this.applyExtensionStatusOverlay(worker, result.activeSessionId, result);
+				this.replayExtensionStatusesToClient(
+					client,
+					result.activeSessionId,
+					latestResult.snapshot.state?.extensionStatuses ?? extensionStatuses,
+				);
+			}
 		}
 	}
 
@@ -3708,6 +3907,7 @@ export class DaemonSupervisor {
 			}
 			client.catchupActiveSessionIds?.delete(resolvedId);
 			client.catchupPurposes?.delete(resolvedId);
+			client.extensionStatusKeysByActiveSessionId?.delete(resolvedId);
 			this.write(client, { type: "session_detached", activeSessionId: resolvedId });
 			void this.syncWorkerExtensionUi(resolvedId);
 		}
@@ -3763,7 +3963,7 @@ export class DaemonSupervisor {
 					summary: publicSummary,
 					messages: [],
 				};
-				const result: DaemonAttachResult = {
+				let result: DaemonAttachResult = {
 					protocol: DAEMON_PROTOCOL_INFO,
 					activeSessionId,
 					snapshot,
@@ -3781,6 +3981,7 @@ export class DaemonSupervisor {
 					},
 					client: { id: "supervisor", capabilities: ["chunked_snapshot"] },
 				};
+				result = this.applyExtensionStatusOverlay(worker, activeSessionId, result);
 				const generations = this.snapshotGenerationsFor(worker, activeSessionId);
 				let generation = generations.get(begin.snapshotId);
 				if (generation?.incoming) {
@@ -3967,9 +4168,15 @@ export class DaemonSupervisor {
 					if (!generation.duplicateResult) {
 						throw new Error(`Duplicate snapshot ${transcript.snapshotId} has no result`);
 					}
-					generation.result = generation.duplicateResult;
+					const reconciledDuplicate = this.applyExtensionStatusOverlay(
+						worker,
+						activeSessionId,
+						generation.duplicateResult,
+					);
+					generation.result = reconciledDuplicate;
+					worker.extensionStatusOverlays?.delete(activeSessionId);
 					if (worker.transcriptCaches.get(activeSessionId) === transcript) {
-						worker.snapshotCache.set(activeSessionId, generation.duplicateResult);
+						worker.snapshotCache.set(activeSessionId, reconciledDuplicate);
 					}
 					this.settleSnapshotDuplicateValidation(generation);
 				}
@@ -4081,6 +4288,7 @@ export class DaemonSupervisor {
 			}
 			publicPayload = Buffer.from(serializeJsonLine(reconstructed));
 		} else if (
+			outboundType === "extension_ui_request" ||
 			sessionEventType === "message_start" ||
 			sessionEventType === "message_end" ||
 			outboundType === "session_replaced" ||
@@ -4096,6 +4304,7 @@ export class DaemonSupervisor {
 		}
 		const replacementSnapshotFollows =
 			decodedOutbound?.type === "session_replaced" && decodedOutbound.snapshotFollows === true;
+		this.updateCachedExtensionStatus(worker, activeSessionId, decodedOutbound);
 		this.invalidateWorkerSnapshot(
 			worker,
 			activeSessionId,
@@ -4110,18 +4319,57 @@ export class DaemonSupervisor {
 			if (replacementSnapshotFollows && !client.capabilities.has("chunked_snapshot")) {
 				continue;
 			}
-			if (outboundType === "extension_ui_request" && !client.supportsExtensionUi) {
+			if (
+				outboundType === "extension_ui_request" &&
+				isDaemonDialogExtensionUiRequest(
+					decodedOutbound?.type === "extension_ui_request" ? decodedOutbound.method : "",
+				) &&
+				!client.supportsExtensionUi
+			) {
 				continue;
 			}
+			const legacyStatusUpdate =
+				outboundType === "extension_ui_request" &&
+				decodedOutbound?.type === "extension_ui_request" &&
+				decodedOutbound.method === "setStatus" &&
+				!client.capabilities.has("extension_status_snapshot");
 			if (client.snapshotActiveSessionIds?.has(activeSessionId)) {
-				this.queueCatchup(client, activeSessionId, outboundType === "session_replaced" ? "replacement" : "resync");
+				if (!legacyStatusUpdate) {
+					this.queueCatchup(
+						client,
+						activeSessionId,
+						outboundType === "session_replaced" ? "replacement" : "resync",
+					);
+				} else {
+					client.pendingExtensionStatusReplayActiveSessionIds ??= new Set();
+					client.pendingExtensionStatusReplayActiveSessionIds.add(activeSessionId);
+				}
 				continue;
 			}
 			if (client.backpressured === true) {
 				this.queueCatchup(client, activeSessionId, outboundType === "session_replaced" ? "replacement" : "resync");
 				continue;
 			}
-			this.writeSerialized(client, publicPayload);
+			const outboundForClient = decodedOutbound ? this.publicOutboundForClient(client, decodedOutbound) : undefined;
+			const payloadForClient = outboundForClient ? Buffer.from(serializeJsonLine(outboundForClient)) : publicPayload;
+			this.writeSerialized(client, payloadForClient);
+			if (outboundForClient) {
+				this.noteDeliveredExtensionStatus(client, outboundForClient);
+				if (
+					!replacementSnapshotFollows &&
+					(outboundForClient.type === "session_replaced" || outboundForClient.type === "session_resynced")
+				) {
+					this.replayExtensionStatusesToClient(
+						client,
+						activeSessionId,
+						this.extensionStatusesForOutbound(decodedOutbound),
+					);
+				}
+			}
+		}
+		if (outboundType === "session_closed") {
+			for (const client of this.clients) client.extensionStatusKeysByActiveSessionId?.delete(activeSessionId);
+			worker.extensionStatusOverlays?.delete(activeSessionId);
 		}
 		if (outboundType === "session_replaced" || outboundType === "session_closed") {
 			void this.refreshWorkerSummaries(worker)
@@ -4268,6 +4516,7 @@ export class DaemonSupervisor {
 						this.createStreamedAttachResult(attached.result, transcript),
 						transcript,
 						purpose,
+						attached.extensionStatuses,
 						releaseTranscript,
 					);
 					releaseTranscript = undefined;
@@ -4300,6 +4549,7 @@ export class DaemonSupervisor {
 					}
 					return;
 				}
+				this.replayExtensionStatusesToClient(client, activeSessionId, attached.extensionStatuses);
 			} catch (error) {
 				releaseTranscript?.();
 				this.log(`Failed to catch up client ${client.id} for ${activeSessionId}: ${String(error)}`);

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -1,42 +1,37 @@
-import type { Component } from "@earendil-works/pi-tui";
+import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.js";
 
 /**
  * Footer component for the prime brand TUI.
  *
- * Renders nothing by default — token counters, cost, model name, cwd, and context %
- * are intentionally hidden. The setters and invalidate/dispose hooks are kept so the
- * existing call sites in interactive-mode keep working without modification, and so
- * `/usage` can expose telemetry without re-plumbing.
+ * The footer is intentionally limited to extension statuses. Token counters,
+ * cost, model name, cwd, and context % remain hidden and are available via
+ * `/usage` where applicable.
  */
 export class FooterComponent implements Component {
-	constructor(private footerData: ReadonlyFooterDataProvider) {
-		void this.footerData;
-	}
+	constructor(private footerData: ReadonlyFooterDataProvider) {}
 
 	setAutoCompactEnabled(_enabled: boolean): void {
-		// no-op while the footer is empty
+		// Kept for compatibility with existing interactive-mode call sites.
 	}
 
 	/**
-	 * No-op: git branch caching now handled by provider.
-	 * Kept for compatibility with existing call sites in interactive-mode.
+	 * No-op: git branch caching is handled by the provider.
 	 */
 	invalidate(): void {
-		// No-op: git branch is cached/invalidated by provider
+		// Git branch is cached and invalidated by the provider.
 	}
 
 	/**
 	 * Clean up resources.
-	 * Git watcher cleanup now handled by provider.
 	 */
 	dispose(): void {
-		// Git watcher cleanup handled by provider
+		// Git watcher cleanup is handled by the provider.
 	}
 
-	render(_width: number): string[] {
-		// Footer is intentionally empty in the prime brand TUI. Telemetry (cost, tokens, model,
-		// cwd, context %) is hidden by default; bring it back via /usage when needed.
-		return [];
+	render(width: number): string[] {
+		const statuses = [...this.footerData.getExtensionStatuses().values()].filter(Boolean);
+		if (statuses.length === 0) return [];
+		return [truncateToWidth(statuses.join("  "), width)];
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5075,7 +5075,16 @@ export class InteractiveMode {
 				} else if (event.type === "side_question_event") {
 					this.handleSideQuestionEvent(event.event);
 				} else if (event.type === "extension_ui_request") {
-					await this.handleConnectionExtensionUiRequest(event.request);
+					// Extension UI requests are emitted by the daemon while a session
+					// replacement is being rebound. Serialize them with session events so
+					// stale status clears cannot race a new session's status update.
+					const generation = this.sessionEventGeneration;
+					const run = this.sessionEventQueue.then(async () => {
+						if (generation !== this.sessionEventGeneration) return;
+						await this.handleConnectionExtensionUiRequest(event.request);
+					});
+					this.sessionEventQueue = run.then(() => undefined).catch(() => {});
+					await run;
 				} else if (event.type === "connection_status") {
 					this.showStatus(
 						event.status === "connected" ? "Daemon reconnected" : "Daemon connection lost; reconnecting…",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2580,6 +2580,13 @@ export class InteractiveMode {
 	private applyConnectionStateSnapshot(state: AgentConnectionState): void {
 		this.bindPromptStashSession(state.sessionId);
 		this.connectionState = state;
+		if (state.extensionStatuses !== undefined) {
+			this.footerDataProvider.clearExtensionStatuses();
+			for (const [key, text] of Object.entries(state.extensionStatuses)) {
+				this.footerDataProvider.setExtensionStatus(key, text);
+			}
+			this.footer.invalidate();
+		}
 		this.updateScopedHeartbeats();
 		// Don't touch contextUsageTokenBaseline: a mid-stream snapshot reflects only completed
 		// turns (the in-flight message isn't persisted yet), so the in-flight delta must keep
@@ -3491,7 +3498,7 @@ export class InteractiveMode {
 		this.renderWidgets();
 	}
 
-	private resetExtensionUI(): void {
+	private resetExtensionUI(options: { preserveStatuses?: boolean } = {}): void {
 		this.cancelActiveConnectionExtensionUiRequests();
 		this.closeHeartbeatManager();
 		if (this.extensionSelector) {
@@ -3508,8 +3515,10 @@ export class InteractiveMode {
 		this.setExtensionFooter(undefined);
 		this.setExtensionHeader(undefined);
 		this.clearExtensionWidgets();
-		this.footerDataProvider.clearExtensionStatuses();
-		this.footer.invalidate();
+		if (!options.preserveStatuses) {
+			this.footerDataProvider.clearExtensionStatuses();
+			this.footer.invalidate();
+		}
 		this.autocompleteProviderWrappers = [];
 		this.setCustomEditorComponent(undefined);
 		this.setupAutocompleteProvider();
@@ -5048,7 +5057,7 @@ export class InteractiveMode {
 					const run = this.sessionEventQueue.then(async () => {
 						if (generation !== this.sessionEventGeneration) return;
 						this.resetSideQuestion();
-						this.resetExtensionUI();
+						this.resetExtensionUI({ preserveStatuses: event.state.extensionStatuses !== undefined });
 						this.applyConnectionStateSnapshot(event.state);
 						this.resetCurrentSessionRenderState();
 						await this.rebindCurrentSession();
@@ -5075,16 +5084,20 @@ export class InteractiveMode {
 				} else if (event.type === "side_question_event") {
 					this.handleSideQuestionEvent(event.event);
 				} else if (event.type === "extension_ui_request") {
-					// Extension UI requests are emitted by the daemon while a session
-					// replacement is being rebound. Serialize them with session events so
-					// stale status clears cannot race a new session's status update.
-					const generation = this.sessionEventGeneration;
-					const run = this.sessionEventQueue.then(async () => {
-						if (generation !== this.sessionEventGeneration) return;
+					if (this.expectsConnectionExtensionUiResponse(event.request)) {
+						// A modal request must not block session events while it waits for input.
 						await this.handleConnectionExtensionUiRequest(event.request);
-					});
-					this.sessionEventQueue = run.then(() => undefined).catch(() => {});
-					await run;
+					} else {
+						// Serialize passive UI updates with replacement events so an old
+						// session cannot race a newer session's status or widget state.
+						const generation = this.sessionEventGeneration;
+						const run = this.sessionEventQueue.then(async () => {
+							if (generation !== this.sessionEventGeneration) return;
+							await this.handleConnectionExtensionUiRequest(event.request);
+						});
+						this.sessionEventQueue = run.then(() => undefined).catch(() => {});
+						await run;
+					}
 				} else if (event.type === "connection_status") {
 					this.showStatus(
 						event.status === "connected" ? "Daemon reconnected" : "Daemon connection lost; reconnecting…",

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -669,6 +669,7 @@ function createAttachResult(
 					capability === "attach_snapshot" ||
 					capability === "event_sequence" ||
 					capability === "extension_ui" ||
+					capability === "extension_status_snapshot" ||
 					capability === "slim_attach" ||
 					capability === "chunked_snapshot",
 			),
@@ -1779,6 +1780,54 @@ describe("DaemonAgentConnection", () => {
 		expect(events).toEqual([]);
 	});
 
+	it("dispatches a streamed replacement before an adjacent legacy status replay", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		await connection.attach();
+		const events: AgentConnectionEvent[] = [];
+		let releaseReplacement!: () => void;
+		const replacementBlocked = new Promise<void>((resolve) => {
+			releaseReplacement = resolve;
+		});
+		connection.subscribe(async (event) => {
+			events.push(event);
+			if (event.type === "session_replaced") await replacementBlocked;
+		});
+		const full = createAttachResult("active-1", "client-1", undefined, 13, {
+			state: createConnectionState("active-1", "session-next"),
+			messages: [],
+		});
+		const { messages: _messages, ...snapshot } = full.snapshot;
+
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-1",
+			snapshotId: "snapshot-replacement-status",
+			snapshot,
+			messageCount: 0,
+			targetChunkBytes: 512 * 1024,
+			purpose: "replacement",
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-1",
+			snapshotId: "snapshot-replacement-status",
+			chunkCount: 0,
+			lastEventSequence: 13,
+		});
+		fakeClient.emitMessage({
+			type: "extension_ui_request",
+			activeSessionId: "active-1",
+			id: "legacy-status-replay",
+			method: "setStatus",
+			payload: { statusKey: "codex", statusText: "23% 1.8d" },
+		});
+
+		await vi.waitFor(() => expect(events).toHaveLength(2));
+		expect(events.map((event) => event.type)).toEqual(["session_replaced", "extension_ui_request"]);
+		releaseReplacement();
+	});
+
 	it("distinguishes chunked catch-up snapshots from runtime replacements", async () => {
 		const fakeClient = new FakeDaemonClient();
 		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
@@ -2006,7 +2055,14 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests.at(-1)).toMatchObject({
 			type: "attach",
 			activeSessionId: "active-1",
-			capabilities: ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"],
+			capabilities: [
+				"attach_snapshot",
+				"event_sequence",
+				"extension_ui",
+				"extension_status_snapshot",
+				"slim_attach",
+				"chunked_snapshot",
+			],
 			resumeCursor: {
 				activeSessionId: "active-1",
 				generation: "generation-active-1",
@@ -2501,7 +2557,14 @@ describe("DaemonAgentConnection", () => {
 			type: "attach",
 			activeSessionId: "active-1",
 			clientId: expect.any(String),
-			capabilities: ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"],
+			capabilities: [
+				"attach_snapshot",
+				"event_sequence",
+				"extension_ui",
+				"extension_status_snapshot",
+				"slim_attach",
+				"chunked_snapshot",
+			],
 			resumeCursor: {
 				activeSessionId: "active-1",
 				generation: "generation-active-1",
@@ -2513,7 +2576,14 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests.at(-1)).toMatchObject({
 			type: "attach",
 			activeSessionId: "active-1",
-			capabilities: ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"],
+			capabilities: [
+				"attach_snapshot",
+				"event_sequence",
+				"extension_ui",
+				"extension_status_snapshot",
+				"slim_attach",
+				"chunked_snapshot",
+			],
 			resumeCursor: {
 				activeSessionId: "active-1",
 				generation: "generation-active-1",
@@ -2572,7 +2642,14 @@ describe("DaemonAgentConnection", () => {
 			activeSessionId: "active-1",
 			supportsExtensionUi: true,
 			clientId: expect.any(String),
-			capabilities: ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"],
+			capabilities: [
+				"attach_snapshot",
+				"event_sequence",
+				"extension_ui",
+				"extension_status_snapshot",
+				"slim_attach",
+				"chunked_snapshot",
+			],
 		});
 
 		fakeClient.emitMessage({

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -253,4 +253,43 @@ describe("daemon extension binding", () => {
 			"assistant:replacement reply",
 		]);
 	});
+
+	it("broadcasts passive extension UI after a session replacement", async () => {
+		const runtime = await createRuntimeForTest((pi) => {
+			pi.on("session_start", (_event, ctx) => {
+				ctx.ui.setStatus("test-status", ctx.model?.id ?? "missing-model");
+			});
+			pi.on("session_shutdown", (_event, ctx) => {
+				ctx.ui.setStatus("test-status", undefined);
+			});
+		}, []);
+
+		const outbound: DaemonOutbound[] = [];
+		const state: ActiveSessionState = {
+			activeSessionId: "active-status",
+			runtime,
+			clients: new Set(),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "generation-status",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: (_state, message) => outbound.push(message),
+			shutdown: () => {},
+		});
+		outbound.length = 0;
+
+		await runtime.newSession();
+
+		const replacementIndex = outbound.findIndex((message) => message.type === "session_replaced");
+		expect(replacementIndex).toBeGreaterThanOrEqual(0);
+		const statusAfterReplacement = outbound
+			.slice(replacementIndex + 1)
+			.find(
+				(message): message is Extract<DaemonOutbound, { type: "extension_ui_request" }> =>
+					message.type === "extension_ui_request" && message.method === "setStatus",
+			);
+		expect(statusAfterReplacement?.payload).toEqual({ statusKey: "test-status", statusText: "faux-daemon" });
+	});
 });

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -15,7 +15,7 @@ import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import type { ExtensionAPI, ExtensionFactory } from "../src/index.js";
 import { createAgentConnectionState } from "../src/modes/agent-connection/snapshot.js";
-import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
+import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import { bindActiveSessionState } from "../src/modes/daemon/daemon-extension-binding.js";
 import type { DaemonOutbound } from "../src/modes/daemon/daemon-protocol.js";
 
@@ -40,7 +40,11 @@ describe("daemon extension binding", () => {
 		}
 	});
 
-	async function createRuntimeForTest(extensionFactory: ExtensionFactory, responses: string[]) {
+	async function createRuntimeForTest(
+		extensionFactory: ExtensionFactory,
+		responses: string[],
+		beforeCreate?: (createCount: number) => void,
+	) {
 		const tempDir = join(tmpdir(), `pi-daemon-extension-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
 
@@ -52,7 +56,10 @@ describe("daemon extension binding", () => {
 		const authStorage = AuthStorage.inMemory();
 		authStorage.setRuntimeApiKey(faux.getModel().provider, "faux-key");
 
+		let createCount = 0;
 		const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+			createCount += 1;
+			beforeCreate?.(createCount);
 			const services = await createAgentSessionServices({
 				cwd,
 				agentDir: tempDir,
@@ -254,10 +261,14 @@ describe("daemon extension binding", () => {
 		]);
 	});
 
-	it("broadcasts passive extension UI after a session replacement", async () => {
+	it("restores the last known extension status immediately after a session replacement", async () => {
+		let sessionStarts = 0;
 		const runtime = await createRuntimeForTest((pi) => {
 			pi.on("session_start", (_event, ctx) => {
-				ctx.ui.setStatus("test-status", ctx.model?.id ?? "missing-model");
+				sessionStarts += 1;
+				if (sessionStarts === 1) {
+					ctx.ui.setStatus("test-status", "known-status");
+				}
 			});
 			pi.on("session_shutdown", (_event, ctx) => {
 				ctx.ui.setStatus("test-status", undefined);
@@ -278,18 +289,116 @@ describe("daemon extension binding", () => {
 			broadcast: (_state, message) => outbound.push(message),
 			shutdown: () => {},
 		});
+		expect(outbound).toContainEqual(
+			expect.objectContaining({
+				type: "extension_ui_request",
+				method: "setStatus",
+				payload: { statusKey: "test-status", statusText: "known-status" },
+			}),
+		);
+		for (let replacement = 0; replacement < 2; replacement += 1) {
+			outbound.length = 0;
+			await runtime.newSession();
+
+			const replacementMessage = outbound.find(
+				(message): message is Extract<DaemonOutbound, { type: "session_replaced" }> =>
+					message.type === "session_replaced",
+			);
+			expect(replacementMessage?.state.extensionStatuses).toEqual({ "test-status": "known-status" });
+		}
+	});
+
+	it("releases the extension UI replacement fence when runtime creation fails", async () => {
+		let sessionStarts = 0;
+		const runtime = await createRuntimeForTest(
+			(pi) => {
+				pi.on("session_start", (_event, ctx) => {
+					sessionStarts += 1;
+					ctx.ui.setStatus("test-status", `status-${sessionStarts}`);
+				});
+			},
+			[],
+			(createCount) => {
+				if (createCount === 2) throw new Error("replacement build failed");
+			},
+		);
+		const outbound: DaemonOutbound[] = [];
+		const state: ActiveSessionState = {
+			activeSessionId: "active-failed-replacement",
+			runtime,
+			clients: new Set(),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "generation-failed-replacement",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: (_state, message) => outbound.push(message),
+			shutdown: () => {},
+		});
+
+		await expect(runtime.newSession()).rejects.toThrow("replacement build failed");
+		await expect(runtime.newSession()).resolves.toEqual({ cancelled: false });
+
+		const replacement = [...outbound]
+			.reverse()
+			.find(
+				(message): message is Extract<DaemonOutbound, { type: "session_replaced" }> =>
+					message.type === "session_replaced",
+			);
+		expect(replacement?.state.extensionStatuses).toEqual({ "test-status": "status-2" });
+	});
+
+	it("does not let an old extension context overwrite a replacement status", async () => {
+		let sessionStarts = 0;
+		let emitOldStatus = () => {};
+		let confirmFromOldUi = async () => false;
+		const runtime = await createRuntimeForTest((pi) => {
+			pi.on("session_start", (_event, ctx) => {
+				sessionStarts += 1;
+				if (sessionStarts === 1) {
+					const oldUi = ctx.ui;
+					oldUi.setStatus("test-status", "old-status");
+					emitOldStatus = () => oldUi.setStatus("test-status", "late-old-status");
+					confirmFromOldUi = () => oldUi.confirm("stale dialog", "should not open", { timeout: 5 });
+				} else {
+					ctx.ui.setStatus("test-status", "new-status");
+				}
+			});
+		}, []);
+
+		const outbound: DaemonOutbound[] = [];
+		const extensionUiClient = { supportsExtensionUi: true } as unknown as DaemonSocketClient;
+		const state: ActiveSessionState = {
+			activeSessionId: "active-stale-status",
+			runtime,
+			clients: new Set([extensionUiClient]),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "generation-stale-status",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: (_state, message) => outbound.push(message),
+			shutdown: () => {},
+		});
 		outbound.length = 0;
 
 		await runtime.newSession();
+		emitOldStatus();
+		expect(await confirmFromOldUi()).toBe(false);
 
-		const replacementIndex = outbound.findIndex((message) => message.type === "session_replaced");
-		expect(replacementIndex).toBeGreaterThanOrEqual(0);
-		const statusAfterReplacement = outbound
-			.slice(replacementIndex + 1)
-			.find(
-				(message): message is Extract<DaemonOutbound, { type: "extension_ui_request" }> =>
-					message.type === "extension_ui_request" && message.method === "setStatus",
-			);
-		expect(statusAfterReplacement?.payload).toEqual({ statusKey: "test-status", statusText: "faux-daemon" });
+		const replacementMessage = outbound.find(
+			(message): message is Extract<DaemonOutbound, { type: "session_replaced" }> =>
+				message.type === "session_replaced",
+		);
+		expect(replacementMessage?.state.extensionStatuses).toEqual({ "test-status": "new-status" });
+		expect(outbound).not.toContainEqual(
+			expect.objectContaining({
+				type: "extension_ui_request",
+				payload: { statusKey: "test-status", statusText: "late-old-status" },
+			}),
+		);
+		expect(outbound).not.toContainEqual(expect.objectContaining({ method: "confirm" }));
 	});
 });

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -25,6 +25,9 @@ import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon
 import {
 	AgentDaemon,
 	cancelPendingExtensionUiRequests,
+	createExtensionStatusReplay,
+	daemonClientSupportsExtensionStatusSnapshot,
+	daemonOutboundForClient,
 	detachClientFromActiveSession,
 	finishClientSnapshotStreaming,
 	getChildActiveSessionStates,
@@ -4034,6 +4037,36 @@ describe("daemon mode helpers", () => {
 			}),
 		).rejects.toThrow("Agent messaging cannot target the sending session");
 		expect(state.runtime.session.prompt).not.toHaveBeenCalled();
+	});
+
+	it("capability-gates extension statuses in replacement snapshots", () => {
+		const legacyClient = makeClient("legacy-client", "active", true);
+		const capableClient = makeClient("capable-client", "active", true);
+		setDaemonClientSessionCapabilities(
+			capableClient,
+			"active",
+			new Set(["extension_ui", "extension_status_snapshot"]),
+		);
+		const state = makeState("active");
+		state.extensionStatuses = new Map([["codex", "23% 1.8d"]]);
+		const replacement: Extract<DaemonOutbound, { type: "session_replaced" }> = {
+			type: "session_replaced",
+			activeSessionId: "active",
+			state: { extensionStatuses: { codex: "23% 1.8d" } } as never,
+			messages: [],
+		};
+
+		expect(daemonClientSupportsExtensionStatusSnapshot(legacyClient, "active")).toBe(false);
+		expect(daemonOutboundForClient(legacyClient, replacement).state.extensionStatuses).toBeUndefined();
+		expect(daemonClientSupportsExtensionStatusSnapshot(capableClient, "active")).toBe(true);
+		expect(daemonOutboundForClient(capableClient, replacement)).toBe(replacement);
+		expect(createExtensionStatusReplay(state)).toEqual([
+			expect.objectContaining({
+				type: "extension_ui_request",
+				method: "setStatus",
+				payload: { statusKey: "codex", statusText: "23% 1.8d" },
+			}),
+		]);
 	});
 
 	it("sends dialog extension UI requests only to UI-capable clients", () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4069,6 +4069,25 @@ describe("daemon mode helpers", () => {
 		]);
 	});
 
+	it("replays legacy status tombstones before current values on resync", () => {
+		const state = makeState("active");
+		state.extensionStatuses = new Map([["current", "ready"]]);
+		const replay = createExtensionStatusReplay(state, new Set(["removed", "current"]));
+		expect(replay.map((message) => message.payload)).toEqual([
+			{ statusKey: "removed", statusText: undefined },
+			{ statusKey: "current", statusText: "ready" },
+		]);
+		const resynced: Extract<DaemonOutbound, { type: "session_resynced" }> = {
+			type: "session_resynced",
+			activeSessionId: "active",
+			snapshot: { state: { extensionStatuses: { current: "ready" } } as never, messages: [] } as never,
+		};
+		const legacyClient = makeClient("legacy-client", "active", true);
+		expect(
+			(daemonOutboundForClient(legacyClient, resynced) as typeof resynced).snapshot.state.extensionStatuses,
+		).toBeUndefined();
+	});
+
 	it("sends dialog extension UI requests only to UI-capable clients", () => {
 		const lineClient = makeClient("line-client", "active", false);
 		const uiClient = makeClient("ui-client", "active", true);

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -84,6 +84,11 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("model_catalog");
 	});
 
+	it("capability-gates extension status snapshots", () => {
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(14);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("extension_status_snapshot");
+	});
+
 	it("schema-gates the RLM max depth commands at their introducing revision", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.get_rlm_max_depth_status).toEqual({ minProtocol: 7, minSchemaRevision: 11 });
 		expect(DAEMON_COMMAND_COMPATIBILITY.set_rlm_max_depth).toEqual({ minProtocol: 7, minSchemaRevision: 11 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1790,7 +1790,13 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(requestWorker).toHaveBeenCalledWith({
 			type: "worker_subscribe",
 			activeSessionId: "active-1",
-			capabilities: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
+			capabilities: [
+				"attach_snapshot",
+				"event_sequence",
+				"extension_status_snapshot",
+				"slim_attach",
+				"chunked_snapshot",
+			],
 			supportsExtensionUi: false,
 		});
 	});

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -4,10 +4,10 @@ import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provide
 import { FooterComponent } from "../src/modes/interactive/components/footer.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
-function createFooterData(providerCount: number): ReadonlyFooterDataProvider {
+function createFooterData(providerCount: number, statuses = new Map<string, string>()): ReadonlyFooterDataProvider {
 	const provider = {
 		getGitBranch: () => "main",
-		getExtensionStatuses: () => new Map<string, string>(),
+		getExtensionStatuses: () => statuses,
 		getAvailableProviderCount: () => providerCount,
 		onBranchChange: (callback: () => void) => {
 			void callback;
@@ -41,5 +41,12 @@ describe("FooterComponent width handling", () => {
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 		}
+	});
+
+	it("renders extension statuses", () => {
+		const statuses = new Map([["codex-usage", "codex 25% 1.8d"]]);
+		const footer = new FooterComponent(createFooterData(1, statuses));
+
+		expect(footer.render(60)).toEqual(["codex 25% 1.8d"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1283,6 +1283,35 @@ describe("InteractiveMode connection events", () => {
 		expect(restoreStreamingMessageFromSnapshot).toHaveBeenNthCalledWith(2, streamingMessage);
 	});
 
+	test("restores extension statuses from a connection snapshot", () => {
+		const restored = new Map<string, string>([["stale", "old"]]);
+		const footerDataProvider = {
+			clearExtensionStatuses: vi.fn(() => restored.clear()),
+			setExtensionStatus: vi.fn((key: string, text: string) => restored.set(key, text)),
+		};
+		const fakeThis = {
+			bindPromptStashSession: vi.fn(),
+			connectionState: undefined as AgentConnectionState | undefined,
+			footerDataProvider,
+			footer: { invalidate: vi.fn(), setAutoCompactEnabled: vi.fn() },
+			updateScopedHeartbeats: vi.fn(),
+			renderRecap: vi.fn(),
+			updateWorkingPulse: vi.fn(),
+			sessionRecap: undefined as string | undefined,
+		};
+		const state = { ...createConnectionState(), extensionStatuses: { codex: "23% 1.8d" } };
+
+		(
+			InteractiveMode.prototype as unknown as {
+				applyConnectionStateSnapshot(this: typeof fakeThis, state: AgentConnectionState): void;
+			}
+		).applyConnectionStateSnapshot.call(fakeThis, state);
+
+		expect([...restored]).toEqual([["codex", "23% 1.8d"]]);
+		expect(footerDataProvider.clearExtensionStatuses).toHaveBeenCalledOnce();
+		expect(fakeThis.footer.invalidate).toHaveBeenCalledOnce();
+	});
+
 	test("clears extension UI when a connection-backed session is replaced", async () => {
 		type SessionReplacedEvent = { type: "session_replaced"; state: AgentConnectionState; messages: [] };
 		let listener: ((event: SessionReplacedEvent) => Promise<void> | void) | undefined;
@@ -1319,6 +1348,7 @@ describe("InteractiveMode connection events", () => {
 		const resetRenderOrder = fakeThis.resetCurrentSessionRenderState.mock.invocationCallOrder[0];
 		const rebindOrder = fakeThis.rebindCurrentSession.mock.invocationCallOrder[0];
 		const renderMessagesOrder = fakeThis.renderInitialMessages.mock.invocationCallOrder[0];
+		expect(fakeThis.resetExtensionUI).toHaveBeenCalledWith({ preserveStatuses: false });
 		expect(resetOrder).toBeLessThan(applySnapshotOrder);
 		expect(applySnapshotOrder).toBeLessThan(resetRenderOrder);
 		expect(resetRenderOrder).toBeLessThan(rebindOrder);
@@ -1598,6 +1628,34 @@ describe("InteractiveMode connection events", () => {
 
 		expect(fakeThis.handleEvent).not.toHaveBeenCalled();
 		expect(fakeThis.renderInitialMessages).toHaveBeenCalledOnce();
+	});
+
+	test("does not queue a modal extension UI request behind session events", async () => {
+		type ExtensionUiEvent = { type: "extension_ui_request"; request: AgentConnectionExtensionUiRequest };
+		let listener: ((event: ExtensionUiEvent) => Promise<void>) | undefined;
+		const blockedQueue = new Promise<void>(() => {});
+		const handleConnectionExtensionUiRequest = vi.fn(async () => {});
+		const fakeThis = {
+			agentConnection: {
+				subscribe: (callback: (event: ExtensionUiEvent) => Promise<void>) => {
+					listener = callback;
+					return vi.fn();
+				},
+			},
+			sessionEventQueue: blockedQueue,
+			sessionEventGeneration: 0,
+			expectsConnectionExtensionUiResponse: () => true,
+			handleConnectionExtensionUiRequest,
+			showError: vi.fn(),
+		};
+		(InteractiveMode.prototype as unknown as { subscribeToAgent(this: typeof fakeThis): void }).subscribeToAgent.call(
+			fakeThis,
+		);
+
+		const request = { id: "dialog-1", method: "confirm", payload: {} };
+		await listener?.({ type: "extension_ui_request", request });
+
+		expect(handleConnectionExtensionUiRequest).toHaveBeenCalledWith(request);
 	});
 });
 

--- a/packages/coding-agent/test/suite/regressions/4656-resume-active-session.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4656-resume-active-session.test.ts
@@ -225,6 +225,10 @@ describe("ENG-4656 active session resume", () => {
 			activeSessionId: sourceActiveSessionId,
 			targetActiveSessionId,
 		});
+		const initialAttach = client.requests[0] as Extract<DaemonCommand, { type: "attach" }>;
+		const reattach = client.requests[2] as Extract<DaemonCommand, { type: "reattach" }>;
+		expect(initialAttach.capabilities).toContain("extension_status_snapshot");
+		expect(reattach.capabilities).toContain("extension_status_snapshot");
 		await expect(connection.getState()).resolves.toMatchObject({
 			activeSessionId: targetActiveSessionId,
 			sessionId: `${targetActiveSessionId}-session`,
@@ -237,6 +241,16 @@ describe("ENG-4656 active session resume", () => {
 		);
 		await connection.dispose();
 		expect(client.requests.at(-1)).toMatchObject({ type: "detach", activeSessionId: targetActiveSessionId });
+	});
+
+	it("does not advertise extension status snapshots for a legacy connection", async () => {
+		const client = new ResumeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(client), sourceActiveSessionId, {
+			supportsExtensionUi: false,
+		});
+		const attach = client.requests[0] as Extract<DaemonCommand, { type: "attach" }>;
+		expect(attach.capabilities).not.toContain("extension_status_snapshot");
+		await connection.dispose();
 	});
 
 	it("keeps other source and target clients attached when one client moves", async () => {


### PR DESCRIPTION
## Summary

- render extension status text (including Codex usage) in the interactive footer
- cache extension statuses per daemon session and restore them atomically in attach, replacement, and resync snapshots
- capability-gate the new snapshot field, with ordered status replay for older clients
- fence stale extension contexts during replacement and keep modal extension UI outside the session-event queue

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-connection-daemon.test.ts test/daemon-extension-binding.test.ts test/interactive-mode-status.test.ts test/daemon-mode.test.ts test/daemon-protocol.test.ts test/footer-width.test.ts` (430 tests)
- manual daemon attach and `/new` checks with the real Codex usage extension; the footer status remained visible throughout replacement

A full coding-agent run passed 3,993 tests; its remaining failures were isolated to unrelated environment/process suites (package update fixtures, clipboard detection, and daemon process timing) and reproduce independently of these changed suites.

Related: #690, #734 (daemon-backed extension UI compatibility; this PR addresses status propagation only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon attach/replacement/resync and supervisor broadcast paths with a new capability and ordering guarantees; mistakes could cause stale footer state or missed status replay for legacy clients, but behavior is heavily tested and scoped to extension UI propagation.
> 
> **Overview**
> Fixes extension footer text (e.g. Codex usage) disappearing after daemon attach, reattach, or session replacement.
> 
> **Daemon protocol (revision 14)** adds `extension_status_snapshot`. The worker caches passive `setStatus` values on `ActiveSessionState` and includes them in connection snapshots. Capable clients get `extensionStatuses` inline; legacy clients still get ordered `setStatus` replays (including tombstones for cleared keys) after attach/replacement/resync, without duplicating snapshot payloads during streaming.
> 
> **Session replacement** wires `beforeSessionReplace` / `sessionReplaceFailed` on `AgentSessionRuntime` so extension UI from tearing-down sessions is fenced and cannot race or overwrite the new binding; replacement snapshots restore statuses atomically before other deferred passive UI.
> 
> **Interactive TUI** applies snapshot statuses to the footer, renders joined extension status lines, skips clearing statuses on replace when the snapshot carries them, and queues passive extension UI on the session event queue while modals stay immediate.
> 
> **Supervisor** mirrors the same capability gating, overlays, and replay paths for multi-worker attach/streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fd28ec6f162a141c518262a2f339ea0ddef006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve extension statuses across daemon sessions and replay them to legacy clients
> - Extension statuses (footer `setStatus` messages) are now captured in daemon session state and included in session snapshots for clients that advertise the new `extension_status_snapshot` capability (schema revision 14).
> - Legacy clients that lack this capability receive synthesized `extension_ui_request:setStatus` replay messages after attach, reattach, session replacement, and catch-up, ensuring statuses are not lost across daemon reconnects.
> - During session replacement, passive extension UI events are deferred until after the replacement snapshot is broadcast, then replayed in order to avoid races with session replacement redraws.
> - `InteractiveMode` now restores extension statuses from connection state snapshots and the footer renders them as a single truncated line.
> - New lifecycle hooks (`setBeforeSessionReplace`, `setSessionReplaceFailed`) on `AgentSessionRuntime` allow the extension binding layer to coordinate deferral and replay around replacement teardown.
> - Behavioral Change: `resetExtensionUI` now accepts `{ preserveStatuses }` — callers passing `true` retain footer status display across UI resets; the default clears statuses as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98f05a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->