### PR TITLE
fix(ai): honor an explicitly configured maxTokens

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `Model.maxTokensExplicit` so an explicitly configured output cap reaches the provider instead of being clamped to the 32000 default ([#755](https://github.com/PrimeIntellect-ai/prime-agent/issues/755)).
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -1,9 +1,21 @@
 import type { Api, Model, SimpleStreamOptions, StreamOptions, ThinkingBudgets, ThinkingLevel } from "../types.js";
 
+/**
+ * Default ceiling on requested output tokens. Most catalog models advertise a far larger
+ * maxTokens than a turn needs, so requests are capped unless the value was configured explicitly.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 32000;
+
+function resolveMaxTokens(model: Model<Api>): number | undefined {
+	if (model.maxTokens <= 0) return undefined;
+	if (model.maxTokensExplicit) return model.maxTokens;
+	return Math.min(model.maxTokens, DEFAULT_MAX_OUTPUT_TOKENS);
+}
+
 export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOptions, apiKey?: string): StreamOptions {
 	return {
 		temperature: options?.temperature,
-		maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? Math.min(model.maxTokens, 32000) : undefined),
+		maxTokens: options?.maxTokens ?? resolveMaxTokens(model),
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
 		transport: options?.transport,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -458,6 +458,11 @@ export interface Model<TApi extends Api> {
 	};
 	contextWindow: number;
 	maxTokens: number;
+	/**
+	 * Set when maxTokens came from explicit configuration rather than the model catalog.
+	 * Explicit values bypass DEFAULT_MAX_OUTPUT_TOKENS so a configured cap reaches the provider unchanged.
+	 */
+	maxTokensExplicit?: boolean;
 	/** Flagship model surfaced above non-featured models of the same provider in pickers. */
 	featured?: boolean;
 	headers?: Record<string, string>;

--- a/packages/ai/test/max-tokens.test.ts
+++ b/packages/ai/test/max-tokens.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildBaseOptions, DEFAULT_MAX_OUTPUT_TOKENS } from "../src/providers/simple-options.js";
+import type { Api, Model } from "../src/types.js";
+
+function testModel(overrides: Partial<Model<Api>> = {}): Model<Api> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 393216,
+		maxTokens: 131072,
+		...overrides,
+	} as Model<Api>;
+}
+
+describe("buildBaseOptions maxTokens", () => {
+	it("caps a catalog model to the default output ceiling", () => {
+		expect(buildBaseOptions(testModel()).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+	});
+
+	it("passes an explicitly configured maxTokens through unchanged", () => {
+		expect(buildBaseOptions(testModel({ maxTokensExplicit: true })).maxTokens).toBe(131072);
+	});
+
+	it("still caps an explicit model that asks for less than the ceiling", () => {
+		const model = testModel({ maxTokens: 8000, maxTokensExplicit: true });
+		expect(buildBaseOptions(model).maxTokens).toBe(8000);
+	});
+
+	it("leaves maxTokens undefined when the model declares none", () => {
+		expect(buildBaseOptions(testModel({ maxTokens: 0 })).maxTokens).toBeUndefined();
+		expect(buildBaseOptions(testModel({ maxTokens: 0, maxTokensExplicit: true })).maxTokens).toBeUndefined();
+	});
+
+	it("lets a per-request maxTokens win over both the model value and the ceiling", () => {
+		expect(buildBaseOptions(testModel(), { maxTokens: 64000 }).maxTokens).toBe(64000);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
+- Fixed a `maxTokens` configured in `models.json` being silently capped at 32000 before the request reached the provider ([#755](https://github.com/PrimeIntellect-ai/prime-agent/issues/755)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -339,7 +339,10 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 	}
 	if (override.input !== undefined) result.input = override.input as ("text" | "image")[];
 	if (override.contextWindow !== undefined) result.contextWindow = override.contextWindow;
-	if (override.maxTokens !== undefined) result.maxTokens = override.maxTokens;
+	if (override.maxTokens !== undefined) {
+		result.maxTokens = override.maxTokens;
+		result.maxTokensExplicit = true;
+	}
 
 	// Merge cost (partial override)
 	if (override.cost) {
@@ -765,6 +768,7 @@ export class ModelRegistry {
 					cost: modelDef.cost ?? defaultCost,
 					contextWindow: modelDef.contextWindow ?? 128000,
 					maxTokens: modelDef.maxTokens ?? 16384,
+					maxTokensExplicit: modelDef.maxTokens !== undefined,
 					headers: undefined,
 					compat,
 				} as Model<Api>);
@@ -1571,6 +1575,7 @@ export class ModelRegistry {
 					cost: modelDef.cost,
 					contextWindow: modelDef.contextWindow,
 					maxTokens: modelDef.maxTokens,
+					maxTokensExplicit: true,
 					headers: undefined,
 					compat: modelDef.compat,
 				} as Model<Api>);

--- a/packages/coding-agent/test/suite/regressions/755-configured-max-tokens.test.ts
+++ b/packages/coding-agent/test/suite/regressions/755-configured-max-tokens.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+import { clearApiKeyCache, ModelRegistry } from "../../../src/core/model-registry.js";
+
+describe("issue #755 configured maxTokens must not be silently clamped", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-755-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = join(tempDir, "models.json");
+		authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+		clearApiKeyCache();
+	});
+
+	function customModel(id: string, maxTokens?: number) {
+		return {
+			id,
+			reasoning: false,
+			contextWindow: 393216,
+			...(maxTokens === undefined ? {} : { maxTokens }),
+		};
+	}
+
+	function loadRegistry(providers: Record<string, unknown>): ModelRegistry {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers }));
+		return ModelRegistry.create(authStorage, modelsJsonPath);
+	}
+
+	// Several built-in providers ship a model called glm-5.2, so match on provider as well as id.
+	function find(registry: ModelRegistry, provider: string, id: string) {
+		const model = registry.getAll().find((m) => m.provider === provider && m.id === id);
+		if (!model) throw new Error(`model ${provider}/${id} not found in registry`);
+		return model;
+	}
+
+	it("marks a models.json maxTokens as explicit and keeps the configured value", () => {
+		const registry = loadRegistry({
+			"glm-h200": {
+				baseUrl: "http://vllm.example.test:8000/v1",
+				api: "openai-completions",
+				apiKey: "TEST_KEY",
+				models: [customModel("glm-5.2", 131072)],
+			},
+		});
+
+		const model = find(registry, "glm-h200", "glm-5.2");
+		expect(model.maxTokens).toBe(131072);
+		expect(model.maxTokensExplicit).toBe(true);
+	});
+
+	it("leaves a custom model that omits maxTokens unmarked so the default ceiling still applies", () => {
+		const registry = loadRegistry({
+			"glm-h200": {
+				baseUrl: "http://vllm.example.test:8000/v1",
+				api: "openai-completions",
+				apiKey: "TEST_KEY",
+				models: [customModel("glm-5.2-default")],
+			},
+		});
+
+		const model = find(registry, "glm-h200", "glm-5.2-default");
+		expect(model.maxTokens).toBe(16384);
+		expect(model.maxTokensExplicit).toBe(false);
+	});
+
+	it("marks a per-model override of a built-in model as explicit", () => {
+		const registry = loadRegistry({
+			anthropic: {
+				modelOverrides: {
+					"claude-sonnet-4-5-20250929": { maxTokens: 200000 },
+				},
+			},
+		});
+
+		const model = find(registry, "anthropic", "claude-sonnet-4-5-20250929");
+		expect(model.maxTokens).toBe(200000);
+		expect(model.maxTokensExplicit).toBe(true);
+	});
+
+	it("leaves built-in models untouched when no override configures maxTokens", () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const model = find(registry, "anthropic", "claude-sonnet-4-5-20250929");
+		expect(model.maxTokensExplicit).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #755.

## Problem

`buildBaseOptions` clamped every request to 32000:

```ts
maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? Math.min(model.maxTokens, 32000) : undefined),
```

`model.maxTokens` is also where user configuration lands, so a `models.json` entry asking for
`"maxTokens": 131072` went on the wire as `max_tokens: 32000`, with no warning and no documented
override. This hits self-hosted and long-output setups hardest, which is where the reporter found it.

## Why not just remove the clamp

The clamp is not a rare guard against bad catalog metadata. 901 of the 1162 models in
`models.generated.ts` that declare a `maxTokens` are above 32000 (128000 on 281 models, 131072 on
113), so removing it outright would change the requested output size for roughly 78% of the catalog
and the cost and latency that come with it. The default is doing real work and is worth keeping.

The bug is narrower than the clamp: an explicitly configured value should not be silently overridden
by a default.

## Change

`Model` gains an optional `maxTokensExplicit`. When set, `buildBaseOptions` uses `model.maxTokens`
unchanged; otherwise the existing 32000 default applies, now named `DEFAULT_MAX_OUTPUT_TOKENS`.

The registry sets the flag at the three places where a `maxTokens` can only have come from
configuration:

- `applyModelOverride` when `override.maxTokens` is present
- `parseModels` when a `models.json` model definition supplies one, since the field is optional there
  and otherwise defaults to 16384
- `applyProviderConfig`, where `maxTokens` is a required field on the programmatic provider input

Catalog models are untouched and keep the default ceiling. A per-request `options.maxTokens` still
takes precedence over both, as before.

## Tests

- `packages/ai/test/max-tokens.test.ts` covers the ceiling, explicit passthrough, an explicit value
  below the ceiling, `maxTokens: 0`, and per-request precedence.
- `packages/coding-agent/test/suite/regressions/755-configured-max-tokens.test.ts` covers the three
  registry paths plus an untouched built-in.

Both fail without the corresponding change: the first asserts 131072 and gets 32000, the second
asserts the flag and gets `undefined`.

Verified with `npm run check` and the affected suites on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildBaseOptions` to respect explicitly configured `maxTokens` without clamping to 32000
> - Adds `maxTokensExplicit` flag to the `Model` interface to distinguish user-configured token caps from catalog defaults.
> - Introduces `resolveMaxTokens` in [`simple-options.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/839/files#diff-457b27d39d330331818bac6fdaa8645cf7bb70b15d95a5940b80f357081f34c3) to pass through the configured value unchanged when `maxTokensExplicit` is true, otherwise caps at `DEFAULT_MAX_OUTPUT_TOKENS` (32000).
> - Updates [`model-registry.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/839/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) to set `maxTokensExplicit: true` for models built from custom configs, catalog entries with an explicit `maxTokens`, and `applyModelOverride` calls.
> - Behavioral Change: models with an explicitly configured `maxTokens` above 32000 will now send that value to providers instead of being silently capped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1d9ad6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->