### PR TITLE
fix(ai): follow RFC 9728 protected-resource metadata in MCP OAuth discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed MCP OAuth discovery to follow RFC 9728 protected-resource metadata, so servers whose authorization server is on another host can be logged into ([#766](https://github.com/PrimeIntellect-ai/prime-agent/issues/766)).
+
 ## [0.7.0] - 2026-08-05
 
 ## [0.6.1] - 2026-08-05

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -26,12 +26,17 @@ interface AuthServerMetadata {
 	scopes_supported?: string[];
 }
 
+/** Protected-resource metadata (RFC 9728). The resource names its authorization servers. */
+interface ProtectedResourceMetadata {
+	authorization_servers?: string[];
+}
+
 export interface McpOAuthConfig {
 	/** MCP server name; provider id becomes `mcp:<server>`. */
 	server: string;
 	/** Human label for UI. */
 	label?: string;
-	/** The MCP endpoint URL — discovery is rooted at its origin. */
+	/** The MCP endpoint URL — discovery starts from its protected-resource metadata. */
 	url: string;
 	/** Pre-registered client id (servers without DCR, e.g. Slack). */
 	clientId?: string;
@@ -47,10 +52,19 @@ interface McpCredentials extends OAuthCredentials {
 
 async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
 	const res = await fetch(url, init);
+	const body = await res.text();
 	if (!res.ok) {
-		throw new Error(`${init?.method ?? "GET"} ${url} failed: ${res.status} ${await res.text()}`);
+		throw new Error(`${init?.method ?? "GET"} ${url} failed: ${res.status} ${body}`);
 	}
-	return res.json();
+	try {
+		return JSON.parse(body);
+	} catch {
+		// A sign-in page served at a well-known URI is a different failure from a 404,
+		// and saying so is the difference between a fixable report and "could not discover".
+		throw new Error(
+			`${init?.method ?? "GET"} ${url} returned non-JSON (content-type ${res.headers.get("content-type") ?? "unset"})`,
+		);
+	}
 }
 
 /** Random, URL-safe CSRF `state` value, independent of the PKCE verifier. */
@@ -63,28 +77,76 @@ function randomState(): string {
 		.replace(/=/g, "");
 }
 
-/** Try the protected-resource and auth-server well-known docs at the URL's origin. */
+/** Path a well-known URI is suffixed with, normalized so a bare origin contributes nothing. */
+function wellKnownSuffix(url: URL): string {
+	return url.pathname.replace(/\/+$/, "");
+}
+
+/** Protected-resource metadata locations for an MCP endpoint (RFC 9728 section 3.1). */
+function protectedResourceUrls(endpoint: URL): string[] {
+	const base = `${endpoint.origin}/.well-known/oauth-protected-resource`;
+	const suffix = wellKnownSuffix(endpoint);
+	return suffix ? [`${base}${suffix}`, base] : [base];
+}
+
+/**
+ * Authorization-server metadata locations for an issuer. RFC 8414 inserts the well-known
+ * segment between host and path; OpenID Connect Discovery appends it to the issuer instead.
+ */
+function authServerUrls(issuer: string): string[] {
+	let url: URL;
+	try {
+		url = new URL(issuer);
+	} catch {
+		return [];
+	}
+	const oauth = `${url.origin}/.well-known/oauth-authorization-server`;
+	const oidc = `${url.origin}/.well-known/openid-configuration`;
+	const suffix = wellKnownSuffix(url);
+	if (!suffix) return [oauth, oidc];
+	return [`${oauth}${suffix}`, `${oidc}${suffix}`, `${url.origin}${suffix}/.well-known/openid-configuration`];
+}
+
+/**
+ * Resolve the authorization server for an MCP endpoint. The endpoint's protected-resource
+ * document is authoritative and routinely names a different host, so it is consulted first;
+ * the endpoint's own origin remains the fallback for servers that publish no such document.
+ */
 async function discover(url: string): Promise<AuthServerMetadata> {
-	const origin = new URL(url).origin;
-	const candidates = [
-		`${origin}/.well-known/oauth-authorization-server`,
-		`${origin}/.well-known/openid-configuration`,
-	];
-	let lastError: unknown;
-	for (const candidate of candidates) {
+	const endpoint = new URL(url);
+	const failures: string[] = [];
+	const attempt = async <T>(candidate: string): Promise<T | undefined> => {
 		try {
-			const meta = (await fetchJson(candidate)) as AuthServerMetadata;
-			if (meta.authorization_endpoint && meta.token_endpoint) {
-				return meta;
-			}
+			return (await fetchJson(candidate)) as T;
 		} catch (error) {
-			lastError = error;
+			failures.push(`${candidate} (${error instanceof Error ? error.message : String(error)})`);
+			return undefined;
+		}
+	};
+
+	const issuers: string[] = [];
+	for (const candidate of protectedResourceUrls(endpoint)) {
+		const meta = await attempt<ProtectedResourceMetadata>(candidate);
+		// The document is server-controlled, so a malformed field must not cost us the origin fallback.
+		const listed = meta?.authorization_servers;
+		const advertised = Array.isArray(listed) ? listed.filter((issuer) => typeof issuer === "string" && issuer) : [];
+		if (advertised.length) {
+			issuers.push(...advertised);
+			break;
 		}
 	}
-	throw new Error(
-		`Could not discover OAuth metadata for ${origin}. ` +
-			`Tried ${candidates.join(", ")}. Last error: ${String(lastError)}`,
-	);
+
+	const seen = new Set<string>();
+	for (const candidate of [...issuers.flatMap(authServerUrls), ...authServerUrls(endpoint.origin)]) {
+		if (seen.has(candidate)) continue;
+		seen.add(candidate);
+		const meta = await attempt<AuthServerMetadata>(candidate);
+		if (!meta) continue;
+		if (meta.authorization_endpoint && meta.token_endpoint) return meta;
+		failures.push(`${candidate} (no authorization_endpoint or token_endpoint)`);
+	}
+
+	throw new Error(`Could not discover OAuth metadata for ${endpoint.origin}. Tried ${failures.join("; ")}`);
 }
 
 /** Dynamic client registration (RFC 7591). Returns the issued client_id. */

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -12,6 +12,36 @@ function urlOf(input: unknown): string {
 	throw new Error(`Unsupported fetch input: ${String(input)}`);
 }
 
+/** Serves the listed documents and 404s everything else, the way a real host does. */
+function stubDiscoveryFetch(routes: Record<string, unknown>): { requested: string[] } {
+	const requested: string[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: unknown): Promise<Response> => {
+			const url = urlOf(input);
+			requested.push(url);
+			const body = routes[url];
+			return body === undefined ? jsonResponse({ error: "not_found" }, 404) : jsonResponse(body);
+		}),
+	);
+	return { requested };
+}
+
+async function loginHeadless(provider: ReturnType<typeof createMcpOAuthProvider>) {
+	let authUrl = "";
+	const creds = await provider.login({
+		onAuth: (info) => {
+			authUrl = info.url;
+		},
+		onPrompt: async () => "",
+		onManualCodeInput: async () => {
+			const params = new URL(authUrl).searchParams;
+			return `${params.get("redirect_uri")}?code=the-code&state=${params.get("state")}`;
+		},
+	});
+	return { creds, authUrl };
+}
+
 const META = {
 	issuer: "https://srv.test",
 	authorization_endpoint: "https://srv.test/authorize",
@@ -156,6 +186,137 @@ describe.sequential("MCP OAuth provider", () => {
 		await expect(provider.login({ onAuth: () => {}, onPrompt: async () => "" })).rejects.toThrow(
 			"dynamic client registration",
 		);
+	});
+
+	// The MCP endpoint host publishes no authorization-server document; the authorization
+	// server lives on another host and is only reachable through RFC 9728 metadata.
+	it("resolves the authorization server from protected-resource metadata", async () => {
+		const as = {
+			issuer: "https://todoist.test",
+			authorization_endpoint: "https://todoist.test/oauth/authorize",
+			token_endpoint: "https://todoist.test/oauth/token",
+			registration_endpoint: "https://todoist.test/oauth/register",
+		};
+		const { requested } = stubDiscoveryFetch({
+			"https://ai.todoist.test/.well-known/oauth-protected-resource/mcp": {
+				resource: "https://ai.todoist.test/mcp",
+				authorization_servers: ["https://todoist.test"],
+			},
+			"https://todoist.test/.well-known/oauth-authorization-server": as,
+			// The endpoint origin also answers, so the assertions below pin precedence
+			// rather than merely proving the origin probe failed.
+			"https://ai.todoist.test/.well-known/oauth-authorization-server": {
+				issuer: "https://ai.todoist.test",
+				authorization_endpoint: "https://ai.todoist.test/stale/authorize",
+				token_endpoint: "https://ai.todoist.test/stale/token",
+				registration_endpoint: "https://ai.todoist.test/stale/register",
+			},
+			[as.registration_endpoint]: { client_id: "todoist-client" },
+			[as.token_endpoint]: { access_token: "access-1", refresh_token: "refresh-1", expires_in: 3600 },
+		});
+
+		const provider = createMcpOAuthProvider({ server: "todoist", url: "https://ai.todoist.test/mcp" });
+		const { creds, authUrl } = await loginHeadless(provider);
+
+		expect(creds.access).toBe("access-1");
+		expect(requested).toContain("https://ai.todoist.test/.well-known/oauth-protected-resource/mcp");
+		expect(new URL(authUrl).origin).toBe("https://todoist.test");
+	});
+
+	// RFC 8414 inserts the well-known segment between host and path, so an issuer of
+	// `https://host/oidc` publishes at `https://host/.well-known/...(/oidc)`, not `https://host/oidc/.well-known/...`.
+	it("resolves an issuer that carries a path", async () => {
+		const as = {
+			issuer: "https://auth.ashby.test/oidc",
+			authorization_endpoint: "https://auth.ashby.test/oidc/authorize",
+			token_endpoint: "https://auth.ashby.test/oidc/token",
+			registration_endpoint: "https://auth.ashby.test/oidc/register",
+		};
+		const { requested } = stubDiscoveryFetch({
+			"https://mcp.ashby.test/.well-known/oauth-protected-resource/mcp/v1": {
+				authorization_servers: ["https://auth.ashby.test/oidc"],
+			},
+			"https://auth.ashby.test/.well-known/oauth-authorization-server/oidc": as,
+			[as.registration_endpoint]: { client_id: "ashby-client" },
+			[as.token_endpoint]: { access_token: "access-2", expires_in: 3600 },
+		});
+
+		const provider = createMcpOAuthProvider({ server: "ashby", url: "https://mcp.ashby.test/mcp/v1" });
+		const { creds } = await loginHeadless(provider);
+
+		expect(creds.access).toBe("access-2");
+		expect(requested).toContain("https://auth.ashby.test/.well-known/oauth-authorization-server/oidc");
+	});
+
+	// Some servers publish only at the bare well-known even though their endpoint carries a path.
+	it("falls back to the bare protected-resource document when the path-suffixed one is absent", async () => {
+		const as = {
+			issuer: "https://ironclad.test",
+			authorization_endpoint: "https://ironclad.test/authorize",
+			token_endpoint: "https://ironclad.test/token",
+			registration_endpoint: "https://ironclad.test/register",
+		};
+		const { requested } = stubDiscoveryFetch({
+			"https://mcp.ironclad.test/.well-known/oauth-protected-resource": {
+				authorization_servers: ["https://ironclad.test"],
+			},
+			"https://ironclad.test/.well-known/oauth-authorization-server": as,
+			[as.registration_endpoint]: { client_id: "ironclad-client" },
+			[as.token_endpoint]: { access_token: "access-4", expires_in: 3600 },
+		});
+
+		const provider = createMcpOAuthProvider({ server: "ironclad", url: "https://mcp.ironclad.test/mcp" });
+		const { creds } = await loginHeadless(provider);
+
+		expect(creds.access).toBe("access-4");
+		expect(requested.slice(0, 2)).toEqual([
+			"https://mcp.ironclad.test/.well-known/oauth-protected-resource/mcp",
+			"https://mcp.ironclad.test/.well-known/oauth-protected-resource",
+		]);
+	});
+
+	// An MCP URL without a path publishes at the bare well-known, and issuers are
+	// commonly advertised with a trailing slash.
+	it("handles a pathless endpoint and a trailing slash on the advertised issuer", async () => {
+		const as = {
+			issuer: "https://api.box.test",
+			authorization_endpoint: "https://api.box.test/authorize",
+			token_endpoint: "https://api.box.test/token",
+			registration_endpoint: "https://api.box.test/register",
+		};
+		const { requested } = stubDiscoveryFetch({
+			"https://mcp.box.test/.well-known/oauth-protected-resource": {
+				authorization_servers: ["https://api.box.test/"],
+			},
+			"https://api.box.test/.well-known/oauth-authorization-server": as,
+			[as.registration_endpoint]: { client_id: "box-client" },
+			[as.token_endpoint]: { access_token: "access-3", expires_in: 3600 },
+		});
+
+		const provider = createMcpOAuthProvider({ server: "box", url: "https://mcp.box.test" });
+		const { creds } = await loginHeadless(provider);
+
+		expect(creds.access).toBe("access-3");
+		expect(requested.filter((url) => url.includes("//.well-known"))).toEqual([]);
+	});
+
+	it("reports a non-JSON metadata document distinctly from a transport failure", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url === "https://portal.test/.well-known/oauth-authorization-server") {
+					return new Response("<!doctype html><title>Sign in</title>", {
+						status: 200,
+						headers: { "Content-Type": "text/html" },
+					});
+				}
+				return jsonResponse({ error: "not_found" }, 404);
+			}),
+		);
+
+		const provider = createMcpOAuthProvider({ server: "portal", url: "https://portal.test/mcp" });
+		await expect(provider.login({ onAuth: () => {}, onPrompt: async () => "" })).rejects.toThrow(/non-JSON/);
 	});
 });
 


