### PR TITLE
fix(agent): fail closed on provider quota exhaustion

### DIFF
--- a/packages/ai/src/utils/stream-failure.ts
+++ b/packages/ai/src/utils/stream-failure.ts
@@ -13,6 +13,7 @@ export type StreamFailureKind =
 	| "safety"
 	| "overloaded"
 	| "rate_limit"
+	| "quota"
 	| "server_error"
 	| "auth"
 	| "invalid_request"
@@ -44,6 +45,7 @@ const KIND_MESSAGES: Record<StreamFailureKind, string> = {
 	safety: "Response blocked by provider safety filters",
 	overloaded: "Provider overloaded",
 	rate_limit: "Provider rate limit exceeded",
+	quota: "Provider usage quota or credit exhausted",
 	server_error: "Provider server error",
 	auth: "Provider authentication failed",
 	invalid_request: "Provider rejected the request",
@@ -63,11 +65,21 @@ export function streamFailureMessage(info: StreamFailureInfo, detail?: string): 
 	return message;
 }
 
-export function classifyStreamFailure(providerErrorType?: string, status?: number): StreamFailureKind {
-	const type = providerErrorType?.toLowerCase() ?? "";
-	if (type === "refusal") return "refusal";
+export function isQuotaExhaustionMessage(value: string): boolean {
+	return /insufficient[_ -]?(?:quota|credits?|funds?)|(?:quota|credits?|funds?)[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up|not enough|unavailable)|(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up)[^\n]{0,80}(?:quota|credits?|funds?|premium requests?|(?:credit|usage|spend(?:ing)?)[_ -]?limit)|(?:credit|usage|spend(?:ing)?)[_ -]?limit[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|reached)|(?:out of|no)[_ -]*(?:premium[_ -]*)?(?:credits?|quota|funds?|requests?)(?:[_ -]*remaining)?|payment required/i.test(
+		value,
+	);
+}
+
+export function classifyStreamFailure(providerErrorType?: string, status?: number, detail?: string): StreamFailureKind {
+	const type = `${providerErrorType ?? ""} ${detail ?? ""}`.trim().toLowerCase();
+	if (status === 402) return "quota";
+	if (/\brefusal\b/.test(type)) return "refusal";
 	if (/sensitive|safety|prohibited_content|blocklist|spii|recitation|content.?filter|guardrail|flagged/.test(type)) {
 		return "safety";
+	}
+	if (isQuotaExhaustionMessage(type)) {
+		return "quota";
 	}
 	if (type.includes("overloaded") || status === 529) return "overloaded";
 	if (type.includes("rate_limit") || type.includes("throttl") || status === 429) return "rate_limit";
@@ -162,7 +174,7 @@ function extractStreamFailureParts(error: unknown): { info: StreamFailureInfo; d
 
 	return {
 		info: {
-			kind: classifyStreamFailure(providerErrorType ?? error.message, status),
+			kind: classifyStreamFailure(providerErrorType, status, `${String(bodyMessage ?? "")} ${error.message}`),
 			providerErrorType,
 			status,
 			requestId,

--- a/packages/ai/src/utils/stream-failure.ts
+++ b/packages/ai/src/utils/stream-failure.ts
@@ -65,8 +65,15 @@ export function streamFailureMessage(info: StreamFailureInfo, detail?: string): 
 	return message;
 }
 
+function isTransientQuotaThrottleMessage(value: string): boolean {
+	return /\bquota metric\b|\b(?:requests?|tokens?)[_ /-]*per[_ -]?(?:second|minute|hour)|\bper[_ -]?(?:second|minute|hour)|\bresource has been exhausted\b[^\n]{0,80}\bcheck quota\b/i.test(
+		value,
+	);
+}
+
 export function isQuotaExhaustionMessage(value: string): boolean {
-	return /insufficient[_ -]?(?:quota|credits?|funds?)|(?:quota|credits?|funds?)[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up|not enough|unavailable)|(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up)[^\n]{0,80}(?:quota|credits?|funds?|premium requests?|(?:credit|usage|spend(?:ing)?)[_ -]?limit)|(?:credit|usage|spend(?:ing)?)[_ -]?limit[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|reached)|(?:out of|no)[_ -]*(?:premium[_ -]*)?(?:credits?|quota|funds?|requests?)(?:[_ -]*remaining)?|payment required/i.test(
+	if (isTransientQuotaThrottleMessage(value)) return false;
+	return /insufficient[_ -]?(?:quota|credits?|funds?)|(?:quota|credits?|funds?)[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up|not enough)|(?:exceed(?:ed)?|exhaust(?:ed)?|deplet(?:ed)?|reached|used up)[^\n]{0,80}(?:quota|credits?|funds?|premium requests?|(?:credit|usage|spend(?:ing)?)[_ -]?limit)|(?:credit|usage|spend(?:ing)?)[_ -]?limit[^\n]{0,48}(?:exceed(?:ed)?|exhaust(?:ed)?|reached)|(?:out of|no)[_ -]*(?:premium[_ -]*)?(?:credits?|quota|funds?|requests?)(?:[_ -]*remaining)?|payment required/i.test(
 		value,
 	);
 }

--- a/packages/ai/test/stream-failure.test.ts
+++ b/packages/ai/test/stream-failure.test.ts
@@ -39,6 +39,9 @@ describe("classifyStreamFailure", () => {
 		[undefined, 529, "overloaded"],
 		["rate_limit_error", undefined, "rate_limit"],
 		[undefined, 429, "rate_limit"],
+		["insufficient_quota", undefined, "quota"],
+		["quota_exceeded", 429, "quota"],
+		[undefined, 402, "quota"],
 		["refusal", undefined, "refusal"],
 		["sensitive", undefined, "safety"],
 		["SAFETY", undefined, "safety"],
@@ -52,6 +55,13 @@ describe("classifyStreamFailure", () => {
 		["something_else", undefined, "unknown"],
 	])("classifies %s / %s as %s", (type, status, expected) => {
 		expect(classifyStreamFailure(type, status)).toBe(expected);
+	});
+
+	test("lets quota detail override a generic 429 error type", () => {
+		expect(classifyStreamFailure("rate_limit_error", 429, "premium request quota exceeded")).toBe("quota");
+		expect(classifyStreamFailure("rate_limit_error", 429, "you exceeded your monthly premium request quota")).toBe(
+			"quota",
+		);
 	});
 });
 
@@ -105,6 +115,23 @@ describe("extractStreamFailureInfo", () => {
 	test("falls back to classifying the message text", () => {
 		expect(extractStreamFailureInfo(new Error("provider overloaded, retry later")).kind).toBe("overloaded");
 		expect(extractStreamFailureInfo("not an error").kind).toBe("unknown");
+	});
+
+	test("classifies quota language from a nested SDK error message", () => {
+		const sdkError = Object.assign(new Error("429 request failed"), {
+			status: 429,
+			error: {
+				type: "error",
+				error: { type: "rate_limit_error", message: "premium request quota exceeded" },
+			},
+			requestID: "req_quota",
+		});
+		expect(extractStreamFailureInfo(sdkError)).toMatchObject({
+			kind: "quota",
+			providerErrorType: "rate_limit_error",
+			status: 429,
+			requestId: "req_quota",
+		});
 	});
 });
 

--- a/packages/ai/test/stream-failure.test.ts
+++ b/packages/ai/test/stream-failure.test.ts
@@ -63,6 +63,28 @@ describe("classifyStreamFailure", () => {
 			"quota",
 		);
 	});
+
+	test("does not treat temporary quota-service unavailability as quota exhaustion", () => {
+		expect(classifyStreamFailure("server_error", 503, "quota service temporarily unavailable")).toBe("server_error");
+	});
+
+	test.each([
+		"Quota exceeded for quota metric 'GenerateRequestsPerMinutePerProjectPerBaseModel': requests per minute",
+		"Resource has been exhausted (e.g. check quota)",
+	])("treats transient quota throttling as a rate limit: %s", (detail) => {
+		expect(classifyStreamFailure("RESOURCE_EXHAUSTED", 429, detail)).toBe("rate_limit");
+	});
+
+	test("keeps explicit account-capacity exhaustion classified as quota", () => {
+		expect(classifyStreamFailure("rate_limit_error", 429, "premium request quota exceeded")).toBe("quota");
+		expect(
+			classifyStreamFailure(
+				"rate_limit_error",
+				429,
+				"You exceeded your current quota. Please check your plan and billing details.",
+			),
+		).toBe("quota");
+	});
 });
 
 describe("streamFailureFromStopReason", () => {

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -111,10 +111,12 @@ The stable `latest.json` and beta `beta.json` manifests use the same JSON shape:
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
-| `retry.provider.maxRetries` | number | SDK default | Provider/SDK retry attempts |
+| `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts; agent-level retry owns the default policy |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
 
 When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs` (e.g., Google's "quota will reset after 5h"), the request fails immediately with an informative error instead of waiting silently. Set to `0` to disable the cap.
+
+Quota and credit exhaustion fail closed without retrying. The first such failure stops the current session and all of its subagents, blocks recurring background prompts, and remains latched until a user sends a new prompt.
 
 ```json
 {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -362,6 +362,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 					rlmSessionDir: options.sessionDir,
 					rlmParentNodeId: options.rlmParentNodeId,
 					rlmParentAgent: options.parentSession.sessionName ?? options.parentSession.sessionId,
+					rlmParentSession: options.parentSession,
 				},
 				runtimeMetadata: {
 					kind: "subagent",

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -4,6 +4,7 @@ import type { Model, ServiceTier } from "@earendil-works/pi-ai";
 import { getAgentDir } from "../config.js";
 import type { AgentSessionMessageController } from "./agent-messages.js";
 import type { AgentObserveController } from "./agent-observe.js";
+import type { AgentSession } from "./agent-session.js";
 import { installAgentTraceUpload } from "./agent-traces.js";
 import { AuthStorage } from "./auth-storage.js";
 import type { AgentAutonomousConfig } from "./autonomous.js";
@@ -74,6 +75,7 @@ export interface AgentSessionCreationOptions {
 	rlmSessionDir?: string;
 	rlmParentNodeId?: string;
 	rlmParentAgent?: string;
+	rlmParentSession?: AgentSession;
 	subagentRuntimeHost?: SubagentRuntimeHost;
 	rlmHeartbeatController?: AgentRlmHeartbeatController;
 	prewarmIpythonKernel?: boolean;
@@ -275,6 +277,7 @@ export async function createAgentSessionFromServices(
 		rlmSessionDir: options.rlmSessionDir,
 		rlmParentNodeId: options.rlmParentNodeId,
 		rlmParentAgent: options.rlmParentAgent,
+		rlmParentSession: options.rlmParentSession,
 		subagentRuntimeHost: options.subagentRuntimeHost,
 		rlmHeartbeatController: options.rlmHeartbeatController,
 		sessionStartEvent: options.sessionStartEvent,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4490,6 +4490,7 @@ export class AgentSession {
 			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
 		await this._prompt(text, {
 			...options,
+			internalPrompt: true,
 			expandPromptTemplates: false,
 			skipInputHandlers: true,
 			skipPrePromptWork: true,
@@ -5001,6 +5002,9 @@ export class AgentSession {
 				...(recovered.suppressAutonomousContinuation ? { suppressAutonomousContinuation: true } : {}),
 			};
 		});
+		if (actions.some((action) => action.payload.kind === "turn") && this.isProviderQuotaCircuitOpen) {
+			this._assertProviderQuotaCircuitClosed();
+		}
 		for (const action of actions) this._admitSessionInput(action, { restore: true });
 		return actions.length;
 	}
@@ -5321,7 +5325,6 @@ export class AgentSession {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
 		if (action.payload.kind === "turn" && this.isProviderQuotaCircuitOpen) {
-			if (options.restore) return { accepted: false, disposition: "queued" };
 			this._assertProviderQuotaCircuitClosed();
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
@@ -5976,13 +5979,13 @@ export class AgentSession {
 				admissionFence.release();
 			}
 		} else {
-			this.agent.state.messages.push(appMessage);
 			this.sessionManager.appendCustomMessageEntryWithRollback(
 				message.customType,
 				message.content,
 				message.display,
 				message.details,
 			);
+			this.agent.state.messages.push(appMessage);
 			this._emit({ type: "message_start", message: appMessage });
 			this._emit({ type: "message_end", message: appMessage });
 		}
@@ -9024,7 +9027,7 @@ export class AgentSession {
 			timestamp: Date.now(),
 		} satisfies CustomMessage<ProviderQuotaFailure>;
 		try {
-			this.sessionManager.appendCustomMessageEntry(
+			this.sessionManager.appendCustomMessageEntryWithRollback(
 				message.customType,
 				message.content,
 				message.display,
@@ -9041,6 +9044,7 @@ export class AgentSession {
 		const error = new Error(this._formatProviderQuotaFailure(failure));
 		this.requestAbort();
 		this._cancelSessionActions((action) => action.payload.kind === "turn", error);
+		this.agent.clearAllQueues();
 		this._pendingNextTurnMessages = [];
 		const descendants = new Set<AgentSession>();
 		for (const run of this._activeRlmChildRuns.values()) {
@@ -9083,10 +9087,15 @@ export class AgentSession {
 	private _resetProviderQuotaCircuit(): void {
 		const root = this._familyRootSession();
 		if (!root._providerQuotaFailure) return;
-		root.sessionManager.appendCustomEntryWithRollback(PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE, {
-			state: "reset",
-			timestamp: Date.now(),
-		} satisfies ProviderQuotaCircuitEntry);
+		try {
+			root.sessionManager.appendCustomEntryWithRollback(PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE, {
+				state: "reset",
+				timestamp: Date.now(),
+			} satisfies ProviderQuotaCircuitEntry);
+		} catch {
+			// Explicit user authorization clears the live latch. Without a durable reset,
+			// a later reload remains conservatively fail-closed on the persisted trip.
+		}
 		root._providerQuotaFailure = undefined;
 	}
 
@@ -9799,12 +9808,12 @@ export class AgentSession {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
 		if (this._disposed || this._disposing) throw new Error("Cannot spawn a subagent after its parent was disposed");
-		this._assertProviderQuotaCircuitClosed();
 
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
 		const sessionName = requestedSessionName ?? createDefaultRlmSubagentSessionName(prompt, childNodeId);
 		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
+		this._assertProviderQuotaCircuitClosed();
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -686,6 +686,14 @@ interface PreparedCommandPayload extends SessionCommandPayload {
 
 type QueuedSessionAction = SessionAction<PreparedTurnPayload | PreparedCommandPayload>;
 
+function sessionCommandUsesProvider(command: SessionSlashCommand): boolean {
+	return command.name === "compact" || command.name === "refine";
+}
+
+function sessionActionUsesProvider(action: QueuedSessionAction): boolean {
+	return action.payload.kind === "turn" || sessionCommandUsesProvider(action.payload.command);
+}
+
 interface PreparedPromptPreparation {
 	result: Awaited<ReturnType<ExtensionRunner["emitBeforeAgentStart"]>>;
 	/** Base system prompt captured at emitBeforeAgentStart, for stale-base refresh at handoff. */
@@ -5002,7 +5010,7 @@ export class AgentSession {
 				...(recovered.suppressAutonomousContinuation ? { suppressAutonomousContinuation: true } : {}),
 			};
 		});
-		if (actions.some((action) => action.payload.kind === "turn") && this.isProviderQuotaCircuitOpen) {
+		if (actions.some(sessionActionUsesProvider) && this.isProviderQuotaCircuitOpen) {
 			this._assertProviderQuotaCircuitClosed();
 		}
 		for (const action of actions) this._admitSessionInput(action, { restore: true });
@@ -5324,7 +5332,7 @@ export class AgentSession {
 		if (this._disposed || this._disposing) {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
-		if (action.payload.kind === "turn" && this.isProviderQuotaCircuitOpen) {
+		if (sessionActionUsesProvider(action) && this.isProviderQuotaCircuitOpen) {
 			this._assertProviderQuotaCircuitClosed();
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
@@ -5620,6 +5628,7 @@ export class AgentSession {
 				this._notifySessionInputCheckpointChange();
 				this._emitQueueUpdate();
 				try {
+					if (sessionCommandUsesProvider(input.command)) this._assertProviderQuotaCircuitClosed();
 					this._appendDurableSessionCommandMessage(input.text, input.command, false);
 					this._actionStore.ticketFor(action).settleDelivered({ status: "not_applicable" });
 					this._settleAgentMessage(action.agentMessageId, "delivery");
@@ -7026,6 +7035,7 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string, options: { skipAbort?: boolean } = {}): Promise<CompactionResult> {
+		this._assertProviderQuotaCircuitClosed();
 		if (options.skipAbort && this.isStreaming) {
 			throw new Error("Cannot compact without aborting while the agent is running.");
 		}
@@ -7156,9 +7166,12 @@ export class AgentSession {
 			}
 		}
 
-		const { summary, firstKeptEntryId, tokensBefore, details } =
-			extensionCompaction ??
-			(await compact(preparation, model, apiKey, headers, customInstructions, signal, this.thinkingLevel));
+		let result = extensionCompaction;
+		if (!result) {
+			this._assertProviderQuotaCircuitClosed();
+			result = await compact(preparation, model, apiKey, headers, customInstructions, signal, this.thinkingLevel);
+		}
+		const { summary, firstKeptEntryId, tokensBefore, details } = result;
 
 		if (signal.aborted) {
 			throw new Error("Compaction cancelled");
@@ -7578,6 +7591,7 @@ export class AgentSession {
 			return { shouldRefine: false, rationale: "No model selected." };
 		}
 		const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+		this._assertProviderQuotaCircuitClosed();
 		return reviewAutoRefine(
 			this.agent.state.messages,
 			this._loadMergedHarnessState(),
@@ -7623,6 +7637,7 @@ export class AgentSession {
 		} = {},
 		internal: { skipAbort?: boolean } = {},
 	): Promise<RefinementResult> {
+		this._assertProviderQuotaCircuitClosed();
 		// Queued /refine executes from the session-input pump between turns;
 		// refine never aborts the agent (planning is backgrounded and the apply
 		// phase waits for quiescence), so skipAbort only asserts the pump's
@@ -7789,6 +7804,7 @@ export class AgentSession {
 			: baselineScope === "global"
 				? globalPlanningState
 				: localPlanningState!;
+		this._assertProviderQuotaCircuitClosed();
 		const plan = await planRefinement(
 			this.agent.state.messages,
 			planningState,
@@ -9043,7 +9059,7 @@ export class AgentSession {
 	private _failClosedForProviderQuota(failure: ProviderQuotaFailure): void {
 		const error = new Error(this._formatProviderQuotaFailure(failure));
 		this.requestAbort();
-		this._cancelSessionActions((action) => action.payload.kind === "turn", error);
+		this._cancelSessionActions(sessionActionUsesProvider, error);
 		this.agent.clearAllQueues();
 		this._pendingNextTurnMessages = [];
 		const descendants = new Set<AgentSession>();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -44,6 +44,7 @@ import {
 	cleanupSessionResources,
 	getSupportedThinkingLevels,
 	isContextOverflow,
+	isQuotaExhaustionMessage,
 	modelsAreEqual,
 	resetApiProviders,
 	supportsFastMode,
@@ -469,6 +470,8 @@ export interface AgentSessionConfig {
 	rlmParentNodeId?: string;
 	/** Parent agent name/id shown in child communication doctrine. */
 	rlmParentAgent?: string;
+	/** Live parent session used to share family-wide safety state. */
+	rlmParentSession?: AgentSession;
 	/** Host responsible for creating RLM subagent runtimes. */
 	subagentRuntimeHost?: SubagentRuntimeHost;
 	/** Host-side autonomous continuation policy. */
@@ -549,6 +552,8 @@ export interface PromptOptions {
 	followUpQueueKey?: string;
 	/** Source of input for extension input event handlers. Defaults to "interactive". */
 	source?: InputSource;
+	/** Host-generated recurring work must not clear a tripped provider quota circuit. */
+	automatic?: boolean;
 	/** Internal hook used by RPC mode to observe prompt preflight acceptance or rejection. */
 	preflightResult?: (success: boolean, queued?: boolean) => void;
 	/** Queue instead of starting immediately when the session is idle but already has queued work. */
@@ -575,6 +580,25 @@ interface InternalPromptOptions extends PromptOptions {
 	returnAfterAccepted?: boolean;
 	agentMessageId?: string;
 }
+
+interface ProviderQuotaFailure {
+	timestamp: number;
+	sessionId: string;
+	sessionName?: string;
+	childId?: string;
+	provider: string;
+	model: string;
+	status?: number;
+	requestId?: string;
+	errorMessage: string;
+}
+
+type ProviderQuotaCircuitEntry =
+	| { state: "tripped"; failure: ProviderQuotaFailure }
+	| { state: "reset"; timestamp: number };
+
+const PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE = "prime-agent.provider-quota-circuit";
+const PROVIDER_QUOTA_NOTICE_CUSTOM_TYPE = "provider_quota_exhausted";
 
 type SubmissionExtensionCommandPolicy = "execute" | "reject" | "ignore";
 
@@ -1207,6 +1231,7 @@ export class AgentSession {
 	private _rlmSessionDir?: string;
 	private _rlmParentNodeId?: string;
 	private _rlmParentAgent?: string;
+	private _rlmParentSession?: AgentSession;
 	private _repliedToParentSinceTask: boolean | undefined;
 	private _parentReplyCount = 0;
 	private _subagentRuntimeHost?: SubagentRuntimeHost;
@@ -1231,6 +1256,7 @@ export class AgentSession {
 	private _rlmChildUnsubscribes = new Map<string, () => void>();
 	/** Latest recap for this session, written by the daemon summarizer; read by a parent to label its child snapshots. */
 	private _currentRecap?: string;
+	private _providerQuotaFailure?: ProviderQuotaFailure;
 
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
@@ -1320,6 +1346,10 @@ export class AgentSession {
 		this._rlmSessionDir = config.rlmSessionDir;
 		this._rlmParentNodeId = config.rlmParentNodeId;
 		this._rlmParentAgent = config.rlmParentAgent;
+		this._rlmParentSession = config.rlmParentSession;
+		if (!this._rlmParentSession) {
+			this._providerQuotaFailure = this._loadProviderQuotaCircuit();
+		}
 		// A resumed child may have replied before this process started; false would
 		// claim knowledge that is not present in the session transcript.
 		this._repliedToParentSinceTask =
@@ -3503,6 +3533,9 @@ export class AgentSession {
 				this._lastAssistantMessage = event.message;
 
 				const assistantMsg = event.message as AssistantMessage;
+				if (this._isProviderQuotaExhausted(assistantMsg)) {
+					this._tripProviderQuotaCircuit(assistantMsg);
+				}
 				if (assistantMsg.stopReason !== "error") {
 					addAutonomousUsage(this._autonomousState, assistantMsg.usage);
 				}
@@ -4503,6 +4536,7 @@ export class AgentSession {
 		message: CustomMessage,
 		options?: InternalPromptOptions & { executionPolicy?: TurnExecutionPolicy },
 	): Promise<void> {
+		this._assertProviderQuotaCircuitClosed();
 		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
 		const admissionFence = await this._acquireDirectTurnAdmissionFence(options?.signal).catch((error: unknown) => {
 			throwIfPromptAdmissionCancelled(options?.signal);
@@ -4571,6 +4605,9 @@ export class AgentSession {
 	}
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
+		const explicitUserPrompt =
+			options?.automatic !== true && options?.internalPrompt !== true && options?.source !== "extension";
+		if (!explicitUserPrompt) this._assertProviderQuotaCircuitClosed();
 		if (!this.isStreaming) {
 			this._sessionInputPumpSuspended = false;
 			this._assertSessionActionAdmissionAvailable();
@@ -4644,6 +4681,7 @@ export class AgentSession {
 					await this.waitForSessionInputIdle();
 					return;
 				}
+				if (explicitUserPrompt) this._resetProviderQuotaCircuit();
 
 				const queueForStreaming = this.isStreaming;
 				const queueForBusy = options?.queueIfBusy === true && this._isBusyForSessionInput("preflight");
@@ -5282,6 +5320,10 @@ export class AgentSession {
 		if (this._disposed || this._disposing) {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
+		if (action.payload.kind === "turn" && this.isProviderQuotaCircuitOpen) {
+			if (options.restore) return { accepted: false, disposition: "queued" };
+			this._assertProviderQuotaCircuitClosed();
+		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
@@ -5651,6 +5693,7 @@ export class AgentSession {
 	}
 
 	private async _startPreparedTurnActions(actions: QueuedSessionAction[], epoch: number): Promise<void> {
+		this._assertProviderQuotaCircuitClosed();
 		let nextTurnMessages: CustomMessage[] = [];
 		const activeTurns = () =>
 			actions.filter(
@@ -5717,6 +5760,7 @@ export class AgentSession {
 			let promptPromise: Promise<void>;
 			try {
 				promptPromise = this._sessionActionCommitContext.run(commitFence.owner, () => {
+					this._assertProviderQuotaCircuitClosed();
 					if (
 						this._isSessionInputHandoffDeferred(epoch) ||
 						this.isStreaming ||
@@ -5933,7 +5977,7 @@ export class AgentSession {
 			}
 		} else {
 			this.agent.state.messages.push(appMessage);
-			this.sessionManager.appendCustomMessageEntry(
+			this.sessionManager.appendCustomMessageEntryWithRollback(
 				message.customType,
 				message.content,
 				message.display,
@@ -8906,6 +8950,146 @@ export class AgentSession {
 			.find((entry): entry is SessionMessageEntry => entry.type === "message" && entry.message === message);
 	}
 
+	private _familyRootSession(): AgentSession {
+		let root: AgentSession = this;
+		while (root._rlmParentSession) root = root._rlmParentSession;
+		return root;
+	}
+
+	private _loadProviderQuotaCircuit(): ProviderQuotaFailure | undefined {
+		let failure: ProviderQuotaFailure | undefined;
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type !== "custom" || entry.customType !== PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE) continue;
+			const data = entry.data;
+			if (!data || typeof data !== "object") continue;
+			const circuit = data as Partial<ProviderQuotaCircuitEntry>;
+			if (circuit.state === "reset") {
+				failure = undefined;
+				continue;
+			}
+			if (circuit.state !== "tripped" || !("failure" in circuit)) continue;
+			const candidate = circuit.failure;
+			if (
+				candidate &&
+				typeof candidate.timestamp === "number" &&
+				typeof candidate.sessionId === "string" &&
+				typeof candidate.provider === "string" &&
+				typeof candidate.model === "string" &&
+				typeof candidate.errorMessage === "string"
+			) {
+				failure = candidate;
+			}
+		}
+		return failure;
+	}
+
+	private _providerQuotaCircuitFailure(): ProviderQuotaFailure | undefined {
+		return this._familyRootSession()._providerQuotaFailure;
+	}
+
+	get isProviderQuotaCircuitOpen(): boolean {
+		return this._providerQuotaCircuitFailure() !== undefined;
+	}
+
+	private _formatProviderQuotaFailure(failure: ProviderQuotaFailure): string {
+		const source = failure.childId
+			? `subagent ${failure.sessionName ?? failure.sessionId} (${failure.childId})`
+			: `session ${failure.sessionName ?? failure.sessionId}`;
+		const status = failure.status === undefined ? "" : `, status ${failure.status}`;
+		const requestId = failure.requestId ? ` [request_id: ${failure.requestId}]` : "";
+		return `Provider quota exhausted in ${source} using ${failure.provider}/${failure.model}${status}${requestId}. All agent-family background work was stopped. Send a new user prompt to retry explicitly.`;
+	}
+
+	private _assertProviderQuotaCircuitClosed(): void {
+		const failure = this._providerQuotaCircuitFailure();
+		if (failure) throw new Error(this._formatProviderQuotaFailure(failure));
+	}
+
+	private _appendProviderQuotaNotice(failure: ProviderQuotaFailure): void {
+		const content = this._formatProviderQuotaFailure(failure);
+		try {
+			this.sessionManager.appendCustomEntryWithRollback(PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE, {
+				state: "tripped",
+				failure,
+			} satisfies ProviderQuotaCircuitEntry);
+		} catch {
+			// The in-memory circuit remains authoritative if persistence is unavailable.
+		}
+		const message = {
+			role: "custom" as const,
+			customType: PROVIDER_QUOTA_NOTICE_CUSTOM_TYPE,
+			content,
+			display: true,
+			details: failure,
+			timestamp: Date.now(),
+		} satisfies CustomMessage<ProviderQuotaFailure>;
+		try {
+			this.sessionManager.appendCustomMessageEntry(
+				message.customType,
+				message.content,
+				message.display,
+				message.details,
+			);
+		} catch {
+			// The live event still makes the failure visible to attached clients.
+		}
+		this._emit({ type: "message_start", message });
+		this._emit({ type: "message_end", message });
+	}
+
+	private _failClosedForProviderQuota(failure: ProviderQuotaFailure): void {
+		const error = new Error(this._formatProviderQuotaFailure(failure));
+		this.requestAbort();
+		this._cancelSessionActions((action) => action.payload.kind === "turn", error);
+		this._pendingNextTurnMessages = [];
+		const descendants = new Set<AgentSession>();
+		for (const run of this._activeRlmChildRuns.values()) {
+			if (run.session) descendants.add(run.session);
+		}
+		for (const child of this._rlmChildSessions.values()) descendants.add(child);
+		for (const child of descendants) child._failClosedForProviderQuota(failure);
+		this._cancelActiveRlmChildRuns(error.message);
+		this._emitQueueUpdate();
+	}
+
+	private _tripProviderQuotaCircuit(message: AssistantMessage): void {
+		const root = this._familyRootSession();
+		if (root._providerQuotaFailure) return;
+		const details = this._getProviderStreamFailureDetails(message);
+		const rawStatus = details?.status;
+		const status =
+			typeof rawStatus === "number"
+				? rawStatus
+				: typeof rawStatus === "string" && Number.isInteger(Number(rawStatus))
+					? Number(rawStatus)
+					: undefined;
+		const rawRequestId = details?.requestId;
+		const failure: ProviderQuotaFailure = {
+			timestamp: Date.now(),
+			sessionId: this.sessionId,
+			...(this.sessionName ? { sessionName: this.sessionName } : {}),
+			...(this._rlmParentNodeId ? { childId: this._rlmParentNodeId } : {}),
+			provider: message.provider,
+			model: message.model,
+			...(status !== undefined ? { status } : {}),
+			...(typeof rawRequestId === "string" ? { requestId: rawRequestId } : {}),
+			errorMessage: message.errorMessage ?? "Provider quota exhausted",
+		};
+		root._providerQuotaFailure = failure;
+		root._appendProviderQuotaNotice(failure);
+		root._failClosedForProviderQuota(failure);
+	}
+
+	private _resetProviderQuotaCircuit(): void {
+		const root = this._familyRootSession();
+		if (!root._providerQuotaFailure) return;
+		root.sessionManager.appendCustomEntryWithRollback(PROVIDER_QUOTA_CIRCUIT_CUSTOM_TYPE, {
+			state: "reset",
+			timestamp: Date.now(),
+		} satisfies ProviderQuotaCircuitEntry);
+		root._providerQuotaFailure = undefined;
+	}
+
 	private _createRlmSubagentRuntimeOptions(options: {
 		id: string;
 		prompt: string;
@@ -8999,6 +9183,7 @@ export class AgentSession {
 			rlmSessionDir: options.sessionDir,
 			rlmParentNodeId: options.rlmParentNodeId,
 			rlmParentAgent: options.parentSession.sessionName ?? options.parentSession.sessionId,
+			rlmParentSession: options.parentSession,
 			sessionStartEvent: { type: "session_start", reason: "startup" },
 		});
 		if (child.sessionName !== options.sessionName) {
@@ -9599,6 +9784,7 @@ export class AgentSession {
 				`RLM recursion depth limit reached (RLM_DEPTH=${this._rlmDepth}, RLM_MAX_DEPTH=${this._rlmMaxDepth})`,
 			);
 		}
+		this._assertProviderQuotaCircuitClosed();
 		if (requestedSessionName) {
 			if (this._pendingRlmSubagentSessionNames.has(requestedSessionName)) {
 				throw new Error(formatAgentSessionNameUnavailable(requestedSessionName, this._rlmDepth + 1));
@@ -9613,6 +9799,7 @@ export class AgentSession {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
 		if (this._disposed || this._disposing) throw new Error("Cannot spawn a subagent after its parent was disposed");
+		this._assertProviderQuotaCircuitClosed();
 
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
@@ -9963,11 +10150,21 @@ export class AgentSession {
 			return false;
 		}
 
+		if (this._isProviderQuotaExhausted(message)) {
+			return false;
+		}
+
 		if (this._isStructuredPermanentProviderRetryExhausted(message)) {
 			return false;
 		}
 
 		return true;
+	}
+
+	private _isProviderQuotaExhausted(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error") return false;
+		if (this._getProviderStreamFailureKind(message) === "quota") return true;
+		return isQuotaExhaustionMessage(message.errorMessage ?? "");
 	}
 
 	private _isFauxProviderQueueExhausted(message: AssistantMessage): boolean {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -687,7 +687,14 @@ interface PreparedCommandPayload extends SessionCommandPayload {
 type QueuedSessionAction = SessionAction<PreparedTurnPayload | PreparedCommandPayload>;
 
 function sessionCommandUsesProvider(command: SessionSlashCommand): boolean {
-	return command.name === "compact" || command.name === "refine";
+	if (command.name === "compact") return true;
+	if (command.name !== "refine") return false;
+	try {
+		return parseRefineCommandOptions(command.args).rollbackId === undefined;
+	} catch {
+		// Invalid rollback syntax fails during command execution without inference.
+		return false;
+	}
 }
 
 function sessionActionUsesProvider(action: QueuedSessionAction): boolean {
@@ -7637,7 +7644,7 @@ export class AgentSession {
 		} = {},
 		internal: { skipAbort?: boolean } = {},
 	): Promise<RefinementResult> {
-		this._assertProviderQuotaCircuitClosed();
+		if (!options.rollbackId) this._assertProviderQuotaCircuitClosed();
 		// Queued /refine executes from the session-input pump between turns;
 		// refine never aborts the agent (planning is backgrounded and the apply
 		// phase waits for quiescence), so skipAbort only asserts the pump's
@@ -7773,7 +7780,7 @@ export class AgentSession {
 		}
 
 		const model = this.model;
-		const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+		const requestAuth = options.rollbackId ? undefined : await this._getRequiredRequestAuth(model);
 		const globalHarnessStateDir = getGlobalHarnessStateDir();
 		const localHarnessStateDir = this._localHarnessStateDir();
 		const requestedScope = options.global ? "global" : "local";
@@ -7804,15 +7811,15 @@ export class AgentSession {
 			: baselineScope === "global"
 				? globalPlanningState
 				: localPlanningState!;
-		this._assertProviderQuotaCircuitClosed();
+		if (!options.rollbackId) this._assertProviderQuotaCircuitClosed();
 		const plan = await planRefinement(
 			this.agent.state.messages,
 			planningState,
 			history,
 			model,
-			apiKey,
+			requestAuth?.apiKey ?? "",
 			options,
-			headers,
+			requestAuth?.headers,
 			signal,
 			this.thinkingLevel,
 		);

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -392,6 +392,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		rlmSessionDir: options.rlmSessionDir,
 		rlmParentNodeId: options.rlmParentNodeId,
 		rlmParentAgent: options.rlmParentAgent,
+		rlmParentSession: options.rlmParentSession,
 		subagentRuntimeHost: options.subagentRuntimeHost,
 		sessionStartEvent: options.sessionStartEvent,
 		prewarmIpythonKernel: options.prewarmIpythonKernel,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -29,7 +29,7 @@ export interface AutoRefineSettings {
 
 export interface ProviderRetrySettings {
 	timeoutMs?: number; // SDK/provider request timeout in milliseconds
-	maxRetries?: number; // SDK/provider retry attempts
+	maxRetries?: number; // SDK/provider retry attempts; default: 0
 	maxRetryDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
 
@@ -881,10 +881,10 @@ export class SettingsManager {
 		};
 	}
 
-	getProviderRetrySettings(): { timeoutMs?: number; maxRetries?: number; maxRetryDelayMs: number } {
+	getProviderRetrySettings(): { timeoutMs?: number; maxRetries: number; maxRetryDelayMs: number } {
 		return {
 			timeoutMs: this.settings.retry?.provider?.timeoutMs,
-			maxRetries: this.settings.retry?.provider?.maxRetries,
+			maxRetries: this.settings.retry?.provider?.maxRetries ?? 0,
 			maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
 		};
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -707,6 +707,7 @@ export function resolveRuntimeSessionOptions(
 		rlmSessionDir: runtimeSessionOptions?.rlmSessionDir,
 		rlmParentNodeId: runtimeSessionOptions?.rlmParentNodeId,
 		rlmParentAgent: runtimeSessionOptions?.rlmParentAgent,
+		rlmParentSession: runtimeSessionOptions?.rlmParentSession,
 		subagentRuntimeHost: runtimeSessionOptions?.subagentRuntimeHost,
 	};
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1604,6 +1604,7 @@ export class AgentDaemon {
 					streamingBehavior,
 					followUpQueueKey: `heartbeat:${runnableJob.id}`,
 					source: "rpc",
+					automatic: true,
 				},
 				getRunnableJob,
 			);
@@ -1616,6 +1617,7 @@ export class AgentDaemon {
 			{
 				streamingBehavior: "followUp",
 				source: "rpc",
+				automatic: true,
 			},
 			canPrompt,
 			false,
@@ -2361,6 +2363,7 @@ export class AgentDaemon {
 					rlmSessionDir: options.sessionDir,
 					rlmParentNodeId: options.rlmParentNodeId,
 					rlmParentAgent: options.parentSession.sessionName ?? options.parentSession.sessionId,
+					rlmParentSession: options.parentSession,
 				},
 				runtimeMetadata: {
 					kind: "subagent",

--- a/packages/coding-agent/test/provider-quota-retry.test.ts
+++ b/packages/coding-agent/test/provider-quota-retry.test.ts
@@ -1,0 +1,80 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { createAgentSession } from "../src/core/sdk.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+describe("provider quota retry safety", () => {
+	let server: Server | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(async () => {
+		session?.dispose();
+		if (server?.listening) await new Promise<void>((resolve) => server?.close(() => resolve()));
+	});
+
+	it("makes exactly one HTTP request for a quota-flavored 429 by default", async () => {
+		let requestCount = 0;
+		server = createServer((_request, response) => {
+			requestCount++;
+			response.writeHead(429, {
+				"content-type": "application/json",
+				"request-id": "req_http_quota",
+			});
+			response.end(
+				JSON.stringify({
+					type: "error",
+					error: {
+						type: "rate_limit_error",
+						message: "premium request quota exceeded",
+					},
+				}),
+			);
+		});
+		await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+		const model: Model<"anthropic-messages"> = {
+			id: "claude-fable-5",
+			name: "Claude Fable 5",
+			api: "anthropic-messages",
+			provider: "github-copilot",
+			baseUrl: `http://127.0.0.1:${address.port}`,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+			contextWindow: 1_000_000,
+			maxTokens: 16_384,
+		};
+		const authStorage = AuthStorage.inMemory();
+		authStorage.setRuntimeApiKey(model.provider, "test-token");
+		const result = await createAgentSession({
+			model,
+			authStorage,
+			settingsManager: SettingsManager.inMemory(),
+			sessionManager: SessionManager.inMemory(),
+			resourceLoader: createTestResourceLoader(),
+			noTools: "all",
+		});
+		session = result.session;
+
+		await session.prompt("trigger quota").catch(() => undefined);
+
+		expect(requestCount).toBe(1);
+		expect(session.isProviderQuotaCircuitOpen).toBe(true);
+		const lastAssistant = [...session.messages].reverse().find((message) => message.role === "assistant");
+		expect(lastAssistant).toMatchObject({
+			stopReason: "error",
+			diagnostics: [
+				{
+					type: "provider_stream_failure",
+					details: { kind: "quota", status: 429, requestId: "req_http_quota" },
+				},
+			],
+		});
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -526,4 +526,15 @@ describe("SettingsManager", () => {
 			expect(JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8")).idleEvictionMinutes).toBe("off");
 		});
 	});
+
+	describe("financial safety defaults", () => {
+		it("disables provider-layer retries by default while preserving explicit overrides", () => {
+			const defaults = SettingsManager.create(projectDir, agentDir);
+			expect(defaults.getProviderRetrySettings().maxRetries).toBe(0);
+
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ retry: { provider: { maxRetries: 2 } } }));
+			const overridden = SettingsManager.create(projectDir, agentDir);
+			expect(overridden.getProviderRetrySettings().maxRetries).toBe(2);
+		});
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
@@ -96,6 +96,23 @@ describe("AgentSession financial safety", () => {
 		expect(harness.faux.state.callCount).toBe(0);
 	});
 
+	it("allows inference-free refinement rollback while the quota circuit is open", async () => {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		await (harness.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_refine_rollback"),
+		} as AgentEvent);
+
+		await expect(harness.session.refine({ rollbackId: "missing_refinement" })).rejects.toThrow(
+			"Refinement missing_refinement not found",
+		);
+		await harness.session.prompt("/refine rollback missing_refinement");
+
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(true);
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
 	it("rejects recovered provider turns atomically while the quota circuit is open", async () => {
 		const source = await createHarness();
 		const target = await createHarness();

--- a/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
@@ -3,7 +3,8 @@ import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentSession } from "../../src/core/agent-session.js";
 import { SessionManager } from "../../src/core/session-manager.js";
-import { createHarness, type Harness } from "./harness.js";
+import { createHarness, getUserTexts, type Harness } from "./harness.js";
+import { createDeferred, withStreaming } from "./scheduling.js";
 
 type SessionInternals = {
 	_processAgentEvent: (event: AgentEvent) => Promise<void>;
@@ -74,6 +75,43 @@ describe("AgentSession financial safety", () => {
 		expect(harness.faux.state.callCount).toBe(2);
 	});
 
+	it("does not let an inbound agent message reset the quota circuit", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await (harness.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_agent_message"),
+		} as AgentEvent);
+		harness.setResponses([fauxAssistantMessage("must not run")]);
+
+		await expect(harness.session.acceptAgentMessagePrompt("child cancellation notice")).rejects.toThrow(
+			/quota exhausted.*req_agent_message/i,
+		);
+
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(true);
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
+	it("rejects recovered provider turns atomically while the quota circuit is open", async () => {
+		const source = await createHarness();
+		const target = await createHarness();
+		harnesses.push(source, target);
+		withStreaming(source, true);
+		await source.session.followUp("recover this queued turn");
+		const snapshot = source.session.getSessionActionRecoverySnapshot();
+		expect(snapshot.actions).toHaveLength(1);
+
+		await (target.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_restore"),
+		} as AgentEvent);
+
+		await expect(target.session.restoreSessionActions(snapshot)).rejects.toThrow(/quota exhausted.*req_restore/i);
+		expect(target.session.getSessionActionRecoverySnapshot().actions).toEqual([]);
+		expect(target.session.queuedActionCount).toBe(0);
+		expect(target.faux.state.callCount).toBe(0);
+	});
+
 	it("keeps transient rate limits on the bounded agent-level retry path", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
@@ -120,6 +158,94 @@ describe("AgentSession financial safety", () => {
 		expect(resetReload.session.isProviderQuotaCircuitOpen).toBe(false);
 	});
 
+	it("clears the live quota latch when persisting an explicit reset fails", async () => {
+		const original = await createHarness({ persistSession: true });
+		harnesses.push(original);
+		await (original.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_reset_write"),
+		} as AgentEvent);
+		original.sessionManager.flushNow();
+		const sessionFile = original.sessionManager.getSessionFile();
+		expect(sessionFile).toBeTruthy();
+		vi.spyOn(original.sessionManager, "appendCustomEntryWithRollback").mockImplementationOnce(() => {
+			throw new Error("disk full");
+		});
+		original.setResponses([fauxAssistantMessage("recovered")]);
+
+		await original.session.prompt("explicit retry despite reset persistence failure");
+
+		expect(original.session.isProviderQuotaCircuitOpen).toBe(false);
+		expect(original.faux.state.callCount).toBe(1);
+		original.sessionManager.flushNow();
+
+		const resetReload = await createHarness({ sessionManager: SessionManager.open(sessionFile!) });
+		harnesses.push(resetReload);
+		expect(resetReload.session.isProviderQuotaCircuitOpen).toBe(true);
+	});
+
+	it("rolls back a quota notice that fails after mutating the session tree", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const appendCustomMessage = harness.sessionManager.appendCustomMessageEntry.bind(harness.sessionManager);
+		vi.spyOn(harness.sessionManager, "appendCustomMessageEntry").mockImplementationOnce(
+			(customType, content, display, details) => {
+				appendCustomMessage(customType, content, display, details);
+				throw new Error("disk full");
+			},
+		);
+
+		await (harness.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_notice_rollback"),
+		} as AgentEvent);
+
+		const branch = harness.sessionManager.getBranch();
+		const circuitEntry = branch.find(
+			(entry) => entry.type === "custom" && entry.customType === "prime-agent.provider-quota-circuit",
+		);
+		expect(circuitEntry).toBeDefined();
+		expect(
+			branch.some((entry) => entry.type === "custom_message" && entry.customType === "provider_quota_exhausted"),
+		).toBe(false);
+
+		const laterEntryId = harness.sessionManager.appendCustomEntryWithRollback("post-quota-test");
+		expect(harness.sessionManager.getEntry(laterEntryId)?.parentId).toBe(circuitEntry?.id);
+	});
+
+	it("purges queued turns at both session and agent layers before an explicit reset", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		withStreaming(harness, true);
+		await harness.session.steer("stale session steering");
+		harness.session.agent.steer({
+			role: "user",
+			content: [{ type: "text", text: "stale agent steering" }],
+			timestamp: Date.now(),
+		});
+		harness.session.agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "stale agent follow-up" }],
+			timestamp: Date.now(),
+		});
+		expect(harness.session.queuedActionCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		await (harness.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_queued"),
+		} as AgentEvent);
+
+		expect(harness.session.queuedActionCount).toBe(0);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+		withStreaming(harness, false);
+		harness.setResponses([fauxAssistantMessage("recovered")]);
+		await harness.session.prompt("explicit retry");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(getUserTexts(harness)).toEqual(["explicit retry"]);
+	});
+
 	it("cascades a child quota failure to the parent and every sibling", async () => {
 		const parent = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
 		const child = await createHarness({ rlmDepth: 1, rlmParentSession: parent.session });
@@ -162,6 +288,39 @@ describe("AgentSession financial safety", () => {
 			.find((event) => event.child.id === spawned.rlm_child_id && event.child.status === "cancelled");
 		expect(terminalUpdate?.child.error).toContain("req_inline_child");
 		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("blocks a child when quota trips during its final name-availability check", async () => {
+		const availabilityReached = createDeferred();
+		const releaseAvailability = createDeferred();
+		const parent = await createHarness({
+			rlmDepth: 0,
+			rlmMaxDepth: 1,
+			agentMessageController: {
+				assertSessionNameAvailable: async () => {
+					availabilityReached.resolve();
+					await releaseAvailability.promise;
+				},
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage: async () => {
+					throw new Error("Unexpected agent message");
+				},
+			},
+		});
+		const sibling = await createHarness({ rlmDepth: 1, rlmParentSession: parent.session });
+		harnesses.push(parent, sibling);
+
+		const spawn = parent.session.runRlmChild("race quota with child admission");
+		await availabilityReached.promise;
+		await (sibling.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_admission_race"),
+		} as AgentEvent);
+		releaseAvailability.resolve();
+
+		await expect(spawn).rejects.toThrow(/quota exhausted.*req_admission_race/i);
+		expect(parent.eventsOfType("rlm_child_update")).toEqual([]);
+		expect(parent.faux.state.callCount).toBe(0);
 	});
 
 	it("keeps explicit abort cascading to active children", async () => {

--- a/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
@@ -67,6 +67,10 @@ describe("AgentSession financial safety", () => {
 			/quota exhausted.*request_id: req_quota/i,
 		);
 		await expect(harness.session.runRlmChild("background child")).rejects.toThrow(/quota exhausted/i);
+		await expect(harness.session.prompt("/compact")).rejects.toThrow(/quota exhausted.*request_id: req_quota/i);
+		expect(harness.faux.state.callCount).toBe(1);
+		await harness.session.prompt("/goal");
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(true);
 		expect(harness.faux.state.callCount).toBe(1);
 
 		await harness.session.prompt("retry after fixing quota");
@@ -107,6 +111,30 @@ describe("AgentSession financial safety", () => {
 		} as AgentEvent);
 
 		await expect(target.session.restoreSessionActions(snapshot)).rejects.toThrow(/quota exhausted.*req_restore/i);
+		expect(target.session.getSessionActionRecoverySnapshot().actions).toEqual([]);
+		expect(target.session.queuedActionCount).toBe(0);
+		expect(target.faux.state.callCount).toBe(0);
+	});
+
+	it("rejects a restored provider-backed session command while the quota circuit is open", async () => {
+		const source = await createHarness();
+		const target = await createHarness();
+		harnesses.push(source, target);
+		withStreaming(source, true);
+		await source.session.prompt("/compact", { streamingBehavior: "followUp" });
+		const snapshot = source.session.getSessionActionRecoverySnapshot();
+		expect(snapshot.actions).toEqual([
+			expect.objectContaining({ payload: expect.objectContaining({ kind: "session_command" }) }),
+		]);
+
+		await (target.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_restore_command"),
+		} as AgentEvent);
+
+		await expect(target.session.restoreSessionActions(snapshot)).rejects.toThrow(
+			/quota exhausted.*req_restore_command/i,
+		);
 		expect(target.session.getSessionActionRecoverySnapshot().actions).toEqual([]);
 		expect(target.session.queuedActionCount).toBe(0);
 		expect(target.faux.state.callCount).toBe(0);
@@ -213,11 +241,13 @@ describe("AgentSession financial safety", () => {
 		expect(harness.sessionManager.getEntry(laterEntryId)?.parentId).toBe(circuitEntry?.id);
 	});
 
-	it("purges queued turns at both session and agent layers before an explicit reset", async () => {
+	it("purges queued provider work at both session and agent layers before an explicit reset", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
 		withStreaming(harness, true);
+		const compact = vi.spyOn(harness.session, "compact");
 		await harness.session.steer("stale session steering");
+		await harness.session.prompt("/compact", { streamingBehavior: "followUp" });
 		harness.session.agent.steer({
 			role: "user",
 			content: [{ type: "text", text: "stale agent steering" }],
@@ -228,7 +258,7 @@ describe("AgentSession financial safety", () => {
 			content: [{ type: "text", text: "stale agent follow-up" }],
 			timestamp: Date.now(),
 		});
-		expect(harness.session.queuedActionCount).toBe(1);
+		expect(harness.session.queuedActionCount).toBe(2);
 		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
 
 		await (harness.session as unknown as SessionInternals)._processAgentEvent({
@@ -243,6 +273,7 @@ describe("AgentSession financial safety", () => {
 		await harness.session.prompt("explicit retry");
 
 		expect(harness.faux.state.callCount).toBe(1);
+		expect(compact).not.toHaveBeenCalled();
 		expect(getUserTexts(harness)).toEqual(["explicit retry"]);
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-financial-safety.test.ts
@@ -1,0 +1,178 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSession } from "../../src/core/agent-session.js";
+import { SessionManager } from "../../src/core/session-manager.js";
+import { createHarness, type Harness } from "./harness.js";
+
+type SessionInternals = {
+	_processAgentEvent: (event: AgentEvent) => Promise<void>;
+	_activeRlmChildRuns: Map<string, unknown>;
+};
+
+function providerFailure(kind: string, errorMessage: string, requestId = "req_test"): AssistantMessage {
+	return {
+		...fauxAssistantMessage("", { stopReason: "error", errorMessage }),
+		diagnostics: [
+			{
+				type: "provider_stream_failure",
+				timestamp: Date.now(),
+				details: { kind, status: 429, requestId },
+			},
+		],
+	};
+}
+
+function activeRun(id: string, session?: AgentSession) {
+	return {
+		id,
+		prompt: `task ${id}`,
+		sessionName: id,
+		sessionDir: `/tmp/${id}`,
+		status: "running",
+		settled: false,
+		abort: vi.fn(() => session?.requestAbort()),
+		publication: {
+			promise: Promise.resolve(),
+			resolve: vi.fn(),
+			reject: vi.fn(),
+		},
+		session,
+		emitUpdate: vi.fn(),
+	};
+}
+
+describe("AgentSession financial safety", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("fails closed on quota exhaustion and requires an explicit user prompt to reset", async () => {
+		const harness = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
+		harnesses.push(harness);
+		harness.setResponses([
+			providerFailure("quota", "Provider usage quota exhausted", "req_quota"),
+			fauxAssistantMessage("recovered"),
+		]);
+
+		await harness.session.prompt("trigger quota").catch(() => undefined);
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(true);
+		await expect(harness.session.prompt("scheduled work", { source: "rpc", automatic: true })).rejects.toThrow(
+			/quota exhausted.*request_id: req_quota/i,
+		);
+		await expect(harness.session.runRlmChild("background child")).rejects.toThrow(/quota exhausted/i);
+		expect(harness.faux.state.callCount).toBe(1);
+
+		await harness.session.prompt("retry after fixing quota");
+
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(false);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("keeps transient rate limits on the bounded agent-level retry path", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			providerFailure("rate_limit", "Provider rate limit exceeded"),
+			fauxAssistantMessage("recovered"),
+		]);
+
+		await harness.session.prompt("retry transient failure");
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("auto_retry_start")).toHaveLength(1);
+		expect(harness.session.isProviderQuotaCircuitOpen).toBe(false);
+	});
+
+	it("persists the quota latch and its explicit reset across session reloads", async () => {
+		const original = await createHarness({ persistSession: true });
+		harnesses.push(original);
+		await (original.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_persisted"),
+		} as AgentEvent);
+		original.sessionManager.flushNow();
+		const sessionFile = original.sessionManager.getSessionFile();
+		expect(sessionFile).toBeTruthy();
+
+		const restored = await createHarness({ sessionManager: SessionManager.open(sessionFile!) });
+		harnesses.push(restored);
+		expect(restored.session.isProviderQuotaCircuitOpen).toBe(true);
+		await expect(restored.session.prompt("scheduled work", { source: "rpc", automatic: true })).rejects.toThrow(
+			/req_persisted/,
+		);
+		expect(restored.faux.state.callCount).toBe(0);
+
+		restored.setResponses([fauxAssistantMessage("recovered")]);
+		await restored.session.prompt("explicit retry");
+		expect(restored.session.isProviderQuotaCircuitOpen).toBe(false);
+		restored.sessionManager.flushNow();
+
+		const resetReload = await createHarness({ sessionManager: SessionManager.open(sessionFile!) });
+		harnesses.push(resetReload);
+		expect(resetReload.session.isProviderQuotaCircuitOpen).toBe(false);
+	});
+
+	it("cascades a child quota failure to the parent and every sibling", async () => {
+		const parent = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
+		const child = await createHarness({ rlmDepth: 1, rlmParentSession: parent.session });
+		const sibling = await createHarness({ rlmDepth: 1, rlmParentSession: parent.session });
+		harnesses.push(parent, child, sibling);
+		const parentAbort = vi.spyOn(parent.session, "requestAbort");
+		const childAbort = vi.spyOn(child.session, "requestAbort");
+		const siblingAbort = vi.spyOn(sibling.session, "requestAbort");
+		const childRun = activeRun("child", child.session);
+		const siblingRun = activeRun("sibling", sibling.session);
+		const parentInternals = parent.session as unknown as SessionInternals;
+		parentInternals._activeRlmChildRuns.set("child", childRun);
+		parentInternals._activeRlmChildRuns.set("sibling", siblingRun);
+
+		await (child.session as unknown as SessionInternals)._processAgentEvent({
+			type: "message_end",
+			message: providerFailure("quota", "premium request quota exceeded", "req_child"),
+		} as AgentEvent);
+
+		expect(parent.session.isProviderQuotaCircuitOpen).toBe(true);
+		expect(parentAbort).toHaveBeenCalled();
+		expect(childAbort).toHaveBeenCalled();
+		expect(siblingAbort).toHaveBeenCalled();
+		expect(childRun.status).toBe("cancelled");
+		expect(siblingRun.status).toBe("cancelled");
+		expect((siblingRun as typeof siblingRun & { error?: string }).error).toContain("req_child");
+	});
+
+	it("shares the quota circuit through the inline subagent runtime", async () => {
+		const harness = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
+		harnesses.push(harness);
+		harness.setResponses([providerFailure("quota", "premium request quota exceeded", "req_inline_child")]);
+
+		const spawned = await harness.session.runRlmChild("trigger quota in inline child");
+		await vi.waitFor(() => expect(harness.session.isProviderQuotaCircuitOpen).toBe(true));
+
+		const terminalUpdate = harness
+			.eventsOfType("rlm_child_update")
+			.reverse()
+			.find((event) => event.child.id === spawned.rlm_child_id && event.child.status === "cancelled");
+		expect(terminalUpdate?.child.error).toContain("req_inline_child");
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("keeps explicit abort cascading to active children", async () => {
+		const harness = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
+		harnesses.push(harness);
+		const run = activeRun("child");
+		(harness.session as unknown as SessionInternals)._activeRlmChildRuns.set("child", run);
+
+		await harness.session.abort();
+
+		expect(run.status).toBe("cancelled");
+		expect(run.abort).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2146,6 +2146,42 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.sessionManager.getBranch().at(-1)?.id).toBe(followUpEntryId);
 	});
 
+	it("does not retain a non-triggering custom message when persistence fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		vi.spyOn(harness.sessionManager, "appendCustomMessageEntry").mockImplementationOnce(() => {
+			throw new Error("custom message append failed");
+		});
+
+		await expect(
+			harness.session.sendCustomMessage({
+				customType: "failed-custom-message",
+				content: "must not survive",
+				display: true,
+				details: {},
+			}),
+		).rejects.toThrow("custom message append failed");
+
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "failed-custom-message",
+			),
+		).toBe(false);
+		expect(
+			harness.sessionManager
+				.getBranch()
+				.some((entry) => entry.type === "custom_message" && entry.customType === "failed-custom-message"),
+		).toBe(false);
+
+		harness.setResponses([fauxAssistantMessage("clean context")]);
+		await harness.session.prompt("continue after failure");
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "failed-custom-message",
+			),
+		).toBe(false);
+	});
+
 	it("does not record a benign compaction skip as a command failure", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -73,8 +73,10 @@ export interface HarnessOptions {
 	agentMessageController?: AgentSessionMessageController;
 	subagentRuntimeHost?: SubagentRuntimeHost;
 	persistSession?: boolean;
+	sessionManager?: SessionManager;
 	rlmDepth?: number;
 	rlmMaxDepth?: number;
+	rlmParentSession?: AgentSession;
 	autonomous?: AgentAutonomousConfig;
 	autoRefineReviewer?: AutoRefineReviewer;
 	serializedRefine?: boolean;
@@ -118,9 +120,9 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const withConfiguredAuth = options.withConfiguredAuth ?? true;
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
 
-	const sessionManager = options.persistSession
-		? SessionManager.create(tempDir, join(tempDir, "sessions"))
-		: SessionManager.inMemory();
+	const sessionManager =
+		options.sessionManager ??
+		(options.persistSession ? SessionManager.create(tempDir, join(tempDir, "sessions")) : SessionManager.inMemory());
 	const settingsManager = SettingsManager.inMemory(options.settings);
 
 	const authStorage = AuthStorage.inMemory();
@@ -199,6 +201,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		extensionRunnerRef,
 		rlmDepth: options.rlmDepth,
 		rlmMaxDepth: options.rlmMaxDepth,
+		rlmParentSession: options.rlmParentSession,
 		autonomous: options.autonomous,
 		autoRefineReviewer: options.autoRefineReviewer,
 		serializedRefine: options.serializedRefine,


### PR DESCRIPTION
This PR prevents Prime Agent from continuing background inference after a provider reports quota or credit exhaustion.

Quota exhaustion was previously handled like a transient rate limit. This allowed retries to occur at both the provider SDK and agent layers while detached subagents and daemon-scheduled work could remain active. With multiple agents running concurrently, those retries could substantially amplify model usage.

The new behavior treats quota exhaustion as a terminal, family-wide condition. Prime Agent stops the current session and its subagents, blocks automatic background work, and requires an explicit user prompt before attempting inference again.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core inference, retry, and multi-session orchestration on billing-sensitive failures; misclassification could block legitimate work or still allow unwanted retries.
> 
> **Overview**
> **Provider stream failures** now include a dedicated `quota` kind: HTTP 402, quota/credit language in errors, and nested SDK messages are classified separately from transient 429 throttling (per-minute metrics, “resource exhausted” hints). `classifyStreamFailure` takes optional detail text so quota wording can override a generic `rate_limit_error` type.
> 
> **Agent sessions** trip a **provider quota circuit** on the root when any family member hits quota: abort in-flight work, cancel queued provider-backed actions (turns, `/compact`, inference `/refine`), clear agent queues, stop RLM children, and persist trip/reset markers plus a user-visible notice. Subagents share state via `rlmParentSession`; daemon/cron prompts set `automatic: true` so they cannot clear the latch—only an explicit user prompt does. Quota failures are excluded from agent-level auto-retry; inference-free `/refine rollback` still works.
> 
> **Retry defaults**: provider SDK `maxRetries` defaults to **0** (agent-level retry owns policy), documented in settings. Custom messages persist with rollback on append failure so half-written quota notices do not corrupt the branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1164892c5245e8e36aeac05b156d4fd7322bc133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed on provider quota exhaustion by implementing a quota circuit breaker in agent sessions
> - Introduces a provider quota circuit in `AgentSession` that trips when a quota/credit exhaustion error is detected, halting all subsequent provider-backed work (turns, compaction, refinement, subagent spawning) until an explicit user prompt resets it.
> - Adds a new `'quota'` stream failure kind in [stream-failure.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/795/files#diff-2587e64b20a4d7daabfd77ca9486cd89366592abf324c6a08c41e8a8822aa474) with helpers to distinguish true quota exhaustion from transient rate-limit throttling; HTTP 402 responses are classified as `'quota'`.
> - Quota circuit state is persisted to the session branch and propagated across the session family (parent → subagents) so all related sessions share the same safety latch.
> - Daemon-originated automatic/cron prompts are marked with `PromptOptions.automatic = true` so they cannot reset a tripped circuit; only an explicit user prompt clears it.
> - `provider.maxRetries` now defaults to `0` to avoid repeated costly retries on quota failures.
> - Risk: any session that hits a quota error will stop all autonomous background work immediately and stay stopped until the user sends a new prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1164892.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->