### PR TITLE
show current openrouter models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a shared strict parser for the OpenRouter model catalog, exposed from the root package export.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -5,6 +5,7 @@ export * from "./api-registry.js";
 export * from "./env-api-keys.js";
 export * from "./log.js";
 export * from "./models.js";
+export * from "./openrouter-models.js";
 export type { BedrockOptions, BedrockThinkingDisplay } from "./providers/amazon-bedrock.js";
 export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from "./providers/anthropic.js";
 export type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses.js";

--- a/packages/ai/src/openrouter-models.ts
+++ b/packages/ai/src/openrouter-models.ts
@@ -1,0 +1,111 @@
+import type { KnownProvider, Model } from "./types.js";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const EFFORT_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * Parse a single page of the OpenRouter model catalog into normalized models.
+ * Skips malformed individual entries, drops the live `:batch` routes, and only
+ * keeps routes that advertise tool support. Throws on a malformed top-level
+ * payload or a payload with a missing `data` array.
+ */
+export function parseOpenRouterModels(payload: unknown): Model<"openai-completions">[] {
+	if (!isObject(payload) || !Array.isArray(payload.data)) {
+		throw new Error("Invalid OpenRouter model catalog payload");
+	}
+	const models: Model<"openai-completions">[] = [];
+	for (const raw of payload.data as unknown[]) {
+		const model = parseOpenRouterModel(raw);
+		if (model) models.push(model);
+	}
+	return models;
+}
+
+function parseOpenRouterModel(raw: unknown): Model<"openai-completions"> | undefined {
+	if (!isObject(raw)) return undefined;
+	const id = typeof raw.id === "string" ? raw.id : undefined;
+	if (!id) return undefined;
+	const parameters = stringArray(raw.supported_parameters);
+	if (!parameters.includes("tools") || id.endsWith(":batch")) return undefined;
+
+	const architecture = isObject(raw.architecture) ? raw.architecture : {};
+	const output = stringArray(architecture.output_modalities);
+	if (output.length > 0 && !output.includes("text")) return undefined;
+
+	const input: ("text" | "image")[] = hasImageInput(architecture) ? ["text", "image"] : ["text"];
+
+	const pricing = isObject(raw.pricing) ? raw.pricing : {};
+	const toCost = (value: unknown): number => {
+		const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+		return Number.isFinite(n) && n > 0 ? n * 1_000_000 : 0;
+	};
+
+	const contextWindow = finitePositive(raw.context_length) ?? 4096;
+	const topProvider = isObject(raw.top_provider) ? raw.top_provider : {};
+	const model: Model<"openai-completions"> = {
+		id,
+		name: typeof raw.name === "string" ? raw.name : id,
+		api: "openai-completions",
+		provider: "openrouter" as KnownProvider,
+		baseUrl: OPENROUTER_BASE_URL,
+		reasoning: parameters.includes("reasoning"),
+		input,
+		cost: {
+			input: toCost(pricing.prompt),
+			output: toCost(pricing.completion),
+			cacheRead: toCost(pricing.input_cache_read),
+			cacheWrite: toCost(pricing.input_cache_write),
+		},
+		contextWindow,
+		maxTokens: finitePositive(topProvider.max_completion_tokens) ?? 4096,
+	};
+	if (model.maxTokens > contextWindow) model.maxTokens = contextWindow;
+	if (model.reasoning) {
+		const thinkingLevelMap = deriveThinkingLevelMap(isObject(raw.reasoning) ? raw.reasoning : undefined);
+		if (thinkingLevelMap) model.thinkingLevelMap = thinkingLevelMap;
+	}
+	if (id.includes("deepseek-v4")) {
+		model.compat = { requiresReasoningContentOnAssistantMessages: true, thinkingFormat: "deepseek" };
+	}
+	return model;
+}
+
+/**
+ * `supported_efforts` is an allowlist; when it is absent OpenRouter accepts every
+ * gateway effort, so no level is pinned. `mandatory` routes reject "none", so
+ * "off" is marked unsupported.
+ */
+function deriveThinkingLevelMap(
+	reasoning: Record<string, unknown> | undefined,
+): Model<"openai-completions">["thinkingLevelMap"] | undefined {
+	const map: NonNullable<Model<"openai-completions">["thinkingLevelMap"]> = {};
+	if (reasoning?.mandatory === true) map.off = null;
+	if (Array.isArray(reasoning?.supported_efforts)) {
+		const efforts = new Set(stringArray(reasoning.supported_efforts));
+		for (const level of EFFORT_LEVELS) {
+			map[level] = efforts.has(level) ? level : null;
+		}
+	}
+	return Object.keys(map).length > 0 ? map : undefined;
+}
+
+function hasImageInput(architecture: Record<string, unknown>): boolean {
+	const modalities = stringArray(architecture.input_modalities);
+	if (modalities.length > 0) return modalities.includes("image");
+	// Legacy combined field, e.g. "text+image->text"; only the input side counts.
+	const modality = typeof architecture.modality === "string" ? architecture.modality : "";
+	return modality.split("->")[0].includes("image");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function finitePositive(value: unknown): number | undefined {
+	const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+	return Number.isFinite(n) && n > 0 ? n : undefined;
+}

--- a/packages/ai/test/openrouter-models.test.ts
+++ b/packages/ai/test/openrouter-models.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "vitest";
+import { getSupportedThinkingLevels } from "../src/models.js";
+import { parseOpenRouterModels } from "../src/openrouter-models.js";
+
+describe("parseOpenRouterModels", () => {
+	const entry = (overrides: Record<string, unknown> = {}) => ({
+		id: "vendor/model",
+		name: "Model",
+		supported_parameters: ["tools"],
+		architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+		pricing: { prompt: "0.000001", completion: "0.000002", input_cache_read: "0.0000001" },
+		top_provider: { max_completion_tokens: 8192 },
+		context_length: 32768,
+		...overrides,
+	});
+
+	test("parses a normal entry with structured modalities and pricing", () => {
+		const [model] = parseOpenRouterModels({ data: [entry()] });
+		expect(model.id).toBe("vendor/model");
+		expect(model.api).toBe("openai-completions");
+		expect(model.provider).toBe("openrouter");
+		expect(model.input).toEqual(["text"]);
+		expect(model.cost.input).toBe(1);
+		expect(model.cost.output).toBe(2);
+		expect(Math.abs(model.cost.cacheRead - 0.1)).toBeLessThan(1e-9);
+		expect(model.cost.cacheWrite).toBe(0);
+		expect(model.contextWindow).toBe(32768);
+		expect(model.maxTokens).toBe(8192);
+		expect(model.reasoning).toBe(false);
+	});
+
+	test("detects image from structured input_modalities and legacy modality", () => {
+		expect(
+			parseOpenRouterModels({
+				data: [entry({ architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] } })],
+			})[0].input,
+		).toEqual(["text", "image"]);
+		expect(
+			parseOpenRouterModels({
+				data: [entry({ architecture: { modality: "text+image->text", output_modalities: ["text"] } })],
+			})[0].input,
+		).toEqual(["text", "image"]);
+	});
+
+	test("skips non-tool and :batch entries", () => {
+		const models = parseOpenRouterModels({
+			data: [entry(), entry({ id: "no/tools", supported_parameters: [] }), entry({ id: "vendor/model:batch" })],
+		});
+		expect(models.map((m) => m.id)).toEqual(["vendor/model"]);
+	});
+
+	test("skips non-text-output models when output modalities present", () => {
+		const models = parseOpenRouterModels({
+			data: [entry({ architecture: { output_modalities: ["audio"] } })],
+		});
+		expect(models).toEqual([]);
+	});
+
+	test("mandatory reasoning sets off:null and maps supported efforts", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					supported_parameters: ["tools", "reasoning"],
+					reasoning: { mandatory: true, supported_efforts: ["xhigh", "high", "medium", "low", "minimal"] },
+				}),
+			],
+		});
+		expect(model.reasoning).toBe(true);
+		expect(model.thinkingLevelMap?.off).toBeNull();
+		expect(model.thinkingLevelMap?.low).toBe("low");
+		expect(model.thinkingLevelMap?.xhigh).toBe("xhigh");
+		expect(model.thinkingLevelMap?.max).toBeNull();
+	});
+
+	test("optional reasoning leaves off unpinned and hides unsupported efforts", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					supported_parameters: ["tools", "reasoning"],
+					reasoning: { mandatory: false, supported_efforts: ["max"] },
+				}),
+			],
+		});
+		expect(model.thinkingLevelMap?.off).toBeUndefined();
+		expect(model.thinkingLevelMap?.medium).toBeNull();
+		expect(model.thinkingLevelMap?.max).toBe("max");
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "max"]);
+	});
+
+	test("absent supported_efforts keeps every gateway effort selectable", () => {
+		const [optional] = parseOpenRouterModels({
+			data: [entry({ supported_parameters: ["tools", "reasoning"], reasoning: { mandatory: false } })],
+		});
+		expect(optional.thinkingLevelMap).toBeUndefined();
+		expect(getSupportedThinkingLevels(optional)).toEqual(["off", "minimal", "low", "medium", "high"]);
+
+		const [mandatory] = parseOpenRouterModels({
+			data: [entry({ supported_parameters: ["tools", "reasoning"], reasoning: { mandatory: true } })],
+		});
+		expect(mandatory.thinkingLevelMap).toEqual({ off: null });
+		expect(getSupportedThinkingLevels(mandatory)).toEqual(["minimal", "low", "medium", "high"]);
+	});
+
+	test("a reasoning object without the reasoning parameter does not enable reasoning", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({ supported_parameters: ["tools"], reasoning: { mandatory: true, supported_efforts: ["high"] } }),
+			],
+		});
+		expect(model.reasoning).toBe(false);
+		expect(model.thinkingLevelMap).toBeUndefined();
+	});
+
+	test("legacy output-only image modality is not treated as vision input", () => {
+		const [model] = parseOpenRouterModels({ data: [entry({ architecture: { modality: "text->text+image" } })] });
+		expect(model.input).toEqual(["text"]);
+	});
+
+	test("tolerates null, invalid, negative and NaN pricing", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					pricing: { prompt: null, completion: "NaN", input_cache_read: "-5", input_cache_write: "not-a-number" },
+				}),
+			],
+		});
+		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
+	test("clamps maxTokens to context window and falls back on null limits", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					context_length: 10000,
+					top_provider: { max_completion_tokens: 999999 },
+				}),
+			],
+		});
+		expect(model.maxTokens).toBe(10000);
+		const [fallback] = parseOpenRouterModels({
+			data: [entry({ context_length: null, top_provider: { max_completion_tokens: null } })],
+		});
+		expect(fallback.contextWindow).toBe(4096);
+		expect(fallback.maxTokens).toBe(4096);
+	});
+
+	test("applies deepseek compat correction", () => {
+		const [model] = parseOpenRouterModels({ data: [entry({ id: "deepseek/deepseek-v4-pro" })] });
+		expect(model.compat).toEqual({ requiresReasoningContentOnAssistantMessages: true, thinkingFormat: "deepseek" });
+	});
+
+	test("throws on a malformed top-level payload but skips malformed entries", () => {
+		expect(() => parseOpenRouterModels({})).toThrow();
+		expect(() => parseOpenRouterModels([1, 2])).toThrow();
+		const models = parseOpenRouterModels({ data: [{}, 1, "x", entry({ id: 123 })] });
+		expect(models.length).toBe(0);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added live OpenRouter model discovery so the model browser reflects OpenRouter’s current catalog, with the generated snapshot retained as an offline/failure fallback.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -32,6 +32,7 @@ export async function listModels(modelRegistry: ModelRegistry, searchPattern?: s
 		console.error(chalk.yellow(`Warning: errors loading models.json:\n${loadError}`));
 	}
 
+	await modelRegistry.refreshOpenRouterModels();
 	const models = await modelRegistry.refreshAvailableModels();
 
 	if (models.length === 0) {

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -29,6 +29,7 @@ import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import { getAgentDir, VERSION } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
+import { getOpenRouterModels } from "./openrouter-model-catalog.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
 	fetchAuthorizedPrivatePrimeInferenceModelIds,
@@ -372,6 +373,29 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+function resolveOpenRouterCatalog(staticModels: Model<Api>[], live: Model<Api>[] | undefined): Model<Api>[] {
+	if (!live || live.length === 0) return staticModels;
+	const liveIds = new Set(live.map((m) => m.id));
+	const staticById = new Map(staticModels.map((m) => [m.id, m]));
+	const resolved = live.map((model) => {
+		const s = staticById.get(model.id);
+		if (!s) return model;
+		return {
+			...model,
+			compat: s.compat ?? model.compat,
+			featured: s.featured,
+			headers: s.headers,
+			thinkingLevelMap: { ...s.thinkingLevelMap, ...model.thinkingLevelMap },
+		};
+	});
+	for (const s of staticModels) {
+		if (liveIds.has(s.id)) continue;
+		const virtual = s.id === "auto" || s.id.startsWith("openrouter/") || s.id.startsWith("~");
+		if (virtual) resolved.push(s);
+	}
+	return resolved;
+}
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -437,6 +461,7 @@ export class ModelRegistry {
 	private openAICodexModelsCache: { authFingerprint: string; modelIds: Set<string>; refreshedAt: number } | undefined;
 	private backgroundPrivatePrimeAuthorization: { fingerprint: string; promise: Promise<void> } | undefined;
 	private loadError: string | undefined = undefined;
+	private liveOpenRouterModels: Model<Api>[] | undefined;
 
 	/** Re-register dynamic OAuth providers (e.g. user MCP servers) after refresh() resets the registry. */
 	private onOAuthProvidersReset?: () => void;
@@ -540,7 +565,10 @@ export class ModelRegistry {
 		modelOverrides: Map<string, Map<string, ModelOverride>>,
 	): Model<Api>[] {
 		return getProviders().flatMap((provider) => {
-			const models = getModels(provider as KnownProvider) as Model<Api>[];
+			const models =
+				provider === "openrouter"
+					? resolveOpenRouterCatalog(getModels("openrouter") as Model<Api>[], this.liveOpenRouterModels)
+					: (getModels(provider as KnownProvider) as Model<Api>[]);
 			const providerOverride = overrides.get(provider);
 			const perModelOverrides = modelOverrides.get(provider);
 
@@ -786,6 +814,17 @@ export class ModelRegistry {
 		return this.getAvailable();
 	}
 
+	/** Refresh the live OpenRouter catalog. Only explicit catalog queries call this. */
+	async refreshOpenRouterModels(): Promise<void> {
+		if (isOfflineModeEnabled()) return;
+		try {
+			const models = await getOpenRouterModels();
+			if (models) this.liveOpenRouterModels = models;
+		} catch {
+			// Keep the previous live catalog (or none, falling back to the snapshot).
+		}
+	}
+
 	private async refreshPrivatePrimeInferenceAuthorization(
 		previousPrivateModelIds = new Set(this.authorizedPrivatePrimeInferenceModelIds),
 		previousTeamId = this.authorizedPrivatePrimeInferenceTeamId,
@@ -940,6 +979,7 @@ export class ModelRegistry {
 	}
 
 	async refreshModelCatalog(): Promise<ModelCatalogSnapshot> {
+		await this.refreshOpenRouterModels();
 		const availableModels = await this.refreshAvailableModels();
 		const availablePrivateModels = new Set(
 			availableModels.filter(isPrivatePrimeInferenceModel).map((model) => `${model.provider}/${model.id}`),

--- a/packages/coding-agent/src/core/openrouter-model-catalog.ts
+++ b/packages/coding-agent/src/core/openrouter-model-catalog.ts
@@ -1,0 +1,62 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { parseOpenRouterModels } from "@earendil-works/pi-ai";
+
+const URL = "https://openrouter.ai/api/v1/models?output_modalities=text";
+const TTL_MS = 5 * 60_000;
+const TIMEOUT_MS = 3_000;
+const BACKOFF_MS = 30_000;
+
+let cached: { models: Model<Api>[]; fetchedAt: number } | undefined;
+let inFlight: Promise<Model<Api>[] | undefined> | undefined;
+let lastAttemptAt = 0;
+
+/** Reset the process-wide cache (exported for tests). */
+export function resetOpenRouterModelCache(): void {
+	cached = undefined;
+	inFlight = undefined;
+	lastAttemptAt = 0;
+}
+
+/**
+ * Fetch the live OpenRouter catalog with a bounded timeout. Returns the last
+ * known-good catalog on a failed or backed-off refresh, `undefined` on a cold
+ * miss, and deduplicates concurrent callers. Offline handling is left to the
+ * caller, which never makes a request in offline mode.
+ */
+export async function getOpenRouterModels(
+	fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<Model<Api>[] | undefined> {
+	const now = Date.now();
+	if (cached && now - cached.fetchedAt < TTL_MS) return cached.models;
+	if (inFlight) return inFlight;
+	if (now - lastAttemptAt < BACKOFF_MS) return cached?.models;
+	lastAttemptAt = now;
+
+	const run = async (): Promise<Model<Api>[] | undefined> => {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+		try {
+			const response = await fetchImpl(URL, { signal: controller.signal });
+			if (!response.ok) return cached?.models;
+			const models = parseOpenRouterModels(await response.json());
+			if (models.length === 0) return cached?.models;
+			cached = { models, fetchedAt: Date.now() };
+			return models;
+		} catch {
+			return cached?.models;
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+	const promise = run();
+	inFlight = promise;
+	promise.then(
+		() => {
+			if (inFlight === promise) inFlight = undefined;
+		},
+		() => {
+			if (inFlight === promise) inFlight = undefined;
+		},
+	);
+	return promise;
+}

--- a/packages/coding-agent/test/openrouter-live-registry.test.ts
+++ b/packages/coding-agent/test/openrouter-live-registry.test.ts
@@ -1,0 +1,121 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { resetOpenRouterModelCache } from "../src/core/openrouter-model-catalog.js";
+
+const rawEntries = [
+	{
+		id: "meta/muse-spark-1.2",
+		name: "Meta: Muse Spark 1.2",
+		supported_parameters: ["tools", "reasoning"],
+		architecture: {
+			modality: "text+image+file+audio+video->text",
+			input_modalities: ["text", "image", "video", "file", "audio"],
+			output_modalities: ["text"],
+		},
+		pricing: { prompt: "0.00000125", completion: "0.00000425", input_cache_read: "0.00000015" },
+		top_provider: { max_completion_tokens: null },
+		context_length: 1048576,
+		reasoning: {
+			mandatory: true,
+			supported_efforts: ["xhigh", "high", "medium", "low", "minimal"],
+			default_effort: "medium",
+		},
+	},
+	{
+		id: "deepseek/deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		supported_parameters: ["tools", "reasoning"],
+		architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+		pricing: { prompt: "0.000000435", completion: "0.0000019" },
+		top_provider: { max_completion_tokens: 8192 },
+		context_length: 32768,
+		reasoning: { mandatory: false, supported_efforts: ["xhigh", "high"] },
+	},
+];
+
+const liveResponse = (): Partial<Response> => ({ ok: true, status: 200, json: async () => ({ data: rawEntries }) });
+
+describe("ModelRegistry live OpenRouter catalog", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-openrouter-live-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = join(tempDir, "models.json");
+		authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		resetOpenRouterModelCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => liveResponse() as Response),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		resetOpenRouterModelCache();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	test("adds a newly released model from the live catalog", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const snapshot = await registry.refreshModelCatalog();
+		const model = snapshot.models.find((m) => m.provider === "openrouter" && m.id === "meta/muse-spark-1.2");
+		expect(model).toBeDefined();
+		expect(model?.thinkingLevelMap?.off).toBeNull();
+		expect(model?.input).toEqual(["text", "image"]);
+	});
+
+	test("preserves virtual aliases absent from live and curated static compat", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const snapshot = await registry.refreshModelCatalog();
+		expect(snapshot.models.some((m) => m.provider === "openrouter" && m.id === "auto")).toBe(true);
+		const deepseek = snapshot.models.find((m) => m.provider === "openrouter" && m.id === "deepseek/deepseek-v4-pro");
+		expect(deepseek?.compat).toEqual({
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		});
+	});
+
+	test("a custom same-id model still wins over the live entry", async () => {
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					openrouter: {
+						api: "openai-completions",
+						apiKey: "TEST_KEY",
+						models: [
+							{
+								id: "meta/muse-spark-1.2",
+								name: "Custom Muse",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 1000,
+								maxTokens: 100,
+							},
+						],
+					},
+				},
+			}),
+		);
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		const model = registry.find("openrouter", "meta/muse-spark-1.2");
+		expect(model?.name).toBe("Custom Muse");
+		expect(model?.reasoning).toBe(false);
+	});
+
+	test("second refresh retains live models", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		await registry.refreshModelCatalog();
+		expect(registry.find("openrouter", "meta/muse-spark-1.2")).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/openrouter-model-catalog.test.ts
+++ b/packages/coding-agent/test/openrouter-model-catalog.test.ts
@@ -1,0 +1,97 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getOpenRouterModels, resetOpenRouterModelCache } from "../src/core/openrouter-model-catalog.js";
+
+const model: Model<Api> = {
+	id: "vendor/live-new",
+	name: "Live New",
+	api: "openai-completions",
+	provider: "openrouter",
+	baseUrl: "https://openrouter.ai/api/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4000,
+	maxTokens: 1000,
+};
+
+const okResponse = (): Partial<Response> => ({
+	ok: true,
+	status: 200,
+	json: async () => ({
+		data: [
+			{
+				id: "vendor/live-new",
+				name: "Live New",
+				supported_parameters: ["tools"],
+				architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+				pricing: {},
+				top_provider: { max_completion_tokens: 1000 },
+				context_length: 4000,
+			},
+		],
+	}),
+});
+
+afterEach(() => resetOpenRouterModelCache());
+
+describe("getOpenRouterModels", () => {
+	test("returns cached results without a second fetch", async () => {
+		const fetchMock = vi.fn(async () => okResponse() as Response);
+		const first = await getOpenRouterModels(fetchMock as typeof fetch);
+		const second = await getOpenRouterModels(fetchMock as typeof fetch);
+		expect(first?.[0].id).toBe("vendor/live-new");
+		expect(second?.[0].id).toBe("vendor/live-new");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("deduplicates concurrent callers", async () => {
+		let resolveGate: (() => void) | undefined;
+		const gate = new Promise<void>((r) => {
+			resolveGate = r;
+		});
+		const fetchMock = vi.fn(async () => {
+			await gate;
+			return okResponse() as Response;
+		});
+		const p1 = getOpenRouterModels(fetchMock as typeof fetch);
+		const p2 = getOpenRouterModels(fetchMock as typeof fetch);
+		resolveGate?.();
+		const [a, b] = await Promise.all([p1, p2]);
+		expect(a?.[0].id).toBe("vendor/live-new");
+		expect(b?.[0].id).toBe("vendor/live-new");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("returns undefined on a cold failure", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+
+	test("returns last-known-good on a later failure and backs off", async () => {
+		vi.useFakeTimers();
+		const start = Date.now();
+		const fetchMock = vi
+			.fn(async () => okResponse() as Response)
+			.mockResolvedValueOnce(okResponse() as Response)
+			.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) } as Response);
+		await getOpenRouterModels(fetchMock as typeof fetch);
+		// Expire the fresh cache so the next call fetches and fails.
+		vi.setSystemTime(start + 5 * 60_000 + 1);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toEqual([model]);
+		// Third call within the backoff window must not fetch again.
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toEqual([model]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		vi.useRealTimers();
+	});
+
+	test("returns undefined on a malformed payload", async () => {
+		const fetchMock = vi.fn(async () => ({ ...okResponse(), json: async () => ({ not: "data" }) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+
+	test("treats a zero-valid-model payload as a failure", async () => {
+		const fetchMock = vi.fn(async () => ({ ...okResponse(), json: async () => ({ data: [{}] }) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
- openrouter adds and drops models constantly, but our list came from a snapshot baked in at release time. new models like meta/muse-spark-1.2 never showed up, and models openrouter had removed stayed in the picker.
- the catalog is now fetched from openrouter when you open the model picker or run `model list`. the snapshot is still used offline, when the request fails, and as the fallback before the first successful fetch.
- reasoning info comes from the live api too. muse spark 1.2 has to think, so it no longer offers "off", and effort levels a model does not support are hidden instead of being offered and failing.
- your models.json overrides, custom models, and provider logins still win over anything fetched. the router aliases openrouter/auto and the ~*-latest entries are kept even though the filtered endpoint does not return them.
- cached for 5 minutes with a 3 second timeout, one shared request between callers, and a 30 second backoff after a failure. startup never waits on the network, so nothing feels slower.
- the generator still has its own copy of this parsing. wiring it to the shared parser and regenerating the snapshot is a small follow-up (measured as a one line diff), left out here to keep this reviewable.

tested against the live api: 275 openrouter models with muse spark 1.2 present, 272 from the snapshot with PI_OFFLINE=1. also verified in a clean container with no daemon or prior state.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show live OpenRouter model catalog with fallback to static snapshot
> - Adds `parseOpenRouterModels` in [`packages/ai/src/openrouter-models.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/804/files#diff-72b94a81b18b69003032ae3e45c50805864bb85275242ccd014789a860b797ce) to normalize raw OpenRouter catalog entries into typed `Model<'openai-completions'>` objects, filtering non-tool, `:batch`, and non-text-output routes.
> - Adds `getOpenRouterModels` in [`packages/coding-agent/src/core/openrouter-model-catalog.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/804/files#diff-826a7bde17d30273d5f74ccb977e7c9735958ff4dc6cc6c05b71d559433ee627): a process-wide cached fetcher with TTL, timeout, deduplication, and last-known-good fallback on failures.
> - `ModelRegistry` merges live OpenRouter data with the curated static snapshot, preserving virtual aliases (`auto`, `openrouter/*`, `~*`) and static compat/featured flags absent from live results.
> - The `list-models` CLI now calls `refreshOpenRouterModels()` before listing so newly released models appear without a snapshot rebuild.
> - Behavioral Change: on each registry refresh, a live HTTP fetch to OpenRouter is attempted; cold failures return `undefined` and fall back silently to the static snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7fdc2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->