### PR TITLE
Support anonymous HTTP MCP servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added anonymous HTTP MCP server support ([#745](https://github.com/PrimeIntellect-ai/prime-agent/pull/745) by [@tanvesh01](https://github.com/tanvesh01)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -13,8 +13,8 @@ issues = await linear.list_issues(team="Engineering")
 ```
 
 The MCP connection runs inside the kernel via the official `mcp` Python SDK. The
-host's only jobs are interactive login (browser OAuth) and minting/refreshing
-credentials in `auth.json`.
+host resolves connection settings and, when needed, handles browser OAuth and
+credential refresh in `auth.json`.
 
 ## Table of Contents
 
@@ -106,6 +106,9 @@ server fields:
 | `headers` | Extra static HTTP headers sent on every request |
 | `enabled` | Set `false` to force-disable even when credentials exist |
 
+Omit both `oauth` and `bearerTokenEnvVar` for a server that accepts
+unauthenticated requests.
+
 > `stdio` (local-subprocess) servers are not yet wired through to the kernel —
 > the host drops non-HTTP entries — so an integration must target an HTTP endpoint.
 
@@ -160,13 +163,15 @@ def __getattr__(name):
     return getattr(acme, name)
 ```
 
-The base class connects with the `mcp` SDK, resolves the URL/headers from the host
-(honoring the `mcpServers` config), injects the bearer token from `auth.json`
-(refreshing when expired), and binds the server's tools as async methods. Authoring
-is a few lines — the package above is the whole integration.
+The base class connects with the `mcp` SDK, resolves the URL and headers from the
+host, injects a bearer token when the server requires one, and binds the server's
+tools as async methods. Authoring is a few lines — the package above is the whole
+integration.
 
 ### Authentication
 
+- **None** (omit `oauth` and `bearerTokenEnvVar`): Prime connects without an
+  `Authorization` header. Static `headers` are still included when configured.
 - **OAuth** (`"oauth": true`): the user runs `/login` → MCP Connections → your server (or
   `/mcp login acme`). Works when the server supports OAuth 2.1 dynamic client
   registration (RFC 7591); login discovers the auth server, registers a client,
@@ -198,7 +203,7 @@ Methods:
 
 Exceptions (both importable from `rlm`):
 
-- `NotEnabled` — raised when no usable credentials exist (not logged in).
+- `NotEnabled` — raised when an authenticated server has no usable credentials.
 - `McpToolError` — raised when a tool call returns a result flagged as an error.
 
 ## Enable-by-login lifecycle
@@ -218,10 +223,9 @@ activate the integration.
 
 **User-authored integrations are not auth-gated this way.** A skill you drop into
 a skills directory is loaded like any other skill — visible to the model and
-imported into the kernel immediately, regardless of `auth.json`. It simply fails
-at call time with `NotEnabled` until credentials exist. So make the skill's
-`SKILL.md` tell the model how to connect when a call raises `NotEnabled`, matching
-the auth mode you configured:
+imported into the kernel immediately. Anonymous servers work immediately;
+authenticated servers fail at call time with `NotEnabled` until credentials
+exist. Make the skill's `SKILL.md` explain the configured auth mode:
 
 - **OAuth** (`"oauth": true`): instruct the user to run `/mcp login <server>` (or
   `/login` → MCP Connections). `/mcp login` only works for OAuth servers.
@@ -242,7 +246,8 @@ the auth mode you configured:
   URL. A previously stored official credential is *not* reused for the override, to
   avoid sending the official token to your endpoint. Authenticate such an override
   via `bearerTokenEnvVar` only — OAuth credentials are not honored for a
-  catalog-name override. (Use a name that isn't a built-in to get OAuth.)
+  catalog-name override, or omit authentication for a public endpoint. (Use a
+  name that isn't a built-in to get OAuth.)
 - **Multi-session daemon.** OAuth provider registration is process-global; a
   user-declared server unique to one daemon session is re-registered on that
   session's next reload.

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -123,9 +123,10 @@ export class McpManager {
 		this.registeredUserProviderIds = current;
 	}
 
-	/** True when valid credentials exist for the integration (drives enablement). */
+	/** True when the integration can connect anonymously or has valid credentials. */
 	private isAuthed(integration: ResolvedIntegration): boolean {
 		if (integration.enabled === false) return false;
+		if (!integration.usesOAuth && !integration.bearerTokenEnvVar) return true;
 		if (integration.bearerTokenEnvVar && process.env[integration.bearerTokenEnvVar]?.trim()) {
 			return true;
 		}
@@ -172,7 +173,10 @@ export class McpManager {
 				if (!server) throw new Error("mcp.config requires a server");
 				const integration = this.integrations.get(server);
 				if (!integration) return {};
-				const config: Record<string, unknown> = { url: integration.url };
+				const config: Record<string, unknown> = {
+					url: integration.url,
+					requiresAuth: integration.usesOAuth || Boolean(integration.bearerTokenEnvVar),
+				};
 				if (integration.headers && Object.keys(integration.headers).length > 0) {
 					config.headers = integration.headers;
 				}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -102,7 +102,7 @@ export type McpServerConfig =
 			headers?: Record<string, string>;
 			/** Env var holding a static bearer token (skips OAuth). */
 			bearerTokenEnvVar?: string;
-			/** Use the generic OAuth login flow for this server. */
+			/** Use generic OAuth login; omit for bearer-token or anonymous access. */
 			oauth?: boolean;
 			/** Force-disable even when credentials exist. */
 			enabled?: boolean;

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -107,9 +107,13 @@ describe("McpManager", () => {
 		const handlers = manager.hostHandlers();
 		expect(await handlers["mcp.config"]({ server: "linear" })).toEqual({
 			url: "https://proxy.test/mcp",
+			requiresAuth: true,
 			headers: { "X-Extra": "1" },
 		});
-		expect(await handlers["mcp.config"]({ server: "notion" })).toEqual({ url: "https://mcp.notion.com/mcp" });
+		expect(await handlers["mcp.config"]({ server: "notion" })).toEqual({
+			url: "https://mcp.notion.com/mcp",
+			requiresAuth: true,
+		});
 	});
 
 	it("does not treat an oauth override of a catalog name as authed via the official stored cred", () => {
@@ -126,6 +130,20 @@ describe("McpManager", () => {
 		});
 		// Must NOT be enabled — else the official token would be sent to the override URL.
 		expect(manager.listStatus().find((s) => s.server === "linear")?.enabled).toBe(false);
+	});
+
+	it("enables anonymous HTTP servers without credentials", async () => {
+		const manager = new McpManager({
+			authStorage,
+			getUserServers: () => ({
+				public: { type: "http", url: "https://public.test/mcp" },
+			}),
+		});
+		expect(manager.listStatus().find((s) => s.server === "public")?.enabled).toBe(true);
+		expect(await manager.hostHandlers()["mcp.config"]({ server: "public" })).toEqual({
+			url: "https://public.test/mcp",
+			requiresAuth: false,
+		});
 	});
 
 	it("honors a bearer-token env var for user-declared servers", () => {

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -189,19 +189,30 @@ class McpIntegration:
 
     # -- connection ---------------------------------------------------------
 
-    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
-        """Host-resolved (url, extra_headers), honoring a user's mcpServers override.
-        Falls back to the class ``url`` and no extra headers on host error."""
+    async def _resolve_connection_config(
+        self,
+    ) -> tuple[str | None, dict[str, str], bool]:
+        """Resolve URL, headers, and whether the configured server requires auth."""
         try:
             cfg = await host_request("mcp.config", {"server": self.server})
         except RuntimeError:
             cfg = {}
         url = cfg.get("url") if isinstance(cfg, dict) else None
         headers = cfg.get("headers") if isinstance(cfg, dict) else None
+        requires_auth = cfg.get("requiresAuth") if isinstance(cfg, dict) else None
         if not (isinstance(url, str) and url):
             url = self.url
         extra = headers if isinstance(headers, dict) else {}
-        return url, {str(k): str(v) for k, v in extra.items()}
+        return (
+            url,
+            {str(k): str(v) for k, v in extra.items()},
+            requires_auth if isinstance(requires_auth, bool) else True,
+        )
+
+    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
+        """Host-resolved URL and headers, honoring a user's mcpServers override."""
+        url, headers, _ = await self._resolve_connection_config()
+        return url, headers
 
     async def _open_session(self, stack: AsyncExitStack):
         """Open an initialized MCP ClientSession bound to ``stack``.
@@ -214,24 +225,25 @@ class McpIntegration:
 
         from mcp import ClientSession  # noqa: PLC0415
 
-        url, extra_headers = await self._resolve_config()
+        url, headers, requires_auth = await self._resolve_connection_config()
         if not url:
             raise ValueError(
                 f"{type(self).__name__} must set `url` or override `_open_session`"
             )
-        token = await self._resolve_token()
+        if requires_auth:
+            token = await self._resolve_token()
+            # Extra configured headers first, Authorization last so it always wins.
+            headers = {**headers, "Authorization": f"Bearer {token}"}
         transport = _resolve_streamable_http()
-        # Extra configured headers first, Authorization last so it always wins.
-        auth_header = {**extra_headers, "Authorization": f"Bearer {token}"}
 
         # SDK signatures vary: some take headers=, others only http_client=.
         params = inspect.signature(transport).parameters
         if "headers" in params:
-            cm = transport(url, headers=auth_header)
+            cm = transport(url, headers=headers)
         elif "http_client" in params:
             import httpx  # noqa: PLC0415
 
-            client = await stack.enter_async_context(httpx.AsyncClient(headers=auth_header))
+            client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
             cm = transport(url, http_client=client)
         else:
             raise RuntimeError(

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -192,18 +192,24 @@ class McpIntegrationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             Bad()
 
-    def _run_open_session_with_transport(self, transport):
+    def _run_open_session_with_transport(self, transport, *, config=None, write_auth=True):
         """Drive the real _open_session against a fake transport callable.
 
         `transport` must declare its real parameters (headers= or http_client=)
         so the signature inspection in _open_session is exercised faithfully.
         """
-        self._write_auth(
-            {"type": "oauth", "access": "tok-xyz", "refresh": "r", "expires": (time.time() + 3600) * 1000}
-        )
+        if write_auth:
+            self._write_auth(
+                {
+                    "type": "oauth",
+                    "access": "tok-xyz",
+                    "refresh": "r",
+                    "expires": (time.time() + 3600) * 1000,
+                }
+            )
 
         async def fake_host_request(req_type, payload):
-            return {}  # no host URL override; _resolve_url falls back to self.url
+            return config or {}  # no URL override by default; fall back to self.url
 
         with mock.patch.object(mcp_base, "host_request", fake_host_request), \
              mock.patch.object(mcp_base, "_resolve_streamable_http", lambda: transport), \
@@ -234,6 +240,27 @@ class McpIntegrationTest(unittest.TestCase):
 
         self._run_open_session_with_transport(transport)
         self.assertEqual(captured["headers"], {"Authorization": "Bearer tok-xyz"})
+
+    def test_open_session_allows_anonymous_server(self):
+        captured = {}
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, headers=None):
+            captured["headers"] = headers
+            return _CM()
+
+        self._run_open_session_with_transport(
+            transport,
+            config={"requiresAuth": False, "headers": {"X-Extra": "1"}},
+            write_auth=False,
+        )
+        self.assertEqual(captured["headers"], {"X-Extra": "1"})
 
     def test_open_session_uses_http_client_signature(self):
         # streamable_http_client(url, *, http_client=...) — must NOT pass headers=


### PR DESCRIPTION
## Summary

- enable user-declared HTTP MCP servers when neither OAuth nor a bearer-token environment variable is configured
- pass an optional `requiresAuth` flag to the kernel so `McpIntegration` omits the `Authorization` header for public endpoints
- document anonymous MCP configuration and preserve static headers

## Why

`McpIntegration` currently resolves a bearer token for every HTTP server. Public MCP endpoints such as Exa's hosted free tier therefore raise `NotEnabled` even though the endpoint accepts unauthenticated requests.

The new host response field is backward-compatible: new runtimes default a missing `requiresAuth` to `true`, while old runtimes ignore the extra field.

## Validation

- `PYTHONPATH="$PWD/prime-agent-runtime/src" ~/.prime/agent/kernel-venv/bin/python -m unittest discover -s prime-agent-runtime/test -p 'test_mcp_base.py'`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/mcp-manager.test.ts`
- `npm run check`
- live smoke test against `https://mcp.exa.ai/mcp` discovered `web_search_exa` and `web_fetch_exa` without credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to MCP HTTP connection and enablement logic with tests; OAuth and bearer-token paths unchanged. Default `requiresAuth: true` when absent preserves behavior for older runtimes.
> 
> **Overview**
> Enables **user-declared HTTP MCP servers** that need neither OAuth nor a bearer-token env var to connect and show as **enabled** without credentials in `auth.json`.
> 
> The host **`McpManager`** treats integrations with no `oauth` and no `bearerTokenEnvVar` as authenticated for enablement, and **`mcp.config`** now returns **`requiresAuth`** so the kernel knows whether to attach credentials. **`McpIntegration._open_session`** skips token resolution and omits **`Authorization`** when `requiresAuth` is false, while still sending configured static **`headers`**.
> 
> Docs and settings comments describe omitting both auth fields for public endpoints; built-in OAuth/bearer behavior is unchanged. Missing **`requiresAuth`** on older hosts still defaults to requiring auth in the runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06dc9e464d858a0a092453cba5858f5ec7bd2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support anonymous HTTP MCP servers without requiring authentication credentials
> - Extends `McpManager.isAuthed` to treat integrations as enabled when neither `oauth` nor `bearerTokenEnvVar` is configured, covering anonymous HTTP servers.
> - Adds a `requiresAuth` boolean to `mcp.config` responses so the runtime knows whether to attach an `Authorization: Bearer` header.
> - Updates `McpIntegration._open_session` in the Python runtime to skip token resolution and omit the `Authorization` header when `requiresAuth` is `false`.
> - Behavioral Change: previously, HTTP MCP integrations without credentials were treated as disabled; they now connect as anonymous servers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b06dc9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->