### PR TITLE
feat(ai): add OpenRouter OAuth provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added an OpenRouter OAuth provider so OpenRouter can be authenticated with a browser sign-in instead of an API key ([#775](https://github.com/PrimeIntellect-ai/prime-agent/pull/775) by [@andrew-scott-fischer](https://github.com/andrew-scott-fischer)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,7 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - OpenRouter
  */
 
 // Anthropic
@@ -19,6 +20,8 @@ export {
 } from "./github-copilot.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
+// OpenRouter
+export { loginOpenRouter, openrouterOAuthProvider, refreshOpenRouterToken } from "./openrouter.js";
 
 export * from "./types.js";
 
@@ -29,12 +32,14 @@ export * from "./types.js";
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
+import { openrouterOAuthProvider } from "./openrouter.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	openrouterOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/openrouter.ts
+++ b/packages/ai/src/utils/oauth/openrouter.ts
@@ -1,0 +1,329 @@
+/**
+ * OpenRouter OAuth PKCE flow.
+ *
+ * OpenRouter's authorize endpoint has no `client_id`, `scope`, or `state`
+ * parameter — the exchange returns an API key rather than an access/refresh
+ * token pair, and there is no refresh endpoint. CSRF protection comes from a
+ * randomly-generated callback path instead of a `state` value: only a request
+ * to that exact path is accepted.
+ *
+ * NOTE: This module uses Node.js http.createServer for the OAuth callback
+ * server. It is only intended for CLI use, not browser environments.
+ */
+
+import type { Server, ServerResponse } from "node:http";
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
+import { generatePKCE } from "./pkce.js";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+// OpenRouter's authorize page hangs on a `127.0.0.1` callback_url and only
+// proceeds for `localhost`, which is also the host its own docs use. The other
+// providers here default to the loopback IP; this one must not.
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "localhost";
+const AUTHORIZE_URL = "https://openrouter.ai/auth";
+const TOKEN_URL = "https://openrouter.ai/api/v1/auth/keys";
+
+type JsonObject = Record<string, unknown>;
+
+type NodeApis = {
+	createServer: typeof import("node:http").createServer;
+};
+
+let nodeApis: NodeApis | null = null;
+let nodeApisPromise: Promise<NodeApis> | null = null;
+
+async function getNodeApis(): Promise<NodeApis> {
+	if (nodeApis) return nodeApis;
+	if (!nodeApisPromise) {
+		if (typeof process === "undefined" || (!process.versions?.node && !process.versions?.bun)) {
+			throw new Error("OpenRouter OAuth is only available in Node.js environments");
+		}
+		nodeApisPromise = import("node:http").then((httpModule) => ({
+			createServer: httpModule.createServer,
+		}));
+	}
+	nodeApis = await nodeApisPromise;
+	return nodeApis;
+}
+
+function sendHtml(response: ServerResponse, status: number, html: string): void {
+	response.statusCode = status;
+	response.setHeader("content-type", "text/html; charset=utf-8");
+	response.setHeader("cache-control", "no-store");
+	response.end(html);
+}
+
+function parseAuthorizationInput(input: string): string | undefined {
+	const value = input.trim();
+	if (!value) return undefined;
+
+	try {
+		return new URL(value).searchParams.get("code") ?? undefined;
+	} catch {
+		// not a URL
+	}
+
+	if (value.includes("code=")) {
+		return new URLSearchParams(value).get("code") ?? undefined;
+	}
+
+	return value;
+}
+
+function errorDetail(body: JsonObject): string | undefined {
+	if (typeof body.error_description === "string") return body.error_description;
+	if (typeof body.message === "string") return body.message;
+	if (typeof body.error === "string") return body.error;
+	if (body.error && typeof body.error === "object" && !Array.isArray(body.error)) {
+		const message = (body.error as JsonObject).message;
+		if (typeof message === "string") return message;
+	}
+	return undefined;
+}
+
+async function exchangeAuthorizationCode(
+	code: string,
+	verifier: string,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	let response: Response;
+	try {
+		response = await fetch(TOKEN_URL, {
+			method: "POST",
+			headers: { accept: "application/json", "content-type": "application/json" },
+			body: JSON.stringify({ code, code_verifier: verifier, code_challenge_method: "S256" }),
+			signal,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw new Error("Login cancelled");
+		throw error;
+	}
+
+	let body: JsonObject = {};
+	try {
+		const parsed = (await response.json()) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed as JsonObject;
+	} catch {
+		if (response.ok) throw new Error("OpenRouter OAuth returned invalid JSON");
+	}
+
+	if (!response.ok) {
+		const detail = errorDetail(body);
+		throw new Error(`OpenRouter OAuth key exchange failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}`);
+	}
+
+	if (typeof body.key !== "string" || body.key.length === 0) {
+		throw new Error('OpenRouter OAuth response carries no "key"');
+	}
+
+	return {
+		access: body.key,
+		refresh: "",
+		expires: Number.MAX_SAFE_INTEGER,
+	};
+}
+
+type CallbackResult = { code: string } | null;
+
+type OpenRouterCallbackServer = {
+	callbackUrl: string;
+	close: () => void;
+	/** Hand the login over to manual code entry unless the callback already claimed it. */
+	cancelWait: () => void;
+	/** Resolves with the code once the browser redirect hits the callback, or null once cancelled. */
+	waitForCode: () => Promise<CallbackResult>;
+};
+
+async function startCallbackServer(callbackPath: string, signal?: AbortSignal): Promise<OpenRouterCallbackServer> {
+	if (signal?.aborted) throw new Error("Login cancelled");
+	const { createServer } = await getNodeApis();
+
+	let settled = false;
+	let resolveWait: (value: CallbackResult) => void = () => {};
+	let rejectWait: (error: Error) => void = () => {};
+	const waitForCodePromise = new Promise<CallbackResult>((resolve, reject) => {
+		resolveWait = resolve;
+		rejectWait = reject;
+	});
+	// An abort landing before anyone awaits waitForCode() must not surface as an
+	// unhandled rejection; the real await further down still observes it.
+	waitForCodePromise.catch(() => {});
+
+	const finishResolve = (value: CallbackResult): void => {
+		if (settled) return;
+		settled = true;
+		resolveWait(value);
+	};
+	const finishReject = (error: Error): void => {
+		if (settled) return;
+		settled = true;
+		rejectWait(error);
+	};
+
+	const server: Server = createServer((request, response) => {
+		try {
+			const requestUrl = new URL(request.url ?? "/", `http://${CALLBACK_HOST}`);
+			if (request.method !== "GET" || requestUrl.pathname !== callbackPath) {
+				sendHtml(response, 404, oauthErrorHtml("OAuth callback route not found."));
+				return;
+			}
+
+			const oauthError = requestUrl.searchParams.get("error");
+			if (oauthError) {
+				const description = requestUrl.searchParams.get("error_description") ?? oauthError;
+				sendHtml(response, 400, oauthErrorHtml("OpenRouter authorization was denied.", description));
+				finishResolve(null);
+				return;
+			}
+
+			const code = requestUrl.searchParams.get("code");
+			if (!code) {
+				sendHtml(response, 400, oauthErrorHtml("OpenRouter returned no authorization code."));
+				return;
+			}
+
+			sendHtml(response, 200, oauthSuccessHtml("Signed in to OpenRouter. You may now close this page."));
+			finishResolve({ code });
+		} catch {
+			sendHtml(response, 500, oauthErrorHtml("Internal error while processing the OAuth callback."));
+		}
+	});
+
+	let onAbort: (() => void) | undefined;
+	if (signal) {
+		onAbort = () => finishReject(new Error("Login cancelled"));
+		signal.addEventListener("abort", onAbort, { once: true });
+	}
+
+	const close = (): void => {
+		if (onAbort) signal?.removeEventListener("abort", onAbort);
+		server.close();
+	};
+
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, CALLBACK_HOST, () => {
+			server.removeListener("error", reject);
+			server.on("error", (error) => finishReject(error));
+
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				close();
+				reject(new Error("Could not determine the OpenRouter OAuth callback port"));
+				return;
+			}
+
+			resolve({
+				callbackUrl: `http://${CALLBACK_HOST}:${address.port}${callbackPath}`,
+				close,
+				cancelWait: () => finishResolve(null),
+				waitForCode: () => waitForCodePromise,
+			});
+		});
+	});
+}
+
+/**
+ * Login with OpenRouter OAuth (PKCE, loopback callback server).
+ */
+export async function loginOpenRouter(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+	const { verifier, challenge } = await generatePKCE();
+	const callbackPath = `/oauth/callback/${crypto.randomUUID()}`;
+	const server = await startCallbackServer(callbackPath, callbacks.signal);
+
+	try {
+		const authorizeUrl = new URL(AUTHORIZE_URL);
+		authorizeUrl.search = new URLSearchParams({
+			callback_url: server.callbackUrl,
+			code_challenge: challenge,
+			code_challenge_method: "S256",
+		}).toString();
+
+		callbacks.onAuth({
+			url: authorizeUrl.toString(),
+			instructions:
+				"Complete sign-in in your browser. If the browser is on another machine, paste the final redirect URL here.",
+		});
+
+		let code: string | undefined;
+
+		if (callbacks.onManualCodeInput) {
+			let manualInput: string | undefined;
+			let manualError: Error | undefined;
+			const manualPromise = callbacks
+				.onManualCodeInput()
+				.then((input) => {
+					manualInput = input;
+					server.cancelWait();
+				})
+				.catch((error) => {
+					manualError = error instanceof Error ? error : new Error(String(error));
+					server.cancelWait();
+				});
+
+			const result = await server.waitForCode();
+
+			if (manualError) throw manualError;
+
+			if (result?.code) {
+				code = result.code;
+			} else if (manualInput) {
+				code = parseAuthorizationInput(manualInput);
+			}
+
+			if (!code) {
+				await manualPromise;
+				if (manualError) throw manualError;
+				if (manualInput) code = parseAuthorizationInput(manualInput);
+			}
+		} else {
+			const result = await server.waitForCode();
+			if (result?.code) code = result.code;
+		}
+
+		if (!code) {
+			const input = await callbacks.onPrompt({
+				message: "Paste the authorization code (or full redirect URL):",
+				placeholder: server.callbackUrl,
+			});
+			code = parseAuthorizationInput(input);
+		}
+
+		if (!code) {
+			throw new Error("Missing authorization code");
+		}
+
+		callbacks.onProgress?.("Exchanging authorization code for an API key...");
+		return await exchangeAuthorizationCode(code, verifier, callbacks.signal);
+	} finally {
+		server.close();
+	}
+}
+
+/**
+ * OpenRouter's issued key has no refresh token or refresh endpoint. This is
+ * dead code in practice because `expires` is set far in the future at login
+ * time, but exists to fail loudly (rather than silently) if it is ever
+ * invoked against a corrupted or hand-edited credential.
+ */
+export async function refreshOpenRouterToken(_credentials: OAuthCredentials): Promise<OAuthCredentials> {
+	throw new Error("OpenRouter OAuth credentials don't support refresh. Run /login again.");
+}
+
+export const openrouterOAuthProvider: OAuthProviderInterface = {
+	id: "openrouter",
+	name: "OpenRouter",
+	usesCallbackServer: true,
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginOpenRouter(callbacks);
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshOpenRouterToken(credentials);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};

