### PR TITLE
fix(coding-agent): preserve harness state on interrupted writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+- Fixed interrupted Python harness writes truncating the last valid continual harness state ([#834](https://github.com/PrimeIntellect-ai/prime-agent/pull/834) by [@ssynb](https://github.com/ssynb)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/prime-agent-runtime/src/rlm/harness.py
+++ b/prime-agent-runtime/src/rlm/harness.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
@@ -294,8 +295,25 @@ class HarnessState:
             },
             "refinements": [asdict(event) for event in self.refinements],
         }
-        with self.file_path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
+        existing_mode = self.file_path.stat().st_mode & 0o777 if self.file_path.exists() else None
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.file_path.parent,
+                prefix=f".{self.file_path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as f:
+                temp_path = Path(f.name)
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            if existing_mode is not None:
+                temp_path.chmod(existing_mode)
+            os.replace(temp_path, self.file_path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink()
         self._loaded_mtime = self._disk_mtime()
         return self
 

--- a/prime-agent-runtime/test/test_harness.py
+++ b/prime-agent-runtime/test/test_harness.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from rlm import harness as package_harness
 from rlm import rlm as callable_rlm
@@ -133,6 +134,27 @@ class HarnessStateTest(unittest.TestCase):
             self.assertIn("await rlm.list_subagents()", overview)
             self.assertIn("receiver_role='child'", overview)
             self.assertIn("refinements: 1", reloaded.overview())
+
+    def test_interrupted_save_preserves_last_valid_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "harness_state.json"
+            state = HarnessState(state_path)
+            state.create_memory("Existing", "Must survive a failed save.", id="existing")
+            original = state_path.read_bytes()
+
+            def interrupted_dump(data, file, **kwargs):
+                file.write('{"schema":')
+                file.flush()
+                raise OSError("simulated interrupted write")
+
+            with patch.object(json, "dump", side_effect=interrupted_dump):
+                with self.assertRaisesRegex(OSError, "simulated interrupted write"):
+                    state.create_memory("New", "Must not replace valid state.", id="new")
+
+            self.assertEqual(state_path.read_bytes(), original)
+            reloaded = HarnessState(state_path)
+            self.assertEqual(reloaded.get("memory", "existing").content, "Must survive a failed save.")
+            self.assertIsNone(reloaded.get("memory", "new"))
 
     def test_load_ignores_unknown_json_keys(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- write Python-side continual harness state through a same-directory temporary file
- atomically replace the state file only after JSON serialization succeeds
- preserve the previous valid state when serialization is interrupted

## Root cause

`HarnessState.save()` opened `harness_state.json` with `"w"` before JSON serialization completed. An exception or interruption during `json.dump()` therefore truncated the last valid file. Because corrupt harness JSON is intentionally loaded as empty state, a later save could turn that transient failure into persistent memory loss.

## User impact

Interrupted kernel-side memory or refinement writes now leave the last valid continual harness state intact instead of potentially losing all persisted entries.

## Validation

- `uv run --quiet --isolated --no-project --python 3.12 --with ipykernel --with nest-asyncio --with tyro --with mcp --with httpx python -m unittest discover -s test -p 'test_*.py'` (65 tests)
- `npm run check` (Biome, TypeScript, installer render, browser smoke)
- deterministic interrupted-serialization reproduction: old state remained byte-for-byte unchanged


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `HarnessState.save` to preserve state file on interrupted writes
> - Replaces direct JSON writes in [`harness.py`](https://github.com/PrimeIntellect-ai/prime-agent/pull/834/files#diff-441d64dfc5d74f553c86b609beff62210693b468d021d8bded095dea768138cf) with an atomic write: JSON is written to a `NamedTemporaryFile` in the same directory, then swapped into place via `os.replace`.
> - If the write fails mid-way, the original state file is left untouched and the temp file is cleaned up in a `finally` block.
> - When overwriting an existing file, its permission bits are copied to the temp file before replacement.
> - Adds a test that patches `json.dump` to raise `OSError` mid-write and asserts the prior state is preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36b0b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->