### PR TITLE
feat(ai,coding-agent): advisory model-fitness skill with generation-time benchmark metadata

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+<<<<<<< HEAD
+=======
+- Added an OpenRouter OAuth provider so OpenRouter can be authenticated with a browser sign-in instead of an API key ([#775](https://github.com/PrimeIntellect-ai/prime-agent/pull/775) by [@andrew-scott-fischer](https://github.com/andrew-scott-fischer)).
+- Added optional `benchmarks` metadata (Artificial Analysis intelligence/coding/agentic indices) to `Model`, populated at catalog generation time from the already-fetched OpenRouter catalog.
+
+>>>>>>> a986fbc4 (feat(ai,coding-agent): add advisory model-fitness skill for delegation)
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -19,6 +19,7 @@ import {
 	type OpenAICompletionsCompat,
 } from "../src/types.js";
 import { MODELS as EXISTING_MODELS } from "../src/models.generated.js";
+import { buildOpenRouterBenchmarkIndex, matchOpenRouterBenchmarks } from "./openrouter-benchmarks.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -2321,7 +2322,16 @@ async function generateModels() {
 		}));
 	allModels.push(...azureOpenAiModels);
 
+	// Attach external benchmark indices from the already-fetched OpenRouter
+	// catalog. Models without benchmark coverage simply omit the field.
+	const openRouterBenchmarkIndex = buildOpenRouterBenchmarkIndex(await fetchOpenRouterCatalog());
+	let benchmarkedModels = 0;
 	for (const model of allModels) {
+		const benchmarks = matchOpenRouterBenchmarks(openRouterBenchmarkIndex, model);
+		if (benchmarks) {
+			model.benchmarks = benchmarks;
+			benchmarkedModels++;
+		}
 		applyThinkingLevelMetadata(model);
 	}
 
@@ -2387,6 +2397,9 @@ export const MODELS = {
 			if (model.featured) {
 				output += `\t\t\tfeatured: true,\n`;
 			}
+			if (model.benchmarks) {
+				output += `\t\t\tbenchmarks: ${JSON.stringify(model.benchmarks)},\n`;
+			}
 			output += `\t\t} satisfies Model<"${model.api}">,\n`;
 		}
 
