### PR TITLE
fix(coding-agent): cache process start id to fix daemon handshake livelock on Windows

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -18,6 +18,14 @@ const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVIS
 
 const OWNER_VERSION = 1;
 const REGISTRY_LOCK_STALE_MS = 5000;
+const REGISTRY_LOCK_UPDATE_MS = 1000;
+const REGISTRY_LOCK_RETRIES = 500;
+const REGISTRY_LOCK_RETRY_MS = 10;
+const STARTUP_FENCE_POLL_MS = 250;
+const SHUTDOWN_ADMISSION_FILE_NAME = "shutdown-admission.json";
+const SHUTDOWN_ADMISSION_LEASE_MS = 5000;
+const SHUTDOWN_ADMISSION_REFRESH_MS = 1000;
+const SHUTDOWN_ADMISSION_WAIT_MS = 50;
 
 // getProcessStartId() synchronously shells out to `powershell.exe` on Windows
 // (see session-lease.ts) to read a pid's start time. That call alone commonly
@@ -32,6 +40,11 @@ const REGISTRY_LOCK_STALE_MS = 5000;
 // briefly is safe; the TTL bounds the (already narrow, non-security) staleness
 // window for the rare case of a pid being recycled, matching the tolerance
 // this file already accepts elsewhere (e.g. REGISTRY_LOCK_STALE_MS above).
+// This is the same lookup daemon-update-restart.ts's createProcessIdentityLivenessCheck
+// throttles for the identical reason (PROCESS_START_ID_RECHECK_MS = 1000 there); this
+// file uses 5000ms because the expiry is computed AFTER the (potentially 1.1-1.25s,
+// occasionally multi-second) lookup returns, not before, so a shorter TTL closer to
+// the observed steady-state lookup cost would leave little to no effective caching.
 const PROCESS_START_ID_CACHE_TTL_MS = 5000;
 const processStartIdCache = new Map<number, { value: string | undefined; expiresAt: number }>();
 
