### PR TITLE
feat(coding-agent): add session-only model switch

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -904,6 +904,7 @@ export interface ModelCycleResult {
 
 interface ModelSelectOptions {
 	waitForExtensions?: boolean;
+	persistDefault?: boolean;
 }
 
 interface ToolDefinitionEntry {
@@ -6685,7 +6686,8 @@ export class AgentSession {
 
 	/**
 	 * Set model directly.
-	 * Validates that the model is available, saves to session and settings.
+	 * Validates that the model is available and saves it to the session. The
+	 * configured default is updated unless persistDefault is false.
 	 * @throws Error if the model is not available
 	 */
 	async setModel(model: Model<any>, options: ModelSelectOptions = {}): Promise<void> {
@@ -6701,7 +6703,9 @@ export class AgentSession {
 		const serviceTier = this._getServiceTierForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (options.persistDefault !== false) {
+			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -86,7 +86,18 @@ interface BuiltinSlashCommandAlias {
 
 const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
-	{ name: "model", description: "Select model (opens selector UI)", argumentHint: "[search]", takesArgument: true },
+	{
+		name: "model",
+		description: "Select model and save it as the default",
+		argumentHint: "[search]",
+		takesArgument: true,
+	},
+	{
+		name: "switch",
+		description: "Switch model for this session without changing the default",
+		argumentHint: "[search]",
+		takesArgument: true,
+	},
 	{ name: "effort", description: "Select reasoning/thinking level (opens selector UI)", argumentHint: "[level]" },
 	{ name: "fast", description: "Toggle OpenAI Fast mode" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -985,12 +985,20 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 	}
 
-	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {
+	async setModel(
+		provider: string,
+		modelId: string,
+		options?: { persistDefault?: boolean },
+	): Promise<AgentConnectionModel> {
+		if (options?.persistDefault === false && !this.client.supportsServerCapability("session_model_selection")) {
+			throw new DaemonCapabilityUnavailableError("set_model", "session_model_selection");
+		}
 		return this.requestData<AgentConnectionModel>({
 			type: "set_model",
 			activeSessionId: this.activeSessionId,
 			provider,
 			modelId,
+			...(options?.persistDefault === undefined ? {} : { persistDefault: options.persistDefault }),
 		});
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -407,7 +407,11 @@ export class InProcessAgentConnection implements AgentConnection {
 		this.session.abortBash();
 	}
 
-	async setModel(provider: string, modelId: string): Promise<AgentConnectionModel> {
+	async setModel(
+		provider: string,
+		modelId: string,
+		options?: { persistDefault?: boolean },
+	): Promise<AgentConnectionModel> {
 		const availableModels = await this.session.modelRegistry.refreshAvailableModels();
 		const model = availableModels.find((candidate) => {
 			return candidate.provider === provider && candidate.id === modelId;
@@ -415,7 +419,7 @@ export class InProcessAgentConnection implements AgentConnection {
 		if (!model) {
 			throw new Error(`Model not found: ${provider}/${modelId}`);
 		}
-		await this.session.setModel(model);
+		await this.session.setModel(model, options);
 		return model;
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -711,7 +711,7 @@ export interface AgentConnection {
 	executeBashAndWait(command: string): Promise<BashResult>;
 	abortBash(): Promise<void>;
 
-	setModel(provider: string, modelId: string): Promise<AgentConnectionModel>;
+	setModel(provider: string, modelId: string, options?: { persistDefault?: boolean }): Promise<AgentConnectionModel>;
 	cycleModel(direction?: "forward" | "backward"): Promise<AgentConnectionModelCycleResult | undefined>;
 	setScopedModels(scopedModels: AgentConnectionScopedModel[]): Promise<void>;
 	setThinkingLevel(level: ThinkingLevel): Promise<void>;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4285,6 +4285,7 @@ export class AgentDaemon {
 				}
 				await session.setModel(model, {
 					waitForExtensions: !(session.isStreaming || session.isCompacting),
+					persistDefault: command.persistDefault,
 				});
 				return success(command.id, "set_model", model);
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 adds capability-gated session-only model selection.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-dc8e153ae46b";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -100,7 +101,8 @@ export type DaemonServerCapability =
 	| "transient_bash"
 	| "session_input_admission"
 	| "prompt_admission_cancellation"
-	| "queue_message_mutation";
+	| "queue_message_mutation"
+	| "session_model_selection";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
@@ -139,6 +141,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"session_input_admission",
 	"prompt_admission_cancellation",
 	"queue_message_mutation",
+	"session_model_selection",
 ];
 
 export interface DaemonRuntimeIdentity {
@@ -553,7 +556,14 @@ export type DaemonCommand =
 			promoteOwnedSession?: boolean;
 	  }
 	| { id?: string; type: "heartbeat_update"; activeSessionId: string; action: AgentHeartbeatUpdateAction }
-	| { id?: string; type: "set_model"; activeSessionId: string; provider: string; modelId: string }
+	| {
+			id?: string;
+			type: "set_model";
+			activeSessionId: string;
+			provider: string;
+			modelId: string;
+			persistDefault?: boolean;
+	  }
 	| { id?: string; type: "cycle_model"; activeSessionId: string; direction?: "forward" | "backward" }
 	| { id?: string; type: "set_scoped_models"; activeSessionId: string; scopedModels: AgentConnectionScopedModel[] }
 	| { id?: string; type: "set_thinking_level"; activeSessionId: string; level: ThinkingLevel }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1263,10 +1263,12 @@ export class InteractiveMode {
 			takesArgument: command.takesArgument,
 		}));
 
-		const modelCommand = slashCommands.find((command) => command.name === "model");
-		if (modelCommand) {
-			modelCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
-				getModelArgumentCompletions(prefix, this.getCachedModelCandidates());
+		for (const commandName of ["model", "switch"]) {
+			const modelCommand = slashCommands.find((command) => command.name === commandName);
+			if (modelCommand) {
+				modelCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null =>
+					getModelArgumentCompletions(prefix, this.getCachedModelCandidates());
+			}
 		}
 
 		const effortCommand = slashCommands.find((command) => command.name === "effort");
@@ -4680,10 +4682,10 @@ export class InteractiveMode {
 					await this.showModelsSelector();
 					return;
 				}
-				if (commandName === "model") {
+				if (commandName === "model" || commandName === "switch") {
 					const searchTerm = commandArgs || undefined;
 					this.editor.setText("");
-					await this.handleModelCommand(searchTerm);
+					await this.handleModelCommand(searchTerm, commandName === "model");
 					return;
 				}
 				if (commandName === "effort") {
@@ -7639,9 +7641,9 @@ export class InteractiveMode {
 		});
 	}
 
-	private async handleModelCommand(searchTerm?: string): Promise<void> {
+	private async handleModelCommand(searchTerm?: string, persistDefault = true): Promise<void> {
 		if (!searchTerm) {
-			this.showModelSelector();
+			this.showModelSelector(undefined, persistDefault);
 			return;
 		}
 
@@ -7651,14 +7653,14 @@ export class InteractiveMode {
 				const authFlows = this.createAuthFlows();
 				const providerOptions = authFlows.getLoginProviderOptions();
 				if (!(await this.ensureModelProviderConfigured(model, authFlows, providerOptions))) return;
-				await this.completeModelSelection(model);
+				await this.completeModelSelection(model, persistDefault);
 			} catch (error) {
 				this.showError(error instanceof Error ? error.message : String(error));
 			}
 			return;
 		}
 
-		this.showModelSelector(searchTerm);
+		this.showModelSelector(searchTerm, persistDefault);
 	}
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined> {
@@ -7679,10 +7681,10 @@ export class InteractiveMode {
 		}
 	}
 
-	private async applySelectedModel(model: AgentConnectionModel): Promise<void> {
+	private async applySelectedModel(model: AgentConnectionModel, persistDefault = true): Promise<void> {
 		const connection = this.agentConnection;
 		const sessionId = this.connectionState?.sessionId;
-		await connection.setModel(model.provider, model.id);
+		await connection.setModel(model.provider, model.id, { persistDefault });
 		const state = await connection.getState();
 		if (
 			this.agentConnection !== connection ||
@@ -7691,7 +7693,7 @@ export class InteractiveMode {
 		) {
 			return;
 		}
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (persistDefault) this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 		this.patchConnectionState({
 			model: state.model ?? model,
 			serviceTier: state.serviceTier,
@@ -7704,9 +7706,9 @@ export class InteractiveMode {
 		this.setupAutocompleteProvider();
 	}
 
-	private async completeModelSelection(model: AgentConnectionModel): Promise<void> {
+	private async completeModelSelection(model: AgentConnectionModel, persistDefault = true): Promise<void> {
 		this.showStatus(`Switching model: ${model.id}`);
-		await this.applySelectedModel(model);
+		await this.applySelectedModel(model, persistDefault);
 		this.showStatus(`Model: ${model.id}`);
 		void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 		this.checkDaxnutsEasterEgg(model);
@@ -8017,11 +8019,15 @@ export class InteractiveMode {
 			});
 	}
 
-	private showModelSelector(initialSearchInput?: string): void {
-		void this.showConfigurationMenu("models", initialSearchInput);
+	private showModelSelector(initialSearchInput?: string, persistDefault = true): void {
+		void this.showConfigurationMenu("models", initialSearchInput, persistDefault);
 	}
 
-	private showConfigurationMenu(initialTab: ConfigurationMenuTab, initialModelSearch?: string): Promise<void> {
+	private showConfigurationMenu(
+		initialTab: ConfigurationMenuTab,
+		initialModelSearch?: string,
+		persistDefault = true,
+	): Promise<void> {
 		const modelCatalog = this.getCachedModelCandidates();
 		const authFlows = this.createAuthFlows();
 		const providerOptions = authFlows.getLoginProviderOptions();
@@ -8135,7 +8141,7 @@ export class InteractiveMode {
 							);
 							if (!ready || settled) return;
 							conceal();
-							await this.completeModelSelection(model);
+							await this.completeModelSelection(model, persistDefault);
 							completed = true;
 						} catch (error) {
 							show();

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./suite/harness.js";
+
+describe("/switch session model persistence", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("changes only the active model when default persistence is disabled", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			settings: { defaultProvider: "faux", defaultModel: "faux-1" },
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!, { persistDefault: false });
+		await harness.settingsManager.flush();
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.settingsManager.getDefaultProvider()).toBe("faux");
+		expect(harness.settingsManager.getDefaultModel()).toBe("faux-1");
+		expect(harness.settingsManager.getGlobalSettings()).toMatchObject({
+			defaultProvider: "faux",
+			defaultModel: "faux-1",
+		});
+	});
+
+	it("still updates the configured default for an explicit model selection", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+			settings: { defaultProvider: "faux", defaultModel: "faux-1" },
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!);
+		await harness.settingsManager.flush();
+
+		expect(harness.settingsManager.getDefaultProvider()).toBe("faux");
+		expect(harness.settingsManager.getDefaultModel()).toBe("faux-2");
+	});
+});

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -68,6 +68,10 @@ describe("daemon protocol helpers", () => {
 		);
 	});
 
+	it("capability-gates session-only model selection", () => {
+		expect(DAEMON_SCHEMA_REVISION).toBe(17);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("session_model_selection");
+	});
 	it("capability-gates explicit subagent deletion instead of schema-gating it", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.delete_rlm_subagent).toEqual({
 			minProtocol: 7,

--- a/packages/coding-agent/test/interactive-mode-model-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-model-command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentConnectionModel } from "../src/modes/agent-connection/index.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+type ModelSelectionContext = {
+	agentConnection: {
+		setModel: (provider: string, modelId: string, options?: { persistDefault?: boolean }) => Promise<void>;
+		getState: () => Promise<{
+			sessionId: string;
+			model: AgentConnectionModel;
+			serviceTier: "default";
+			availableThinkingLevels: [];
+		}>;
+	};
+	connectionState: { sessionId: string };
+	settingsManager: { setDefaultModelAndProvider: (provider: string, modelId: string) => void };
+	patchConnectionState: (patch: Record<string, unknown>) => void;
+	footer: { invalidate: () => void };
+	subagentSummaryLine: { invalidate: () => void };
+	updateEditorBorderColor: () => void;
+	setupAutocompleteProvider: () => void;
+};
+
+type InteractiveModePrototype = {
+	applySelectedModel(
+		this: ModelSelectionContext,
+		model: AgentConnectionModel,
+		persistDefault?: boolean,
+	): Promise<void>;
+};
+
+const prototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+const model = { provider: "openai", id: "gpt-test" } as AgentConnectionModel;
+
+function makeContext(): ModelSelectionContext {
+	return {
+		agentConnection: {
+			setModel: vi.fn(async () => {}),
+			getState: vi.fn(async () => ({
+				sessionId: "session-1",
+				model,
+				serviceTier: "default" as const,
+				availableThinkingLevels: [] as [],
+			})),
+		},
+		connectionState: { sessionId: "session-1" },
+		settingsManager: { setDefaultModelAndProvider: vi.fn() },
+		patchConnectionState: vi.fn(),
+		footer: { invalidate: vi.fn() },
+		subagentSummaryLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		setupAutocompleteProvider: vi.fn(),
+	};
+}
+
+describe("interactive model selection", () => {
+	it("switches the session model without changing the default", async () => {
+		const context = makeContext();
+
+		await prototype.applySelectedModel.call(context, model, false);
+
+		expect(context.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-test", { persistDefault: false });
+		expect(context.settingsManager.setDefaultModelAndProvider).not.toHaveBeenCalled();
+	});
+
+	it("persists selections made by the model command", async () => {
+		const context = makeContext();
+
+		await prototype.applySelectedModel.call(context, model);
+
+		expect(context.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-test", { persistDefault: true });
+		expect(context.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-test");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2226,7 +2226,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 		await fakeThis.applySelectedModel(model);
 
-		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5");
+		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5", { persistDefault: true });
 		expect(fakeThis.uiServices.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(order).toEqual(["connection", "settings"]);
 		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({
@@ -2299,7 +2299,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 		await fakeThis.handleModelCommand("gpt-5.5");
 
-		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5");
+		expect(fakeThis.agentConnection.setModel).toHaveBeenCalledWith("openai", "gpt-5.5", { persistDefault: true });
 		expect(fakeThis.uiServices.settingsManager.setDefaultModelAndProvider).toHaveBeenCalledWith("openai", "gpt-5.5");
 		expect(fakeThis.patchConnectionState).toHaveBeenCalledWith({
 			model,
@@ -2569,7 +2569,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 		expect(loginProvider).toHaveBeenCalledWith(provider);
 		expect(getModelCatalog).toHaveBeenCalledTimes(1);
-		expect(applySelectedModel).toHaveBeenCalledWith(model);
+		expect(applySelectedModel).toHaveBeenCalledWith(model, true);
 		expect(hide).toHaveBeenCalledTimes(1);
 		await expect(result).resolves.toBeUndefined();
 	});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -75,6 +75,7 @@ describe("built-in slash commands", () => {
 	test("marks argument commands as taking a free-form argument", () => {
 		for (const [name, argumentHint] of [
 			["model", "[search]"],
+			["switch", "[search]"],
 			["export", "[path]"],
 			["import", "<path.jsonl>"],
 			["name", "[name]"],


### PR DESCRIPTION
The `/model` command changes the active model and saves that selection as the configured default. This adds `/switch`, which uses the same exact-match lookup, autocomplete, provider authentication, and selector UI while changing only the current session model.

The persistence choice now reaches the real session backend rather than suppressing only InteractiveMode's duplicate settings write. In-process and daemon connections carry `persistDefault`; `AgentSession.setModel` still records the session's `model_change`, but skips the global settings update for `/switch`. `/model` keeps its existing behavior.

Daemon clients capability-gate session-only model selection so an older daemon fails clearly instead of silently persisting it. A real-session regression verifies that `/switch` leaves the configured default unchanged, alongside focused command, connection, protocol, and UI tests.

This addresses the `/switch` persistence defect reported in #1248. That issue's separate mid-run SDK/extension loop-switching proposal is outside this PR.

Verification: 6 focused test files, 255 tests passed; `npm run check` passed through the pre-commit hook.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/switch` slash command for session-only model selection without persisting the default
> - Adds a new `/switch` slash command alongside the existing `/model` command; `/model` saves the selection as the configured default, `/switch` changes the model for the current session only.
> - Threads a `persistDefault` flag through `AgentSession.setModel`, `AgentConnection.setModel`, and the interactive mode model selection flow to control whether the global default is updated.
> - Bumps `DAEMON_SCHEMA_REVISION` to 17 and adds a `session_model_selection` server capability; daemon connections throw `DaemonCapabilityUnavailableError` if session-only selection is requested against a server that lacks this capability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77ea195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->