### PR DESCRIPTION
Fixes #766.

## The defect

`discover()` probed only two documents, both at the MCP endpoint's own origin:

```ts
/** Try the protected-resource and auth-server well-known docs at the URL's origin. */
async function discover(url: string): Promise<AuthServerMetadata> {
	const origin = new URL(url).origin;
	const candidates = [
		`${origin}/.well-known/oauth-authorization-server`,
		`${origin}/.well-known/openid-configuration`,
	];
```

The doc comment names protected-resource metadata; `oauth-protected-resource` appears nowhere in the tree at `b9a4461`. RFC 9728 makes that document the resource's own statement of which authorization server to use, and it routinely names a different host, so `/mcp login` was impossible for those servers.

## The change

1. Fetch the protected-resource document first: path-suffixed (`/.well-known/oauth-protected-resource/mcp/v1`), then bare root. Both are needed — see ironclad below.
2. Resolve each advertised issuer with the RFC 8414 path-insertion form (`https://host/.well-known/oauth-authorization-server/oidc`) and the OpenID Connect Discovery path-append form.
3. Fall back to today's two origin-rooted probes, unchanged, for servers publishing no such document.
4. Split `fetchJson`'s transport failure from its JSON-parse failure.

`refreshToken()` inherits this through its existing `discover()` call; no call site changed. Point 4 is not cosmetic: Ashby returns **HTTP 200 with an HTML sign-in page** at `/.well-known/oauth-authorization-server`, so today's failure is a bare `SyntaxError: Unexpected token '<'` with no indication of which document was bad.

