### PR TITLE
fix(coding-agent): honor model scope for subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed agent-driven model discovery and subagent selection to honor the user's configured model scope.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -148,7 +148,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/login`, `/logout` | OAuth authentication |
 | `/model` | Switch models |
 | `/effort` | Set reasoning/thinking level |
-| `/scoped-models` | Enable/disable models for Ctrl+P cycling |
+| `/scoped-models` | Set models available for cycling and agent-driven selection |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Open the searchable session view |
 | `/new`, `/clear` | Start a new session |
@@ -554,7 +554,7 @@ cat README.md | prime-agent -p "Summarize this text"
 | `--model <pattern>` | Model pattern or ID (supports `provider/id` and optional `:<thinking>`) |
 | `--api-key <key>` | API key (overrides env vars) |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
-| `--models <patterns>` | Comma-separated patterns for Ctrl+P cycling |
+| `--models <patterns>` | Comma-separated model scope for cycling and agent-driven selection |
 
 Use `prime-agent model list [search]` to list available models.
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -153,7 +153,7 @@ Supported `rlm.run` options are:
 - `name`: a unique readable child session name; and
 - `model`: an exact `provider/model` selector from `rlm.find_models()`.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options fail instead of being ignored. Model search is bounded to the user's configured model scope when one is active, then further limited to executable models with active, non-expired credentials. If no scope is configured, all executable models remain searchable. If an exact selection is outside the scope, unavailable, or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
 
 ## Child Execution
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -190,7 +190,7 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `enabledModels` | string[] | - | Model patterns for Ctrl+P cycling (same format as `--models` CLI flag) |
+| `enabledModels` | string[] | - | Model scope for cycling and agent-driven selection (same format as `--models`) |
 
 ```json
 {

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -40,7 +40,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/login`, `/logout` | Manage OAuth or API-key credentials |
 | `/model` | Switch models |
 | `/effort` | Set the reasoning/thinking level |
-| `/scoped-models` | Enable/disable models for Ctrl+P cycling |
+| `/scoped-models` | Set models available for cycling and agent-driven selection |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
@@ -207,7 +207,7 @@ cat README.md | prime-agent -p "Summarize this text"
 | `--model <pattern>` | Model pattern or ID; supports `provider/id` and optional `:<thinking>` |
 | `--api-key <key>` | API key, overriding environment variables |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
