### PR TITLE
fix: use Cmd-V for image paste on macOS

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -134,7 +134,7 @@ The editor can be temporarily replaced by other UI, like built-in `/settings` or
 | File reference | Type `@` to fuzzy-search project files |
 | Path completion | Tab to complete paths |
 | Multi-line | Shift+Enter (or Ctrl+Enter on Windows Terminal) |
-| Images | Ctrl+V to paste (Alt+V on Windows), or drag onto terminal |
+| Images | Cmd+V on macOS / Ctrl+V on Linux to paste (Alt+V on Windows), or drag onto terminal |
 | Bash commands | `!command` runs and sends output to LLM, `!!command` runs without sending |
 
 Standard editing keybindings for delete word, undo, etc. See [docs/keybindings.md](docs/keybindings.md).

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -10,7 +10,9 @@ After editing `keybindings.json`, run `/reload` in Prime Agent to apply the chan
 
 ## Key Format
 
-`modifier+key` where modifiers are `ctrl`, `shift`, `alt` (combinable) and keys are:
+`modifier+key` where modifiers are `ctrl`, `shift`, `alt`, `super` (combinable) and keys are:
+
+`super` is the Command key on macOS (e.g. `super+v` for Cmd+V). It is only delivered by terminals that report it (e.g. via the Kitty keyboard protocol); terminals that handle Cmd+V themselves paste the clipboard directly instead.
 
 - **Letters:** `a-z`
 - **Digits:** `0-9`
