### PR TITLE
feat(coding-agent): add hidden manual continuation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Changed a lone `.` submission to resume the prior intent through a hidden host continuation without adding a visible user message.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -27,6 +27,7 @@ The editor can be replaced temporarily by built-in UI such as `/settings` or by 
 | Images | Paste with Ctrl+V, Alt+V on Windows, or drag into the terminal |
 | Shell command | `!command` runs and sends output to the model |
 | Hidden shell command | `!!command` runs without sending output to the model |
+| Continue | Enter `.` by itself to resume the most recent intent without adding a visible user message |
 | External editor | Ctrl+G opens `$VISUAL` or `$EDITOR` |
 
 See [Keybindings](keybindings.md) for all shortcuts and customization.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -179,6 +179,7 @@ import {
 	type CustomMessage,
 	createCompactionOutcomeMessage,
 	createHeartbeatPromptMessage,
+	createManualContinueMessage,
 	createRlmChildFailureMessage,
 	createRlmChildTerminalNoticeMessage,
 	createSessionSlashCommandMessage,
@@ -187,6 +188,7 @@ import {
 	HEARTBEAT_PROMPT_PREVIEW_LABEL,
 	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
 	isSessionSlashCommandMessage,
+	MANUAL_CONTINUE_PROMPT,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { throwIfPromptAdmissionCancelled } from "./prompt-admission.js";
@@ -4451,12 +4453,37 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
-		return this._prompt(text, options);
+		const normalized = this._normalizeManualContinuation(text, options);
+		return this._prompt(normalized.text, normalized.options);
 	}
 
 	/** Resolve once the session has accepted ownership, before queued or active execution completes. */
 	async promptUntilAccepted(text: string, options?: PromptOptions): Promise<void> {
-		return this._prompt(text, { ...options, returnAfterAccepted: true });
+		const normalized = this._normalizeManualContinuation(text, options);
+		return this._prompt(normalized.text, { ...normalized.options, returnAfterAccepted: true });
+	}
+
+	private _normalizeManualContinuation(
+		text: string,
+		options?: PromptOptions,
+	): { text: string; options?: PromptOptions } {
+		if (
+			text.trim() !== "." ||
+			options?.internalPrompt ||
+			options?.customMessage ||
+			(options?.images?.length ?? 0) > 0 ||
+			(options?.content?.length ?? 0) > 0
+		) {
+			return { text, options };
+		}
+		return {
+			text: MANUAL_CONTINUE_PROMPT,
+			options: {
+				...options,
+				customMessage: createManualContinueMessage(),
+				internalPrompt: true,
+			},
+		};
 	}
 
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -33,6 +33,14 @@ export const SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE = "session_slash_command_r
 export const COMPACTION_OUTCOME_CUSTOM_TYPE = "compaction_outcome";
 export const RLM_CHILD_FAILURE_CUSTOM_TYPE = "rlm_child_failure";
 export const RLM_CHILD_TERMINAL_NOTICE_CUSTOM_TYPE = "rlm_child_terminal_notice";
+export const MANUAL_CONTINUE_CUSTOM_TYPE = "manual_continue";
+export const MANUAL_CONTINUE_PROMPT = `<system-notice>
+Continue.
+
+- Resume the most recent intent and carry unfinished work to completion.
+- If interrupted mid-step, continue from that point.
+- Do not pause to summarize progress, reconfirm the plan, or ask whether to proceed.
+</system-notice>`;
 
 export interface SessionSlashCommandDetails {
 	command: SessionSlashCommand;
@@ -277,6 +285,16 @@ export function createCustomMessage(
 	};
 }
 
+export function createManualContinueMessage(timestamp = Date.now()): CustomMessage {
+	return {
+		role: "custom",
+		customType: MANUAL_CONTINUE_CUSTOM_TYPE,
+		content: MANUAL_CONTINUE_PROMPT,
+		display: false,
+		timestamp,
+	};
+}
+
 export function createSessionSlashCommandMessage(
 	command: SessionSlashCommand,
 	details: Omit<SessionSlashCommandDetails, "command"> = {},
@@ -442,6 +460,13 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						timestamp: m.timestamp,
 					};
 				case "custom": {
+					if (m.customType === MANUAL_CONTINUE_CUSTOM_TYPE) {
+						return {
+							role: "user",
+							content: [{ type: "text", text: MANUAL_CONTINUE_PROMPT }],
+							timestamp: m.timestamp,
+						};
+					}
 					if (
 						m.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE ||
 						m.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE ||

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4989,7 +4989,8 @@ export class InteractiveMode {
 				this.clearSideQuestion({ abort: true });
 				this.flushPendingBashComponents();
 				const images = this.collectImagesFor(text);
-				this.editor.addToHistory?.(text);
+				const manualContinue = text === "." && (images?.length ?? 0) === 0;
+				if (!manualContinue) this.editor.addToHistory?.(text);
 				this.editor.setText("");
 				const promptStashAfterClear = this.promptStash;
 				submissionOutcome = (await this.admitPendingStartupPrompts?.()) ?? "admitted";

--- a/packages/coding-agent/test/manual-continue.test.ts
+++ b/packages/coding-agent/test/manual-continue.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { AgentSession, type PromptOptions } from "../src/core/agent-session.js";
+import {
+	convertToLlm,
+	createManualContinueMessage,
+	MANUAL_CONTINUE_CUSTOM_TYPE,
+	MANUAL_CONTINUE_PROMPT,
+} from "../src/core/messages.js";
+
+describe("manual continuation", () => {
+	it("normalizes a lone host prompt at the session input boundary", () => {
+		const normalize = (
+			AgentSession.prototype as unknown as {
+				_normalizeManualContinuation(
+					text: string,
+					options?: PromptOptions,
+				): { text: string; options?: PromptOptions };
+			}
+		)._normalizeManualContinuation;
+		const normalized = normalize.call({}, ".");
+		expect(normalized).toMatchObject({
+			text: MANUAL_CONTINUE_PROMPT,
+			options: {
+				internalPrompt: true,
+				customMessage: { customType: MANUAL_CONTINUE_CUSTOM_TYPE, display: false },
+			},
+		});
+		expect(normalize.call({}, ".", { images: [{ type: "image", data: "x", mimeType: "image/png" }] })).toEqual({
+			text: ".",
+			options: { images: [{ type: "image", data: "x", mimeType: "image/png" }] },
+		});
+	});
+
+	it("persists a hidden custom message while giving the model the continuation directive", () => {
+		const message = createManualContinueMessage(123);
+		expect(message).toMatchObject({
+			role: "custom",
+			customType: MANUAL_CONTINUE_CUSTOM_TYPE,
+			display: false,
+			timestamp: 123,
+		});
+		expect(convertToLlm([message])).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: MANUAL_CONTINUE_PROMPT }],
+				timestamp: 123,
+			},
+		]);
+	});
+});


### PR DESCRIPTION
A lone `.` submission now resumes the most recent intent through a hidden host-authored continuation. The session persists the hidden custom message and presents the continuation directive to the model without adding a visible user turn.

Normalize the input at the AgentSession boundary so interactive, daemon, and SDK prompts agree. Keep image-bearing dot prompts unchanged, omit continuation submissions from editor history, and document the interactive behavior.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hidden manual continuation via lone '.' submission in coding agent
> - A lone `.` entered as a prompt in `AgentSession` is normalized into a hidden internal continuation directive via the new `_normalizeManualContinuation` helper in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/793/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae), resuming the prior intent without adding a visible user message.
> - A new `createManualContinueMessage` factory and `MANUAL_CONTINUE_CUSTOM_TYPE` constant are added in [messages.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/793/files#diff-73eea4d8b225402c51131d2c2e34f8c5c0a555902f25a75555185ccd6f090553); the `convertToLlm` transformer maps this custom message to a `user`-role LLM message instead of dropping it.
> - The interactive mode editor skips recording `.` in input history when no images are attached.
> - Behavioral Change: submitting `.` alone now silently injects a system-level continuation prompt into the LLM context rather than sending a literal `.` as a user message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7534988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->