### PR TITLE
fix(coding-agent): bound JSONL command reads from untrusted local peers

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -126,7 +126,7 @@ import {
 import { createAgentConnectionToolDefinition } from "../agent-connection/tool-definition.js";
 import type { AgentConnectionHeartbeat, AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
 import { waitForHeadlessCompletion } from "../headless-completion.js";
-import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
+import { attachJsonlLineReader, serializeJsonLine, UNTRUSTED_JSONL_MAX_LINE_CHARS } from "../rpc/jsonl.js";
 import { encodePrivateFrame, PrivateFrameDecoder } from "../session-worker/private-framing.js";
 import {
 	type ActiveSessionState,
@@ -3036,9 +3036,17 @@ export class AgentDaemon {
 				socket.off("end", onEnd);
 			};
 		} else {
-			client.detachInput = attachJsonlLineReader(socket, (line) => {
-				void this.handleLine(client, line);
-			});
+			client.detachInput = attachJsonlLineReader(
+				socket,
+				(line) => {
+					void this.handleLine(client, line);
+				},
+				{
+					maxLineLength: UNTRUSTED_JSONL_MAX_LINE_CHARS,
+					onLineOverflow: () =>
+						this.log(`dropping oversized JSONL command line (exceeded ${UNTRUSTED_JSONL_MAX_LINE_CHARS} chars)`),
+				},
+			);
 		}
 
 		let cleanedUp = false;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -45,7 +45,7 @@ import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js
 import { SettingsManager } from "../../core/settings-manager.js";
 import { signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
-import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
+import { attachJsonlLineReader, serializeJsonLine, UNTRUSTED_JSONL_MAX_LINE_CHARS } from "../rpc/jsonl.js";
 import type { PrivateFrame } from "../session-worker/private-framing.js";
 import { createActiveSessionId, type DaemonSocketClient } from "./active-session-state.js";
 import { CommandRecoveryJournal, createCommandIdempotencyKey } from "./command-recovery-journal.js";
@@ -1039,7 +1039,13 @@ export class DaemonSupervisor {
 			() => client.socket.destroy(),
 		);
 
-		client.detachInput = attachJsonlLineReader(socket, (line) => void this.handleLine(client, line));
+		client.detachInput = attachJsonlLineReader(socket, (line) => void this.handleLine(client, line), {
+			maxLineLength: UNTRUSTED_JSONL_MAX_LINE_CHARS,
+			onLineOverflow: () =>
+				this.log(
+					`dropping oversized command from client ${client.id} (exceeded ${UNTRUSTED_JSONL_MAX_LINE_CHARS} chars)`,
+				),
+		});
 		let cleaned = false;
 		const cleanup = () => {
 			if (cleaned) {

--- a/packages/coding-agent/src/modes/rpc/jsonl.ts
+++ b/packages/coding-agent/src/modes/rpc/jsonl.ts
@@ -17,6 +17,14 @@ export interface JsonlLineReaderOptions {
 }
 
 /**
+ * Ceiling for a single JSONL record accepted from an untrusted local peer
+ * (daemon sockets, RPC stdin). Prevents a newline-free stream from growing
+ * process memory without bound, while staying generous enough for legitimate
+ * large commands such as a big prompt.
+ */
+export const UNTRUSTED_JSONL_MAX_LINE_CHARS = 16 * 1024 * 1024;
+
+/**
  * Attach an LF-only JSONL reader to a stream.
  *
  * This intentionally does not use Node readline. Readline splits on additional

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -11,7 +11,7 @@ import type {
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionSessionWatcher,
 } from "../agent-connection/types.js";
-import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+import { attachJsonlLineReader, serializeJsonLine, UNTRUSTED_JSONL_MAX_LINE_CHARS } from "./jsonl.js";
 import { createRpcExtensionUiBridge } from "./rpc-extension-ui-context.js";
 import type {
 	RpcCommand,
@@ -542,7 +542,13 @@ async function runRpcModeWithConnectionInternal(
 	};
 	process.stdin.on("end", onInputEnd);
 	detachInput = (() => {
-		const detachJsonl = attachJsonlLineReader(process.stdin, dispatchInputLine);
+		const detachJsonl = attachJsonlLineReader(process.stdin, dispatchInputLine, {
+			maxLineLength: UNTRUSTED_JSONL_MAX_LINE_CHARS,
+			onLineOverflow: () =>
+				process.stderr.write(
+					`prime-agent: dropping oversized RPC input line (exceeded ${UNTRUSTED_JSONL_MAX_LINE_CHARS} chars)\n`,
+				),
+		});
 		return () => {
 			detachJsonl();
 			process.stdin.off("end", onInputEnd);


### PR DESCRIPTION
## Problem

`attachJsonlLineReader` already supports `maxLineLength` + `onLineOverflow`, and the worker-stderr reader uses it (`64 * 1024`). But the readers fed by untrusted local input pass no bound:

- the public daemon supervisor socket (`daemon-supervisor.ts`)
- the daemon client socket (`daemon-mode.ts`)
- RPC stdin (`rpc-mode.ts`)

A local peer that can reach the socket (or RPC stdin) can send a newline-free stream, and the reader accumulates it without limit, growing process memory — a local memory-exhaustion vector.

## Change

Wire the existing mechanism into those three readers with a shared 16 MiB ceiling (`UNTRUSTED_JSONL_MAX_LINE_CHARS`), logging and dropping oversized lines. 16 MiB is generous enough for legitimate large commands (e.g. a big prompt) while still finite. Scoped deliberately to the untrusted-input readers; the daemon-client/worker readers consume output from processes this agent itself spawned and are left as-is.

## Testing

`rpc-jsonl` + `daemon-protocol` (23 tests) and `daemon-mode` (190 tests) pass. Pre-commit `biome check` + `tsgo --noEmit` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound JSONL command reads from untrusted local peers to 16 MiB
> Adds a 16 MiB per-line limit (`UNTRUSTED_JSONL_MAX_LINE_CHARS`) to JSONL readers that handle input from untrusted local peers. Oversized lines are dropped rather than processed, and a diagnostic message is logged or written to stderr.
>
> - [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/830/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) and [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/830/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) enforce the limit on incoming client commands, logging the client ID when a line is dropped
> - [rpc-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/830/files#diff-8c65d8a4b5f198749ad7b30d5099f2da25c8e568d14a4c756b8d68199276bdbe) enforces the limit on stdin input, writing a diagnostic to stderr on overflow
> - The constant is defined and exported from [jsonl.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/830/files#diff-304d7897da39bddd729733b2b2f6e50937a73f26f156687c07a7859106eaaca5)
> - Behavioral Change: previously unbounded JSONL reads from local peers now silently drop lines exceeding 16 MiB instead of processing them
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bf5f72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->