### PR TITLE
feat(coding-agent): add native Windows support

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -237,11 +237,14 @@ jobs:
           const baseUrl = process.env.INSTALL_BASE_URL;
           if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
           const installer = fs.readFileSync("install.sh", "utf8");
-          const renderInstaller = (channel) => installer
+          const windowsInstaller = fs.readFileSync("install.ps1", "utf8");
+          const renderInstaller = (source, channel) => source
             .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
             .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
-          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller("stable"));
-          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller("beta"));
+          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller(installer, "stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller(installer, "beta"));
+          fs.writeFileSync("/tmp/prime-agent-install.ps1", renderInstaller(windowsInstaller, "stable"));
+          fs.writeFileSync("/tmp/prime-agent-install-beta.ps1", renderInstaller(windowsInstaller, "beta"));
           NODE
 
       - name: Extract production release notes
@@ -296,6 +299,16 @@ jobs:
           aws s3 cp /tmp/prime-agent-install-beta.sh "s3://${R2_BUCKET}/install-beta.sh" \
             --endpoint-url "$R2_ENDPOINT_URL" \
             --content-type text/x-shellscript \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
             --cache-control no-cache
 
       - name: Create production GitHub release
@@ -379,6 +392,16 @@ jobs:
             --content-type text/x-shellscript \
             --cache-control no-cache
 
+          aws s3 cp /tmp/prime-agent-install.ps1 "s3://${R2_BUCKET}/install.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
+          aws s3 cp /tmp/prime-agent-install-beta.ps1 "s3://${R2_BUCKET}/install-beta.ps1" \
+            --endpoint-url "$R2_ENDPOINT_URL" \
+            --content-type text/plain \
+            --cache-control no-cache
+
           printf 'Automated beta build from `%s` (`%s`).\n' "$DEFAULT_BRANCH" "$BUILD_REF" > /tmp/beta-release-notes.md
 
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/beta" >/dev/null 2>&1; then
@@ -409,4 +432,4 @@ jobs:
           fi
 
           gh release upload beta "$BETA_DIR"/* --clobber
-          echo "Beta installer: ${R2_PUBLIC_BASE_URL%/}/install-beta.sh"
+          echo "Beta installers: ${R2_PUBLIC_BASE_URL%/}/install-beta.sh and ${R2_PUBLIC_BASE_URL%/}/install-beta.ps1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,16 +115,67 @@ jobs:
         working-directory: ${{ matrix.package }}
         run: ${{ matrix.command }}
 
+  windows:
+    name: Windows native smoke
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Check PowerShell installer
+        run: node scripts/check-windows-installer.mjs
+
+      - name: Test Windows runtime paths
+        working-directory: packages/coding-agent
+        shell: pwsh
+        run: |
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/command-recovery-journal.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-lease.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-launch.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-catalog-process.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/windows-job-object.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-supervisor-process.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-autonomous.test.ts test/tools.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npx tsx ../../node_modules/vitest/dist/cli.js --run test/bash-close-hang-windows.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $env:PRIME_AGENT_KERNEL_VENV = Join-Path $env:RUNNER_TEMP "prime-agent-kernel-venv"
+          npx tsx src/core/kernel/bootstrap-cli.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & "$env:PRIME_AGENT_KERNEL_VENV\Scripts\python.exe" -c "import ipykernel, rlm, dill"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   build-check-test:
     name: build-check-test
     if: always()
-    needs: [build-check, test]
+    needs: [build-check, test, windows]
     runs-on: ubuntu-latest
     steps:
       - name: Verify CI results
         env:
           BUILD_CHECK_RESULT: ${{ needs.build-check.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          WINDOWS_RESULT: ${{ needs.windows.result }}
         run: |
           test "$BUILD_CHECK_RESULT" = success
           test "$TEST_RESULT" = success
+          test "$WINDOWS_RESULT" = success

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Install the latest stable release on macOS or Linux:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
 ```
 
-The installer downloads a versioned release, verifies its SHA-256 checksum, installs the `prime-agent` command, and can prepare the IPython runtime used by the agent.
+On Windows x64, install x64 Node.js 22.8.0 or newer and Git for Windows, then run in PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
+The installers download a versioned release, verify its SHA-256 checksum, install the `prime-agent` command, and can prepare the IPython runtime used by the agent.
 
 Start Prime Agent from the repository or directory you want it to work in:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,154 @@
+[CmdletBinding()]
+param(
+	[ValidateSet("stable", "beta")]
+	[string]$Channel = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$downloadBaseUrl = "__PRIME_AGENT_DOWNLOAD_BASE_URL__".TrimEnd("/")
+$minimumNodeVersion = [Version]"22.8.0"
+$tempDirectory = $null
+$previousBootstrapTools = [Environment]::GetEnvironmentVariable("PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL", "Process")
+$previousBootstrapKernel = [Environment]::GetEnvironmentVariable("PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL", "Process")
+$previousInstallUv = [Environment]::GetEnvironmentVariable("PRIME_AGENT_INSTALL_UV", "Process")
+
+function Get-RequiredCommand {
+	param(
+		[string]$Name,
+		[string]$InstallMessage
+	)
+
+	$command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+	if (-not $command) {
+		throw $InstallMessage
+	}
+	return $command
+}
+
+function Get-Sha256 {
+	param([string]$Path)
+
+	$stream = [IO.File]::OpenRead($Path)
+	$sha256 = [Security.Cryptography.SHA256]::Create()
+	try {
+		return [BitConverter]::ToString($sha256.ComputeHash($stream)).Replace("-", "").ToLowerInvariant()
+	} finally {
+		$sha256.Dispose()
+		$stream.Dispose()
+	}
+}
+
+function Get-WebText {
+	param([string]$Uri)
+
+	$response = Invoke-WebRequest -UseBasicParsing -Uri $Uri
+	if ($response.Content -is [byte[]]) {
+		return [Text.Encoding]::UTF8.GetString($response.Content)
+	}
+	return [string]$response.Content
+}
+
+function Get-BashPath {
+	$candidates = @()
+	foreach ($programFiles in @(
+		[Environment]::GetEnvironmentVariable("ProgramFiles"),
+		[Environment]::GetEnvironmentVariable("ProgramFiles(x86)"),
+		[Environment]::GetEnvironmentVariable("LOCALAPPDATA")
+	)) {
+		if ($programFiles) {
+			$relativePath = if ($programFiles -eq [Environment]::GetEnvironmentVariable("LOCALAPPDATA")) {
+				"Programs\Git\bin\bash.exe"
+			} else {
+				"Git\bin\bash.exe"
+			}
+			$candidates += Join-Path $programFiles $relativePath
+		}
+	}
+	foreach ($candidate in $candidates) {
+		if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+			return $candidate
+		}
+	}
+	return $null
+}
+
+try {
+	if ($downloadBaseUrl.Contains("__PRIME_AGENT_")) {
+		throw "This source template is not an installer. Use the published install.ps1 URL."
+	}
+
+	$node = Get-RequiredCommand "node.exe" "Node.js 22.8.0 or newer is required: https://nodejs.org/"
+	$npm = Get-RequiredCommand "npm.cmd" "npm is required and normally ships with Node.js: https://nodejs.org/"
+	if (-not (Get-BashPath)) {
+		throw "Git Bash is required to run Prime Agent on Windows: https://git-scm.com/download/win"
+	}
+
+	$nodeVersionText = (& $node.Source --version | Out-String).Trim().TrimStart([char]"v")
+	try {
+		$nodeVersion = [Version]($nodeVersionText.Split("-")[0])
+	} catch {
+		throw "Could not parse Node.js version: $nodeVersionText"
+	}
+	if ($nodeVersion -lt $minimumNodeVersion) {
+		throw "Node.js $minimumNodeVersion or newer is required; found $nodeVersion."
+	}
+	$nodeArchitecture = (& $node.Source -p "process.arch" | Out-String).Trim()
+	if ($nodeArchitecture -ne "x64") {
+		throw "Prime Agent native Windows support requires x64 Node.js; found $nodeArchitecture."
+	}
+
+	$version = (Get-WebText "$downloadBaseUrl/$Channel").Trim()
+	if ($version.StartsWith("v", [StringComparison]::Ordinal)) {
+		$version = $version.Substring(1)
+	}
+	$identifier = "(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+	if ($version -notmatch "^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-$identifier(?:\.$identifier)*)?$") {
+		throw "Invalid Prime Agent version returned by the $Channel channel: $version"
+	}
+
+	$tempDirectory = Join-Path ([IO.Path]::GetTempPath()) "prime-agent-$([Guid]::NewGuid().ToString('N'))"
+	New-Item -ItemType Directory -Path $tempDirectory | Out-Null
+	$tarballName = "prime-agent-$version.tgz"
+	$tarballPath = Join-Path $tempDirectory $tarballName
+	$checksumsPath = Join-Path $tempDirectory "SHA256SUMS"
+	$releaseUrl = "$downloadBaseUrl/releases/v$version"
+
+	Write-Host "Downloading Prime Agent $version..."
+	Invoke-WebRequest -UseBasicParsing -Uri "$releaseUrl/$tarballName" -OutFile $tarballPath
+	Invoke-WebRequest -UseBasicParsing -Uri "$releaseUrl/SHA256SUMS" -OutFile $checksumsPath
+
+	$checksumPattern = "^([0-9a-fA-F]{64})\s+\*?$([Regex]::Escape($tarballName))$"
+	$checksumLine = Get-Content -LiteralPath $checksumsPath | Where-Object { $_ -match $checksumPattern } | Select-Object -First 1
+	if (-not $checksumLine -or $checksumLine -notmatch $checksumPattern) {
+		throw "Checksum for $tarballName was not found in SHA256SUMS."
+	}
+	$expectedChecksum = $Matches[1].ToLowerInvariant()
+	$actualChecksum = Get-Sha256 $tarballPath
+	if ($actualChecksum -ne $expectedChecksum) {
+		throw "Checksum mismatch for $tarballName."
+	}
+
+	$env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = "1"
+	$env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = "1"
+	$env:PRIME_AGENT_INSTALL_UV = "1"
+	& $npm.Source install -g --no-fund --no-audit --loglevel=error --progress=false $tarballPath
+	if ($LASTEXITCODE -ne 0) {
+		throw "npm install failed with exit code $LASTEXITCODE."
+	}
+
+	Write-Host "Prime Agent $version installed. Run: prime-agent"
+} finally {
+	[Environment]::SetEnvironmentVariable("PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL", $previousBootstrapTools, "Process")
+	[Environment]::SetEnvironmentVariable("PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL", $previousBootstrapKernel, "Process")
+	[Environment]::SetEnvironmentVariable("PRIME_AGENT_INSTALL_UV", $previousInstallUv, "Process")
+	if ($tempDirectory) {
+		try {
+			Remove-Item -LiteralPath $tempDirectory -Recurse -Force
+		} catch {
+			Write-Warning "Could not remove temporary installer directory: $tempDirectory"
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3343,7 +3343,6 @@
 			"version": "2.16.2",
 			"hasInstallScript": true,
 			"license": "MIT",
-			"optional": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
 			}
@@ -5367,6 +5366,7 @@
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
 				"jiti": "^2.7.0",
+				"koffi": "2.16.2",
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "cd packages/ai && npm run dev:tsc",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:installer && npm run check:browser-smoke",
-		"check:installer": "node scripts/check-installer-render.mjs",
+		"check:installer": "node scripts/check-installer-render.mjs && node scripts/check-windows-installer.mjs",
 		"check:browser-smoke": "node scripts/check-browser-smoke.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- Added a checksum-verifying PowerShell installer and Windows CI coverage ([#665](https://github.com/PrimeIntellect-ai/prime-agent/issues/665)).
+- Fixed managed kernel bootstrap using the Windows virtual-environment layout ([#660](https://github.com/PrimeIntellect-ai/prime-agent/issues/660)).
+- Fixed daemon command recovery compaction on platforms without directory fsync support ([#666](https://github.com/PrimeIntellect-ai/prime-agent/issues/666)).
+- Fixed stale session lease recovery on Windows ([#667](https://github.com/PrimeIntellect-ai/prime-agent/issues/667)).
+- Fixed core daemon, kernel, and bash child processes opening visible console windows on Windows ([#668](https://github.com/PrimeIntellect-ai/prime-agent/issues/668)).
+- Fixed repeated PowerShell windows during Windows process tracking by reading process start times through the native Win32 API.
+- Fixed Windows daemon worker crashes leaving Git Bash descendants alive by assigning gated Bash processes to a kill-on-close Job Object.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -16,7 +16,14 @@ To try the latest beta built from `main`:
 curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
 ```
 
-Both commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
+On Windows x64, install x64 Node.js 22.8.0 or newer and Git for Windows, then run one of these commands in PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+irm https://app.primeintellect.ai/prime-agent/install-beta.ps1 | iex
+```
+
+These commands fetch versioned Prime Agent release artifacts and install the `prime-agent` command. The inherited npm workspace identifiers in the source tree are not the public install path.
 
 Then start Prime Agent in the project directory you want it to work on:
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -76,7 +76,7 @@ The Python side does not call providers or implement an agent loop.
 The kernel is created lazily on first IPython use. Python resolution is:
 
 1. `PRIME_AGENT_KERNEL_PYTHON`, when it can import `ipykernel`;
-2. `~/.prime/agent/kernel-venv/bin/python`, bootstrapped with `uv`; or
+2. `~/.prime/agent/kernel-venv/bin/python` (`Scripts\\python.exe` on Windows), bootstrapped with `uv`; or
 3. the XDG data location when `~/.prime` is not writable.
 
 The managed environment includes Python 3.11, `ipykernel`, and `prime-agent-runtime`. A bootstrap marker detects stale environments.

--- a/packages/coding-agent/docs/windows-job-object-evaluation.md
+++ b/packages/coding-agent/docs/windows-job-object-evaluation.md
@@ -1,0 +1,21 @@
+# Windows Job Object evaluation
+
+**Accessed:** 2026-08-06
+
+## Recommendation
+
+Use exact **`koffi@2.16.2`** as a direct coding-agent dependency. The repository already resolved this MIT-licensed Node-API 8 package through TUI, included its tested Windows x64 prebuilt binary, and externalized it from the esbuild CLI bundle. Making it direct adds no new package or version; it makes required daemon isolation fail closed instead of depending on an optional transitive install.
+
+Koffi 3.1.3/3.1.4 were evaluated but rejected for this change because the configured npm registry age policy refused both. No policy bypass is needed.
+
+## Design
+
+A Windows daemon worker creates and retains a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. The worker itself and its non-Bash children remain outside the Job, so replacement supervisors survive worker failure. Before a local Bash command runs, Bash blocks on an anonymous stdin pipe; the worker assigns its PID with `AssignProcessToJobObject`, then releases the gate. Git for Windows resolves from the public `bin\\bash.exe` path to direct `usr\\bin\\bash.exe`, preventing its launcher from creating an unassigned descendant first.
+
+The Job uses only kernel handles and an anonymous pipe. Process identity checks reuse Koffi and `GetProcessTimes`, avoiding a PowerShell subprocess for every PID check. This adds no persistent file or network I/O. Missing Koffi, unsupported architecture, invalid PID, or failed `CreateJobObjectW`, `SetInformationJobObject`, `OpenProcess`, `AssignProcessToJobObject`, or `CloseHandle` rejects execution.
+
+## Evidence and risk
+
+A dedicated Windows causality test runs without a supervisor: with the same direct Bash executable and active blocker command, the assigned leaf exits with its owner while the no-Job control survives until explicit cleanup. It passes alongside all 8 supervisor process tests (with 6 additional platform skips), including replacement recovery after a hard worker kill.
+
+Koffi is memory-unsafe FFI; the implementation therefore limits the raw `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` layout to the supported Windows x64 target and checks every Win32 result. Microsoft documents [Job inheritance and lifecycle](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects), [kill-on-close](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information), and [process assignment](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject). Koffi documents [Windows x64 prebuilt support](https://koffi.dev/platforms) and [Node-API compatibility](https://koffi.dev/start).

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -1,12 +1,22 @@
 # Windows Setup
 
-Prime Agent requires a bash shell on Windows. Checked locations (in order):
+Native Windows requires x64 Node.js 22.8.0 or newer and [Git for Windows](https://git-scm.com/download/win). ARM64 Node.js is not supported.
+
+Install the stable release from PowerShell:
+
+```powershell
+irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
+```
+
+The installer verifies the release SHA-256 checksum before invoking npm. At runtime, Prime Agent resolves bash in these locations (in order):
 
 1. Custom path from `~/.prime/agent/settings.json`
 2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
-3. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
+3. `bash.exe` on PATH for foreground sessions
 
-For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient.
+After installation, run `prime-agent` from PowerShell, Windows Terminal, or Git Bash. Prime Agent uses the detected bash executable for model-generated shell commands. In daemon workers, Git for Windows resolves from the public `bin\\bash.exe` path to the direct `usr\\bin\\bash.exe` executable so process isolation is applied before Bash creates descendants.
+
+Windows daemon workers require Git for Windows, hold a kill-on-close Job Object, and assign each local Bash process before releasing an anonymous startup pipe. Other Bash implementations remain available to foreground sessions but are rejected in daemon workers because their descendants cannot be guaranteed to join the Job. If the worker crashes, Windows terminates that Bash process tree; replacement supervisors remain outside the Job. This adds no persistent file or network I/O. Missing native support or any failed Win32 call prevents the worker from accepting commands instead of running without isolation.
 
 ## Custom Shell Path
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -11,7 +11,7 @@ irm https://app.primeintellect.ai/prime-agent/install.ps1 | iex
 The installer verifies the release SHA-256 checksum before invoking npm. At runtime, Prime Agent resolves bash in these locations (in order):
 
 1. Custom path from `~/.prime/agent/settings.json`
-2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
+2. Git Bash (`C:\Program Files\Git\bin\bash.exe` or `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`)
 3. `bash.exe` on PATH for foreground sessions
 
 After installation, run `prime-agent` from PowerShell, Windows Terminal, or Git Bash. Prime Agent uses the detected bash executable for model-generated shell commands. In daemon workers, Git for Windows resolves from the public `bin\\bash.exe` path to the direct `usr\\bin\\bash.exe` executable so process isolation is applied before Bash creates descendants.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -61,6 +61,7 @@
 		"hosted-git-info": "^9.0.2",
 		"ignore": "^7.0.5",
 		"jiti": "^2.7.0",
+		"koffi": "2.16.2",
 		"marked": "^15.0.12",
 		"minimatch": "^10.2.3",
 		"proper-lockfile": "^4.1.2",

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -692,6 +692,7 @@ async function runStart(parsed: ParsedDaemonClientCommand): Promise<void> {
 		...sessionArgs.daemonArgs.filter((arg) => arg !== "--background" && arg !== "-d"),
 	];
 	const child = spawn(process.execPath, daemonArgs, {
+		windowsHide: true,
 		cwd: sessionArgs.config?.cwd ?? process.cwd(),
 		detached: true,
 		env: process.env,

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -372,6 +372,7 @@ async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promi
 		process.execPath,
 		[...process.execArgv, entrypoint, "--mode", "daemon", "--daemon-socket", socketPath],
 		{
+			windowsHide: true,
 			cwd: spawnCwd ?? process.cwd(),
 			detached: true,
 			env,

--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -548,6 +548,7 @@ export async function launchDaemonUpdateRestartCoordinator(
 		...(originActiveSessionId ? [DAEMON_UPDATE_RESTART_ORIGIN_FLAG, originActiveSessionId] : []),
 	]);
 	const child = spawn(launch.command, launch.args, {
+		windowsHide: true,
 		cwd: options.cwd ?? process.cwd(),
 		detached: true,
 		env: coordinatorEnvironment(agentDir),

--- a/packages/coding-agent/src/cli/owned-session-worker.ts
+++ b/packages/coding-agent/src/cli/owned-session-worker.ts
@@ -344,6 +344,7 @@ export async function runOwnedSessionWorkerFrontend(
 			? ["inherit", "inherit", "inherit", "ipc"]
 			: [bridgeStdin ? "pipe" : "inherit", "pipe", "pipe", "ipc"];
 		const child = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: process.cwd(),
 			detached: process.platform !== "win32",
 			env: {

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -492,6 +492,7 @@ function runChildProcess(
 	options.signal?.throwIfAborted();
 	return new Promise((resolve) => {
 		const child = spawn(command, args, {
+			windowsHide: true,
 			cwd: options.cwd,
 			detached: process.platform !== "win32",
 			shell: options.shell === true,

--- a/packages/coding-agent/src/core/exec.ts
+++ b/packages/coding-agent/src/core/exec.ts
@@ -59,6 +59,7 @@ export async function execCommand(
 ): Promise<ExecResult> {
 	return new Promise((resolve) => {
 		const proc = spawn(command, args, {
+			windowsHide: true,
 			cwd,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -36,6 +36,7 @@ export const DEFAULT_RLM_EXTRA_UV_ARGS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) =>
 export const DEFAULT_RLM_EXTRA_IMPORT_NAMES = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.importName);
 export const DEFAULT_RLM_EXTRA_IMPORT_LABELS = DEFAULT_RLM_EXTRA_PACKAGES.map((pkg) => pkg.promptLabel);
 const UV_INSTALL_COMMAND = "curl -LsSf https://astral.sh/uv/install.sh | sh";
+const UV_INSTALL_POWERSHELL_COMMAND = "irm https://astral.sh/uv/install.ps1 | iex";
 const REQUIRED_HARNESS_METHODS = [
 	"create_memory",
 	"update_memory",
@@ -117,6 +118,10 @@ function expandHome(filePath: string): string {
 	if (filePath === "~") return os.homedir();
 	if (filePath.startsWith("~/")) return path.join(os.homedir(), filePath.slice(2));
 	return filePath;
+}
+
+function venvPython(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
 }
 
 function fileContentHash(filePath: string): string {
@@ -374,6 +379,7 @@ async function resolveWritableKernelVenvDir(): Promise<string> {
 function run(command: string, args: string[], options: { stdio?: "ignore" | "inherit" } = {}): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, args, {
+			windowsHide: true,
 			env: process.env,
 			stdio: options.stdio ?? "ignore",
 		});
@@ -518,21 +524,29 @@ async function ensureUv(options: EnsureKernelPythonOptions): Promise<string> {
 	const localUv = path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "uv.exe" : "uv");
 	if (await isExecutable(localUv)) return localUv;
 
+	const installer =
+		process.platform === "win32"
+			? {
+					command: "powershell.exe",
+					args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", UV_INSTALL_POWERSHELL_COMMAND],
+					hint: UV_INSTALL_POWERSHELL_COMMAND,
+				}
+			: { command: "sh", args: ["-c", UV_INSTALL_COMMAND], hint: UV_INSTALL_COMMAND };
 	const shouldInstallUv =
 		process.env.PRIME_AGENT_INSTALL_UV === "1" || (!options.onProgress && (await confirmUvInstall()));
 	if (!shouldInstallUv) {
 		throw new Error(
-			`uv is required to set up the Python kernel. Install uv yourself: ${UV_INSTALL_COMMAND}, ` +
+			`uv is required to set up the Python kernel. Install uv yourself: ${installer.hint}, ` +
 				"or set PRIME_AGENT_INSTALL_UV=1 to let prime-agent run that installer.",
 		);
 	}
 
 	reportProgress(options, "› installing uv (one-time)…");
 	try {
-		await run("sh", ["-c", UV_INSTALL_COMMAND], { stdio: options.onProgress ? "ignore" : "inherit" });
+		await run(installer.command, installer.args, { stdio: options.onProgress ? "ignore" : "inherit" });
 	} catch (error) {
 		throw new Error(
-			`couldn't install uv from astral.sh; install it yourself: ${UV_INSTALL_COMMAND}, then re-run prime-agent. ${errorMessage(error)}`,
+			`couldn't install uv from astral.sh; install it yourself: ${installer.hint}, then re-run prime-agent. ${errorMessage(error)}`,
 		);
 	}
 
@@ -725,7 +739,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = venvPython(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +900,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = venvPython(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -173,6 +173,7 @@ class ForkServer {
 				// The template only imports; its own cwd/env are irrelevant since each
 				// forked child applies the per-kernel cwd/env itself. Inherit the daemon's.
 				const proc = spawn(this.params.python, ["-c", FORK_SERVER_SCRIPT, socketPath], {
+					windowsHide: true,
 					env: this.launchEnv,
 					stdio: ["ignore", "ignore", "pipe"],
 				});

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -645,6 +645,7 @@ export class KernelManager {
 
 		if (!forked) {
 			const kernel = spawn(python, ["-m", "ipykernel_launcher", "-f", connection.path], {
+				windowsHide: true,
 				cwd: this.options.cwd,
 				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
 				stdio: ["ignore", "pipe", "pipe"],

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2379,6 +2379,7 @@ export class DefaultPackageManager implements PackageManager {
 
 	private spawnCommand(command: string, args: string[], options?: { cwd?: string }): ChildProcess {
 		return spawn(command, args, {
+			windowsHide: true,
 			cwd: options?.cwd,
 			stdio: isStdoutTakenOver() ? ["ignore", 2, 2] : "inherit",
 			shell: shouldUseWindowsShell(command),
@@ -2393,6 +2394,7 @@ export class DefaultPackageManager implements PackageManager {
 	): ChildProcessByStdio<null, Readable, Readable> {
 		const baseEnv = getEnv();
 		return spawn(command, args, {
+			windowsHide: true,
 			cwd: options?.cwd,
 			stdio: ["ignore", "pipe", "pipe"],
 			shell: shouldUseWindowsShell(command),

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
+import { getWindowsProcessStartTicks } from "../utils/windows-job-object.js";
 
 export const SESSION_LEASES_ENABLED_ENV = "PRIME_AGENT_INTERNAL_SESSION_LEASES";
 export const SESSION_LEASE_OWNER_ID_ENV = "PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID";
@@ -110,8 +111,6 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-type ProcessQuery = (command: string, args: string[]) => string;
-
 function runProcessQuery(command: string, args: string[]): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
@@ -119,19 +118,18 @@ function runProcessQuery(command: string, args: string[]): string {
 	});
 }
 
-export function getWindowsProcessStartId(pid: number, query: ProcessQuery = runProcessQuery): string | undefined {
+type WindowsProcessStartQuery = (pid: number) => bigint | undefined;
+
+export function getWindowsProcessStartId(
+	pid: number,
+	query: WindowsProcessStartQuery = getWindowsProcessStartTicks,
+): string | undefined {
 	if (!Number.isInteger(pid) || pid <= 0) {
 		return undefined;
 	}
 	try {
-		const startTicks = query("powershell.exe", [
-			"-NoLogo",
-			"-NoProfile",
-			"-NonInteractive",
-			"-Command",
-			`([System.Diagnostics.Process]::GetProcessById(${pid})).StartTime.ToUniversalTime().Ticks`,
-		]).trim();
-		return /^\d+$/.test(startTicks) ? `win:${startTicks}` : undefined;
+		const startTicks = query(pid);
+		return typeof startTicks === "bigint" && startTicks > 0n ? `win:${startTicks}` : undefined;
 	} catch {
 		return undefined;
 	}
@@ -265,7 +263,12 @@ export function acquireSessionLease(
 			} catch (error) {
 				rmSync(candidateDirectory, { recursive: true, force: true });
 				const code = (error as NodeJS.ErrnoException).code;
-				if (code !== "EEXIST" && code !== "ENOTEMPTY") {
+				const destinationExists = existsSync(directory);
+				if (
+					code !== "EEXIST" &&
+					code !== "ENOTEMPTY" &&
+					!(process.platform === "win32" && code === "EPERM" && destinationExists)
+				) {
 					throw error;
 				}
 				const existingOwner = readLeaseOwner(directory);

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "node:fs";
+import { Writable } from "node:stream";
+import { finished } from "node:stream/promises";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { spawn } from "child_process";
@@ -8,18 +10,29 @@ import { truncateToVisualLines } from "../../modes/interactive/components/visual
 import { theme } from "../../modes/interactive/theme/theme.js";
 import { waitForChildProcess } from "../../utils/child-process.js";
 import {
+	getDirectWindowsBashPath,
 	getShellConfig,
 	getShellEnv,
 	killProcessTree,
 	trackDetachedChildPid,
 	untrackDetachedChildPid,
 } from "../../utils/shell.js";
+import { assignProcessToWindowsDaemonWorkerJob, hasWindowsDaemonWorkerJob } from "../../utils/windows-job-object.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { previewBashCommand } from "./code-preview.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 import { getTextOutput, invalidArgText, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult } from "./truncate.js";
+
+const WINDOWS_JOB_CLEANUP_TIMEOUT_MS = 5000;
+const WINDOWS_JOB_STARTUP_GATE_COMMIT = "start\n";
+const WINDOWS_JOB_GATED_COMMAND = `IFS= read -r _ || exit 125
+exec "$1" -c "$2"`;
+
+function withoutBashStartupEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	return Object.fromEntries(Object.entries(environment).filter(([key]) => key.toUpperCase() !== "BASH_ENV"));
+}
 
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
@@ -67,25 +80,56 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 	return {
 		exec: (command, cwd, { onData, signal, timeout, env }) => {
 			return new Promise((resolve, reject) => {
-				const { shell, args } = getShellConfig(options?.shellPath);
+				if (signal?.aborted) {
+					reject(new Error("aborted"));
+					return;
+				}
+				const { shell: configuredShell, args } = getShellConfig(options?.shellPath);
 				if (!existsSync(cwd)) {
 					reject(new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`));
 					return;
 				}
-				const child = spawn(shell, [...args, command], {
-					cwd,
-					detached: process.platform !== "win32",
-					env: env ?? getShellEnv(),
-					stdio: ["ignore", "pipe", "pipe"],
+				const useWindowsJob = hasWindowsDaemonWorkerJob();
+				const shell = useWindowsJob ? getDirectWindowsBashPath(configuredShell) : configuredShell;
+				const environment = env ?? getShellEnv();
+				const childEnvironment = useWindowsJob ? withoutBashStartupEnvironment(environment) : environment;
+				const child = spawn(
+					shell,
+					useWindowsJob
+						? [...args, WINDOWS_JOB_GATED_COMMAND, "prime-agent-job-gate", shell, command]
+						: [...args, command],
+					{
+						windowsHide: true,
+						cwd,
+						detached: process.platform !== "win32",
+						env: childEnvironment,
+						stdio: useWindowsJob ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+					},
+				);
+				const childExit = waitForChildProcess(child);
+				const terminationErrors: unknown[] = [];
+				let rejectStop!: (reason: Error) => void;
+				const stop = new Promise<never>((_, rejectStopped) => {
+					rejectStop = rejectStopped;
 				});
-				if (child.pid) trackDetachedChildPid(child.pid);
+				const childCompletion = Promise.race([childExit, stop]);
+				let terminationAttempted = false;
+				const terminateChildTree = (reason: string) => {
+					terminationAttempted = true;
+					if (child.pid && child.exitCode === null && child.signalCode === null && !killProcessTree(child.pid)) {
+						terminationErrors.push(new Error(`Could not terminate Bash process tree after ${reason}`));
+					}
+				};
+				let tracked = false;
+				let safeToUntrack = false;
 				let timedOut = false;
 				let timeoutHandle: NodeJS.Timeout | undefined;
 				// Set timeout if provided.
 				if (timeout !== undefined && timeout > 0) {
 					timeoutHandle = setTimeout(() => {
 						timedOut = true;
-						if (child.pid) killProcessTree(child.pid);
+						terminateChildTree("timeout");
+						rejectStop(new Error(`timeout:${timeout}`));
 					}, timeout * 1000);
 				}
 				// Stream stdout and stderr.
@@ -93,35 +137,89 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 				child.stderr?.on("data", onData);
 				// Handle abort signal by killing the entire process tree.
 				const onAbort = () => {
-					if (child.pid) killProcessTree(child.pid);
+					terminateChildTree("abort");
+					rejectStop(new Error("aborted"));
 				};
 				if (signal) {
 					if (signal.aborted) onAbort();
 					else signal.addEventListener("abort", onAbort, { once: true });
 				}
-				// Handle shell spawn errors and wait for the process to terminate without hanging
-				// on inherited stdio handles held by detached descendants.
-				waitForChildProcess(child)
-					.then((code) => {
-						if (child.pid) untrackDetachedChildPid(child.pid);
-						if (timeoutHandle) clearTimeout(timeoutHandle);
-						if (signal) signal.removeEventListener("abort", onAbort);
-						if (signal?.aborted) {
-							reject(new Error("aborted"));
-							return;
+
+				const run = async () => {
+					try {
+						if (child.pid && !useWindowsJob) {
+							trackDetachedChildPid(child.pid);
+							tracked = true;
 						}
-						if (timedOut) {
-							reject(new Error(`timeout:${timeout}`));
-							return;
+						if (signal?.aborted) throw new Error("aborted");
+						if (useWindowsJob) {
+							if (!child.pid) throw new Error("Failed to obtain gated Bash process id");
+							const startupGate = child.stdin;
+							if (!(startupGate instanceof Writable))
+								throw new Error("Failed to create gated Bash startup pipe");
+							assignProcessToWindowsDaemonWorkerJob(child.pid);
+							trackDetachedChildPid(child.pid);
+							tracked = true;
+							startupGate.end(WINDOWS_JOB_STARTUP_GATE_COMMIT);
+							await finished(startupGate);
 						}
+						const code = await childCompletion;
+						safeToUntrack = true;
+						if (signal?.aborted) throw new Error("aborted");
+						if (timedOut) throw new Error(`timeout:${timeout}`);
 						resolve({ exitCode: code });
-					})
-					.catch((err) => {
-						if (child.pid) untrackDetachedChildPid(child.pid);
+					} catch (error) {
+						if (
+							child.exitCode === null &&
+							child.signalCode === null &&
+							(!terminationAttempted || terminationErrors.length > 0)
+						) {
+							terminateChildTree("failed startup or execution");
+						}
+						const cleanupErrors: unknown[] = [...terminationErrors];
+						let cleanupTimer: NodeJS.Timeout | undefined;
+						try {
+							await Promise.race([
+								childExit,
+								new Promise<never>((_, rejectCleanup) => {
+									cleanupTimer = setTimeout(
+										() => rejectCleanup(new Error("Timed out terminating failed gated Bash process")),
+										WINDOWS_JOB_CLEANUP_TIMEOUT_MS,
+									);
+								}),
+							]);
+						} catch (cleanupError) {
+							if (cleanupError !== error) cleanupErrors.push(cleanupError);
+						} finally {
+							if (cleanupTimer) clearTimeout(cleanupTimer);
+						}
+						safeToUntrack = cleanupErrors.length === 0 && (child.exitCode !== null || child.signalCode !== null);
+						const failure = signal?.aborted
+							? new Error("aborted")
+							: timedOut
+								? new Error(`timeout:${timeout}`)
+								: error;
+						const failureMessage = failure instanceof Error ? failure.message : String(failure);
+						const cleanupMessage = cleanupErrors
+							.map((cleanupError) =>
+								cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+							)
+							.join("; ");
+						reject(
+							cleanupErrors.length > 0
+								? new AggregateError(
+										[failure, ...cleanupErrors],
+										`${failureMessage}; Bash process-tree cleanup failed: ${cleanupMessage}`,
+									)
+								: failure,
+						);
+					} finally {
+						if (tracked && child.pid && safeToUntrack) untrackDetachedChildPid(child.pid);
 						if (timeoutHandle) clearTimeout(timeoutHandle);
 						if (signal) signal.removeEventListener("abort", onAbort);
-						reject(err);
-					});
+					}
+				};
+				void run();
 			});
 		},
 	};

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,6 +4,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { IMAGE_MIME_TYPES } from "../../utils/mime.js";
+import { getShellConfig, getWindowsGitBashLauncherPath } from "../../utils/shell.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 import { withKernelBootPermit } from "../kernel/boot-gate.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
@@ -297,19 +298,23 @@ export interface IpythonToolOptions {
 }
 
 function quoteScriptMagicArgument(value: string): string {
-	return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\"'\"'")}'`;
+	if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
+	return process.platform === "win32" ? `"${value.replaceAll('"', '\\"')}"` : `'${value.replace(/'/g, "'\"'\"'")}'`;
 }
 
 function applyShellSettingsToBashMagicCell(
 	code: string,
 	options: Pick<IpythonToolOptions, "commandPrefix" | "shellPath"> | undefined,
 ): string {
-	const commandPrefix = options?.commandPrefix;
-	const shellPath = options?.shellPath?.trim();
-	if (!commandPrefix && !shellPath) return code;
-
 	const bashCell = parseIpythonBashCell(code);
 	if (!bashCell) return code;
+
+	const commandPrefix = options?.commandPrefix;
+	const configuredShellPath = options?.shellPath?.trim();
+	const shellPath =
+		configuredShellPath ||
+		(process.platform === "win32" ? getWindowsGitBashLauncherPath(getShellConfig().shell) : undefined);
+	if (!commandPrefix && !shellPath) return code;
 
 	const firstLine =
 		shellPath && bashCell.magicArguments.trim().length === 0

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -109,6 +109,7 @@ import { shouldRunOnboarding } from "./modes/interactive/onboarding.js";
 import { initTheme, preloadCodeHighlighter, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
 import { handleConfigCommand } from "./package-manager-cli.js";
 import { isLocalPath } from "./utils/paths.js";
+import { initializeWindowsDaemonWorkerJob } from "./utils/windows-job-object.js";
 
 /**
  * Read all content from piped stdin.
@@ -1025,8 +1026,10 @@ export interface MainOptions {
 
 export async function main(args: string[], options?: MainOptions) {
 	resetTimings();
-	if (isDaemonWorkerProcess()) {
+	const daemonWorkerProcess = isDaemonWorkerProcess();
+	if (daemonWorkerProcess) {
 		waitForDaemonWorkerStartupGate();
+		initializeWindowsDaemonWorkerJob();
 	}
 	installFileLogSink();
 	if (isDaemonCatalogProcess()) {
@@ -1293,7 +1296,7 @@ export async function main(args: string[], options?: MainOptions) {
 	// --list-models still takes the full path to print and exit.
 	if (appMode === "daemon" && parsed.listModels === undefined) {
 		printTimings();
-		if (isDaemonWorkerProcess()) {
+		if (daemonWorkerProcess) {
 			await runDaemonMode({
 				socketPath: parsed.daemonSocket,
 				defaultSessionConfig: daemonDefaultSessionConfig,

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -208,7 +208,14 @@ export class CommandRecoveryJournal {
 		renameSync(tempPath, this.path);
 		const directoryDescriptor = openSync(dirname(this.path), "r");
 		try {
-			fsyncSync(directoryDescriptor);
+			try {
+				fsyncSync(directoryDescriptor);
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (code !== "EPERM" && code !== "EINVAL" && code !== "ENOTSUP") {
+					throw error;
+				}
+			}
 		} finally {
 			closeSync(directoryDescriptor);
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -393,6 +393,7 @@ export class DaemonCatalogClient {
 	private async spawnCatalog(): Promise<void> {
 		const launch = createCliSubprocessLaunchSpec(["--version"]);
 		const child = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: process.cwd(),
 			env: createCliSubprocessEnv({ ...process.env, [DAEMON_CATALOG_ROLE_ENV]: "1" }),
 			stdio: ["ignore", "ignore", "ignore", "ipc"],

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -182,6 +182,7 @@ import { DaemonSessionSummarizer } from "./daemon-session-summarizer.js";
 import {
 	cleanupDaemonSocketPath,
 	type DaemonSocketIdentity,
+	defaultDaemonSocketDir,
 	defaultDaemonSocketPath,
 	getDaemonSocketIdentity,
 	prepareDaemonSocketPath,
@@ -756,7 +757,11 @@ export class AgentDaemon {
 		}
 		this.supervisorLaunchInProgress = true;
 		const key = createHash("sha256").update(supervisorSocketPath).digest("hex").slice(0, 12);
-		const lockDirectory = join(dirname(supervisorSocketPath), `.supervisor-launch-${key}.lock`);
+		const lockRoot = process.platform === "win32" ? defaultDaemonSocketDir() : dirname(supervisorSocketPath);
+		if (process.platform === "win32") {
+			mkdirSync(lockRoot, { recursive: true, mode: 0o700 });
+		}
+		const lockDirectory = join(lockRoot, `.supervisor-launch-${key}.lock`);
 		let ownsLock = false;
 		try {
 			for (let attempt = 0; attempt < 3 && !ownsLock; attempt++) {
@@ -773,7 +778,11 @@ export class AgentDaemon {
 				} catch (error) {
 					rmSync(candidateDirectory, { recursive: true, force: true });
 					const code = (error as NodeJS.ErrnoException).code;
-					if (code !== "EEXIST" && code !== "ENOTEMPTY") {
+					const collided =
+						code === "EEXIST" ||
+						code === "ENOTEMPTY" ||
+						(process.platform === "win32" && code === "EPERM" && existsSync(lockDirectory));
+					if (!collided) {
 						throw error;
 					}
 					let ownerPid: number | undefined;
@@ -816,6 +825,7 @@ export class AgentDaemon {
 			delete environment[SESSION_LEASES_ENABLED_ENV];
 			delete environment[SESSION_LEASE_OWNER_ID_ENV];
 			const child = spawn(launch.command, launch.args, {
+				windowsHide: true,
 				cwd: this.options.defaultSessionConfig.cwd ?? process.cwd(),
 				detached: true,
 				env: environment,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -29,6 +29,7 @@ import {
 	SESSION_SCHEDULED_JOBS_FILENAME,
 } from "../../core/cron-jobs.js";
 import {
+	type ActiveOrphanProcess,
 	clearOrphanProcessJournal,
 	isOrphanProcessIdentityCurrent,
 	ORPHAN_PROCESS_JOURNAL_ENV,
@@ -43,7 +44,7 @@ import {
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
-import { signalProcessGroupOrProcess } from "../../utils/child-process.js";
+import { signalProcessGroupOrProcess, signalProcessTree } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
 import type { PrivateFrame } from "../session-worker/private-framing.js";
@@ -2113,6 +2114,7 @@ export class DaemonSupervisor {
 		const launch = createCliSubprocessLaunchSpec(["--mode", "daemon", "--daemon-socket", socketPath]);
 		await this.assertRecoveryAllowed();
 		const child: ChildProcess = spawn(launch.command, launch.args, {
+			windowsHide: true,
 			cwd: createCommand.config?.cwd ?? process.cwd(),
 			detached: true,
 			env: createCliSubprocessEnv({
@@ -2703,6 +2705,26 @@ export class DaemonSupervisor {
 		}
 	}
 
+	private async reapOrphanProcesses(orphanProcesses: readonly ActiveOrphanProcess[]): Promise<boolean> {
+		if (process.platform === "win32") {
+			const deadline = Date.now() + 5000;
+			let remaining = orphanProcesses.filter(isOrphanProcessIdentityCurrent);
+			while (remaining.length > 0 && Date.now() < deadline) {
+				await delay(25);
+				remaining = remaining.filter(isOrphanProcessIdentityCurrent);
+			}
+			return remaining.length === 0;
+		}
+		let complete = true;
+		for (const orphan of orphanProcesses) {
+			if (!isOrphanProcessIdentityCurrent(orphan)) continue;
+			if (!signalProcessTree(orphan.pid, "SIGKILL") && isOrphanProcessIdentityCurrent(orphan)) {
+				complete = false;
+			}
+		}
+		return complete;
+	}
+
 	private async recoverWorker(worker: ResidentWorker): Promise<void> {
 		if (this.isWorkerRecoveryCancelled(worker)) {
 			return;
@@ -2821,29 +2843,26 @@ export class DaemonSupervisor {
 	private async recoverUncertainWorkerOperations(worker: ResidentWorker, killWorkerProcess = true): Promise<void> {
 		await this.assertRecoveryAllowed();
 		if (killWorkerProcess) {
-			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+			const signaled = signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+			if (
+				!signaled &&
+				worker.descriptor.processStartId &&
+				getProcessStartId(worker.descriptor.pid) === worker.descriptor.processStartId
+			) {
+				throw new Error(`Could not terminate session worker ${worker.descriptor.pid}`);
+			}
 		}
 		const orphanProcessJournalPath = worker.descriptor.orphanProcessJournalPath;
 		if (orphanProcessJournalPath) {
 			try {
-				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid)) {
-					if (!isOrphanProcessIdentityCurrent(orphan)) {
-						continue;
-					}
-					const { pid } = orphan;
-					try {
-						process.kill(-pid, "SIGKILL");
-					} catch {
-						try {
-							process.kill(pid, "SIGKILL");
-						} catch {
-							// The detached resource may already have exited.
-						}
-					}
+				const orphanProcesses = readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid);
+				if (!(await this.reapOrphanProcesses(orphanProcesses))) {
+					throw new Error("One or more orphaned process trees could not be terminated");
 				}
 				clearOrphanProcessJournal(orphanProcessJournalPath);
 			} catch (error) {
 				this.log(`Could not reap orphaned worker resources: ${String(error)}`);
+				throw error;
 			}
 		}
 		const journal = new WorkerRecoveryJournal(worker.descriptor.recoveryJournalPath);
@@ -4848,6 +4867,7 @@ export class DaemonSupervisor {
 			delete environment[SESSION_LEASES_ENABLED_ENV];
 			delete environment[SESSION_LEASE_OWNER_ID_ENV];
 			const replacement = spawn(launch.command, launch.args, {
+				windowsHide: true,
 				cwd: this.defaultSessionConfig.cwd ?? process.cwd(),
 				detached: true,
 				env: environment,

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -464,6 +464,7 @@ async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
 		await new Promise<void>((resolve, reject) => {
 			// Windows package managers are commonly .cmd shims. Use the shell so Node can execute them.
 			const child = spawn(step.command, step.args, {
+				windowsHide: true,
 				stdio: "inherit",
 				shell: shouldUseWindowsShell(step.command),
 			});

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -1,8 +1,9 @@
-import type { ChildProcess } from "node:child_process";
+import { type ChildProcess, spawnSync } from "node:child_process";
 import { constants } from "node:os";
 import { basename } from "node:path";
 
 const EXIT_STDIO_GRACE_MS = 100;
+const WINDOWS_TREE_KILL_TIMEOUT_MS = 5000;
 
 const WINDOWS_SHELL_COMMANDS = new Set(["npm", "npx", "pnpm", "yarn", "yarnpkg", "corepack"]);
 
@@ -12,17 +13,37 @@ export function shouldUseWindowsShell(command: string): boolean {
 	return commandName.endsWith(".cmd") || commandName.endsWith(".bat") || WINDOWS_SHELL_COMMANDS.has(commandName);
 }
 
-export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {
+export function signalProcessTree(pid: number, signal: NodeJS.Signals): boolean {
+	if (process.platform === "win32") {
+		const result = spawnSync("taskkill.exe", ["/F", "/T", "/PID", String(pid)], {
+			stdio: "ignore",
+			timeout: WINDOWS_TREE_KILL_TIMEOUT_MS,
+			windowsHide: true,
+		});
+		return !result.error && result.status === 0;
+	}
 	try {
 		process.kill(-pid, signal);
-		return;
+		return true;
 	} catch {
 		// Fall back when process groups are unavailable or the group already exited.
 	}
 	try {
 		process.kill(pid, signal);
+		return true;
 	} catch {
 		// The process may already be fully reaped.
+		return false;
+	}
+}
+
+export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): boolean {
+	if (process.platform !== "win32") return signalProcessTree(pid, signal);
+	try {
+		process.kill(pid, signal);
+		return true;
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -98,6 +98,7 @@ function runCommand(
 		timeout: timeoutMs,
 		maxBuffer: maxBufferBytes,
 		env: options?.env,
+		windowsHide: true,
 	});
 
 	if (result.error) {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -252,6 +252,7 @@ function runGit(cwd: string, args: string[]): string | null {
 	const result = spawnSync("git", ["--no-optional-locks", ...args], {
 		cwd,
 		encoding: "utf8",
+		windowsHide: true,
 		stdio: ["ignore", "pipe", "ignore"],
 	});
 	if (result.status !== 0 || typeof result.stdout !== "string") return null;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -30,6 +30,14 @@ export function getDirectWindowsBashPath(shellPath: string): string {
 	return join(gitRoot, "usr", "bin", "bash.exe");
 }
 
+export function getWindowsGitBashLauncherPath(shellPath: string): string {
+	if (process.platform !== "win32") return shellPath;
+	const gitRoot = gitForWindowsRoot(shellPath);
+	const launcher = gitRoot ? join(gitRoot, "bin", "bash.exe") : undefined;
+	if (!launcher || !existsSync(launcher)) throw new Error("Windows shell execution requires Git for Windows bash.exe");
+	return launcher;
+}
+
 /**
  * Find bash executable on PATH (cross-platform)
  */

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -10,16 +10,24 @@ export interface ShellConfig {
 	args: string[];
 }
 
+function gitForWindowsRoot(shellPath: string): string | undefined {
+	const normalized = shellPath.replaceAll("\\", "/").toLowerCase();
+	const root = normalized.endsWith("/usr/bin/bash.exe")
+		? dirname(dirname(dirname(shellPath)))
+		: normalized.endsWith("/bin/bash.exe")
+			? dirname(dirname(shellPath))
+			: undefined;
+	if (!root || !existsSync(join(root, "cmd", "git.exe")) || !existsSync(join(root, "usr", "bin", "bash.exe"))) {
+		return undefined;
+	}
+	return root;
+}
+
 export function getDirectWindowsBashPath(shellPath: string): string {
 	if (process.platform !== "win32") return shellPath;
-	if (shellPath.replaceAll("\\", "/").toLowerCase().endsWith("/usr/bin/bash.exe") && existsSync(shellPath)) {
-		return shellPath;
-	}
-	const directPath = join(dirname(dirname(shellPath)), "usr", "bin", "bash.exe");
-	if (!existsSync(directPath)) {
-		throw new Error("Windows daemon process isolation requires Git for Windows bash.exe");
-	}
-	return directPath;
+	const gitRoot = gitForWindowsRoot(shellPath);
+	if (!gitRoot) throw new Error("Windows daemon process isolation requires Git for Windows bash.exe");
+	return join(gitRoot, "usr", "bin", "bash.exe");
 }
 
 /**
@@ -29,7 +37,7 @@ function findBashOnPath(): string | null {
 	if (process.platform === "win32") {
 		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
 		try {
-			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000 });
+			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 			if (result.status === 0 && result.stdout) {
 				const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 				if (firstMatch && existsSync(firstMatch)) {
@@ -44,7 +52,7 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000 });
+		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 		if (result.status === 0 && result.stdout) {
 			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 			if (firstMatch) {
@@ -83,6 +91,10 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		const programFilesX86 = process.env["ProgramFiles(x86)"];
 		if (programFilesX86) {
 			paths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
+		}
+		const localAppData = process.env.LOCALAPPDATA;
+		if (localAppData) {
+			paths.push(`${localAppData}\\Programs\\Git\\bin\\bash.exe`);
 		}
 
 		for (const path of paths) {

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,12 +1,25 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
-import { spawn, spawnSync } from "child_process";
+import { delimiter, dirname, join } from "node:path";
+import { spawnSync } from "child_process";
 import { getBinDir } from "../config.js";
 import { recordOrphanProcessState } from "../core/orphan-process-journal.js";
+import { signalProcessTree } from "./child-process.js";
 
 export interface ShellConfig {
 	shell: string;
 	args: string[];
+}
+
+export function getDirectWindowsBashPath(shellPath: string): string {
+	if (process.platform !== "win32") return shellPath;
+	if (shellPath.replaceAll("\\", "/").toLowerCase().endsWith("/usr/bin/bash.exe") && existsSync(shellPath)) {
+		return shellPath;
+	}
+	const directPath = join(dirname(dirname(shellPath)), "usr", "bin", "bash.exe");
+	if (!existsSync(directPath)) {
+		throw new Error("Windows daemon process isolation requires Git for Windows bash.exe");
+	}
+	return directPath;
 }
 
 /**
@@ -187,28 +200,6 @@ export function killTrackedDetachedChildren(): void {
 /**
  * Kill a process and all its children (cross-platform)
  */
-export function killProcessTree(pid: number): void {
-	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
-		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
-				stdio: "ignore",
-				detached: true,
-			});
-		} catch {
-			// Ignore errors if taskkill fails
-		}
-	} else {
-		// Use SIGKILL on Unix/Linux/Mac
-		try {
-			process.kill(-pid, "SIGKILL");
-		} catch {
-			// Fallback to killing just the child if process group kill fails
-			try {
-				process.kill(pid, "SIGKILL");
-			} catch {
-				// Process already dead
-			}
-		}
-	}
+export function killProcessTree(pid: number): boolean {
+	return signalProcessTree(pid, "SIGKILL");
 }

