### PR TITLE
fix(prime-agent-runtime): kill subprocess tree on TimeoutExpired to prevent Windows kernel hangs

### DIFF
--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import types
 from dataclasses import dataclass
@@ -344,3 +345,72 @@ def __getattr__(name: str) -> Any:  # noqa: D401 - module-level lazy attr hook
 
         return getattr(mcp_base, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def _subprocess_kill_tree(pid: int) -> None:
+    """Kill *pid* and its descendants so no pipe-holding grandchild survives."""
+    import subprocess as _sp
+
+    if sys.platform == "win32":
+        try:
+            _sp.run(["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True, timeout=15)
+        except BaseException:
+            pass
+    else:
+        try:
+            if os.getpgid(pid) != os.getpgid(0):
+                os.killpg(os.getpgid(pid), 9)
+            else:
+                os.kill(pid, 9)
+        except BaseException:
+            try:
+                os.kill(pid, 9)
+            except BaseException:
+                pass
+
+
+def _install_subprocess_run_kill_tree() -> None:
+    import subprocess as _sp
+
+    if getattr(_sp, "_prime_agent_kill_tree_patched", False):
+        return
+    _orig_run = _sp.run
+
+    def _run(*popenargs, input=None, capture_output=False, timeout=None, check=False, **kwargs):
+        if timeout is None:
+            return _orig_run(*popenargs, input=input, capture_output=capture_output,
+                             timeout=None, check=check, **kwargs)
+        if input is not None:
+            if kwargs.get("stdin") is not None:
+                raise ValueError("stdin and input arguments may not both be used.")
+            kwargs["stdin"] = _sp.PIPE
+        if capture_output:
+            if kwargs.get("stdout") is not None or kwargs.get("stderr") is not None:
+                raise ValueError("stdout and stderr arguments may not both be used with capture_output.")
+            kwargs["stdout"] = _sp.PIPE
+            kwargs["stderr"] = _sp.PIPE
+        with _sp.Popen(*popenargs, **kwargs) as process:
+            try:
+                stdout, stderr = process.communicate(input, timeout=timeout)
+            except _sp.TimeoutExpired as exc:
+                _subprocess_kill_tree(process.pid)
+                process.kill()
+                process.wait()
+                exc.stdout = None
+                exc.stderr = None
+                raise
+            except BaseException:
+                process.kill()
+                raise
+            retcode = process.poll()
+            if check and retcode:
+                raise _sp.CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
+        return _sp.CompletedProcess(process.args, retcode, stdout, stderr)
+
+    _sp.run = _run
+    _sp._prime_agent_kill_tree_patched = True
+
+
+if os.environ.get("PRIME_AGENT_DISABLE_SUBPROCESS_KILL_TREE") != "1":
+    _install_subprocess_run_kill_tree()
+

--- a/prime-agent-runtime/test/test_subprocess_kill_tree.py
+++ b/prime-agent-runtime/test/test_subprocess_kill_tree.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+import rlm
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+    except PermissionError:
+        return True
+
+
+class SubprocessKillTreeInstallTest(unittest.TestCase):
+    """The kill-tree monkeypatch is installed on import and is idempotent."""
+
+    def test_patch_installed(self) -> None:
+        self.assertTrue(getattr(subprocess, "_prime_agent_kill_tree_patched", False))
+        # subprocess.run must now be the patched wrapper, not the stdlib original.
+        self.assertEqual(subprocess.run.__name__, "_run")
+
+    def test_install_is_idempotent(self) -> None:
+        original = subprocess.run
+        rlm._install_subprocess_run_kill_tree()
+        rlm._install_subprocess_run_kill_tree()
+        self.assertIs(subprocess.run, original)
+
+    def test_disable_env_flag(self) -> None:
+        """PRIME_AGENT_DISABLE_SUBPROCESS_KILL_TREE=1 leaves subprocess.run untouched."""
+        code = (
+            "import os, subprocess; "
+            "os.environ['PRIME_AGENT_DISABLE_SUBPROCESS_KILL_TREE'] = '1'; "
+            "import rlm; "
+            "print(getattr(subprocess, '_prime_agent_kill_tree_patched', False))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "False")
+
+
+class SubprocessRunBehaviorTest(unittest.TestCase):
+    """The patched subprocess.run preserves normal semantics."""
+
+    def test_normal_run_with_capture_output(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "print('hello')"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "hello")
+
+    def test_run_without_timeout_delegates(self) -> None:
+        # timeout=None must keep the original code path (no behavior change).
+        result = subprocess.run([sys.executable, "-c", "print('plain')"], capture_output=True, text=True)
+        self.assertEqual(result.stdout.strip(), "plain")
+
+    def test_check_true_raises_called_process_error(self) -> None:
+        with self.assertRaises(subprocess.CalledProcessError) as ctx:
+            subprocess.run([sys.executable, "-c", "import sys; sys.exit(3)"], check=True, timeout=30)
+        self.assertEqual(ctx.exception.returncode, 3)
+
+    def test_input_and_timeout(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read().upper())"],
+            input="abc",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.stdout, "ABC")
+
+
+class SubprocessKillTreeBehaviorTest(unittest.TestCase):
+    """On TimeoutExpired the whole tree must die so a grandchild cannot hold the pipes."""
+
+    def test_timeout_expired_kills_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pidfile = os.path.join(temp_dir, "grandchild.pid")
+            # Parent python process spawns a grandchild that sleeps and records
+            # its pid, then the parent sleeps too -- both inherit the pipes of
+            # subprocess.run(capture_output=True), which is exactly the Windows
+            # hang scenario (child killed, grandchild keeps the pipe open).
+            grandchild_code = (
+                f"import time, os; open({pidfile!r}, 'w').write(str(os.getpid())); time.sleep(60)"
+            )
+            parent_code = (
+                "import subprocess, sys, time; "
+                f"p = subprocess.Popen([sys.executable, '-c', {grandchild_code!r}]); "
+                "time.sleep(60)"
+            )
+            started = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                subprocess.run(
+                    [sys.executable, "-c", parent_code],
+                    capture_output=True,
+                    timeout=2,
+                )
+            elapsed = time.monotonic() - started
+            self.assertLess(elapsed, 15, f"TimeoutExpired took too long: {elapsed:.1f}s")
+
+            # On Windows the grandchild must be dead (tree kill). On POSIX the
+            # parent is in our process group, so only the direct child is killed
+            # by design (killpg would take down the test process itself).
+            if sys.platform == "win32":
+                self.assertTrue(os.path.exists(pidfile), "grandchild never started")
+                with open(pidfile, encoding="utf-8") as f:
+                    grandchild_pid = int(f.read().strip())
+                deadline = time.monotonic() + 5
+                while _pid_alive(grandchild_pid) and time.monotonic() < deadline:
+                    time.sleep(0.1)
+                self.assertFalse(
+                    _pid_alive(grandchild_pid),
+                    "grandchild survived the kill-tree; it would hold the pipes forever",
+                )
+
+
+@unittest.skipUnless(hasattr(os, "getpgid"), "POSIX process groups required")
+class SubprocessKillTreePosixBranchTest(unittest.TestCase):
+    """The POSIX branch must never killpg our own process group."""
+
+    def setUp(self) -> None:
+        self.platform_patch = mock.patch("rlm.sys.platform", "linux")
+        self.platform_patch.start()
+
+    def tearDown(self) -> None:
+        self.platform_patch.stop()
+
+    def test_same_group_kills_only_pid(self) -> None:
+        with (
+            mock.patch("rlm.os.getpgid", side_effect=lambda pid: 100),
+            mock.patch("rlm.os.killpg") as killpg,
+            mock.patch("rlm.os.kill") as kill,
+        ):
+            rlm._subprocess_kill_tree(42)
+        killpg.assert_not_called()
+        kill.assert_called_with(42, 9)
+
+    def test_different_group_kills_group(self) -> None:
+        with (
+            mock.patch("rlm.os.getpgid", side_effect=lambda pid: 100 if pid == 0 else 200),
+            mock.patch("rlm.os.killpg") as killpg,
+            mock.patch("rlm.os.kill") as kill,
+        ):
+            rlm._subprocess_kill_tree(42)
+        killpg.assert_called_with(200, 9)
+        kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The IPython kernel can hang forever on Windows when an agent runs a command that spawns a long-lived grandchild process. The common trigger is `subprocess.run(["powershell", "Start-Process <gui-app>", ...], capture_output=True, timeout=N)`: `Start-Process` launches a GUI application that **inherits the stdout/stderr pipes** of the powershell process.

Observed in a real session on Windows 11: the kernel sat for 9 minutes in `subprocess.py:559`, and the only recovery was killing the session.

## Root cause

When the timeout fires, `subprocess.run` kills only the direct child, then -- on Windows -- calls `process.communicate()` a second time **without a timeout** to collect partial output:

```python
except TimeoutExpired as exc:
    process.kill()
    if _mswindows:
        exc.stdout, exc.stderr = process.communicate()  # waits for pipe EOF forever
    else:
        process.wait()
    raise
```

That second `communicate()` waits for EOF on the stdout/stderr pipes. The grandchild (the GUI app launched via `Start-Process`) is still alive and holds them open, so EOF never arrives and the kernel wedges permanently. `py-spy dump` confirmed the stack (`subprocess.py:559`) and a surviving grandchild whose powershell parent was already dead (`Get-CimInstance`).

On POSIX this exact hang cannot happen: the stdlib path is `process.kill()` + `process.wait()` with no second `communicate()`. The timeout still leaves grandchild processes behind, but the kernel itself does not wedge.

## Fix

Install a small wrapper around `subprocess.run` in the kernel runtime (`prime-agent-runtime/src/rlm/__init__.py`). On `TimeoutExpired` it kills the **entire process tree** before the final `wait()`:

- Windows: `taskkill /PID <pid> /T /F`
- POSIX: `os.killpg` -- only when the child's process group differs from the kernel's own group; otherwise falls back to `os.kill(pid, SIGKILL)` so a plain `subprocess.run` (which inherits the kernel's group) can never kill the kernel itself

The direct child is also `kill()`ed explicitly so the wait cannot hang even if `taskkill` is unavailable. `TimeoutExpired` is re-raised with standard semantics (partial output dropped, matching the POSIX stdlib behavior). Calls without `timeout=` are untouched, and the wrapper can be disabled with `PRIME_AGENT_DISABLE_SUBPROCESS_KILL_TREE=1`.

## Verification

- New `test/test_subprocess_kill_tree.py` (9 cases): patch installed and idempotent, env-flag opt-out, normal `run`/`check=True`/`input=` semantics preserved, and the hang scenario -- a python parent spawning a sleeping python grandchild that records its pid -- where `timeout=2` raises `TimeoutExpired` in ~2s **and the grandchild is confirmed dead on Windows**. The POSIX branch is covered with mocked `getpgid`/`killpg`/`kill` (same-group vs different-group).
- Full runtime suite: 74 tests pass (2 POSIX-only skips on Windows).
- Live reproduction on Windows 11: the original hang now raises `TimeoutExpired` in ~3s with no surviving grandchildren, instead of hanging forever.
- `npm run check` passes (Biome, TypeScript, installer render, browser smoke).

## Note

The bug is Windows-specific; on Linux/macOS behavior is unchanged except that a timed-out run now also cleans up grandchild processes when their process group differs from the kernel's.

Related: #748 (daemon-side livelock that can leave the host unresponsive to the kernel), #764 (kernel crash report with a related killpg footgun).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Kill subprocess tree on `TimeoutExpired` to prevent Windows kernel hangs
> - Adds `_subprocess_kill_tree` in [rlm/__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/770/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3) to terminate a process and all descendants: uses `taskkill /T /F` on Windows and `os.killpg`/`os.kill(SIGKILL)` on POSIX.
> - Monkeypatches `subprocess.run` via `_install_subprocess_run_kill_tree` so that on `TimeoutExpired`, the full process tree is killed before re-raising, preventing orphaned grandchildren from holding pipes open.
> - The patch is applied at import time unless `PRIME_AGENT_DISABLE_SUBPROCESS_KILL_TREE=1` is set, and is idempotent.
> - Adds tests covering install behavior, normal `subprocess.run` semantics, tree-kill on timeout (including grandchild verification on Windows), and POSIX branch logic.
> - Risk: importing `rlm` globally replaces `subprocess.run` for the entire process; the original is preserved and non-timeout paths delegate unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cecd46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->