@@ -40,27 +53,23 @@ export function cachedProcessStartId(
 	lookup: (pid: number) => string | undefined = getProcessStartId,
 	now: () => number = Date.now,
 ): string | undefined {
-	const nowMs = now();
 	const cached = processStartIdCache.get(pid);
-	if (cached && cached.expiresAt > nowMs) {
+	if (cached && cached.expiresAt > now()) {
 		return cached.value;
 	}
 	const value = lookup(pid);
-	processStartIdCache.set(pid, { value, expiresAt: nowMs + PROCESS_START_ID_CACHE_TTL_MS });
+	// Stamp the expiry from AFTER the lookup returns, not before: the lookup
+	// itself can take as long as the TTL (or longer, cold), and computing the
+	// deadline from the start time would make slow lookups produce an entry
+	// that is already expired the moment it is stored — caching nothing at
+	// all in exactly the environments this fix targets.
+	processStartIdCache.set(pid, { value, expiresAt: now() + PROCESS_START_ID_CACHE_TTL_MS });
 	return value;
 }
 
 export function clearProcessStartIdCacheForTests(): void {
 	processStartIdCache.clear();
 }
-const REGISTRY_LOCK_UPDATE_MS = 1000;
-const REGISTRY_LOCK_RETRIES = 500;
-const REGISTRY_LOCK_RETRY_MS = 10;
-const STARTUP_FENCE_POLL_MS = 250;
-const SHUTDOWN_ADMISSION_FILE_NAME = "shutdown-admission.json";
-const SHUTDOWN_ADMISSION_LEASE_MS = 5000;
-const SHUTDOWN_ADMISSION_REFRESH_MS = 1000;
-const SHUTDOWN_ADMISSION_WAIT_MS = 50;
 
 type DaemonSupervisorOwnerPhase = "starting" | "owner" | "stopping";
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -27,24 +27,13 @@ const SHUTDOWN_ADMISSION_LEASE_MS = 5000;
 const SHUTDOWN_ADMISSION_REFRESH_MS = 1000;
 const SHUTDOWN_ADMISSION_WAIT_MS = 50;
 
-// getProcessStartId() synchronously shells out to `powershell.exe` on Windows
-// (see session-lease.ts) to read a pid's start time. That call alone commonly
-// costs 100ms-1s+, worse under load, and every worker_auth attempt during the
-// daemon supervisor<->worker handshake calls it through isProcessIdentityAlive
-// below for the SAME supervisor pid. Because that synchronous spawn blocks the
-// worker's event loop while the client's own request timeout keeps ticking
-// independently, the client can time out and reconnect before the worker ever
-// finishes computing the value it needed to answer the *previous* attempt —
-// a livelock where every retry loses the race by a small margin. A pid's
-// start time is immutable for as long as that pid stays alive, so caching it
-// briefly is safe; the TTL bounds the (already narrow, non-security) staleness
-// window for the rare case of a pid being recycled, matching the tolerance
-// this file already accepts elsewhere (e.g. REGISTRY_LOCK_STALE_MS above).
-// This is the same lookup daemon-update-restart.ts's createProcessIdentityLivenessCheck
-// throttles for the identical reason (PROCESS_START_ID_RECHECK_MS = 1000 there); this
-// file uses 5000ms because the expiry is computed AFTER the (potentially 1.1-1.25s,
-// occasionally multi-second) lookup returns, not before, so a shorter TTL closer to
-// the observed steady-state lookup cost would leave little to no effective caching.
+// getProcessStartId() synchronously spawns powershell.exe on Windows (session-lease.ts),
+// costing 100ms-1s+. Every worker_auth attempt hits it for the same supervisor pid, blocking
+// the worker's event loop past the client's 1000ms per-attempt timeout, so the handshake
+// livelocks with every retry losing the race. A pid's start time is immutable while that pid
+// is alive, so caching it briefly is safe; this is not a security boundary. 5000ms rather than
+// daemon-update-restart.ts's PROCESS_START_ID_RECHECK_MS = 1000 because the expiry below is
+// stamped after the lookup returns, so a TTL near the lookup's own cost would cache nothing.
 const PROCESS_START_ID_CACHE_TTL_MS = 5000;
 const processStartIdCache = new Map<number, { value: string | undefined; expiresAt: number }>();
 
@@ -58,11 +47,8 @@ export function cachedProcessStartId(
 		return cached.value;
 	}
 	const value = lookup(pid);
-	// Stamp the expiry from AFTER the lookup returns, not before: the lookup
-	// itself can take as long as the TTL (or longer, cold), and computing the
-	// deadline from the start time would make slow lookups produce an entry
-	// that is already expired the moment it is stored — caching nothing at
-	// all in exactly the environments this fix targets.
+	// Expiry is stamped after the lookup returns: a lookup slower than the TTL
+	// would otherwise store an entry that is already expired.
 	processStartIdCache.set(pid, { value, expiresAt: now() + PROCESS_START_ID_CACHE_TTL_MS });
 	return value;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -18,6 +18,41 @@ const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVIS
 
 const OWNER_VERSION = 1;
 const REGISTRY_LOCK_STALE_MS = 5000;
+
+// getProcessStartId() synchronously shells out to `powershell.exe` on Windows
+// (see session-lease.ts) to read a pid's start time. That call alone commonly
+// costs 100ms-1s+, worse under load, and every worker_auth attempt during the
+// daemon supervisor<->worker handshake calls it through isProcessIdentityAlive
+// below for the SAME supervisor pid. Because that synchronous spawn blocks the
+// worker's event loop while the client's own request timeout keeps ticking
+// independently, the client can time out and reconnect before the worker ever
+// finishes computing the value it needed to answer the *previous* attempt —
+// a livelock where every retry loses the race by a small margin. A pid's
+// start time is immutable for as long as that pid stays alive, so caching it
+// briefly is safe; the TTL bounds the (already narrow, non-security) staleness
+// window for the rare case of a pid being recycled, matching the tolerance
+// this file already accepts elsewhere (e.g. REGISTRY_LOCK_STALE_MS above).
+const PROCESS_START_ID_CACHE_TTL_MS = 5000;
+const processStartIdCache = new Map<number, { value: string | undefined; expiresAt: number }>();
+
+export function cachedProcessStartId(
+	pid: number,
+	lookup: (pid: number) => string | undefined = getProcessStartId,
+	now: () => number = Date.now,
+): string | undefined {
+	const nowMs = now();
+	const cached = processStartIdCache.get(pid);
+	if (cached && cached.expiresAt > nowMs) {
+		return cached.value;
+	}
+	const value = lookup(pid);
+	processStartIdCache.set(pid, { value, expiresAt: nowMs + PROCESS_START_ID_CACHE_TTL_MS });
+	return value;
+}
+
+export function clearProcessStartIdCacheForTests(): void {
+	processStartIdCache.clear();
+}
 const REGISTRY_LOCK_UPDATE_MS = 1000;
 const REGISTRY_LOCK_RETRIES = 500;
 const REGISTRY_LOCK_RETRY_MS = 10;
@@ -525,7 +560,7 @@ function isProcessIdentityAlive(identity: ProcessIdentity): boolean {
 	if (!identity.processStartId) {
 		return true;
 	}
-	const observed = getProcessStartId(identity.pid);
+	const observed = cachedProcessStartId(identity.pid);
 	return observed === undefined || observed === identity.processStartId;
 }
 
@@ -533,7 +568,7 @@ function matchesExactProcessIdentity(identity: ProcessIdentity): boolean {
 	if (!isProcessAlive(identity.pid)) {
 		return false;
 	}
-	return identity.processStartId === undefined || getProcessStartId(identity.pid) === identity.processStartId;
+	return identity.processStartId === undefined || cachedProcessStartId(identity.pid) === identity.processStartId;
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/packages/coding-agent/test/daemon-supervisor-ownership-process-cache.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership-process-cache.test.ts
@@ -55,6 +55,26 @@ describe("cachedProcessStartId", () => {
 		expect(calls).toEqual([1, 2]);
 	});
 
+	it("does not produce an already-expired entry when the lookup itself is slower than the TTL", () => {
+		clearProcessStartIdCacheForTests();
+		let calls = 0;
+		let now = 1_000;
+		// Simulate a slow synchronous lookup (the real-world powershell.exe spawn
+		// this cache exists for) that itself takes longer than the cache TTL.
+		// The expiry must be computed from when the lookup RETURNS, not when it
+		// STARTED, or the entry is already stale the instant it's stored.
+		const lookup = (pid: number) => {
+			calls++;
+			now += 5_500;
+			return `win:${pid}-start`;
+		};
+
+		expect(cachedProcessStartId(42, lookup, () => now)).toBe("win:42-start");
+		expect(cachedProcessStartId(42, lookup, () => now)).toBe("win:42-start");
+
+		expect(calls).toBe(1);
+	});
+
 	it("caches an undefined result too, so a slow negative lookup isn't repeated", () => {
 		clearProcessStartIdCacheForTests();
 		let calls = 0;

--- a/packages/coding-agent/test/daemon-supervisor-ownership-process-cache.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership-process-cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+	cachedProcessStartId,
+	clearProcessStartIdCacheForTests,
+} from "../src/modes/daemon/daemon-supervisor-ownership.js";
+
+describe("cachedProcessStartId", () => {
+	it("reuses the observed start id for the same pid within the TTL", () => {
+		clearProcessStartIdCacheForTests();
+		let calls = 0;
+		const lookup = (pid: number) => {
+			calls++;
+			return `win:${pid}-start`;
+		};
+		let now = 1_000;
+
+		expect(cachedProcessStartId(42, lookup, () => now)).toBe("win:42-start");
+		now += 100;
+		expect(cachedProcessStartId(42, lookup, () => now)).toBe("win:42-start");
+		now += 100;
+		expect(cachedProcessStartId(42, lookup, () => now)).toBe("win:42-start");
+
+		expect(calls).toBe(1);
+	});
+
+	it("re-queries once the cache entry expires", () => {
+		clearProcessStartIdCacheForTests();
+		let calls = 0;
+		const lookup = (pid: number) => {
+			calls++;
+			return `win:${pid}-start-${calls}`;
+		};
+		let now = 1_000;
+
+		expect(cachedProcessStartId(7, lookup, () => now)).toBe("win:7-start-1");
+		now += 5_001; // past the 5000ms TTL
+		expect(cachedProcessStartId(7, lookup, () => now)).toBe("win:7-start-2");
+
+		expect(calls).toBe(2);
+	});
+
+	it("caches independently per pid", () => {
+		clearProcessStartIdCacheForTests();
+		const calls: number[] = [];
+		const lookup = (pid: number) => {
+			calls.push(pid);
+			return `win:${pid}`;
+		};
+		const now = () => 1_000;
+
+		expect(cachedProcessStartId(1, lookup, now)).toBe("win:1");
+		expect(cachedProcessStartId(2, lookup, now)).toBe("win:2");
+		expect(cachedProcessStartId(1, lookup, now)).toBe("win:1");
+
+		expect(calls).toEqual([1, 2]);
+	});
+
+	it("caches an undefined result too, so a slow negative lookup isn't repeated", () => {
+		clearProcessStartIdCacheForTests();
+		let calls = 0;
+		const lookup = () => {
+			calls++;
+			return undefined;
+		};
+		const now = () => 1_000;
+
+		expect(cachedProcessStartId(9, lookup, now)).toBeUndefined();
+		expect(cachedProcessStartId(9, lookup, now)).toBeUndefined();
+
+		expect(calls).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

On Windows the daemon supervisor↔worker `worker_auth` handshake livelocks: every `prime-agent -p ...` invocation fails after the full 30s connect budget with

```
Error: Timed out after 30000ms waiting for the Prime Agent daemon response to "create".
```

and the worker log showing only `Prime Agent daemon listening on \\.\pipe\prime-agent-worker-...`, nothing after.

## Root cause

`isProcessIdentityAlive()` and `matchesExactProcessIdentity()` in `daemon-supervisor-ownership.ts` call `getProcessStartId(pid)`, which on Windows synchronously spawns `powershell.exe` via `execFileSync` to read the pid's `StartTime`. That spawn costs 100ms-1s+, worse under load, and blocks the worker's event loop for its duration.

`assertDaemonSupervisorOwnerCurrent()` runs on every `worker_auth` attempt and hits this for the same supervisor pid every time. Meanwhile the client's retry loop (`daemon-supervisor.ts:2322-2352`) calls `authenticateWorker(token, claim, 1000)` — a literal 1000ms per attempt — inside a 30s total budget.

Once the spawn cost exceeds ~1000ms, the two independent timers never align: the client gives up and reconnects on a new socket just before the worker finishes blocking and writes its response, so the write lands on a peer that is already destroyed. This repeats every ~1.1-1.25s for the full 30s. A livelock, not a hang.

I ruled out the transport first: a standalone `node:net` named-pipe request/response between two separate `node.exe` processes completes in 5ms, on both Node 22.17.0 and 24.2.0.

An instrumented build isolates the call:

```
[DEBUG] handleLine: worker_auth validation passed, calling assertSupervisorClaimCurrent
   (~1.1s - 1.25s gap; ~22s on the first, cold call)
[DEBUG] handleLine: assertSupervisorClaimCurrent resolved fingerprint=...
[DEBUG] handleLine: wrote worker_auth success response, accepted=false   <-- client already gone
```

That gap, in a function otherwise just `readFileSync` + `process.kill(pid, 0)`, is the `execFileSync` cost.

## Fix

Cache the observed start id per pid behind a 5s TTL, in the two functions that take the slow path.

This is safe because a pid's start time is immutable for as long as that pid is alive. The TTL only bounds staleness for a recycled pid, and this check is crash-recovery bookkeeping, not a security boundary — `worker_auth`'s actual boundary is the per-worker secret `authenticationToken`, checked separately and unaffected here. `isProcessAlive()` is still verified fresh on every call, before the cached start id is consulted.

Not a new pattern in this codebase: `daemon-update-restart.ts`'s `createProcessIdentityLivenessCheck()` already throttles this same lookup for the same reason. The TTL choice, and why the expiry is stamped after the lookup returns rather than before, are documented at the constant.

`session-lease.ts` and `getProcessStartId` are untouched — the redundant calls all originate from this ownership layer, so the cache lives there.

## Verification

- Reproduced with an instrumented build (trace above). After the fix a real `-p` invocation returns `42`, exit 0, with the handshake completing in ~1.4s instead of never completing within 30s.
- Added `test/daemon-supervisor-ownership-process-cache.test.ts`, 5 cases including a lookup slower than the TTL itself. All pass, and they fail without the fix.
- Ran `test/daemon-*.test.ts` before and after: identical failure set (23 pre-existing Windows temp-dir `EACCES`/`EPERM` failures, unrelated to this change).
- `npm run check` passes.

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance fix in crash-recovery identity checks; auth still relies on tokens and fresh `isProcessAlive`; brief cache only affects start-id comparison for live pids.
> 
> **Overview**
> Adds a **5s per-pid cache** for Windows process start-id lookups so repeated `worker_auth` ownership checks do not synchronously spawn PowerShell on every attempt.
> 
> `isProcessIdentityAlive` and `matchesExactProcessIdentity` now call `cachedProcessStartId` instead of `getProcessStartId` directly; cache expiry is set **after** the lookup returns so slow lookups still get a useful TTL. One-time acquisition paths (`acquireDaemonSupervisorOwnership`, shutdown admission, startup fence) still use uncached `getProcessStartId`.
> 
> New unit tests cover TTL reuse, expiry, per-pid isolation, slow lookups, and caching `undefined` results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a197a9191f282f4b4913ffc648466345e4e3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache process start ID lookups to fix daemon handshake livelock on Windows
> - Introduces `cachedProcessStartId` in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/748/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) with a 5000ms TTL to avoid repeated synchronous `getProcessStartId` calls that caused a livelock during daemon handshakes on Windows.
> - Both `isProcessIdentityAlive` and `matchesExactProcessIdentity` now use the cached lookup instead of calling `getProcessStartId` directly.
> - Adds `clearProcessStartIdCacheForTests` to reset cache state between tests, and a new test suite covering TTL, per-pid isolation, slow lookups, and `undefined` caching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04a197a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->