### PR TITLE
fix(coding-agent): cap transcript rendering on session resync

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed reconnecting to long sessions replaying the entire transcript and making the UI unresponsive ([#774](https://github.com/PrimeIntellect-ai/prime-agent/issues/774)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2861,6 +2861,7 @@ export class InteractiveMode {
 		await this.renderSessionContext(this.getSessionContextFromConnectionSnapshot(snapshot), {
 			clearChat: true,
 			updateFooter: true,
+			limitTranscript: true,
 		});
 		await this.restoreStreamingMessageFromSnapshot(snapshot.streamingMessage);
 		await this.refreshConnectionQueue();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1482,7 +1482,11 @@ describe("InteractiveMode connection events", () => {
 		expect((fakeThis as unknown as { activeBashComponent: unknown }).activeBashComponent).toBe(activeBashComponent);
 		expect(
 			(fakeThis as unknown as { renderSessionContext: ReturnType<typeof vi.fn> }).renderSessionContext,
-		).toHaveBeenCalledWith(expect.anything(), { clearChat: true, updateFooter: true });
+		).toHaveBeenCalledWith(expect.anything(), {
+			clearChat: true,
+			limitTranscript: true,
+			updateFooter: true,
+		});
 		expect(startAssistantStreamingMessage).toHaveBeenCalledWith(streamingMessage);
 		expect(refreshCommandCatalogForCurrentSession).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/suite/regressions/774-session-resync-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/774-session-resync-render.test.ts
@@ -1,0 +1,109 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { Container } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { emptyGoalState } from "../../../src/core/goals.js";
+import type { AgentConnectionSnapshot, AgentConnectionState } from "../../../src/modes/agent-connection/types.js";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
+
+function createConnectionState(messageCount: number): AgentConnectionState {
+	return {
+		activeSessionId: "active-1",
+		cwd: "/tmp/project",
+		thinkingLevel: "medium",
+		serviceTier: "default",
+		availableThinkingLevels: ["minimal", "low", "medium", "high", "xhigh"],
+		isStreaming: false,
+		isCompacting: false,
+		isBashRunning: false,
+		retryAttempt: 0,
+		steeringMode: "all",
+		followUpMode: "all",
+		sessionId: "session-1",
+		leafId: null,
+		autoCompactionEnabled: true,
+		messageCount,
+		sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+		compactionCount: 0,
+		goal: emptyGoalState(),
+		scopedModels: [],
+		activeToolNames: [],
+		contextUsage: undefined,
+	};
+}
+
+function userMessage(index: number): Extract<AgentMessage, { role: "user" }> {
+	return {
+		role: "user",
+		content: `message-${index}`,
+		timestamp: index,
+	};
+}
+
+describe("issue #774 session resync rendering", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("limits a large resync transcript to the recent render window", async () => {
+		const messages = Array.from({ length: 401 }, (_, index) => userMessage(index));
+		const renderedMessages: AgentMessage[] = [];
+		const chatContainer = new Container();
+		const snapshot: AgentConnectionSnapshot = {
+			state: createConnectionState(messages.length),
+			messages,
+		};
+		const fakeThis = {
+			activeBashComponent: undefined,
+			sideQuestionBash: undefined,
+			sideQuestionComponent: undefined,
+			sideQuestionBashDiscarded: undefined,
+			streamingComponent: undefined,
+			streamingMessage: undefined,
+			pendingTools: new Map(),
+			ipythonToolComponents: new Map(),
+			lateIpythonSentAgentMessages: new Map(),
+			toolOutputExpanded: false,
+			chatContainer,
+			editor: { addToHistory: vi.fn() },
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			resetPendingToolState: vi.fn(),
+			preloadToolDefinitions: vi.fn(async () => {}),
+			settingsManager: { getShowImages: () => true },
+			getCachedToolDefinition: () => undefined,
+			getCurrentCwd: () => process.cwd(),
+			getRetryAttempt: () => 0,
+			ui: { requestRender: vi.fn() },
+			addMessageToChat: (message: AgentMessage) => {
+				renderedMessages.push(message);
+			},
+			applyConnectionStateSnapshot: vi.fn(),
+			isBashRunning: () => false,
+			replaceSubagentSummary: vi.fn(),
+			getSessionContextFromConnectionSnapshot: (value: AgentConnectionSnapshot) => ({
+				messages: value.messages,
+				thinkingLevel: value.state.thinkingLevel,
+				serviceTier: value.state.serviceTier,
+				model: null,
+			}),
+			restoreStreamingMessageFromSnapshot: vi.fn(async () => {}),
+			refreshConnectionQueue: vi.fn(async () => {}),
+			updateTerminalTitle: vi.fn(),
+			setGoalAnnouncementBaseline: vi.fn(),
+			syncGoalTray: vi.fn(),
+			syncWorkingLoader: vi.fn(),
+			getGoalState: () => emptyGoalState(),
+		} as unknown as InteractiveMode;
+		Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+
+		await (
+			InteractiveMode.prototype as unknown as {
+				renderResyncedSession(this: InteractiveMode, value: AgentConnectionSnapshot): Promise<void>;
+			}
+		).renderResyncedSession.call(fakeThis, snapshot);
+
+		expect(renderedMessages).toHaveLength(400);
+		expect(renderedMessages).toEqual(messages.slice(1));
+	});
+});


### PR DESCRIPTION
## Summary

- Applied the existing 400-message transcript render window to session resyncs.
- Added an issue-specific regression for a 401-message resync.
- Updated the coding-agent changelog.

## Root cause

Initial session rendering already capped the visible transcript, but `renderResyncedSession` called `renderSessionContext` without `limitTranscript`. Reconnect/recovery therefore rebuilt the entire transcript, making long sessions expensive to render and delaying TUI input.

## Validation

- Reproduced the pre-fix regression: 401 messages rendered instead of 400.
- Passed `test/interactive-mode-status.test.ts` and `test/suite/regressions/774-session-resync-render.test.ts` (151 tests).
- Passed `npm run check`: Biome, TypeScript, installer render, and browser smoke checks.
- Passed the commit pre-commit checks.

Fixes #774

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap transcript rendering in `InteractiveMode.renderResyncedSession` to prevent UI freeze on long sessions
> Reconnecting to sessions with long transcripts caused the entire transcript to be replayed, making the UI unresponsive. Passes `limitTranscript: true` to `renderSessionContext` during session resync in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/790/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316), capping rendering to the 400 most recent messages. A regression test verifies the cap with a 401-message snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 292257b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->