### PR TITLE
fix(ai): repair invalid unicode escape prefixes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed malformed Unicode escape prefixes causing streamed tool-call arguments such as Windows paths to be discarded.
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -1,6 +1,15 @@
 import { parse as partialParse } from "partial-json";
 
-const VALID_JSON_ESCAPES = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
+const VALID_JSON_ESCAPES: Record<string, true> = {
+	'"': true,
+	"\\": true,
+	"/": true,
+	b: true,
+	f: true,
+	n: true,
+	r: true,
+	t: true,
+};
 
 function isControlCharacter(char: string): boolean {
 	const codePoint = char.codePointAt(0);
@@ -66,7 +75,7 @@ export function repairJson(json: string): string {
 				}
 			}
 
-			if (VALID_JSON_ESCAPES.has(nextChar)) {
+			if (VALID_JSON_ESCAPES[nextChar]) {
 				repaired += `\\${nextChar}`;
 				index += 1;
 				continue;

--- a/packages/ai/test/json-parse.test.ts
+++ b/packages/ai/test/json-parse.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseStreamingJson, repairJson } from "../src/utils/json-parse.js";
+
+const WINDOWS_PATH = ["C:", "users", "workspace", "project"].join("\\");
+const MALFORMED_WINDOWS_PATH_JSON = `{"path":"${WINDOWS_PATH}"}`;
+
+describe("repairJson", () => {
+	it("repairs invalid unicode escape prefixes", () => {
+		expect(repairJson(MALFORMED_WINDOWS_PATH_JSON)).toBe(JSON.stringify({ path: WINDOWS_PATH }));
+	});
+
+	it("preserves valid unicode escapes", () => {
+		const json = `{"value":"\\u0041"}`;
+
+		expect(repairJson(json)).toBe(json);
+	});
+});
+
+describe("parseStreamingJson", () => {
+	it("retains unescaped backslashes in Windows paths", () => {
+		expect(parseStreamingJson(MALFORMED_WINDOWS_PATH_JSON)).toEqual({ path: WINDOWS_PATH });
+	});
+});


### PR DESCRIPTION
## Problem

`repairJson()` validates `\uXXXX` escapes separately, but the generic escape lookup also treated every `\u` prefix as valid. Malformed streamed tool arguments such as `{"path":"C:\users\workspace"}` therefore remained invalid, and `parseStreamingJson()` eventually returned an empty object instead of the tool arguments.

## Fix

- Preserve `\u` escapes only when they contain exactly four hexadecimal digits.
- Escape malformed `\u` prefixes using the existing invalid-escape repair path.
- Add regression coverage for unescaped Windows paths and valid Unicode escapes.
- Record the user-visible fix under the AI package's Unreleased changelog.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/json-parse.test.ts` in `packages/ai` (3 tests passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `repairJson` to preserve malformed Unicode escape prefixes in streamed tool-call arguments
> Removes `'u'` from the `VALID_JSON_ESCAPES` lookup in [`json-parse.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/827/files#diff-77e0781eb08fb6dbe9c71a2343a1245f2481e3525365953f99dcdd8228affa94) so that `\u` not followed by 4 hex digits is repaired to `\\u` instead of being accepted as a valid escape. This prevents streamed tool-call arguments containing Windows paths (e.g. `C:\Users\...`) from being silently discarded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 293d582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->