### PR TITLE
fix(ai): restore Kimi K3 reasoning levels

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Kimi K3 reasoning levels being restricted to max when provider catalogs omit an explicit effort map.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -92,16 +92,6 @@ const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
 	max: null,
 } as const;
 
-const KIMI_K3_THINKING_LEVEL_MAP = {
-	off: null,
-	minimal: null,
-	low: null,
-	medium: null,
-	high: null,
-	xhigh: null,
-	max: "max",
-} as const;
-
 const DEEPSEEK_V4_COMPAT: OpenAICompletionsCompat = {
 	requiresReasoningContentOnAssistantMessages: true,
 	thinkingFormat: "deepseek",
@@ -324,10 +314,6 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	}
 	if (model.api === "openai-completions" && model.id.includes("deepseek-v4")) {
 		mergeThinkingLevelMap(model, DEEPSEEK_V4_THINKING_LEVEL_MAP);
-	}
-	const kimiK3Id = model.id.toLowerCase();
-	if (!model.thinkingLevelMap && (/^k3(-|$)/.test(kimiK3Id) || /(^|\/)kimi-k3(-|$)/.test(kimiK3Id))) {
-		mergeThinkingLevelMap(model, KIMI_K3_THINKING_LEVEL_MAP);
 	}
 	if (isGoogleThinkingApi(model) && isGemini3ProModel(model.id)) {
 		mergeThinkingLevelMap(model, { off: null, minimal: null, low: "LOW", medium: null, high: "HIGH" });


### PR DESCRIPTION
OpenRouter and Prime Inference already mark Kimi K3 as reasoning-capable, but the model generator applied a max-only fallback when provider catalogs omitted an explicit effort map. Prime Agent consequently clamped high and lower settings to max.

Remove that fallback so Kimi K3 models use the standard generated reasoning capability and effort resolution already present in the current provider catalogs.

Validation: 12 focused tests passed; `npm run check` passed.
