### PR TITLE
Add per-spawn service tier selection to RLM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Added config-gated per-spawn RLM service-tier selection with validation, inheritance, and fast-mode clamping.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -23,7 +23,7 @@ flowchart TD
 When the model delegates work:
 
 ```python
-handle = await rlm("inspect the API", name="api-reviewer")
+handle = await rlm("inspect the API", name="api-reviewer", service_tier="default")
 print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
 ```
 
@@ -150,10 +150,11 @@ await rlm.run("subtask")
 
 Supported `rlm.run` options are:
 
-- `name`: a unique readable child session name; and
-- `model`: an exact `provider/model` selector from `rlm.find_models()`.
+- `name`: a unique readable child session name;
+- `model`: an exact `provider/model` selector from `rlm.find_models()`; and
+- `service_tier`: one of `auto`, `default`, `flex`, `scale`, `priority`, or `None`, subject to the `rlmAllowedServiceTiers` settings allowlist.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options, invalid service-tier values, and service tiers excluded by `rlmAllowedServiceTiers` fail instead of being ignored. When `rlmAllowedServiceTiers` is unset, it contains exactly the configured `defaultServiceTier` (which defaults to `default`). Omitting `service_tier` inherits the parent's tier. An explicit `priority` tier uses the existing fast-mode clamp for the selected child model. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
 
 ## Child Execution
 

--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -55,11 +55,15 @@ Each `%%bash` cell is a temporary subshell, while Python state and `%cd` changes
 The callable `rlm` object is preloaded in the kernel. Spawn a child with a direct call:
 
 ```python
-handle = await rlm("Review the authentication flow for security issues", name="auth-reviewer")
+handle = await rlm(
+    "Review the authentication flow for security issues",
+    name="auth-reviewer",
+    service_tier="default",
+)
 print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
 ```
 