## Evidence

I ran the real `createMcpOAuthProvider().login()` against production servers with `fetch` restricted to `GET /.well-known/` requests, so discovery ran end to end and the DCR/token requests were blocked. Same harness on both sides.

Before, at `b9a4461`:

| Endpoint | origin `oauth-authorization-server` | origin `openid-configuration` | Result |
|---|---|---|---|
| `https://ai.todoist.net/mcp` | 404 | 404 | fails |
| `https://mcp.ashbyhq.com/mcp/v1` | 200 (HTML) | 200 (HTML) | fails, `SyntaxError` |
| `https://mcp.box.com` | 401 | 401 | fails |
| `https://drivemcp.googleapis.com/mcp/v1` | 404 | 404 | fails |
| `https://mcp.na1.ironcladapp.com/mcp` | 404 | 404 | fails |
| `https://mcp.shippo.com` | 403 | 403 | fails |
| `https://mcp.linear.app/mcp` | 200 | — | resolves |

After:

| Endpoint | Protected-resource document | Authorization server resolved |
|---|---|---|
| `https://ai.todoist.net/mcp` | `…/oauth-protected-resource/mcp` | `https://todoist.com` (DCR available) |
| `https://mcp.ashbyhq.com/mcp/v1` | `…/oauth-protected-resource/mcp/v1` | `https://mcp-auth.ashbyhq.com/oidc` (DCR available) |
| `https://mcp.box.com` | `…/oauth-protected-resource` | `https://api.box.com/` (no DCR) |
| `https://drivemcp.googleapis.com/mcp/v1` | `…/oauth-protected-resource/mcp/v1` | `https://accounts.google.com/` (no DCR) |
| `https://mcp.na1.ironcladapp.com/mcp` | suffixed 404, then bare root 200 | `https://ironcladapp.com` (no DCR) |
| `https://mcp.shippo.com` | `…/oauth-protected-resource` | `https://goshippo.com` (DCR available) |
| `https://mcp.linear.app/mcp` | `…/oauth-protected-resource/mcp` | `https://mcp.linear.app` (unchanged) |

