### PR TITLE
fix(runtime): use SDK HTTP client factory for streamable MCP transport

### DIFF
--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -109,6 +109,13 @@ def _resolve_streamable_http():
     )
 
 
+def _build_mcp_http_client(headers: dict[str, str]):
+    """Return an SDK-configured streamable-HTTP client with ``headers`` applied."""
+    from mcp.shared._httpx_utils import create_mcp_http_client  # noqa: PLC0415
+
+    return create_mcp_http_client(headers=headers)
+
+
 class McpIntegration:
     """Subclass and set :attr:`server` (and :attr:`url` for remote servers).
 
@@ -225,13 +232,13 @@ class McpIntegration:
         auth_header = {**extra_headers, "Authorization": f"Bearer {token}"}
 
         # SDK signatures vary: some take headers=, others only http_client=.
+        # The http_client path must use the SDK factory: a bare httpx.AsyncClient
+        # defaults to a 5s read timeout and aborts long tool calls with ReadTimeout.
         params = inspect.signature(transport).parameters
         if "headers" in params:
             cm = transport(url, headers=auth_header)
         elif "http_client" in params:
-            import httpx  # noqa: PLC0415
-
-            client = await stack.enter_async_context(httpx.AsyncClient(headers=auth_header))
+            client = await stack.enter_async_context(_build_mcp_http_client(auth_header))
             cm = transport(url, http_client=client)
         else:
             raise RuntimeError(

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -253,6 +253,36 @@ class McpIntegrationTest(unittest.TestCase):
         self._run_open_session_with_transport(transport)
         self.assertIsNotNone(captured["http_client"])
 
+    def test_open_session_http_client_uses_mcp_timeouts(self):
+        # Bare httpx.AsyncClient defaults to a 5s read timeout, which aborts long
+        # MCP tool calls with ReadTimeout. The http_client branch must use the SDK
+        # factory so MCP defaults (30s general / 300s SSE read) apply.
+        captured = {}
+
+        class _CM:
+            async def __aenter__(self_inner):
+                return ("read", "write", None)
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        def transport(url, *, http_client=None):
+            captured["http_client"] = http_client
+            return _CM()
+
+        self._run_open_session_with_transport(transport)
+        client = captured["http_client"]
+        self.assertIsNotNone(client)
+        timeout = client.timeout
+        # Literals (not SDK constants): pin values that keep long tool calls alive.
+        # A 5s read timeout is what the bare-httpx regression used to apply.
+        self.assertEqual(timeout.connect, 30.0)
+        self.assertEqual(timeout.write, 30.0)
+        self.assertEqual(timeout.pool, 30.0)
+        self.assertEqual(timeout.read, 300.0)
+        # Authorization must still be injected on the prebuilt client.
+        self.assertEqual(client.headers.get("Authorization"), "Bearer tok-xyz")
+
     def test_resolve_config_prefers_host_override_and_headers(self):
         async def host_with_override(req_type, payload):
             return {"url": "https://override.test/mcp", "headers": {"X-Extra": "1"}}


### PR DESCRIPTION
## Summary

fixes #784

On the modern MCP streamable-HTTP path, `McpIntegration._open_session` only
accepts a prebuilt `http_client`. It previously constructed a bare
`httpx.AsyncClient(headers=...)`, which inherits httpx’s default **5s** timeout.
Long MCP tool calls (e.g. TinyFish `fetch_content` on slow docs pages) failed
with `httpx.ReadTimeout` after ~6s wall time.

Use `mcp.shared._httpx_utils.create_mcp_http_client(headers=...)` instead so the
transport gets the SDK defaults (**30s** general / **300s** SSE read) on an
httpx2 client. The older `headers=` transport branch is unchanged.

## Changes

- `prime-agent-runtime/src/rlm/mcp_base.py`
  - Add `_build_mcp_http_client` that lazily calls `create_mcp_http_client`
  - Wire the `http_client=` branch through that helper
- `prime-agent-runtime/test/test_mcp_base.py`
  - Add `test_open_session_http_client_uses_mcp_timeouts`: drives real
    `_open_session`, asserts connect/write/pool `30.0`, read `300.0`, and
    preserved `Authorization`
  - Timeout expectations are **literals** (not SDK constants) so a silent SDK
    default shrink does not auto-pass

## Root cause (brief)

Current `mcp` 2.x exposes:

```python
streamable_http_client(url, *, http_client=None, ...)
```

with no `headers=` parameter, so `_open_session` takes the `http_client` branch
and must supply the client. A bare httpx client defaults to
`Timeout(timeout=5.0)`. There is no `mcpServers` timeout setting; the fix
belongs in the runtime.

## Evidence

Same TinyFish `fetch_content` URL
(`https://effect.website/docs/requirements-management/layers/`):

| Client | Result |
|---|---|
| Bare `httpx.AsyncClient` (old path) | FAIL ~6s `ReadTimeout` |
| `create_mcp_http_client` (30/300) | OK ~24s |
| `httpx2` `Timeout(30, read=60)` | OK ~20.6s |

User-visible failure is **ReadTimeout** on the POST/`client.stream` path. Tool
args such as `per_url_timeout_ms` cannot help once the kernel client has already
timed out. Using the SDK factory also returns httpx2, which matches the
transport’s typed client API (including `client.sse` on the GET path).

## Test plan

- [x] `cd prime-agent-runtime && PYTHONPATH=src python -m unittest discover -s test -v`
  - 65 tests OK (kernel venv with `mcp` / `httpx` / `httpx2`)
- [x] New regression:
  `test_open_session_http_client_uses_mcp_timeouts`
- [ ] CI (`npm run check` / package tests) on this PR
  - Change is Python-only under `prime-agent-runtime`; that package is not a
    separate CI matrix job today. Runtime unittest above is the direct coverage.

## Scope / non-goals

- No `mcpServers.timeout` settings field (follow-up if desired)
- No host `mcp.config` / OAuth changes
- No server-side tool budget changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `McpIntegration._open_session` to use SDK HTTP client factory for streamable MCP transport
> - Replaces bare `httpx.AsyncClient(headers=auth_header)` with a new `_build_mcp_http_client` helper that calls the MCP SDK's `create_mcp_http_client` factory, applying auth headers on top of SDK defaults.
> - The SDK factory sets longer timeouts (connect/write/pool = 30s, read = 300s) vs. httpx's default 5s read timeout, which caused premature disconnects on slow MCP streams.
> - A new test in [test_mcp_base.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/785/files#diff-b3ee6a356ae29d5a25ba8a2aee48573297ddf389d3a85157bd878fbff7b58508) asserts the correct timeout values and Authorization header presence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2df5cf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->