-The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model.
+The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, service tier, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model or service tier. Valid service tiers are `auto`, `default`, `flex`, `scale`, `priority`, and `None`; `priority` is clamped to `default` for child models without fast-mode support. Explicit `service_tier` overrides must be listed in the `rlmAllowedServiceTiers` settings array; when that setting is unset, only the configured `defaultServiceTier` is allowed. Omitting `service_tier` preserves parent-tier inheritance.
 
 Spawn independent children in separate calls and end the turn instead of awaiting completion:
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -18,8 +18,21 @@ Edit directly or use `/settings` for common options.
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | `"xhigh"` | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
+| `defaultServiceTier` | string | `"default"` | Default provider service tier: `"auto"`, `"default"`, `"flex"`, `"scale"`, or `"priority"` |
+| `rlmAllowedServiceTiers` | array | `[defaultServiceTier]` | Service tiers allowed as explicit `rlm(..., service_tier=...)` overrides; use JSON `null` for Python `None` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
+
+An RLM child inherits the parent service tier when `service_tier` is omitted. Explicit overrides require an entry in `rlmAllowedServiceTiers`. For example, opt in to `priority` with:
+
+```json
+{
+  "defaultServiceTier": "default",
+  "rlmAllowedServiceTiers": ["default", "flex", "priority"]
+}
+```
+
+When `rlmAllowedServiceTiers` is absent, its effective value contains only `defaultServiceTier`.
 
 #### thinkingBudgets
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -223,6 +223,7 @@ import {
 	createRlmRunHostHandler,
 	findRlmModelMatches,
 	normalizeRequestedRlmSubagentModel,
+	normalizeRequestedRlmSubagentServiceTier,
 	normalizeRequestedRlmSubagentSessionName,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
@@ -9013,7 +9014,9 @@ export class AgentSession {
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
+		serviceTier?: ServiceTier;
 	}): CreateRlmSubagentRuntimeOptions {
+		const serviceTier = options.serviceTier === undefined ? this.serviceTier : options.serviceTier;
 		return {
 			parentSession: this,
 			id: options.id,
@@ -9023,8 +9026,7 @@ export class AgentSession {
 			sessionDir: options.sessionDir,
 			model: options.model,
 			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
-			serviceTier:
-				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
+			serviceTier: serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : serviceTier,
 			scopedModels: [...this._scopedModels],
 			activeToolNames: this.getActiveToolNames(),
 			allowedToolNames: this._allowedToolNames ? [...this._allowedToolNames] : undefined,
@@ -9686,13 +9688,24 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, service_tier: rawServiceTier, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedServiceTier = normalizeRequestedRlmSubagentServiceTier(rawServiceTier);
+		if (requestedServiceTier !== undefined) {
+			const allowedServiceTiers = this.settingsManager.getRlmAllowedServiceTiers();
+			if (!allowedServiceTiers.includes(requestedServiceTier)) {
+				const allowedValues =
+					allowedServiceTiers.map((tier) => (tier === null ? "null" : tier)).join(", ") || "none";
+				throw new Error(
+					`rlm.run service_tier ${String(rawServiceTier)} is not allowed; allowed values are ${allowedValues}`,
+				);
+			}
+		}
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9782,6 +9795,7 @@ export class AgentSession {
 				spawnCode,
 				sessionDir: childSessionDir,
 				model: modelSelection.model,
+				serviceTier: requestedServiceTier,
 			}),
 			onSessionPublished: publishChildSession,
 		};

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -128,7 +128,8 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
-			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"A child inherits your model and service tier when those options are omitted. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"`service_tier` may be `auto`, `default`, `flex`, `scale`, `priority`, or `None`, but only values in the `rlmAllowedServiceTiers` settings array are accepted. When that setting is absent, only `defaultServiceTier` is allowed. `priority` is clamped to `default` when the selected child model does not support fast mode.",
 		);
 		if (hasAgentMessage) {
 			parts.push(
@@ -178,6 +179,7 @@ export function buildSubagentGuidance(
 		"# Delegating to sub-agents",
 		"",
 		"Spawn independent, self-contained work with `handle = await rlm('task', name='worker')`. This returns at admission, not completion; keep the handle to stop or inspect the child later.",
+		"Set a child's service tier only when its value appears in `rlmAllowedServiceTiers`; omit it to inherit the parent's tier. When the setting is absent, only `defaultServiceTier` is allowed. Explicit `priority` remains subject to child-model fast-mode clamping.",
 	];
 	if (options.hasAgentMessage) {
 		lines.push(

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -58,6 +58,18 @@ const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
 export const DEFAULT_RLM_MODEL_SEARCH_LIMIT = 8;
 export const MAX_RLM_MODEL_SEARCH_LIMIT = 20;
 
+const RLM_SERVICE_TIERS = ["auto", "default", "flex", "scale", "priority"] as const;
+
+/** Validate and normalize an orchestrator-supplied child service tier. */
+export function normalizeRequestedRlmSubagentServiceTier(value: unknown): ServiceTier | undefined {
+	if (value === undefined) return undefined;
+	if (value === null) return null;
+	if (typeof value !== "string" || !(RLM_SERVICE_TIERS as readonly string[]).includes(value)) {
+		throw new Error(`rlm.run service_tier must be one of ${RLM_SERVICE_TIERS.join(", ")} or null`);
+	}
+	return value as ServiceTier;
+}
+
 /** Validate and normalize an orchestrator-supplied subagent session name. */
 export function normalizeRequestedRlmSubagentSessionName(value: unknown): string | undefined {
 	if (value === undefined) {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -127,6 +127,8 @@ export interface Settings {
 	recentModels?: string[]; // "provider/id" keys, most-recently-used first
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	defaultServiceTier?: ServiceTier;
+	/** Service tiers that rlm(...) may request explicitly; defaults to defaultServiceTier. */
+	rlmAllowedServiceTiers?: ServiceTier[];
 	rlmMaxDepth?: number; // default for new sessions; unset falls through to RLM_MAX_DEPTH, then 1
 	idleEvictionMinutes?: number | "off"; // global daemon policy; default: 90
 	transport?: TransportSetting; // default: "auto"
@@ -766,6 +768,12 @@ export class SettingsManager {
 		this.globalSettings.defaultServiceTier = serviceTier;
 		this.markModified("defaultServiceTier");
 		this.save();
+	}
+
+	getRlmAllowedServiceTiers(): ServiceTier[] {
+		return this.settings.rlmAllowedServiceTiers
+			? [...this.settings.rlmAllowedServiceTiers]
+			: [this.getDefaultServiceTier()];
 	}
 
 	getRlmMaxDepth(): number | undefined {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -9,6 +9,7 @@ import {
 	type Context,
 	createAssistantMessageEventStream,
 	getModel,
+	type ServiceTier,
 	type TextContent,
 	type Usage,
 } from "@earendil-works/pi-ai";
@@ -250,6 +251,7 @@ describe("AgentSession rlm recursion", () => {
 		options: {
 			depth?: number;
 			maxDepth?: number;
+			serviceTier?: ServiceTier;
 			streamFn?: StreamFn;
 			agentMessageController?: AgentSessionMessageController;
 			subagentRuntimeHost?: SubagentRuntimeHost;
@@ -273,6 +275,7 @@ describe("AgentSession rlm recursion", () => {
 				systemPrompt: "",
 				tools: [],
 				thinkingLevel: "off",
+				serviceTier: options.serviceTier,
 			},
 			streamFn: options.streamFn ?? ((_model, context) => streamAnswer(`child answer: ${userText(context)}`)),
 		});
@@ -2158,6 +2161,70 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({ depth: 1, maxDepth: 1 });
 
 		await expect(root.runRlmChild("nested")).rejects.toThrow("RLM recursion depth limit reached");
+	});
+
+	it("sets an explicit per-spawn service tier and otherwise inherits the parent tier", async () => {
+		const settingsManager = SettingsManager.inMemory({ rlmAllowedServiceTiers: ["flex", null] });
+		const root = createSession({ serviceTier: "scale", settingsManager });
+		const explicit = await root.runRlmChild("flex tier child", { service_tier: "flex" });
+		const inherited = await root.runRlmChild("inherited tier child");
+		const automatic = await root.runRlmChild("automatic tier child", { service_tier: null });
+
+		await waitFor(
+			() =>
+				root.getRlmChildSession(explicit.rlm_child_id) !== undefined &&
+				root.getRlmChildSession(inherited.rlm_child_id) !== undefined &&
+				root.getRlmChildSession(automatic.rlm_child_id) !== undefined,
+		);
+		expect(root.getRlmChildSession(explicit.rlm_child_id)?.serviceTier).toBe("flex");
+		expect(root.getRlmChildSession(inherited.rlm_child_id)?.serviceTier).toBe("scale");
+		expect(root.getRlmChildSession(automatic.rlm_child_id)?.serviceTier).toBe("default");
+	});
+
+	it("clamps an explicit priority tier for an unsupported child model", async () => {
+		const settingsManager = SettingsManager.inMemory({ rlmAllowedServiceTiers: ["priority"] });
+		const root = createSession({ settingsManager });
+		const spawned = await root.runRlmChild("priority child", { service_tier: "priority" });
+
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		expect(root.getRlmChildSession(spawned.rlm_child_id)?.serviceTier).toBe("default");
+	});
+
+	it("defaults the RLM spawn allowlist to the configured default service tier", async () => {
+		expect(SettingsManager.inMemory().getRlmAllowedServiceTiers()).toEqual(["default"]);
+		const settingsManager = SettingsManager.inMemory({ defaultServiceTier: "scale" });
+		expect(settingsManager.getRlmAllowedServiceTiers()).toEqual(["scale"]);
+		const root = createSession({ serviceTier: "scale", settingsManager });
+
+		await expect(root.runRlmChild("disallowed default tier", { service_tier: "default" })).rejects.toThrow(
+			"rlm.run service_tier default is not allowed; allowed values are scale",
+		);
+	});
+
+	it("allows configured RLM spawn tiers including priority", async () => {
+		const settingsManager = SettingsManager.inMemory({ rlmAllowedServiceTiers: ["default", "priority"] });
+		const root = createSession({ settingsManager });
+		const spawned = await root.runRlmChild("priority child", { service_tier: "priority" });
+
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		expect(root.getRlmChildSession(spawned.rlm_child_id)?.serviceTier).toBe("default");
+	});
+
+	it("rejects an explicit RLM spawn tier excluded by the allowlist", async () => {
+		const settingsManager = SettingsManager.inMemory({ rlmAllowedServiceTiers: ["default", "priority"] });
+		const root = createSession({ settingsManager });
+
+		await expect(root.runRlmChild("flex tier child", { service_tier: "flex" })).rejects.toThrow(
+			"rlm.run service_tier flex is not allowed; allowed values are default, priority",
+		);
+	});
+
+	it.each(["fast", 1, {}, "PRIORITY"])("rejects invalid per-spawn service tier %j", async (serviceTier) => {
+		const root = createSession();
+
+		await expect(root.runRlmChild("invalid tier", { service_tier: serviceTier })).rejects.toThrow(
+			"rlm.run service_tier must be one of auto, default, flex, scale, priority or null",
+		);
 	});
 
 	it("rejects unsupported rlm.run kwargs loudly", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -502,6 +502,19 @@ describe("SettingsManager", () => {
 			expect(servers?.shared).toEqual({ type: "http", url: "https://project.shared/mcp" });
 		});
 	});
+
+	describe("RLM service-tier allowlist", () => {
+		it("defaults to the configured default service tier and accepts an explicit array", () => {
+			expect(SettingsManager.inMemory().getRlmAllowedServiceTiers()).toEqual(["default"]);
+			expect(SettingsManager.inMemory({ defaultServiceTier: "flex" }).getRlmAllowedServiceTiers()).toEqual(["flex"]);
+			expect(
+				SettingsManager.inMemory({
+					rlmAllowedServiceTiers: ["default", "priority"],
+				}).getRlmAllowedServiceTiers(),
+			).toEqual(["default", "priority"]);
+		});
+	});
+
 	describe("idle worker eviction", () => {
 		it("defaults to 90 minutes and treats none as off", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -111,6 +111,9 @@ describe("buildRlmPrompt", () => {
 		expect(prompt).toContain("exact returned selector");
 		expect(prompt).toContain("An unavailable requested model fails spawn");
 		expect(prompt).toContain("decide whether to retry or omit `model`");
+		expect(prompt).toContain("`service_tier` may be `auto`, `default`, `flex`, `scale`, `priority`, or `None`");
+		expect(prompt).toContain("only values in the `rlmAllowedServiceTiers` settings array are accepted");
+		expect(prompt).toContain("When that setting is absent, only `defaultServiceTier` is allowed");
 		expect(prompt).not.toContain("model choices for subagents");
 	});
 

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -22,6 +22,13 @@ except Exception:  # pragma: no cover - only available in kernels
     get_ipython = None  # type: ignore[assignment]
 
 HOST_COMM_TARGET = "host.request"
+RLM_SERVICE_TIERS = ("auto", "default", "flex", "scale", "priority")
+
+
+def _validate_service_tier(value: Any) -> None:
+    if value is None or value in RLM_SERVICE_TIERS:
+        return
+    raise ValueError(f"service_tier must be one of {', '.join(RLM_SERVICE_TIERS)} or None")
 
 
 @dataclass(frozen=True)
@@ -144,9 +151,12 @@ async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:
     """Spawn a recursive Prime Agent child and return once its task is admitted.
 
     ``model`` selects a child with an exact ``provider/model`` selector.
+    ``service_tier`` requests an allowed override of the parent tier for this child.
     """
     if not isinstance(prompt, str):
         raise TypeError(f"prompt must be str, got {type(prompt).__name__}")
+    if "service_tier" in kwargs:
+        _validate_service_tier(kwargs["service_tier"])
     payload = await host_request("rlm.run", {"prompt": prompt, "kwargs": kwargs})
     return _spawn_handle_from_payload(payload)
 

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -94,6 +94,30 @@ class RlmSubagentRegistryTest(unittest.TestCase):
         self.assertEqual(result.name, "api-reviewer")
         self.assertEqual(result.model, "deepseek/deepseek-v4-flash")
 
+    def test_forwards_per_spawn_service_tier_to_host(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "rlm_child_id": "sub-a1b2c3d4",
+                "name": "priority-worker",
+                "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                "model": "openai-codex/gpt-5.5",
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            asyncio.run(rlm_module.rlm("use the priority tier", service_tier="priority"))
+            asyncio.run(rlm_module.rlm("use the default tier", service_tier=None))
+
+        self.assertEqual(host_request.await_args_list[0].args[1]["kwargs"]["service_tier"], "priority")
+        self.assertIsNone(host_request.await_args_list[1].args[1]["kwargs"]["service_tier"])
+
+    def test_rejects_invalid_per_spawn_service_tier(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "service_tier must be one of auto, default, flex, scale, priority or None",
+        ):
+            asyncio.run(rlm_module.rlm("invalid tier", service_tier="fast"))
+
     def test_finds_authenticated_models_through_host(self) -> None:
         host_request = AsyncMock(
             return_value={


### PR DESCRIPTION
Allow each RLM spawn to request a service tier with `auto`, `default`, `flex`, `scale`, `priority`, or `None`. Omitted requests continue to inherit the parent tier, and priority requests retain the existing fast-mode clamp for unsupported child models.

Gate every explicit override with the new `rlmAllowedServiceTiers` settings array. When the array is unset, its effective value contains only `defaultServiceTier`, which defaults to `default`, so costly tiers such as `priority` require explicit user opt-in in the settings file.

Validate the option in both the Python runtime shim and the TypeScript host so invalid cross-boundary requests fail clearly. Document the configuration and call shape, and cover selection, inheritance, allowlist defaults, rejection, clamping, and forwarding.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-spawn `service_tier` selection to RLM subagent calls
> - `rlm.run` now accepts a `service_tier` kwarg (`'auto'`, `'default'`, `'flex'`, `'scale'`, `'priority'`); invalid values are rejected immediately in both the Python runtime and the TypeScript agent session.
> - Allowed tiers are enforced via a new `rlmAllowedServiceTiers` setting; unset defaults to `[defaultServiceTier]`. A new `SettingsManager.getRlmAllowedServiceTiers` method exposes the effective allowlist.
> - If `service_tier` is omitted, the child run inherits the parent session's tier. If `'priority'` is requested for a model without fast-mode support, the tier is clamped to `'default'`.
> - The RLM system prompt is updated to document valid tier values and allowlist behavior.
> - Behavioral Change: `rlm.run` calls specifying a tier outside `rlmAllowedServiceTiers` now throw/raise instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2940377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->