--- a/packages/coding-agent/src/utils/windows-job-object.ts
+++ b/packages/coding-agent/src/utils/windows-job-object.ts
@@ -1,0 +1,149 @@
+import { createRequire } from "node:module";
+import type * as Koffi from "koffi";
+
+const cjsRequire = createRequire(import.meta.url);
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+const DOTNET_FILE_TIME_OFFSET_TICKS = 504911232000000000n;
+
+type NativeHandle = unknown;
+
+type WindowsJobApi = {
+	createJobObject: (securityAttributes: null, name: null) => NativeHandle;
+	setInformationJobObject: (job: NativeHandle, informationClass: number, information: Buffer, size: number) => boolean;
+	openProcess: (access: number, inheritHandle: boolean, pid: number) => NativeHandle;
+	assignProcessToJobObject: (job: NativeHandle, process: NativeHandle) => boolean;
+	getProcessTimes: (
+		process: NativeHandle,
+		creationTime: Buffer,
+		exitTime: Buffer,
+		kernelTime: Buffer,
+		userTime: Buffer,
+	) => boolean;
+	closeHandle: (handle: NativeHandle) => boolean;
+	getLastError: () => number;
+};
+
+let api: WindowsJobApi | undefined;
+let daemonWorkerJob: NativeHandle | undefined;
+
+function windowsJobApi(): WindowsJobApi {
+	if (api) return api;
+	const koffi = cjsRequire("koffi") as typeof Koffi;
+	const kernel32 = koffi.load("kernel32.dll");
+	api = {
+		createJobObject: kernel32.func(
+			"void* __stdcall CreateJobObjectW(void*, void*)",
+		) as WindowsJobApi["createJobObject"],
+		setInformationJobObject: kernel32.func(
+			"bool __stdcall SetInformationJobObject(void*, int, void*, uint32_t)",
+		) as WindowsJobApi["setInformationJobObject"],
+		openProcess: kernel32.func(
+			"void* __stdcall OpenProcess(uint32_t, bool, uint32_t)",
+		) as WindowsJobApi["openProcess"],
+		assignProcessToJobObject: kernel32.func(
+			"bool __stdcall AssignProcessToJobObject(void*, void*)",
+		) as WindowsJobApi["assignProcessToJobObject"],
+		getProcessTimes: kernel32.func(
+			"bool __stdcall GetProcessTimes(void*, void*, void*, void*, void*)",
+		) as WindowsJobApi["getProcessTimes"],
+		closeHandle: kernel32.func("bool __stdcall CloseHandle(void*)") as WindowsJobApi["closeHandle"],
+		getLastError: kernel32.func("uint32_t __stdcall GetLastError()") as WindowsJobApi["getLastError"],
+	};
+	return api;
+}
+
+function win32Failure(operation: string, errorCode: number): Error {
+	return new Error(`${operation} failed with Win32 error ${errorCode}`);
+}
+
+function closeNativeHandle(jobApi: WindowsJobApi, handle: NativeHandle, context: string): void {
+	if (!jobApi.closeHandle(handle)) {
+		throw win32Failure(`CloseHandle (${context})`, jobApi.getLastError());
+	}
+}
+
+function failureWithCleanup(jobApi: WindowsJobApi, handle: NativeHandle, failure: Error, context: string): Error {
+	try {
+		closeNativeHandle(jobApi, handle, context);
+		return failure;
+	} catch (cleanupError) {
+		const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+		return new AggregateError(
+			[failure, cleanupError],
+			`${failure.message}; native handle cleanup failed: ${cleanupMessage}`,
+		);
+	}
+}
+
+export function getWindowsProcessStartTicks(pid: number): bigint | undefined {
+	if (process.platform !== "win32" || !Number.isInteger(pid) || pid <= 0) return undefined;
+	const jobApi = windowsJobApi();
+	const processHandle = jobApi.openProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+	if (!processHandle) return undefined;
+
+	let startTicks: bigint | undefined;
+	try {
+		const creationTime = Buffer.alloc(8);
+		const exitTime = Buffer.alloc(8);
+		if (jobApi.getProcessTimes(processHandle, creationTime, exitTime, Buffer.alloc(8), Buffer.alloc(8))) {
+			const fileTime = (BigInt(creationTime.readUInt32LE(4)) << 32n) | BigInt(creationTime.readUInt32LE(0));
+			if (fileTime > 0n && exitTime.readBigUInt64LE() === 0n) {
+				startTicks = fileTime + DOTNET_FILE_TIME_OFFSET_TICKS;
+			}
+		}
+	} finally {
+		if (!jobApi.closeHandle(processHandle)) startTicks = undefined;
+	}
+	return startTicks;
+}
+
+export function initializeWindowsDaemonWorkerJob(): void {
+	if (process.platform !== "win32") return;
+	if (daemonWorkerJob) return;
+	if (process.arch !== "x64") {
+		throw new Error(`Windows daemon process isolation requires x64, received ${process.arch}`);
+	}
+
+	const jobApi = windowsJobApi();
+	const job = jobApi.createJobObject(null, null);
+	if (!job) {
+		throw win32Failure("CreateJobObjectW", jobApi.getLastError());
+	}
+
+	// ponytail: x64-only layout matches the supported Windows target; use Koffi structs when adding other architectures.
+	const information = Buffer.alloc(144);
+	information.writeUInt32LE(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, 16);
+	if (!jobApi.setInformationJobObject(job, JOB_OBJECT_EXTENDED_LIMIT_INFORMATION, information, information.length)) {
+		const failure = win32Failure("SetInformationJobObject", jobApi.getLastError());
+		throw failureWithCleanup(jobApi, job, failure, "Job Object initialization");
+	}
+	daemonWorkerJob = job;
+}
+
+export function hasWindowsDaemonWorkerJob(): boolean {
+	return daemonWorkerJob !== undefined;
+}
+
+export function assignProcessToWindowsDaemonWorkerJob(pid: number): void {
+	if (!daemonWorkerJob) {
+		throw new Error("Windows daemon worker Job Object is not initialized");
+	}
+	if (!Number.isInteger(pid) || pid <= 0) {
+		throw new Error(`Cannot assign invalid process id ${pid} to Windows daemon worker Job Object`);
+	}
+
+	const jobApi = windowsJobApi();
+	const processHandle = jobApi.openProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid);
+	if (!processHandle) {
+		throw win32Failure("OpenProcess", jobApi.getLastError());
+	}
+	if (!jobApi.assignProcessToJobObject(daemonWorkerJob, processHandle)) {
+		const failure = win32Failure("AssignProcessToJobObject", jobApi.getLastError());
+		throw failureWithCleanup(jobApi, processHandle, failure, "process assignment");
+	}
+	closeNativeHandle(jobApi, processHandle, "process assignment");
+}

