### PR TITLE
docs(coding-agent): document Cua Driver desktop automation

### DIFF
--- a/packages/coding-agent/docs/cua-driver.md
+++ b/packages/coding-agent/docs/cua-driver.md
@@ -1,0 +1,105 @@
+# Drive desktop applications with Cua Driver
+
+This guide shows you how to let Prime Agent operate desktop applications on the
+current macOS, Windows, or Linux host through the Cua Driver skill.
+
+## Before you start
+
+- Install and authenticate Prime Agent.
+- Use an interactive desktop session. Cua Driver operates the host desktop; it
+  is not a sandbox.
+- Review the [Cua Driver platform requirements](https://cua.ai/docs/how-to-guides/driver/install).
+
+## Install Cua Driver
+
+On macOS or Linux:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://cua.ai/driver/install.ps1 | iex
+```
+
+Verify that the installed driver can inspect the current desktop:
+
+```bash
+cua-driver --version
+cua-driver call list_apps
+```
+
+On macOS, grant Accessibility and Screen Recording to the installed Cua Driver
+application:
+
+```bash
+cua-driver permissions grant
+cua-driver permissions status
+```
+
+## Install the Prime Agent skill
+
+Create Prime Agent's native skill directory, then ask Cua Driver to install its
+version-matched skill pack.
+
+On macOS or Linux:
+
+```bash
+mkdir -p ~/.prime/agent/skills
+```
+
+On Windows PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force "$HOME\.prime\agent\skills" | Out-Null
+```
+
+Then install and verify the skill:
+
+```bash
+cua-driver skills install
+cua-driver skills status
+```
+
+In an active Prime Agent session, run `/reload`. You can then ask Prime Agent to
+use Cua Driver in ordinary language or invoke the skill explicitly:
+
+```text
+/skill:cua-driver Open Calculator, compute 6 × 7, and verify the result.
+```
+
+Prime Agent calls Cua Driver from its persistent IPython environment. No local
+MCP registration is required. To print the current setup instructions from the
+installed driver, run:
+
+```bash
+cua-driver mcp-config --client prime-agent
+```
+
+## Troubleshooting
+
+### The skill is not listed
+
+Confirm that `cua-driver skills status` reports a Prime Agent link, then run
+`/reload`. Prime Agent also discovers skills from the shared
+`~/.agents/skills/` directory.
+
+### The driver cannot see or control an application
+
+Run `cua-driver doctor`. On macOS, also run `cua-driver permissions status` and
+confirm that both Accessibility and Screen Recording are granted to Cua Driver.
+
+### A long-running task loses its target
+
+Ask Prime Agent to take a fresh Cua Driver snapshot before retrying. Window IDs,
+snapshot IDs, and element tokens describe observed state and should not be
+reused after the desktop changes.
+
+## Related documentation
+
+- [Prime Agent skills](skills.md)
+- [Prime Agent RLM programming model](rlm.md)
+- [Cua Driver agent connection guide](https://cua.ai/docs/how-to-guides/driver/connect-your-agent)
+- [Cua Driver action policy](https://cua.ai/docs/reference/cua-driver/action-selection-policy)

--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -61,6 +61,10 @@
           "path": "skills.md"
         },
         {
+          "title": "Desktop Automation with Cua Driver",
+          "path": "cua-driver.md"
+        },
+        {
           "title": "MCP Integrations",
           "path": "mcp-integrations.md"
         },

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -38,6 +38,7 @@ Public releases are currently installed from versioned release artifacts. The in
 
 - [Extensions](extensions.md) - TypeScript modules for tools, commands, events, and custom UI.
 - [Skills](skills.md) - markdown and Python-backed skills, including how to ask Prime Agent to create them.
+- [Desktop automation with Cua Driver](cua-driver.md) - install the Cua Driver skill and operate host applications.
 - [MCP integrations](mcp-integrations.md) - use MCP servers through Python skills without expanding the model's tool surface.
 - [Prompt templates](prompt-templates.md) - reusable prompts that expand from slash commands.
 - [Themes](themes.md) - built-in and custom terminal themes.


### PR DESCRIPTION
## Summary

- add a focused guide for installing Cua Driver and its Prime Agent skill
- document native `/reload` and `/skill:cua-driver` usage, permissions, and troubleshooting
- link the guide from the documentation index and navigation

This deliberately uses Prime Agent’s native skill system and persistent IPython environment instead of registering a local stdio MCP server.

Counterpart: trycua/cua#2944 adds Prime Agent discovery and setup guidance to Cua Driver.

## Validation

- `git diff --check`
- parsed `packages/coding-agent/docs/docs.json` with Node.js
- verified all referenced local documentation files exist
- verified all three linked Cua documentation pages return HTTP 200

Biome excludes these documentation paths, so it reports that no files were processed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or application code modifications.
> 
> **Overview**
> Adds a new **Cua Driver** guide (`cua-driver.md`) for driving host desktop apps from Prime Agent via the native skill path—not a local stdio MCP server.
> 
> The guide covers driver install (macOS/Linux/Windows), macOS permissions, creating `~/.prime/agent/skills`, `cua-driver skills install`, session **`/reload`**, and **`/skill:cua-driver`** usage from the persistent IPython environment. It also documents troubleshooting (skill discovery, permissions, stale snapshot/window tokens) and links to related Prime Agent and Cua docs.
> 
> **Navigation** is updated in `docs.json` (Customization → “Desktop Automation with Cua Driver”) and on `index.md` under Customization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b9d03b8fd10a23b197c91d9f2bdfe90ece486c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Cua Driver desktop automation skill for Prime Agent
> Adds a new guide at [cua-driver.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/742/files#diff-4c808eb78c76ec13076dbab511ababb6914384c38baa656f128ab412f6975487) covering installation, permissions setup, and usage of the Cua Driver skill across macOS, Windows, and Linux. The doc is registered in [docs.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/742/files#diff-882036ef3174d7c3b16acecda7937bf6ed12c1eb1b8fafd15333c4d76e9e7df9) and linked from the Customization section of [index.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/742/files#diff-218d46321638f6fc86d50aefd277a2551b50e631d37a957a72e9abac03aa1d8c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70b9d03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->