@@ -97,7 +99,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.exit` | `ctrl+d` | Exit (when editor empty) |
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
-| `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
+| `app.clipboard.pasteImage` | `super+v` (Cmd+V) on macOS, `ctrl+v` on Linux (`alt+v` on Windows) | Paste image from clipboard |
 
 ### Sessions
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -117,7 +117,7 @@ prime-agent @README.md "Summarize this"
 prime-agent @src/app.ts @src/app.test.ts "Review these together"
 ```
 
-Images can be pasted with Ctrl+V (Alt+V on Windows) or dragged into supported terminals.
+Images can be pasted with Cmd+V on macOS, Ctrl+V on Linux (Alt+V on Windows), or dragged into supported terminals.
 
 ### Run Shell Commands
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -24,7 +24,7 @@ The editor can be replaced temporarily by built-in UI such as `/settings` or by 
 | File reference | Type `@` to fuzzy-search project files |
 | Path completion | Press Tab to complete paths |
 | Multi-line input | Shift+Enter, or Ctrl+Enter on Windows Terminal |
-| Images | Paste with Ctrl+V, Alt+V on Windows, or drag into the terminal |
+| Images | Paste with Cmd+V on macOS / Ctrl+V on Linux, Alt+V on Windows, or drag into the terminal |
 | Shell command | `!command` runs and sends output to the model |
 | Hidden shell command | `!!command` runs without sending output to the model |
 | External editor | Ctrl+G opens `$VISUAL` or `$EDITOR` |

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -63,6 +63,17 @@ export interface AppKeybindings {
 
 export type AppKeybinding = keyof AppKeybindings;
 
+/**
+ * Default key for pasting from the clipboard. macOS uses Command-V (the
+ * platform paste convention); Linux keeps Control-V and native Windows uses
+ * Alt-V so the binding does not collide with the terminal's paste shortcut.
+ */
+export function defaultPasteImageKeys(platform: NodeJS.Platform = process.platform): KeyId {
+	if (platform === "win32") return "alt+v";
+	if (platform === "darwin") return "super+v";
+	return "ctrl+v";
+}
+
 declare module "@earendil-works/pi-tui" {
 	interface Keybindings extends AppKeybindings {}
 }
@@ -115,7 +126,7 @@ export const KEYBINDINGS = {
 		description: "Restore queued messages",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
+		defaultKeys: defaultPasteImageKeys(),
 		description: "Paste image from clipboard",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },

--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -36,6 +36,10 @@ function formatKeyPart(part: string, platform: NodeJS.Platform): string {
 	if (platform === "darwin" && normalized === "alt") {
 		return "Option";
 	}
+	// Command is the macOS paste shortcut (super in keybinding ids).
+	if (platform === "darwin" && normalized === "super") {
+		return "Cmd";
+	}
 	return normalized.charAt(0).toUpperCase() + normalized.slice(1);
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4141,7 +4141,7 @@ export class InteractiveMode {
 			}
 		};
 
-		// Handle clipboard image paste (triggered on Ctrl+V)
+		// Handle clipboard image paste (triggered on Command+V on macOS, Ctrl+V elsewhere)
 		this.defaultEditor.onPasteImage = () => {
 			this.handleClipboardImagePaste();
 		};

--- a/packages/coding-agent/test/custom-editor.test.ts
+++ b/packages/coding-agent/test/custom-editor.test.ts
@@ -1,7 +1,7 @@
 import type { AutocompleteProvider, EditorTheme, OverlayHandle, TUI } from "@earendil-works/pi-tui";
 import { CURSOR_MARKER, setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { KeybindingsManager } from "../src/core/keybindings.js";
+import { defaultPasteImageKeys, KeybindingsManager } from "../src/core/keybindings.js";
 import { CustomEditor } from "../src/modes/interactive/components/custom-editor.js";
 
 const passthrough = (text: string) => text;
@@ -90,6 +90,26 @@ describe("CustomEditor", () => {
 		editor.handleInput("\x1b");
 
 		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("triggers clipboard image paste on the platform-default paste key", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const handler = vi.fn();
+		editor.onPasteImage = handler;
+
+		const pasteKey = defaultPasteImageKeys();
+		if (pasteKey === "super+v") {
+			// macOS: Command+V arrives as a Kitty CSI-u sequence with the super modifier.
+			editor.handleInput("\x1b[118;9u");
+			// Control+V must no longer trigger image paste on macOS.
+			editor.handleInput("\x16");
+		} else if (pasteKey === "ctrl+v") {
+			editor.handleInput("\x16");
+		} else {
+			editor.handleInput("\x1b[118;3u"); // Windows: alt+v
+		}
+
 		expect(handler).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/keybinding-hints.test.ts
+++ b/packages/coding-agent/test/keybinding-hints.test.ts
@@ -8,6 +8,18 @@ describe("keybinding hint formatting", () => {
 		expect(formatKeyText("shift+ctrl+p/alt+up", "darwin")).toBe("Shift+Ctrl+P/Option+↑");
 	});
 
+	it("labels the Command key as Cmd on macOS", () => {
+		expect(formatKeyText("super+v", "darwin")).toBe("Cmd+V");
+		expect(formatKeyText("super+shift+v", "darwin")).toBe("Cmd+Shift+V");
+		expect(formatKeyText("ctrl+super+p", "darwin")).toBe("Ctrl+Cmd+P");
+	});
+
+	it("keeps the Super modifier literal on linux and Windows", () => {
+		expect(formatKeyText("super+v", "linux")).toBe("Super+V");
+		expect(formatKeyText("super+v", "win32")).toBe("Super+V");
+		expect(formatKeyText("super+shift+v", "linux")).toBe("Super+Shift+V");
+	});
+
 	it("keeps canonical modifier names on linux", () => {
 		expect(formatKeyText("ctrl+p", "linux")).toBe("Ctrl+P");
 		expect(formatKeyText("alt+enter", "linux")).toBe("Alt+Enter");

--- a/packages/coding-agent/test/keybindings-defaults.test.ts
+++ b/packages/coding-agent/test/keybindings-defaults.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { defaultPasteImageKeys, KEYBINDINGS } from "../src/core/keybindings.js";
+
+describe("app.clipboard.pasteImage default key", () => {
+	it("uses Command-V (super+v) on macOS", () => {
+		expect(defaultPasteImageKeys("darwin")).toBe("super+v");
+	});
+
+	it("uses Control-V on Linux", () => {
+		expect(defaultPasteImageKeys("linux")).toBe("ctrl+v");
+	});
+
+	it("uses Alt-V on Windows so it never collides with the terminal paste", () => {
+		expect(defaultPasteImageKeys("win32")).toBe("alt+v");
+	});
+
+	it("resolves the live default from the host platform", () => {
+		expect(KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys).toBe(defaultPasteImageKeys());
+	});
+});


### PR DESCRIPTION
## Summary

- Use Cmd-V (`super+v`) as the image-paste shortcut on macOS.
- Keep Ctrl-V on Linux and Alt-V on Windows.
- Display `super` as `Cmd` in macOS shortcut hints.
- Add platform-default and editor behavior tests.

This targets image paste. Normal text paste remains terminal-native.

## Validation

- Focused coding-agent tests: 28 passed
- Repository checks: passed (Biome, installer render, browser smoke, TypeScript).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized interactive keybinding and documentation changes for image paste only; no auth, session, or provider logic touched.
> 
> **Overview**
> Aligns **clipboard image paste** with macOS conventions by defaulting `app.clipboard.pasteImage` to **`super+v` (Cmd+V)** on darwin instead of Control+V. Linux stays on `ctrl+v` and Windows on `alt+v` via a new **`defaultPasteImageKeys()`** helper wired into `KEYBINDINGS`.
> 
> Shortcut hints on macOS now label the **`super`** modifier as **Cmd**, and keybinding docs document **`super`** (including Kitty-style delivery). User-facing docs (README, quickstart, usage) describe Cmd+V on macOS for images. **Text paste** remains terminal-native.
> 
> Tests cover platform defaults, editor paste handling (including that Ctrl+V no longer triggers image paste on macOS), and hint formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072536ea85db724296c8a6c24357149ab3a80634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix image paste keybinding to use Cmd+V on macOS instead of Ctrl+V
> - Adds `defaultPasteImageKeys()` in [keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/746/files#diff-f93dc44960592e9f476dd0994e2f5f2f96756644ce1c9ffaa4e45dab0db65739) to return the correct paste key per platform: `super+v` on macOS, `ctrl+v` on Linux, `alt+v` on Windows.
> - Updates `formatKeyPart` in [keybinding-hints.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/746/files#diff-c352eb3ff4e96b143ad2486bd54abf1cd60ac214293033084fadbf3f55414397) to display `super` as `Cmd` on macOS.
> - Updates documentation and quickstart guides to reflect platform-specific shortcuts.
> - Behavioral Change: macOS users now trigger image paste with Cmd+V; Ctrl+V no longer activates paste on macOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 072536e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->