### PR TITLE
fix(coding-agent): show MCP login path for websearch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/skills/websearch/SKILL.md
+++ b/packages/coding-agent/skills/websearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: websearch
-description: Search Google via the Serper API. Takes a single query. Returns titles, URLs, snippets, and knowledge-graph data.
+description: Search Google via the Serper API. Configure access via /login, then MCP Connections, then Serper (web search). Takes one query and returns titles, URLs, snippets, and knowledge-graph data.
 ---
 
 # Web Search
@@ -9,9 +9,9 @@ Search the web via the Serper Google Search API.
 
 ## Setup
 
-Get a free API key at https://serper.dev, then run `/login` in Prime Agent and
-choose "Serper (web search)" to paste it. The key is stored in Prime Agent and
-made available to this skill automatically.
+Get a free API key at https://serper.dev, then run `/login` in Prime Agent,
+switch to **MCP Connections**, and choose **Serper (web search)** to paste it.
+The key is stored in Prime Agent and made available to this skill automatically.
 
 If web search reports a missing key, walk the user through those two steps;
 don't ask them to set environment variables.

--- a/packages/coding-agent/skills/websearch/src/websearch/websearch.py
+++ b/packages/coding-agent/skills/websearch/src/websearch/websearch.py
@@ -151,7 +151,7 @@ async def run(
             "Web search is not set up yet: no Serper API key is configured.\n"
             "Tell the user how to enable it:\n"
             "  1. Get a free API key at https://serper.dev (sign up, copy the key).\n"
-            "  2. In Prime Agent, run /login and choose \"Serper (web search)\", then paste the key.\n"
+            "  2. In Prime Agent, run /login, switch to MCP Connections, choose \"Serper (web search)\", and paste the key.\n"
             "Do not ask the user to set environment variables. Once the key is saved, web search works automatically."
         )
 

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -468,6 +468,9 @@ Content`,
 			const { skills } = loader.getSkills();
 			const websearch = skills.find((s) => s.name === "websearch");
 			expect(websearch).toBeDefined();
+			expect(websearch?.description).toContain("/login");
+			expect(websearch?.description).toContain("MCP Connections");
+			expect(websearch?.description).toContain("Serper (web search)");
 			expect(websearch?.kind).toBe("python");
 			if (websearch?.kind === "python") {
 				expect(websearch.python.importName).toBe("websearch");


### PR DESCRIPTION
## Problem

The text shown for the bundled WebSearch skill is sourced from the `description` field in `skills/websearch/SKILL.md`. That frontmatter only described search inputs and outputs, so the command UI did not tell users how to authenticate.

The longer skill instructions and the missing-key response were also slightly stale: they said to run `/login` and choose Serper, but `/login` opens on **Providers** while **Serper (web search)** is deliberately listed under **MCP Connections**. The current docs already show the complete path.

## Fix

Keep all user-facing guidance aligned on:

`/login` → **MCP Connections** → **Serper (web search)**

Specifically:

- add the login path to the `SKILL.md` frontmatter description shown by the skill command UI
- update the skill setup body
- update the Python missing-key response
- assert that the bundled skill's loaded description contains the full path
- record the fix under Unreleased

No auth behavior, MCP registration, settings, releases, or installer behavior changes.

## Validation

- `npm run build` ✅
- `npm run check` ✅
- `npm run test:ci -- test/resource-loader.test.ts` in `packages/coding-agent` ✅ (25/25)
- `python3 -m py_compile packages/coding-agent/skills/websearch/src/websearch/websearch.py` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and user-facing copy only; no auth, MCP, or runtime behavior changes.
> 
> **Overview**
> **Bundled `websearch` setup copy** now consistently tells users to configure Serper via `/login` → **MCP Connections** → **Serper (web search)**, matching where that option actually lives in the UI (not the default **Providers** tab).
> 
> Updates include the `SKILL.md` frontmatter description (shown in the skill command UI), the setup section body, the Python missing-key message from `websearch.run()`, a **Unreleased** changelog entry, and resource-loader tests that assert the loaded bundled skill description includes the full path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec43d636fb639cc8d642ff722356b0d5eee74d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP login path guidance for websearch skill Serper configuration
> Updates the websearch skill to direct users through `/login → MCP Connections → Serper (web search)` when configuring a Serper API key. The missing-key error message in [`websearch.py`](https://github.com/PrimeIntellect-ai/prime-agent/pull/809/files#diff-345ba871c0c38a3314764f17b955327ef4df51ce1cb00e73e61a68d38e3c67e3) and the skill description in [`SKILL.md`](https://github.com/PrimeIntellect-ai/prime-agent/pull/809/files#diff-1fa3cf679226bf4ca02b0a5f760a555a0288ac5e79d925855803d2fef9a15251) both now include this path. A test assertion is added to verify the bundled skill description contains the correct navigation steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ec43d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->