Ashby, Box and Google exercise the three edge cases the helpers exist for: an issuer carrying a path, an issuer advertised with a trailing slash, and a path-suffixed document where the bare root 404s. Ironclad is the reverse — its suffixed document 404s and only the bare root answers.

Three of these discover successfully but advertise no `registration_endpoint`, so they still need a pre-registered client id. That is the separate gap the reporter notes; this PR does not address it.

## Tests

Five cases added to `packages/ai/test/mcp-oauth.test.ts` (10 pass, 5 pre-existing unchanged). I mutation-checked them — each mutant is caught by exactly one test, and each passes at HEAD only when it should:

| Mutation | Caught by |
|---|---|
| drop the bare-root protected-resource fallback | `falls back to the bare protected-resource document…` |
| probe the endpoint origin before the advertised issuer | `resolves the authorization server from protected-resource metadata` |
| drop the RFC 8414 path-insertion form | `resolves an issuer that carries a path` |
| revert the `fetchJson` non-JSON split | `reports a non-JSON metadata document distinctly…` |

The precedence test serves a valid authorization-server document at the endpoint origin too, so it pins that the protected-resource document wins rather than merely that the origin probe failed.

`npm run check` is clean.

## Verification

- [x] Quoted code and the `oauth-protected-resource` absence checked against `main` @ `b9a4461`.
- [x] Before/after table produced by running this branch and `b9a4461` through the same harness against live servers.
- [x] `npm run check`; `packages/ai/test/mcp-oauth.test.ts` 10/10.
- [ ] **No login completed end to end.** I have accounts on none of these services, so the harness stops at client registration. What is verified is that discovery resolves an authorization server advertising `authorization_endpoint`, `token_endpoint`, and `S256` among its `code_challenge_methods_supported` — not that the subsequent DCR + PKCE exchange succeeds.
- [ ] The "17 of 36" figure is the reporter's measurement, not mine. I verified the seven endpoints above.

