### PR TITLE
fix(daemon): namespace socket by agent dir without lengthening paths

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto";
 import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
+import { getAgentDir } from "../../config.js";
 
 const DAEMON_SOCKET_MODE = 0o600;
 const DAEMON_SOCKET_DIR_MODE = 0o700;
@@ -35,9 +37,9 @@ export interface DaemonSocketIdentity {
 
 export function defaultDaemonSocketPath(): string {
 	if (process.platform === "win32") {
-		return "\\\\.\\pipe\\prime-agent-daemon";
+		return `\\\\.\\pipe\\prime-agent-daemon-${agentDirSocketSuffix()}`;
 	}
-	return join(defaultDaemonSocketDir(), "daemon.sock");
+	return join(defaultDaemonSocketDir(), `daemon-${agentDirSocketSuffix()}.sock`);
 }
 
 export async function acquireDaemonSocketPathLease(socketPath: string): Promise<DaemonSocketPathLease | undefined> {
@@ -214,6 +216,21 @@ function assertSocketLease(socketPath: string, lease: DaemonSocketPathLease): vo
 export function defaultDaemonSocketDir(): string {
 	const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
 	return join(tmpdir(), `prime-agent-${suffix}`);
+}
+
+/**
+ * Daemon identity must include the agent state dir: two installs sharing one
+ * uid-keyed socket (e.g. a fork pointed at PRIME_AGENT_CODING_AGENT_DIR and a
+ * vanilla install) would otherwise attach to whichever daemon started first and
+ * silently run sessions under the other install's code and state.
+ *
+ * The suffix goes into the socket FILENAME, not the directory: worker socket
+ * paths in the shared directory already sit at ~103 chars, right at the macOS
+ * sun_path limit (104) — a longer directory name makes bind() silently
+ * truncate the path and every later stat of the full path fail with ENOENT.
+ */
+function agentDirSocketSuffix(): string {
+	return createHash("sha256").update(resolve(getAgentDir())).digest("hex").slice(0, 8);
 }
 
 function ensureDefaultDaemonSocketDir(socketPath: string): void {

--- a/packages/coding-agent/test/daemon-socket.test.ts
+++ b/packages/coding-agent/test/daemon-socket.test.ts
@@ -13,15 +13,15 @@ import {
 } from "../src/modes/daemon/daemon-socket.js";
 
 describe("defaultDaemonSocketPath", () => {
-	it("uses a fixed Windows named pipe path", () => {
+	it("uses an agent-dir-suffixed Windows named pipe path", () => {
 		if (process.platform !== "win32") {
 			return;
 		}
 
-		expect(defaultDaemonSocketPath()).toBe("\\\\.\\pipe\\prime-agent-daemon");
+		expect(defaultDaemonSocketPath()).toMatch(/^\\\\\.\\pipe\\prime-agent-daemon-[0-9a-f]{8}$/);
 	});
 
-	it("uses a per-user Unix socket directory", () => {
+	it("uses a per-user Unix socket directory with an agent-dir-suffixed filename", () => {
 		if (process.platform === "win32") {
 			return;
 		}
@@ -30,7 +30,27 @@ describe("defaultDaemonSocketPath", () => {
 		const socketPath = defaultDaemonSocketPath();
 
 		expect(dirname(socketPath)).toBe(join(tmpdir(), `prime-agent-${suffix}`));
-		expect(basename(socketPath)).toBe("daemon.sock");
+		expect(basename(socketPath)).toMatch(/^daemon-[0-9a-f]{8}\.sock$/);
+	});
+
+	it("derives distinct socket paths for distinct agent dirs", () => {
+		const original = process.env.PRIME_AGENT_CODING_AGENT_DIR;
+		try {
+			process.env.PRIME_AGENT_CODING_AGENT_DIR = "/tmp/agent-dir-a";
+			const a = defaultDaemonSocketPath();
+			process.env.PRIME_AGENT_CODING_AGENT_DIR = "/tmp/agent-dir-b";
+			const b = defaultDaemonSocketPath();
+			expect(a).not.toBe(b);
+			if (process.platform !== "win32") {
+				expect(dirname(a)).toBe(dirname(b));
+			}
+		} finally {
+			if (original === undefined) {
+				delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
+			} else {
+				process.env.PRIME_AGENT_CODING_AGENT_DIR = original;
+			}
+		}
 	});
 
 	it("checks a live daemon before acquiring the socket path lock", async () => {


### PR DESCRIPTION
## Summary
- Include `PRIME_AGENT_CODING_AGENT_DIR` in daemon socket identity so distinct agent dirs get distinct daemons (instead of silently sharing whichever uid-keyed daemon started first).
- Put the agent-dir hash in the socket **filename** (`daemon-<hash8>.sock`), not the directory, so worker socket paths stay within the macOS `sun_path` limit.
- Cover distinct agent dirs (Unix + Windows pipe) in `daemon-socket` tests.

Fixes #768. Related path-length constraint: #669.

## Test plan
- [x] `npm --prefix packages/coding-agent test -- test/daemon-socket.test.ts` (8/8)
- [ ] Manually: start a vanilla daemon (`prime-agent -p "hi"`), then `PRIME_AGENT_CODING_AGENT_DIR=~/.prime-b/agent prime-agent -p "hi"` and confirm a second daemon/socket under `$TMPDIR/prime-agent-<uid>/daemon-<hash>.sock`
- [ ] Confirm `prime-agent doctor` / `ps` still lists both daemons via socket-dir scan


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Namespace daemon socket path by agent directory using an 8-char hash suffix
> - `defaultDaemonSocketPath` in [`daemon-socket.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/786/files#diff-59c4ea71700afcf7d09d14c5d30e2c73fd0c71b28284e8758cd8fbd4b2337dbc) now appends an 8-hex-character suffix derived from the SHA-256 hash of the resolved `PRIME_AGENT_CODING_AGENT_DIR` path, producing distinct socket names per agent directory.
> - On Unix, only the filename changes (e.g. `daemon-<hash>.sock`); the per-user directory is unchanged, keeping paths within `sun_path` limits.
> - On Windows, the named pipe name gains the same suffix (e.g. `\\.\pipe\prime-agent-daemon-<hash>`).
> - Behavioral Change: any existing code or tooling that assumes a fixed socket path (`daemon.sock` or `prime-agent-daemon`) will no longer find the socket at that location.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa353ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->