### PR TITLE
fix(ai): attribute OpenRouter requests to Prime Agent

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -34,6 +34,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { getOpenRouterHeaders } from "../utils/openrouter-headers.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -464,6 +465,9 @@ function createClient(
 	}
 
 	const headers = { ...model.headers };
+	if (model.provider === "openrouter") {
+		Object.assign(headers, getOpenRouterHeaders());
+	}
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { getOpenRouterHeaders } from "../utils/openrouter-headers.js";
 import {
 	formatStreamFailureMessage,
 	recordStreamFailure,
@@ -184,6 +185,9 @@ function createClient(
 
 	const compat = getCompat(model);
 	const headers = { ...model.headers };
+	if (model.provider === "openrouter") {
+		Object.assign(headers, getOpenRouterHeaders());
+	}
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({

--- a/packages/ai/src/utils/openrouter-headers.ts
+++ b/packages/ai/src/utils/openrouter-headers.ts
@@ -1,0 +1,7 @@
+export function getOpenRouterHeaders(): Record<string, string> {
+	return {
+		"HTTP-Referer": "https://github.com/PrimeIntellect-ai/prime-agent",
+		"X-OpenRouter-Title": "Prime Agent",
+		"X-OpenRouter-Categories": "cli-agent",
+	};
+}

--- a/packages/ai/test/openrouter-app-attribution.test.ts
+++ b/packages/ai/test/openrouter-app-attribution.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICompletions } from "../src/providers/openai-completions.js";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.js";
+import type { Api, Model } from "../src/types.js";
+import { getOpenRouterHeaders } from "../src/utils/openrouter-headers.js";
+
+const mockState = vi.hoisted(() => ({ headers: [] as Record<string, string>[] }));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = { completions: { create: () => this.request() } };
+		responses = { create: () => this.request() };
+
+		constructor(options: { defaultHeaders?: Record<string, string> }) {
+			mockState.headers.push(options.defaultHeaders ?? {});
+		}
+
+		private request() {
+			const data = { async *[Symbol.asyncIterator]() {} };
+			return {
+				withResponse: async () => ({
+					data,
+					response: { status: 200, headers: new Headers() },
+				}),
+			};
+		}
+	}
+	return { default: FakeOpenAI };
+});
+
+function model<T extends Api>(api: T): Model<T> {
+	return {
+		id: "test/model",
+		name: "Test model",
+		api,
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 1024,
+	} as Model<T>;
+}
+
+async function startRequest(api: "openai-completions" | "openai-responses", headers?: Record<string, string>) {
+	const context = { messages: [{ role: "user" as const, content: "hi", timestamp: Date.now() }] };
+	const stream =
+		api === "openai-completions"
+			? streamOpenAICompletions(model("openai-completions"), context, { apiKey: "test", headers })
+			: streamOpenAIResponses(model("openai-responses"), context, { apiKey: "test", headers });
+	for await (const event of stream) {
+		if (event.type === "done" || event.type === "error") break;
+	}
+}
+
+describe("OpenRouter app attribution", () => {
+	beforeEach(() => {
+		mockState.headers = [];
+	});
+
+	it("identifies Prime Agent with the required attribution headers", () => {
+		expect(getOpenRouterHeaders()).toEqual({
+			"HTTP-Referer": "https://github.com/PrimeIntellect-ai/prime-agent",
+			"X-OpenRouter-Title": "Prime Agent",
+			"X-OpenRouter-Categories": "cli-agent",
+		});
+	});
+
+	it.each(["openai-completions", "openai-responses"] as const)(
+		"attributes %s requests and lets explicit headers override defaults",
+		async (api) => {
+			await startRequest(api, { "X-OpenRouter-Title": "Local override" });
+			expect(mockState.headers).toHaveLength(1);
+			expect(mockState.headers[0]).toMatchObject({
+				"HTTP-Referer": "https://github.com/PrimeIntellect-ai/prime-agent",
+				"X-OpenRouter-Title": "Local override",
+				"X-OpenRouter-Categories": "cli-agent",
+			});
+		},
+	);
+});


### PR DESCRIPTION
OpenRouter currently labels Prime Agent sessions as `api` because neither OpenAI-compatible transport sends the application attribution headers required by OpenRouter.

Add one shared header helper and apply it to completion and Responses clients when the provider is OpenRouter. Identify the app with the upstream repository URL, display it as Prime Agent, and classify it as a CLI agent. Merge caller headers afterward so explicit integrations retain authority over these defaults.

Capture both client configurations in a focused regression that also proves caller overrides remain intact.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenRouter attribution headers to all OpenRouter requests
> Introduces a `getOpenRouterHeaders` utility in [openrouter-headers.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/847/files#diff-3a351eb3b8d3b8fccf22f6376e290875cd491d2e385adb285ef8c8d591c9ccb2) that returns fixed attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`, `X-OpenRouter-Categories`). Both [openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/847/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246) and [openai-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/847/files#diff-4f45a06d4fa91c758631624991582298b307980aa919b7677cc82830bf2a6aa5) now merge these headers into the client config when `model.provider === "openrouter"`. Explicitly provided headers can still override the defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ccd35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->