### PR TITLE
fix(coding-agent): surface RLM subagent registry persistence failures

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2389,7 +2389,7 @@ export class AgentDaemon {
 					runtime.session.setSessionName(options.sessionName);
 				}
 				if (runtime.session.sessionFile) {
-					this.recordRlmSubagentRegistryEntry(parentState, {
+					const persisted = this.recordRlmSubagentRegistryEntry(parentState, {
 						childId: options.id,
 						sessionName: options.sessionName,
 						sessionDir: options.sessionDir,
@@ -2406,6 +2406,15 @@ export class AgentDaemon {
 						status: "running",
 						createdAt: runtime.metadata.createdAt,
 					});
+					if (!persisted) {
+						this.log(
+							`RLM subagent ${options.sessionName} (${options.id}) published without durable registry persistence; parent may not rediscover it after restart`,
+						);
+					}
+				} else {
+					this.log(
+						`RLM subagent ${options.sessionName} (${options.id}) published before its session file existed; skipping durable registry persistence`,
+					);
 				}
 				options.onSessionPublished?.(runtime.session);
 			},


### PR DESCRIPTION
## Problem

In the RLM child-creation callback (`DaemonMode`), the boolean returned by `recordRlmSubagentRegistryEntry` is discarded, and the registry write is skipped entirely when `runtime.session.sessionFile` is falsy — yet `onSessionPublished` fires the child either way:

```ts
if (runtime.session.sessionFile) {
    this.recordRlmSubagentRegistryEntry(parentState, { ... }); // return value ignored
}
options.onSessionPublished?.(runtime.session);
```

`recordRlmSubagentRegistryEntry` → `appendRlmSubagentRegistryEntry` returns `false` on a disk-full or permission failure. If that write fails (or the session file isn't written yet) and the process then crashes, the child transcript can remain on disk while the parent registry has no row for it, so the parent can't rediscover the child after restart.

The other lifecycle paths already treat this boolean as significant: the completion path drops the child when `completeRlmSubagentRuntime(...) === false`, and the deletion path throws on append failure. Only the creation path ignored it.

## Change

Capture the return value and log when a child is published without durable registration (both the failed-write case and the no-session-file case), so the gap is observable instead of silent. Behavior on the success path is unchanged.

This is the conservative fix. A stricter option — refusing to publish until registration succeeds — is possible but changes behavior for an already-running child, so I left that call to maintainers.

## Testing

`daemon-mode` + `acp-rlm-subagents` suites pass (191 tests). Pre-commit `biome check` + `tsgo --noEmit` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log RLM subagent registry persistence failures in `AgentDaemon`
> The return value of `recordRlmSubagentRegistryEntry` is now captured and checked. A log line is emitted when durable persistence fails, and a separate log line is emitted when persistence is skipped due to a missing session file. Previously, failures were silent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc1df6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->