### PR TITLE
feat(coding-agent): support per-child thinking levels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added an optional `thinking` option to `rlm(...)` so child agents can use reasoning levels independent of their parents ([#798](https://github.com/PrimeIntellect-ai/prime-agent/pull/798) by [@ixmxvii-hash](https://github.com/ixmxvii-hash)).
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -150,10 +150,11 @@ await rlm.run("subtask")
 
 Supported `rlm.run` options are:
 
-- `name`: a unique readable child session name; and
-- `model`: an exact `provider/model` selector from `rlm.find_models()`.
+- `name`: a unique readable child session name;
+- `model`: an exact `provider/model` selector from `rlm.find_models()`; and
+- `thinking`: one of `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model and thinking level. Whether inherited or explicitly requested, the thinking level is clamped to the selected child model's capabilities. An explicit `thinking` value does not depend on the parent's current level. Some reasoning-capable models cannot disable reasoning, so `off` may clamp upward to their lowest supported level. The effective level is persisted in the child session.
 
 ## Child Execution
 

--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -59,7 +59,20 @@ handle = await rlm("Review the authentication flow for security issues", name="a
 print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
 ```
 
-The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model.
+The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent's provider configuration, skills, tools, retry policy, and resource loader. It uses the parent model unless another configured model is requested, and it inherits the parent's thinking level unless an explicit level is requested.
+
+Thinking can be selected independently for a child:
+
+```python
+handle = await rlm(
+    "Review the authentication flow for security issues",
+    name="auth-reviewer",
+    model="anthropic/claude-opus-4-7",
+    thinking="max",
+)
+```
+
+Valid levels are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. An omitted level inherits the parent level; an explicit level overrides it. In both cases the host clamps the level to the selected model's capabilities. Some reasoning-capable models cannot disable reasoning, so `off` may clamp upward to their lowest supported level. The effective level is persisted in the child session.
 
 Spawn independent children in separate calls and end the turn instead of awaiting completion:
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -4,6 +4,7 @@
 
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { APP_NAME } from "../config.js";
+import { isValidThinkingLevel, VALID_THINKING_LEVELS } from "../core/thinking-levels.js";
 
 export type Mode = "text" | "json" | "rpc" | "acp" | "daemon";
 
@@ -59,15 +60,10 @@ export interface Args {
 	diagnostics: Array<{ type: "warning" | "error"; message: string }>;
 }
 
-export const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const REMOVED_BUILTIN_TOOL_NAMES = new Set(["read", "write", "grep", "find", "ls"]);
 const BUILTIN_TOOL_NAMES = ["ipython"];
 
 export const INTERNAL_RUNTIME_COMMAND_MARKER = "\0prime-agent-runtime-command";
-
-export function isValidThinkingLevel(level: string): level is ThinkingLevel {
-	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
-}
 
 export function parseArgs(args: string[]): Args {
 	const result: Args = {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -59,7 +59,7 @@ export interface Args {
 	diagnostics: Array<{ type: "warning" | "error"; message: string }>;
 }
 
-const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const REMOVED_BUILTIN_TOOL_NAMES = new Set(["read", "write", "grep", "find", "ls"]);
 const BUILTIN_TOOL_NAMES = ["ipython"];
 

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -8,13 +8,13 @@ import { expandTildePath } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
 import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
+import { isValidThinkingLevel } from "../core/thinking-levels.js";
 import { DaemonClient, type DaemonClientMessageListener } from "../modes/daemon/daemon-client.js";
 import type { DaemonOutbound, DaemonResponse } from "../modes/daemon/daemon-protocol.js";
 import { matchesSessionIdSuffix } from "../modes/daemon/daemon-session-id.js";
 import type { SessionSummary } from "../modes/daemon/daemon-session-list.js";
 import { defaultDaemonSocketPath } from "../modes/daemon/daemon-socket.js";
 import { isLocalPath } from "../utils/paths.js";
-import { isValidThinkingLevel } from "./args.js";
 import { formatSessionListTable } from "./daemon-list-format.js";
 import { runPs, runReap } from "./daemon-ps.js";
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -266,6 +266,7 @@ import {
 } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
+import { VALID_THINKING_LEVELS } from "./thinking-levels.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { IpythonKernelProvisioner } from "./tools/ipython.js";
@@ -960,7 +961,7 @@ interface RlmSubagentModelSelection {
 // ============================================================================
 
 /** Standard thinking levels */
-const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+const THINKING_LEVELS: ThinkingLevel[] = [...VALID_THINKING_LEVELS];
 
 /** Cap on the post-compaction kernel namespace probe so a wedged kernel can't stall recovery. */
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -224,6 +224,7 @@ import {
 	findRlmModelMatches,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
+	normalizeRequestedRlmSubagentThinkingLevel,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
@@ -8913,6 +8914,7 @@ export class AgentSession {
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
+		requestedThinkingLevel?: ThinkingLevel;
 	}): CreateRlmSubagentRuntimeOptions {
 		return {
 			parentSession: this,
@@ -8922,7 +8924,10 @@ export class AgentSession {
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
 			model: options.model,
-			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
+			thinkingLevel: clampThinkingLevel(
+				options.model,
+				options.requestedThinkingLevel ?? this.thinkingLevel,
+			) as ThinkingLevel,
 			serviceTier:
 				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
 			scopedModels: [...this._scopedModels],
@@ -9586,13 +9591,14 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, thinking: rawThinking, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedThinkingLevel = normalizeRequestedRlmSubagentThinkingLevel(rawThinking);
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9682,6 +9688,7 @@ export class AgentSession {
 				spawnCode,
 				sessionDir: childSessionDir,
 				model: modelSelection.model,
+				requestedThinkingLevel,
 			}),
 			onSessionPublished: publishChildSession,
 		};

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -6,11 +6,11 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, getLogger, type KnownProvider, type Model, modelsAreEqual } from "@earendil-works/pi-ai";
 import chalk from "chalk";
 import { minimatch } from "minimatch";
-import { isValidThinkingLevel } from "../cli/args.js";
 import { APP_NAME } from "../config.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { isPrivatePrimeInferenceModel } from "./prime-inference-models.js";
+import { isValidThinkingLevel } from "./thinking-levels.js";
 
 const log = getLogger("coding-agent.model-resolver");
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -129,6 +129,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
 			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your current thinking level by default, clamped to its selected model. Pass `thinking='max'` to override it independently; valid levels are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Explicit levels are also clamped to the selected model; some reasoning-capable models cannot disable reasoning, so `off` may clamp upward to their lowest supported level.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -1,9 +1,9 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
-import { isValidThinkingLevel, VALID_THINKING_LEVELS } from "../cli/args.js";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
 import type { HostRequestHandler } from "./kernel/index.js";
+import { isValidThinkingLevel, VALID_THINKING_LEVELS } from "./thinking-levels.js";
 
 export interface RlmRunRequest {
 	prompt: string;
@@ -68,6 +68,9 @@ export function normalizeRequestedRlmSubagentThinkingLevel(value: unknown): Thin
 		throw new Error("rlm.run thinking must be a string");
 	}
 	const thinking = value.trim();
+	if (!thinking) {
+		throw new Error("rlm.run thinking must not be empty");
+	}
 	if (!isValidThinkingLevel(thinking)) {
 		throw new Error(`rlm.run thinking must be one of: ${VALID_THINKING_LEVELS.join(", ")}`);
 	}

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -1,5 +1,6 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
+import { isValidThinkingLevel, VALID_THINKING_LEVELS } from "../cli/args.js";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
 import type { HostRequestHandler } from "./kernel/index.js";
@@ -57,6 +58,21 @@ export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindMode
 const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
 export const DEFAULT_RLM_MODEL_SEARCH_LIMIT = 8;
 export const MAX_RLM_MODEL_SEARCH_LIMIT = 20;
+
+/** Validate and normalize an orchestrator-supplied child thinking level. */
+export function normalizeRequestedRlmSubagentThinkingLevel(value: unknown): ThinkingLevel | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run thinking must be a string");
+	}
+	const thinking = value.trim();
+	if (!isValidThinkingLevel(thinking)) {
+		throw new Error(`rlm.run thinking must be one of: ${VALID_THINKING_LEVELS.join(", ")}`);
+	}
+	return thinking;
+}
 
 /** Validate and normalize an orchestrator-supplied subagent session name. */
 export function normalizeRequestedRlmSubagentSessionName(value: unknown): string | undefined {

--- a/packages/coding-agent/src/core/thinking-levels.ts
+++ b/packages/coding-agent/src/core/thinking-levels.ts
@@ -1,0 +1,16 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+
+/** Shared canonical list and validator for CLI and core RLM thinking levels. */
+export const VALID_THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const satisfies readonly ThinkingLevel[];
+
+export function isValidThinkingLevel(level: string): level is ThinkingLevel {
+	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
+}

--- a/packages/coding-agent/test/rlm-child-thinking.test.ts
+++ b/packages/coding-agent/test/rlm-child-thinking.test.ts
@@ -1,5 +1,5 @@
 import { fauxAssistantMessage, type SimpleStreamOptions } from "@earendil-works/pi-ai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeRequestedRlmSubagentThinkingLevel } from "../src/core/rlm-runtime.js";
 import { createHarness } from "./suite/harness.js";
 
@@ -12,12 +12,21 @@ function getReasoning(options: SimpleStreamOptions | undefined): string | undefi
 }
 
 describe("native RLM child thinking", () => {
+	beforeEach(() => {
+		vi.stubEnv("RLM_DEPTH", "0");
+		vi.stubEnv("RLM_MAX_DEPTH", "1");
+	});
+
+	afterEach(() => vi.unstubAllEnvs());
+
 	it("normalizes supported levels, trims whitespace, and rejects invalid values", () => {
 		for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const) {
 			expect(normalizeRequestedRlmSubagentThinkingLevel(level)).toBe(level);
 		}
 		expect(normalizeRequestedRlmSubagentThinkingLevel(undefined)).toBeUndefined();
 		expect(normalizeRequestedRlmSubagentThinkingLevel("  high  ")).toBe("high");
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel("")).toThrow("rlm.run thinking must not be empty");
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel("   ")).toThrow("rlm.run thinking must not be empty");
 		expect(() => normalizeRequestedRlmSubagentThinkingLevel(null)).toThrow("rlm.run thinking must be a string");
 		expect(() => normalizeRequestedRlmSubagentThinkingLevel(42)).toThrow("rlm.run thinking must be a string");
 		expect(() => normalizeRequestedRlmSubagentThinkingLevel(" HIGH ")).toThrow(

--- a/packages/coding-agent/test/rlm-child-thinking.test.ts
+++ b/packages/coding-agent/test/rlm-child-thinking.test.ts
@@ -1,0 +1,105 @@
+import { fauxAssistantMessage, type SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { normalizeRequestedRlmSubagentThinkingLevel } from "../src/core/rlm-runtime.js";
+import { createHarness } from "./suite/harness.js";
+
+const provider = "faux-rlm-child-thinking";
+
+type SeenRequest = { model: string; reasoning: string | undefined };
+
+function getReasoning(options: SimpleStreamOptions | undefined): string | undefined {
+	return options?.reasoning;
+}
+
+describe("native RLM child thinking", () => {
+	it("normalizes supported levels, trims whitespace, and rejects invalid values", () => {
+		for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const) {
+			expect(normalizeRequestedRlmSubagentThinkingLevel(level)).toBe(level);
+		}
+		expect(normalizeRequestedRlmSubagentThinkingLevel(undefined)).toBeUndefined();
+		expect(normalizeRequestedRlmSubagentThinkingLevel("  high  ")).toBe("high");
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel(null)).toThrow("rlm.run thinking must be a string");
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel(42)).toThrow("rlm.run thinking must be a string");
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel(" HIGH ")).toThrow(
+			"rlm.run thinking must be one of: off, minimal, low, medium, high, xhigh, max",
+		);
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel("turbo")).toThrow(
+			"rlm.run thinking must be one of: off, minimal, low, medium, high, xhigh, max",
+		);
+	});
+
+	it("inherits the parent level and passes the effective level to the child provider", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{ id: "parent-model", reasoning: true },
+				{ id: "child-model", reasoning: true },
+			],
+		});
+		try {
+			harness.session.setThinkingLevel("high");
+			const seenRequests: SeenRequest[] = [];
+			harness.setResponses([
+				(_context, options, _state, model) => {
+					seenRequests.push({
+						model: model.id,
+						reasoning: getReasoning(options as SimpleStreamOptions | undefined),
+					});
+					return fauxAssistantMessage("inherited thinking child answer");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("inherit the parent thinking level", {
+				model: `${provider}/child-model`,
+			});
+			await vi.waitFor(async () => {
+				expect((await harness.session.listRlmSubagents()).subagents[0]?.status).toBe("completed");
+			});
+			const childEntry = (await harness.session.listRlmSubagents()).subagents[0];
+			const child = childEntry && harness.session.getRlmChildSession(childEntry.rlm_child_id);
+			expect(child?.thinkingLevel).toBe("high");
+			expect(seenRequests).toContainEqual({ model: "child-model", reasoning: "high" });
+			expect(result.model).toBe(`${provider}/child-model`);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("uses an explicit level independently and clamps it to the child model", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [
+				{ id: "parent-model", reasoning: true },
+				{ id: "child-model", reasoning: true },
+			],
+		});
+		try {
+			harness.session.setThinkingLevel("low");
+			const seenRequests: SeenRequest[] = [];
+			harness.setResponses([
+				(_context, options, _state, model) => {
+					seenRequests.push({
+						model: model.id,
+						reasoning: getReasoning(options as SimpleStreamOptions | undefined),
+					});
+					return fauxAssistantMessage("explicit thinking child answer");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("use an explicit thinking level", {
+				model: `${provider}/child-model`,
+				thinking: "max",
+			});
+			await vi.waitFor(async () => {
+				expect((await harness.session.listRlmSubagents()).subagents[0]?.status).toBe("completed");
+			});
+			const childEntry = (await harness.session.listRlmSubagents()).subagents[0];
+			const child = childEntry && harness.session.getRlmChildSession(childEntry.rlm_child_id);
+			expect(child?.thinkingLevel).toBe("high");
+			expect(seenRequests).toContainEqual({ model: "child-model", reasoning: "high" });
+			expect(result.model).toBe(`${provider}/child-model`);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/3885-subagent-runtime-host.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3885-subagent-runtime-host.test.ts
@@ -50,7 +50,7 @@ describe("ENG-3885 subagent runtime host", () => {
 		const faux = registerFauxProvider({
 			models: [
 				{ id: "faux-parent", reasoning: true },
-				{ id: "faux-child", reasoning: false },
+				{ id: "faux-child", reasoning: true },
 			],
 		});
 		const authStorage = AuthStorage.inMemory();
@@ -72,6 +72,7 @@ describe("ENG-3885 subagent runtime host", () => {
 				baseUrl: model.baseUrl,
 			})),
 		});
+		let hostedChildThinkingLevel: string | undefined;
 
 		const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 			cwd,
@@ -80,6 +81,9 @@ describe("ENG-3885 subagent runtime host", () => {
 			sessionStartEvent,
 			sessionOptions,
 		}) => {
+			if (sessionOptions?.model?.id === "faux-child") {
+				hostedChildThinkingLevel = sessionOptions.thinkingLevel;
+			}
 			const services = await createAgentSessionServices({
 				cwd,
 				agentDir,
@@ -146,6 +150,7 @@ describe("ENG-3885 subagent runtime host", () => {
 
 		const resultPromise = runtime.session.runRlmChild("inspect child runtime", {
 			model: `${faux.getModel("faux-child")!.provider}/faux-child`,
+			thinking: "high",
 		});
 
 		await waitFor(() => childStarted && runtime.listSubagentRuntimes().length === 1);
@@ -153,6 +158,8 @@ describe("ENG-3885 subagent runtime host", () => {
 		expect(childRuntime).toBeInstanceOf(AgentSessionRuntime);
 		expect(childRuntime?.session.sessionId).not.toBe(runtime.session.sessionId);
 		expect(childRuntime?.session.model?.id).toBe("faux-child");
+		expect(hostedChildThinkingLevel).toBe("high");
+		expect(childRuntime?.session.thinkingLevel).toBe("high");
 		expect(childRuntime?.metadata).toEqual(
 			expect.objectContaining({
 				kind: "subagent",

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -111,6 +111,13 @@ describe("buildRlmPrompt", () => {
 		expect(prompt).toContain("exact returned selector");
 		expect(prompt).toContain("An unavailable requested model fails spawn");
 		expect(prompt).toContain("decide whether to retry or omit `model`");
+		expect(prompt).toContain("inherits your current thinking level");
+		expect(prompt).toContain("thinking='max'");
+		expect(prompt).toContain("valid levels are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`");
+		expect(prompt).toContain("Explicit levels are also clamped to the selected model");
+		expect(prompt).toContain(
+			"some reasoning-capable models cannot disable reasoning, so `off` may clamp upward to their lowest supported level.",
+		);
 		expect(prompt).not.toContain("model choices for subagents");
 	});
 

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -144,6 +144,11 @@ async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:
     """Spawn a recursive Prime Agent child and return once its task is admitted.
 
     ``model`` selects a child with an exact ``provider/model`` selector.
+    ``thinking`` optionally selects the child's reasoning level independently of
+    the parent. Valid levels are ``off``, ``minimal``, ``low``, ``medium``,
+    ``high``, ``xhigh``, and ``max``; the host clamps the requested level to
+    the selected model's capabilities. If omitted, the child inherits the
+    parent's level before clamping.
     """
     if not isinstance(prompt, str):
         raise TypeError(f"prompt must be str, got {type(prompt).__name__}")

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -77,6 +77,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                     "check the API",
                     name="api-reviewer",
                     model="deepseek/deepseek-v4-flash",
+                    thinking="max",
                 )
             )
 
@@ -87,6 +88,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                 "kwargs": {
                     "name": "api-reviewer",
                     "model": "deepseek/deepseek-v4-flash",
+                    "thinking": "max",
                 },
             },
         )


### PR DESCRIPTION
## Summary

- add an optional `thinking` keyword to native `rlm(...)` child spawns
- inherit the parent thinking level when omitted, or independently clamp an explicit level to the selected child model
- document the API and cover Python forwarding, inline execution, provider requests, and hosted/daemon child construction

## API

```python
handle = await rlm(
    "review the authentication flow",
    name="auth-reviewer",
    model="anthropic/claude-opus-5",
    thinking="max",
)
```

Valid values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Unknown or invalid values fail loudly. This does not change the daemon protocol because the finalized thinking level already exists in the internal child-runtime options.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/rlm-child-thinking.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/3885-subagent-runtime-host.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/system-prompt.test.ts`
- `.venv/bin/python -m unittest test/test_subagent_registry.py`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-child thinking level support to `rlm.run` in coding agent
> - `rlm.run` now accepts an optional `thinking` kwarg to set the reasoning level for a child agent session independently of its parent.
> - When `thinking` is omitted, the child inherits the parent's thinking level; when provided, the value is validated, normalized, and clamped to the child model's capabilities.
> - Extracts `VALID_THINKING_LEVELS` and `isValidThinkingLevel` into a new shared module [`thinking-levels.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/798/files#diff-7897093f92589b7a24ce01a6035d106ebaf16e383bb34d4f9039111386d778af), removing duplication across CLI and core modules.
> - Adds a `normalizeRequestedRlmSubagentThinkingLevel` utility in [`rlm-runtime.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/798/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7) that throws for non-string, empty, or unrecognized values.
> - Risk: some models may clamp `"off"` upward to a minimum supported level; invalid `thinking` values now throw errors at call time rather than being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ed4f07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->