### PR TITLE
fix(ai): include cache tokens in Bedrock total fallback

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Bedrock usage totals to include cache-read and cache-write tokens when the API omits its native total.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -450,7 +450,9 @@ function handleMetadata(
 		output.usage.output = event.usage.outputTokens || 0;
 		output.usage.cacheRead = event.usage.cacheReadInputTokens || 0;
 		output.usage.cacheWrite = event.usage.cacheWriteInputTokens || 0;
-		output.usage.totalTokens = event.usage.totalTokens || output.usage.input + output.usage.output;
+		output.usage.totalTokens =
+			event.usage.totalTokens ||
+			output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 		calculateCost(model, output.usage);
 	}
 }

--- a/packages/ai/test/bedrock-total-tokens.test.ts
+++ b/packages/ai/test/bedrock-total-tokens.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Deterministic coverage for Bedrock usage totals.
+ *
+ * Bedrock's ConverseStream metadata event may omit `totalTokens`. When it does,
+ * the provider must compute the total from all four components, including cache
+ * reads and cache writes. A native total, when present, stays authoritative.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const bedrockMock = vi.hoisted(() => ({
+	streamEvents: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		send(): Promise<Record<string, unknown>> {
+			const events = [...bedrockMock.streamEvents];
+			return Promise.resolve({
+				$metadata: { httpStatusCode: 200, requestId: "mock-request-id" },
+				stream: (async function* () {
+					for (const event of events) {
+						yield event;
+					}
+				})(),
+			});
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { getModel } from "../src/models.js";
+import { streamBedrock } from "../src/providers/amazon-bedrock.js";
+import type { Context, Usage } from "../src/types.js";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+async function streamUsage(usage: Record<string, number>): Promise<Usage> {
+	bedrockMock.streamEvents = [
+		{ messageStart: { role: "assistant" } },
+		{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "hi" } } },
+		{ contentBlockStop: { contentBlockIndex: 0 } },
+		{ messageStop: { stopReason: "end_turn" } },
+		{ metadata: { usage } },
+	];
+
+	const model = getModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-5-20250929-v1:0");
+	const message = await streamBedrock(model, context, { cacheRetention: "none" }).result();
+
+	expect(message.stopReason).toBe("stop");
+	return message.usage;
+}
+
+describe("bedrock total tokens", () => {
+	it("includes cache read and cache write tokens when the metadata event omits a native total", async () => {
+		const usage = await streamUsage({
+			inputTokens: 10,
+			outputTokens: 5,
+			cacheReadInputTokens: 100,
+			cacheWriteInputTokens: 40,
+		});
+
+		expect(usage.input).toBe(10);
+		expect(usage.output).toBe(5);
+		expect(usage.cacheRead).toBe(100);
+		expect(usage.cacheWrite).toBe(40);
+		expect(usage.totalTokens).toBe(155);
+	});
+
+	it("includes cache read and cache write tokens when the native total is zero", async () => {
+		const usage = await streamUsage({
+			inputTokens: 10,
+			outputTokens: 5,
+			cacheReadInputTokens: 100,
+			cacheWriteInputTokens: 40,
+			totalTokens: 0,
+		});
+
+		expect(usage.totalTokens).toBe(155);
+	});
+
+	it("keeps the native total when the metadata event reports one", async () => {
+		const usage = await streamUsage({
+			inputTokens: 10,
+			outputTokens: 5,
+			cacheReadInputTokens: 100,
+			cacheWriteInputTokens: 40,
+			totalTokens: 999,
+		});
+
+		expect(usage.totalTokens).toBe(999);
+	});
+});


### PR DESCRIPTION
## Summary
- Fixed Bedrock fallback totals to include cache-read and cache-write tokens when the API omits its native total.
- Preserved native totals and existing component and cost accounting.

## Testing
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/bedrock-total-tokens.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Bedrock `totalTokens` fallback to include cache-read and cache-write tokens
> When the Bedrock API omits or returns a falsy `totalTokens`, the fallback in `handleMetadata` previously summed only input and output tokens. It now also includes `cacheRead` and `cacheWrite` tokens, matching the true total. A new test suite in [bedrock-total-tokens.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/777/files#diff-60429983560016caab709a90784bdb38e2603dd3e96dd8f5728bb0c0d9e7f1cc) verifies both the fallback path and the case where a native total is preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0270b8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->