### PR TITLE
fix(coding-agent): revive tombstoned workers on retry

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1549,6 +1549,8 @@ export class DaemonSupervisor {
 				const worker = direct ?? (await this.findWorkerForClient(client, command.activeSessionId)).worker;
 				this.assertWorkerAccessibleToClient(client, worker, command.activeSessionId);
 				worker.intentionalStop = false;
+				worker.descriptor.stopRequestedAt = undefined;
+				worker.descriptor.archiveOnStop = undefined;
 				worker.descriptor.lifecycle = "recovering";
 				worker.descriptor.consecutiveFailures = 0;
 				this.persistWorker(worker);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1248,6 +1248,69 @@ describe("daemon worker supervisor monitoring", () => {
 		},
 	);
 
+	it("clears an intentional-stop tombstone before retrying a worker", async () => {
+		type RetryWorker = {
+			descriptor: {
+				workerId: string;
+				rootActiveSessionId: string;
+				rootSessionId: string;
+				lifecycle: "ready" | "recovering";
+				consecutiveFailures: number;
+				stopRequestedAt?: string;
+				archiveOnStop?: boolean;
+			};
+			intentionalStop: boolean;
+			summaries: Map<string, SessionSummary>;
+		};
+		type RetryHarness = {
+			workers: Map<string, RetryWorker>;
+			persistWorker: ReturnType<typeof vi.fn>;
+			recoverWorker: ReturnType<typeof vi.fn>;
+			handleCommand(
+				client: DaemonSocketClient,
+				command: { type: "retry_worker"; activeSessionId: string },
+			): Promise<unknown>;
+		};
+		const worker: RetryWorker = {
+			descriptor: {
+				workerId: "worker-1",
+				rootActiveSessionId: "active-1",
+				rootSessionId: "session-1",
+				lifecycle: "ready",
+				consecutiveFailures: 2,
+				stopRequestedAt: new Date().toISOString(),
+				archiveOnStop: true,
+			},
+			intentionalStop: true,
+			summaries: new Map(),
+		};
+		const persistWorker = vi.fn(() => {
+			expect(worker.intentionalStop).toBe(false);
+			expect(worker.descriptor.stopRequestedAt).toBeUndefined();
+			expect(worker.descriptor.archiveOnStop).toBeUndefined();
+			expect(worker.descriptor.lifecycle).toBe("recovering");
+			expect(worker.descriptor.consecutiveFailures).toBe(0);
+		});
+		const recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			persistWorker,
+			recoverWorker,
+			assertWorkerAccessibleToClient: vi.fn(),
+		}) as RetryHarness;
+
+		await supervisor.handleCommand({} as DaemonSocketClient, {
+			type: "retry_worker",
+			activeSessionId: worker.descriptor.rootSessionId,
+		});
+
+		expect(persistWorker).toHaveBeenCalledOnce();
+		expect(recoverWorker).toHaveBeenCalledWith(worker);
+		expect(persistWorker.mock.invocationCallOrder[0]).toBeLessThan(recoverWorker.mock.invocationCallOrder[0]!);
+	});
+
 	it("cancels an in-flight recovery after an intentional stop tombstone", async () => {
 		vi.useFakeTimers();
 		type RecoveryWorker = {


### PR DESCRIPTION
## What broke

A stopped session worker can leave a saved stop marker behind. Running `retry_worker` cleared the in-memory stop flag, but not the saved marker, so recovery immediately cancelled itself. The session then stayed unavailable with:

```text
Session worker is not connected
```

## Fix

When the user explicitly retries a worker, clear its saved stop markers before starting recovery. This matches the existing recovery behavior for client-owned workers.

## Scope

This only changes the explicit `retry_worker` path. Automatic recovery and normal stop behavior are unchanged. There is no daemon protocol change.

## Validation

- Added a regression test that recreates a tombstoned worker and verifies the stop markers are cleared and saved before recovery starts.
- `daemon-supervisor-monitor.test.ts`: 43 tests passed.
- `npm run check` passed.