--- a/packages/ai/test/openrouter-oauth.test.ts
+++ b/packages/ai/test/openrouter-oauth.test.ts
@@ -1,0 +1,176 @@
+import { get as httpGet } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getOAuthProvider } from "../src/utils/oauth/index.js";
+import { loginOpenRouter, openrouterOAuthProvider, refreshOpenRouterToken } from "../src/utils/oauth/openrouter.js";
+import type { OAuthCredentials } from "../src/utils/oauth/types.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	if (input instanceof Request) return input.url;
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function getJsonBody(init?: RequestInit): Record<string, string> {
+	if (typeof init?.body !== "string") {
+		throw new Error(`Expected string request body, got ${typeof init?.body}`);
+	}
+	return JSON.parse(init.body) as Record<string, string>;
+}
+
+/** Extracts callback_url from the authorize URL passed to onAuth. */
+function callbackUrlFrom(authUrl: string): string {
+	const url = new URL(authUrl);
+	const callbackUrl = url.searchParams.get("callback_url");
+	if (!callbackUrl) throw new Error("Missing callback_url in authorize URL");
+	return callbackUrl;
+}
+
+/** Makes a real GET request against the loopback callback server and returns the status code. */
+function fetchStatus(url: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		httpGet(url, (res) => {
+			res.resume();
+			res.on("end", () => resolve(res.statusCode ?? 0));
+		}).on("error", reject);
+	});
+}
+
+describe.sequential("OpenRouter OAuth", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("is registered as a built-in OAuth provider", () => {
+		expect(getOAuthProvider("openrouter")).toBe(openrouterOAuthProvider);
+		expect(openrouterOAuthProvider.usesCallbackServer).toBe(true);
+	});
+
+	it("exchanges an authorization code for a bare, non-expiring credential", async () => {
+		let authUrl = "";
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://openrouter.ai/api/v1/auth/keys");
+			expect(init?.method).toBe("POST");
+			const body = getJsonBody(init);
+			expect(body.code).toBe("manual-code");
+			expect(body.code_challenge_method).toBe("S256");
+			expect(typeof body.code_verifier).toBe("string");
+			return jsonResponse({ key: "sk-or-v1-test-key" });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await loginOpenRouter({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => {
+				throw new Error("onPrompt should not be reached when manual input resolves first");
+			},
+			onManualCodeInput: async () => {
+				const callbackUrl = callbackUrlFrom(authUrl);
+				return `${callbackUrl}?code=manual-code`;
+			},
+		});
+
+		expect(credentials.access).toBe("sk-or-v1-test-key");
+		expect(credentials.refresh).toBe("");
+		expect(credentials.expires).toBe(Number.MAX_SAFE_INTEGER);
+		expect("type" in credentials).toBe(false);
+		expect(fetchMock).toHaveBeenCalledOnce();
+
+		// expires must survive a JSON round trip as a finite number, not serialize to null.
+		const roundTripped = JSON.parse(JSON.stringify(credentials)) as OAuthCredentials;
+		expect(roundTripped.expires).toBe(Number.MAX_SAFE_INTEGER);
+		expect(Number.isFinite(roundTripped.expires)).toBe(true);
+	});
+
+	it("rejects when the exchange responds with a non-2xx status", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ error: "invalid_grant", error_description: "Code expired" }, 403)),
+		);
+
+		await expect(
+			loginOpenRouter({
+				onAuth: () => {},
+				onPrompt: async () => "",
+				onManualCodeInput: async () => "raw-code",
+			}),
+		).rejects.toThrow(/OpenRouter OAuth key exchange failed \(HTTP 403\).*Code expired/);
+	});
+
+	it("rejects when the response body has no key", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({})),
+		);
+
+		await expect(
+			loginOpenRouter({
+				onAuth: () => {},
+				onPrompt: async () => "",
+				onManualCodeInput: async () => "raw-code",
+			}),
+		).rejects.toThrow(/carries no "key"/);
+	});
+
+	it("rejects when the response key is an empty string", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ key: "" })),
+		);
+
+		await expect(
+			loginOpenRouter({
+				onAuth: () => {},
+				onPrompt: async () => "",
+				onManualCodeInput: async () => "raw-code",
+			}),
+		).rejects.toThrow(/carries no "key"/);
+	});
+
+	it("only accepts a callback at the randomly generated path", async () => {
+		let authUrl = "";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ key: "sk-or-v1-real" })),
+		);
+
+		const loginPromise = loginOpenRouter({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => {
+				throw new Error("onPrompt should not be reached");
+			},
+			onManualCodeInput: async () => {
+				const callbackUrl = callbackUrlFrom(authUrl);
+				const wrongPathUrl = callbackUrl.replace(/\/oauth\/callback\/[^?]+/, "/oauth/callback/wrong-path");
+				const status = await fetchStatus(`${wrongPathUrl}?code=x`);
+				expect(status).toBe(404);
+				return `${callbackUrl}?code=manual-code`;
+			},
+		});
+
+		const credentials = await loginPromise;
+		expect(credentials.access).toBe("sk-or-v1-real");
+	});
+
+	it("refreshToken throws instead of returning a dead credential", async () => {
+		await expect(
+			refreshOpenRouterToken({ access: "sk-or-v1-old", refresh: "", expires: Number.MAX_SAFE_INTEGER }),
+		).rejects.toThrow(/don't support refresh/);
+	});
+
+	it("getApiKey returns the access token", () => {
+		const credentials: OAuthCredentials = { access: "sk-or-v1-abc", refresh: "", expires: Number.MAX_SAFE_INTEGER };
+		expect(openrouterOAuthProvider.getApiKey(credentials)).toBe("sk-or-v1-abc");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
+- Added OpenRouter to `/login` as a subscription provider, alongside the existing API-key entry ([#775](https://github.com/PrimeIntellect-ai/prime-agent/pull/775) by [@andrew-scott-fischer](https://github.com/andrew-scott-fischer)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- OpenRouter
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.json` and auto-refresh when expired.
 
@@ -34,6 +35,12 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+### OpenRouter
+
+- `/login` opens a browser flow where you configure the key OpenRouter issues
+- If credentials stop working, run `/login` again
+- `OPENROUTER_API_KEY` still works and appears as a separate "OpenRouter" entry in `/login`; `auth.json` holds one credential per provider, so an OAuth login replaces a stored API key
 
 ## API Keys
 


### PR DESCRIPTION
Adds a PKCE login flow for OpenRouter so `/login` can authenticate with a browser sign-in instead of requiring `OPENROUTER_API_KEY`.

- New `openrouterOAuthProvider` in `packages/ai/src/utils/oauth/openrouter.ts`, registered in `BUILT_IN_OAUTH_PROVIDERS`
- OpenRouter shows up as a subscription entry in `/login` alongside its existing API-key entry, the same way `anthropic` already does
- The `OPENROUTER_API_KEY` environment variable and `auth.json` API-key entries are unchanged

Implementation notes:

- OpenRouter's authorize endpoint has no `state` parameter, so CSRF protection comes from a random UUID callback path; only a request to that exact path is accepted
- The callback host is `localhost` rather than the `127.0.0.1` the other providers default to. OpenRouter's authorize page does not proceed with a `127.0.0.1` callback_url
- The callback server binds an ephemeral port, and `callbacks.signal` is forwarded to both the server and the token exchange
- The exchange returns an API key rather than an access/refresh pair and there is no refresh endpoint, so `refreshToken()` throws to route the user back to `/login`
- The exchange response carries no expiry, so `expires` is stored far in the future. A key that expires or is revoked server-side therefore surfaces as a provider 401 rather than the "run /login" auth-failed message

Verified against the live service: browser sign-in, an inference call, and credential reuse across a restart.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenRouter OAuth provider with PKCE browser login flow
> - Adds `openrouterOAuthProvider` to the built-in OAuth providers list, enabling OpenRouter login via browser sign-in instead of a manual API key.
> - Implements a full PKCE-based login flow in [openrouter.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/775/files#diff-48645384163946682f69df5de80242f482ad7162e08a8a122f9a7411b75e441a): starts a transient loopback callback server, opens a browser to the OpenRouter authorize URL, and exchanges the authorization code for an API key.
> - Supports manual code entry as a fallback when browser callback is unavailable; accepts a full redirect URL, query string, or bare code.
> - Returned credentials use `Number.MAX_SAFE_INTEGER` as the expiry (keys do not expire), and `refreshOpenRouterToken` always throws since OpenRouter keys cannot be refreshed.
> - Behavioral Change: any code attempting to refresh OpenRouter credentials will receive an explicit error rather than a silent failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bf267f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->