### PR TITLE
feat(ai): SuperGrok OAuth device login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added SuperGrok / X Premium OAuth device login for the existing xAI provider.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1101,6 +1101,7 @@ Several providers require OAuth authentication instead of static API keys:
 - **Anthropic** (Claude Pro/Max subscription)
 - **OpenAI Codex** (ChatGPT Plus/Pro subscription, access to GPT-5.x Codex models)
 - **GitHub Copilot** (Copilot subscription)
+- **xAI SuperGrok** (SuperGrok / X Premium subscription, device login)
 
 For paid Cloud Code Assist subscriptions, set `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` to your project ID.
 
@@ -1167,6 +1168,7 @@ import {
   loginAnthropic,
   loginOpenAICodex,
   loginGitHubCopilot,
+  loginXai,
   loginGeminiCli,
 
   // Token management

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,8 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - OpenAI Codex (ChatGPT Plus/Pro)
+ * - xAI SuperGrok
  */
 
 // Anthropic
@@ -19,8 +21,9 @@ export {
 } from "./github-copilot.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
-
 export * from "./types.js";
+// xAI SuperGrok
+export { loginXai, refreshXaiToken, xaiOAuthProvider } from "./xai.js";
 
 // ============================================================================
 // Provider Registry
@@ -30,11 +33,13 @@ import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { xaiOAuthProvider } from "./xai.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,178 @@
+/**
+ * xAI SuperGrok / X Premium OAuth device flow.
+ */
+
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+const CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const DEVICE_URL = "https://auth.x.ai/oauth2/device/code";
+const SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+function formHeaders(): Record<string, string> {
+	return {
+		Accept: "application/json",
+		"Content-Type": "application/x-www-form-urlencoded",
+	};
+}
+
+function expiresAt(expiresIn: number | undefined): number {
+	const ttlMs = expiresIn && expiresIn > 0 ? expiresIn * 1000 : 60 * 60 * 1000;
+	return Date.now() + ttlMs - 5 * 60 * 1000;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+		const timeout = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+function assertHttps(url: string): string {
+	const parsed = new URL(url);
+	if (parsed.protocol !== "https:") {
+		throw new Error("Untrusted verification URL in xAI OAuth response");
+	}
+	return parsed.href;
+}
+
+export async function refreshXaiToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+	const response = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: formHeaders(),
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: credentials.refresh,
+			client_id: CLIENT_ID,
+		}),
+	});
+	if (!response.ok) {
+		throw new Error(`xAI token refresh failed (${response.status})`);
+	}
+	const data = (await response.json()) as {
+		access_token?: string;
+		refresh_token?: string;
+		expires_in?: number;
+	};
+	if (!data.access_token) {
+		throw new Error("xAI token refresh response is missing access_token");
+	}
+	return {
+		access: data.access_token,
+		refresh: data.refresh_token ?? credentials.refresh,
+		expires: expiresAt(data.expires_in),
+	};
+}
+
+export async function loginXai(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+	const deviceResponse = await fetch(DEVICE_URL, {
+		method: "POST",
+		headers: formHeaders(),
+		body: new URLSearchParams({
+			client_id: CLIENT_ID,
+			scope: SCOPE,
+		}),
+		signal: callbacks.signal,
+	});
+	if (!deviceResponse.ok) {
+		throw new Error(`xAI device code request failed (${deviceResponse.status})`);
+	}
+
+	const device = (await deviceResponse.json()) as {
+		device_code?: string;
+		user_code?: string;
+		verification_uri?: string;
+		verification_uri_complete?: string;
+		expires_in?: number;
+		interval?: number;
+	};
+	if (!device.device_code || !device.user_code || !device.verification_uri) {
+		throw new Error("xAI device code response is missing required fields");
+	}
+
+	const verificationUri = assertHttps(device.verification_uri);
+	callbacks.onAuth({
+		url: device.verification_uri_complete ? assertHttps(device.verification_uri_complete) : verificationUri,
+		instructions: `Open ${verificationUri} and enter code: ${device.user_code}`,
+	});
+	callbacks.onProgress?.("Waiting for xAI authorization...");
+
+	const deadline =
+		Date.now() + (device.expires_in && device.expires_in > 0 ? device.expires_in * 1000 : 30 * 60 * 1000);
+	let intervalMs = Math.max((device.interval ?? 5) * 1000, 1000);
+
+	while (Date.now() < deadline) {
+		if (callbacks.signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+		await sleep(Math.min(intervalMs, Math.max(0, deadline - Date.now())), callbacks.signal);
+
+		const response = await fetch(TOKEN_URL, {
+			method: "POST",
+			headers: formHeaders(),
+			body: new URLSearchParams({
+				grant_type: DEVICE_GRANT,
+				client_id: CLIENT_ID,
+				device_code: device.device_code,
+			}),
+			signal: callbacks.signal,
+		});
+		const body = (await response.json().catch(() => ({}))) as {
+			access_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			error?: string;
+			error_description?: string;
+			interval?: number;
+		};
+
+		if (response.ok) {
+			if (!body.access_token || !body.refresh_token) {
+				throw new Error("xAI token response is missing access_token or refresh_token");
+			}
+			return {
+				access: body.access_token,
+				refresh: body.refresh_token,
+				expires: expiresAt(body.expires_in),
+			};
+		}
+		if (body.error === "authorization_pending") {
+			continue;
+		}
+		if (body.error === "slow_down") {
+			intervalMs = typeof body.interval === "number" && body.interval > 0 ? body.interval * 1000 : intervalMs + 5000;
+			continue;
+		}
+		if (body.error === "access_denied" || body.error === "authorization_denied") {
+			throw new Error("xAI device authorization was denied");
+		}
+		if (body.error === "expired_token") {
+			throw new Error("xAI device code expired; run login again");
+		}
+		throw new Error(
+			`xAI device token exchange failed (${response.status}): ${body.error_description ?? body.error ?? response.statusText}`,
+		);
+	}
+
+	throw new Error("xAI device authorization timed out");
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai",
+	name: "xAI SuperGrok",
+	login: loginXai,
+	refreshToken: refreshXaiToken,
+	getApiKey: (credentials) => credentials.access,
+};

--- a/packages/ai/test/xai-oauth.test.ts
+++ b/packages/ai/test/xai-oauth.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getOAuthProvider, resetOAuthProviders } from "../src/utils/oauth/index.js";
+import { loginXai, refreshXaiToken, xaiOAuthProvider } from "../src/utils/oauth/xai.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+describe("xAI SuperGrok OAuth", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("runs device login with pending and slow_down polling", async () => {
+		vi.useFakeTimers();
+		const tokenResponses = [
+			jsonResponse({ error: "authorization_pending" }, 400),
+			jsonResponse({ error: "slow_down", interval: 7 }, 400),
+			jsonResponse({ access_token: "access", refresh_token: "refresh", expires_in: 3600 }),
+		];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit) => {
+				const url = getUrl(input);
+				if (url.endsWith("/oauth2/device/code")) {
+					const body = new URLSearchParams(String(init?.body));
+					expect(body.get("client_id")).toBe("b1a00492-073a-47ea-816f-4c329264a828");
+					expect(body.get("scope")).toContain("grok-cli:access");
+					return jsonResponse({
+						device_code: "device",
+						user_code: "ABCD-EFGH",
+						verification_uri: "https://accounts.x.ai/oauth2/device",
+						verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=ABCD-EFGH",
+						expires_in: 1800,
+						interval: 5,
+					});
+				}
+				if (url.endsWith("/oauth2/token")) {
+					const response = tokenResponses.shift();
+					if (!response) {
+						throw new Error("Unexpected extra token poll");
+					}
+					return response;
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			}),
+		);
+
+		let authUrl = "";
+		const loginPromise = loginXai({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+		});
+
+		await vi.advanceTimersByTimeAsync(5000);
+		await vi.advanceTimersByTimeAsync(5000);
+		await vi.advanceTimersByTimeAsync(7000);
+
+		const credentials = await loginPromise;
+		expect(authUrl).toContain("user_code=ABCD-EFGH");
+		expect(credentials).toMatchObject({ access: "access", refresh: "refresh" });
+		expect(credentials.expires).toBeGreaterThan(Date.now());
+	});
+
+	it("rejects non-https verification URLs", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				jsonResponse({
+					device_code: "device",
+					user_code: "ABCD-EFGH",
+					verification_uri: "http://evil.example/device",
+					expires_in: 1800,
+				}),
+			),
+		);
+		await expect(
+			loginXai({
+				onAuth: () => {},
+				onPrompt: async () => "",
+			}),
+		).rejects.toThrow("Untrusted verification URL");
+	});
+
+	it("refreshes access tokens and keeps an unrotated refresh token", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ access_token: "new-access", expires_in: 3600 })),
+		);
+		const credentials = await refreshXaiToken({
+			access: "old",
+			refresh: "same-refresh",
+			expires: 0,
+		});
+		expect(credentials.access).toBe("new-access");
+		expect(credentials.refresh).toBe("same-refresh");
+		expect(xaiOAuthProvider.getApiKey(credentials)).toBe("new-access");
+	});
+
+	it("registers as a built-in OAuth provider", () => {
+		resetOAuthProviders();
+		expect(getOAuthProvider("xai")).toBe(xaiOAuthProvider);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Added SuperGrok / X Premium OAuth device login for the xAI provider.
+- Changed the default xAI model to `grok-4.5`.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -80,6 +80,7 @@ For each built-in provider, Prime Agent maintains a list of tool-capable models,
 - Anthropic Claude Pro/Max
 - OpenAI ChatGPT Plus/Pro (Codex)
 - GitHub Copilot
+- xAI SuperGrok / X Premium
 
 **API keys:**
 - Anthropic

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- xAI SuperGrok or X Premium
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.json` and auto-refresh when expired.
 
@@ -34,6 +35,10 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+### xAI SuperGrok
+
+Select xAI SuperGrok in `/login`, open the device page, and enter the code. SuperGrok and eligible X Premium subscriptions are supported. OAuth and API-key credentials share the `xai` auth slot.
 
 ## API Keys
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -30,7 +30,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"github-copilot": "gpt-5.4",
 	openrouter: "moonshotai/kimi-k2.6",
 	"vercel-ai-gateway": "zai/glm-5.1",
-	xai: "grok-4.20-0309-reasoning",
+	xai: "grok-4.5",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.7",
 	zai: "glm-5.1",


### PR DESCRIPTION
Adds SuperGrok / X Premium device OAuth on the existing `xai` provider. Tokens refresh automatically. Default xAI model is `grok-4.5`.

`/login` → xAI SuperGrok, then use built-in xAI models against `api.x.ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces OAuth token acquisition and refresh against xAI’s auth endpoints and changes the default xAI model, which affects auth handling and out-of-the-box model selection without touching core inference paths.
> 
> **Overview**
> Adds **SuperGrok / X Premium** subscription auth for the existing **`xai`** provider via OAuth **device login** (open verification URL, enter user code, poll until authorized). **`loginXai`**, **`refreshXaiToken`**, and **`xaiOAuthProvider`** are exported from **`prime-agent-ai/oauth`** and registered alongside the other built-in OAuth providers so **`/login`** and **`getOAuthApiKey`** can use the same **`xai`** auth slot as API keys.
> 
> The device flow polls **`auth.x.ai`** with **`authorization_pending`** / **`slow_down`** handling, rejects non-HTTPS verification URLs, and refreshes access tokens while preserving the refresh token when the issuer does not rotate it. Vitest coverage exercises polling, URL hardening, refresh, and registry wiring.
> 
> Docs and changelogs in **`packages/ai`** and **`packages/coding-agent`** document the new login path. The coding-agent default xAI model changes from **`grok-4.20-0309-reasoning`** to **`grok-4.5`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c3b5470efc1825b37de59a1c38c98e3c24957d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add xAI SuperGrok OAuth device login flow to the xAI provider
> - Implements OAuth 2.0 device authorization flow in [`packages/ai/src/utils/oauth/xai.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/752/files#diff-a09114a3bec83ce83a7c3dfcaaf770c8e5e78ece71fae3b8e6de5109a64df65b), supporting polling with `authorization_pending`, `slow_down` backoff, `access_denied`, and `expired_token` error handling.
> - Adds `loginXai` and `refreshXaiToken` functions and registers `xaiOAuthProvider` in the built-in OAuth provider registry so `getOAuthProvider('xai')` resolves to it.
> - Changes the default xAI model in [`packages/coding-agent/src/core/model-resolver.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/752/files#diff-22e2eb9b044dcbda43aec220ab0d91127a4f6ed0cc7e2757843bd6bc6aeaa144) from `grok-4.20-0309-reasoning` to `grok-4.5`.
> - Behavioral Change: non-HTTPS verification URIs returned in device responses are now rejected with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2c3b54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->