### PR TITLE
fix(agent): stop parallel tool preflight after abort

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed parallel tool batches continuing to preflight later tool calls after cancellation.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -698,6 +698,10 @@ async function executeToolCallsParallel(
 	const finalizedCalls: FinalizedToolCallEntry[] = [];
 
 	for (const toolCall of toolCalls) {
+		if (signal?.aborted) {
+			break;
+		}
+
 		await emit({
 			type: "tool_execution_start",
 			toolCallId: toolCall.id,

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -336,33 +336,52 @@ describe("agentLoop with AgentMessage", () => {
 				},
 			],
 		};
+		const preflighted: string[] = [];
 		const config: AgentLoopConfig = {
 			model: createModel(),
 			convertToLlm: identityConverter,
-			beforeToolCall: async () => {
+			toolExecution: "parallel",
+			beforeToolCall: async ({ toolCall }) => {
+				preflighted.push(toolCall.id);
 				controller.abort();
 				return undefined;
 			},
 		};
 		const assistantMessage = createAssistantMessage(
-			[{ type: "toolCall", id: "tool_1", name: "wait", arguments: {} }],
+			[
+				{ type: "toolCall", id: "tool_1", name: "wait", arguments: {} },
+				{ type: "toolCall", id: "tool_2", name: "wait", arguments: {} },
+			],
 			"toolUse",
 		);
-		const streamFn = () => {
+		const streamFn = vi.fn(() => {
 			const stream = new MockAssistantStream();
 			queueMicrotask(() => {
 				stream.push({ type: "done", reason: "toolUse", message: assistantMessage });
 			});
 			return stream;
-		};
+		});
 
+		const events: AgentEvent[] = [];
 		const stream = agentLoop([createUserMessage("Hello")], context, config, controller.signal, streamFn);
-		for await (const _event of stream) {
-			// consume
+		for await (const event of stream) {
+			events.push(event);
 		}
 		await stream.result();
 
+		const toolStartIds = events.flatMap((event) => (event.type === "tool_execution_start" ? [event.toolCallId] : []));
+		const toolEndIds = events.flatMap((event) => (event.type === "tool_execution_end" ? [event.toolCallId] : []));
+		const toolResultIds = events.flatMap((event) =>
+			event.type === "message_end" && event.message.role === "toolResult" ? [event.message.toolCallId] : [],
+		);
+
 		expect(toolExecute).not.toHaveBeenCalled();
+		expect(preflighted).toEqual(["tool_1"]);
+		expect(toolStartIds).toEqual(["tool_1"]);
+		expect(toolEndIds).toEqual(["tool_1"]);
+		expect(toolResultIds).toEqual(["tool_1"]);
+		expect(streamFn).toHaveBeenCalledTimes(1);
+		expect(events.some((event) => event.type === "agent_end")).toBe(true);
 	});
 
 	it("should stop a sequential tool batch after aborting a tool call", async () => {


### PR DESCRIPTION
## Summary
- Stopped parallel tool batches from preflighting later calls after cancellation.
- Kept the active call's lifecycle balanced and preserved normal parallel execution behavior.

## Testing
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-loop.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `executeToolCallsParallel` to stop preflighting tool calls after abort
> When an `AbortSignal` fires mid-batch, the parallel tool execution loop previously continued to preflight and emit events for remaining tool calls. This fix adds an early-abort check at the top of the loop in [agent-loop.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/779/files#diff-376f09356e91b96550338f3566a60be2314088842fee692254a264429ae081ea), breaking out before emitting `tool_execution_start` or running preflight for any subsequent calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a9a8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->