### PR TITLE
docs(coding-agent): sync daemon protocol docs

### DIFF
--- a/packages/coding-agent/docs/agent-connection.md
+++ b/packages/coding-agent/docs/agent-connection.md
@@ -102,7 +102,7 @@ The protocol does not promise that every historical event remains replayable. Du
 
 ## Command Lifecycle and Idempotency
 
-The public daemon protocol is JSONL-framed and currently at protocol v4. Commands may be sent in versioned envelopes containing protocol metadata, client ID, and command ID.
+The public daemon protocol is JSONL-framed and currently at protocol v7 with schema revision 13. Commands may be sent in versioned envelopes containing protocol metadata, client ID, and command ID.
 
 Mutating commands are recorded before dispatch. A repeated completed command returns its recorded result. A command known to have been received but lacking a durable result is reported as uncertain instead of being replayed blindly. Clients acknowledge durable results so old journal entries can be compacted.
 

--- a/packages/coding-agent/docs/daemon.md
+++ b/packages/coding-agent/docs/daemon.md
@@ -73,7 +73,7 @@ Due ticks are claimed and advanced before prompt delivery. A crash therefore doe
 
 Resident workers keep scheduling across supervisor replacement. Worker recovery marks uncertain claims interrupted, keeps the advanced schedule, and resumes future ticks only. The supervisor routes schedule commands and merges worker summaries for global listing.
 
-## Public Daemon Protocol v4
+## Public Daemon Protocol v7
 
 The public local socket is JSONL-framed. The current protocol provides:
 
@@ -88,7 +88,7 @@ The public local socket is JSONL-framed. The current protocol provides:
 - daemon-side headless completion, session-header, bash, and retry operations; and
 - structured errors for recoverable cases such as an already-active session or uncertain mutation result.
 
-Protocol version and schema revision are independent. A compatible addition can be capability-gated or require a schema revision; an incompatible wire change requires a protocol bump.
+Protocol version and schema revision are independent; the current schema revision is 13. A compatible addition can be capability-gated or require a schema revision; an incompatible wire change requires a protocol bump.
 
 Protocol v1 is retained only for the one-release update handoff that prepares and stops an older daemon. A busy older daemon that cannot produce a recovery manifest is left running.
 


### PR DESCRIPTION
## Summary
- Updated daemon architecture documentation to protocol v7 and schema revision 13.
- Preserved the historical protocol v1 update-handoff note.

## Testing
- `rg 'protocol v[0-9]' packages/coding-agent/docs/`
- `rg 'Public Daemon Protocol' packages/coding-agent/docs/`
- `rg 'DAEMON_PROTOCOL_VERSION|DAEMON_SCHEMA_REVISION' packages/coding-agent/src/modes/daemon/daemon-protocol.ts`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update coding-agent daemon protocol docs to v7 and schema revision 13
> Updates version references in [agent-connection.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/780/files#diff-7b40d5b81bac3f24c7e110d66c48de23829cbca28b757749f14b4737bf9fdcbd) and [daemon.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/780/files#diff-86495cb36fe24122a460f5db19b2143f6113eb50ff1f0f2f2968851d433b411d) to reflect the current public daemon protocol version (v4 → v7) and schema revision (13).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82ade9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->