### PR TITLE
fix(coding-agent): clear selected session anchors on agent deactivate

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2079,6 +2079,14 @@ export class AgentsViewMode implements Component, Focusable {
 			this.pendingDeleteAgent = undefined;
 			this.clearDeleteConfirmation({ render: false });
 			this.selectedActiveSessionId = undefined;
+			// The deactivated session stays in the roster but moves to the
+			// Inactive section; clear the selection anchors so the next
+			// restoreSelection() keeps the cursor where it was in the list
+			// instead of re-anchoring onto the now-inactive row.
+			this.selectedRowIdentity = undefined;
+			this.selectedSessionKey = undefined;
+			this.persistentState.selectedRowIdentity = undefined;
+			this.persistentState.selectedSessionKey = undefined;
 			this.setStatusMessage("Agent inactive", { render: false });
 			await this.refreshSessions();
 		} catch (error) {


### PR DESCRIPTION
When an agent is deactivated it moves to the Inactive section of the
agents view. Clear the selection anchors (`selectedRowIdentity`,
`selectedSessionKey` and their `persistentState` copies) so `restoreSelection()`
keeps the cursor where it was in the list instead of re-anchoring onto the
now-inactive row.

This makes batch-deactivating several running sessions behave like every other
list UI: the cursor stays in place (on the next session that shifted up) rather
than teleporting to the distant Inactive section.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear selection anchors in `AgentsViewMode` on agent deactivate
> When an agent is deactivated, `selectedRowIdentity`, `selectedSessionKey`, and their `persistentState` counterparts are now set to `undefined`. This prevents a subsequent `restoreSelection()` call from re-anchoring onto the now-inactive row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 660239d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->