--- a/packages/coding-agent/test/bash-close-hang-windows.test.ts
+++ b/packages/coding-agent/test/bash-close-hang-windows.test.ts
@@ -33,7 +33,7 @@ function cleanupDetachedChild(pidFile: string): void {
 	const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
 	if (Number.isFinite(pid) && pid > 0) {
 		try {
-			execFileSync("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore" });
+			execFileSync("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", timeout: 5000 });
 		} catch {
 			// Process may have already exited.
 		}
@@ -79,6 +79,18 @@ describe.skipIf(process.platform !== "win32")("Windows child-process close handl
 
 	afterEach(() => {
 		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("rejects an already-aborted command without spawning Bash", async () => {
+		const marker = join(testDir, "already-aborted-ran");
+		const command = `node -e "require('fs').writeFileSync(process.argv[1], 'ran')" ${toBashSingleQuotedArg(marker)}`;
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			createLocalBashOperations().exec(command, testDir, { onData: () => {}, signal: controller.signal }),
+		).rejects.toThrow("aborted");
+		expect(existsSync(marker)).toBe(false);
 	});
 
 	it("executeBash resolves after the shell exits even if inherited stdio handles stay open", async () => {

--- a/packages/coding-agent/test/clipboard-image.test.ts
+++ b/packages/coding-agent/test/clipboard-image.test.ts
@@ -125,7 +125,8 @@ describe("readClipboardImage", () => {
 			}
 
 			if (command === "powershell.exe") {
-				const spawnOptions = options as { env?: NodeJS.ProcessEnv };
+				const spawnOptions = options as { env?: NodeJS.ProcessEnv; windowsHide?: boolean };
+				expect(spawnOptions.windowsHide).toBe(true);
 				expect(spawnOptions.env?.PI_WSL_CLIPBOARD_IMAGE_PATH).toBeUndefined();
 				expect(args[2]).toContain("$path = 'C:\\Users\\O''Hare\\clip.png'");
 				if (!tmpFile) {

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	ensureInteractiveDaemonRunning,
@@ -34,13 +34,17 @@ interface FakeDaemon {
 	close: () => Promise<void>;
 }
 
+function testSocketPath(directory: string): string {
+	return process.platform === "win32" ? `\\\\.\\pipe\\${basename(directory)}` : join(directory, "d.sock");
+}
+
 function send(socket: Socket, message: unknown): void {
 	socket.write(`${JSON.stringify(message)}\n`);
 }
 
 async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-"));
-	const socketPath = join(dir, "d.sock");
+	const socketPath = testSocketPath(dir);
 	const server: Server = createServer((socket) => {
 		socket.on("error", () => undefined);
 		send(socket, {
@@ -109,7 +113,7 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 
 async function startCrashingDaemon(): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-crash-"));
-	const socketPath = join(dir, "d.sock");
+	const socketPath = testSocketPath(dir);
 	const child = spawn(
 		process.execPath,
 		[
@@ -276,7 +280,7 @@ describe("ensureInteractiveDaemonRunning", () => {
 	it("fails fast with the daemon log tail when the spawned daemon exits during startup", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-startup-crash-"));
 		const entrypoint = join(dir, "crash.mjs");
-		const socketPath = join(dir, "d.sock");
+		const socketPath = testSocketPath(dir);
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 		const logPath = getDaemonLogPath(socketPath);
@@ -303,7 +307,7 @@ describe("ensureInteractiveDaemonRunning", () => {
 	it("names the missing daemon log when the daemon crashes before logging", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-startup-silent-"));
 		const entrypoint = join(dir, "crash.mjs");
-		const socketPath = join(dir, "d.sock");
+		const socketPath = testSocketPath(dir);
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 		writeFileSync(entrypoint, "process.exit(7);");
@@ -324,7 +328,7 @@ describe("ensureInteractiveDaemonRunning", () => {
 
 	it("surfaces a spawn error when the child never emits exit", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-spawn-error-"));
-		const socketPath = join(dir, "d.sock");
+		const socketPath = testSocketPath(dir);
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 
@@ -342,7 +346,7 @@ describe("ensureInteractiveDaemonRunning", () => {
 	it("succeeds when the spawned child loses the race to an already-serving daemon", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-startup-race-"));
 		const entrypoint = join(dir, "loser.mjs");
-		const socketPath = join(dir, "d.sock");
+		const socketPath = testSocketPath(dir);
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 		writeFileSync(entrypoint, "process.exit(7);");
@@ -380,7 +384,7 @@ describe("ensureInteractiveDaemonRunning", () => {
 	it("does not attribute a previous run's log to a daemon that crashed before logging", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-startup-stale-"));
 		const entrypoint = join(dir, "crash.mjs");
-		const socketPath = join(dir, "d.sock");
+		const socketPath = testSocketPath(dir);
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 		const logPath = getDaemonLogPath(socketPath);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -44,6 +44,10 @@ import {
 } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
+
+function testSocketPath(directory: string, name: string): string {
+	return process.platform === "win32" ? `\\\\.\\pipe\\${basename(directory)}-${name}` : join(directory, name);
+}
 
 describe("daemon mode helpers", () => {
 	it("preserves envelope client identity while registering prompt admission", () => {
@@ -491,7 +495,7 @@ describe("daemon mode helpers", () => {
 			const realDir = join(tempDir, "real");
 			const aliasDir = join(tempDir, "alias");
 			mkdirSync(realDir);
-			symlinkSync(realDir, aliasDir, "dir");
+			symlinkSync(realDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
 			const parentPath = join(realDir, "parent.jsonl");
 			writeFileSync(parentPath, "");
 			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
@@ -1478,7 +1482,7 @@ describe("daemon mode helpers", () => {
 
 	it("does not retry supervisor agent-message rejections", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-msg-"));
-		const socketPath = join(tempDir, "d.sock");
+		const socketPath = testSocketPath(tempDir, "d.sock");
 		let connectionCount = 0;
 		const server: Server = createServer((socket) => {
 			connectionCount++;
@@ -1553,7 +1557,7 @@ describe("daemon mode helpers", () => {
 
 	it("routes worker-local session renames through the supervisor", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-worker-rename-"));
-		const socketPath = join(tempDir, "s");
+		const socketPath = testSocketPath(tempDir, "s");
 		let receivedCommand: Record<string, unknown> | undefined;
 		let releaseResponse: () => void = () => {};
 		const responseGate = new Promise<void>((resolve) => {
@@ -1634,7 +1638,7 @@ describe("daemon mode helpers", () => {
 
 	it("does not retry permanent ambiguity errors from the supervisor", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-ambiguous-"));
-		const socketPath = join(tempDir, "s");
+		const socketPath = testSocketPath(tempDir, "s");
 		let requestCount = 0;
 		const server = createServer((socket) => {
 			socket.write(
@@ -2471,7 +2475,7 @@ describe("daemon mode helpers", () => {
 			const realDir = join(tempDir, "real");
 			const aliasDir = join(tempDir, "alias");
 			mkdirSync(realDir);
-			symlinkSync(realDir, aliasDir, "dir");
+			symlinkSync(realDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
 			const daemon = new AgentDaemon("/tmp/prime-agent-family-paths.sock", {
 				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
 				createRuntime: vi.fn(),

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -3,12 +3,14 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR, getCronJobsPath } from "../src/config.js";
 import { AgentCronJobStore } from "../src/core/cron-jobs.js";
 import { readActiveOrphanProcesses } from "../src/core/orphan-process-journal.js";
 import {
 	acquireSessionLease,
+	getProcessStartId,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "../src/core/session-lease.js";
@@ -17,9 +19,11 @@ import { DaemonAgentConnection } from "../src/modes/agent-connection/daemon-agen
 import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
+import { signalProcessGroupOrProcess } from "../src/utils/child-process.js";
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
-const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
+const tsxPreflightPath = resolve(__dirname, "../../../node_modules/tsx/dist/preflight.cjs");
+const tsxLoaderUrl = pathToFileURL(resolve(__dirname, "../../../node_modules/tsx/dist/loader.mjs")).href;
 const blockingProcessPath = resolve(__dirname, "fixtures/blocking-process.mjs");
 const tempDirs: string[] = [];
 const children = new Set<ChildProcess>();
@@ -41,31 +45,39 @@ afterEach(async () => {
 		}
 	}
 	daemonSockets.clear();
-	for (const child of children) {
+	const trackedChildren = [...children];
+	for (const child of trackedChildren) {
 		if (child.exitCode === null && child.signalCode === null) {
 			child.kill("SIGTERM");
 		}
 	}
+	await Promise.all(trackedChildren.map((child) => waitForExit(child)));
 	children.clear();
-	for (const pid of workerPids) {
+	const trackedWorkerPids = [...workerPids];
+	for (const pid of trackedWorkerPids) {
 		try {
 			process.kill(pid, "SIGCONT");
 		} catch {
 			// Already gone.
 		}
-		try {
-			process.kill(-pid, "SIGTERM");
-		} catch {
-			try {
-				process.kill(pid, "SIGTERM");
-			} catch {
-				// Already gone.
-			}
-		}
+		signalProcessGroupOrProcess(pid, "SIGTERM");
 	}
+	await Promise.all(trackedWorkerPids.map((pid) => waitForProcessGone(pid)));
 	workerPids.clear();
 	for (const directory of tempDirs.splice(0)) {
-		rmSync(directory, { recursive: true, force: true });
+		const deadline = Date.now() + 5000;
+		while (true) {
+			try {
+				rmSync(directory, { recursive: true, force: true });
+				break;
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (process.platform !== "win32" || (code !== "EPERM" && code !== "ENOTEMPTY") || Date.now() >= deadline) {
+					throw error;
+				}
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+			}
+		}
 	}
 });
 
@@ -73,6 +85,11 @@ function tempDir(): string {
 	const directory = mkdtempSync(join(tmpdir(), "prime-daemon-supervisor-test-"));
 	tempDirs.push(directory);
 	return directory;
+}
+
+function testSocketPath(prefix: string): string {
+	const name = `${prefix}-${process.pid}-${randomUUID().slice(0, 8)}`;
+	return process.platform === "win32" ? `\\\\.\\pipe\\${name}` : join(tmpdir(), `${name}.sock`);
 }
 
 function spawnSupervisor(
@@ -84,7 +101,19 @@ function spawnSupervisor(
 	daemonSockets.add(socketPath);
 	const child = spawn(
 		process.execPath,
-		[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", socketPath, "--offline", ...extraArgs],
+		[
+			"--require",
+			tsxPreflightPath,
+			"--import",
+			tsxLoaderUrl,
+			cliPath,
+			"--mode",
+			"daemon",
+			"--daemon-socket",
+			socketPath,
+			"--offline",
+			...extraArgs,
+		],
 		{
 			cwd,
 			env: {
@@ -189,6 +218,9 @@ async function connectEventually(socketPath: string, child?: ChildProcess): Prom
 		try {
 			await client.connect(250);
 			await client.waitForHello(1000);
+			if (child && client.hello?.supervisorPid !== child.pid) {
+				throw new Error(`Supervisor hello pid ${client.hello?.supervisorPid} did not match child pid ${child.pid}`);
+			}
 			return client;
 		} catch (error) {
 			lastError = error;
@@ -246,11 +278,15 @@ async function waitForExit(child: ChildProcess): Promise<void> {
 	});
 }
 
-async function waitForProcessGone(pid: number): Promise<void> {
+async function waitForProcessGone(pid: number, processStartId?: string): Promise<void> {
 	const deadline = Date.now() + 10_000;
 	while (Date.now() < deadline) {
 		try {
 			process.kill(pid, 0);
+			const observedProcessStartId = processStartId ? getProcessStartId(pid) : undefined;
+			if (observedProcessStartId && observedProcessStartId !== processStartId) {
+				return;
+			}
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "ESRCH") {
 				return;
@@ -291,7 +327,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-passive-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-passive");
 		mkdirSync(projectDir, { recursive: true });
 
 		const parentManager = SessionManager.create(projectDir, sessionDir);
@@ -404,7 +440,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-owned-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-owned");
 		mkdirSync(projectDir, { recursive: true });
 		const sessionManager = SessionManager.create(projectDir, sessionDir);
 		sessionManager.appendMessage({ role: "user", content: "owned worker fixture", timestamp: 1 });
@@ -502,7 +538,7 @@ describe("daemon supervisor resident workers", () => {
 		const root = tempDir();
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
-		const socketPath = join(tmpdir(), `prime-supervisor-owned-adopt-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-owned-adopt");
 		mkdirSync(projectDir, { recursive: true });
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
@@ -551,10 +587,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(
-			tmpdir(),
-			`prime-supervisor-root-message-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
-		);
+		const socketPath = testSocketPath("prime-supervisor-root-message");
 		mkdirSync(projectDir, { recursive: true });
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
@@ -601,10 +634,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(
-			tmpdir(),
-			`prime-supervisor-archived-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
-		);
+		const socketPath = testSocketPath("prime-supervisor-archived-cron");
 		mkdirSync(projectDir, { recursive: true });
 		const sessionManager = SessionManager.create(projectDir, sessionDir);
 		sessionManager.appendMessage({ role: "user", content: "do not revive me", timestamp: 1 });
@@ -657,10 +687,7 @@ describe("daemon supervisor resident workers", () => {
 			const agentDir = join(root, "agent");
 			const projectDir = join(root, "project");
 			const sessionDir = join(agentDir, "sessions");
-			const socketPath = join(
-				tmpdir(),
-				`prime-supervisor-orphan-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
-			);
+			const socketPath = testSocketPath("prime-supervisor-orphan-cron");
 			mkdirSync(projectDir, { recursive: true });
 			const sessionManager = SessionManager.create(projectDir, sessionDir);
 			sessionManager.appendMessage({ role: "user", content: "old scheduled work", timestamp: 1 });
@@ -709,7 +736,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(root, "custom-sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-restart-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-restart");
 		mkdirSync(projectDir, { recursive: true });
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir, ["--session-dir", sessionDir, "--no-tools"]);
@@ -736,7 +763,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const missingCwd = join(root, "missing-project");
-		const socketPath = join(tmpdir(), `prime-supervisor-spawn-error-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-spawn-error");
 		mkdirSync(projectDir, { recursive: true });
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
@@ -762,7 +789,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-shutdown-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-shutdown");
 		mkdirSync(projectDir, { recursive: true });
 		const sessionManager = SessionManager.create(projectDir, sessionDir);
 		sessionManager.appendMessage({ role: "user", content: "stop with daemon", timestamp: 1 });
@@ -835,10 +862,7 @@ describe("daemon supervisor resident workers", () => {
 			const agentDir = join(root, "agent");
 			const projectDir = join(root, "project");
 			const sessionDir = join(agentDir, "sessions");
-			const socketPath = join(
-				tmpdir(),
-				`prime-supervisor-stop-race-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
-			);
+			const socketPath = testSocketPath("prime-supervisor-stop-race");
 			mkdirSync(projectDir, { recursive: true });
 			const sessionManager = SessionManager.create(projectDir, sessionDir);
 			sessionManager.appendMessage({ role: "user", content: "stop me", timestamp: 1 });
@@ -921,7 +945,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-smoke-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor-smoke");
 		mkdirSync(projectDir, { recursive: true });
 		const sessionFiles = Array.from({ length: 2 }, (_, index) => {
 			const manager = SessionManager.create(projectDir, sessionDir);
@@ -995,10 +1019,7 @@ describe("daemon supervisor resident workers", () => {
 			const agentDir = join(root, "agent");
 			const projectDir = join(root, "project");
 			const sessionDir = join(agentDir, "sessions");
-			const socketPath = join(
-				tmpdir(),
-				`prime-supervisor-many-roots-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
-			);
+			const socketPath = testSocketPath("prime-supervisor-many-roots");
 			mkdirSync(projectDir, { recursive: true });
 			const sessionFiles = Array.from({ length: PROCESS_STRESS_WORKERS }, (_, index) => {
 				const manager = SessionManager.create(projectDir, sessionDir);
@@ -1133,7 +1154,7 @@ describe("daemon supervisor resident workers", () => {
 		const agentDir = join(root, "agent");
 		const projectDir = join(root, "project");
 		const sessionDir = join(agentDir, "sessions");
-		const socketPath = join(tmpdir(), `prime-supervisor-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		const socketPath = testSocketPath("prime-supervisor");
 		mkdirSync(projectDir, { recursive: true });
 		const sessionManager = SessionManager.create(projectDir, sessionDir);
 		const largePrompt = `large:${"x".repeat(600 * 1024)}`;
@@ -1251,7 +1272,13 @@ describe("daemon supervisor resident workers", () => {
 		});
 
 		const descriptor = readWorkerDescriptor(agentDir);
-		await startBlockingBash(client, activeSessionId, join(root, "orphan-blocker.ready"));
+		const blockerReadyPath = join(root, "orphan-blocker.ready");
+		await startBlockingBash(client, activeSessionId, blockerReadyPath);
+		const blockerPid = Number(readFileSync(blockerReadyPath, "utf8").trim());
+		if (Number.isInteger(blockerPid) && blockerPid > 0) workerPids.add(blockerPid);
+		expect(blockerPid).toBeGreaterThan(0);
+		const blockerProcessStartId = getProcessStartId(blockerPid);
+		expect(blockerProcessStartId).toBeTruthy();
 		if (!descriptor.orphanProcessJournalPath) {
 			throw new Error("Resident worker did not persist its orphan-process journal path");
 		}
@@ -1276,6 +1303,14 @@ describe("daemon supervisor resident workers", () => {
 		for (const pid of orphanPids) {
 			workerPids.delete(pid);
 		}
+		try {
+			await waitForProcessGone(blockerPid, blockerProcessStartId);
+		} catch (error) {
+			throw new Error(
+				`${String(error)}; worker=${createdSummary.workerPid}; orphanRoots=${orphanPids.join(",")}\n${readDaemonLogs(agentDir)}`,
+			);
+		}
+		workerPids.delete(blockerPid);
 
 		let recovered: SessionSummary | undefined;
 		const recoveryDeadline = Date.now() + 20_000;
@@ -1316,7 +1351,7 @@ describe("daemon supervisor resident workers", () => {
 			const agentDir = join(root, "agent");
 			const projectDir = join(root, "project");
 			const sessionDir = join(agentDir, "sessions");
-			const socketPath = join(tmpdir(), `prime-worker-cron-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+			const socketPath = testSocketPath("prime-worker-cron");
 			mkdirSync(projectDir, { recursive: true });
 			const sessionManager = SessionManager.create(projectDir, sessionDir);
 			sessionManager.appendMessage({ role: "user", content: "scheduled work", timestamp: 1 });

--- a/packages/coding-agent/test/edit-summary.test.ts
+++ b/packages/coding-agent/test/edit-summary.test.ts
@@ -113,7 +113,7 @@ describe("edit summaries", () => {
 			const file = join(realCwd, "same.ts");
 			mkdirSync(realCwd);
 			writeFileSync(file, "old");
-			symlinkSync(realCwd, linkedCwd, "dir");
+			symlinkSync(realCwd, linkedCwd, process.platform === "win32" ? "junction" : "dir");
 
 			const message = assistant([
 				{ type: "toolCall", id: "one", name: "ipython", arguments: {} },

--- a/packages/coding-agent/test/fixtures/blocking-process-tree.mjs
+++ b/packages/coding-agent/test/fixtures/blocking-process-tree.mjs
@@ -1,0 +1,4 @@
+import { writeFileSync } from "node:fs";
+
+writeFileSync(process.argv[2], JSON.stringify({ pid: process.pid, parentPid: process.ppid }));
+setInterval(() => {}, 1000);

--- a/packages/coding-agent/test/fixtures/windows-job-worker.ts
+++ b/packages/coding-agent/test/fixtures/windows-job-worker.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+import { createLocalBashOperations } from "../../src/core/tools/bash.js";
+import { initializeWindowsDaemonWorkerJob } from "../../src/utils/windows-job-object.js";
+
+const [mode, cwd, markerPath, shellPath] = process.argv.slice(2);
+if (!mode || !cwd || !markerPath || !shellPath) {
+	throw new Error("Expected mode, cwd, marker path, and shell path");
+}
+if (mode === "job") {
+	initializeWindowsDaemonWorkerJob();
+} else if (mode !== "control") {
+	throw new Error(`Unknown mode: ${mode}`);
+}
+
+const quote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`;
+const blocker = resolve(import.meta.dirname, "blocking-process-tree.mjs");
+const command = [process.execPath, blocker, markerPath].map(quote).join(" ");
+await createLocalBashOperations({ shellPath }).exec(command, cwd, { onData: () => {} });

--- a/packages/coding-agent/test/git-context-windows.test.ts
+++ b/packages/coding-agent/test/git-context-windows.test.ts
@@ -1,0 +1,17 @@
+import type { SpawnSyncReturns } from "node:child_process";
+import { expect, it, vi } from "vitest";
+
+const spawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ spawnSync }));
+
+it("hides Git metadata subprocess windows", async () => {
+	spawnSync.mockReturnValue({ status: 1, stdout: "" } as unknown as SpawnSyncReturns<string>);
+	const { captureGitContext } = await import("../src/utils/git.js");
+
+	expect(captureGitContext("C:\\repo")).toBeNull();
+	expect(spawnSync).toHaveBeenCalledTimes(3);
+	for (const call of spawnSync.mock.calls) {
+		expect(call[2]).toEqual(expect.objectContaining({ windowsHide: true }));
+	}
+});

--- a/packages/coding-agent/test/herdr-agent-state.test.ts
+++ b/packages/coding-agent/test/herdr-agent-state.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	createHerdrAgentStateExtension,
@@ -13,6 +13,10 @@ import type { ExtensionAPI } from "../src/core/extensions/types.js";
 interface RecordedRequest {
 	method: string;
 	params: Record<string, unknown>;
+}
+
+function testSocketPath(directory: string): string {
+	return process.platform === "win32" ? `\\\\.\\pipe\\herdr-${basename(directory)}` : join(directory, "h.sock");
 }
 
 function createMockPi() {
@@ -183,7 +187,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -222,7 +226,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -281,7 +285,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -305,7 +309,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -337,7 +341,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -380,7 +384,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -419,7 +423,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -452,7 +456,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);
@@ -483,7 +487,7 @@ describe("herdrAgentStateExtension", () => {
 		const tempDir = join(tmpdir(), `hrd-${Math.random().toString(36).slice(2, 8)}`);
 		mkdirSync(tempDir, { recursive: true });
 		cleanupPaths.push(tempDir);
-		const socketPath = join(tempDir, "h.sock");
+		const socketPath = testSocketPath(tempDir);
 
 		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
 		cleanupServers.push(server);

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -7,6 +7,7 @@ import type { ExtensionContext } from "../src/core/extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../src/core/kernel/bootstrap.js";
 import { type ExecuteResult, KernelBusyAfterInterruptError, KernelManager } from "../src/core/kernel/index.js";
 import { createIpythonToolDefinition, IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+import * as shellModule from "../src/utils/shell.js";
 
 let tempDir = "";
 
@@ -261,6 +262,43 @@ describe("IpythonKernelProvisioner", () => {
 			"\n \r\n\t%%script /custom/bash\r\nexport TEST_PREFIX=1\necho body",
 			expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
 		);
+	});
+
+	it.runIf(process.platform === "win32")("uses the Git for Windows launcher for bare bash cells", async () => {
+		const execute = vi.fn<KernelManager["execute"]>().mockResolvedValueOnce(okExecuteResult());
+		const manager = { execute } as unknown as KernelManager;
+		const provisioner = {
+			ensure: vi.fn(async () => manager),
+			kill: vi.fn(async () => {}),
+		} as unknown as IpythonKernelProvisioner;
+		const tool = createIpythonToolDefinition(tempDir, { provisioner, shellPath: "   " });
+
+		await tool.execute("tool-call", { code: "%%bash\ncygpath -w /" }, undefined, undefined, {} as ExtensionContext);
+
+		expect(execute).toHaveBeenCalledWith(
+			`%%script "${shellModule.getShellConfig().shell}"\ncygpath -w /`,
+			expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
+		);
+	});
+
+	it.runIf(process.platform === "win32")("does not resolve Bash for Python cells", async () => {
+		const execute = vi.fn<KernelManager["execute"]>().mockResolvedValueOnce(okExecuteResult());
+		const manager = { execute } as unknown as KernelManager;
+		const provisioner = {
+			ensure: vi.fn(async () => manager),
+			kill: vi.fn(async () => {}),
+		} as unknown as IpythonKernelProvisioner;
+		const getShellConfig = vi.spyOn(shellModule, "getShellConfig");
+		const tool = createIpythonToolDefinition(tempDir, { provisioner });
+
+		await tool.execute("tool-call", { code: "value = 42" }, undefined, undefined, {} as ExtensionContext);
+
+		expect(getShellConfig).not.toHaveBeenCalled();
+		expect(execute).toHaveBeenCalledWith(
+			"value = 42",
+			expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
+		);
+		getShellConfig.mockRestore();
 	});
 
 	it("lets the user wait when an interrupted kernel is still busy", async () => {

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -9,11 +9,13 @@ import { KernelManager } from "../src/core/kernel/index.js";
 function resolveKernelPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+		process.platform === "win32"
+			? join(homedir(), ".prime", "agent", "kernel-venv", "Scripts", "python.exe")
+			: join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
 		if (!existsSync(python)) continue;
-		const check = spawnSync(python, ["-c", "import ipykernel, dill"], { encoding: "utf8" });
+		const check = spawnSync(python, ["-c", "import ipykernel, dill"], { encoding: "utf8", windowsHide: true });
 		if (check.status === 0) return python;
 	}
 	return null;

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -190,20 +190,24 @@ Content`,
 
 				mkdirSync(join(agentDir), { recursive: true });
 				mkdirSync(join(tempDir, ".prime", "agent"), { recursive: true });
-				symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), "dir");
-				symlinkSync(sharedSkillsDir, join(agentDir, "skills"), "dir");
-				symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), "dir");
-				symlinkSync(sharedThemesDir, join(agentDir, "themes"), "dir");
-				symlinkSync(sharedExtensionsDir, join(tempDir, ".prime", "agent", "extensions"), "dir");
-				symlinkSync(sharedSkillsDir, join(tempDir, ".prime", "agent", "skills"), "dir");
-				symlinkSync(sharedPromptsDir, join(tempDir, ".prime", "agent", "prompts"), "dir");
-				symlinkSync(sharedThemesDir, join(tempDir, ".prime", "agent", "themes"), "dir");
+				const linkType = process.platform === "win32" ? "junction" : "dir";
+				symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), linkType);
+				symlinkSync(sharedSkillsDir, join(agentDir, "skills"), linkType);
+				symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), linkType);
+				symlinkSync(sharedThemesDir, join(agentDir, "themes"), linkType);
+				symlinkSync(sharedExtensionsDir, join(tempDir, ".prime", "agent", "extensions"), linkType);
+				symlinkSync(sharedSkillsDir, join(tempDir, ".prime", "agent", "skills"), linkType);
+				symlinkSync(sharedPromptsDir, join(tempDir, ".prime", "agent", "prompts"), linkType);
+				symlinkSync(sharedThemesDir, join(tempDir, ".prime", "agent", "themes"), linkType);
 
 				const result = await packageManager.resolve();
+				const sharedSkills = result.skills.filter((resource) =>
+					pathEndsWith(resource.path, join("shared-skill", "SKILL.md")),
+				);
 
 				expect({
 					extensions: result.extensions.length,
-					skills: result.skills.length,
+					skills: sharedSkills.length,
 					prompts: result.prompts.length,
 					themes: result.themes.length,
 				}).toEqual({
@@ -216,7 +220,7 @@ Content`,
 				// Project auto-discovered has higher precedence than user auto-discovered,
 				// so the surviving entry should be scoped to project.
 				expect(result.extensions[0].metadata.scope).toBe("project");
-				expect(result.skills[0].metadata.scope).toBe("project");
+				expect(sharedSkills[0]?.metadata.scope).toBe("project");
 				expect(result.prompts[0].metadata.scope).toBe("project");
 				expect(result.themes[0].metadata.scope).toBe("project");
 			} finally {

--- a/packages/coding-agent/test/paths.test.ts
+++ b/packages/coding-agent/test/paths.test.ts
@@ -26,7 +26,7 @@ describe("canonicalizePath", () => {
 		expect(canonicalizePath(file)).toBe(realpathSync(file));
 	});
 
-	it("resolves symlinks to their targets", () => {
+	it.skipIf(process.platform === "win32")("resolves file symlinks to their targets", () => {
 		const dir = createTempDir();
 		const target = join(dir, "target.txt");
 		const link = join(dir, "link.txt");
@@ -40,7 +40,7 @@ describe("canonicalizePath", () => {
 		const targetDir = join(dir, "target-dir");
 		const linkDir = join(dir, "link-dir");
 		mkdirSync(targetDir);
-		symlinkSync(targetDir, linkDir, "dir");
+		symlinkSync(targetDir, linkDir, process.platform === "win32" ? "junction" : "dir");
 		expect(canonicalizePath(linkDir)).toBe(realpathSync(targetDir));
 	});
 
@@ -50,7 +50,7 @@ describe("canonicalizePath", () => {
 		expect(canonicalizePath(nonexistent)).toBe(nonexistent);
 	});
 
-	it("falls back to the raw path for a dangling symlink", () => {
+	it.skipIf(process.platform === "win32")("falls back to the raw path for a dangling file symlink", () => {
 		const dir = createTempDir();
 		const target = join(dir, "target.txt");
 		const link = join(dir, "link.txt");

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -179,8 +179,9 @@ Project skill`,
 
 			mkdirSync(agentDir, { recursive: true });
 			mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
-			symlinkSync(sharedExtDir, join(agentDir, "extensions"), "dir");
-			symlinkSync(sharedExtDir, join(cwd, ".prime", "agent", "extensions"), "dir");
+			const linkType = process.platform === "win32" ? "junction" : "dir";
+			symlinkSync(sharedExtDir, join(agentDir, "extensions"), linkType);
+			symlinkSync(sharedExtDir, join(cwd, ".prime", "agent", "extensions"), linkType);
 
 			const loader = new DefaultResourceLoader({ cwd, agentDir });
 			await loader.reload();

--- a/packages/coding-agent/test/session-lease.test.ts
+++ b/packages/coding-agent/test/session-lease.test.ts
@@ -1,7 +1,11 @@
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import type * as Koffi from "koffi";
 import { lockSync } from "proper-lockfile";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -27,6 +31,22 @@ function createTempDir(): string {
 	return directory;
 }
 
+function retainWindowsProcessHandle(pid: number): () => void {
+	const koffi = createRequire(import.meta.url)("koffi") as typeof Koffi;
+	const kernel32 = koffi.load("kernel32.dll");
+	const openProcess = kernel32.func("void* __stdcall OpenProcess(uint32_t, bool, uint32_t)") as (
+		access: number,
+		inheritHandle: boolean,
+		processId: number,
+	) => unknown;
+	const closeHandle = kernel32.func("bool __stdcall CloseHandle(void*)") as (handle: unknown) => boolean;
+	const handle = openProcess(0x1000, false, pid);
+	if (!handle) throw new Error(`Could not retain process ${pid} for test`);
+	return () => {
+		if (!closeHandle(handle)) throw new Error(`Could not close retained process ${pid}`);
+	};
+}
+
 function enabledEnvironment(owner: string): NodeJS.ProcessEnv {
 	return {
 		[SESSION_LEASES_ENABLED_ENV]: "1",
@@ -35,39 +55,46 @@ function enabledEnvironment(owner: string): NodeJS.ProcessEnv {
 }
 
 describe("session leases", () => {
-	it("reads an invariant process start identity on Windows", () => {
-		const calls: Array<{ command: string; args: string[] }> = [];
-		const processStartId = getWindowsProcessStartId(42, (command, args) => {
-			calls.push({ command, args });
-			return "638880485801234567\r\n";
+	it("reads a Windows process start identity without launching a shell", () => {
+		const queriedPids: number[] = [];
+		const processStartId = getWindowsProcessStartId(42, (pid) => {
+			queriedPids.push(pid);
+			return 638880485801234567n;
 		});
 
 		expect(processStartId).toBe("win:638880485801234567");
-		expect(calls).toEqual([
-			{
-				command: "powershell.exe",
-				args: [
-					"-NoLogo",
-					"-NoProfile",
-					"-NonInteractive",
-					"-Command",
-					"([System.Diagnostics.Process]::GetProcessById(42)).StartTime.ToUniversalTime().Ticks",
-				],
-			},
-		]);
+		expect(queriedPids).toEqual([42]);
 	});
 
-	it("rejects invalid Windows process start identities", () => {
+	it("rejects unavailable and invalid Windows process start identities", () => {
 		let queryCount = 0;
 		const query = () => {
 			queryCount++;
-			return "not-a-start-time";
+			return undefined;
 		};
 
 		expect(getWindowsProcessStartId(42, query)).toBeUndefined();
 		expect(getWindowsProcessStartId(0, query)).toBeUndefined();
 		expect(queryCount).toBe(1);
 	});
+
+	it.skipIf(process.platform !== "win32")(
+		"rejects an exited Windows process whose object is still retained",
+		async () => {
+			const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 100)"], {
+				stdio: "ignore",
+				windowsHide: true,
+			});
+			if (!child.pid) throw new Error("Could not obtain child pid");
+			const release = retainWindowsProcessHandle(child.pid);
+			try {
+				await once(child, "exit");
+				expect(getWindowsProcessStartId(child.pid)).toBeUndefined();
+			} finally {
+				release();
+			}
+		},
+	);
 
 	it("rejects a second live owner with a typed active-session error", () => {
 		const agentDir = createTempDir();
@@ -146,10 +173,13 @@ describe("session leases", () => {
 
 	it("treats symlink aliases as the same persisted session", () => {
 		const agentDir = createTempDir();
-		const sessionPath = join(agentDir, "session.jsonl");
-		const aliasPath = join(agentDir, "session-alias.jsonl");
+		const sessionDir = join(agentDir, "sessions");
+		const aliasDir = join(agentDir, "sessions-alias");
+		const sessionPath = join(sessionDir, "session.jsonl");
+		const aliasPath = join(aliasDir, "session.jsonl");
+		mkdirSync(sessionDir);
 		writeFileSync(sessionPath, "");
-		symlinkSync(sessionPath, aliasPath);
+		symlinkSync(sessionDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
 		const first = acquireSessionLease(sessionPath, agentDir, enabledEnvironment("resident-a"));
 
 		expect(() => acquireSessionLease(aliasPath, agentDir, enabledEnvironment("owned-b"))).toThrow(

--- a/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-autonomous.test.ts
@@ -13,6 +13,8 @@ import {
 import type { AgentCronJob } from "../../src/core/cron-jobs.js";
 import { createHarness, getAssistantTexts, getMessageText, getUserTexts, type Harness } from "./harness.js";
 
+const nodeCommand = process.platform === "win32" ? `"${process.execPath}"` : process.execPath;
+
 function isProcessRunning(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
@@ -206,7 +208,7 @@ describe("AgentSession autonomous mode", () => {
 		const state = createAutonomousRuntimeState({
 			enabled: true,
 			maxTurns: 1,
-			gates: { commands: [`${process.execPath} -e "process.exit(0)"`] },
+			gates: { commands: [`${nodeCommand} -e "process.exit(0)"`] },
 		});
 		state.turnsUsed = 1;
 		state.lastGateFailure = {
@@ -230,7 +232,7 @@ describe("AgentSession autonomous mode", () => {
 			autonomous: {
 				enabled: true,
 				maxContinuations: 1,
-				gates: { commands: [`${process.execPath} -e "process.exit(0)"`] },
+				gates: { commands: [`${nodeCommand} -e "process.exit(0)"`] },
 			},
 		});
 		harnesses.push(harness);
@@ -248,7 +250,7 @@ describe("AgentSession autonomous mode", () => {
 				enabled: true,
 				maxContinuations: 1,
 				gates: {
-					commands: [`${process.execPath} -e "console.error('gate failed'); process.exit(1)"`],
+					commands: [`${nodeCommand} -e "console.error('gate failed'); process.exit(1)"`],
 					maxRetries: 2,
 				},
 			},
@@ -270,7 +272,7 @@ describe("AgentSession autonomous mode", () => {
 				enabled: true,
 				maxContinuations: 2,
 				gates: {
-					commands: [`${process.execPath} -e "console.error('gate failed'); process.exit(1)"`],
+					commands: [`${nodeCommand} -e "console.error('gate failed'); process.exit(1)"`],
 					maxRetries: 2,
 				},
 			},
@@ -295,7 +297,7 @@ describe("AgentSession autonomous mode", () => {
 				enabled: true,
 				maxContinuations: 2,
 				gates: {
-					commands: [`${process.execPath} -e "console.error('gate failed'); process.exit(1)"`],
+					commands: [`${nodeCommand} -e "console.error('gate failed'); process.exit(1)"`],
 					maxRetries: 2,
 				},
 			},
@@ -349,7 +351,7 @@ describe("AgentSession autonomous mode", () => {
 		});
 		try {
 			const counter = join(tempDir, "verification", "public_feedback_scores.jsonl");
-			const gate = `${process.execPath} -e "const fs=require('fs'); const p='${counter}'; const n=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim().split(/\\n/).filter(Boolean).length:0; fs.appendFileSync(p,JSON.stringify({run:n+1,score:0})+'\\n'); process.exit(1);"`;
+			const gate = `${nodeCommand} -e "const fs=require('fs'); const p='verification/public_feedback_scores.jsonl'; const n=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim().split(/\\n/).filter(Boolean).length:0; fs.appendFileSync(p,JSON.stringify({run:n+1,score:0})+'\\n'); process.exit(1);"`;
 			const state = createAutonomousRuntimeState(
 				{ enabled: true, maxContinuations: 3, gates: { commands: [gate], maxRetries: 3 } },
 				{ cwd: tempDir },
@@ -388,7 +390,7 @@ describe("AgentSession autonomous mode", () => {
 		try {
 			const candidate = join(tempDir, "candidate.txt");
 			writeFileSync(candidate, "bad\n");
-			const gate = `${process.execPath} -e "const fs=require('fs'); process.exit(fs.readFileSync('candidate.txt','utf8').trim()==='good'?0:1)"`;
+			const gate = `${nodeCommand} -e "const fs=require('fs'); process.exit(fs.readFileSync('candidate.txt','utf8').trim()==='good'?0:1)"`;
 			const state = createAutonomousRuntimeState({
 				enabled: true,
 				maxContinuations: 3,
@@ -411,7 +413,7 @@ describe("AgentSession autonomous mode", () => {
 	});
 
 	it("bounds captured autonomous gate output", async () => {
-		const gate = `${process.execPath} -e "process.stdout.write('x'.repeat(20000)); process.exit(1)"`;
+		const gate = `${nodeCommand} -e "process.stdout.write('x'.repeat(20000)); process.exit(1)"`;
 		const state = createAutonomousRuntimeState({
 			enabled: true,
 			maxContinuations: 1,
@@ -446,7 +448,7 @@ describe("AgentSession autonomous mode", () => {
 			const state = createAutonomousRuntimeState({
 				enabled: true,
 				maxContinuations: 1,
-				gates: { commands: [`${process.execPath} gate.cjs`], maxRetries: 1, timeoutMs: 250 },
+				gates: { commands: [`${nodeCommand} gate.cjs`], maxRetries: 1, timeoutMs: 250 },
 			});
 			const startedAt = Date.now();
 
@@ -465,7 +467,7 @@ describe("AgentSession autonomous mode", () => {
 	});
 
 	it("terminates an autonomous gate without mutating retry state when the session is aborted", async () => {
-		const gate = `${process.execPath} -e "const fs=require('fs'); fs.writeFileSync('gate.pid', String(process.pid)); setTimeout(() => {}, 60000)"`;
+		const gate = `${nodeCommand} -e "const fs=require('fs'); fs.writeFileSync('gate.pid', String(process.pid)); setTimeout(() => {}, 60000)"`;
 		const harness = await createHarness({
 			autonomous: {
 				enabled: true,
@@ -502,7 +504,7 @@ describe("AgentSession autonomous mode", () => {
 		const state = createAutonomousRuntimeState({
 			enabled: true,
 			maxContinuations: 5,
-			gates: { commands: [`${process.execPath} -e "process.exit(1)"`], maxRetries: 1 },
+			gates: { commands: [`${nodeCommand} -e "process.exit(1)"`], maxRetries: 1 },
 		});
 
 		const first = await nextAutonomousContinuation(state, fauxAssistantMessage("Done."), { cwd: process.cwd() });
@@ -532,7 +534,7 @@ describe("AgentSession autonomous mode", () => {
 		});
 		try {
 			const generated = join(tempDir, "generated.txt");
-			const gate = `${process.execPath} -e "const fs=require('fs'); fs.appendFileSync('${generated}', 'run\\n'); process.exit(1);"`;
+			const gate = `${nodeCommand} -e "const fs=require('fs'); fs.appendFileSync('generated.txt', 'run\\n'); process.exit(1);"`;
 			const state = createAutonomousRuntimeState(
 				{ enabled: true, maxContinuations: 3, gates: { commands: [gate], maxRetries: 3 } },
 				{ cwd: tempDir },

--- a/packages/coding-agent/test/suite/regressions/4428-remove-legacy-pi-mono-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4428-remove-legacy-pi-mono-tools.test.ts
@@ -10,6 +10,7 @@ import { createAgentSession } from "../../../src/core/sdk.js";
 import { SessionManager } from "../../../src/core/session-manager.js";
 import { SettingsManager } from "../../../src/core/settings-manager.js";
 import { allToolNames, createAllToolDefinitions } from "../../../src/core/tools/index.js";
+import { getShellConfig } from "../../../src/utils/shell.js";
 
 describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 	let tempDir: string;
@@ -109,23 +110,26 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 	});
 
 	it("applies shell settings to ipython bash cells", async () => {
-		const shellPath = join(tempDir, "custom-shell.sh");
-		writeFileSync(shellPath, "#!/bin/sh\nprintf 'custom-shell\\n'\nexec /bin/sh \"$@\"\n");
-		chmodSync(shellPath, 0o755);
+		const shellPath = process.platform === "win32" ? getShellConfig().shell : join(tempDir, "custom-shell.sh");
+		if (process.platform !== "win32") {
+			writeFileSync(shellPath, "#!/bin/sh\nprintf 'custom-shell\\n'\nexec /bin/sh \"$@\"\n");
+			chmodSync(shellPath, 0o755);
+		}
 
-		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const cwd = process.platform === "win32" ? process.cwd() : tempDir;
+		const settingsManager = SettingsManager.create(cwd, agentDir);
 		settingsManager.setShellCommandPrefix("echo prefix-from-settings");
 		settingsManager.setShellPath(shellPath);
-		const sessionManager = SessionManager.inMemory(tempDir);
+		const sessionManager = SessionManager.inMemory(cwd);
 		const resourceLoader = new DefaultResourceLoader({
-			cwd: tempDir,
+			cwd,
 			agentDir,
 			settingsManager,
 		});
 		await resourceLoader.reload();
 
 		const { session } = await createAgentSession({
-			cwd: tempDir,
+			cwd,
 			agentDir,
 			model: getModel("anthropic", "claude-sonnet-5")!,
 			settingsManager,
@@ -145,7 +149,45 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 				.map((item) => item.text)
 				.join("");
 
-			expect(output).toContain("custom-shell\nprefix-from-settings\nbody");
+			expect(output).toContain(
+				process.platform === "win32" ? "prefix-from-settings\nbody" : "custom-shell\nprefix-from-settings\nbody",
+			);
+		} finally {
+			await session.disposeAsync();
+		}
+	});
+
+	it.runIf(process.platform === "win32")("uses Git Bash for ipython bash cells by default on Windows", async () => {
+		const cwd = process.cwd();
+		const settingsManager = SettingsManager.create(cwd, agentDir);
+		const sessionManager = SessionManager.inMemory(cwd);
+		const resourceLoader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			settingsManager,
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+			tools: ["ipython"],
+		});
+
+		try {
+			const ipythonTool = session.agent.state.tools.find((tool) => tool.name === "ipython");
+			expect(ipythonTool).toBeTruthy();
+			const result = await ipythonTool!.execute("tool-1", { code: "%%bash\ncygpath -w /" });
+			const output = result.content
+				.filter((item): item is { type: "text"; text: string } => item.type === "text")
+				.map((item) => item.text)
+				.join("");
+
+			expect(output).toMatch(/Git[\\/]/);
 		} finally {
 			await session.disposeAsync();
 		}

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -191,7 +191,7 @@ describe("Coding Agent Tools", () => {
 			expect(readFileSync(testFile, "utf-8")).toBe(originalContent);
 		});
 
-		it("should include EACCES for read-only files", async () => {
+		it("should include the platform permission code for read-only files", async () => {
 			const testFile = join(testDir, "edit-readonly.txt");
 			writeFileSync(testFile, "hello\n");
 			chmodSync(testFile, 0o444);
@@ -201,7 +201,9 @@ describe("Coding Agent Tools", () => {
 					path: testFile,
 					edits: [{ oldText: "hello", newText: "world" }],
 				}),
-			).rejects.toThrow(`Could not edit file: ${testFile}. Error code: EACCES.`);
+			).rejects.toThrow(
+				`Could not edit file: ${testFile}. Error code: ${process.platform === "win32" ? "EPERM" : "EACCES"}.`,
+			);
 		});
 
 		it("should include the original error message for unknown edit access errors", async () => {
@@ -230,15 +232,18 @@ describe("Coding Agent Tools", () => {
 			expect(result).toEqual({ error: `Could not edit file: ${missingFile}. Error code: ENOENT.` });
 		});
 
-		it("should include EACCES in diff preview for unreadable files", async () => {
-			const unreadableFile = join(testDir, "unreadable-preview.txt");
-			writeFileSync(unreadableFile, "hello\n");
-			chmodSync(unreadableFile, 0o222);
+		it.skipIf(process.platform === "win32")(
+			"should include EACCES in diff preview for unreadable files",
+			async () => {
+				const unreadableFile = join(testDir, "unreadable-preview.txt");
+				writeFileSync(unreadableFile, "hello\n");
+				chmodSync(unreadableFile, 0o222);
 
-			const result = await computeEditsDiff(unreadableFile, [{ oldText: "hello", newText: "world" }], testDir);
+				const result = await computeEditsDiff(unreadableFile, [{ oldText: "hello", newText: "world" }], testDir);
 
-			expect(result).toEqual({ error: `Could not edit file: ${unreadableFile}. Error code: EACCES.` });
-		});
+				expect(result).toEqual({ error: `Could not edit file: ${unreadableFile}. Error code: EACCES.` });
+			},
+		);
 	});
 
 	describe("bash tool", () => {

--- a/packages/coding-agent/test/windows-job-object.test.ts
+++ b/packages/coding-agent/test/windows-job-object.test.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { getProcessStartId } from "../src/core/session-lease.js";
 import { signalProcessGroupOrProcess } from "../src/utils/child-process.js";
-import { getDirectWindowsBashPath } from "../src/utils/shell.js";
+import { getDirectWindowsBashPath, getWindowsGitBashLauncherPath } from "../src/utils/shell.js";
 
 const workerPath = resolve(__dirname, "fixtures/windows-job-worker.ts");
 const tsxPreflightPath = resolve(__dirname, "../../../node_modules/tsx/dist/preflight.cjs");
@@ -102,6 +102,24 @@ describe.skipIf(process.platform !== "win32")("Windows daemon worker Job Object"
 			mkdirSync(join(root, "usr", "bin"), { recursive: true });
 			writeFileSync(shellPath, "not git bash");
 			expect(() => getDirectWindowsBashPath(shellPath)).toThrow("requires Git for Windows");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves the validated Git for Windows launcher", () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-git-bash-launcher-"));
+		try {
+			const shellPath = join(root, "usr", "bin", "bash.exe");
+			const launcherPath = join(root, "bin", "bash.exe");
+			mkdirSync(join(root, "cmd"), { recursive: true });
+			mkdirSync(join(root, "usr", "bin"), { recursive: true });
+			mkdirSync(join(root, "bin"), { recursive: true });
+			writeFileSync(join(root, "cmd", "git.exe"), "git");
+			writeFileSync(shellPath, "bash");
+			writeFileSync(launcherPath, "launcher");
+
+			expect(getWindowsGitBashLauncherPath(shellPath)).toBe(launcherPath);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/windows-job-object.test.ts
+++ b/packages/coding-agent/test/windows-job-object.test.ts
@@ -1,11 +1,12 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { getProcessStartId } from "../src/core/session-lease.js";
 import { signalProcessGroupOrProcess } from "../src/utils/child-process.js";
+import { getDirectWindowsBashPath } from "../src/utils/shell.js";
 
 const workerPath = resolve(__dirname, "fixtures/windows-job-worker.ts");
 const tsxPreflightPath = resolve(__dirname, "../../../node_modules/tsx/dist/preflight.cjs");
@@ -94,6 +95,18 @@ async function removeDirectory(path: string): Promise<void> {
 }
 
 describe.skipIf(process.platform !== "win32")("Windows daemon worker Job Object", () => {
+	it("rejects a non-Git bash executable for daemon isolation", () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-unsupported-bash-"));
+		try {
+			const shellPath = join(root, "usr", "bin", "bash.exe");
+			mkdirSync(join(root, "usr", "bin"), { recursive: true });
+			writeFileSync(shellPath, "not git bash");
+			expect(() => getDirectWindowsBashPath(shellPath)).toThrow("requires Git for Windows");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("kills an assigned Bash leaf when its owner exits while the no-Job control survives", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-agent-job-causality-"));
 		const tracked = new Map<number, string | undefined>();

--- a/packages/coding-agent/test/windows-job-object.test.ts
+++ b/packages/coding-agent/test/windows-job-object.test.ts
@@ -1,0 +1,193 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { getProcessStartId } from "../src/core/session-lease.js";
+import { signalProcessGroupOrProcess } from "../src/utils/child-process.js";
+
+const workerPath = resolve(__dirname, "fixtures/windows-job-worker.ts");
+const tsxPreflightPath = resolve(__dirname, "../../../node_modules/tsx/dist/preflight.cjs");
+const tsxLoaderUrl = pathToFileURL(resolve(__dirname, "../../../node_modules/tsx/dist/loader.mjs")).href;
+const gitBashPath = "C:\\Program Files\\Git\\usr\\bin\\bash.exe";
+const delay = (ms: number) => new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+
+async function waitForStartId(pid: number): Promise<string> {
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		const startId = getProcessStartId(pid);
+		if (startId) return startId;
+		await delay(25);
+	}
+	throw new Error(`Could not read process identity for ${pid}`);
+}
+
+function isProcessRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForIdentityGone(pid: number, startId?: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		if (!isProcessRunning(pid)) return;
+		const observedStartId = getProcessStartId(pid);
+		if (startId && observedStartId && observedStartId !== startId) return;
+		await delay(25);
+	}
+	throw new Error(`Process identity ${pid}/${startId} remained alive`);
+}
+
+async function waitForMarker(path: string, child: ChildProcess, diagnostics: () => string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (!existsSync(path) && Date.now() < deadline) {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			throw new Error(`Job worker exited before its blocker started: ${diagnostics()}`);
+		}
+		await delay(25);
+	}
+	if (!existsSync(path)) throw new Error(`Job worker blocker did not start: ${diagnostics()}`);
+}
+
+async function terminateTrackedIdentity(pid: number, startId?: string): Promise<Error | undefined> {
+	if (!isProcessRunning(pid)) return undefined;
+	if (!startId) {
+		const signaled = signalProcessGroupOrProcess(pid, "SIGKILL");
+		return new Error(
+			`Process ${pid} was registered before its identity could be read; forced cleanup ${signaled ? "was sent" : "failed"}`,
+		);
+	}
+	const deadline = Date.now() + 2000;
+	while (isProcessRunning(pid) && Date.now() < deadline) {
+		const observedStartId = getProcessStartId(pid);
+		if (observedStartId && observedStartId !== startId) return undefined;
+		if (observedStartId === startId) {
+			return signalProcessGroupOrProcess(pid, "SIGKILL")
+				? undefined
+				: new Error(`Could not terminate process identity ${pid}/${startId}`);
+		}
+		await delay(25);
+	}
+	if (!isProcessRunning(pid)) return undefined;
+	const signaled = signalProcessGroupOrProcess(pid, "SIGKILL");
+	return new Error(
+		`Could not verify process identity ${pid}/${startId} before forced cleanup; signal ${signaled ? "was sent" : "failed"}`,
+	);
+}
+
+async function removeDirectory(path: string): Promise<void> {
+	const deadline = Date.now() + 5000;
+	while (true) {
+		try {
+			rmSync(path, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (Date.now() >= deadline) throw error;
+			await delay(25);
+		}
+	}
+}
+
+describe.skipIf(process.platform !== "win32")("Windows daemon worker Job Object", () => {
+	it("kills an assigned Bash leaf when its owner exits while the no-Job control survives", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-job-causality-"));
+		const tracked = new Map<number, string | undefined>();
+		const cleanupErrors: unknown[] = [];
+		const bashEnvMarker = join(root, "bash-env-ran");
+		const bashEnvPath = join(root, "bash-env.sh");
+		writeFileSync(
+			bashEnvPath,
+			`printf startup > '${bashEnvMarker.replaceAll("\\", "/").replaceAll("'", `'"'"'`)}'\n`,
+		);
+		let testError: unknown;
+		try {
+			for (const mode of ["job", "control"] as const) {
+				const markerPath = join(root, `${mode}.json`);
+				let diagnostics = "";
+				const child = spawn(
+					process.execPath,
+					[
+						"--require",
+						tsxPreflightPath,
+						"--import",
+						tsxLoaderUrl,
+						workerPath,
+						mode,
+						root,
+						markerPath,
+						gitBashPath,
+					],
+					{
+						cwd: root,
+						env: { ...process.env, ...(mode === "job" ? { BASH_ENV: bashEnvPath } : {}) },
+						stdio: ["ignore", "pipe", "pipe"],
+						windowsHide: true,
+					},
+				);
+				child.stdout?.on("data", (chunk) => {
+					diagnostics += chunk.toString();
+				});
+				child.stderr?.on("data", (chunk) => {
+					diagnostics += chunk.toString();
+				});
+				if (!child.pid) throw new Error("Could not obtain Job worker pid");
+				tracked.set(child.pid, undefined);
+				const workerStartId = await waitForStartId(child.pid);
+				tracked.set(child.pid, workerStartId);
+				await waitForMarker(markerPath, child, () => diagnostics);
+				if (mode === "job") expect(existsSync(bashEnvMarker)).toBe(false);
+				const blocker = JSON.parse(readFileSync(markerPath, "utf8")) as { pid: number; parentPid: number };
+				tracked.set(blocker.pid, undefined);
+				tracked.set(blocker.parentPid, undefined);
+				const leafStartId = await waitForStartId(blocker.pid);
+				tracked.set(blocker.pid, leafStartId);
+				const parentStartId = await waitForStartId(blocker.parentPid);
+				tracked.set(blocker.parentPid, parentStartId);
+
+				process.kill(child.pid, "SIGKILL");
+				await waitForIdentityGone(child.pid, workerStartId);
+				tracked.delete(child.pid);
+				if (mode === "job") {
+					await waitForIdentityGone(blocker.pid, leafStartId);
+					tracked.delete(blocker.pid);
+					await waitForIdentityGone(blocker.parentPid, parentStartId);
+					tracked.delete(blocker.parentPid);
+				} else {
+					await delay(500);
+					expect(getProcessStartId(blocker.pid)).toBe(leafStartId);
+				}
+			}
+		} catch (error) {
+			testError = error;
+		} finally {
+			for (const [pid, startId] of tracked) {
+				const error = await terminateTrackedIdentity(pid, startId);
+				if (error) cleanupErrors.push(error);
+			}
+			for (const [pid, startId] of tracked) {
+				try {
+					await waitForIdentityGone(pid, startId);
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+			}
+			try {
+				await removeDirectory(root);
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+		}
+		if (cleanupErrors.length > 0) {
+			throw new AggregateError(
+				testError ? [testError, ...cleanupErrors] : cleanupErrors,
+				"Windows Job test cleanup failed",
+			);
+		}
+		if (testError) throw testError;
+	});
+});

--- a/scripts/check-windows-installer.mjs
+++ b/scripts/check-windows-installer.mjs
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+const source = readFileSync("install.ps1", "utf8");
+for (const placeholder of ["__PRIME_AGENT_DOWNLOAD_BASE_URL__", "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__"]) {
+	if (!source.includes(placeholder)) throw new Error(`Windows installer is missing ${placeholder}`);
+}
+for (const requirement of ["process.arch", "requires x64 Node.js", "Programs\\Git\\bin\\bash.exe"]) {
+	if (!source.includes(requirement)) throw new Error(`Windows installer is missing requirement: ${requirement}`);
+}
+
+if (process.platform !== "win32") {
+	console.log("Windows installer template check passed; behavioral check skipped off Windows.");
+	process.exit(0);
+}
+
+const directory = mkdtempSync(join(tmpdir(), "prime-agent-windows-installer-"));
+const packageBytes = Buffer.from("prime-agent-test-package\n");
+const packageChecksum = createHash("sha256").update(packageBytes).digest("hex");
+let channelVersion = "v0.7.0";
+let serveBadChecksum = false;
+
+const server = createServer((request, response) => {
+	const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+	if (path === "/stable") {
+		response.end(`${channelVersion}\n`);
+		return;
+	}
+	if (path === "/releases/v0.7.0/prime-agent-0.7.0.tgz") {
+		response.end(packageBytes);
+		return;
+	}
+	if (path === "/releases/v0.7.0/SHA256SUMS") {
+		const checksum = serveBadChecksum ? "0".repeat(64) : packageChecksum;
+		response.end(`${checksum}  prime-agent-0.7.0.tgz\n`);
+		return;
+	}
+	response.statusCode = 404;
+	response.end("not found\n");
+});
+
+function runPowerShell(scriptPath, environment) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			"powershell.exe",
+			["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+			{ env: environment, windowsHide: true },
+		);
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", reject);
+		child.on("exit", (code) => resolve({ code, output: `${stdout}${stderr}` }));
+	});
+}
+
+await new Promise((resolve, reject) => {
+	server.once("error", reject);
+	server.listen(0, "127.0.0.1", resolve);
+});
+
+try {
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Windows installer test server has no TCP address");
+	const baseUrl = `http://127.0.0.1:${address.port}`;
+	const scriptPath = join(directory, "install.ps1");
+	writeFileSync(
+		scriptPath,
+		source
+			.replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
+			.replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", "stable"),
+		"utf8",
+	);
+
+	const binDirectory = join(directory, "bin");
+	const npmLog = join(directory, "npm.log");
+	mkdirSync(binDirectory, { recursive: true });
+	writeFileSync(
+		join(binDirectory, "npm.cmd"),
+		[
+			"@echo off",
+			`> "%PRIME_AGENT_INSTALLER_TEST_LOG%" echo %PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL% %PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL% %PRIME_AGENT_INSTALL_UV%`,
+			`>> "%PRIME_AGENT_INSTALLER_TEST_LOG%" echo %*`,
+			"exit /b 0",
+			"",
+		].join("\r\n"),
+	);
+	const fakeProgramFiles = join(directory, "Program Files");
+	const fakeGitBin = join(fakeProgramFiles, "Git", "bin");
+	mkdirSync(fakeGitBin, { recursive: true });
+	copyFileSync(process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe", join(fakeGitBin, "bash.exe"));
+
+	const environment = {
+		...process.env,
+		PATH: `${binDirectory};${process.env.PATH ?? ""}`,
+		ProgramFiles: fakeProgramFiles,
+		PRIME_AGENT_INSTALLER_TEST_LOG: npmLog,
+	};
+	const success = await runPowerShell(scriptPath, environment);
+	if (success.code !== 0) throw new Error(`Windows installer success case failed:\n${success.output}`);
+	const npmInvocation = readFileSync(npmLog, "utf8");
+	if (!npmInvocation.includes("1 1 1")) throw new Error("Windows installer did not enable postinstall bootstrap");
+	if (!npmInvocation.includes("install -g") || !npmInvocation.includes("prime-agent-0.7.0.tgz")) {
+		throw new Error(`Unexpected npm invocation:\n${npmInvocation}`);
+	}
+
+	unlinkSync(npmLog);
+	serveBadChecksum = true;
+	const checksumFailure = await runPowerShell(scriptPath, environment);
+	if (checksumFailure.code === 0 || !checksumFailure.output.includes("Checksum mismatch")) {
+		throw new Error(`Windows installer accepted a bad checksum:\n${checksumFailure.output}`);
+	}
+	if (existsSync(npmLog)) throw new Error("Windows installer invoked npm after checksum failure");
+
+	serveBadChecksum = false;
+	for (const invalidVersion of ["vv0.7.0", "01.2.3", "1.2.3-."]) {
+		channelVersion = invalidVersion;
+		const invalidVersionFailure = await runPowerShell(scriptPath, environment);
+		if (invalidVersionFailure.code === 0 || !invalidVersionFailure.output.includes("Invalid Prime Agent version")) {
+			throw new Error(`Windows installer accepted invalid version ${invalidVersion}:\n${invalidVersionFailure.output}`);
+		}
+		if (existsSync(npmLog)) throw new Error(`Windows installer invoked npm for invalid version ${invalidVersion}`);
+	}
+
+	console.log("Windows installer check passed.");
+} finally {
+	await new Promise((resolve) => server.close(resolve));
+	rmSync(directory, { recursive: true, force: true });
+}

--- a/scripts/pack-prime-agent-release.mjs
+++ b/scripts/pack-prime-agent-release.mjs
@@ -213,7 +213,15 @@ function copyPackageContents(sourceDir, targetDir, packageJson) {
 }
 
 function run(command, args, cwd) {
-	const result = spawnSync(command, args, {
+	let npmExecPath = command === "npm" ? process.env.npm_execpath : undefined;
+	if (command === "npm" && process.platform === "win32" && !npmExecPath) {
+		const bundledNpm = join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+		if (!existsSync(bundledNpm)) {
+			throw new Error("Cannot locate npm-cli.js; run this packer through npm run release:pack");
+		}
+		npmExecPath = bundledNpm;
+	}
+	const result = spawnSync(npmExecPath ? process.execPath : command, npmExecPath ? [npmExecPath, ...args] : args, {
 		cwd,
 		stdio: "pipe",
 		encoding: "utf8",
@@ -222,7 +230,8 @@ function run(command, args, cwd) {
 	if (result.status !== 0) {
 		if (result.stdout) process.stdout.write(result.stdout);
 		if (result.stderr) process.stderr.write(result.stderr);
-		throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+		const detail = result.error ? `: ${result.error.message}` : "";
+		throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}${detail}`);
 	}
 
 	if (result.stderr) process.stderr.write(result.stderr);


### PR DESCRIPTION
## Summary

- add a PowerShell 5.1 installer with strict SemVer parsing, SHA-256 verification, x64/Git-for-Windows checks, and release-channel integration
- fix Windows kernel venv resolution, directory-fsync handling, stale lease recovery, hidden child processes, and named-pipe test fixtures
- add fail-closed Windows Job Object isolation so daemon Bash trees are assigned before commands run and are terminated after worker crashes
- replace repeated PowerShell PID queries with native `GetProcessTimes`, and add Windows CI coverage for installer, kernel, daemon, and recovery paths

## Process safety

- Windows daemon isolation supports x64 Node.js and Git for Windows only
- worker and replacement supervisor processes remain outside the Job; only gated Bash trees are assigned
- native/assignment failures reject command execution instead of degrading to an unisolated mode
- no persistent disk or network I/O is added by Job isolation

## Validation

- clean latest-main worktree: fresh `npm ci`, root build, checks, and Windows-targeted tests (89 passed, 7 platform skips)
- final shell-contract update: TypeScript and Biome checks plus Windows-targeted tests (90 passed, 7 platform skips)
- packaged install smoke: global package loaded exact `koffi@2.16.2`; hard worker kill removed the Bash leaf and a replacement worker became ready
- public diff scanned for credentials, private keys, personal paths, email addresses, and non-test localhost URLs

Builds on the reports and proposed fixes in #663, #664, and #670.

Closes #660
Closes #665
Closes #666
Closes #667
Closes #668

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent daemon lifecycle, session leases, and child-process termination on Windows using memory-unsafe FFI; failures are intended to fail closed but mis-assignment or Win32 errors could block Bash or leave orphans.
> 
> **Overview**
> Adds **native Windows x64** support: a published **PowerShell installer**, release/CI wiring, and runtime fixes so daemon workers, the Python kernel, and Bash behave correctly on Windows.
> 
> **Install & docs:** New `install.ps1` (channel, SHA-256, x64 Node 22.8+, Git for Windows) is rendered and uploaded beside the shell installers; README/quickstart document `irm … | iex`. Root `check:installer` runs `check-windows-installer.mjs`. **`koffi@2.16.2`** is a direct dependency for Win32 FFI.
> 
> **Daemon process isolation:** Daemon workers create a **kill-on-close Job Object** and gate Bash through Git’s direct `usr\bin\bash.exe` so the process is assigned to the job before descendants start; worker crash tears down that Bash tree while supervisors stay outside the job. Session lease identity on Windows uses **`GetProcessTimes`** via Koffi instead of spawning PowerShell per PID; lease/supervisor lock renames tolerate Windows `EPERM` when the destination already exists.
> 
> **Cross-platform spawn hygiene:** `windowsHide: true` on spawns; `signalProcessTree` / `taskkill` for tree kills; kernel bootstrap uses `Scripts\python.exe` and PowerShell `uv` install on Windows; command-recovery journal skips directory fsync when unsupported.
> 
> **CI:** New `windows-latest` job (installer check, Windows-targeted vitest, kernel bootstrap + import smoke) gates `build-check-test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef7b8e56dc5f2de92eb230c53ee409c33c8ee53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Windows support with PowerShell installer, Job Object isolation, and hidden console windows
> - Adds [install.ps1](https://github.com/PrimeIntellect-ai/prime-agent/pull/744/files#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806), a PowerShell installer for Windows x64 that requires Node.js ≥22.8.0 and Git Bash, downloads the release tarball, verifies SHA-256, and installs via npm.
> - Introduces [windows-job-object.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/744/files#diff-336c1a599b762f2a14274cdfbf05023b45f26c7166c40afbeb5a13e8dc3f9b0d) using `koffi` to bind Win32 Job Object APIs, enabling reliable process-tree termination for daemon workers on Windows.
> - Adds `windowsHide: true` to all `spawn`/`spawnSync` calls across the codebase so no console windows appear on Windows.
> - Fixes `venvPython` to use `Scripts/python.exe` on Windows and updates `ensureUv` to invoke the PowerShell-based uv installer instead of `sh`.
> - Fixes session lease acquisition to treat `EPERM` on rename (when destination exists) as contention rather than throwing, matching Windows filesystem semantics.
> - Adds new Git-for-Windows shell helpers (`gitForWindowsRoot`, `getDirectWindowsBashPath`, `getWindowsGitBashLauncherPath`) and probes `LOCALAPPDATA\Programs\Git` for bash detection.
> - Risk: `koffi` is added as a runtime dependency; Windows-specific paths (Job Objects, named pipes, junction symlinks) are active only on `win32`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9581b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->