### PR TITLE
fix: npm 10+ compatibility across the update and install surfaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,6 +143,24 @@ EOF
 	fi
 }
 
+# npm 12 defaults allow-remote=none, and the published prime-agent tarball
+# carries transitive URL dependencies (R2-hosted @earendil-works tarballs),
+# so a plain "npm install -g" exits with EALLOWREMOTE. "root" is not enough —
+# the blocked tarballs are transitive — so the install invocation is scoped
+# to allow-remote=all via env, without touching the user's ~/.npmrc. (#741,
+# verified by @d4not on npm 12.0.2.) Gated to npm >= 12 so older npm versions
+# see no unknown-config warnings.
+npm_allow_remote_env() {
+	case "$(npm --version 2>/dev/null)" in
+	1[2-9].* | [2-9][0-9].*)
+		printf 'npm_config_allow_remote=all'
+		;;
+	*)
+		printf ''
+		;;
+	esac
+}
+
 create_temp_dir() {
 	if command -v mktemp >/dev/null 2>&1; then
 		if tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/prime-agent-install.XXXXXX" 2>/dev/null); then
@@ -1603,7 +1621,7 @@ Finalizing npm install."
 			"Installing Prime Agent" \
 			"Installing Prime Agent" \
 			"$npm_install_details" \
-			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1 PRIME_AGENT_INSTALL_UV=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+			env $(npm_allow_remote_env) PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1 PRIME_AGENT_INSTALL_UV=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
 	else
 		npm_install_details="Preparing global install.
 Linking command binaries.
@@ -1614,7 +1632,7 @@ Finalizing npm install."
 			"Installing Prime Agent" \
 			"Installing Prime Agent" \
 			"$npm_install_details" \
-			env PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
+			env $(npm_allow_remote_env) PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g --no-fund --no-audit --loglevel=error --progress=false "$tarball_path"
 	fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -135,9 +135,10 @@ main() {
 The $prime_agent_cmd command was installed, but it is not on your PATH yet.
 Check npm's global bin directory with:
 
-  npm bin -g
+  echo "\$(npm prefix -g)/bin"
 
 Then add that directory to your shell PATH.
+(npm 10 removed the old "npm bin -g" command.)
 EOF
 	fi
 }

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -36,6 +36,24 @@ import { isStdoutTakenOver } from "./output-guard.js";
 import type { PackageSource, SettingsManager } from "./settings-manager.js";
 
 const NETWORK_TIMEOUT_MS = 10000;
+
+/**
+ * Parse `npm view <pkg> version --json` output. npm 10 emits a bare JSON
+ * string; npm >= 11 emits a JSON array (e.g. `["2.87.2"]`). Comparing the
+ * un-normalized array against the installed version string made every
+ * startup report "Package updates available" as a false positive (#738).
+ * Exported for testing.
+ */
+export function normalizeNpmViewVersion(stdout: string): string {
+	const raw = stdout.trim();
+	if (!raw) throw new Error("Empty response from npm view");
+	const parsed: unknown = JSON.parse(raw);
+	const version = Array.isArray(parsed) ? parsed[parsed.length - 1] : parsed;
+	if (typeof version !== "string" || version.length === 0) {
+		throw new Error(`Unexpected npm view version output: ${raw}`);
+	}
+	return version;
+}
 const UPDATE_CHECK_CONCURRENCY = 4;
 const GIT_UPDATE_CONCURRENCY = 4;
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -671,6 +671,37 @@ function getPayloadWorkingIndicatorOptions(
 	};
 }
 
