### PR TITLE
docs: correct rlm() result-return description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Prime Agent is an open-source coding and research agent for general and long-run
 Prime Agent combines a persistent Python control environment with durable harness state, so useful working context and reusable operating patterns can outlive a single chat window.
 
 - **Everything is programmatic:** persistent IPython is the built-in model tool; file operations, shell commands, tool use, subagents, and context management happen through code.
-- **Subagents are built in:** `rlm(...)` spawns real child agents for parallel or background work and returns their results programmatically.
+- **Subagents are built in:** `rlm(...)` spawns real child agents for parallel or background work and returns a handle immediately; their results arrive asynchronously through agent messages or files.
 - **The harness can improve:** `/refine` reviews the current trajectory and can apply small, evidence-backed updates to supplemental harness state. It never rewrites the immutable base system prompt, and recorded snapshots support rollback.
 - **Skills are executable:** skills are importable Python packages, and the built-in skill creator can turn recurring workflows into project or personal skills.
 - **Sessions run in the background:** daemon-backed agents keep running when the terminal disconnects and can be reattached later.


### PR DESCRIPTION
## Problem

`README.md` states:

> **Subagents are built in:** `rlm(...)` spawns real child agents for parallel or background work and returns their results programmatically.

`rlm(...)` actually returns an `RLMSpawnHandle` at task admission — not the child's result. Results arrive later via agent messages or files. This is what the code does and what the repo's own `docs/rlm.md` says:

> The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer.
> Results arrive only through explicit `agent_message` replies or files, never as an `rlm()` return value.

The README bullet is the only place that contradicts this.

## Change

Reword the bullet to match the implementation and `docs/rlm.md`. The conceptual "prompt-as-a-variable" line above it is left as-is.

## Testing

Docs only. Pre-commit `biome check` + `tsgo --noEmit` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct `rlm()` return behavior description in README
> Updates [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/829/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to accurately describe that `rlm()` returns a handle immediately, with results arriving asynchronously via agent messages or files, rather than returning results programmatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca79b88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->