### PR TITLE
feat(ai): add OpenRouter session routing and Responses transport

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Added OpenRouter session grouping and sticky routing through each request's opaque Prime session identifier.
+- Added an optional stateless OpenRouter Responses transport with a pre-stream Chat Completions fallback.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -15,6 +15,7 @@ import { getEnvApiKey, getPrimeTeamId } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
 	AssistantMessage,
+	AssistantMessageEvent,
 	CacheRetention,
 	Context,
 	ImageContent,
@@ -37,6 +38,7 @@ import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { streamSimpleOpenAIResponses } from "./openai-responses.js";
 import { buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -437,14 +439,108 @@ export const streamSimpleOpenAICompletions: StreamFunction<"openai-completions",
 	const clampedReasoning = reasoningSpecified ? clampThinkingLevel(model, requestedReasoning) : undefined;
 	const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
 	const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
-
-	return streamOpenAICompletions(model, context, {
+	const chatOptions = {
 		...base,
 		reasoningEffort,
 		reasoningEnabled: reasoningSpecified ? clampedReasoning !== "off" : undefined,
 		toolChoice,
-	} satisfies OpenAICompletionsOptions);
+	} satisfies OpenAICompletionsOptions;
+
+	if (model.provider === "openrouter" && options?.openRouterResponses) {
+		return streamOpenRouterResponsesWithChatFallback(model, context, options, chatOptions);
+	}
+
+	return streamOpenAICompletions(model, context, chatOptions);
 };
