### PR TITLE
fix(coding-agent): include Bedrock in Node bundle

### DIFF
--- a/packages/coding-agent/scripts/bundle.mjs
+++ b/packages/coding-agent/scripts/bundle.mjs
@@ -11,9 +11,9 @@
  * compiled Bun binary), keyed off the __PI_BUNDLED__ define below, so extension
  * imports of pi packages share the bundle's module instances.
  */
-import { chmodSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
@@ -29,10 +29,33 @@ try {
 	buildId = `release-${JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).version}`;
 }
 
+function verifyNodeOnlyProviderAssets() {
+	const missing = new Set();
+	const referencePattern = /importNodeOnlyProvider\((['"])(\.\/[^'"]+\.js)\1\)/g;
+	for (const fileName of readdirSync(outdir)) {
+		if (!fileName.endsWith(".js")) continue;
+		const filePath = join(outdir, fileName);
+		const source = readFileSync(filePath, "utf8");
+		for (const match of source.matchAll(referencePattern)) {
+			const specifier = match[2];
+			const target = resolve(dirname(filePath), specifier);
+			if (!existsSync(target)) {
+				missing.add(`${fileName} -> ${specifier}`);
+			}
+		}
+	}
+	if (missing.size > 0) {
+		throw new Error(`Bundle contains missing node-only provider assets:\n${[...missing].map((entry) => `- ${entry}`).join("\n")}`);
+	}
+}
+
 rmSync(outdir, { recursive: true, force: true });
 
 await build({
-	entryPoints: [join(packageDir, "dist", "cli.js")],
+	entryPoints: {
+		cli: join(packageDir, "dist", "cli.js"),
+		"amazon-bedrock": join(packageDir, "..", "ai", "dist", "providers", "amazon-bedrock.js"),
+	},
 	outdir,
 	bundle: true,
 	splitting: true,
@@ -47,6 +70,8 @@ await build({
 	},
 	logLevel: "warning",
 });
+
+verifyNodeOnlyProviderAssets();
 
 chmodSync(join(outdir, "cli.js"), 0o755);
 console.log("bundled dist/cli.js -> dist/bundle/");


### PR DESCRIPTION
## Summary

- add the compiled Amazon Bedrock provider as an explicit esbuild entry alongside the CLI
- keep the existing lazy node-only provider loading path intact
- fail the bundle step when an `importNodeOnlyProvider("./x.js")` reference points to an asset that was not emitted

## Root cause

`packages/ai/src/providers/register-builtins.ts` loads Bedrock through `importNodeOnlyProvider("./amazon-bedrock.js")`, where the helper calls `import(specifier)`. Because that import specifier is dynamic from esbuild's perspective, the coding-agent bundle does not emit `dist/bundle/amazon-bedrock.js` even though the generated CLI chunk still references it.

This is reproducible on current `main`: a clean build produced no Bedrock bundle asset while the CLI chunk contained the unresolved `./amazon-bedrock.js` reference.

## Validation

Before the fix, the new integrity check failed with:

```text
Bundle contains missing node-only provider assets:
- chunk-27BW5CFV.js -> ./amazon-bedrock.js
```

After adding the explicit entry:

- root `npm run build` passed
- `dist/bundle/amazon-bedrock.js` was emitted and imports successfully
- the emitted module exports `streamBedrock` and `streamSimpleBedrock`
- root `npm run check` passed
- `npm pack --workspace packages/coding-agent --dry-run --json` includes `dist/bundle/amazon-bedrock.js`
- `git diff --check` passed

This addresses the source-side cause of #751. The already-published v0.7.0 artifact still requires a replacement release or a new release after this lands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include Amazon Bedrock provider in coding-agent Node bundle
> - Adds `amazon-bedrock` as a second esbuild entry point in [bundle.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/860/files#diff-8606e8936a1a9a467bc717dab8da4d6bafd17f129a8e044e3054e4567b18803d), alongside the existing `cli` entry, so the Bedrock provider is emitted into the bundle output.
> - Adds a `verifyNodeOnlyProviderAssets` post-build check that scans output `.js` files for `importNodeOnlyProvider` calls and throws if any referenced asset files are missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36842d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->