### PR TITLE
fix(coding-agent): run %%bash cells in Git Bash on Windows, not WSL bash

### DIFF
--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -233,6 +233,16 @@ function createKernelStartupAbortError(): Error {
 	return new Error("Kernel startup aborted");
 }
 
+/**
+ * Kernel process env. The kernel has no interactive terminal, so a git
+ * credential prompt could never be answered and would hang the cell until the
+ * user aborts — default GIT_TERMINAL_PROMPT=0 so git fails fast instead. An
+ * explicit GIT_TERMINAL_PROMPT in the host env or per-kernel overrides wins.
+ */
+function buildKernelEnv(overrides?: Record<string, string>): NodeJS.ProcessEnv {
+	return { GIT_TERMINAL_PROMPT: "0", ...process.env, ...overrides };
+}
+
 function raceStartupWithAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
 	if (!signal) {
 		return promise;
@@ -622,7 +632,7 @@ export class KernelManager {
 					// Match the direct-spawn env exactly: merge the current host env with
 					// the per-kernel overrides, applied fresh in the child (the template's
 					// inherited env snapshot may be stale by fork time).
-					env: this.options.env ? { ...process.env, ...this.options.env } : { ...process.env },
+					env: buildKernelEnv(this.options.env),
 				});
 				forked = true;
 			} catch (err) {
@@ -646,7 +656,7 @@ export class KernelManager {
 		if (!forked) {
 			const kernel = spawn(python, ["-m", "ipykernel_launcher", "-f", connection.path], {
 				cwd: this.options.cwd,
-				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
+				env: buildKernelEnv(this.options.env),
 				stdio: ["ignore", "pipe", "pipe"],
 			});
 			this.kernel = kernel;

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -4,6 +4,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { IMAGE_MIME_TYPES } from "../../utils/mime.js";
+import { getWindowsIpythonBashScriptPath } from "../../utils/shell.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 import { withKernelBootPermit } from "../kernel/boot-gate.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
@@ -273,7 +274,7 @@ export interface IpythonToolOptions {
 	env?: Record<string, string>;
 	/** Command prefix prepended to every %%bash cell. */
 	commandPrefix?: string;
-	/** Optional explicit shell path for bare %%bash cells. */
+	/** Optional explicit shell path for bare %%bash cells. Defaults to Git Bash on Windows. */
 	shellPath?: string;
 	sessionId?: string;
 	/** Typed host request handlers for the kernel↔host bridge (rlm.run, goal.*, …). */
@@ -297,19 +298,24 @@ export interface IpythonToolOptions {
 }
 
 function quoteScriptMagicArgument(value: string): string {
-	return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\"'\"'")}'`;
+	// `~` must stay unquoted: it appears in 8.3 short paths (C:/PROGRA~1/...), and
+	// on Windows IPython parses the %%script line with shlex in non-posix mode,
+	// where quotes are kept literally and would corrupt the program path.
+	return /^[A-Za-z0-9_@%+=:,./~-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\"'\"'")}'`;
 }
 
 function applyShellSettingsToBashMagicCell(
 	code: string,
 	options: Pick<IpythonToolOptions, "commandPrefix" | "shellPath"> | undefined,
 ): string {
-	const commandPrefix = options?.commandPrefix;
-	const shellPath = options?.shellPath?.trim();
-	if (!commandPrefix && !shellPath) return code;
-
 	const bashCell = parseIpythonBashCell(code);
 	if (!bashCell) return code;
+
+	const commandPrefix = options?.commandPrefix;
+	// On Windows, default bare %%bash cells to Git Bash; a bare "bash" would
+	// resolve to WSL's System32\bash.exe (see getWindowsIpythonBashScriptPath).
+	const shellPath = options?.shellPath?.trim() || getWindowsIpythonBashScriptPath();
+	if (!commandPrefix && !shellPath) return code;
 
 	const firstLine =
 		shellPath && bashCell.magicArguments.trim().length === 0

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
+import { delimiter, dirname, resolve } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.js";
 import { recordOrphanProcessState } from "../core/orphan-process-journal.js";
@@ -45,6 +45,40 @@ function findBashOnPath(): string | null {
 }
 
 /**
+ * Candidate Git Bash locations on Windows, in preference order: the standard
+ * install dirs first, then bash resolved relative to any git.exe on PATH
+ * (`Git\cmd\git.exe` / `Git\mingw64\bin\git.exe` → `Git\bin\bash.exe`).
+ */
+function findGitBashCandidates(): string[] {
+	const paths: string[] = [];
+	const programFiles = process.env.ProgramFiles;
+	if (programFiles) {
+		paths.push(`${programFiles}\\Git\\bin\\bash.exe`);
+	}
+	const programFilesX86 = process.env["ProgramFiles(x86)"];
+	if (programFilesX86) {
+		paths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
+	}
+
+	try {
+		const result = spawnSync("where", ["git.exe"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
+		if (result.status === 0 && result.stdout) {
+			for (const line of result.stdout.trim().split(/\r?\n/)) {
+				const gitExe = line.trim();
+				if (!gitExe) continue;
+				const dir = dirname(gitExe);
+				paths.push(resolve(dir, "..", "bin", "bash.exe"));
+				paths.push(resolve(dir, "..", "..", "bin", "bash.exe"));
+			}
+		}
+	} catch {
+		// Ignore errors
+	}
+
+	return paths;
+}
+
+/**
  * Resolve shell configuration based on platform and an optional explicit shell path.
  * Resolution order:
  * 1. User-specified shellPath
@@ -62,15 +96,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 
 	if (process.platform === "win32") {
 		// 2. Try Git Bash in known locations
-		const paths: string[] = [];
-		const programFiles = process.env.ProgramFiles;
-		if (programFiles) {
-			paths.push(`${programFiles}\\Git\\bin\\bash.exe`);
-		}
-		const programFilesX86 = process.env["ProgramFiles(x86)"];
-		if (programFilesX86) {
-			paths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
-		}
+		const paths = findGitBashCandidates();
 
 		for (const path of paths) {
 			if (existsSync(path)) {
@@ -104,6 +130,70 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	}
 
 	return { shell: "sh", args: ["-c"] };
+}
+
+/**
+ * Convert a Windows bash path into a form IPython's `%%script` magic can parse.
+ * IPython splits the magic line with shlex in non-posix mode on Windows, which
+ * keeps quotes literally and mangles backslash escapes, so the program token
+ * must use forward slashes and contain no spaces. Paths under "Program Files"
+ * are converted to their 8.3 short name (e.g. C:/PROGRA~1/Git/bin/bash.exe).
+ * Returns undefined when no space-free form can be produced.
+ */
+function toIpythonScriptPath(bashPath: string): string | undefined {
+	if (!bashPath.includes(" ")) {
+		return bashPath.replace(/\\/g, "/");
+	}
+
+	try {
+		const escaped = bashPath.replace(/'/g, "''");
+		const result = spawnSync(
+			"powershell.exe",
+			[
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				`(New-Object -ComObject Scripting.FileSystemObject).GetFile('${escaped}').ShortPath`,
+			],
+			{ encoding: "utf-8", timeout: 10000, windowsHide: true },
+		);
+		const shortPath = result.status === 0 ? result.stdout.trim().split(/\r?\n/)[0] : "";
+		if (shortPath && !shortPath.includes(" ") && existsSync(shortPath)) {
+			return shortPath.replace(/\\/g, "/");
+		}
+	} catch {
+		// Ignore errors
+	}
+	return undefined;
+}
+
+let cachedWindowsIpythonBashScriptPath: string | null | undefined;
+
+/**
+ * Default shell for `%%bash` cells on Windows: Git Bash, as a `%%script`-parseable
+ * path. Without this, a bare `%%bash` resolves "bash" through CreateProcess, which
+ * finds C:\Windows\System32\bash.exe (WSL) before anything on PATH — and inside WSL
+ * there is no Git Credential Manager, so `git push` blocks on a credential prompt
+ * the kernel can never answer and the cell hangs until aborted.
+ * Returns undefined off Windows or when no usable Git Bash is found (the caller
+ * then leaves bare `%%bash` cells untouched). Memoized per process.
+ */
+export function getWindowsIpythonBashScriptPath(): string | undefined {
+	if (process.platform !== "win32") {
+		return undefined;
+	}
+	if (cachedWindowsIpythonBashScriptPath === undefined) {
+		cachedWindowsIpythonBashScriptPath = null;
+		for (const candidate of findGitBashCandidates()) {
+			if (!existsSync(candidate)) continue;
+			const scriptPath = toIpythonScriptPath(candidate);
+			if (scriptPath) {
+				cachedWindowsIpythonBashScriptPath = scriptPath;
+				break;
+			}
+		}
+	}
+	return cachedWindowsIpythonBashScriptPath ?? undefined;
 }
 
 export function getShellEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -7,6 +7,7 @@ import type { ExtensionContext } from "../src/core/extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../src/core/kernel/bootstrap.js";
 import { type ExecuteResult, KernelBusyAfterInterruptError, KernelManager } from "../src/core/kernel/index.js";
 import { createIpythonToolDefinition, IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+import * as shellModule from "../src/utils/shell.js";
 
 let tempDir = "";
 
@@ -261,6 +262,75 @@ describe("IpythonKernelProvisioner", () => {
 			"\n \r\n\t%%script /custom/bash\r\nexport TEST_PREFIX=1\necho body",
 			expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
 		);
+	});
+
+	it("defaults bare %%bash cells to the Windows Git Bash script path", async () => {
+		const getDefaultShell = vi
+			.spyOn(shellModule, "getWindowsIpythonBashScriptPath")
+			.mockReturnValue("C:/PROGRA~1/Git/bin/bash.exe");
+		try {
+			const execute = vi.fn<KernelManager["execute"]>().mockResolvedValueOnce(okExecuteResult());
+			const manager = { execute } as unknown as KernelManager;
+			const ensure = vi.fn(async () => manager);
+			const kill = vi.fn(async () => {});
+			const provisioner = { ensure, kill } as unknown as IpythonKernelProvisioner;
+			const tool = createIpythonToolDefinition(tempDir, { provisioner });
+
+			await tool.execute("tool-call", { code: "%%bash\ngit push" }, undefined, undefined, {} as ExtensionContext);
+
+			// The 8.3 short path must survive unquoted: IPython parses %%script lines
+			// with shlex in non-posix mode on Windows, where quotes are kept literally.
+			expect(execute).toHaveBeenCalledWith(
+				"%%script C:/PROGRA~1/Git/bin/bash.exe\ngit push",
+				expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
+			);
+		} finally {
+			getDefaultShell.mockRestore();
+		}
+	});
+
+	it("prefers an explicit shellPath over the Windows default", async () => {
+		const getDefaultShell = vi
+			.spyOn(shellModule, "getWindowsIpythonBashScriptPath")
+			.mockReturnValue("C:/PROGRA~1/Git/bin/bash.exe");
+		try {
+			const execute = vi.fn<KernelManager["execute"]>().mockResolvedValueOnce(okExecuteResult());
+			const manager = { execute } as unknown as KernelManager;
+			const ensure = vi.fn(async () => manager);
+			const kill = vi.fn(async () => {});
+			const provisioner = { ensure, kill } as unknown as IpythonKernelProvisioner;
+			const tool = createIpythonToolDefinition(tempDir, { provisioner, shellPath: "/custom/bash" });
+
+			await tool.execute("tool-call", { code: "%%bash\ngit push" }, undefined, undefined, {} as ExtensionContext);
+
+			expect(execute).toHaveBeenCalledWith(
+				"%%script /custom/bash\ngit push",
+				expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
+			);
+		} finally {
+			getDefaultShell.mockRestore();
+		}
+	});
+
+	it("leaves bare %%bash cells untouched when no Windows Git Bash is resolvable", async () => {
+		const getDefaultShell = vi.spyOn(shellModule, "getWindowsIpythonBashScriptPath").mockReturnValue(undefined);
+		try {
+			const execute = vi.fn<KernelManager["execute"]>().mockResolvedValueOnce(okExecuteResult());
+			const manager = { execute } as unknown as KernelManager;
+			const ensure = vi.fn(async () => manager);
+			const kill = vi.fn(async () => {});
+			const provisioner = { ensure, kill } as unknown as IpythonKernelProvisioner;
+			const tool = createIpythonToolDefinition(tempDir, { provisioner });
+
+			await tool.execute("tool-call", { code: "%%bash\ngit push" }, undefined, undefined, {} as ExtensionContext);
+
+			expect(execute).toHaveBeenCalledWith(
+				"%%bash\ngit push",
+				expect.objectContaining({ signal: undefined, onStream: expect.any(Function) }),
+			);
+		} finally {
+			getDefaultShell.mockRestore();
+		}
 	});
 
 	it("lets the user wait when an interrupted kernel is still busy", async () => {


### PR DESCRIPTION
## Problem

On Windows, a bare `%%bash` cell in the IPython kernel resolves `bash` through CreateProcess, which finds `C:\Windows\System32\bash.exe` (**WSL**) before anything on PATH — even when Git Bash is installed and earlier in PATH.

Inside WSL there is no Git Credential Manager, so `git push` (or any command that prompts) blocks on a username/password prompt that the kernel can never answer — the kernel runs with `allow_stdin: false` and no TTY. The cell hangs until the user aborts, and the kernel can die with it. Observed in a real session as a **3-minute hang on `git push`**, with commits authored as `root@<host>.localdomain` (the WSL default identity).

## Fix

- **Bare `%%bash` cells are rewritten to `%%script <Git Bash>` by default on Windows** via a new `getWindowsIpythonBashScriptPath()` helper (`utils/shell.ts`). An explicit `shellPath` setting still wins. Git Bash is located in the standard install dirs or derived from `git.exe` on PATH.
- The resolved path is converted to its **8.3 short path with forward slashes** (`C:/PROGRA~1/Git/bin/bash.exe`). This is required because IPython parses `%%script` lines on Windows with shlex in non-posix mode, which keeps quotes literally and mangles backslash escapes — verified against the installed IPython: only a space-free, forward-slash path survives parsing (`quoteScriptMagicArgument` now also keeps `~` unquoted for this).
- **The kernel env now defaults to `GIT_TERMINAL_PROMPT=0`** (`kernel/index.ts`): when no credential helper can answer, git fails fast with a clear error instead of hanging the cell forever. An explicit host or per-kernel value still takes precedence.

## Verification

- 3 new tests in `ipython-provisioner.test.ts` (Windows default applied, explicit `shellPath` wins, no Git Bash → cell untouched). They fail against the old code and pass with the fix.
- End-to-end simulation of the script magic with the real kernel venv (`arg_split` + `create_subprocess_exec` + cell via stdin): runs Git Bash (`/mingw64/bin/git`, `credential.helper=manager`) and a `git ls-remote` to a nonexistent repo authenticates via GCM and fails fast in ~2s — no hang.
- `npm run check` (biome + tsgo + installer + browser-smoke) passes. The 6 remaining test failures on Windows (fake-python sh stubs, chmod-based EACCES) are pre-existing on main and unrelated.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `%%bash` cells to use Git Bash on Windows instead of WSL bash
> - On Windows, bare `%%bash` cells (with no explicit shell arguments) are rewritten to `%%script` invocations using a resolved Git Bash path via the new `getWindowsIpythonBashScriptPath()` helper in [`utils/shell.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/842/files#diff-194f91e121efc11aa3db177a21b23875cc1356e8e41a4464533c0da0b9b8e0fe).
> - Git Bash discovery scans standard Program Files locations and also checks for `bash.exe` relative to any `git.exe` found on PATH, replacing previously hardcoded paths.
> - Windows paths with spaces are converted to 8.3 short paths (via PowerShell/COM) to avoid breaking IPython's `%%script` argument parser; `~` is also left unquoted to prevent corruption of Windows short paths.
> - Kernel child processes now default to `GIT_TERMINAL_PROMPT=0` across both forked and directly spawned code paths.
> - Behavioral Change: on Windows, `%%bash` cells will run in Git Bash instead of WSL bash when Git Bash is available; cells are left unchanged if no suitable path is found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bbe038.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->