+
+function streamOpenRouterResponsesWithChatFallback(
+	model: Model<"openai-completions">,
+	context: Context,
+	options: SimpleStreamOptions,
+	chatOptions: OpenAICompletionsOptions,
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	const { compat, ...modelWithoutCompat } = model;
+	const responsesModel: Model<"openai-responses"> = {
+		...modelWithoutCompat,
+		api: "openai-responses",
+		compat: {
+			sendSessionIdHeader: false,
+			supportsLongCacheRetention: false,
+			openRouterRouting: compat?.openRouterRouting,
+		},
+	};
+
+	(async () => {
+		let started = false;
+		try {
+			const responsesStream = streamSimpleOpenAIResponses(responsesModel, context, options);
+			for await (const event of responsesStream) {
+				if (event.type === "start") started = true;
+				if (
+					event.type === "error" &&
+					!started &&
+					!options.signal?.aborted &&
+					isOpenRouterResponsesTransportFailure(event.error)
+				) {
+					await forwardAssistantEvents(stream, streamOpenAICompletions(model, context, chatOptions));
+					return;
+				}
+				stream.push(event);
+			}
+			stream.end();
+		} catch (error) {
+			const reason = options.signal?.aborted ? "aborted" : "error";
+			const message: AssistantMessage = {
+				role: "assistant",
+				content: [],
+				api: responsesModel.api,
+				provider: responsesModel.provider,
+				model: responsesModel.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: reason,
+				errorMessage: error instanceof Error ? error.message : String(error),
+				timestamp: Date.now(),
+			};
+			stream.push({ type: "error", reason, error: message });
+			stream.end();
+		}
+	})();
+
+	return stream;
+}
+
+async function forwardAssistantEvents(
+	target: AssistantMessageEventStream,
+	source: AsyncIterable<AssistantMessageEvent>,
+): Promise<void> {
+	for await (const event of source) target.push(event);
+	target.end();
+}
+
+function isOpenRouterResponsesTransportFailure(message: AssistantMessage): boolean {
+	const diagnostic = message.diagnostics
+		?.slice()
+		.reverse()
+		.find((entry) => entry.type === "provider_stream_failure");
+	const status = diagnostic?.details?.status;
+	const kind = diagnostic?.details?.kind;
+
+	if (status === 404 || status === 405 || status === 501) return true;
+	if (kind === "server_error" || kind === "malformed_response") return true;
+	if (kind !== "invalid_request") return false;
+
+	return /(?:responses?|endpoint).*(?:unsupported|not supported|unavailable|not found)|(?:unsupported|not supported|unavailable).*(?:responses?|endpoint)/i.test(
+		message.errorMessage ?? "",
+	);
+}
 
 function createClient(
 	model: Model<"openai-completions">,
@@ -516,10 +612,11 @@ function buildParams(
 ) {
 	const messages = convertMessages(model, context, compat);
 
-	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
+	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & { session_id?: string } = {
 		model: model.id,
 		messages,
 		stream: true,
+		session_id: model.provider === "openrouter" ? options?.sessionId : undefined,
 		prompt_cache_key:
 			(model.baseUrl.includes("api.openai.com") && cacheRetention !== "none") ||
 			(cacheRetention === "long" && compat.supportsLongCacheRetention)

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -8,7 +8,7 @@ import type {
 	CacheRetention,
 	Context,
 	Model,
-	OpenAIResponsesCompat,
+	OpenRouterRouting,
 	SimpleStreamOptions,
 	StreamFunction,
 	StreamOptions,
@@ -26,7 +26,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
-const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
+const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode", "openrouter"]);
 
 /**
  * Resolve cache retention preference.
@@ -42,15 +42,22 @@ function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention 
 	return "short";
 }
 
-function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCompat> {
+interface ResolvedOpenAIResponsesCompat {
+	sendSessionIdHeader: boolean;
+	supportsLongCacheRetention: boolean;
+	openRouterRouting?: OpenRouterRouting;
+}
+
+function getCompat(model: Model<"openai-responses">): ResolvedOpenAIResponsesCompat {
 	return {
 		sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
+		openRouterRouting: model.compat?.openRouterRouting,
 	};
 }
 
 function getPromptCacheRetention(
-	compat: Required<OpenAIResponsesCompat>,
+	compat: ResolvedOpenAIResponsesCompat,
 	cacheRetention: CacheRetention,
 ): "24h" | undefined {
 	return cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined;
@@ -227,12 +234,17 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 	const compat = getCompat(model);
-	const params: ResponseCreateParamsStreaming = {
+	const params: ResponseCreateParamsStreaming & {
+		session_id?: string;
+		provider?: OpenRouterRouting;
+	} = {
 		model: model.id,
 		input: messages,
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
 		prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
+		session_id: model.provider === "openrouter" ? options?.sessionId : undefined,
+		provider: model.provider === "openrouter" ? compat.openRouterRouting : undefined,
 		store: false,
 	};
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -147,6 +147,8 @@ export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ModelThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
+	/** Prefer OpenRouter's stateless Responses transport, with a pre-stream Chat fallback. */
+	openRouterResponses?: boolean;
 }
 
 // Generic StreamFunction with typed options.
@@ -333,6 +335,8 @@ export interface OpenAIResponsesCompat {
 	sendSessionIdHeader?: boolean;
 	/** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
 	supportsLongCacheRetention?: boolean;
+	/** OpenRouter-specific routing preferences for Responses requests. */
+	openRouterRouting?: OpenRouterRouting;
 }
 
 /** Compatibility settings for Anthropic Messages-compatible APIs. */

--- a/packages/ai/test/openai-completions-prompt-cache.test.ts
+++ b/packages/ai/test/openai-completions-prompt-cache.test.ts
@@ -13,6 +13,7 @@ interface FakeOpenAIClientOptions {
 interface CapturedCompletionsPayload {
 	prompt_cache_key?: string;
 	prompt_cache_retention?: "24h" | "in-memory" | null;
+	session_id?: string;
 }
 
 const mockState = vi.hoisted(() => ({
@@ -141,6 +142,26 @@ describe("openai-completions prompt caching", () => {
 
 		expect(payload?.prompt_cache_key).toBeUndefined();
 		expect(payload?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("groups OpenRouter Chat Completions requests by the Prime session identifier", async () => {
+		const model = createModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+		});
+		const { payload } = await captureRequest({ sessionId: "019fd549-abb7-734a-9c7d-d7a2944fab30" }, model);
+
+		expect(payload?.session_id).toBe("019fd549-abb7-734a-9c7d-d7a2944fab30");
+	});
+
+	it("omits the OpenRouter session identifier for other OpenAI-compatible providers", async () => {
+		const model = createModel({
+			provider: "custom-proxy",
+			baseUrl: "https://proxy.example.com/v1",
+		});
+		const { payload } = await captureRequest({ sessionId: "session-proxy" }, model);
+
+		expect(payload?.session_id).toBeUndefined();
 	});
 
 	it("uses PI_CACHE_RETENTION for direct OpenAI requests", async () => {

--- a/packages/ai/test/openrouter-responses-transport.test.ts
+++ b/packages/ai/test/openrouter-responses-transport.test.ts
@@ -1,0 +1,223 @@
+import { Type } from "typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { streamSimpleOpenAICompletions } from "../src/providers/openai-completions.js";
+import type { Context, Model, OpenRouterRouting } from "../src/types.js";
+
+type ResponsesMode = "success" | "unavailable" | "context-overflow" | "auth" | "rate-limit" | "post-start";
+
+interface CapturedChatPayload {
+	model?: string;
+	session_id?: string;
+}
+
+interface CapturedResponsesPayload {
+	model?: string;
+	input?: unknown[];
+	tools?: Array<{ type?: string; name?: string }>;
+	reasoning?: { effort?: string; summary?: string };
+	prompt_cache_key?: string;
+	session_id?: string;
+	provider?: OpenRouterRouting;
+	store?: boolean;
+}
+
+const mockState = vi.hoisted(() => ({
+	responsesMode: "success" as ResponsesMode,
+	chatCalls: [] as CapturedChatPayload[],
+	responsesCalls: [] as CapturedResponsesPayload[],
+}));
+
+function providerError(status: number, type: string, message: string): Error {
+	return Object.assign(new Error(message), {
+		status,
+		error: { type, message },
+	});
+}
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (params: CapturedChatPayload) => {
+					mockState.chatCalls.push(params);
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								choices: [{ delta: {}, finish_reason: "stop" }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							};
+						},
+					};
+					return {
+						withResponse: async () => ({
+							data: stream,
+							response: { status: 200, headers: new Headers() },
+						}),
+					};
+				},
+			},
+		};
+
+		responses = {
+			create: (params: CapturedResponsesPayload) => {
+				mockState.responsesCalls.push(params);
+				return {
+					withResponse: async () => {
+						switch (mockState.responsesMode) {
+							case "unavailable":
+								throw providerError(404, "not_found_error", "Responses endpoint is unavailable");
+							case "context-overflow":
+								throw providerError(400, "context_length_exceeded", "Input exceeds the model context window");
+							case "auth":
+								throw providerError(401, "authentication_error", "Invalid API key");
+							case "rate-limit":
+								throw providerError(429, "rate_limit_error", "Rate limit exceeded");
+						}
+
+						const mode = mockState.responsesMode;
+						const stream = {
+							async *[Symbol.asyncIterator]() {
+								if (mode === "post-start") {
+									throw providerError(500, "server_error", "Responses stream failed");
+								}
+								yield {
+									type: "response.completed",
+									response: {
+										id: "resp_openrouter",
+										status: "completed",
+										usage: {
+											input_tokens: 4,
+											output_tokens: 1,
+											total_tokens: 5,
+											input_tokens_details: { cached_tokens: 0 },
+										},
+									},
+								};
+							},
+						};
+						return {
+							data: stream,
+							response: { status: 200, headers: new Headers() },
+						};
+					},
+				};
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+function createModel(): Model<"openai-completions"> {
+	return {
+		id: "openai/gpt-5.6-luna",
+		name: "OpenAI: GPT-5.6 Luna",
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: true,
+		thinkingLevelMap: { high: "high" },
+		input: ["text"],
+		cost: { input: 0.1, output: 0.6, cacheRead: 0.01, cacheWrite: 0.125 },
+		contextWindow: 1_050_000,
+		maxTokens: 128_000,
+		compat: {
+			thinkingFormat: "openrouter",
+			openRouterRouting: { order: ["openai", "azure"] },
+		},
+	};
+}
+
+const context: Context = {
+	systemPrompt: "Use the available tool when asked.",
+	messages: [{ role: "user", content: "Reply briefly.", timestamp: 1 }],
+	tools: [
+		{
+			name: "read",
+			description: "Read one file.",
+			parameters: Type.Object({ path: Type.String() }),
+		},
+	],
+};
+
+async function run(options: { openRouterResponses?: boolean } = {}) {
+	return streamSimpleOpenAICompletions(createModel(), context, {
+		apiKey: "test-key",
+		sessionId: "019fd549-abb7-734a-9c7d-d7a2944fab30",
+		reasoning: "high",
+		...options,
+	}).result();
+}
+
+describe("OpenRouter Responses transport", () => {
+	beforeEach(() => {
+		mockState.responsesMode = "success";
+		mockState.chatCalls.length = 0;
+		mockState.responsesCalls.length = 0;
+	});
+
+	it("uses Chat Completions by default", async () => {
+		const result = await run();
+
+		expect(result.stopReason).toBe("stop");
+		expect(mockState.chatCalls).toHaveLength(1);
+		expect(mockState.responsesCalls).toHaveLength(0);
+	});
+
+	it("uses stateless Responses with session, cache, routing, tool, and reasoning fields when enabled", async () => {
+		const result = await run({ openRouterResponses: true });
+
+		expect(result.stopReason).toBe("stop");
+		expect(mockState.chatCalls).toHaveLength(0);
+		expect(mockState.responsesCalls).toHaveLength(1);
+		expect(mockState.responsesCalls[0]).toMatchObject({
+			model: "openai/gpt-5.6-luna",
+			prompt_cache_key: "019fd549-abb7-734a-9c7d-d7a2944fab30",
+			session_id: "019fd549-abb7-734a-9c7d-d7a2944fab30",
+			provider: { order: ["openai", "azure"] },
+			store: false,
+			reasoning: { effort: "high", summary: "auto" },
+			tools: [{ type: "function", name: "read" }],
+		});
+		expect(mockState.responsesCalls[0].input).toHaveLength(2);
+	});
+
+	it("falls back once to Chat when the Responses endpoint is unavailable before start", async () => {
+		mockState.responsesMode = "unavailable";
+
+		const result = await run({ openRouterResponses: true });
+
+		expect(result.stopReason).toBe("stop");
+		expect(mockState.responsesCalls).toHaveLength(1);
+		expect(mockState.chatCalls).toHaveLength(1);
+		expect(mockState.chatCalls[0].session_id).toBe("019fd549-abb7-734a-9c7d-d7a2944fab30");
+	});
+
+	it.each(["context-overflow", "auth", "rate-limit"] as const)(
+		"does not fall back to Chat after a %s failure",
+		async (mode) => {
+			mockState.responsesMode = mode;
+
+			const result = await run({ openRouterResponses: true });
+
+			expect(result.stopReason).toBe("error");
+			expect(mockState.responsesCalls).toHaveLength(1);
+			expect(mockState.chatCalls).toHaveLength(0);
+		},
+	);
+
+	it("does not fall back after the Responses stream starts", async () => {
+		mockState.responsesMode = "post-start";
+
+		const result = await run({ openRouterResponses: true });
+
+		expect(result.stopReason).toBe("error");
+		expect(mockState.responsesCalls).toHaveLength(1);
+		expect(mockState.chatCalls).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Added OpenRouter dashboard grouping and sticky routing through the existing opaque Prime session identifier.
+- Added the hot-reloaded, default-off `openRouter.responses` setting with Chat Completions fallback before streaming starts.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -119,6 +119,12 @@ The `key` field supports three formats:
 
 OAuth credentials are also stored here after `/login` and managed automatically.
 
+### OpenRouter
+
+Prime Agent sends its opaque local session UUID as OpenRouter's `session_id` request field. OpenRouter groups related requests in its dashboard and uses the identifier for sticky upstream routing. Prime Agent still sends the complete conversation context on every request.
+
+OpenRouter uses Chat Completions by default. Set `openRouter.responses: true` in `settings.json`, `settings.yml`, or `settings.yaml` to prefer the stateless Responses API. Prime Agent falls back to Chat only when Responses is unavailable before streaming starts. The setting is read for each request and therefore hot reloads without restarting the session.
+
 ### Prime Inference
 
 Prime Inference uses the OpenAI-compatible endpoint at `https://api.pinference.ai/api/v1`. Set `PRIME_API_KEY` or store an API key for `prime-inference` via `/login`.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -34,6 +34,24 @@ Edit directly or use `/settings` for common options.
 }
 ```
 
+### OpenRouter Transport
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `openRouter.responses` | boolean | `false` | Prefer OpenRouter's stateless Responses API and fall back to Chat Completions only when the Responses transport is unavailable before streaming starts |
+
+Prime Agent sends its opaque local session UUID as `session_id` on both OpenRouter transports. OpenRouter uses it for dashboard grouping and sticky upstream routing. When prompt caching is enabled, Responses also sends the same value as `prompt_cache_key`. Both transports send the complete conversation context on every request.
+
+```json
+{
+  "openRouter": {
+    "responses": true
+  }
+}
+```
+
+Chat Completions remains the default. When Responses is enabled, cancellation, context overflow, authentication, rate limiting, invalid input, and failures after streaming starts do not cross transports.
+
 ### UI & Display
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -315,6 +315,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				timeoutMs: options?.timeoutMs ?? providerRetrySettings.timeoutMs,
 				maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
 				maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
+				openRouterResponses: settingsManager.getOpenRouterResponses(),
 				headers: auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined,
 			});
 		},

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -72,6 +72,11 @@ export interface WarningSettings {
 	anthropicExtraUsage?: boolean; // default: true
 }
 
+export interface OpenRouterSettings {
+	/** Prefer the stateless Responses API for OpenRouter requests. Default: false. */
+	responses?: boolean;
+}
+
 export type TransportSetting = Transport;
 
 /**
@@ -128,6 +133,7 @@ export interface Settings {
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	defaultServiceTier?: ServiceTier;
 	rlmMaxDepth?: number; // default for new sessions; unset falls through to RLM_MAX_DEPTH, then 1
+	openRouter?: OpenRouterSettings;
 	idleEvictionMinutes?: number | "off"; // global daemon policy; default: 90
 	transport?: TransportSetting; // default: "auto"
 	steeringMode?: "all" | "one-at-a-time";
@@ -770,6 +776,10 @@ export class SettingsManager {
 
 	getRlmMaxDepth(): number | undefined {
 		return this.globalSettings.rlmMaxDepth;
+	}
+
+	getOpenRouterResponses(): boolean {
+		return this.settings.openRouter?.responses ?? false;
 	}
 
 	setRlmMaxDepth(maxDepth: number): void {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -502,6 +502,14 @@ describe("SettingsManager", () => {
 			expect(servers?.shared).toEqual({ type: "http", url: "https://project.shared/mcp" });
 		});
 	});
+
+	describe("OpenRouter Responses transport", () => {
+		it("defaults to Chat Completions and accepts an explicit opt-in", () => {
+			expect(SettingsManager.inMemory().getOpenRouterResponses()).toBe(false);
+			expect(SettingsManager.inMemory({ openRouter: { responses: true } }).getOpenRouterResponses()).toBe(true);
+		});
+	});
+
 	describe("idle worker eviction", () => {
 		it("defaults to 90 minutes and treats none as off", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);


### PR DESCRIPTION
Send Prime’s opaque session identifier as OpenRouter’s `session_id` so Chat Completions requests from one session share dashboard grouping and sticky upstream routing.

Add a default-off `openRouter.responses` setting that selects OpenRouter’s stateless Responses transport on each provider request. The Responses path keeps the session ID, prompt cache key, provider routing, tools, and reasoning settings. It falls back to Chat Completions only when the Responses endpoint is unavailable before streaming starts; authentication, rate-limit, context, cancellation, and post-start failures stay on the selected transport.

Verified the changed AI provider paths with 17 focused tests and the settings path with 34 focused tests. `npm run check` also passes, including Biome, TypeScript, installer rendering, and the browser smoke check.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenRouter session routing and Responses transport with Chat Completions fallback
> - Adds `session_id` to OpenRouter Chat Completions and Responses requests, populated from `options.sessionId`, for dashboard grouping and sticky routing.
> - Introduces a new `openRouterResponses` option in `SimpleStreamOptions` that routes OpenRouter requests through the stateless Responses transport instead of Chat Completions.
> - When `openRouterResponses` is enabled, a `streamOpenRouterResponsesWithChatFallback` helper automatically falls back to Chat Completions if the Responses transport fails before streaming begins (e.g. 404, 405, 501, or unsupported endpoint).
> - Adds a `getOpenRouterResponses()` getter in [`settings-manager.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/818/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab) reading from `openRouter.responses` (default `false`), wired into the agent session in [`sdk.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/818/files#diff-93182c4e55eb0fc99d29b25ad0eff2d8178ebc5a728296e70c3767615f493c60).
> - Behavioral Change: OpenRouter Responses requests now include tool call support and optional provider routing preferences via `compat.openRouterRouting`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f70cd58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->