-| `--models <patterns>` | Comma-separated patterns for Ctrl+P cycling |
+| `--models <patterns>` | Comma-separated model scope for cycling and agent-driven selection |
 
 Use `prime-agent model list [search]` to list available models.
 

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -178,7 +178,7 @@ const TOP_LEVEL_OPTION_GROUPS: ReadonlyArray<{ heading: string; options: readonl
 			["--provider <name>", "Select a model provider"],
 			["--model <id>", "Select a model"],
 			["--api-key <key>", "Use an API key for this run"],
-			["--models <patterns>", "Set comma-separated models for cycling"],
+			["--models <patterns>", "Set model scope for cycling and agent-driven selection"],
 			["--thinking <level>", "Set reasoning: off, minimal, low, medium, high, xhigh, max"],
 		],
 	},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -411,7 +411,7 @@ export interface AgentSessionConfig {
 	cwd: string;
 	/** Config dir backing credentials (auth.json); exported to the kernel for skills. */
 	agentDir?: string;
-	/** Models to cycle through with Ctrl+P (from --models flag) */
+	/** User-scoped models for cycling and agent-driven model selection. */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
 	/** Resource loader for skills, prompts, themes, context files, system prompt */
 	resourceLoader: ResourceLoader;
@@ -4207,7 +4207,7 @@ export class AgentSession {
 		this._autonomousContinuationSuppressedMessages.add(message);
 	}
 
-	/** Scoped models for cycling (from --models flag) */
+	/** User-scoped models for cycling and agent-driven model selection. */
 	get scopedModels(): ReadonlyArray<{
 		model: Model<any>;
 		thinkingLevel?: ThinkingLevel;
@@ -4215,7 +4215,7 @@ export class AgentSession {
 		return this._scopedModels;
 	}
 
-	/** Update scoped models for cycling */
+	/** Update the models available for cycling and agent-driven model selection. */
 	setScopedModels(scopedModels: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>): void {
 		this._scopedModels = scopedModels;
 	}
@@ -9541,16 +9541,22 @@ export class AgentSession {
 		assertAgentSessionNameAvailable(catalog, input);
 	}
 
-	private async _authenticatedRlmModels(): Promise<Model<Api>[]> {
+	private _isRlmModelInScope(model: Model<Api>): boolean {
+		return (
+			this._scopedModels.length === 0 || this._scopedModels.some((scoped) => modelsAreEqual(scoped.model, model))
+		);
+	}
+
+	private async _availableRlmModels(): Promise<Model<Api>[]> {
 		return (await this._modelRegistry.getExecutableModels()).filter((model) => {
 			const status = this._modelRegistry.getProviderAuthStatus(model.provider);
-			return status.source !== "stale" && status.label !== "expired";
+			return status.source !== "stale" && status.label !== "expired" && this._isRlmModelInScope(model);
 		});
 	}
 
 	async findRlmModels(query: string, limit: number): Promise<RlmFindModelsResult> {
 		return {
-			models: findRlmModelMatches(query, await this._authenticatedRlmModels(), limit),
+			models: findRlmModelMatches(query, await this._availableRlmModels(), limit),
 		};
 	}
 
@@ -9564,10 +9570,13 @@ export class AgentSession {
 		}
 
 		const normalizedReference = reference.toLowerCase();
-		if (`${parentModel.provider}/${parentModel.id}`.toLowerCase() === normalizedReference) {
+		if (
+			`${parentModel.provider}/${parentModel.id}`.toLowerCase() === normalizedReference &&
+			this._isRlmModelInScope(parentModel)
+		) {
 			return { model: parentModel };
 		}
-		const model = (await this._authenticatedRlmModels()).find(
+		const model = (await this._availableRlmModels()).find(
 			(candidate) => `${candidate.provider}/${candidate.id}`.toLowerCase() === normalizedReference,
 		);
 		if (!model) {

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -128,7 +128,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
-			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. Search results honor the user's configured model scope when present. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -35,7 +35,7 @@ export interface CreateAgentSessionOptions extends AgentSessionCreationOptions {
 	model?: Model<any>;
 	/** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
 	thinkingLevel?: ThinkingLevel;
-	/** Models available for cycling (Ctrl+P in interactive mode) */
+	/** User-scoped models for cycling and agent-driven model selection */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
 
 	/**

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -154,7 +154,7 @@ export interface Settings {
 	enableBuiltinSkills?: boolean; // default: true - load built-in skills shipped with prime-agent
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
-	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
+	enabledModels?: string[]; // Model scope for cycling and agent-driven selection
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default: "user-only"
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -55,6 +55,63 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("limits agent model discovery and selection to the user's model scope", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model" }, { id: "scoped-model" }, { id: "out-of-scope-model" }],
+		});
+		try {
+			harness.session.setScopedModels([
+				{ model: harness.getModel("parent-model")! },
+				{ model: harness.getModel("scoped-model")! },
+			]);
+
+			const discovered = await harness.session.findRlmModels("", 20);
+			expect(discovered.models.map((model) => model.selector)).toEqual([
+				`${provider}/parent-model`,
+				`${provider}/scoped-model`,
+			]);
+			await expect(harness.session.findRlmModels("out of scope", 20)).resolves.toEqual({ models: [] });
+			await expect(
+				harness.session.runRlmChild("reject the out-of-scope model", {
+					model: `${provider}/out-of-scope-model`,
+				}),
+			).rejects.toThrow(
+				`Requested subagent model "${provider}/out-of-scope-model" is unavailable, unauthenticated, or expired`,
+			);
+
+			harness.setResponses([fauxAssistantMessage("scoped child answer")]);
+			const result = await harness.session.runRlmChild("use the scoped model", {
+				model: `${provider}/scoped-model`,
+			});
+			expect(result.model).toBe(`${provider}/scoped-model`);
+			await vi.waitFor(async () => {
+				const childEntry = (await harness.session.listRlmSubagents()).subagents[0];
+				expect(childEntry?.status).toBe("completed");
+				const child = harness.session.getRlmChildSession(childEntry!.rlm_child_id);
+				expect(child?.model?.id).toBe("scoped-model");
+				expect((await child!.findRlmModels("", 20)).models.map((model) => model.selector)).toEqual([
+					`${provider}/parent-model`,
+					`${provider}/scoped-model`,
+				]);
+			});
+
+			harness.session.setScopedModels([{ model: harness.getModel("scoped-model")! }]);
+			expect((await harness.session.findRlmModels("", 20)).models.map((model) => model.selector)).toEqual([
+				`${provider}/scoped-model`,
+			]);
+			await expect(
+				harness.session.runRlmChild("reject the parent outside the updated scope", {
+					model: `${provider}/parent-model`,
+				}),
+			).rejects.toThrow(
+				`Requested subagent model "${provider}/parent-model" is unavailable, unauthenticated, or expired`,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("omits providers whose credentials are marked expired", async () => {
 		const harness = await createHarness({ provider, models: [{ id: "parent-model" }, { id: "child-model" }] });
 		try {


### PR DESCRIPTION
## Why

A human's scoped model configuration is an explicit curation boundary, not only a cycling preference. Prime Agent currently searches the full authenticated model catalog for agent-driven model discovery and explicit subagent overrides, which can route delegated work to a model the human deliberately excluded.

## What changed

- Intersect agent-driven model discovery with the current model scope and executable, non-expired models.
- Reject explicit subagent model overrides outside the current scope, including an out-of-scope parent selector.
- Preserve the full executable catalog when no scope is configured.
- Preserve implicit parent-model inheritance when no model override is requested.
- Carry the scope into spawned children so nested discovery follows the same boundary.
- Document that `/scoped-models`, `--models`, and `enabledModels` also govern agent-driven selection.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4649-subagent-model-selection.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subagent model discovery and selection to honor the user's configured model scope
> - Adds `_isRlmModelInScope` to `AgentSession` to check whether a model falls within the user's configured scope, and replaces `_authenticatedRlmModels` with `_availableRlmModels` that filters by both auth status and scope.
> - `findRlmModels` and `_resolveRlmSubagentModel` now use `_availableRlmModels`, so out-of-scope models are excluded from discovery and treated as unavailable for subagent spawning.
> - Behavioral Change: subagent model selections outside the configured scope now fail with an 'unavailable, unauthenticated, or expired' error rather than succeeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85b8397.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->