### PR TITLE
fix(rlm): accept empty Codex model catalogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed an empty OpenAI Codex discovery catalog blocking configured RLM child models that remain usable through interactive selection. Nonempty catalogs still restrict child admission to the models they list.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -392,13 +392,18 @@ function readOpenAICodexModelIds(value: unknown): Set<string> {
 		throw new Error("Invalid OpenAI Codex model catalog");
 	}
 	return new Set(
-		value.models.flatMap((model) => {
+		value.models.map((model) => {
 			if (!model || typeof model !== "object" || !("slug" in model) || typeof model.slug !== "string") {
-				return [];
+				throw new Error("Invalid OpenAI Codex model catalog");
 			}
-			return [model.slug];
+			return model.slug;
 		}),
 	);
+}
+
+function filterModelsByOpenAICodexCatalog(models: Model<Api>[], modelIds: Set<string>): Model<Api>[] {
+	if (modelIds.size === 0) return models;
+	return models.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
 }
 
 const PRIVATE_PRIME_AUTHORIZATION_CACHE_FILE = "prime-inference-private-models.json";
@@ -980,7 +985,7 @@ export class ModelRegistry {
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return filterModelsByOpenAICodexCatalog(availableModels, cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1002,12 +1007,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return filterModelsByOpenAICodexCatalog(availableModels, modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return filterModelsByOpenAICodexCatalog(availableModels, cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -110,6 +110,70 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("uses configured Codex models when discovery returns an empty catalog", async () => {
+		const codexProvider = "openai-codex";
+		const harness = await createHarness({
+			provider: codexProvider,
+			models: [{ id: "parent-model" }, { id: "spark-model" }],
+		});
+		const fetchModels = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-1"));
+
+			await expect(harness.session.findRlmModels("spark", 8)).resolves.toMatchObject({
+				models: [{ selector: `${codexProvider}/spark-model` }],
+			});
+			harness.setResponses([fauxAssistantMessage("exact child answer")]);
+			const exact = await harness.session.runRlmChild("use exact Spark", {
+				model: `${codexProvider}/spark-model`,
+			});
+
+			expect(exact.model).toBe(`${codexProvider}/spark-model`);
+			expect(fetchModels).toHaveBeenCalledOnce();
+		} finally {
+			vi.unstubAllGlobals();
+			harness.cleanup();
+		}
+	});
+
+	it("does not trust a malformed nonempty Codex catalog", async () => {
+		const codexProvider = "openai-codex";
+		const harness = await createHarness({
+			provider: codexProvider,
+			models: [{ id: "parent-model" }, { id: "spark-model" }],
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ models: [{}] }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			),
+		);
+		try {
+			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-1"));
+
+			await expect(harness.session.findRlmModels("spark", 8)).resolves.toEqual({ models: [] });
+			await expect(
+				harness.session.runRlmChild("reject malformed discovery", {
+					model: `${codexProvider}/spark-model`,
+				}),
+			).rejects.toThrow("is unavailable, unauthenticated, or expired");
+		} finally {
+			vi.unstubAllGlobals();
+			harness.cleanup();
+		}
+	});
+
 	it("includes private Prime models authorized for the selected team", async () => {
 		const harness = await createHarness({ provider, models: [{ id: "parent-model" }] });
 		const fetchModels = vi.fn(


### PR DESCRIPTION
OpenAI Codex model discovery can return a successful empty catalog even when configured models remain executable through interactive selection. RLM child admission treated that response as an authoritative empty allowlist and rejected every alternate Codex model.

Treat an empty successful catalog as unavailable entitlement information and retain the configured authenticated models. Continue to enforce nonempty catalogs as account allowlists, and reject malformed entries rather than broadening admission.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLM child model selection to accept empty Codex model catalogs
> - Introduces `filterModelsByOpenAICodexCatalog` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/835/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) to centralize catalog filtering: an empty catalog set now skips filtering entirely, leaving configured `openai-codex` models usable.
> - Previously, an empty discovery response caused all `openai-codex` models to be excluded; non-empty catalogs still gate models to those listed.
> - `readOpenAICodexModelIds` now throws on malformed non-empty catalog entries instead of silently dropping them, triggering the fallback path that excludes codex models unless a valid cache exists.
> - Behavioral Change: malformed non-empty catalogs now throw and fall back rather than silently returning a partial set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c885ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->