### PR TITLE
fix(coding-agent): decode large worker frames linearly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed large fragmented session-worker frames repeatedly copying their accumulated bytes and starving daemon commands such as session-tree requests.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/modes/session-worker/private-framing.ts
+++ b/packages/coding-agent/src/modes/session-worker/private-framing.ts
@@ -51,7 +51,10 @@ export function encodePrivateFrame<THeader extends object>(
 }
 
 export class PrivateFrameDecoder<THeader extends object> {
-	private buffered: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+	private chunks: Buffer<ArrayBufferLike>[] = [];
+	private firstChunkIndex = 0;
+	private firstChunkOffset = 0;
+	private bufferedLength = 0;
 
 	constructor(
 		private readonly validateHeader: PrivateFrameHeaderValidator<THeader>,
@@ -59,20 +62,20 @@ export class PrivateFrameDecoder<THeader extends object> {
 	) {}
 
 	get bufferedBytes(): number {
-		return this.buffered.length;
+		return this.bufferedLength;
 	}
 
 	push(chunk: Uint8Array): PrivateFrame<THeader>[] {
 		if (chunk.length > 0) {
-			const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-			this.buffered = this.buffered.length === 0 ? buffer : Buffer.concat([this.buffered, buffer]);
+			this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+			this.bufferedLength += chunk.length;
 		}
 
 		const frames: PrivateFrame<THeader>[] = [];
-		let offset = 0;
-		while (this.buffered.length - offset >= FRAME_PREFIX_BYTES) {
-			const headerLength = this.buffered.readUInt32BE(offset);
-			const payloadLength = this.buffered.readUInt32BE(offset + 4);
+		while (this.bufferedLength >= FRAME_PREFIX_BYTES) {
+			const prefix = this.peekBytes(FRAME_PREFIX_BYTES);
+			const headerLength = prefix.readUInt32BE(0);
+			const payloadLength = prefix.readUInt32BE(4);
 			assertFrameLength("header length", headerLength, this.limits.maxHeaderBytes);
 			assertFrameLength("payload length", payloadLength, this.limits.maxPayloadBytes);
 			if (headerLength === 0) {
@@ -80,15 +83,14 @@ export class PrivateFrameDecoder<THeader extends object> {
 			}
 
 			const frameLength = FRAME_PREFIX_BYTES + headerLength + payloadLength;
-			if (this.buffered.length - offset < frameLength) {
+			if (this.bufferedLength < frameLength) {
 				break;
 			}
 
-			const headerStart = offset + FRAME_PREFIX_BYTES;
-			const payloadStart = headerStart + headerLength;
+			const headerBuffer = this.peekBytes(FRAME_PREFIX_BYTES + headerLength).subarray(FRAME_PREFIX_BYTES);
 			let decoded: unknown;
 			try {
-				decoded = JSON.parse(this.buffered.toString("utf8", headerStart, payloadStart));
+				decoded = JSON.parse(headerBuffer.toString("utf8"));
 			} catch (error) {
 				throw new Error(
 					`Invalid private frame header JSON: ${error instanceof Error ? error.message : String(error)}`,
@@ -98,22 +100,80 @@ export class PrivateFrameDecoder<THeader extends object> {
 				throw new Error("Invalid private frame routing header");
 			}
 
-			frames.push({
-				header: decoded,
-				payload: Buffer.from(this.buffered.subarray(payloadStart, payloadStart + payloadLength)),
-			});
-			offset += frameLength;
-		}
-
-		if (offset > 0) {
-			this.buffered = Buffer.from(this.buffered.subarray(offset));
+			this.consumeBytes(FRAME_PREFIX_BYTES + headerLength);
+			frames.push({ header: decoded, payload: this.readBytes(payloadLength) });
 		}
 		return frames;
 	}
 
 	finish(): void {
-		if (this.buffered.length !== 0) {
-			throw new Error(`Private frame channel ended with ${this.buffered.length} incomplete bytes`);
+		if (this.bufferedLength !== 0) {
+			throw new Error(`Private frame channel ended with ${this.bufferedLength} incomplete bytes`);
+		}
+	}
+
+	private peekBytes(length: number): Buffer<ArrayBufferLike> {
+		const first = this.chunks[this.firstChunkIndex];
+		if (first && first.length - this.firstChunkOffset >= length) {
+			return first.subarray(this.firstChunkOffset, this.firstChunkOffset + length);
+		}
+
+		const result = Buffer.allocUnsafe(length);
+		this.copyBytes(result, length);
+		return result;
+	}
+
+	private readBytes(length: number): Buffer<ArrayBufferLike> {
+		const result = Buffer.allocUnsafe(length);
+		this.copyBytes(result, length);
+		this.consumeBytes(length);
+		return result;
+	}
+
+	private copyBytes(target: Buffer<ArrayBufferLike>, length: number): void {
+		let chunkIndex = this.firstChunkIndex;
+		let chunkOffset = this.firstChunkOffset;
+		let targetOffset = 0;
+		while (targetOffset < length) {
+			const chunk = this.chunks[chunkIndex];
+			if (!chunk) {
+				throw new Error("Private frame decoder buffer underflow");
+			}
+			const copyLength = Math.min(length - targetOffset, chunk.length - chunkOffset);
+			chunk.copy(target, targetOffset, chunkOffset, chunkOffset + copyLength);
+			targetOffset += copyLength;
+			chunkOffset += copyLength;
+			if (chunkOffset === chunk.length) {
+				chunkIndex++;
+				chunkOffset = 0;
+			}
+		}
+	}
+
+	private consumeBytes(length: number): void {
+		let remaining = length;
+		while (remaining > 0) {
+			const chunk = this.chunks[this.firstChunkIndex];
+			if (!chunk) {
+				throw new Error("Private frame decoder buffer underflow");
+			}
+			const consumed = Math.min(remaining, chunk.length - this.firstChunkOffset);
+			remaining -= consumed;
+			this.firstChunkOffset += consumed;
+			if (this.firstChunkOffset === chunk.length) {
+				this.firstChunkIndex++;
+				this.firstChunkOffset = 0;
+			}
+		}
+
+		this.bufferedLength -= length;
+		if (this.bufferedLength === 0) {
+			this.chunks = [];
+			this.firstChunkIndex = 0;
+			this.firstChunkOffset = 0;
+		} else if (this.firstChunkIndex >= 1024) {
+			this.chunks = this.chunks.slice(this.firstChunkIndex);
+			this.firstChunkIndex = 0;
 		}
 	}
 }

--- a/packages/coding-agent/test/session-worker-private-framing.test.ts
+++ b/packages/coding-agent/test/session-worker-private-framing.test.ts
@@ -42,6 +42,23 @@ describe("private worker framing", () => {
 		]);
 	});
 
+	it("decodes a fragmented multi-megabyte payload without stalling", () => {
+		const payload = Buffer.alloc(16 * 1024 * 1024, 0xab);
+		const encoded = encodePrivateFrame({ type: "snapshot", requestId: "large" }, payload);
+		const decoder = new PrivateFrameDecoder(isTestHeader);
+		const frames = [];
+
+		for (let offset = 0; offset < encoded.length; offset += 1024) {
+			frames.push(...decoder.push(encoded.subarray(offset, offset + 1024)));
+		}
+
+		expect(frames).toHaveLength(1);
+		expect(frames[0]?.header).toEqual({ type: "snapshot", requestId: "large" });
+		expect(frames[0]?.payload.equals(payload)).toBe(true);
+		expect(decoder.bufferedBytes).toBe(0);
+		decoder.finish();
+	});
+
 	it("rejects invalid lengths, JSON, and routing headers", () => {
 		const oversized = Buffer.alloc(8);
 		oversized.writeUInt32BE(1025, 0);


### PR DESCRIPTION
Large session-tree responses can reach tens of megabytes. The private worker decoder currently rebuilds the entire accumulated frame for every socket chunk, which makes fragmented decoding quadratic and can starve unrelated daemon commands until their clients time out.

Retain incoming chunks until a complete frame arrives, then validate the header and copy the payload once. The private wire format, limits, and channel API remain unchanged. Add a fragmented 16 MiB payload regression that would time out against the repeated-concatenation path.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PrivateFrameDecoder` to process large fragmented frames without repeated copying
> - Replaces the single growing `Buffer` accumulation in `PrivateFrameDecoder` with a chunked buffering strategy, storing incoming data as a list of chunks and advancing a cursor rather than concatenating on every push.
> - Adds `peekBytes`, `readBytes`, `copyBytes`, and `consumeBytes` helpers in [private-framing.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/803/files#diff-0b722e1ad1d1905bb8bea2bcdd449f23cfa40de4b3657ef6a39029390934f602) to operate across chunk boundaries with minimal copying.
> - Adds periodic compaction of consumed leading chunks to bound memory overhead.
> - A new test feeds a ~16 MiB payload in 1 KiB chunks to verify correct decoding and accurate `bufferedBytes` / `finish` behavior.
> - Behavioral Change: `bufferedBytes` now accurately reflects remaining buffered data, and `finish` reports the correct remaining byte count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0749530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->