### PR TITLE
fix(coding-agent): add Prime process marker

### DIFF
--- a/packages/coding-agent/src/cli-main.ts
+++ b/packages/coding-agent/src/cli-main.ts
@@ -6,6 +6,7 @@ import {
 	isOwnedSessionWorkerProcess,
 	maybeRunOwnedSessionWorkerFrontend,
 } from "./cli/owned-session-worker.js";
+import { markCodingAgentProcess } from "./cli/process-marker.js";
 import { APP_NAME } from "./config.js";
 
 export async function runCli(): Promise<void> {
@@ -16,7 +17,7 @@ export async function runCli(): Promise<void> {
 	}
 
 	process.title = APP_NAME;
-	process.env.PI_CODING_AGENT = "true";
+	markCodingAgentProcess();
 	process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 	installOwnedSessionWorkerOwnerWatch();

--- a/packages/coding-agent/src/cli/process-marker.ts
+++ b/packages/coding-agent/src/cli/process-marker.ts
@@ -1,0 +1,8 @@
+/**
+ * Mark the current process so child processes can identify both the Pi-compatible
+ * coding-agent environment and Prime Agent specifically.
+ */
+export function markCodingAgentProcess(env: NodeJS.ProcessEnv = process.env): void {
+	env.PI_CODING_AGENT = "true";
+	env.PRIME_AGENT = "true";
+}

--- a/packages/coding-agent/test/process-marker.test.ts
+++ b/packages/coding-agent/test/process-marker.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { markCodingAgentProcess } from "../src/cli/process-marker.js";
+
+describe("markCodingAgentProcess", () => {
+	test("keeps the Pi marker and adds a Prime Agent marker for inherited subprocesses", () => {
+		const env: NodeJS.ProcessEnv = {};
+
+		markCodingAgentProcess(env);
+
+		expect(env.PI_CODING_AGENT).toBe("true");
+		expect(env.PRIME_AGENT).toBe("true");
+	});
+});


### PR DESCRIPTION
## Summary

- keep `PI_CODING_AGENT=true` for compatibility with Pi-aware integrations
- add `PRIME_AGENT=true` before Prime starts daemon/session work
- cover both inherited process markers with a focused regression test

## Why

Prime currently exports only Pi's `PI_CODING_AGENT=true` marker. Shell tools, kernels, tmux scanners, prompts, and other subprocess-aware integrations therefore cannot distinguish a Prime Agent session from Pi at the environment layer.

The change is additive: existing Pi-aware tooling keeps working, while Prime-aware tooling can key off `PRIME_AGENT=true`.

## Validation

- regression test failed before the helper existed
- `npm test --workspace packages/coding-agent -- process-marker.test.ts` -> 1 passed
- `npm run check` -> passed
- `git diff --check` -> clean

Fixes #750

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PRIME_AGENT` environment variable marker to coding agent CLI process
> Extracts process marking into a new `markCodingAgentProcess()` helper in [`process-marker.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/859/files#diff-60a381a985dfe028e3946ddf62aeaa908cc0db3d985f5a221cef8547983afb00) that sets both `PI_CODING_AGENT=true` and `PRIME_AGENT=true`. Previously, only `PI_CODING_AGENT` was set directly in [`cli-main.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/859/files#diff-e57932765556fa05fee8fb9a725b5331351c1da77a2d9e6e4163237a369b2a69).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d14b66f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->