### PR TITLE
fix(runtime): accept RLMSpawnHandle in delete_subagent and align name attributes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+- Fixed `rlm.delete_subagent()` rejecting the handle returned by `rlm(...)`, and added matching `name`/`session_name` aliases so either spelling works on spawn handles and subagent records ([#854](https://github.com/PrimeIntellect-ai/prime-agent/pull/854) by [@sashankh](https://github.com/sashankh)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -31,6 +31,11 @@ class RLMSpawnHandle:
     session_dir: Path
     model: str
 
+    @property
+    def session_name(self) -> str:
+        """Alias for :attr:`name`, matching :attr:`RLMSubagent.session_name`."""
+        return self.name
+
 
 @dataclass(frozen=True)
 class RLMModel:
@@ -48,6 +53,11 @@ class RLMSubagent:
     session_name: str
     session_dir: Path
     status: str
+
+    @property
+    def name(self) -> str:
+        """Alias for :attr:`session_name`, matching :attr:`RLMSpawnHandle.name`."""
+        return self.session_name
 
 
 def _install_control_comm_handlers() -> None:
@@ -216,16 +226,23 @@ async def list_subagents() -> list[RLMSubagent]:
     return [_subagent_from_payload(entry) for entry in entries]
 
 
-async def delete_subagent(target: str | RLMSubagent) -> RLMSubagent:
-    """Delete one running or retained direct child from the current parent session."""
-    if isinstance(target, RLMSubagent):
+async def delete_subagent(target: str | RLMSubagent | RLMSpawnHandle) -> RLMSubagent:
+    """Delete one running or retained direct child from the current parent session.
+
+    Accepts the child name, an :class:`RLMSubagent` from :func:`list_subagents`, or the
+    :class:`RLMSpawnHandle` returned by ``rlm(...)``/:func:`run`.
+    """
+    if isinstance(target, (RLMSubagent, RLMSpawnHandle)):
         selector = target.rlm_child_id
     elif isinstance(target, str):
         selector = target.strip()
         if not selector:
             raise ValueError("target must not be empty")
     else:
-        raise TypeError(f"target must be str or RLMSubagent, got {type(target).__name__}")
+        raise TypeError(
+            "target must be str, RLMSubagent, or RLMSpawnHandle, "
+            f"got {type(target).__name__}"
+        )
     payload = await host_request("rlm.delete_subagent", {"target": selector})
     return _subagent_from_payload(payload.get("subagent"), "rlm.delete_subagent")
 
@@ -294,7 +311,9 @@ class _RLMCallable:
     async def list_subagents(self) -> list[RLMSubagent]:
         return await list_subagents()
 
-    async def delete_subagent(self, target: str | RLMSubagent) -> RLMSubagent:
+    async def delete_subagent(
+        self, target: str | RLMSubagent | RLMSpawnHandle
+    ) -> RLMSubagent:
         return await delete_subagent(target)
 
     async def __call__(self, prompt: str, **kwargs: Any) -> RLMSpawnHandle:

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -191,7 +191,9 @@ class RlmSubagentRegistryTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "target must not be empty"):
             asyncio.run(rlm_module.delete_subagent("   "))
-        with self.assertRaisesRegex(TypeError, "target must be str or RLMSubagent"):
+        with self.assertRaisesRegex(
+            TypeError, "target must be str, RLMSubagent, or RLMSpawnHandle"
+        ):
             asyncio.run(rlm_module.delete_subagent(123))
 
     def test_rejects_invalid_registry_payload(self) -> None:
@@ -219,6 +221,87 @@ class RlmSubagentRegistryTest(unittest.TestCase):
         with patch.object(rlm_module, "host_request", host_request):
             with self.assertRaisesRegex(RuntimeError, "missing session_name"):
                 asyncio.run(rlm_module.list_subagents())
+
+
+class RlmSpawnHandleInteropTest(unittest.TestCase):
+    """Regression tests for issue #824: handle/subagent name + delete interop."""
+
+    def _handle(self) -> "rlm_module.RLMSpawnHandle":
+        return rlm_module.RLMSpawnHandle(
+            rlm_child_id="sub-a1b2c3d4",
+            name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            model="test/model",
+        )
+
+    def _subagent(self) -> "rlm_module.RLMSubagent":
+        return rlm_module.RLMSubagent(
+            rlm_child_id="sub-a1b2c3d4",
+            active_session_id="active-child",
+            session_id="session-child",
+            session_name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            status="running",
+        )
+
+    def test_spawn_handle_exposes_session_name_alias(self) -> None:
+        handle = self._handle()
+        self.assertEqual(handle.session_name, "api-reviewer")
+        self.assertEqual(handle.session_name, handle.name)
+
+    def test_subagent_exposes_name_alias(self) -> None:
+        subagent = self._subagent()
+        self.assertEqual(subagent.name, "api-reviewer")
+        self.assertEqual(subagent.name, subagent.session_name)
+
+    def test_both_types_agree_on_the_same_child(self) -> None:
+        self.assertEqual(self._handle().session_name, self._subagent().session_name)
+        self.assertEqual(self._handle().name, self._subagent().name)
+
+    def test_delete_subagent_accepts_a_spawn_handle(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "subagent": {
+                    "rlm_child_id": "sub-a1b2c3d4",
+                    "active_session_id": None,
+                    "session_id": "session-child",
+                    "session_name": "api-reviewer",
+                    "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                    "status": "completed",
+                }
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            deleted = asyncio.run(rlm_module.rlm.delete_subagent(self._handle()))
+
+        host_request.assert_awaited_once_with(
+            "rlm.delete_subagent",
+            {"target": "sub-a1b2c3d4"},
+        )
+        self.assertEqual(deleted.rlm_child_id, "sub-a1b2c3d4")
+        self.assertEqual(deleted.name, "api-reviewer")
+
+    def test_spawn_handle_and_subagent_resolve_to_the_same_selector(self) -> None:
+        for target in (self._handle(), self._subagent()):
+            host_request = AsyncMock(
+                return_value={
+                    "subagent": {
+                        "rlm_child_id": "sub-a1b2c3d4",
+                        "active_session_id": None,
+                        "session_id": "session-child",
+                        "session_name": "api-reviewer",
+                        "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                        "status": "completed",
+                    }
+                }
+            )
+            with patch.object(rlm_module, "host_request", host_request):
+                asyncio.run(rlm_module.delete_subagent(target))
+            host_request.assert_awaited_once_with(
+                "rlm.delete_subagent",
+                {"target": "sub-a1b2c3d4"},
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`rlm()` returns an `RLMSpawnHandle` whose child name field is `name`, while `rlm.list_subagents()` returns `RLMSubagent` objects whose child name field is `session_name`. Neither type carried the other's attribute, and `delete_subagent()` accepted only `str | RLMSubagent`, so the natural call `await rlm.delete_subagent(handle)` on the handle just returned by `rlm(...)` raised `TypeError`.

This matters because the shipped system prompt teaches exactly the call that fails:

> Delete a direct child explicitly with `await rlm.delete_subagent(child)` when it is no longer needed.

## Reproduction

Confirmed live from the IPython kernel of a running prime-agent session, before the fix:

```
handle type: RLMSpawnHandle | .name = pi-arch
handle.session_name    -> AttributeError: 'RLMSpawnHandle' object has no attribute 'session_name'
delete_subagent(handle) -> TypeError: target must be str or RLMSubagent, got RLMSpawnHandle
registry type: RLMSubagent | .session_name = pi-arch
RLMSubagent.name       -> AttributeError: 'RLMSubagent' object has no attribute 'name'
```

## Changes

- `delete_subagent()` accepts `RLMSpawnHandle` in addition to `str` and `RLMSubagent`, resolving the selector from `rlm_child_id` exactly as it already does for `RLMSubagent`.
- `RLMSpawnHandle.session_name` and `RLMSubagent.name` added as read-only aliases, so either spelling works on either type and both documented spellings become correct.
- Type hints widened on both the module-level function and the `rlm` proxy method.

Behavior for existing `str` and `RLMSubagent` targets is unchanged. The `TypeError` message now lists all three accepted types; the one existing assertion pinned to the old message was updated.

## Tests

Added `RlmSpawnHandleInteropTest` to `prime-agent-runtime/test/test_subagent_registry.py` covering each symptom in the issue: the `session_name` alias, the `name` alias, both types agreeing on the same child, `delete_subagent` accepting a handle, and handle/subagent resolving to an identical host selector.

```
$ uv run python -m unittest discover -s test -p 'test_subagent_registry.py'
Ran 15 tests in 0.009s
OK
```

Full runtime suite goes from 64 to 69 tests. Two pre-existing `ModuleNotFoundError: No module named 'mcp'` errors in `test_mcp_base.py` are present identically on unmodified `main` and are unrelated to this change.

fixes #824

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `delete_subagent` to accept `RLMSpawnHandle` and align `name`/`session_name` attributes
> - `delete_subagent` now accepts an `RLMSpawnHandle` (the value returned by `rlm(...)`) in addition to `str` and `RLMSubagent`, resolving it via `rlm_child_id`.
> - `RLMSpawnHandle` gains a `session_name` property aliasing `name`; `RLMSubagent` gains a `name` property aliasing `session_name`, making the two types interchangeable for name lookups.
> - New test class `RlmSpawnHandleInteropTest` in [test_subagent_registry.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/854/files#diff-75abf03ff4e1d298c5622c9acffeb219d7cef6b86503d10ad261e1993a64a7dd) covers the alias properties and `delete_subagent` behavior for spawn handles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0b90d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->