### PR TITLE
fix(coding-agent): namespace daemon socket by agent dir

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+- Fixed default daemon sockets sharing one supervisor across distinct `PRIME_AGENT_CODING_AGENT_DIR` values ([#768](https://github.com/PrimeIntellect-ai/prime-agent/issues/768)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto";
 import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
+import { getAgentDir } from "../../config.js";
 
 const DAEMON_SOCKET_MODE = 0o600;
 const DAEMON_SOCKET_DIR_MODE = 0o700;
@@ -34,10 +36,17 @@ export interface DaemonSocketIdentity {
 }
 
 export function defaultDaemonSocketPath(): string {
+	const suffix = agentDirSocketSuffix();
 	if (process.platform === "win32") {
-		return "\\\\.\\pipe\\prime-agent-daemon";
+		return `\\\\.\\pipe\\prime-agent-daemon-${suffix}`;
 	}
-	return join(defaultDaemonSocketDir(), "daemon.sock");
+	return join(defaultDaemonSocketDir(), `daemon-${suffix}.sock`);
+}
+
+function agentDirSocketSuffix(): string {
+	const agentDir = resolve(getAgentDir());
+	const normalized = process.platform === "win32" ? agentDir.toLowerCase() : agentDir;
+	return createHash("sha256").update(normalized).digest("hex").slice(0, 8);
 }
 
 export async function acquireDaemonSocketPathLease(socketPath: string): Promise<DaemonSocketPathLease | undefined> {

--- a/packages/coding-agent/test/daemon-socket.test.ts
+++ b/packages/coding-agent/test/daemon-socket.test.ts
@@ -4,7 +4,8 @@ import { createConnection, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.js";
 import {
 	cleanupDaemonSocketPath,
 	defaultDaemonSocketPath,
@@ -13,24 +14,56 @@ import {
 } from "../src/modes/daemon/daemon-socket.js";
 
 describe("defaultDaemonSocketPath", () => {
-	it("uses a fixed Windows named pipe path", () => {
+	const originalAgentDir = process.env[ENV_AGENT_DIR];
+
+	afterEach(() => {
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+	});
+
+	it("namespaces the Windows named pipe path by agent directory", () => {
 		if (process.platform !== "win32") {
 			return;
 		}
 
-		expect(defaultDaemonSocketPath()).toBe("\\\\.\\pipe\\prime-agent-daemon");
+		process.env[ENV_AGENT_DIR] = "C:\\prime-a\\agent";
+		const first = defaultDaemonSocketPath();
+		process.env[ENV_AGENT_DIR] = "C:\\prime-b\\agent";
+		const second = defaultDaemonSocketPath();
+
+		expect(first).toMatch(/^\\\\\.\\pipe\\prime-agent-daemon-[a-f0-9]{8}$/);
+		expect(second).toMatch(/^\\\\\.\\pipe\\prime-agent-daemon-[a-f0-9]{8}$/);
+		expect(first).not.toBe(second);
 	});
 
-	it("uses a per-user Unix socket directory", () => {
+	it("uses a per-user Unix socket directory and namespaces the daemon socket by agent directory", () => {
 		if (process.platform === "win32") {
 			return;
 		}
 
 		const suffix = typeof process.getuid === "function" ? String(process.getuid()) : "user";
-		const socketPath = defaultDaemonSocketPath();
+		process.env[ENV_AGENT_DIR] = "/tmp/prime-a/agent";
+		const first = defaultDaemonSocketPath();
+		process.env[ENV_AGENT_DIR] = "/tmp/prime-b/agent";
+		const second = defaultDaemonSocketPath();
 
-		expect(dirname(socketPath)).toBe(join(tmpdir(), `prime-agent-${suffix}`));
-		expect(basename(socketPath)).toBe("daemon.sock");
+		expect(dirname(first)).toBe(join(tmpdir(), `prime-agent-${suffix}`));
+		expect(dirname(second)).toBe(join(tmpdir(), `prime-agent-${suffix}`));
+		expect(basename(first)).toMatch(/^daemon-[a-f0-9]{8}\.sock$/);
+		expect(basename(second)).toMatch(/^daemon-[a-f0-9]{8}\.sock$/);
+		expect(first).not.toBe(second);
+	});
+
+	it("keeps the agent-directory namespace stable for equivalent paths", () => {
+		const agentDir = process.platform === "win32" ? "C:\\prime-a\\agent\\.." : "/tmp/prime-a/agent/..";
+		process.env[ENV_AGENT_DIR] = agentDir;
+		const socketPath = defaultDaemonSocketPath();
+		process.env[ENV_AGENT_DIR] = agentDir;
+
+		expect(defaultDaemonSocketPath()).toBe(socketPath);
 	});
 
 	it("checks a live daemon before acquiring the socket path lock", async () => {


### PR DESCRIPTION
## Summary

- Namespace the default daemon socket by the resolved Prime Agent config directory.
- Keep the shared per-user socket directory unchanged so worker socket paths do not get longer.
- Add regression coverage for distinct `PRIME_AGENT_CODING_AGENT_DIR` values producing distinct default daemon sockets.

Fixes #768

## Testing

- `npm run check`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-socket.test.ts test/daemon-ps.test.ts test/daemon-ps-format.test.ts test/daemon-launch.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Namespace daemon socket path by agent directory to prevent supervisor sharing
> Previously, all coding agent instances used a fixed daemon socket name, causing instances with different `PRIME_AGENT_CODING_AGENT_DIR` values to share the same supervisor. The fix adds an 8-hex-character SHA-256 suffix derived from the normalized agent directory path to the socket name. On Windows the pipe becomes `\\.\pipe\prime-agent-daemon-<hash>`; on Unix the socket becomes `daemon-<hash>.sock`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b649247.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->