@@ -2407,6 +2420,7 @@ export const MODELS = {
 	console.log(`\nModel Statistics:`);
 	console.log(`  Total tool-capable models: ${totalModels}`);
 	console.log(`  Reasoning-capable models: ${reasoningModels}`);
+	console.log(`  Models with benchmark metadata: ${benchmarkedModels}`);
 
 	for (const [provider, models] of Object.entries(providers)) {
 		console.log(`  ${provider}: ${Object.keys(models).length} models`);

--- a/packages/ai/scripts/openrouter-benchmarks.ts
+++ b/packages/ai/scripts/openrouter-benchmarks.ts
@@ -1,0 +1,103 @@
+/**
+ * Cross-reference helper for catalog generation: extracts the benchmark indices
+ * OpenRouter embeds in its public model catalog (Artificial Analysis scores)
+ * and matches them onto models from any provider, so `models.generated.ts` can
+ * carry them without a runtime network call.
+ *
+ * Matching is conservative: exact id first, then a normalized token-multiset
+ * key so first-party ids like "claude-sonnet-4-5" match OpenRouter's
+ * "anthropic/claude-4.5-sonnet". Ambiguous keys are dropped rather than
+ * guessing. Unmatched models simply carry no benchmark metadata.
+ */
+
+import type { ModelBenchmarks } from "../src/types.js";
+
+export type OpenRouterBenchmarkIndex = Map<string, ModelBenchmarks | undefined>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toScore(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 100) {
+		return undefined;
+	}
+	return value;
+}
+
+/** Extract the benchmark block from one raw OpenRouter catalog entry, if present. */
+export function readOpenRouterBenchmarks(entry: unknown): ModelBenchmarks | undefined {
+	if (!isRecord(entry) || !isRecord(entry.benchmarks)) return undefined;
+	const aa = entry.benchmarks.artificial_analysis;
+	if (!isRecord(aa)) return undefined;
+	const benchmarks: ModelBenchmarks = {};
+	const intelligence = toScore(aa.intelligence_index);
+	const coding = toScore(aa.coding_index);
+	const agentic = toScore(aa.agentic_index);
+	if (intelligence !== undefined) benchmarks.intelligence = intelligence;
+	if (coding !== undefined) benchmarks.coding = coding;
+	if (agentic !== undefined) benchmarks.agentic = agentic;
+	return Object.keys(benchmarks).length > 0 ? benchmarks : undefined;
+}
+
+/**
+ * Normalize a model id to a token-multiset key. Splits on non-alphanumerics,
+ * drops date (YYYYMMDD) and version (vN) tokens, and sorts, so word-order and
+ * punctuation differences across catalogs collapse ("claude-sonnet-4-5" ==
+ * "claude-4.5-sonnet-20250929").
+ */
+export function benchmarkTokenKey(modelId: string): string {
+	const suffix = modelId.includes("/") ? modelId.slice(modelId.indexOf("/") + 1) : modelId;
+	const tokens = suffix
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((token) => token.length > 0 && !/^\d{8}$/.test(token) && !/^v\d+$/.test(token));
+	tokens.sort();
+	return tokens.join(".");
+}
+
+/**
+ * Build a lookup from an OpenRouter catalog (the `data` array). Exact lowercase
+ * ids and canonical slugs are indexed directly; token keys are indexed only
+ * when a single catalog record owns the key.
+ */
+export function buildOpenRouterBenchmarkIndex(catalog: unknown[]): OpenRouterBenchmarkIndex {
+	const index: OpenRouterBenchmarkIndex = new Map();
+	const byTokenKey = new Map<string, ModelBenchmarks | null>();
+
+	for (const entry of catalog) {
+		if (!isRecord(entry) || typeof entry.id !== "string") continue;
+		const benchmarks = readOpenRouterBenchmarks(entry);
+		if (!benchmarks) continue;
+		const ids = [entry.id.toLowerCase()];
+		if (typeof entry.canonical_slug === "string" && entry.canonical_slug) {
+			ids.push(entry.canonical_slug.toLowerCase());
+		}
+		for (const id of ids) {
+			index.set(id, benchmarks);
+		}
+		const tokenKey = benchmarkTokenKey(entry.id);
+		if (tokenKey) {
+			const existing = byTokenKey.get(tokenKey);
+			// Same record repeated under id + canonical slug is fine; two distinct
+			// benchmark blocks for one key is ambiguous and must not match.
+			byTokenKey.set(tokenKey, existing === undefined ? benchmarks : existing === benchmarks ? benchmarks : null);
+		}
+	}
+
+	for (const [key, benchmarks] of byTokenKey) {
+		if (benchmarks) index.set(`token:${key}`, benchmarks);
+	}
+	return index;
+}
+
+/** Look up benchmarks for a model. OpenRouter ids match exactly; other providers fall back to the token key. */
+export function matchOpenRouterBenchmarks(
+	index: OpenRouterBenchmarkIndex,
+	model: { provider: string; id: string },
+): ModelBenchmarks | undefined {
+	const exact = index.get(model.id.toLowerCase());
+	if (exact) return exact;
+	const tokenKey = benchmarkTokenKey(model.id);
+	return tokenKey ? index.get(`token:${tokenKey}`) : undefined;
+}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -435,6 +435,16 @@ export interface VercelGatewayRouting {
 	order?: string[];
 }
 
+/** Benchmark indices attached at catalog generation time (0-100 scale). */
+export interface ModelBenchmarks {
+	/** Artificial Analysis Intelligence Index. */
+	intelligence?: number;
+	/** Artificial Analysis Coding Index. */
+	coding?: number;
+	/** Artificial Analysis Agentic Index. */
+	agentic?: number;
+}
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api> {
 	id: string;
@@ -459,6 +469,13 @@ export interface Model<TApi extends Api> {
 	maxTokens: number;
 	/** Flagship model surfaced above non-featured models of the same provider in pickers. */
 	featured?: boolean;
+	/**
+	 * External benchmark indices (0-100 scale) attached at catalog generation time.
+	 * Currently sourced from Artificial Analysis scores embedded in the OpenRouter
+	 * catalog. Absent when no benchmark source covers the model; consumers must
+	 * treat absence as "unknown", never as a zero score.
+	 */
+	benchmarks?: ModelBenchmarks;
 	headers?: Record<string, string>;
 	/** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
 	compat?: TApi extends "openai-completions"

--- a/packages/ai/test/openrouter-benchmarks.test.ts
+++ b/packages/ai/test/openrouter-benchmarks.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	benchmarkTokenKey,
+	buildOpenRouterBenchmarkIndex,
+	matchOpenRouterBenchmarks,
+	readOpenRouterBenchmarks,
+} from "../scripts/openrouter-benchmarks.js";
+
+const catalog = [
+	{
+		id: "anthropic/claude-sonnet-4.5",
+		canonical_slug: "anthropic/claude-4.5-sonnet-20250929",
+		benchmarks: { artificial_analysis: { intelligence_index: 36.4, coding_index: 52.1, agentic_index: 24.6 } },
+	},
+	{
+		id: "openai/gpt-5.6-terra",
+		canonical_slug: "openai/gpt-5.6-terra",
+		benchmarks: { artificial_analysis: { intelligence_index: 54, coding_index: 76.7, agentic_index: 47.4 } },
+	},
+	{ id: "unbenchmarked/model", benchmarks: { design_arena: [] } },
+];
+
+describe("openrouter benchmark cross-reference", () => {
+	it("reads the embedded Artificial Analysis indices", () => {
+		expect(readOpenRouterBenchmarks(catalog[0])).toEqual({ intelligence: 36.4, coding: 52.1, agentic: 24.6 });
+		expect(readOpenRouterBenchmarks(catalog[2])).toBeUndefined();
+		expect(readOpenRouterBenchmarks({})).toBeUndefined();
+	});
+
+	it("matches OpenRouter provider ids exactly", () => {
+		const index = buildOpenRouterBenchmarkIndex(catalog);
+		expect(matchOpenRouterBenchmarks(index, { provider: "openrouter", id: "anthropic/claude-sonnet-4.5" })).toEqual({
+			intelligence: 36.4,
+			coding: 52.1,
+			agentic: 24.6,
+		});
+	});
+
+	it("matches first-party ids with different punctuation and word order", () => {
+		const index = buildOpenRouterBenchmarkIndex(catalog);
+		expect(matchOpenRouterBenchmarks(index, { provider: "anthropic", id: "claude-sonnet-4-5" })).toEqual({
+			intelligence: 36.4,
+			coding: 52.1,
+			agentic: 24.6,
+		});
+		expect(matchOpenRouterBenchmarks(index, { provider: "openai", id: "gpt-5.6-terra" })?.coding).toBe(76.7);
+	});
+
+	it("normalizes token keys by dropping dates and versions", () => {
+		expect(benchmarkTokenKey("anthropic/claude-4.5-sonnet-20250929")).toBe(benchmarkTokenKey("claude-sonnet-4-5"));
+		expect(benchmarkTokenKey("us.anthropic.claude-sonnet-4-5-v1:0")).toContain("claude");
+	});
+
+	it("returns undefined for unmatched models instead of guessing", () => {
+		const index = buildOpenRouterBenchmarkIndex(catalog);
+		expect(matchOpenRouterBenchmarks(index, { provider: "mistral", id: "mistral-large-3" })).toBeUndefined();
+	});
+
+	it("drops ambiguous token keys", () => {
+		const ambiguous = buildOpenRouterBenchmarkIndex([
+			{ id: "a/foo-bar", benchmarks: { artificial_analysis: { coding_index: 10 } } },
+			{ id: "b/bar-foo", benchmarks: { artificial_analysis: { coding_index: 90 } } },
+		]);
+		expect(matchOpenRouterBenchmarks(ambiguous, { provider: "other", id: "foo-bar" })).toBeUndefined();
+		expect(matchOpenRouterBenchmarks(ambiguous, { provider: "openrouter", id: "a/foo-bar" })?.coding).toBe(10);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed agent-driven model discovery and subagent selection to honor the user's configured model scope.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Changed agent-driven model discovery and subagent selection to honor the user's configured model scope.
+- Added an advisory `model-fitness` skill that recommends task-appropriate subagent models from scoped candidates, generation-time benchmark annotations, cost, and recorded outcomes.
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -148,7 +148,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/login`, `/logout` | OAuth authentication |
 | `/model` | Switch models |
 | `/effort` | Set reasoning/thinking level |
-| `/scoped-models` | Enable/disable models for Ctrl+P cycling |
+| `/scoped-models` | Set models available for cycling and agent-driven selection |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Open the searchable session view |
 | `/new`, `/clear` | Start a new session |
@@ -554,7 +554,7 @@ cat README.md | prime-agent -p "Summarize this text"
 | `--model <pattern>` | Model pattern or ID (supports `provider/id` and optional `:<thinking>`) |
 | `--api-key <key>` | API key (overrides env vars) |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
-| `--models <patterns>` | Comma-separated patterns for Ctrl+P cycling |
+| `--models <patterns>` | Comma-separated model scope for cycling and agent-driven selection |
 
 Use `prime-agent model list [search]` to list available models.
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -153,7 +153,7 @@ Supported `rlm.run` options are:
 - `name`: a unique readable child session name; and
 - `model`: an exact `provider/model` selector from `rlm.find_models()`.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options fail instead of being ignored. Model search is bounded to the user's configured model scope when one is active, then further limited to executable models with active, non-expired credentials. If no scope is configured, all executable models remain searchable. If an exact selection is outside the scope, unavailable, or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
 
 ## Child Execution
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -155,6 +155,8 @@ Supported `rlm.run` options are:
 
 Unknown options fail instead of being ignored. Model search is bounded to the user's configured model scope when one is active, then further limited to executable models with active, non-expired credentials. If no scope is configured, all executable models remain searchable. If an exact selection is outside the scope, unavailable, or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
 
+For advisory task-to-model selection, the bundled `model-fitness` skill exposes `recommend`, `explain`, and `record_outcome`. Its candidate metadata — including generation-time benchmark annotations — comes from the same scoped/executable catalog through the read-only `model_fitness.candidates` host request, then applies benchmark priors and independently verified local outcomes. The skill returns an exact selector only; admission still revalidates it, and omitting `model` preserves parent-model inheritance.
+
 ## Child Execution
 
 `AgentSession.runRlmChild()` performs the following sequence:

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -190,7 +190,7 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `enabledModels` | string[] | - | Model patterns for Ctrl+P cycling (same format as `--models` CLI flag) |
+| `enabledModels` | string[] | - | Model scope for cycling and agent-driven selection (same format as `--models`) |
 
 ```json
 {

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -50,9 +50,38 @@ Prime Agent ships with built-in skills that load by default:
 
 - `prime-intellect` - Prime Intellect products and workflows via the prime CLI: verifiers environments and the Environments Hub, evaluations (local and hosted), Hosted Training and prime-rl, sandboxes, tunnels, Prime Inference, GPU compute, and storage. Reference docs for each area load on demand from the skill's `references/` directory.
 - `skill-creator` - teaches the agent to create new skills: markdown skill layout, frontmatter rules, placement and precedence, and the full Python-backed skill contract (package layout, `run()` convention, optional CLI, kernel venv behavior) with a working template in `references/python-skills.md`.
+- `model-fitness` - a Python-backed advisory model selector for delegated tasks, combining OpenRouter benchmark priors, scoped model metadata, cost, and verified local outcomes.
 - `websearch` - a Python-backed Google search skill using the [Serper](https://serper.dev) API.
 
 Built-in skills behave like any other skill but have the lowest precedence: a user, project, package, or `--skill` skill with the same name overrides the built-in one.
+
+### model-fitness
+
+Use `model-fitness` when delegating work and the task may warrant a model other
+than the parent's. The skill is advisory: it returns an exact scoped model
+selector and score breakdown, and the agent still passes it explicitly to
+`rlm(..., model=selector)`. If no model clears the task requirements, omit the
+`model` argument to keep normal parent-model inheritance.
+
+```python
+recommendation = await model_fitness.recommend(
+    "Review the refactor for correctness and regressions",
+    task_family="code_review",
+)
+if recommendation["recommended"] is not None:
+    child = await rlm(
+        "Review the refactor for correctness and regressions",
+        model=recommendation["recommended"]["selector"],
+    )
+```
+
+Benchmark scores are baked into the generated model catalog at build time (see
+`packages/ai/scripts/generate-models.ts`), sourced from the OpenRouter catalog's
+embedded Artificial Analysis intelligence/coding/agentic indices. Coverage is
+partial: models without benchmark data are scored with a neutral low-confidence
+prior, and unpriced models are flagged rather than treated as free. Independently
+verified local outcomes can be recorded with `model_fitness.record_outcome(...)`;
+ordinary child completion is not treated as proof of quality.
 
 ### websearch
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -40,7 +40,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/login`, `/logout` | Manage OAuth or API-key credentials |
 | `/model` | Switch models |
 | `/effort` | Set the reasoning/thinking level |
-| `/scoped-models` | Enable/disable models for Ctrl+P cycling |
+| `/scoped-models` | Set models available for cycling and agent-driven selection |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
@@ -207,7 +207,7 @@ cat README.md | prime-agent -p "Summarize this text"
 | `--model <pattern>` | Model pattern or ID; supports `provider/id` and optional `:<thinking>` |
 | `--api-key <key>` | API key, overriding environment variables |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
-| `--models <patterns>` | Comma-separated patterns for Ctrl+P cycling |
+| `--models <patterns>` | Comma-separated model scope for cycling and agent-driven selection |
 
 Use `prime-agent model list [search]` to list available models.
 

--- a/packages/coding-agent/skills/model-fitness/SKILL.md
+++ b/packages/coding-agent/skills/model-fitness/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: model-fitness
+description: Recommend a scoped, authenticated subagent model for a delegated task using generation-time benchmark annotations, task requirements, declared cost, and recorded local outcomes. Use when delegating work with rlm(...) and a model other than the parent may be more capable or cost-effective for the task.
+---
+
+# Model Fitness
+
+Recommendations are advisory. This skill does not spawn subagents and never changes
+the parent model. Use the returned exact selector explicitly:
+
+```python
+recommendation = await model_fitness.recommend(
+    "Review the authentication refactor for regressions",
+    task_family="code_review",
+)
+selector = recommendation["recommended"]["selector"]
+child = await rlm("Review the authentication refactor", model=selector)
+```
+
+If `recommended` is `None`, omit the `model` argument and keep normal parent-model
+inheritance. Spawn admission remains authoritative and rechecks scope, credentials,
+and executable availability.
+
+## API
+
+- `await model_fitness.recommend(task, task_family=None, requirements=None, limit=3)`
+  ranks currently scoped, authenticated, executable models. Requirements may include
+  `image`, `reasoning`, `min_context_tokens`, `min_output_tokens`, `max_cost_usd`,
+  `quality_floor`, `expected_input_tokens`, `expected_output_tokens`, and `explore`.
+- `await model_fitness.record_outcome(selector, task_family, verdict, score=None,
+  task=None, duration_ms=None, cost_usd=None, evidence=None)` records an independently
+  verified outcome in the local continual-harness memory. Verdicts are
+  `validated_pass`, `validated_fail`, `accepted`, `rejected`, and `unknown`.
+- `await model_fitness.explain(selector, task_family=None, task=None)` shows the
+  benchmark prior, local evidence, hard-filter status, and score breakdown.
+
+## Data provenance and missing metadata
+
+Benchmark scores are baked into the generated model catalog at build time by
+`packages/ai/scripts/generate-models.ts`, from the OpenRouter catalog's embedded
+Artificial Analysis intelligence/coding/agentic indices. Coverage is partial:
+a candidate without benchmark data is scored with a neutral, low-confidence prior
+(absence means "unknown", never zero) and reported in `warnings`. Declared cost
+comes from the same catalog; a model with all-zero pricing is treated as unpriced
+(no cost penalty), not free. Local outcomes recorded via `record_outcome` refine
+the prior with a decaying Bayesian posterior; ordinary child completion is not
+evidence of correctness.

--- a/packages/coding-agent/skills/model-fitness/pyproject.toml
+++ b/packages/coding-agent/skills/model-fitness/pyproject.toml
@@ -1,0 +1,19 @@
+# Kernel-side package for the bundled model-fitness skill. It uses the kernel's
+# pre-installed HTTP/runtime packages and the local harness store; no published
+# Prime Agent dependency is declared.
+[project]
+name = "model-fitness"
+version = "0.1.0"
+description = "Prime Agent model-fitness skill: advisory benchmark-driven subagent model selection"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+model_fitness = "rlm.skill:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/model_fitness"]

--- a/packages/coding-agent/skills/model-fitness/src/model_fitness/__init__.py
+++ b/packages/coding-agent/skills/model-fitness/src/model_fitness/__init__.py
@@ -1,0 +1,563 @@
+"""Advisory model selection for Prime Agent delegation.
+
+The skill combines two bounded inputs:
+
+1. Prime Agent's current scoped, authenticated, executable model candidates,
+   including generation-time benchmark annotations and declared costs; and
+2. independently verified local outcome observations stored in harness memory.
+
+Benchmark scores come from the generated model catalog (`models.generated.ts`),
+which `packages/ai/scripts/generate-models.ts` annotates from the OpenRouter
+catalog's embedded Artificial Analysis indices. A candidate without benchmark
+coverage is scored with a neutral, low-confidence prior — absence is unknown,
+not zero.
+
+The skill returns exact Prime Agent selectors and explanations. It never spawns
+a child; the caller decides whether to pass the returned selector to ``rlm``.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Literal, TypedDict
+
+import rlm
+
+SchemaVersion = "prime-agent.model-fitness/v1"
+OutcomeVerdict = Literal["validated_pass", "validated_fail", "accepted", "rejected", "unknown"]
+MEMORY_PATH_PREFIX = "model-fitness/v1"
+BENCHMARK_PRIOR_STRENGTH = 6.0
+OUTCOME_HALF_LIFE_DAYS = 45.0
+MAX_OBSERVATIONS_READ = 500
+NEUTRAL_QUALITY_PRIOR = 0.5
+BENCHMARK_SOURCE = "generated-catalog:openrouter/artificial-analysis"
+
+TASK_PROFILES: dict[str, dict[str, Any]] = {
+    "code_review": {
+        "quality_floor": 0.60,
+        "weights": {"coding": 0.45, "intelligence": 0.30, "agentic": 0.25},
+        "expected_input_tokens": 12_000,
+        "expected_output_tokens": 2_500,
+    },
+    "code_write": {
+        "quality_floor": 0.62,
+        "weights": {"coding": 0.55, "agentic": 0.30, "intelligence": 0.15},
+        "expected_input_tokens": 20_000,
+        "expected_output_tokens": 5_000,
+    },
+    "planning": {
+        "quality_floor": 0.58,
+        "weights": {"agentic": 0.45, "intelligence": 0.40, "coding": 0.15},
+        "expected_input_tokens": 16_000,
+        "expected_output_tokens": 4_000,
+    },
+    "research": {
+        "quality_floor": 0.56,
+        "weights": {"intelligence": 0.55, "agentic": 0.25, "coding": 0.20},
+        "expected_input_tokens": 24_000,
+        "expected_output_tokens": 4_000,
+    },
+    "execution": {
+        "quality_floor": 0.54,
+        "weights": {"agentic": 0.50, "coding": 0.35, "intelligence": 0.15},
+        "expected_input_tokens": 18_000,
+        "expected_output_tokens": 4_000,
+    },
+    "transform": {
+        "quality_floor": 0.45,
+        "weights": {"coding": 0.45, "intelligence": 0.35, "agentic": 0.20},
+        "expected_input_tokens": 8_000,
+        "expected_output_tokens": 3_000,
+    },
+}
+
+
+class Requirements(TypedDict, total=False):
+    image: bool
+    reasoning: bool
+    min_context_tokens: int
+    min_output_tokens: int
+    quality_floor: float
+    max_cost_usd: float
+    expected_input_tokens: int
+    expected_output_tokens: int
+    explore: bool
+
+
+@dataclass(frozen=True)
+class ScoreParts:
+    benchmark_quality: float
+    local_quality: float
+    confidence: float
+    cost_usd: float | None
+    fitness: float
+    evidence_count: int
+    prior_only: bool
+    benchmarked: bool
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _utc_timestamp(epoch: float | None = None) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch or _now()))
+
+
+def _validate_str(name: str, value: Any, *, allow_none: bool = False) -> str | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be str" + (" or None" if allow_none else "") + f", got {type(value).__name__}")
+    if not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _validate_requirements(requirements: Requirements | None) -> dict[str, Any]:
+    if requirements is None:
+        return {}
+    if not isinstance(requirements, dict):
+        raise TypeError(f"requirements must be dict or None, got {type(requirements).__name__}")
+    normalized = dict(requirements)
+    for key in ("image", "reasoning", "explore"):
+        if key in normalized and not isinstance(normalized[key], bool):
+            raise TypeError(f"requirements.{key} must be bool, got {type(normalized[key]).__name__}")
+    for key in ("min_context_tokens", "min_output_tokens", "expected_input_tokens", "expected_output_tokens"):
+        if key in normalized and (not isinstance(normalized[key], int) or isinstance(normalized[key], bool)):
+            raise TypeError(f"requirements.{key} must be int, got {type(normalized[key]).__name__}")
+    for key in ("quality_floor", "max_cost_usd"):
+        if key in normalized and not isinstance(normalized[key], (int, float)):
+            raise TypeError(f"requirements.{key} must be a number, got {type(normalized[key]).__name__}")
+    unknown = sorted(set(normalized) - set(Requirements.__annotations__))
+    if unknown:
+        raise ValueError(f"unsupported requirements: {', '.join(unknown)}")
+    return normalized
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _candidate_benchmarks(candidate: dict[str, Any]) -> dict[str, float] | None:
+    raw = candidate.get("benchmarks")
+    if not isinstance(raw, dict):
+        return None
+    benchmarks: dict[str, float] = {}
+    for key in ("intelligence", "coding", "agentic"):
+        value = raw.get(key)
+        if isinstance(value, (int, float)) and math.isfinite(value) and 0 <= value <= 100:
+            benchmarks[key] = float(value)
+    return benchmarks or None
+
+
+def _weighted_benchmark(benchmarks: dict[str, float] | None, weights: dict[str, float]) -> tuple[float | None, list[str]]:
+    if benchmarks is None:
+        return None, []
+    terms: list[tuple[float, float, str]] = []
+    for key, weight in weights.items():
+        value = benchmarks.get(key)
+        if value is not None:
+            terms.append((value / 100.0, float(weight), f"{key}={value:.1f}"))
+    total_weight = sum(weight for _, weight, _ in terms)
+    if total_weight <= 0:
+        return None, []
+    return sum(value * weight for value, weight, _ in terms) / total_weight, [label for _, _, label in terms]
+
+
+def _parse_observed_at(metadata: dict[str, Any]) -> float | None:
+    value = metadata.get("observedAt")
+    if not isinstance(value, str):
+        return None
+    try:
+        return time.mktime(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ"))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _local_observations(selector: str, task_family: str) -> list[dict[str, Any]]:
+    observations: list[dict[str, Any]] = []
+    try:
+        memories = list(rlm.get_harness_state().list("memory"))
+    except Exception:
+        return []
+    for entry in memories:
+        metadata = getattr(entry, "metadata", None)
+        if not isinstance(metadata, dict) or metadata.get("schema") != SchemaVersion:
+            continue
+        if metadata.get("type") != "outcome":
+            continue
+        if metadata.get("model", {}).get("selector") != selector:
+            continue
+        if metadata.get("task", {}).get("family") != task_family:
+            continue
+        signal = metadata.get("signal") if isinstance(metadata.get("signal"), dict) else {}
+        verdict = signal.get("verdict")
+        score = signal.get("score")
+        weight = signal.get("weight", 1.0)
+        if verdict not in {"validated_pass", "validated_fail", "accepted", "rejected", "unknown"}:
+            continue
+        if score is not None and (not isinstance(score, (int, float)) or not 0 <= score <= 1):
+            continue
+        if not isinstance(weight, (int, float)) or weight <= 0:
+            continue
+        observations.append(
+            {
+                "id": getattr(entry, "id", ""),
+                "verdict": verdict,
+                "score": float(score) if isinstance(score, (int, float)) else None,
+                "weight": float(weight),
+                "observed_at": _parse_observed_at(metadata),
+            }
+        )
+    observations.sort(key=lambda item: item.get("observed_at") or 0, reverse=True)
+    return observations[:MAX_OBSERVATIONS_READ]
+
+
+def _quality(candidate: dict[str, Any], task_family: str, weights: dict[str, float]) -> ScoreParts:
+    benchmarks = _candidate_benchmarks(candidate)
+    benchmark_quality, _terms = _weighted_benchmark(benchmarks, weights)
+    observations = _local_observations(str(candidate["selector"]), task_family)
+    benchmarked = benchmark_quality is not None
+    prior = benchmark_quality if benchmarked else NEUTRAL_QUALITY_PRIOR
+    alpha = BENCHMARK_PRIOR_STRENGTH * prior
+    beta = BENCHMARK_PRIOR_STRENGTH * (1.0 - prior)
+    evidence_weight = 0.0
+    now = _now()
+    for observation in observations:
+        if observation["verdict"] == "unknown" or observation["score"] is None:
+            continue
+        age_days = max(0.0, (now - (observation.get("observed_at") or now)) / 86_400)
+        weight = observation["weight"] * (0.5 ** (age_days / OUTCOME_HALF_LIFE_DAYS))
+        score = float(observation["score"])
+        alpha += weight * score
+        beta += weight * (1.0 - score)
+        evidence_weight += weight
+    # A conservative 10% lower credible bound; for alpha+beta >= 2 this normal
+    # approximation is adequate for ranking and avoids a scipy dependency.
+    total = alpha + beta
+    mean = alpha / total
+    variance = (alpha * beta) / ((total * total) * (total + 1.0))
+    conservative_quality = max(0.0, min(1.0, mean - 1.2815515655446004 * math.sqrt(max(variance, 0.0))))
+    effective_count = max(0, len([o for o in observations if o["verdict"] != "unknown" and o["score"] is not None]))
+    # A catalog benchmark is a population-level prior: use it directly until
+    # repository-specific verified outcomes exist. Blend the posterior mean once
+    # sparse evidence arrives; use the conservative lower bound only after
+    # several observations so one pass/fail cannot dominate the prior.
+    local_quality = prior if evidence_weight == 0 else mean if effective_count < 3 else conservative_quality
+    confidence = min(1.0, total / (BENCHMARK_PRIOR_STRENGTH + 12.0)) * (0.75 if benchmarked else 0.5)
+    return ScoreParts(
+        benchmark_quality=prior,
+        local_quality=local_quality,
+        confidence=confidence,
+        cost_usd=None,
+        fitness=0.0,
+        evidence_count=effective_count,
+        prior_only=evidence_weight == 0,
+        benchmarked=benchmarked,
+    )
+
+
+def _estimated_cost(candidate: dict[str, Any], requirements: dict[str, Any], profile: dict[str, Any]) -> float | None:
+    """Estimated task cost in USD from declared route pricing. None means unpriced, not free."""
+    expected_input = requirements.get("expected_input_tokens", profile["expected_input_tokens"])
+    expected_output = requirements.get("expected_output_tokens", profile["expected_output_tokens"])
+    cost = candidate.get("cost") if isinstance(candidate.get("cost"), dict) else {}
+    input_price = _safe_float(cost.get("input"))
+    output_price = _safe_float(cost.get("output"))
+    if input_price is None or output_price is None or (input_price == 0 and output_price == 0):
+        return None
+    return (expected_input * input_price + expected_output * output_price) / 1_000_000
+
+
+def _hard_filter(candidate: dict[str, Any], requirements: dict[str, Any], profile: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    required_tokens = requirements.get("min_context_tokens")
+    if required_tokens is not None and candidate.get("contextWindow", 0) < required_tokens:
+        reasons.append(f"contextWindow {candidate.get('contextWindow')} < required {required_tokens}")
+    required_output = requirements.get("min_output_tokens")
+    if required_output is not None and candidate.get("maxTokens", 0) < required_output:
+        reasons.append(f"maxTokens {candidate.get('maxTokens')} < required {required_output}")
+    if requirements.get("image") is True and "image" not in (candidate.get("input") or []):
+        reasons.append("image input required")
+    if requirements.get("reasoning") is True and candidate.get("reasoning") is not True:
+        reasons.append("reasoning required")
+    expected_total = requirements.get("expected_input_tokens", profile["expected_input_tokens"]) + requirements.get(
+        "expected_output_tokens", profile["expected_output_tokens"]
+    )
+    if candidate.get("contextWindow", 0) < expected_total:
+        reasons.append(f"contextWindow {candidate.get('contextWindow')} < expected task tokens {expected_total}")
+    return reasons
+
+
+def _score(candidate: dict[str, Any], task_family: str, requirements: dict[str, Any]) -> tuple[ScoreParts, list[str]]:
+    profile = TASK_PROFILES[task_family]
+    parts = _quality(candidate, task_family, profile["weights"])
+    cost = _estimated_cost(candidate, requirements, profile)
+    quality_floor = float(requirements.get("quality_floor", profile["quality_floor"]))
+    reasons = [
+        f"benchmark_prior={parts.benchmark_quality:.3f}" if parts.benchmarked else "benchmark_prior=unknown(neutral 0.5)",
+        f"local_quality={parts.local_quality:.3f}",
+        f"evidence={parts.evidence_count}",
+    ]
+    if parts.local_quality < quality_floor:
+        return parts, [f"quality {parts.local_quality:.3f} < floor {quality_floor:.3f}"]
+    max_cost = requirements.get("max_cost_usd")
+    if max_cost is not None and cost is None:
+        return parts, ["unpriced model cannot satisfy a strict max_cost_usd budget"]
+    if max_cost is not None and cost is not None and cost > float(max_cost):
+        return parts, [f"estimated cost ${cost:.4f} > budget ${float(max_cost):.4f}"]
+    # Cost is a soft denominator so quality still dominates. Unpriced models get
+    # no cost penalty (factor 1.0) and are flagged rather than treated as free.
+    reference_cost = 0.05
+    cost_factor = 1.0 + math.log1p(cost / reference_cost) if cost is not None else 1.0
+    fitness = parts.local_quality / cost_factor
+    if cost is None:
+        reasons.append("unpriced: no cost penalty applied")
+    if candidate.get("featured"):
+        fitness *= 1.01
+        reasons.append("featured tie preference")
+    return ScoreParts(
+        benchmark_quality=parts.benchmark_quality,
+        local_quality=parts.local_quality,
+        confidence=parts.confidence,
+        cost_usd=cost,
+        fitness=fitness,
+        evidence_count=parts.evidence_count,
+        prior_only=parts.prior_only,
+        benchmarked=parts.benchmarked,
+    ), reasons
+
+
+def _candidate_result(
+    candidate: dict[str, Any],
+    parts: ScoreParts,
+    reasons: list[str],
+    rejected: list[str],
+) -> dict[str, Any]:
+    return {
+        "selector": candidate["selector"],
+        "provider": candidate["provider"],
+        "id": candidate["id"],
+        "name": candidate.get("name") or candidate["id"],
+        "score": round(parts.fitness, 6),
+        "quality": round(parts.local_quality, 4),
+        "benchmark_prior": round(parts.benchmark_quality, 4),
+        "confidence": round(parts.confidence, 3),
+        "estimated_cost_usd": round(parts.cost_usd, 6) if parts.cost_usd is not None else None,
+        "evidence_count": parts.evidence_count,
+        "prior_only": parts.prior_only,
+        "reasons": reasons,
+        "rejected_reasons": rejected,
+        "benchmark_source": BENCHMARK_SOURCE if parts.benchmarked else None,
+        "metadata": {
+            "reasoning": bool(candidate.get("reasoning")),
+            "input": candidate.get("input") or [],
+            "contextWindow": candidate.get("contextWindow"),
+            "maxTokens": candidate.get("maxTokens"),
+            "cost": candidate.get("cost"),
+            "featured": bool(candidate.get("featured")),
+            "benchmarks": candidate.get("benchmarks"),
+        },
+    }
+
+
+def _project_key() -> str:
+    cwd = os.environ.get("PWD", "")
+    return sha256(cwd.encode("utf-8")).hexdigest()[:12] if cwd else "unknown"
+
+
+async def _candidates() -> list[dict[str, Any]]:
+    payload = await rlm.host_request("model_fitness.candidates")
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise RuntimeError("model_fitness.candidates response did not contain a model list")
+    return [model for model in models if isinstance(model, dict)]
+
+
+def _infer_task_family(task: str) -> str:
+    normalized = task.lower()
+    if any(term in normalized for term in ("review", "audit", "critique", "regression")):
+        return "code_review"
+    if any(term in normalized for term in ("implement", "write", "fix", "edit", "refactor", "test")):
+        return "code_write"
+    if any(term in normalized for term in ("plan", "architect", "design", "decompose")):
+        return "planning"
+    if any(term in normalized for term in ("research", "investigate", "compare", "explain")):
+        return "research"
+    if any(term in normalized for term in ("run", "execute", "terminal", "shell", "command")):
+        return "execution"
+    return "transform"
+
+
+async def recommend(
+    task: str,
+    task_family: str | None = None,
+    requirements: Requirements | None = None,
+    limit: int = 3,
+) -> dict[str, Any]:
+    """Rank currently eligible subagent models for a delegated task.
+
+    Returns a dict with `recommended` (None when no model clears the hard
+    filters/quality floor), `alternatives`, `warnings`, and `assumptions`. The
+    recommendation is advisory; pass `recommended["selector"]` explicitly to
+    `rlm(..., model=selector)` or omit `model` to inherit the parent model.
+    """
+    _validate_str("task", task)
+    if task_family is None:
+        task_family = _infer_task_family(task)
+    _validate_str("task_family", task_family)
+    if task_family not in TASK_PROFILES:
+        raise ValueError(f"task_family must be one of: {', '.join(sorted(TASK_PROFILES))}")
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 20:
+        raise TypeError("limit must be an integer from 1 to 20")
+    requirements_dict = _validate_requirements(requirements)
+    candidates = await _candidates()
+    profile = TASK_PROFILES[task_family]
+    warnings: list[str] = []
+    assumptions = [
+        "recommendation is advisory; spawn admission rechecks scope and authentication",
+        "benchmark scores are build-time priors, not guarantees for this repository or task",
+        "completion is not treated as a quality signal until an independent verdict is recorded",
+    ]
+    unbenchmarked = sum(1 for candidate in candidates if _candidate_benchmarks(candidate) is None)
+    if unbenchmarked:
+        warnings.append(f"{unbenchmarked} of {len(candidates)} candidates have no benchmark coverage and use a neutral prior")
+
+    ranked: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for candidate in candidates:
+        hard_reasons = _hard_filter(candidate, requirements_dict, profile)
+        if hard_reasons:
+            rejected.append(
+                _candidate_result(candidate, ScoreParts(0.0, 0.0, 0.0, None, 0.0, 0, True, False), [], hard_reasons)
+            )
+            continue
+        parts, reasons = _score(candidate, task_family, requirements_dict)
+        floor_failures = [reason for reason in reasons if reason.startswith(("quality ", "estimated cost ", "unpriced model"))]
+        if floor_failures:
+            rejected.append(_candidate_result(candidate, parts, reasons, floor_failures))
+            continue
+        ranked.append(_candidate_result(candidate, parts, reasons, []))
+    ranked.sort(key=lambda item: (-item["score"], item["estimated_cost_usd"] if item["estimated_cost_usd"] is not None else math.inf, item["selector"]))
+    exploration = next((item for item in ranked if item["evidence_count"] < 3 and item["confidence"] < 0.7), None)
+    recommended = ranked[0] if ranked else None
+    if not candidates:
+        warnings.append("no scoped, authenticated, executable models are available")
+    elif not ranked:
+        warnings.append("no eligible model cleared the task requirements and quality floor")
+    return {
+        "task_family": task_family,
+        "recommended": recommended,
+        "alternatives": ranked[1 : max(1, limit)],
+        "candidates": ranked[: max(1, limit)],
+        "rejected": rejected[: max(1, limit)],
+        "exploration_candidate": exploration if requirements_dict.get("explore") else None,
+        "warnings": warnings,
+        "assumptions": assumptions,
+    }
+
+
+async def explain(selector: str, task_family: str | None = None, task: str | None = None) -> dict[str, Any]:
+    """Explain benchmark and local evidence for one exact candidate selector."""
+    _validate_str("selector", selector)
+    if task_family is None:
+        task_family = _infer_task_family(task or "")
+    if task_family not in TASK_PROFILES:
+        raise ValueError(f"task_family must be one of: {', '.join(sorted(TASK_PROFILES))}")
+    candidates = await _candidates()
+    candidate = next((item for item in candidates if item.get("selector") == selector), None)
+    if candidate is None:
+        raise ValueError(f"model {selector!r} is not currently scoped, authenticated, and executable")
+    profile = TASK_PROFILES[task_family]
+    benchmarks = _candidate_benchmarks(candidate)
+    benchmark_quality, benchmark_terms = _weighted_benchmark(benchmarks, profile["weights"])
+    return {
+        "selector": selector,
+        "task_family": task_family,
+        "candidate": candidate,
+        "benchmark": {
+            "source": BENCHMARK_SOURCE if benchmarks else None,
+            "quality_prior": benchmark_quality,
+            "terms": benchmark_terms,
+            "indices": benchmarks,
+        },
+        "local_observations": _local_observations(selector, task_family),
+    }
+
+
+async def record_outcome(
+    selector: str,
+    task_family: str,
+    verdict: OutcomeVerdict,
+    score: float | None = None,
+    task: str | None = None,
+    duration_ms: int | None = None,
+    cost_usd: float | None = None,
+    evidence: str | None = None,
+) -> dict[str, Any]:
+    """Record an independently verified outcome for a selected model.
+
+    The outcome is stored as an immutable local harness memory entry. Use it only
+    after checking the child's work (tests, review, diff inspection, or explicit
+    acceptance). Ordinary child completion is not evidence of correctness.
+    """
+    _validate_str("selector", selector)
+    _validate_str("task_family", task_family)
+    if task_family not in TASK_PROFILES:
+        raise ValueError(f"task_family must be one of: {', '.join(sorted(TASK_PROFILES))}")
+    if verdict not in {"validated_pass", "validated_fail", "accepted", "rejected", "unknown"}:
+        raise ValueError("verdict must be validated_pass, validated_fail, accepted, rejected, or unknown")
+    if score is None:
+        score = {"validated_pass": 1.0, "accepted": 1.0, "validated_fail": 0.0, "rejected": 0.0}.get(verdict)
+    if score is not None and (not isinstance(score, (int, float)) or not 0 <= score <= 1):
+        raise TypeError("score must be a number between 0 and 1")
+    if duration_ms is not None and (not isinstance(duration_ms, int) or isinstance(duration_ms, bool) or duration_ms < 0):
+        raise TypeError("duration_ms must be a non-negative integer or None")
+    if cost_usd is not None and (not isinstance(cost_usd, (int, float)) or cost_usd < 0):
+        raise TypeError("cost_usd must be a non-negative number or None")
+    _validate_str("task", task, allow_none=True)
+    _validate_str("evidence", evidence, allow_none=True)
+    observed_at = _utc_timestamp()
+    event_id = sha256(f"{selector}\0{task_family}\0{verdict}\0{observed_at}\0{time.time_ns()}".encode()).hexdigest()[:16]
+    project_key = _project_key()
+    title = f"Model fitness: {task_family} {verdict} on {selector}"
+    content = evidence or title
+    metadata = {
+        "schema": SchemaVersion,
+        "type": "outcome",
+        "project": {"key": project_key},
+        "task": {"family": task_family, **({"summary": task[:300]} if task else {})},
+        "model": {"selector": selector},
+        "source": {"kind": "field_outcome"},
+        "signal": {"verdict": verdict, **({"score": float(score)} if score is not None else {}), "weight": 1.0},
+        "telemetry": {
+            **({"durationMs": duration_ms} if duration_ms is not None else {}),
+            **({"costUsd": cost_usd} if cost_usd is not None else {}),
+        },
+        "observedAt": observed_at,
+    }
+    entry = rlm.harness.create_memory(
+        title,
+        content,
+        id=f"mf-v1-{project_key}-{event_id}",
+        path=f"{MEMORY_PATH_PREFIX}/{project_key}/{task_family}",
+        metadata=metadata,
+    )
+    return {"recorded": True, "id": entry.id, "metadata": metadata}
+
+
+async def run(task: str, task_family: str | None = None, requirements: Requirements | None = None, limit: int = 3) -> dict[str, Any]:
+    """Alias for recommend(), used by the skill CLI wrapper."""
+    return await recommend(task, task_family=task_family, requirements=requirements, limit=limit)
+
+
+__all__ = ["TASK_PROFILES", "explain", "recommend", "record_outcome", "run"]

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -178,7 +178,7 @@ const TOP_LEVEL_OPTION_GROUPS: ReadonlyArray<{ heading: string; options: readonl
 			["--provider <name>", "Select a model provider"],
 			["--model <id>", "Select a model"],
 			["--api-key <key>", "Use an API key for this run"],
-			["--models <patterns>", "Set comma-separated models for cycling"],
+			["--models <patterns>", "Set model scope for cycling and agent-driven selection"],
 			["--thinking <level>", "Set reasoning: off, minimal, low, medium, high, xhigh, max"],
 		],
 	},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -188,6 +188,7 @@ import {
 	IPYTHON_STATE_RESTORED_CUSTOM_TYPE,
 	isSessionSlashCommandMessage,
 } from "./messages.js";
+import { createModelFitnessCandidatesHostHandler, projectModelFitnessCandidate } from "./model-fitness.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { throwIfPromptAdmissionCancelled } from "./prompt-admission.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -8666,6 +8667,9 @@ export class AgentSession {
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
+			"model_fitness.candidates": createModelFitnessCandidatesHostHandler(async () => ({
+				models: (await this._availableRlmModels()).map(projectModelFitnessCandidate),
+			})),
 			"model.info": async () => ({
 				id: this.model?.id ?? null,
 				provider: this.model?.provider ?? null,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -411,7 +411,7 @@ export interface AgentSessionConfig {
 	cwd: string;
 	/** Config dir backing credentials (auth.json); exported to the kernel for skills. */
 	agentDir?: string;
-	/** Models to cycle through with Ctrl+P (from --models flag) */
+	/** User-scoped models for cycling and agent-driven model selection. */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
 	/** Resource loader for skills, prompts, themes, context files, system prompt */
 	resourceLoader: ResourceLoader;
@@ -4207,7 +4207,7 @@ export class AgentSession {
 		this._autonomousContinuationSuppressedMessages.add(message);
 	}
 
-	/** Scoped models for cycling (from --models flag) */
+	/** User-scoped models for cycling and agent-driven model selection. */
 	get scopedModels(): ReadonlyArray<{
 		model: Model<any>;
 		thinkingLevel?: ThinkingLevel;
@@ -4215,7 +4215,7 @@ export class AgentSession {
 		return this._scopedModels;
 	}
 
-	/** Update scoped models for cycling */
+	/** Update the models available for cycling and agent-driven model selection. */
 	setScopedModels(scopedModels: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>): void {
 		this._scopedModels = scopedModels;
 	}
@@ -9541,16 +9541,22 @@ export class AgentSession {
 		assertAgentSessionNameAvailable(catalog, input);
 	}
 
-	private async _authenticatedRlmModels(): Promise<Model<Api>[]> {
+	private _isRlmModelInScope(model: Model<Api>): boolean {
+		return (
+			this._scopedModels.length === 0 || this._scopedModels.some((scoped) => modelsAreEqual(scoped.model, model))
+		);
+	}
+
+	private async _availableRlmModels(): Promise<Model<Api>[]> {
 		return (await this._modelRegistry.getExecutableModels()).filter((model) => {
 			const status = this._modelRegistry.getProviderAuthStatus(model.provider);
-			return status.source !== "stale" && status.label !== "expired";
+			return status.source !== "stale" && status.label !== "expired" && this._isRlmModelInScope(model);
 		});
 	}
 
 	async findRlmModels(query: string, limit: number): Promise<RlmFindModelsResult> {
 		return {
-			models: findRlmModelMatches(query, await this._authenticatedRlmModels(), limit),
+			models: findRlmModelMatches(query, await this._availableRlmModels(), limit),
 		};
 	}
 
@@ -9564,10 +9570,13 @@ export class AgentSession {
 		}
 
 		const normalizedReference = reference.toLowerCase();
-		if (`${parentModel.provider}/${parentModel.id}`.toLowerCase() === normalizedReference) {
+		if (
+			`${parentModel.provider}/${parentModel.id}`.toLowerCase() === normalizedReference &&
+			this._isRlmModelInScope(parentModel)
+		) {
 			return { model: parentModel };
 		}
-		const model = (await this._authenticatedRlmModels()).find(
+		const model = (await this._availableRlmModels()).find(
 			(candidate) => `${candidate.provider}/${candidate.id}`.toLowerCase() === normalizedReference,
 		);
 		if (!model) {

--- a/packages/coding-agent/src/core/model-fitness.ts
+++ b/packages/coding-agent/src/core/model-fitness.ts
@@ -1,0 +1,55 @@
+import type { Api, Model, ModelBenchmarks, ModelThinkingLevel } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import type { HostRequestHandler } from "./kernel/index.js";
+
+export interface ModelFitnessModelCost {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+}
+
+/** Read-only model metadata projected to the model-fitness skill. Never include credentials or provider config. */
+export interface ModelFitnessCandidate {
+	provider: string;
+	id: string;
+	name: string;
+	selector: string;
+	reasoning: boolean;
+	supportedThinkingLevels: ModelThinkingLevel[];
+	input: ("text" | "image")[];
+	contextWindow: number;
+	maxTokens: number;
+	cost: ModelFitnessModelCost;
+	featured?: boolean;
+	/** Generation-time benchmark indices; absent means "no coverage", not zero. */
+	benchmarks?: ModelBenchmarks;
+}
+
+export interface ModelFitnessCandidatesResult {
+	models: ModelFitnessCandidate[];
+}
+
+export type ModelFitnessCandidatesHandler = () => ModelFitnessCandidatesResult | Promise<ModelFitnessCandidatesResult>;
+
+/** Project an already-authorized/scope-filtered model for advisory fitness ranking. */
+export function projectModelFitnessCandidate(model: Model<Api>): ModelFitnessCandidate {
+	return {
+		provider: model.provider,
+		id: model.id,
+		name: model.name || model.id,
+		selector: `${model.provider}/${model.id}`,
+		reasoning: model.reasoning,
+		supportedThinkingLevels: getSupportedThinkingLevels(model),
+		input: [...model.input],
+		contextWindow: model.contextWindow,
+		maxTokens: model.maxTokens,
+		cost: { ...model.cost },
+		...(model.featured ? { featured: true } : {}),
+		...(model.benchmarks ? { benchmarks: { ...model.benchmarks } } : {}),
+	};
+}
+
+export function createModelFitnessCandidatesHostHandler(handler: ModelFitnessCandidatesHandler): HostRequestHandler {
+	return async () => ({ models: (await handler()).models });
+}

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -128,7 +128,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
-			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. Search results honor the user's configured model scope when present. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -128,7 +128,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
-			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. Search results honor the user's configured model scope when present. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your model. If the delegated task may warrant a different model, prefer `await model_fitness.recommend(...)` when the model-fitness skill is installed; otherwise use `await rlm.find_models(...)` and an exact returned selector. Search and recommendations honor the user's configured model scope when present. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -35,7 +35,7 @@ export interface CreateAgentSessionOptions extends AgentSessionCreationOptions {
 	model?: Model<any>;
 	/** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
 	thinkingLevel?: ThinkingLevel;
-	/** Models available for cycling (Ctrl+P in interactive mode) */
+	/** User-scoped models for cycling and agent-driven model selection */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
 
 	/**

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -154,7 +154,7 @@ export interface Settings {
 	enableBuiltinSkills?: boolean; // default: true - load built-in skills shipped with prime-agent
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
-	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
+	enabledModels?: string[]; // Model scope for cycling and agent-driven selection
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default: "user-only"
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)

--- a/packages/coding-agent/test/builtin-skills.test.ts
+++ b/packages/coding-agent/test/builtin-skills.test.ts
@@ -254,6 +254,15 @@ describe("builtin skills", () => {
 			expect(rlmHeartbeat?.kind === "python" && rlmHeartbeat.python.importName).toBe("rlm_heartbeat");
 		});
 
+		it("loads the bundled model-fitness skill as a python skill", () => {
+			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
+
+			const modelFitness = skills.find((s) => s.name === "model-fitness");
+			expect(modelFitness).toBeDefined();
+			expect(modelFitness?.kind).toBe("python");
+			expect(modelFitness?.kind === "python" && modelFitness.python.importName).toBe("model_fitness");
+		});
+
 		it("does not ship orchestration heartbeat as a built-in skill", () => {
 			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
 

--- a/packages/coding-agent/test/kernel-model-fitness-skill.test.ts
+++ b/packages/coding-agent/test/kernel-model-fitness-skill.test.ts
@@ -1,0 +1,125 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBundledSkillsDir } from "../src/config.js";
+import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+function bundledModelFitnessSkill(): PythonSkillRuntimeInfo {
+	const packagePath = join(getBundledSkillsDir(), "model-fitness");
+	return {
+		name: "model-fitness",
+		importName: "model_fitness",
+		packagePath,
+		pyprojectPath: join(packagePath, "pyproject.toml"),
+	};
+}
+
+describe("model-fitness skill over the kernel host bridge", { tags: ["kernel-heavy"] }, () => {
+	let tempDir: string;
+	let provisioner: IpythonKernelProvisioner | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-model-fitness-skill-"));
+		mkdirSync(join(tempDir, "harness"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await provisioner?.dispose();
+		provisioner = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("recommends and records outcomes through the candidate host projection", async () => {
+		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			env: {
+				RLM_HARNESS_STATE_DIR: join(tempDir, "harness"),
+			},
+			pythonSkills: [bundledModelFitnessSkill()],
+			hostHandlers: {
+				"model_fitness.candidates": async (payload) => {
+					requests.push({ type: "model_fitness.candidates", payload });
+					return {
+						models: [
+							{
+								provider: "openrouter",
+								id: "openai/gpt-5.6-terra",
+								name: "OpenAI: GPT-5.6 Terra",
+								selector: "openrouter/openai/gpt-5.6-terra",
+								reasoning: true,
+								supportedThinkingLevels: ["off", "low", "medium", "high"],
+								input: ["text", "image"],
+								contextWindow: 1_000_000,
+								maxTokens: 128_000,
+								cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
+								featured: true,
+								benchmarks: { intelligence: 54, coding: 76.7, agentic: 47.4 },
+							},
+							{
+								provider: "openrouter",
+								id: "anthropic/claude-fable-5",
+								name: "Anthropic: Claude Fable 5",
+								selector: "openrouter/anthropic/claude-fable-5",
+								reasoning: true,
+								supportedThinkingLevels: ["off", "low", "medium", "high"],
+								input: ["text", "image"],
+								contextWindow: 200_000,
+								maxTokens: 64_000,
+								cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+								benchmarks: { intelligence: 59.9, coding: 76.5, agentic: 52.8 },
+							},
+						],
+					};
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const result = await manager.execute(`
+import json
+recommendation = await model_fitness.recommend(
+    "Implement a parser and add regression tests",
+    task_family="code_write",
+    requirements={"min_context_tokens": 100000},
+)
+if recommendation["recommended"] is None:
+    print(json.dumps({"debug_recommendation": recommendation}, sort_keys=True))
+else:
+    recorded = await model_fitness.record_outcome(
+        recommendation["recommended"]["selector"],
+        "code_write",
+        "validated_pass",
+        score=1.0,
+        task="Implement a parser",
+    )
+    explained = await model_fitness.explain(recommendation["recommended"]["selector"], task_family="code_write")
+    print(json.dumps({
+        "recommended": recommendation["recommended"],
+        "alternatives": recommendation["alternatives"],
+        "recorded": recorded["recorded"],
+        "observations": explained["local_observations"],
+    }, sort_keys=True))
+`);
+
+		if (result.status !== "ok") {
+			throw new Error(
+				`kernel execution failed: ${result.error?.evalue ?? result.stderr}\n${result.error?.traceback?.join("\n") ?? ""}`,
+			);
+		}
+		expect(result.stderr).toBe("");
+		const output = JSON.parse(result.stdout.trim());
+		if (output.debug_recommendation) {
+			throw new Error(`no recommendation: ${JSON.stringify(output.debug_recommendation)}`);
+		}
+		expect(output.recommended.selector).toBe("openrouter/openai/gpt-5.6-terra");
+		expect(output.recommended.quality).toBeGreaterThan(0.6);
+		expect(output.recommended.estimated_cost_usd).toBeGreaterThan(0);
+		expect(output.alternatives[0].selector).toBe("openrouter/anthropic/claude-fable-5");
+		expect(output.recorded).toBe(true);
+		expect(output.observations[0]).toMatchObject({ verdict: "validated_pass", score: 1 });
+		expect(requests.map((request) => request.type)).toEqual(["model_fitness.candidates", "model_fitness.candidates"]);
+		expect(requests.every((request) => request.payload.type === "model_fitness.candidates")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/model-fitness.test.ts
+++ b/packages/coding-agent/test/model-fitness.test.ts
@@ -1,0 +1,66 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { projectModelFitnessCandidate } from "../src/core/model-fitness.js";
+
+describe("model fitness candidate projection", () => {
+	it("projects only advisory model metadata", () => {
+		const model = {
+			id: "test/model",
+			name: "Test Model",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://example.invalid",
+			reasoning: true,
+			thinkingLevelMap: { max: "max" },
+			input: ["text", "image"],
+			cost: { input: 1.25, output: 5, cacheRead: 0.125, cacheWrite: 1.5 },
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+			featured: true,
+			benchmarks: { intelligence: 50, coding: 70, agentic: 40 },
+			headers: { Authorization: "secret" },
+			compat: { supportsStore: false },
+		} as Model<"openai-completions">;
+
+		expect(projectModelFitnessCandidate(model)).toEqual({
+			provider: "openrouter",
+			id: "test/model",
+			name: "Test Model",
+			selector: "openrouter/test/model",
+			reasoning: true,
+			supportedThinkingLevels: ["off", "minimal", "low", "medium", "high", "max"],
+			input: ["text", "image"],
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+			cost: { input: 1.25, output: 5, cacheRead: 0.125, cacheWrite: 1.5 },
+			featured: true,
+			benchmarks: { intelligence: 50, coding: 70, agentic: 40 },
+		});
+	});
+
+	it("does not mark absent featured flags or emit provider configuration", () => {
+		const projected = projectModelFitnessCandidate({
+			id: "plain",
+			name: "Plain",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+
+		expect(projected).toMatchObject({
+			selector: "anthropic/plain",
+			supportedThinkingLevels: ["off"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+		expect(projected).not.toHaveProperty("featured");
+		expect(projected).not.toHaveProperty("benchmarks");
+		expect(projected).not.toHaveProperty("baseUrl");
+		expect(projected).not.toHaveProperty("headers");
+		expect(projected).not.toHaveProperty("compat");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -55,6 +55,63 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("limits agent model discovery and selection to the user's model scope", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model" }, { id: "scoped-model" }, { id: "out-of-scope-model" }],
+		});
+		try {
+			harness.session.setScopedModels([
+				{ model: harness.getModel("parent-model")! },
+				{ model: harness.getModel("scoped-model")! },
+			]);
+
+			const discovered = await harness.session.findRlmModels("", 20);
+			expect(discovered.models.map((model) => model.selector)).toEqual([
+				`${provider}/parent-model`,
+				`${provider}/scoped-model`,
+			]);
+			await expect(harness.session.findRlmModels("out of scope", 20)).resolves.toEqual({ models: [] });
+			await expect(
+				harness.session.runRlmChild("reject the out-of-scope model", {
+					model: `${provider}/out-of-scope-model`,
+				}),
+			).rejects.toThrow(
+				`Requested subagent model "${provider}/out-of-scope-model" is unavailable, unauthenticated, or expired`,
+			);
+
+			harness.setResponses([fauxAssistantMessage("scoped child answer")]);
+			const result = await harness.session.runRlmChild("use the scoped model", {
+				model: `${provider}/scoped-model`,
+			});
+			expect(result.model).toBe(`${provider}/scoped-model`);
+			await vi.waitFor(async () => {
+				const childEntry = (await harness.session.listRlmSubagents()).subagents[0];
+				expect(childEntry?.status).toBe("completed");
+				const child = harness.session.getRlmChildSession(childEntry!.rlm_child_id);
+				expect(child?.model?.id).toBe("scoped-model");
+				expect((await child!.findRlmModels("", 20)).models.map((model) => model.selector)).toEqual([
+					`${provider}/parent-model`,
+					`${provider}/scoped-model`,
+				]);
+			});
+
+			harness.session.setScopedModels([{ model: harness.getModel("scoped-model")! }]);
+			expect((await harness.session.findRlmModels("", 20)).models.map((model) => model.selector)).toEqual([
+				`${provider}/scoped-model`,
+			]);
+			await expect(
+				harness.session.runRlmChild("reject the parent outside the updated scope", {
+					model: `${provider}/parent-model`,
+				}),
+			).rejects.toThrow(
+				`Requested subagent model "${provider}/parent-model" is unavailable, unauthenticated, or expired`,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("omits providers whose credentials are marked expired", async () => {
 		const harness = await createHarness({ provider, models: [{ id: "parent-model" }, { id: "child-model" }] });
 		try {

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -71,6 +71,16 @@ describe("ENG-4649 subagent model selection", () => {
 				`${provider}/parent-model`,
 				`${provider}/scoped-model`,
 			]);
+			const handlers = (
+				harness.session as unknown as { _createKernelHostHandlers(): HostRequestHandlers }
+			)._createKernelHostHandlers();
+			const fitnessCandidates = handlers["model_fitness.candidates"];
+			if (!fitnessCandidates) throw new Error("Missing model_fitness.candidates host handler");
+			const projected = await fitnessCandidates({});
+			expect((projected.models as Array<{ selector: string }>).map((model) => model.selector)).toEqual([
+				`${provider}/parent-model`,
+				`${provider}/scoped-model`,
+			]);
 			await expect(harness.session.findRlmModels("out of scope", 20)).resolves.toEqual({ models: [] });
 			await expect(
 				harness.session.runRlmChild("reject the out-of-scope model", {
@@ -123,6 +133,10 @@ describe("ENG-4649 subagent model selection", () => {
 				label: "expired",
 			});
 			await expect(harness.session.findRlmModels("", 8)).resolves.toEqual({ models: [] });
+			const handlers = (
+				harness.session as unknown as { _createKernelHostHandlers(): HostRequestHandlers }
+			)._createKernelHostHandlers();
+			await expect(handlers["model_fitness.candidates"]!({})).resolves.toEqual({ models: [] });
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
## Why

Delegating subagents that always inherit the parent model is inefficient and ineffective: the task should dictate the model, and the selected model should be capable of the task while remaining cost-effective. This PR adds the primitives and an advisory skill for that, without changing any default routing behavior.

Stacked on #801 (this uses its scoped/executable candidate boundary); the delta shown here includes that commit until it merges.

## What changed

**Generation-time benchmark metadata (`packages/ai`)**
- `Model` gains an optional `benchmarks` block (Artificial Analysis intelligence/coding/agentic indices, 0-100). Absent means "no coverage", never zero.
- `generate-models.ts` annotates models from the OpenRouter catalog it already fetches — no new network call at build time, none at runtime. A new pure matcher (`scripts/openrouter-benchmarks.ts`) resolves first-party ids to OpenRouter entries conservatively (exact id, then unambiguous token-multiset key; ambiguous keys are dropped, unmatched models omit the field). In a live simulation, ~473/1171 generated models get coverage.

**Advisory skill (`packages/coding-agent`)**
- New bundled Python skill `model-fitness` with `recommend` / `explain` / `record_outcome`. It ranks the current scoped, authenticated, executable candidates by task-family benchmark priors, declared cost, and independently verified local outcomes, returning exact selectors plus score breakdowns.
- New read-only host projection `model_fitness.candidates` exposes safe model metadata only (never credentials, headers, baseUrl, or compat).
- Advisory by construction: the agent still passes the selector explicitly to `rlm(..., model=...)`; spawn admission revalidates scope/auth/executability, and omitting `model` keeps parent-model inheritance.
- Degradation semantics: missing benchmarks -> neutral low-confidence prior (flagged in warnings); all-zero pricing -> "unpriced", no cost penalty, rejected under a strict budget; ordinary child completion is never treated as quality evidence.

## Validation

- `packages/ai/test/openrouter-benchmarks.test.ts` (6 tests: exact/normalized matching, date/version stripping, ambiguity dropping)
- `packages/coding-agent/test/model-fitness.test.ts` (projection safety)
- `test/suite/regressions/4649-subagent-model-selection.test.ts` (projection honors scope + stale auth)
- `test/kernel-model-fitness-skill.test.ts` (kernel-heavy live bridge round-trip)
- `npm run check`

Note: `models.generated.ts` is intentionally not regenerated here; the catalog picks up benchmarks on the next `npm run generate-models`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add advisory model-fitness skill with generation-time benchmark metadata to coding agent
> - Introduces a new bundled Python skill (`model_fitness`) that recommends scoped subagent models using benchmark priors from OpenRouter Artificial Analysis indices baked into the model catalog at generation time, local decayed outcome history, and cost estimates.
> - Adds `ModelBenchmarks` (intelligence, coding, agentic indices on a 0–100 scale) to the `Model` type in `packages/ai/src/types.ts` and populates it during catalog generation via new helpers in [`scripts/openrouter-benchmarks.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/807/files#diff-eb2819720ac96a53a6ad2b128184ae7315ce7c5f9d19a4ef2dd8f4db409865b1).
> - Adds a `model_fitness.candidates` host bridge handler in [`agent-session.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/807/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) that exposes scope-filtered, authenticated, executable model metadata to the kernel skill.
> - Enforces the user's configured model scope across all agent-driven model discovery and subagent spawning paths; out-of-scope models are now rejected rather than falling back silently.
> - Risk: Subagent spawning now rejects any model outside the user's configured scope, which is a behavioral change for users who relied on fallback to any authenticated model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20037c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->