### PR TITLE
fix(tui): recover autocomplete after provider failures

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed autocomplete remaining unavailable after an autocomplete provider request failed.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2391,12 +2391,14 @@ export class Editor implements Component, Focusable {
 	): Promise<void> {
 		if (!this.autocompleteProvider) return;
 
-		const suggestions = await this.autocompleteProvider.getSuggestions(
-			this.state.lines,
-			this.state.cursorLine,
-			this.state.cursorCol,
-			{ signal: controller.signal, force: options.force },
-		);
+		// A rejected provider request must not reject autocompleteRequestTask, or every
+		// later request would fail on `await previousTask`. Treat it as no suggestions.
+		const suggestions = await this.autocompleteProvider
+			.getSuggestions(this.state.lines, this.state.cursorLine, this.state.cursorCol, {
+				signal: controller.signal,
+				force: options.force,
+			})
+			.catch(() => null);
 
 		if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
 			return;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2325,6 +2325,43 @@ describe("Editor component", () => {
 			assert.strictEqual(aborts, 1);
 		});
 
+		it("recovers autocomplete after a failed provider request", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let suggestionCalls = 0;
+
+			const mockProvider: AutocompleteProvider = {
+				getSuggestions: async (lines, _cursorLine, cursorCol) => {
+					suggestionCalls += 1;
+					if (suggestionCalls === 1) {
+						throw new Error("provider unavailable");
+					}
+					return {
+						items: [{ value: "/help", label: "help", description: "Show help" }],
+						prefix: (lines[0] || "").slice(0, cursorCol),
+					};
+				},
+				applyCompletion,
+			};
+
+			editor.setAutocompleteProvider(mockProvider);
+
+			// First request rejects: no suggestions, no unhandled rejection.
+			editor.handleInput("/");
+			await flushAutocomplete();
+			assert.strictEqual(suggestionCalls, 1);
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+
+			// Second request still reaches the provider and displays its suggestions.
+			editor.handleInput("h");
+			await flushAutocomplete();
+			assert.strictEqual(suggestionCalls, 2);
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+			const overlayLines = (
+				editor as unknown as { renderAutocompleteOverlay: (width: number) => string[] }
+			).renderAutocompleteOverlay(60);
+			assert.ok(overlayLines.some((line) => stripVTControlCharacters(line).includes("help")));
+		});
+
 		it("hides autocomplete when backspacing slash command to empty", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
## Summary
- Fixed autocomplete request failures poisoning the editor's serialized request queue.
- Preserved debounce, cancellation, stale-request, and forced-completion behavior.

## Testing
- `node --test --import tsx test/editor.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix autocomplete recovery after provider request failures in TUI editor
> A failed `autocompleteProvider.getSuggestions()` call previously rejected the in-flight autocomplete task, leaving autocomplete permanently unavailable for the session. The fix wraps the provider call in a catch handler in `Editor.runAutocompleteRequest` that returns `null` on rejection, treating failures as no suggestions. Autocomplete is cancelled and the UI re-rendered, and subsequent requests proceed normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc1ec7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->