### PR TITLE
fix(coding-agent): Windows support for kernel bootstrap and console-less daemon spawns

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -201,6 +201,7 @@ function readCommandOutput(
 		encoding: "utf-8",
 		stdio: ["ignore", "pipe", "pipe"],
 		shell: shouldUseWindowsShell(command),
+		windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 	});
 	if (result.status === 0) return result.stdout.trim() || undefined;
 	if (options.requireSuccess) {

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -496,6 +496,9 @@ function runChildProcess(
 			detached: process.platform !== "win32",
 			shell: options.shell === true,
 			stdio: ["ignore", "pipe", "pipe"],
+			// These run inside console-less daemon workers; avoid a console window
+			// flash on Windows (see runGit in utils/git.ts).
+			windowsHide: true,
 		});
 		if (child.pid) {
 			trackDetachedChildPid(child.pid);

--- a/packages/coding-agent/src/core/exec.ts
+++ b/packages/coding-agent/src/core/exec.ts
@@ -62,6 +62,9 @@ export async function execCommand(
 			cwd,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],
+			// Runs inside console-less daemon workers; avoid a console window
+			// flash on Windows (see runGit in utils/git.ts).
+			windowsHide: true,
 			// Merge per-call env over the parent env so callers can scope vars
 			// (e.g. herdr pane identity) without mutating the shared process.env.
 			env: mergeExecEnv(options?.env),

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -10,6 +10,8 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
 		cwd: repoDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		// See runGit in utils/git.ts: avoid a console window flash on Windows.
+		windowsHide: true,
 	});
 	const branch = result.status === 0 ? result.stdout.trim() : "";
 	return branch || null;
