### PR TITLE
feat(coding-agent): filter agents-view saved sessions by project

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -42,6 +42,7 @@ export interface AppKeybindings {
 	"app.agents.delete": true;
 	"app.agents.program": true;
 	"app.agents.rename": true;
+	"app.agents.toggleScope": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
@@ -130,6 +131,10 @@ export const KEYBINDINGS = {
 	"app.agents.delete": { defaultKeys: "ctrl+x", description: "Stop or delete selected agent" },
 	"app.agents.program": { defaultKeys: "ctrl+o", description: "Show the program that spawned subagents" },
 	"app.agents.rename": { defaultKeys: "ctrl+r", description: "Rename selected agent session" },
+	"app.agents.toggleScope": {
+		defaultKeys: "ctrl+f",
+		description: "Filter saved sessions to the current project",
+	},
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],
 		description: "Fold tree branch or move up",

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -27,7 +27,11 @@ import {
 import { canonicalizePath } from "../../utils/paths.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { DaemonAgentConnection } from "../agent-connection/daemon-agent-connection.js";
-import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/types.js";
+import type {
+	AgentConnectionHeartbeat,
+	AgentConnectionSavedSessionInfo,
+	AgentConnectionSavedSessionScope,
+} from "../agent-connection/types.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../daemon/daemon-client.js";
 import {
 	collectDaemonClientEnv,
@@ -165,6 +169,7 @@ export type AgentsViewPersistentState = {
 	query?: string;
 	savedSessions?: AgentConnectionSavedSessionInfo[];
 	lastSuccessfulSavedSessions?: AgentConnectionSavedSessionInfo[];
+	savedScope?: AgentConnectionSavedSessionScope;
 	lastSuccessfulLiveSummaries?: SessionSummary[];
 	savedCatalogGeneration?: number;
 	heartbeats?: AgentConnectionHeartbeat[];
@@ -638,6 +643,7 @@ export class AgentsViewMode implements Component, Focusable {
 	private lastVisibleSummaries: SessionSummary[] = [];
 	private savedSessions: AgentConnectionSavedSessionInfo[] = [];
 	private lastSuccessfulSavedSessions: AgentConnectionSavedSessionInfo[] = [];
+	private savedScope: AgentConnectionSavedSessionScope;
 	private heartbeats: AgentConnectionHeartbeat[] = [];
 	private unifiedRecords: UnifiedSessionRecord[] = [];
 	private unifiedIndex: UnifiedSessionIndex = buildUnifiedSessionIndex([]);
@@ -700,6 +706,7 @@ export class AgentsViewMode implements Component, Focusable {
 		this.lastListedSummaries = persistentState.lastSuccessfulLiveSummaries ?? [];
 		this.savedSessions = persistentState.savedSessions ?? [];
 		this.lastSuccessfulSavedSessions = persistentState.lastSuccessfulSavedSessions ?? this.savedSessions;
+		this.savedScope = persistentState.savedScope ?? "current";
 		this.savedCatalogReady = persistentState.lastSuccessfulSavedSessions !== undefined;
 		this.heartbeats = persistentState.heartbeats ?? [];
 		this.savedCatalogGeneration = persistentState.savedCatalogGeneration ?? 0;
@@ -887,6 +894,10 @@ export class AgentsViewMode implements Component, Focusable {
 				return;
 			}
 			this.handleCtrlC();
+			return;
+		}
+		if (this.editor.getText().length === 0 && this.keybindings.matches(data, "app.agents.toggleScope")) {
+			this.toggleSavedScope();
 			return;
 		}
 		if (this.editor.getText().length === 0 && this.keybindings.matches(data, "app.agents.rename")) {
@@ -2195,6 +2206,21 @@ export class AgentsViewMode implements Component, Focusable {
 		return results.every(Boolean);
 	}
 
+	private toggleSavedScope(): void {
+		this.savedScope = this.savedScope === "all" ? "current" : "all";
+		this.persistentState.savedScope = this.savedScope;
+		// Drop the previous scope's catalog so stale sessions are not rendered while reloading.
+		this.savedSessions = [];
+		this.lastSuccessfulSavedSessions = [];
+		this.persistentState.savedSessions = [];
+		this.persistentState.lastSuccessfulSavedSessions = [];
+		this.setStatusMessage(
+			this.savedScope === "current" ? "Saved sessions: current project" : "Saved sessions: all projects",
+			{ render: false },
+		);
+		void this.refreshSavedSessions();
+	}
+
 	private async refreshSavedSessions(
 		options: { duringReconnect?: boolean; preserveStatusOnError?: boolean } = {},
 	): Promise<boolean> {
@@ -2218,7 +2244,7 @@ export class AgentsViewMode implements Component, Focusable {
 			const sessions = await listDaemonSavedSessions(
 				this.requireClient(),
 				this.getSavedSessionCatalogContext(),
-				"all",
+				this.savedScope,
 				{
 					onSession,
 				},
@@ -2673,6 +2699,7 @@ export class AgentsViewMode implements Component, Focusable {
 				? `${keyText("app.agents.reply")} ${selectedRow?.section === "inactive" ? "resume" : "reply"}`
 				: undefined,
 			`${keyText("app.agents.new")} new`,
+			`${keyText("app.agents.toggleScope")} saved:${this.savedScope === "current" ? "project" : "all"}`,
 			selectedAgent ? `${keyText("app.agents.rename")} rename` : undefined,
 			selectedAgent
 				? `${keyText("app.agents.delete")} ${selectedRow?.section === "inactive" ? "delete" : "stop/deactivate"}`


### PR DESCRIPTION
## Problem

The agents view (`prime-agent agents` / left-arrow from a session) hardcodes the saved-session catalog scope to `"all"` (`agents-view-mode.ts`), so saved sessions from **every** project are mixed into a single list. Resuming a session for the current project means scrolling or typing a search query, even though the underlying plumbing already supports project scoping:

- `SessionManager.list(cwd)` filters saved sessions by exact cwd match
- the daemon `list_saved_sessions` command accepts `scope: "current" | "all"`
- CLI `--continue` / `--resume` already resolve per-project

Only the TUI never exposed the scope.

## Change

- New keybinding `app.agents.toggleScope` (default `ctrl+f`) toggles the saved-session catalog between **current project** and **all projects**.
- The scope lives in `AgentsViewPersistentState`, so it survives agents-view re-entry (drill into a session, left-arrow back) within one visit.
- Defaults to `"current"` — opening the agents view shows the current project's saved sessions first; one keypress widens to everything.
- The hints dock shows the active scope (`saved:project` / `saved:all`) so the state is always visible and the feature is discoverable.
- Toggling clears the previous scope's cached catalog before reloading, so stale cross-project sessions are never rendered while the new list streams in.

No daemon or `SessionManager` changes were needed — the `"current"` scope path was already implemented end-to-end.

## Testing

- `biome check`, `tsgo --noEmit`, installer and browser-smoke checks: pass (ran via the pre-commit hook)
- Agents-view and keybinding suites: 118 tests pass (`agents-view-mode`, `agents-view-state`, `agents-view-inactive-reply`, `agents-view-missing-cwd`, `keybinding-hints`, `keybindings-migration`)
- Manual: build + install, open the agents view in a project directory, `ctrl+f` switches the saved list between project-only and all sessions, with the hint bar reflecting the active scope.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter agents-view saved sessions by current project using a scope toggle
> - Adds a `savedScope` state (`"current"` | `"all"`) to `AgentsViewMode`, persisted across sessions and defaulting to `"current"`.
> - Pressing `ctrl+f` (new `app.agents.toggleScope` keybinding) switches the scope, clears cached results, and reloads saved sessions from the daemon with the selected scope.
> - Updates the UI hint bar to show the current scope and the toggle shortcut.
> - Behavioral Change: saved sessions now default to showing only the current project's sessions rather than all sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4c69ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->