### PR TITLE
fix(coding-agent): preserve Homebrew update ownership

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+
 ## [0.7.1] - 2026-08-07
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -41,7 +41,7 @@ export const SELF_UPDATE_NOT_ATTEMPTED_EXIT_CODE = 75;
 // Install Method Detection
 // =============================================================================
 
-export type InstallMethod = "bun-binary" | "npm" | "pnpm" | "yarn" | "bun" | "unknown";
+export type InstallMethod = "bun-binary" | "homebrew" | "npm" | "pnpm" | "yarn" | "bun" | "unknown";
 
 interface SelfUpdateCommandStep {
 	command: string;
@@ -85,6 +85,9 @@ export function detectInstallMethod(): InstallMethod {
 	if (isBunBinary) {
 		return "bun-binary";
 	}
+	if (isHomebrewInstall()) {
+		return "homebrew";
+	}
 
 	const resolvedPath = `${__dirname}\0${process.execPath || ""}`.toLowerCase().replace(/\\/g, "/");
 
@@ -102,6 +105,11 @@ export function detectInstallMethod(): InstallMethod {
 	}
 
 	return "unknown";
+}
+
+function isHomebrewInstall(): boolean {
+	const packageDir = getPackageDir().toLowerCase().replace(/\\/g, "/");
+	return packageDir.includes("/cellar/") && packageDir.includes("/libexec/lib/node_modules/");
 }
 
 function getInferredNpmInstall(): { root: string; prefix: string } | undefined {
@@ -151,6 +159,7 @@ function getSelfUpdateCommandForMethod(
 	const uninstallAfterInstall = isDirectPackageArtifactSpec(updateSpec);
 	switch (method) {
 		case "bun-binary":
+		case "homebrew":
 			return undefined;
 		case "pnpm":
 			return makeSelfUpdateCommand(
@@ -248,6 +257,7 @@ function getGlobalPackageRoots(method: InstallMethod, _packageName: string, npmC
 			return roots;
 		}
 		case "bun-binary":
+		case "homebrew":
 		case "unknown":
 			return [];
 	}
@@ -318,6 +328,9 @@ export function getSelfUpdateUnavailableInstruction(
 	const method = detectInstallMethod();
 	if (method === "bun-binary") {
 		return `Download from: https://github.com/PrimeIntellect-ai/prime-agent/releases/latest`;
+	}
+	if (method === "homebrew") {
+		return `Update with: brew upgrade ${APP_NAME}`;
 	}
 	const command = getSelfUpdateCommandForMethod(method, packageName, updateSpec, npmCommand, updatePackageName);
 	if (command) {

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -70,6 +70,16 @@ function createNpmPrefixInstall(template = "pi-prefix-"): { prefix: string; pack
 	return { prefix, packageDir };
 }
 
+function createHomebrewInstall(): { packageDir: string } {
+	const prefix = mkdtempSync(join(tmpdir(), "pi-homebrew-"));
+	const packageDir = join(prefix, "Cellar", "prime-agent", "0.7.0", "libexec", "lib", "node_modules", "prime-agent");
+	mkdirSync(packageDir, { recursive: true });
+	tempDir = prefix;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	setExecPath(join(packageDir, "dist", "cli.js"));
+	return { packageDir };
+}
+
 function createPnpmGlobalInstall(): { root: string; packageDir: string } {
 	const temp = mkdtempSync(join(tmpdir(), "pi-pnpm-"));
 	const binDir = join(temp, "bin");
@@ -175,6 +185,15 @@ describe("detectInstallMethod", () => {
 		expect(getUpdateInstruction("@earendil-works/pi-coding-agent")).toBe(
 			"Update @earendil-works/pi-coding-agent using the package manager, wrapper, or source checkout that provides this installation.",
 		);
+	});
+
+	test("leaves Homebrew installs under Homebrew ownership", () => {
+		createHomebrewInstall();
+
+		expect(detectInstallMethod()).toBe("homebrew");
+		expect(getSelfUpdateCommand("prime-agent")).toBeUndefined();
+		expect(getSelfUpdateUnavailableInstruction("prime-agent")).toBe("Update with: brew upgrade prime-agent");
+		expect(getUpdateInstruction("prime-agent")).toBe("Update with: brew upgrade prime-agent");
 	});
 
 	test("self-updates npm installs from custom prefixes", () => {


### PR DESCRIPTION
## Summary

- detect npm packages installed inside a Homebrew Cellar as Homebrew-managed
- prevent `prime-agent update` from constructing an npm command that mutates the versioned keg
- direct Homebrew users to `brew upgrade prime-agent`

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/config.test.ts` (21 tests passed)
- `npm run check`
- reproduced against the local 0.7.0 formula install: the current release constructs `npm --prefix /opt/homebrew/Cellar/prime-agent/0.7.0/libexec install -g prime-agent` with normal permissions

Fixes #844. Supports the official Homebrew submission tracked in #843.

@badlogic please review the package-manager ownership behavior.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent self-update for Homebrew-managed installs and show `brew upgrade` instructions
> - Adds `isHomebrewInstall()` in [config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/846/files#diff-7a2a7db5c2760673cc5ab02f604ef2192373159e49d4258a81ad6885a5fb1827) to detect Cellar keg paths (`/cellar/` + `/libexec/lib/node_modules/`) and classifies them as `"homebrew"` in `detectInstallMethod()`.
> - `getSelfUpdateCommandForMethod()` returns `undefined` for Homebrew installs, suppressing self-update attempts.
> - `getSelfUpdateUnavailableInstruction()` now returns `"Update with: brew upgrade <APP_NAME>"` for Homebrew installs instead of a generic message.
> - Homebrew installs report no global package roots via `getGlobalPackageRoots()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec712a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->