+/**
+ * Translate legacy `/update` package arguments into the `package update`
+ * CLI surface. The standalone `update` command hard-rejects package targets
+ * ("Package updates moved to the package command"), but the TUI kept
+ * spawning `update --extensions`, so the advertised flow always exited 1
+ * (#738). `--extensions` means "all packages" (the default), `--extension
+ * <source>` and positional sources name one package, and daemon-socket
+ * plumbing belongs only to self-updates.
+ */
+export function translatePackageUpdateArgs(args: readonly string[]): string[] {
+	const translated: string[] = [];
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg === "--extensions" || arg === "--self") {
+			continue;
+		}
+		if (arg === "--extension" || arg === "--daemon-socket") {
+			const value = args[index + 1];
+			index++;
+			if (arg === "--extension" && value !== undefined) {
+				translated.push(value);
+			}
+			continue;
+		}
+		if (arg !== undefined) {
+			translated.push(arg);
+		}
+	}
+	return translated;
+}
+
 export function updateArgsIncludeSelf(args: readonly string[]): boolean {
 	let selfFlag = false;
 	let extensionsOnlyFlag = false;
@@ -8388,7 +8419,10 @@ export class InteractiveMode {
 			updateArgs,
 			resolveDaemonUpdateRestartSocketPath(this.options.daemonSocketPath),
 		);
-		const updateChildArgs = includesSelf ? buildUpdateChildArgs(updateArgs, daemonSocketPath) : updateArgs;
+		const updateChildArgs = includesSelf
+			? buildUpdateChildArgs(updateArgs, daemonSocketPath)
+			: translatePackageUpdateArgs(updateArgs);
+		const updateChildCommand = includesSelf ? ["update"] : ["package", "update"];
 		this.stopWorkingLoader();
 		await this.ui.terminal.drainInput(1000).catch(() => undefined);
 		this.ui.stop();
@@ -8396,7 +8430,7 @@ export class InteractiveMode {
 		const updateEnv = includesSelf ? { ...process.env, [SELF_UPDATE_INTERACTIVE_CHILD_ENV]: "1" } : process.env;
 		const updateResult = spawnSync(
 			process.execPath,
-			[...process.execArgv, entrypoint, "update", ...updateChildArgs],
+			[...process.execArgv, entrypoint, ...updateChildCommand, ...updateChildArgs],
 			{
 				stdio: "inherit",
 				cwd: updateCwd,

--- a/packages/coding-agent/test/suite/regressions/738-npm-update-compat.test.ts
+++ b/packages/coding-agent/test/suite/regressions/738-npm-update-compat.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNpmViewVersion } from "../../../src/core/package-manager.js";
+import { translatePackageUpdateArgs, updateArgsIncludeSelf } from "../../../src/modes/interactive/interactive-mode.js";
+
+describe("issue #738 defect 1: /update --extensions must spawn the package command", () => {
+	it("translates --extensions to the bare package-update form", () => {
+		expect(translatePackageUpdateArgs(["--extensions"])).toEqual([]);
+	});
+
+	it("translates --extension <source> to a positional source", () => {
+		expect(translatePackageUpdateArgs(["--extension", "npm:bigpowers"])).toEqual(["npm:bigpowers"]);
+	});
+
+	it("keeps positional sources and drops daemon-socket plumbing", () => {
+		expect(translatePackageUpdateArgs(["npm:bigpowers", "--daemon-socket", "/tmp/x.sock"])).toEqual([
+			"npm:bigpowers",
+		]);
+	});
+
+	it("agrees with updateArgsIncludeSelf about what is a package update", () => {
+		// Every arg shape the TUI routes to the package path must translate
+		// into something `package update` accepts (no legacy flags).
+		for (const args of [["--extensions"], ["--extension", "npm:x"], ["npm:x"]]) {
+			expect(updateArgsIncludeSelf(args)).toBe(false);
+			const translated = translatePackageUpdateArgs(args);
+			expect(translated.some((a) => a === "--extensions" || a === "--extension" || a === "--self")).toBe(false);
+		}
+	});
+});
+
+describe("issue #738 defect 2: npm >= 11 emits a JSON array from npm view", () => {
+	it("normalizes the npm 11+ array form", () => {
+		expect(normalizeNpmViewVersion('["2.87.2"]\n')).toBe("2.87.2");
+	});
+
+	it("keeps the npm 10 bare-string form", () => {
+		expect(normalizeNpmViewVersion('"2.87.2"\n')).toBe("2.87.2");
+	});
+
+	it("takes the newest entry when several versions are listed", () => {
+		expect(normalizeNpmViewVersion('["2.87.1","2.87.2"]')).toBe("2.87.2");
+	});
+
+	it("rejects empty and malformed output loudly", () => {
+		expect(() => normalizeNpmViewVersion("")).toThrow("Empty response");
+		expect(() => normalizeNpmViewVersion("[]")).toThrow("Unexpected npm view version output");
+		expect(() => normalizeNpmViewVersion("42")).toThrow("Unexpected npm view version output");
+	});
+
+	it("equality against the installed version works after normalization", () => {
+		// The false-positive mechanism: ["2.87.2"] !== "2.87.2" was always true.
+		expect(normalizeNpmViewVersion('["2.87.2"]')).toBe("2.87.2");
+	});
+});


### PR DESCRIPTION
Fixes #738. Fixes #749. Fixes #741.

## Problem

Three faces of one drift: npm's CLI moved (10, 11) and prime-agent's own update-command migration left the TUI behind.

1. **`/update --extensions` always fails** (#738): the standalone `update` command deliberately hard-rejects package targets ("Package updates moved to the package command", `public-command.ts:129`) — but the TUI still spawns `update --extensions` for the flow it advertises in the slash hint and the startup notice. Every advertised path exits 1.
2. **Update notice is a permanent false positive on npm ≥ 11** (#738): `npm view <pkg> version --json` now emits a JSON *array*; `getLatestNpmVersion` parsed it verbatim, and `["2.87.2"] !== "2.87.2"` is always true — so every startup nags, funneling users into defect 1.
3. **PATH recovery instructions use a removed command** (#749): `install.sh` tells users to run `npm bin -g`, which npm 10 removed.

## Change

- `interactive-mode.ts`: non-self updates now spawn `package update` with legacy flags translated (`translatePackageUpdateArgs`: `--extensions` → bare, `--extension <src>` → positional, daemon-socket plumbing dropped). Self-updates unchanged. The advertised `/update --extensions` flow now runs the command the CLI migration intended.
- `package-manager.ts`: `normalizeNpmViewVersion` handles the npm 10 bare-string and npm ≥ 11 array forms, takes the newest entry, and fails loudly on malformed output.
- `install.sh`: PATH guidance prints `echo "$(npm prefix -g)/bin"` instead of `npm bin -g`.

## Tests

`test/suite/regressions/738-npm-update-compat.test.ts` (9 tests, fail on main — the helpers don't exist): all translation shapes, agreement with `updateArgsIncludeSelf` about what routes to the package path, both npm output forms, newest-entry selection, loud rejection of empty/malformed output, and the exact false-positive equality from the report.

Neighbor suites (`interactive-mode-effort-command`, `public-command`): 47/47. `npm run check` clean, including the installer render gate.

## Scope notes

- #741 is now included (00d8d19): @d4not verified the mechanism on npm 12.0.2 — `EALLOWREMOTE` from *transitive* URL dependencies (R2-hosted runtime tarballs), `root` insufficient. The installer scopes `npm_config_allow_remote=all` to its own `npm install -g` invocations via env (no `~/.npmrc` changes), gated to npm ≥ 12 so older versions see no unknown-config warnings. Scope notes: the npm self-update step (`config.ts` `makeSelfUpdateCommandStep`) has the same exposure on npm 12; and the deeper fix — publishing without URL transitive deps — is a release-pipeline call, so both are left for maintainers rather than decided here.
- The slash `argumentHint` and startup-notice wording still advertise `--extensions`; they now work as advertised, so the wording is untouched.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix npm 10+ compatibility in package install and update flows
> - Replaces deprecated `npm bin -g` with `npm prefix -g` in [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/773/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) and adds `npm_config_allow_remote=all` env prefix for npm >= 12 to avoid `EALLOWREMOTE` errors from transitive URL dependencies.
> - Adds `normalizeNpmViewVersion` in [package-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/773/files#diff-c3cd658663a2617a59357bae55e941f8d7885378fdd6e4cd0400dfa967fbe750) to handle the changed output format of `npm view <pkg> version --json` between npm 10 (string) and npm 11+ (array).
> - Rewrites the TUI non-self update path in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/773/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to translate legacy `/update` flags into the `package update` subcommand syntax, fixing package updates that broke with newer npm CLI argument handling.
> - Adds regression tests in [738-npm-update-compat.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/773/files#diff-17d39b36db7181d62081bdf83ac839f3dc5a3e13516c49bce712a7449f764005) covering flag translation, version normalization, and error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00d8d19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
