### PR TITLE
fix(coding-agent): show current cwd in session tray

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed the interactive session tray to show the current working directory ([#693](https://github.com/PrimeIntellect-ai/prime-agent/issues/693)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5925,11 +5925,12 @@ export class InteractiveMode {
 
 	private getTrayLocationLabel(): string | undefined {
 		const modelLabel = this.getModelTrayLabel();
+		const cwdLabel = `cwd ${formatSplashCwd(this.getCurrentCwd())}`;
 		const hasChildren = this.options.sessionHasChildren === true || (this.subagentSnapshots?.size ?? 0) > 0;
 		const depthLabel = formatAgentDepthLabel(this.options.sessionDepth, hasChildren);
 		const shortcutsHint = this.getShortcutsTrayHint();
 		const agentsHint = this.getAgentsViewTrayHint();
-		return [agentsHint, depthLabel, modelLabel, shortcutsHint]
+		return [agentsHint, cwdLabel, depthLabel, modelLabel, shortcutsHint]
 			.filter((label): label is string => label !== undefined)
 			.join("  ");
 	}

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3864,6 +3864,44 @@ describe("InteractiveMode splash cwd display", () => {
 	});
 });
 
+describe("InteractiveMode tray location label", () => {
+	type TrayLocationLabelHarness = {
+		options: {
+			sessionDepth?: number;
+			sessionHasChildren?: boolean;
+		};
+		getModelTrayLabel(): string;
+		getShortcutsTrayHint(): string | undefined;
+		getAgentsViewTrayHint(): string | undefined;
+		getCurrentCwd(): string;
+		getTrayLocationLabel(): string | undefined;
+	};
+	const getTrayLocationLabel = (InteractiveMode.prototype as unknown as TrayLocationLabelHarness).getTrayLocationLabel;
+
+	function createHarness(cwd: string): TrayLocationLabelHarness {
+		const fakeThis = Object.create(InteractiveMode.prototype) as TrayLocationLabelHarness;
+		fakeThis.options = { sessionDepth: 0, sessionHasChildren: false };
+		fakeThis.getModelTrayLabel = () => "GPT-5.6 Sol • medium";
+		fakeThis.getShortcutsTrayHint = () => undefined;
+		fakeThis.getAgentsViewTrayHint = () => undefined;
+		fakeThis.getCurrentCwd = () => cwd;
+		return fakeThis;
+	}
+
+	test("includes the current session cwd in the location label", () => {
+		const fakeThis = createHarness("/tmp/project");
+
+		expect(getTrayLocationLabel.call(fakeThis)).toBe("cwd /tmp/project  GPT-5.6 Sol • medium");
+	});
+
+	test("uses compact home-relative formatting for the current session cwd", () => {
+		const cwd = path.join(homedir(), "workspace", "prime-agent");
+		const fakeThis = createHarness(cwd);
+
+		expect(getTrayLocationLabel.call(fakeThis)).toBe("cwd ~/workspace/prime-agent  GPT-5.6 Sol • medium");
+	});
+});
+
 describe("InteractiveMode goal status announcements", () => {
 	test("does not announce active goal usage-only updates", () => {
 		type GoalAnnouncementHarness = {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3900,6 +3900,17 @@ describe("InteractiveMode tray location label", () => {
 
 		expect(getTrayLocationLabel.call(fakeThis)).toBe("cwd ~/workspace/prime-agent  GPT-5.6 Sol • medium");
 	});
+
+	test("preserves existing tray labels around the current session cwd", () => {
+		const fakeThis = createHarness("/tmp/project");
+		fakeThis.options = { sessionDepth: 2, sessionHasChildren: true };
+		fakeThis.getAgentsViewTrayHint = () => "agents/resume";
+		fakeThis.getShortcutsTrayHint = () => "shortcuts";
+
+		expect(getTrayLocationLabel.call(fakeThis)).toBe(
+			"agents/resume  cwd /tmp/project  depth 2  GPT-5.6 Sol • medium  shortcuts",
+		);
+	});
 });
 
 describe("InteractiveMode goal status announcements", () => {


### PR DESCRIPTION
## Summary

- Shows the current session working directory in the interactive session tray.
- Reuses the connection-aware cwd lookup and existing compact home-relative path formatter.

## Motivation

The interactive tray showed navigation, depth, model, and context information but did not identify the project directory for the active session. This was particularly ambiguous when resuming multiple sessions from the Agents view.

Fixes #693

## Changes

- Adds a `cwd <path>` segment to `getTrayLocationLabel()`.
- Formats the value through `formatSplashCwd()` so paths under the user's home directory use `~`.
- Keeps the existing navigation, depth, model, shortcut, and context labels unchanged.
- Adds regression coverage for the current cwd, home-relative formatting, and preservation of the surrounding tray labels.
- Documents the user-visible change in the coding-agent changelog.

## Verification

- Focused test (RED before implementation): the initial run failed the 2 cwd-specific assertions as expected; the existing 150 tests passed.
- Focused test (GREEN): `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-status.test.ts` — 153 tests passed, including the tray-label ordering regression.
- Repository checks: `npm run check` — Biome checked 898 files, installer render check passed, and the command exited successfully.
- `git diff --check` passed.
- Added-line security scan reported no findings.

## Example

Before:

```text
← agents/resume  depth 0  GPT-5.6 Sol • medium                         47k (17%)
```

After:

```text
← agents/resume  cwd /path/to/project  depth 0  GPT-5.6 Sol • medium
```

## Notes for Reviewers

The tray reads the cwd through `getCurrentCwd()`, which prefers the current connection state and falls back to the initial process cwd. No daemon protocol or persisted session format changes are involved.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show current working directory in interactive session tray label
> Adds a `cwd` segment to `InteractiveMode.getTrayLocationLabel` by formatting the current working directory via `formatSplashCwd(getCurrentCwd())` and inserting it between the agents hint and depth label. Three new tests in [interactive-mode-status.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/802/files#diff-437901e4bcf3ed59fe6e211eac1c38b57637ff69b35a384dc4d1b8dfcfcb15d3) verify the label is present, home-relative, and surrounded by the expected segments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fd73b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->