### PR TITLE
fix(coding-agent): clear draft input on Ctrl+C

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `Ctrl+C` leaving draft input in the interactive prompt instead of clearing it.
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 
 ## [0.7.0] - 2026-08-05

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6592,7 +6592,7 @@ export class InteractiveMode {
 	}
 
 	private handleInterruptKey(): void {
-		this.clearEscapeRepeat();
+		this.clearInputBar();
 		this.interruptOrClearInput();
 		this.showCtrlCExitHint();
 	}

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -199,7 +199,7 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
-		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.editor.getText()).toBe("");
 		expect(Reflect.get(InteractiveMode.prototype, "getTrayOverrideLabel").call(mode)).toBe(
 			"Press Ctrl+C again to exit",
 		);
@@ -211,12 +211,12 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		expect(mode.ui.requestRender).toHaveBeenCalled();
 	});
 
-	it("preserves idle draft input on first Ctrl+C", () => {
+	it("clears idle draft input on first Ctrl+C", () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
 
-		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.editor.getText()).toBe("");
 		expect(mode.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
 		expect(mode.shutdown).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Summary

- Clear the interactive prompt draft on the first Ctrl+C.
- Preserve interrupt handling, queued-message restoration, and the existing exit hint.
- Add regression coverage and an Unreleased changelog entry.

## Verification

- npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-ctrl-c.test.ts
- npm run check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `InteractiveMode.handleInterruptKey` to clear draft input on first Ctrl+C
> Previously, pressing Ctrl+C left any typed draft text in the input bar. The fix replaces the initial `clearEscapeRepeat()` call with `clearInputBar()` in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/845/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316), so the input bar is cleared immediately on the first Ctrl+C while the exit hint and interrupt logic remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 777ffde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->