### PR TITLE
fix(coding-agent): keep Homebrew installs package-manager owned

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -41,7 +41,7 @@ export const SELF_UPDATE_NOT_ATTEMPTED_EXIT_CODE = 75;
 // Install Method Detection
 // =============================================================================
 
-export type InstallMethod = "bun-binary" | "npm" | "pnpm" | "yarn" | "bun" | "unknown";
+export type InstallMethod = "bun-binary" | "homebrew" | "npm" | "pnpm" | "yarn" | "bun" | "unknown";
 
 interface SelfUpdateCommandStep {
 	command: string;
@@ -88,6 +88,9 @@ export function detectInstallMethod(): InstallMethod {
 
 	const resolvedPath = `${__dirname}\0${process.execPath || ""}`.toLowerCase().replace(/\\/g, "/");
 
+	if (resolvedPath.includes("/cellar/")) {
+		return "homebrew";
+	}
 	if (resolvedPath.includes("/pnpm/") || resolvedPath.includes("/.pnpm/")) {
 		return "pnpm";
 	}
@@ -151,6 +154,7 @@ function getSelfUpdateCommandForMethod(
 	const uninstallAfterInstall = isDirectPackageArtifactSpec(updateSpec);
 	switch (method) {
 		case "bun-binary":
+		case "homebrew":
 			return undefined;
 		case "pnpm":
 			return makeSelfUpdateCommand(
@@ -248,6 +252,7 @@ function getGlobalPackageRoots(method: InstallMethod, _packageName: string, npmC
 			return roots;
 		}
 		case "bun-binary":
+		case "homebrew":
 		case "unknown":
 			return [];
 	}
@@ -318,6 +323,9 @@ export function getSelfUpdateUnavailableInstruction(
 	const method = detectInstallMethod();
 	if (method === "bun-binary") {
 		return `Download from: https://github.com/PrimeIntellect-ai/prime-agent/releases/latest`;
+	}
+	if (method === "homebrew") {
+		return "This installation is managed by Homebrew. Update it with: brew upgrade prime-agent";
 	}
 	const command = getSelfUpdateCommandForMethod(method, packageName, updateSpec, npmCommand, updatePackageName);
 	if (command) {

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -70,6 +70,16 @@ function createNpmPrefixInstall(template = "pi-prefix-"): { prefix: string; pack
 	return { prefix, packageDir };
 }
 
+function createHomebrewInstall(): { prefix: string; packageDir: string } {
+	const prefix = mkdtempSync(join(tmpdir(), "prime-homebrew-"));
+	const packageDir = join(prefix, "Cellar", "prime-agent", "0.7.0", "libexec", "lib", "node_modules", "prime-agent");
+	mkdirSync(packageDir, { recursive: true });
+	tempDir = prefix;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	setExecPath(join(packageDir, "dist", "cli.js"));
+	return { prefix, packageDir };
+}
+
 function createPnpmGlobalInstall(): { root: string; packageDir: string } {
 	const temp = mkdtempSync(join(tmpdir(), "pi-pnpm-"));
 	const binDir = join(temp, "bin");
@@ -174,6 +184,19 @@ describe("detectInstallMethod", () => {
 		expect(getSelfUpdateCommand("@earendil-works/pi-coding-agent")).toBeUndefined();
 		expect(getUpdateInstruction("@earendil-works/pi-coding-agent")).toBe(
 			"Update @earendil-works/pi-coding-agent using the package manager, wrapper, or source checkout that provides this installation.",
+		);
+	});
+
+	test("keeps Homebrew Cellar installs package-manager owned", () => {
+		createHomebrewInstall();
+
+		expect(detectInstallMethod()).toBe("homebrew");
+		expect(getSelfUpdateCommand("prime-agent")).toBeUndefined();
+		expect(getSelfUpdateUnavailableInstruction("prime-agent")).toBe(
+			"This installation is managed by Homebrew. Update it with: brew upgrade prime-agent",
+		);
+		expect(getUpdateInstruction("prime-agent")).toBe(
+			"This installation is managed by Homebrew. Update it with: brew upgrade prime-agent",
 		);
 	});
 


### PR DESCRIPTION
## Summary

- classify paths inside a Homebrew `Cellar` before the generic `node_modules` npm detection
- keep Homebrew-managed installs out of the internal self-update command path
- direct Homebrew users to `brew upgrade prime-agent`
- add a regression test that models the versioned Homebrew `libexec/lib/node_modules` layout

## Why

Homebrew installs Prime Agent under a versioned Cellar path such as `/opt/homebrew/Cellar/prime-agent/0.7.0/libexec/lib/node_modules/prime-agent`. The generic npm path detection currently treats that as a custom npm prefix, which can make `prime-agent update` construct an npm command against a Homebrew-managed keg.

This change makes package-manager ownership explicit instead of relying on writability of the keg.

## Validation

- `npm test --workspace packages/coding-agent -- config.test.ts` -> 28 passed
- `npm run check` -> Biome, TypeScript, installer render check, and browser smoke check passed
- `git diff --check` -> clean

Fixes #844

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep Homebrew-installed coding agent package-manager owned by detecting Cellar path
> Adds a `"homebrew"` variant to the `InstallMethod` union in [config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/857/files#diff-7a2a7db5c2760673cc5ab02f604ef2192373159e49d4258a81ad6885a5fb1827). When the resolved executable path contains `/cellar/`, `detectInstallMethod` now returns `"homebrew"` instead of falling through to npm/yarn/pnpm/bun detection. Self-update commands return `undefined` for Homebrew installs, and the unavailable-update message instructs users to run `brew upgrade prime-agent` instead of the generic fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1860e2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->