@@ -24,6 +26,8 @@ function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
 			{
 				cwd: repoDir,
 				encoding: "utf8",
+				// See runGit in utils/git.ts: avoid a console window flash on Windows.
+				windowsHide: true,
 			},
 			(error: ExecFileException | null, stdout: string) => {
 				if (error) {

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -376,6 +376,7 @@ function run(command: string, args: string[], options: { stdio?: "ignore" | "inh
 		const child = spawn(command, args, {
 			env: process.env,
 			stdio: options.stdio ?? "ignore",
+			windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 		});
 		child.on("error", reject);
 		child.on("exit", (code, signal) => {
@@ -495,6 +496,12 @@ async function acquireBootstrapLock(venv: string): Promise<() => Promise<void>> 
 			await sleep(BOOTSTRAP_LOCK_RETRY_MS);
 		}
 	}
+}
+
+// uv venv layouts differ by platform: POSIX puts the interpreter at bin/python,
+// Windows at Scripts/python.exe. Hardcoding "bin/python" breaks bootstrap on Windows.
+function venvPythonPath(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
 }
 
 async function findExecutable(name: string): Promise<string | null> {
@@ -725,7 +732,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = venvPythonPath(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +893,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = venvPythonPath(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -175,6 +175,7 @@ class ForkServer {
 				const proc = spawn(this.params.python, ["-c", FORK_SERVER_SCRIPT, socketPath], {
 					env: this.launchEnv,
 					stdio: ["ignore", "ignore", "pipe"],
+					windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 				});
 				this.proc = proc;
 				proc.stderr?.on("data", (buf: Buffer) => {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -648,6 +648,7 @@ export class KernelManager {
 				cwd: this.options.cwd,
 				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
 				stdio: ["ignore", "pipe", "pipe"],
+				windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 			});
 			this.kernel = kernel;
 

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2396,6 +2396,7 @@ export class DefaultPackageManager implements PackageManager {
 			cwd: options?.cwd,
 			stdio: ["ignore", "pipe", "pipe"],
 			shell: shouldUseWindowsShell(command),
+			windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 			env: options?.env ? { ...baseEnv, ...options.env } : baseEnv,
 		});
 	}
@@ -2463,6 +2464,7 @@ export class DefaultPackageManager implements PackageManager {
 			stdio: ["ignore", "pipe", "pipe"],
 			encoding: "utf-8",
 			shell: shouldUseWindowsShell(command),
+			windowsHide: true,
 			env: getEnv(),
 		});
 		if (result.error || result.status !== 0) {

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -25,7 +25,7 @@ async function deleteSessionArtifacts(sessionPath: string): Promise<void> {
 /** Remove the session `.jsonl`, trying the `trash` CLI first, then falling back to unlink. */
 async function removeSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
-	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8", windowsHide: true });
 
 	const getTrashErrorHint = (): string | null => {
 		const parts: string[] = [];

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -116,6 +116,9 @@ function runProcessQuery(command: string, args: string[]): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		// Called from console-less daemon workers; avoid a console window flash
+		// on Windows (see runGit in utils/git.ts).
+		windowsHide: true,
 	});
 }
 

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -77,6 +77,7 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),
 					stdio: ["ignore", "pipe", "pipe"],
+					windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 				});
 				if (child.pid) trackDetachedChildPid(child.pid);
 				let timedOut = false;

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -206,11 +206,16 @@ export class CommandRecoveryJournal {
 			closeSync(descriptor);
 		}
 		renameSync(tempPath, this.path);
-		const directoryDescriptor = openSync(dirname(this.path), "r");
 		try {
-			fsyncSync(directoryDescriptor);
-		} finally {
-			closeSync(directoryDescriptor);
+			const directoryDescriptor = openSync(dirname(this.path), "r");
+			try {
+				fsyncSync(directoryDescriptor);
+			} finally {
+				closeSync(directoryDescriptor);
+			}
+		} catch {
+			// Directory fsync is unavailable on some platforms (e.g. Windows raises
+			// EPERM); the atomic rename still protects readers.
 		}
 		this.recordCount = records.length;
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -396,6 +396,7 @@ export class DaemonCatalogClient {
 			cwd: process.cwd(),
 			env: createCliSubprocessEnv({ ...process.env, [DAEMON_CATALOG_ROLE_ENV]: "1" }),
 			stdio: ["ignore", "ignore", "ignore", "ipc"],
+			windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 		});
 		this.child = child;
 		child.on("message", (value: unknown) => this.handleMessage(value));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8665,7 +8665,7 @@ export class InteractiveMode {
 	private async handleShareCommand(): Promise<void> {
 		// Check if gh is available and logged in
 		try {
-			const authResult = spawnSync("gh", ["auth", "status"], { encoding: "utf-8" });
+			const authResult = spawnSync("gh", ["auth", "status"], { encoding: "utf-8", windowsHide: true });
 			if (authResult.status !== 0) {
 				this.showError("GitHub CLI is not logged in. Run 'gh auth login' first.");
 				return;
@@ -8714,7 +8714,7 @@ export class InteractiveMode {
 
 		try {
 			const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
-				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile]);
+				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile], { windowsHide: true });
 				let stdout = "";
 				let stderr = "";
 				proc.stdout?.on("data", (data) => {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -107,6 +107,7 @@ export class RpcClient {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
+			windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 		});
 
 		// Collect stderr for debugging

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -98,6 +98,7 @@ function runCommand(
 		timeout: timeoutMs,
 		maxBuffer: maxBufferBytes,
 		env: options?.env,
+		windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 	});
 
 	if (result.error) {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -253,6 +253,9 @@ function runGit(cwd: string, args: string[]): string | null {
 		cwd,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		// Daemon workers run without a console; without this, each git spawn makes
+		// Windows allocate a fresh console window (visible flicker).
+		windowsHide: true,
 	});
 	if (result.status !== 0 || typeof result.stdout !== "string") return null;
 	return result.stdout.trim() || null;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -16,7 +16,7 @@ function findBashOnPath(): string | null {
 	if (process.platform === "win32") {
 		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
 		try {
-			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000 });
+			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 			if (result.status === 0 && result.stdout) {
 				const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 				if (firstMatch && existsSync(firstMatch)) {
@@ -31,7 +31,7 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000 });
+		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 		if (result.status === 0 && result.stdout) {
 			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 			if (firstMatch) {
@@ -194,6 +194,7 @@ export function killProcessTree(pid: number): void {
 			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
+				windowsHide: true,
 			});
 		} catch {
 			// Ignore errors if taskkill fails

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -100,7 +100,7 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check that a command both launches and reports a successful version.
 function commandWorks(cmd: string): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS });
+		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS, windowsHide: true });
 		return !result.error && result.status === 0;
 	} catch {
 		return false;
@@ -224,7 +224,10 @@ async function downloadTool(tool: ManagedTool): Promise<string> {
 
 	try {
 		if (assetName.endsWith(".tar.gz")) {
-			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], { stdio: "pipe" });
+			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], {
+				stdio: "pipe",
+				windowsHide: true,
+			});
 			if (extractResult.error || extractResult.status !== 0) {
 				const errMsg = extractResult.error?.message ?? extractResult.stderr?.toString().trim() ?? "unknown error";
 				throw new Error(`Failed to extract ${assetName}: ${errMsg}`);

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -164,6 +164,7 @@ async function walkDirectoryWithFd(
 
 		const child = spawn(fdPath, args, {
 			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true, // avoid console window flash on Windows (console-less daemon workers)
 		});
 		let stdout = "";
 		let resolved = false;


### PR DESCRIPTION
## Summary

On Windows, prime-agent's daemon and session workers run console-less. Every `child_process` spawn from those processes makes Windows allocate a fresh console window, which users see as cmd windows flashing at startup, every ~15s (git footer/context polling), and on every agent tool call. Separately, the IPython kernel bootstrap hardcodes the POSIX venv interpreter path (`bin/python`), which doesn't exist in Windows venvs (`Scripts/python.exe`), so first-time setup on Windows deleted and rebuilt the kernel venv in an endless failure loop ("kernel is still bootstrapping... let me retry").

## Changes

- **Kernel bootstrap** (`core/kernel/bootstrap.ts`): resolve the venv interpreter as `Scripts/python.exe` on Windows, `bin/python` on POSIX, via a new `venvPythonPath()` helper used by both `bootstrapVenv()` and `ensureKernelPythonUncached()`.
- **windowsHide sweep**: add `windowsHide: true` to all background child_process call sites that can run inside console-less daemon/worker processes: git context/branch polling (`utils/git.ts`, `footer-data-provider.ts`), session-lease PowerShell queries, config and package-manager command probes, bash tool, `exec.ts`, autonomous runner, kernel/fork-server/bootstrap spawns, daemon catalog process, fd autocomplete search (`packages/tui`), session trash, `gh` share commands, tar/--version probes, clipboard helpers, rpc client. Interactive spawns (owned session worker with inherited stdio, external editors, self-update) and already-`detached` spawns (which get no console on Windows) are intentionally left untouched.
- **Command recovery journal**: tolerate directory `fsync` failures (Windows raises `EPERM`), matching the existing tolerant pattern in `cron-jobs.ts` — the atomic rename still protects readers. This was spamming `EPERM: operation not permitted, fsync` warnings on every journal compaction.

## Testing

- Verified on Windows 11 (Windows Terminal): before the fix, process monitoring captured each background `git.exe` spawn creating a new `conhost.exe` + `OpenConsole.exe` pair (the visible flashes); after the fix, none are created.
- Kernel bootstrap now completes on Windows: venv created with `ipykernel`, `prime-agent-runtime`, `dill` and default packages import correctly.
- `biome check`, `tsgo --noEmit`, installer and browser-smoke pre-commit checks all pass.
- Note: some tests in `test/kernel-bootstrap.test.ts`, `test/session-lease.test.ts` and `test/ipython-provisioner.test.ts` fail on Windows, but they fail identically on the pristine tree (they use POSIX shell-script fake executables) — pre-existing, not caused by this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows support in coding-agent by hiding console windows and resolving venv Python paths
> - Adds `windowsHide: true` to all `spawn`/`spawnSync`/`execFile` calls across the coding-agent and TUI packages so child processes no longer flash a console window on Windows.
> - Introduces `venvPythonPath()` in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/825/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to return the correct Python interpreter path per platform (`Scripts/python.exe` on Windows, `bin/python` on POSIX), replacing hardcoded `bin/python` paths used during venv bootstrapping and kernel readiness checks.
> - Wraps directory `fsync` in a try/catch in [command-recovery-journal.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/825/files#diff-ad9ad93f7564a34f4c838495026b460ad85292338ab337c5cdca8f48161ecd3a) so journal writes succeed on filesystems that don't support `fsync` (e.g. Windows NTFS), while still completing via atomic rename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0df7848.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->