### PR TITLE
feat(coding-agent): expose ACP quiescence metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added ACP `_meta.quiescence` to report outstanding subagents and remaining autonomous continuations; `session/prompt` rejects if its live child-roster read fails.
 - Fixed resident daemon workers retaining their permitted launch environment across supervisor restarts while keeping client-owned credentials out of descriptor files.
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -934,6 +934,7 @@ interface RlmChildRun {
 	prompt: string;
 	sessionName: string;
 	sessionDir: string;
+	model: Model<Api>;
 	status: RlmChildAgentStatus;
 	error?: string;
 	abort: () => void;
@@ -9455,6 +9456,52 @@ export class AgentSession {
 		return unsubscribe;
 	}
 
+	/**
+	 * Live recursive child roster for connection snapshots.
+	 *
+	 * The run registry is authoritative while a child is queued or running; retained
+	 * sessions preserve completed children and expose any nested work that outlives
+	 * their direct parent run. This deliberately does not reconstruct state from
+	 * observer events, which can predate a newly attached connection.
+	 */
+	getRlmChildSnapshots(): RlmChildAgentSnapshot[] {
+		const snapshots: RlmChildAgentSnapshot[] = [];
+		const recorded = new Set<string>();
+		for (const run of this._activeRlmChildRuns.values()) {
+			if (run.detachedDeletion || this._deletingRlmChildren.has(run.id) || this._deletedRlmChildIds.has(run.id)) {
+				continue;
+			}
+			const child = run.session;
+			snapshots.push({
+				id: run.id,
+				parentId: this._rlmParentNodeId,
+				sessionName: child?.sessionName ?? run.sessionName,
+				model: `${(child?.model ?? run.model).provider}/${(child?.model ?? run.model).id}`,
+				label: rlmChildLabel(run.prompt),
+				status: run.status,
+				sessionDir: run.sessionDir,
+			});
+			recorded.add(run.id);
+			if (child) snapshots.push(...child.getRlmChildSnapshots());
+		}
+		for (const [childId, child] of this._rlmChildSessions) {
+			if (recorded.has(childId) || this._deletingRlmChildren.has(childId) || this._deletedRlmChildIds.has(childId)) {
+				continue;
+			}
+			snapshots.push({
+				id: childId,
+				parentId: this._rlmParentNodeId,
+				sessionName: child.sessionName,
+				model: child.model ? `${child.model.provider}/${child.model.id}` : undefined,
+				label: child.sessionName ?? "child agent",
+				status: "done",
+				sessionDir: child._rlmSessionDir ?? child.sessionManager.getSessionDir(),
+			});
+			snapshots.push(...child.getRlmChildSnapshots());
+		}
+		return snapshots;
+	}
+
 	/** True when any direct or nested subagent is still running or queued. */
 	hasRunningRlmChildren(): boolean {
 		for (const run of this._activeRlmChildRuns.values()) {
@@ -9652,6 +9699,7 @@ export class AgentSession {
 			prompt,
 			sessionName,
 			sessionDir: childSessionDir,
+			model: modelSelection.model,
 			status: "queued",
 			settled: false,
 			abort: noopRlmChildAbort,

--- a/packages/coding-agent/src/modes/acp/acp-meta.ts
+++ b/packages/coding-agent/src/modes/acp/acp-meta.ts
@@ -59,6 +59,13 @@ export interface PrimeAgentRefinementMeta {
 	error?: string;
 }
 
+export interface PrimeAgentQuiescenceMeta {
+	/** Subagents that have not reached a terminal state at the observation point. */
+	outstandingSubagents: number;
+	/** Autonomous continuation slots still available at the observation point. */
+	remainingAutonomousContinuations: number;
+}
+
 export interface PrimeAgentAgentMessageMeta {
 	toolCallId: string;
 	target?: string;
@@ -86,6 +93,7 @@ export interface PrimeAgentSessionMeta {
 	compaction?: { tokensBefore?: number; summary?: string };
 	subagents?: PrimeAgentSubagentMeta[];
 	autonomous?: PrimeAgentAutonomousMeta;
+	quiescence?: PrimeAgentQuiescenceMeta;
 	ipython?: PrimeAgentIpythonMeta;
 }
 

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -100,7 +100,6 @@ interface AcpSessionEntry {
 	id: string;
 	abort: AbortController | undefined;
 	unsubscribe: (() => void) | undefined;
-	children: Map<string, AgentConnectionRlmChildAgentSnapshot>;
 }
 
 /**
@@ -313,9 +312,10 @@ export async function runAcpModeWithConnection(
 				}
 			}
 			const sessionId = randomUUID();
-			const initialSnapshot = await connection.getInitialSnapshot().catch(() => undefined);
-			const children = new Map((initialSnapshot?.children ?? []).map((child) => [child.id, child]));
-			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined, children };
+			// Install the listener before fetching the snapshot. Child updates can arrive
+			// while the snapshot request is in flight; the connection remains the
+			// authoritative source used when quiescence is emitted below.
+			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined };
 			// Subscribe for the session lifetime, not per prompt turn: prime-agent
 			// subagents are fire-and-forget and keep reporting after the spawning turn
 			// ends, so a turn-scoped subscription would drop their updates. One
@@ -333,13 +333,15 @@ export async function runAcpModeWithConnection(
 					return;
 				}
 				if (event.type !== "session_event") return;
-				if (event.event.type === "rlm_child_update") children.set(event.event.child.id, event.event.child);
 				for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
 					notify(update);
 				}
 			});
-			// Claim the single-session slot only once the subscription exists, so a
-			// failed subscribe cannot leave the slot occupied and unusable.
+			// Reconcile after subscribing so updates cannot be lost while the snapshot
+			// request is in flight. Do not turn a failed read into an empty roster.
+			await connection.getInitialSnapshot();
+			// Claim the single-session slot only once the subscription and snapshot are
+			// ready, so a failed setup cannot leave it occupied and unusable.
 			entry.unsubscribe = unsubscribe;
 			session = entry;
 			return {
@@ -374,9 +376,12 @@ export async function runAcpModeWithConnection(
 				// Snapshot after headless completion: detached subagents can publish a
 				// terminal update after the parent model turn has gone idle.
 				const autonomous = autonomousMeta(status);
+				// Read the authoritative live roster at emission time. A session-local
+				// shadow map can miss detached children or updates during the turn.
+				const liveSnapshot = await connection.getInitialSnapshot();
 				const meta = primeAgentMeta({
 					...(autonomous ? { autonomous } : {}),
-					quiescence: quiescenceMeta(status, [...entry.children.values()]),
+					quiescence: quiescenceMeta(status, liveSnapshot.children),
 				});
 				await ctx.client
 					.notify(acp.methods.client.session.update, {

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -10,10 +10,10 @@ import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { InProcessAgentConnection } from "../agent-connection/in-process-agent-connection.js";
-import type { AgentConnection } from "../agent-connection/types.js";
+import type { AgentConnection, AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
 import { type AcpEventMappingState, acpUpdatesForSessionEvent } from "./acp-events.js";
-import { primeAgentMeta } from "./acp-meta.js";
+import { type PrimeAgentAutonomousMeta, primeAgentMeta } from "./acp-meta.js";
 import { type AcpStopReason, acpStopReason } from "./acp-stop-reason.js";
 
 /**
@@ -100,6 +100,7 @@ interface AcpSessionEntry {
 	id: string;
 	abort: AbortController | undefined;
 	unsubscribe: (() => void) | undefined;
+	children: Map<string, AgentConnectionRlmChildAgentSnapshot>;
 }
 
 /**
@@ -137,18 +138,32 @@ function promptContent(blocks: readonly unknown[]): { text: string; images: Imag
 	return { text: texts.join("\n"), images };
 }
 
-function autonomousMeta(status: AgentAutonomousStatus | undefined): Record<string, unknown> | undefined {
+function autonomousMeta(status: AgentAutonomousStatus | undefined): PrimeAgentAutonomousMeta | undefined {
 	if (!status?.enabled) return undefined;
-	return primeAgentMeta({
-		autonomous: {
-			enabled: status.enabled,
-			continuationsUsed: status.continuationsUsed,
-			turnsUsed: status.turnsUsed,
-			tokensUsed: status.tokensUsed,
-			gateAttempt: latestAutonomousGateAttempt(status) || undefined,
-			gateFailure: status.lastGateFailure?.exitText,
-		},
-	});
+	return {
+		enabled: status.enabled,
+		continuationsUsed: status.continuationsUsed,
+		turnsUsed: status.turnsUsed,
+		tokensUsed: status.tokensUsed,
+		gateAttempt: latestAutonomousGateAttempt(status) || undefined,
+		gateFailure: status.lastGateFailure?.exitText,
+	};
+}
+
+function outstandingSubagentCount(children: readonly AgentConnectionRlmChildAgentSnapshot[] | undefined): number {
+	return (children ?? []).filter((child) => child.status === "queued" || child.status === "running").length;
+}
+
+function quiescenceMeta(
+	status: AgentAutonomousStatus,
+	children: readonly AgentConnectionRlmChildAgentSnapshot[] | undefined,
+): { outstandingSubagents: number; remainingAutonomousContinuations: number } {
+	return {
+		outstandingSubagents: outstandingSubagentCount(children),
+		remainingAutonomousContinuations: status.enabled
+			? Math.max(0, status.limits.maxContinuations - status.continuationsUsed)
+			: 0,
+	};
 }
 
 /**
@@ -298,7 +313,9 @@ export async function runAcpModeWithConnection(
 				}
 			}
 			const sessionId = randomUUID();
-			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined };
+			const initialSnapshot = await connection.getInitialSnapshot().catch(() => undefined);
+			const children = new Map((initialSnapshot?.children ?? []).map((child) => [child.id, child]));
+			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined, children };
 			// Subscribe for the session lifetime, not per prompt turn: prime-agent
 			// subagents are fire-and-forget and keep reporting after the spawning turn
 			// ends, so a turn-scoped subscription would drop their updates. One
@@ -316,6 +333,7 @@ export async function runAcpModeWithConnection(
 					return;
 				}
 				if (event.type !== "session_event") return;
+				if (event.event.type === "rlm_child_update") children.set(event.event.child.id, event.event.child);
 				for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
 					notify(update);
 				}
@@ -353,15 +371,20 @@ export async function runAcpModeWithConnection(
 				// Autonomous gates continue inside this same prompt turn: the turn is
 				// only over once the gate loop settles.
 				const status = await connection.waitForHeadlessCompletion();
-				const meta = autonomousMeta(status);
-				if (meta) {
-					await ctx.client
-						.notify(acp.methods.client.session.update, {
-							sessionId: params.sessionId,
-							update: { sessionUpdate: "session_info_update", _meta: meta },
-						})
-						.catch(() => undefined);
-				}
+				// Snapshot after headless completion: detached subagents can publish a
+				// terminal update after the parent model turn has gone idle.
+				const autonomous = autonomousMeta(status);
+				const meta = primeAgentMeta({
+					...(autonomous ? { autonomous } : {}),
+					quiescence: quiescenceMeta(status, [...entry.children.values()]),
+				});
+				await ctx.client
+					.notify(acp.methods.client.session.update, {
+						sessionId: params.sessionId,
+						update: { sessionUpdate: "session_info_update", _meta: meta },
+					})
+					.catch(() => undefined);
+
 				// A turn that failed (provider error, auth, no usable model) must not be
 				// reported as a clean end_turn. Print mode surfaces
 				// `stopReason: "error"` with its errorMessage; ACP previously dropped

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -337,9 +337,16 @@ export async function runAcpModeWithConnection(
 					notify(update);
 				}
 			});
-			// Reconcile after subscribing so updates cannot be lost while the snapshot
-			// request is in flight. Do not turn a failed read into an empty roster.
-			await connection.getInitialSnapshot();
+			try {
+				// Reconcile after subscribing so updates cannot be lost while the snapshot
+				// request is in flight. Do not turn a failed read into an empty roster.
+				await connection.getInitialSnapshot();
+			} catch (error) {
+				// A failed setup never claims the session slot, but it must still release
+				// the listener installed above.
+				unsubscribe();
+				throw error;
+			}
 			// Claim the single-session slot only once the subscription and snapshot are
 			// ready, so a failed setup cannot leave it occupied and unusable.
 			entry.unsubscribe = unsubscribe;

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -262,6 +262,7 @@ export async function runAcpModeWithConnection(
 	// session keeps every event unambiguously attributable; a second session/new
 	// is refused rather than silently sharing conversation state, cwd, and queues.
 	let session: AcpSessionEntry | undefined;
+	let sessionNewInFlight = false;
 	let bound = false;
 
 	const stream =
@@ -284,77 +285,87 @@ export async function runAcpModeWithConnection(
 			_meta: primeAgentMeta({}),
 		}))
 		.onRequest("session/new", async (ctx: any) => {
-			if (!bound) {
-				// Only latch after a successful bind: a rejected bind must not leave
-				// extensions permanently unavailable for the rest of the process.
-				await options.bindHeadlessExtensions?.();
-				bound = true;
-			}
-			if (session) {
+			// Reserve the single-session slot before the first await. Otherwise two
+			// concurrent requests can both pass the empty-slot check while cwd or
+			// snapshot reads are in flight, then overwrite each other's session.
+			if (session || sessionNewInFlight) {
 				throw new Error(
 					"prime-agent ACP mode hosts one session per connection; " +
 						"start another prime-agent process for a second session",
 				);
 			}
-			// prime-agent's cwd is fixed at startup by the session it was launched
-			// with, so a client-supplied cwd cannot be adopted after the fact.
-			// Report the real cwd back in `_meta` rather than failing the request or
-			// letting the client assume a directory the agent is not using.
-			const requestedCwd = (ctx.params as { cwd?: unknown } | undefined)?.cwd;
-			let cwdMismatch: { requested: string; actual: string } | undefined;
-			if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
-				const actual = await connection
-					.getState()
-					.then((state) => state.cwd)
-					.catch(() => undefined);
-				if (actual && !sameCwd(requestedCwd, actual)) {
-					cwdMismatch = { requested: requestedCwd, actual };
-				}
-			}
-			const sessionId = randomUUID();
-			// Install the listener before fetching the snapshot. Child updates can arrive
-			// while the snapshot request is in flight; the connection remains the
-			// authoritative source used when quiescence is emitted below.
-			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined };
-			// Subscribe for the session lifetime, not per prompt turn: prime-agent
-			// subagents are fire-and-forget and keep reporting after the spawning turn
-			// ends, so a turn-scoped subscription would drop their updates. One
-			// mapping state per session keeps streaming bash output correlated with
-			// the run that produced it.
-			const mappingState: AcpEventMappingState = {};
-			const unsubscribe = connection.subscribe((event) => {
-				const notify = (update: Record<string, unknown>) =>
-					void ctx.client.notify(acp.methods.client.session.update, { sessionId, update }).catch(() => undefined);
-				// Heartbeats and cron schedules are connection-level rather than
-				// session events, but they drive the long-running work an ACP client
-				// most needs to observe.
-				if (event.type === "heartbeats_changed") {
-					notify({ sessionUpdate: "session_info_update", _meta: primeAgentMeta({ heartbeatsChanged: true }) });
-					return;
-				}
-				if (event.type !== "session_event") return;
-				for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
-					notify(update);
-				}
-			});
+			sessionNewInFlight = true;
 			try {
-				// Reconcile after subscribing so updates cannot be lost while the snapshot
-				// request is in flight. Do not turn a failed read into an empty roster.
-				await connection.getInitialSnapshot();
-			} catch (error) {
-				// A failed setup never claims the session slot, but it must still release
-				// the listener installed above.
-				unsubscribe();
-				throw error;
+				if (!bound) {
+					// Only latch after a successful bind: a rejected bind must not leave
+					// extensions permanently unavailable for the rest of the process.
+					await options.bindHeadlessExtensions?.();
+					bound = true;
+				}
+				// prime-agent's cwd is fixed at startup by the session it was launched
+				// with, so a client-supplied cwd cannot be adopted after the fact.
+				// Report the real cwd back in `_meta` rather than failing the request or
+				// letting the client assume a directory the agent is not using.
+				const requestedCwd = (ctx.params as { cwd?: unknown } | undefined)?.cwd;
+				let cwdMismatch: { requested: string; actual: string } | undefined;
+				if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
+					const actual = await connection
+						.getState()
+						.then((state) => state.cwd)
+						.catch(() => undefined);
+					if (actual && !sameCwd(requestedCwd, actual)) {
+						cwdMismatch = { requested: requestedCwd, actual };
+					}
+				}
+				const sessionId = randomUUID();
+				// Install the listener before fetching the snapshot. Child updates can arrive
+				// while the snapshot request is in flight; the connection remains the
+				// authoritative source used when quiescence is emitted below.
+				const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined };
+				// Subscribe for the session lifetime, not per prompt turn: prime-agent
+				// subagents are fire-and-forget and keep reporting after the spawning turn
+				// ends, so a turn-scoped subscription would drop their updates. One
+				// mapping state per session keeps streaming bash output correlated with
+				// the run that produced it.
+				const mappingState: AcpEventMappingState = {};
+				const unsubscribe = connection.subscribe((event) => {
+					const notify = (update: Record<string, unknown>) =>
+						void ctx.client
+							.notify(acp.methods.client.session.update, { sessionId, update })
+							.catch(() => undefined);
+					// Heartbeats and cron schedules are connection-level rather than
+					// session events, but they drive the long-running work an ACP client
+					// most needs to observe.
+					if (event.type === "heartbeats_changed") {
+						notify({ sessionUpdate: "session_info_update", _meta: primeAgentMeta({ heartbeatsChanged: true }) });
+						return;
+					}
+					if (event.type !== "session_event") return;
+					for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
+						notify(update);
+					}
+				});
+				try {
+					// Reconcile after subscribing so updates cannot be lost while the snapshot
+					// request is in flight. Do not turn a failed read into an empty roster.
+					await connection.getInitialSnapshot();
+				} catch (error) {
+					// A failed setup never claims the session slot, but it must still release
+					// the listener installed above.
+					unsubscribe();
+					throw error;
+				}
+				// Claim the single-session slot only once the subscription and snapshot are
+				// ready, so a failed setup cannot leave it occupied and unusable.
+				entry.unsubscribe = unsubscribe;
+				session = entry;
+				return {
+					sessionId,
+					...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),
+				};
+			} finally {
+				sessionNewInFlight = false;
 			}
-			// Claim the single-session slot only once the subscription and snapshot are
-			// ready, so a failed setup cannot leave it occupied and unusable.
-			entry.unsubscribe = unsubscribe;
-			session = entry;
-			return {
-				sessionId,
-				...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),
-			};
 		})
 		.onRequest("session/prompt", async (ctx: any) => {
 			const params = ctx.params as { sessionId: string; prompt: readonly unknown[] };

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -62,6 +62,7 @@ import type {
 	AgentConnectionQueueMode,
 	AgentConnectionQueueState,
 	AgentConnectionResourceSnapshot,
+	AgentConnectionRlmChildAgentSnapshot,
 	AgentConnectionSavedSessionInfo,
 	AgentConnectionSavedSessionScope,
 	AgentConnectionScopedModel,
@@ -1467,6 +1468,9 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (message.event.type !== "refine_complete" && message.event.type !== "refine_failed") {
 				this.observeStreamingMessage(message.event);
 			}
+			if (message.event.type === "rlm_child_update") {
+				this.observeRlmChildUpdate(message.event.child);
+			}
 			this.latestSnapshotIsFresh = false;
 			await this.emit({ type: "session_event", event: message.event });
 			return;
@@ -1891,6 +1895,19 @@ export class DaemonAgentConnection implements AgentConnection {
 		} else if (purpose === "resync") {
 			await this.emit({ type: "session_resynced", snapshot: this.latestSnapshot });
 		}
+	}
+
+	private observeRlmChildUpdate(child: AgentConnectionRlmChildAgentSnapshot): void {
+		if (!this.latestSnapshot) return;
+		const children = this.latestSnapshot.children ?? [];
+		const index = children.findIndex((candidate) => candidate.id === child.id);
+		const updatedChildren = [...children];
+		if (index === -1) {
+			updatedChildren.push(child);
+		} else {
+			updatedChildren[index] = child;
+		}
+		this.latestSnapshot = { ...this.latestSnapshot, children: updatedChildren };
 	}
 
 	private observeStreamingMessage(event: AgentSessionEvent): void {

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -74,6 +74,7 @@ export function createAgentConnectionSnapshot(
 			tree: sessionManager.getTree(),
 			leafId: sessionManager.getLeafId(),
 		},
+		children: session.getRlmChildSnapshots(),
 	};
 }
 

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -600,6 +600,7 @@ interface CreateAttachResultOptions {
 	omitSessionContext?: boolean;
 	sessionTree?: DaemonAttachResult["snapshot"]["sessionTree"];
 	parent?: DaemonAttachResult["snapshot"]["parent"];
+	children?: DaemonAttachResult["snapshot"]["children"];
 	replay?: DaemonAttachResult["replay"];
 }
 
@@ -654,6 +655,7 @@ function createAttachResult(
 			lastEventSequence,
 			lastEventCursor,
 			...(options.parent ? { parent: options.parent } : {}),
+			...(options.children ? { children: options.children } : {}),
 		},
 		replay: options.replay ?? {
 			status: "complete",
@@ -2136,6 +2138,40 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests.at(-1)).toMatchObject({
 			type: "attach",
 			activeSessionId: "active-restored",
+		});
+	});
+
+	it("keeps the live child roster after an empty attach snapshot", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) =>
+			createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12, { children: [] });
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await connection.attach();
+		fakeClient.emitMessage({
+			type: "session_event",
+			activeSessionId: "active-1",
+			event: {
+				type: "rlm_child_update",
+				child: {
+					id: "child-live",
+					label: "live child",
+					status: "running",
+					sessionDir: "/tmp/child-live",
+				},
+			},
+			meta: {
+				id: "active-1:13",
+				protocol: DAEMON_PROTOCOL_INFO,
+				activeSessionId: "active-1",
+				sequence: 13,
+				cursor: { generation: "generation-active-1", sequence: 13 },
+				emittedAt: "2026-01-01T00:00:00.000Z",
+			},
+		});
+
+		await expect(connection.getInitialSnapshot()).resolves.toMatchObject({
+			children: [expect.objectContaining({ id: "child-live", status: "running" })],
 		});
 	});
 

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -108,6 +108,7 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 		getActiveToolNames: () => ["ipython"],
 		getContextUsage: () => undefined,
 		cancelRlmChildRun: (childId: string) => childId === "child-1",
+		getRlmChildSnapshots: () => [],
 		getToolDefinition: (toolName: string) => ({
 			name: toolName,
 			label: toolName,

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -173,6 +173,32 @@ describe("ACP mode end to end", () => {
 		close();
 	});
 
+	it("propagates a failed roster read at quiescence emission", async () => {
+		// A snapshot failure while emitting must not degrade to outstandingSubagents: 0.
+		// Reporting a fabricated zero is the false-quiescent answer this metadata
+		// exists to prevent: a consumer would score a turn whose children still run.
+		const connection = fakeAcpConnection({
+			// `initialSnapshot` serves session/new and is then consumed; `finalSnapshot`
+			// serves the emission-time read, which is the one under test here.
+			initialSnapshot: async () => ({ state: { cwd: process.cwd() }, messages: [], children: [] }),
+			finalSnapshot: async () => {
+				throw new Error("roster unavailable");
+			},
+		});
+		const { client, updates, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: process.cwd(), mcpServers: [] });
+		await expect(
+			client.request("session/prompt", {
+				sessionId: session.sessionId,
+				prompt: [{ type: "text", text: "finish" }],
+			}),
+		).rejects.toThrow();
+		const quiescence = updates.find((u) => u.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence);
+		expect(quiescence).toBeUndefined();
+		close();
+	});
+
 	it("counts the authoritative live roster at quiescence emission", async () => {
 		const child = { id: "child-1", label: "child", status: "running", sessionDir: "/tmp/child" };
 		const connection = fakeAcpConnection({

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -84,4 +84,23 @@ describe("ACP mode end to end", () => {
 
 		harness.cleanup();
 	}, 30_000);
+
+	it("emits score-safe quiescence metadata with outstanding work and budget", async () => {
+		const harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("done")]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const { client, updates } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "finish" }],
+		});
+		const quiescence = updates.find((u) => u.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence);
+		expect(quiescence?.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence).toEqual({
+			outstandingSubagents: 0,
+			remainingAutonomousContinuations: 0,
+		});
+		harness.cleanup();
+	}, 30_000);
 });

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -29,6 +29,50 @@ interface ClientHarness {
 	close: () => void;
 }
 
+function fakeAcpConnection(
+	options: {
+		initialSnapshot?: () => Promise<any>;
+		finalSnapshot?: () => Promise<any>;
+		onInitialSnapshot?: (subscribed: boolean) => void;
+	} = {},
+): any {
+	let listener: ((event: any) => void) | undefined;
+	let subscribed = false;
+	const snapshot = { state: { cwd: process.cwd() }, messages: [] };
+	return {
+		subscribe(callback: (event: any) => void) {
+			subscribed = true;
+			listener = callback;
+			return () => {
+				listener = undefined;
+			};
+		},
+		getState: async () => snapshot.state,
+		getMessages: async () => [],
+		getInitialSnapshot: async () => {
+			if (options.onInitialSnapshot) options.onInitialSnapshot(subscribed);
+			if (options.initialSnapshot) {
+				const result = await options.initialSnapshot();
+				options.initialSnapshot = undefined;
+				return result;
+			}
+			if (options.finalSnapshot) return options.finalSnapshot();
+			return snapshot;
+		},
+		promptAndWait: async () => {},
+		waitForHeadlessCompletion: async () => ({
+			enabled: false,
+			continuationsUsed: 0,
+			turnsUsed: 0,
+			tokensUsed: 0,
+			limits: { maxContinuations: 0 },
+		}),
+		emitChild(child: any) {
+			listener?.({ type: "session_event", event: { type: "rlm_child_update", child } });
+		},
+	};
+}
+
 function connectAcpClient(connection: any): ClientHarness {
 	// Two web streams crossed over: agent's stdout is the client's stdin.
 	const toAgent = new TransformStream<Uint8Array, Uint8Array>();
@@ -103,4 +147,47 @@ describe("ACP mode end to end", () => {
 		});
 		harness.cleanup();
 	}, 30_000);
+	it("fails session creation when the initial roster snapshot fails", async () => {
+		const connection = fakeAcpConnection({
+			initialSnapshot: async () => {
+				throw new Error("snapshot unavailable");
+			},
+		});
+		const { client, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		await expect(client.request("session/new", { cwd: process.cwd(), mcpServers: [] })).rejects.toThrow();
+		close();
+	});
+
+	it("subscribes before taking the initial roster snapshot", async () => {
+		let subscribedAtSnapshot: boolean | undefined;
+		const connection = fakeAcpConnection({
+			onInitialSnapshot: (subscribed) => {
+				subscribedAtSnapshot = subscribed;
+			},
+		});
+		const { client, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		await client.request("session/new", { cwd: process.cwd(), mcpServers: [] });
+		expect(subscribedAtSnapshot).toBe(true);
+		close();
+	});
+
+	it("counts the authoritative live roster at quiescence emission", async () => {
+		const child = { id: "child-1", label: "child", status: "running", sessionDir: "/tmp/child" };
+		const connection = fakeAcpConnection({
+			initialSnapshot: async () => ({ state: { cwd: process.cwd() }, messages: [], children: [] }),
+			finalSnapshot: async () => ({ state: { cwd: process.cwd() }, messages: [], children: [child] }),
+		});
+		const { client, updates, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: process.cwd(), mcpServers: [] });
+		await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "finish" }],
+		});
+		const quiescence = updates.find((u) => u.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence);
+		expect(quiescence.update._meta[PRIME_AGENT_META_NAMESPACE].quiescence.outstandingSubagents).toBe(1);
+		close();
+	});
 });

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -34,6 +34,7 @@ function fakeAcpConnection(
 		initialSnapshot?: () => Promise<any>;
 		finalSnapshot?: () => Promise<any>;
 		onInitialSnapshot?: (subscribed: boolean) => void;
+		onUnsubscribe?: () => void;
 	} = {},
 ): any {
 	let listener: ((event: any) => void) | undefined;
@@ -45,6 +46,7 @@ function fakeAcpConnection(
 			listener = callback;
 			return () => {
 				listener = undefined;
+				options.onUnsubscribe?.();
 			};
 		},
 		getState: async () => snapshot.state,
@@ -156,6 +158,23 @@ describe("ACP mode end to end", () => {
 		const { client, close } = connectAcpClient(connection);
 		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
 		await expect(client.request("session/new", { cwd: process.cwd(), mcpServers: [] })).rejects.toThrow();
+		close();
+	});
+
+	it("releases the subscription when the initial roster snapshot fails", async () => {
+		let unsubscribeCount = 0;
+		const connection = fakeAcpConnection({
+			initialSnapshot: async () => {
+				throw new Error("snapshot unavailable");
+			},
+			onUnsubscribe: () => {
+				unsubscribeCount += 1;
+			},
+		});
+		const { client, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		await expect(client.request("session/new", { cwd: process.cwd(), mcpServers: [] })).rejects.toThrow();
+		expect(unsubscribeCount).toBe(1);
 		close();
 	});
 

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,6 +1,6 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
@@ -149,6 +149,39 @@ describe("ACP mode end to end", () => {
 		});
 		harness.cleanup();
 	}, 30_000);
+
+	it("reports a live in-process child that spawned after ACP attached", async () => {
+		const harness = await createHarness({ rlmDepth: 0, rlmMaxDepth: 1 });
+		let releaseChild!: () => void;
+		const childReleased = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		harness.setResponses([
+			async () => {
+				await childReleased;
+				return fauxAssistantMessage("child done");
+			},
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const { client, updates } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		// The child is admitted after ACP attaches, so an attach-time snapshot was
+		// empty. Its run stays live while the independent parent prompt completes.
+		await harness.session.runRlmChild("continue in the background");
+		harness.appendResponses([fauxAssistantMessage("parent done")]);
+		await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "finish the parent turn" }],
+		});
+		const quiescence = updates.find((update) => update.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence);
+		expect(quiescence?.update?._meta?.[PRIME_AGENT_META_NAMESPACE]?.quiescence.outstandingSubagents).toBe(1);
+
+		releaseChild();
+		await vi.waitFor(() => expect(harness.session.getRlmChildSnapshots()[0]?.status).toBe("done"));
+		harness.cleanup();
+	}, 30_000);
+
 	it("fails session creation when the initial roster snapshot fails", async () => {
 		const connection = fakeAcpConnection({
 			initialSnapshot: async () => {

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -178,6 +178,32 @@ describe("ACP mode end to end", () => {
 		close();
 	});
 
+	it("rejects a concurrent session creation while the first snapshot is pending", async () => {
+		let enteredSnapshot!: () => void;
+		let releaseSnapshot!: () => void;
+		const snapshotEntered = new Promise<void>((resolve) => {
+			enteredSnapshot = resolve;
+		});
+		const snapshotReleased = new Promise<void>((resolve) => {
+			releaseSnapshot = resolve;
+		});
+		const connection = fakeAcpConnection({
+			initialSnapshot: async () => {
+				enteredSnapshot();
+				await snapshotReleased;
+				return { state: { cwd: process.cwd() }, messages: [], children: [] };
+			},
+		});
+		const { client, close } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const first = client.request("session/new", { cwd: process.cwd(), mcpServers: [] });
+		await snapshotEntered;
+		await expect(client.request("session/new", { cwd: process.cwd(), mcpServers: [] })).rejects.toThrow();
+		releaseSnapshot();
+		await expect(first).resolves.toMatchObject({ sessionId: expect.any(String) });
+		close();
+	});
+
 	it("subscribes before taking the initial roster snapshot", async () => {
 		let subscribedAtSnapshot: boolean | undefined;
 		const connection = fakeAcpConnection({


### PR DESCRIPTION
## Why

An ACP client cannot currently tell whether a completed turn is safe to act on. Prime Agent subagents are fire-and-forget and keep working after the spawning turn ends, and autonomous mode may still have continuation budget left. A consumer that scores or ends the session at `end_turn` can therefore cut off live work, and the result depends on a race.

This is not derivable client-side: `tool_execution_update`, `auto_retry_*`, `auth_stale` and `recap_update` have no ACP representation, so there is no event stream a client could reconstruct quiescence from.

## What changed

Adds `quiescence` to the existing namespaced envelope:

```
_meta["ai.primeintellect.prime-agent"].quiescence = {
  outstandingSubagents: number,
  remainingAutonomousContinuations: number,
}
```

Counted from the authoritative live roster (queued plus running) rather than reconstructed from child deltas, and emitted after headless completion so it describes the state at the point the turn is reported done.

The turn **reports** rather than **waits**. Blocking `session/prompt` on quiescence would deadlock against detached subagent semantics — a child can legitimately outlive many turns — so the client decides what to do with the signal.

Additive and namespaced: vanilla ACP clients ignore unknown `_meta`. No previously-declared-but-unemitted field is touched.

## Validation

- `npm run check`: Biome 898 files, installer render, browser smoke all pass
- `test/suite/acp-mode.test.ts`: 2/2
- mutation: changing the outstanding count to `+ 1` fails the assertion; restoring passes

Stacked on #805.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP `session/prompt` and `session/new` failure modes (roster read failures now reject prompts) and introduce authoritative child-roster plumbing used by external clients; behavior is additive in `_meta` but correctness-sensitive for scoring/automation.
> 
> **Overview**
> ACP clients get a **quiescence** signal in namespaced `_meta` after each `session/prompt` turn completes headless work: **outstanding subagents** (queued/running from a live roster) and **remaining autonomous continuations**. The turn still reports `end_turn` without blocking on detached children; clients choose how to act on the signal.
> 
> **`AgentSession.getRlmChildSnapshots()`** builds a recursive live child roster from active runs and retained child sessions (with model on runs), and connection snapshots/daemon clients merge **`rlm_child_update`** events so empty attach snapshots do not erase live children.
> 
> **ACP session lifecycle** hardening: subscribe before the initial snapshot, reject `session/new` on snapshot failure (unsubscribe cleanup), guard concurrent `session/new` with an in-flight flag, and **fail `session/prompt`** if the emission-time roster read fails instead of emitting a false zero count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6447725af40a3354c373f0ee926b182803f6f098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose ACP quiescence metadata with live subagent roster in `session/prompt` responses
> - `session/prompt` now emits `_meta.quiescence` after completion, reporting `outstandingSubagents` and `remainingAutonomousContinuations` from a live authoritative child roster snapshot.
> - `AgentSession.getRlmChildSnapshots` provides a recursive, flattened list of child agent snapshots (id, label, status, model, sessionDir) from both the active run registry and retained child sessions.
> - `DaemonAgentConnection` now updates its cached `latestSnapshot.children` as `rlm_child_update` events arrive, keeping the in-memory roster current.
> - `session/new` now rejects concurrent creation attempts while a first request is pending, and rejects (without claiming the session slot) if the initial roster snapshot read fails.
> - Risk: `session/prompt` and `session/new` now fail hard if the live roster snapshot read fails, rather than succeeding with incomplete metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6447725.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->