### PR TITLE
docs(coding-agent): remove stale /resume references

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed stale documentation referencing a `/resume` slash command and a bare `--resume`; session browsing is the agents view (press `←` in a chat or run `prime-agent agents`), and `--resume` requires a session id or path ([#679](https://github.com/PrimeIntellect-ai/prime-agent/issues/679)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -150,7 +150,6 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/effort` | Set reasoning/thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
-| `/resume` | Open the searchable session view |
 | `/new`, `/clear` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session info (file, ID, messages) |
@@ -210,7 +209,7 @@ Sessions auto-save as flat JSONL files under `~/.prime/agent/sessions/`. Each se
 
 ```bash
 prime-agent -c                  # Continue most recent session
-prime-agent -r [path|id]        # Browse past sessions or resume one directly
+prime-agent -r <path|id>        # Resume a saved session directly
 prime-agent --no-session        # Ephemeral mode (don't save)
 prime-agent --fork <path|id>    # Fork specific session file or ID into a new session
 ```
@@ -563,7 +562,7 @@ Use `prime-agent model list [search]` to list available models.
 | Option | Description |
 |--------|-------------|
 | `-c`, `--continue` | Continue most recent session |
-| `-r`, `--resume [path\|id]` | Open the searchable session view, or resume a specific session file or partial UUID |
+| `-r`, `--resume <path\|id>` | Resume a specific session file or partial UUID |
 | `--fork <path\|id>` | Fork specific session file or partial UUID into a new session |
 | `--session-dir <dir>` | Custom session storage directory |
 | `--no-session` | Ephemeral mode (don't save) |

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -303,7 +303,7 @@ user sends prompt ────────────────────�
                                                            │
 user sends another prompt ◄────────────────────────────────┘
 
-/new (new session) or /resume (switch session)
+/new (new session) or resuming a saved session (agents view, `--resume <path|id>`, or `/import`)
   ├─► session_before_switch (can cancel)
   ├─► session_shutdown
   ├─► session_start { reason: "new" | "resume", previousSessionFile? }
@@ -371,7 +371,7 @@ pi.on("session_start", async (event, ctx) => {
 
 #### session_before_switch
 
-Fired before starting a new session (`/new`) or switching sessions (`/resume`).
+Fired before starting a new session (`/new`) or resuming a saved session (`--resume <path|id>`, the agents view, or `/import`).
 
 ```typescript
 pi.on("session_before_switch", async (event, ctx) => {

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -106,7 +106,18 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.session.new` | *(none)* | Start a new session (`/new`) |
 | `app.session.tree` | *(none)* | Open session tree navigator (`/tree`) |
 | `app.session.fork` | *(none)* | Fork current session (`/fork`) |
-| `app.session.resume` | *(none)* | Open session resume picker (`/resume`) |
+| `app.session.resume` | *(none)* | Return to the agents view to browse and resume sessions |
+
+### Agents View
+
+| Keybinding id | Default | Description |
+|--------|---------|-------------|
+| `app.agents.back` | `left` | Return to the agents view |
+| `app.agents.open` | `right` | Open the selected agent or session |
+| `app.agents.reply` | `space` | Reply to the selected agent, or resume an inactive session and send a prompt |
+| `app.agents.new` | `ctrl+n` | Start a new session from the agents view |
+| `app.agents.delete` | `ctrl+x` | Stop or delete the selected agent; press again to confirm |
+| `app.agents.rename` | `ctrl+r` | Rename the selected agent session |
 
 ### Models and Thinking
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -139,10 +139,10 @@ Sessions are saved automatically under `~/.prime/agent/sessions/`:
 
 ```bash
 prime-agent -c                  # Continue the most recent session
-prime-agent -r [path|id]        # Browse sessions or open a specific session
+prime-agent -r <path|id>        # Resume a specific session
 ```
 
-Inside Prime Agent, use `/resume`, `/new`, `/tree`, `/fork`, and `/clone` to manage sessions. Persistent sessions run in worker processes, so closing the TUI detaches from the agent rather than necessarily stopping it. Use `prime-agent agents` to inspect or reattach to active work.
+Inside Prime Agent, press `←` to return to the agents view and resume sessions, or use `/new`, `/tree`, `/fork`, and `/clone` to manage the current session. Persistent sessions run in worker processes, so closing the TUI detaches from the agent rather than necessarily stopping it. Use `prime-agent agents` to inspect or reattach to active work.
 
 ### Non-Interactive Mode
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -703,7 +703,7 @@ const { session: opened } = await createAgentSession({
 const currentProjectSessions = await SessionManager.list(process.cwd());
 const allSessions = await SessionManager.listAll();
 
-// Session replacement API for /new, /resume, /fork, /clone, and import flows.
+// Session replacement API for new, resume, fork, clone, and import flows.
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
   const services = await createAgentSessionServices({ cwd });
   return {

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -14,7 +14,7 @@ The header records the working directory. Current releases keep sessions in a fl
 
 Sessions can be removed by deleting their `.jsonl` files under `~/.prime/agent/sessions/`.
 
-Prime Agent also supports deleting sessions interactively from `/resume` (select a session and press `Ctrl+D`, then confirm). When available, Prime Agent uses the `trash` CLI to avoid permanent deletion.
+Prime Agent also supports deleting sessions interactively from the agents view (`prime-agent agents`; select a session and press `Ctrl+X` twice, then confirm). When available, Prime Agent uses the `trash` CLI to avoid permanent deletion.
 
 ## Session Version
 
@@ -310,7 +310,7 @@ Session metadata (e.g., user-defined display name). Set via `/name` command or `
 {"type":"session_info","id":"k1l2m3n4","parentId":"j0k1l2m3","timestamp":"2024-12-03T14:35:00.000Z","name":"Refactor auth module"}
 ```
 
-The session name is displayed in the session selector (`/resume`) instead of the first message when set.
+The session name is displayed in the agents view session list instead of the first message when set.
 
 ### SessionStateEntry
 

--- a/packages/coding-agent/docs/sessions.md
+++ b/packages/coding-agent/docs/sessions.md
@@ -8,7 +8,7 @@ Sessions auto-save to `~/.prime/agent/sessions/`. Each session is a JSONL file w
 
 ```bash
 prime-agent --continue          # Continue the most recent session
-prime-agent --resume [path|id]  # Browse past sessions or resume one directly
+prime-agent --resume <path|id>  # Resume a saved session directly
 prime-agent --no-session        # Ephemeral mode; do not save
 prime-agent --fork <path|id>    # Fork a session file or partial session ID into a new session
 ```
@@ -21,7 +21,6 @@ For the JSONL file format and SessionManager API, see [Session Format](session-f
 
 | Command | Description |
 |---------|-------------|
-| `/resume` | Browse and select previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set the current session display name |
 | `/session` | Show session info |
@@ -35,18 +34,18 @@ For the JSONL file format and SessionManager API, see [Session Format](session-f
 
 ## Resuming and Deleting Sessions
 
-`/resume` opens an interactive session picker for the current project. `prime-agent --resume` opens the same picker at startup, and `prime-agent --resume <path|id>` resumes a specific session.
+`prime-agent --resume <path|id>` resumes a specific saved session. `prime-agent agents` opens the searchable session view, where running, idle, and saved sessions are listed together.
 
-An invalid ID exits with the closest unambiguous session ID when one is available. To open the picker and send an initial prompt after selecting a session, separate the prompt with `--`: `prime-agent --resume -- "continue this work"`.
+In the chat, press `←` to return to the agents view. Select an inactive session and press space to resume it and send a prompt in one motion; `→` opens the selected session.
 
-In the picker you can:
+An invalid ID exits with the closest unambiguous session ID when one is available. To resume a session and send an initial prompt, separate the prompt with `--`: `prime-agent --resume <id> -- "continue this work"`.
+
+In the agents view you can:
 
 - search by typing
-- toggle path display with Ctrl+P
-- toggle sort mode with Ctrl+S
-- filter to named sessions with Ctrl+N
 - rename with Ctrl+R
-- delete with Ctrl+D, then confirm
+- delete with Ctrl+X twice to confirm
+- start a new session with Ctrl+N
 
 When available, Prime Agent uses the `trash` CLI for deletion instead of permanently removing files.
 
@@ -58,7 +57,7 @@ Use `/name <name>` to set a human-readable session name:
 /name Refactor auth module
 ```
 
-Named sessions are easier to find in `/resume` and `prime-agent --resume`.
+Named sessions are easier to find in `prime-agent agents` and `prime-agent --resume`.
 
 ## Branching with `/tree`
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -42,7 +42,6 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/effort` | Set the reasoning/thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
-| `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session file, ID, and message counts |
@@ -216,7 +215,7 @@ Use `prime-agent model list [search]` to list available models.
 | Option | Description |
 |--------|-------------|
 | `-c`, `--continue` | Continue the most recent session |
-| `-r`, `--resume [path\|id]` | Browse and select a session, or resume a specific session file or partial UUID |
+| `-r`, `--resume <path\|id>` | Resume a specific session file or partial UUID |
 | `--fork <path\|id>` | Fork a session file or partial UUID into a new session |
 | `--session-dir <dir>` | Custom session storage directory |
 | `--no-session` | Ephemeral mode; do not save |


### PR DESCRIPTION
## Summary

- Remove stale `/resume` slash-command and bare `--resume` references from the coding-agent README and docs
- Document the daemon-based session flow: the agents view (press `←` in a chat or run `prime-agent agents`) for browsing sessions, and `--resume <path|id>` for direct resume
- Add the agents view keybindings to `docs/keybindings.md`

Closes #679.

## Validation

- `git diff --check`
- parsed `packages/coding-agent/docs/docs.json` with Node.js
- confirmed no remaining `/resume` references in the coding-agent README or docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or application code modifications.
>
> **Overview**
> Removes stale documentation that presents `/resume` as a builtin slash command and bare `--resume` as a session picker. Session browsing is the daemon-backed agents view: press `←` in a chat or run `prime-agent agents`, and resume a specific session with `--resume <path|id>`.
>
> CLI option tables mark `--resume` as requiring a path or id, `docs/sessions.md` describes the agents view flow (search, space to resume and send, `→` to open, Ctrl+R rename, Ctrl+X delete, Ctrl+N new), `docs/keybindings.md` gains an Agents View section, and `docs/extensions.md` keeps the real `"resume"` event reason while dropping the nonexistent `/resume` command reference. A `[Unreleased]` changelog bullet references #679.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `/resume` slash command references from coding-agent docs
> Updates multiple docs to reflect that the `/resume` slash command no longer exists. Session resumption is now done via `--resume <path|id>` on the CLI or through the agents view (accessible via the left arrow key from chat). Affected files include [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/776/files#diff-b28d42a35be05803ac5e2fb345eca35f4a26a730b783c0447e5b5204b6e1211f), [sessions.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/776/files#diff-8588bae1eb19ab5036b768296ef205f293aceed7e85bd4f686e8e0b3ab208442), [quickstart.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/776/files#diff-23cbacf5e20c0132ac6466ddd518211157234350e0735c29513c748000eee03e), [keybindings.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/776/files#diff-a288769416874da1682145a82f7c22309d8b18dda4cb83037e7268073c03fada), and several others.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e10f820.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->