### PR TITLE
fix(ai): normalize unknown provider stop/status values as structured failures (#707)

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1273,7 +1273,8 @@ function mapStopReason(reason: Anthropic.Messages.StopReason | string): StopReas
 		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
 			return "error";
 		default:
-			// Handle unknown stop reasons gracefully (API may add new values)
-			throw new Error(`Unhandled stop reason: ${reason}`);
+			// Unknown stop reason — route through structured failure path
+			// instead of crashing the stream.  See #707.
+			return "error";
 	}
 }

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -354,10 +354,10 @@ export function mapStopReason(reason: FinishReason): StopReason {
 		case FinishReason.UNEXPECTED_TOOL_CALL:
 		case FinishReason.NO_IMAGE:
 			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// Unknown finish reason — route through structured failure path
+			// instead of crashing the stream.  See #707.
+			return "error";
 	}
 }
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -634,6 +634,8 @@ function mapChatStopReason(reason: string | null): StopReason {
 		case "error":
 			return "error";
 		default:
-			return "stop";
+			// Unknown finish reason — treat as error instead of silently
+			// reporting as successful completion.  See #707.
+			return "error";
 	}
 }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -554,9 +554,9 @@ function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): Sto
 		case "in_progress":
 		case "queued":
 			return "stop";
-		default: {
-			const _exhaustive: never = status;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// Unknown status — route through structured failure path
+			// instead of crashing the stream.  See #707.
+			return "error";
 	}
 }


### PR DESCRIPTION
## Problem

Four providers crash or silently mishandle unknown terminal stop/status values:

| Provider | Current behavior | Issue |
|---|---|---|
| Anthropic | `throw new Error` | Stream crash on unknown stop reason |
| OpenAI Responses | `throw new Error` (exhaustive check) | Stream crash on unknown status |
| Google/Vertex | `throw new Error` (exhaustive check) | Stream crash on unknown finish reason |
| Mistral | `return "stop"` | Silent success on unknown (safety-filtered response reported as complete) |

OpenAI Completions and Amazon Bedrock already handle this correctly.

## Fix

Change all four mappers to `return "error"` on unknown values. This routes them through the existing structured provider-failure path (`StreamFailureError` / failure classification from #313).

All four callers already set `stopReasonRaw` when `stopReason === "error"`, so the raw provider value is preserved for diagnostics:

```typescript
// Anthropic (line 685-687), Google (line 215-216), OpenAI Responses (line 518-519)
if (output.stopReason === "error") {
    output.stopReasonRaw = <raw_value>;
}
```

**Diff summary**: 4 files changed, 14 insertions(+), 11 deletions(-)

Fixes #707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, consistent behavior change in provider mapping only; failures become structured errors instead of throws or false success, with no new APIs or auth/data paths touched.
> 
> **Overview**
> **Unknown terminal stop/status values from four providers no longer crash the stream or look like a clean completion.** Anthropic, Google/Vertex, OpenAI Responses, and Mistral stop-reason mappers now return **`error`** for unrecognized values instead of throwing or (on Mistral) defaulting to **`stop`**.
> 
> That routes through the existing **`StreamFailureError`** / **`streamFailureFromStopReason`** path callers already use when **`stopReason === "error"`**, with **`stopReasonRaw`** still set so the provider’s raw value is available for diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f03f39f40657998c3b2150deff97f0540f74ec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize unknown provider stop/finish reason values as structured failures instead of throwing
> - In `mapStopReason` for [anthropic.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/756/files#diff-beee73f2e789158a9db5395ff9b504999319d491a77dd9cd523f37ded9b0f954), [google-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/756/files#diff-b08913b9ac25a43585c80ef2d0fbd2dfd99de1f59459a69973b05bb6ed70c60d), and [openai-responses-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/756/files#diff-75a92c85369ffe30444d6da4b398bb4fd5b852ff45a5eea02f95b3b2fa48df48), unknown values previously threw an exception; they now return `StopReason 'error'`.
> - In [mistral.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/756/files#diff-6a24a19d42de9ce9d35e7c4dee33d287375cd53e8d147222d7a2993fd2d163e0), unknown finish reasons previously returned `StopReason 'stop'` (masking failures); they now return `StopReason 'error'`.
> - Behavioral Change: Mistral calls with unrecognized finish reasons will now surface as errors rather than appearing as successful completions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f03f39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->