## Deliberately out of scope

- **`WWW-Authenticate` `resource_metadata` (step 1 of the proposal).** Needs an extra unauthenticated probe and reaches into `mcp-manager.ts`. Every server above resolves without it.
- **Recording the resolved issuer on the credential.** Changes the persisted `McpCredentials` shape.
- **Validating that the authorization-server document's `issuer` matches the advertised one** (RFC 9728 SHOULD). Not added because a strict comparison would reject servers that work: Box advertises `https://api.box.com/` and its document reports `https://api.box.com`, and Google advertises `https://accounts.google.com/` against a reported `https://accounts.google.com`. Happy to add it with normalization if you want it here rather than separately.

One note on the fan-out: every advertised issuer is tried in order rather than only `authorization_servers[0]`, with no cap. Say the word if you would rather bound it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP OAuth discovery to follow RFC 9728 protected-resource metadata for cross-host authorization servers
> - The `discover` function in [`packages/ai/src/mcp/oauth.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/837/files#diff-a147fd0fbdc02e28e95472286bcb945e037e1a21e97e9083ad14a6a3a06524a9) now fetches RFC 9728 protected-resource metadata from the MCP endpoint first, reads listed `authorization_servers` issuers, and builds candidate discovery URLs using both RFC 8414 and OIDC discovery patterns before falling back to the endpoint's own origin.
> - Adds support for issuers with path components, path-suffixed well-known URLs, and deduplication of candidate URLs; error messages now enumerate each attempted URL with its failure reason.
> - `fetchJson` is updated to throw a distinct error when a well-known endpoint returns non-JSON content, and includes response body text for non-OK responses.
> - New tests cover cross-host authorization servers, path-based issuers, fallback from path-suffixed to bare protected-resource documents, and non-JSON metadata error reporting.
> - Behavioral Change: discovery now prefers the endpoint's protected-resource metadata over the endpoint origin, which changes resolution order for existing MCP endpoints that serve a protected-resource document.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1c38eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->