### PR TITLE
fix(coding-agent): retain Codex models on empty catalog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed authenticated Codex models being hidden when live model discovery returns no models or is unavailable.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -1001,6 +1001,9 @@ export class ModelRegistry {
 				throw new Error(`OpenAI Codex model discovery failed with HTTP ${response.status}`);
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
+			if (modelIds.size === 0) {
+				return availableModels;
+			}
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
 			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
 		} catch {
@@ -1009,7 +1012,7 @@ export class ModelRegistry {
 					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
 				);
 			}
-			return availableModels.filter((model) => model.provider !== "openai-codex");
+			return availableModels;
 		}
 	}
 

--- a/packages/coding-agent/test/model-registry-codex-catalog.test.ts
+++ b/packages/coding-agent/test/model-registry-codex-catalog.test.ts
@@ -1,0 +1,88 @@
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+
+function codexAccessToken(accountId = "account-id"): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+function createCodexRegistry(access = codexAccessToken()): ModelRegistry {
+	return ModelRegistry.inMemory(
+		AuthStorage.inMemory({
+			"openai-codex": {
+				type: "oauth",
+				access,
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			},
+		}),
+	);
+}
+
+describe("ModelRegistry Codex catalog discovery", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test("keeps authenticated Codex models executable when discovery returns an empty catalog", async () => {
+		const registry = createCodexRegistry();
+		const configuredCodexIds = registry
+			.getAvailable()
+			.filter((model) => model.provider === "openai-codex")
+			.map((model) => model.id);
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ models: [] })));
+
+		const executableCodexIds = (await registry.getExecutableModels())
+			.filter((model) => model.provider === "openai-codex")
+			.map((model) => model.id);
+
+		expect(executableCodexIds).toEqual(configuredCodexIds);
+	});
+
+	test("uses a non-empty live Codex catalog to filter executable models", async () => {
+		const registry = createCodexRegistry();
+		const configuredCodex = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		const allowedModel = configuredCodex[0]!;
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ models: [{ slug: allowedModel.id }] })));
+
+		const executableCodexIds = (await registry.getExecutableModels())
+			.filter((model) => model.provider === "openai-codex")
+			.map((model) => model.id);
+
+		expect(executableCodexIds).toEqual([allowedModel.id]);
+	});
+
+	test("keeps authenticated Codex models executable when discovery fails without a cached catalog", async () => {
+		const registry = createCodexRegistry();
+		const configuredCodexIds = registry
+			.getAvailable()
+			.filter((model) => model.provider === "openai-codex")
+			.map((model) => model.id);
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network unavailable")));
+
+		const executableCodexIds = (await registry.getExecutableModels())
+			.filter((model) => model.provider === "openai-codex")
+			.map((model) => model.id);
+
+		expect(executableCodexIds).toEqual(configuredCodexIds);
+	});
+
+	test("does not expose Codex models when its OAuth access token has no account id", async () => {
+		const registry = createCodexRegistry("not-a-jwt");
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const executableCodexModels = (await registry.getExecutableModels()).filter(
+			(model) => model.provider === "openai-codex",
+		);
+
+		expect(executableCodexModels).toEqual([]);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- retain configured authenticated Codex models when `/backend-api/codex/models` responds with an empty catalog or discovery fails without a usable cache
- preserve live-catalog filtering for non-empty catalogs and retain the existing no-auth/missing-account-id gate
- add isolated model-registry coverage for empty, failed, populated, and malformed-account discovery cases

## Reproducer
A Codex-authenticated Luna model can execute through the direct CLI, but RLM calls `ModelRegistry.getExecutableModels()`. When the authenticated request to `/backend-api/codex/models` returns `{ "models": [] }`, the previous code cached that empty set and rejected every `openai-codex` model before execution. The catalog is advisory availability metadata, not an execution preflight: an empty or unavailable catalog must not override configured OAuth credentials. A non-empty catalog remains authoritative; no credentials or no JWT account id still exposes no Codex models.

## Validation
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-registry-codex-catalog.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Codex advisory catalog filtering in getExecutableModels; auth gates and non-empty catalog filtering stay the same, with new tests covering the edge cases.
> 
> **Overview**
> Fixes **RLM/subagent model selection** when OpenAI Codex live discovery is empty or unavailable: `ModelRegistry.getExecutableModels()` no longer strips all `openai-codex` models after `{ models: [] }` or a failed `/codex/models` call without a usable cache.
> 
> **Empty catalog** responses return the full configured Codex set and **do not** cache an empty slug list. **Discovery errors** without a fresh cache fall back the same way instead of hiding Codex models. **Non-empty** catalogs still filter to live slugs, and tokens **without** a JWT account id still expose no Codex models and skip discovery.
> 
> Adds `model-registry-codex-catalog.test.ts` for empty, populated, failed, and malformed-account cases; changelog entry under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bab55098a43fd9a5ad2851c547edc0c02be4acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ModelRegistry.getExecutableModels` to retain Codex models on empty catalog
> - When live Codex model discovery returns an empty catalog, `getExecutableModels` now returns the full available model list instead of filtering out all `openai-codex` models.
> - On discovery failure with no cached catalog, the error handler also falls back to the full available model list rather than removing provider-based models.
> - New test suite in [`model-registry-codex-catalog.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/765/files#diff-ba53fbf87431f74d55b6b1ea71f094ea5e6ff7dec7d613ce48697d3a2c99fb77) covers empty catalog, non-empty catalog filtering, failure fallback, and OAuth token without account ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bab550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->