### PR TITLE
feat(coding-agent): add Cursor Agent CLI model support

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added Cursor Agent CLI support for using Composer 2.5 and Cursor Grok 4.5 through a Cursor subscription while retaining the Prime Agent harness.
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
 
 ## [0.7.0] - 2026-08-05

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -74,12 +74,15 @@ The Python kernel runtime is set up automatically on first invocation. Set `PRIM
 
 ## Providers & Models
 
-For each built-in provider, Prime Agent maintains a list of tool-capable models, updated with every release. Authenticate via subscription (`/login`) or API key, then select any model from that provider via `/model` (or Ctrl+L).
+For each built-in provider, Prime Agent maintains a list of tool-capable models, updated with every release. Authenticate via `/login`, an API key, or a supported provider CLI, then select any model from that provider via `/model` (or Ctrl+L).
 
-**Subscriptions:**
+**Subscriptions (`/login`):**
 - Anthropic Claude Pro/Max
 - OpenAI ChatGPT Plus/Pro (Codex)
 - GitHub Copilot
+
+**Local CLI subscriptions:**
+- Cursor CLI (Composer 2.5 and Cursor Grok 4.5)
 
 **API keys:**
 - Anthropic
@@ -676,6 +679,7 @@ prime-agent --thinking high "Solve this complex problem"
 | `PI_SKIP_VERSION_CHECK` | Skip the Prime Agent version update check at startup. This prevents the release manifest request |
 | `PRIME_AGENT_DOWNLOAD_BASE_URL` | Override the Prime Agent release manifest and tarball base URL |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
+| `CURSOR_AGENT_PATH` | Override the `cursor-agent` executable used for Cursor CLI models |
 | `PRIME_API_KEY` | Prime Inference API key; also used for trace sharing if it has `agent_traces` scope |
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -1,10 +1,11 @@
 # Providers
 
-Prime Agent supports subscription-based providers via OAuth and API key providers via environment variables or the auth file. Its built-in model catalog is updated with each Prime Agent release.
+Prime Agent supports subscription-based providers via OAuth or local provider CLIs and API key providers via environment variables or the auth file. Its built-in model catalog is updated with each Prime Agent release.
 
 ## Table of Contents
 
 - [Subscriptions](#subscriptions)
+- [Cursor CLI](#cursor-cli)
 - [API Keys](#api-keys)
 - [Auth File](#auth-file)
 - [Cloud Providers](#cloud-providers)
@@ -34,6 +35,25 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+## Cursor CLI
+
+Prime Agent can use Cursor Composer 2.5 and Cursor Grok 4.5 through the local Cursor Agent CLI while retaining Prime Agent's own prompts, tools, Python kernel, and subagents.
+
+1. [Install the Cursor CLI](https://cursor.com/docs/cli/installation).
+2. Authenticate it with `cursor-agent login` (or `agent login`).
+3. Select `cursor/composer-2.5` or `cursor/grok-4.5` in `/model`, or start directly:
+
+```bash
+prime-agent --provider cursor --model composer-2.5
+prime-agent --provider cursor --model grok-4.5
+```
+
+Prime Agent starts `cursor-agent acp` in Ask mode for each model request and uses the Cursor subscription already configured by the CLI. The Cursor process runs in an isolated temporary directory without Prime Agent's other provider credentials, and Prime Agent executes tool calls returned in the structured response. The selected Cursor model still receives the full Prime system prompt, conversation history, tool schemas, and attached images.
+
+Ask mode disables Cursor edits and command execution, and Prime Agent rejects ACP permission requests, but this is not an OS-level sandbox: Cursor retains its read/search behavior, and supplied context can contain absolute host paths. Use this integration only when you trust the installed Cursor CLI and the Cursor service with that context.
+
+Set `CURSOR_AGENT_PATH` when the executable is not named `cursor-agent` or is not on `PATH`. `CURSOR_API_KEY`, `CURSOR_API_ENDPOINT`, proxy settings, and Cursor's credential-store environment are inherited by the child process when configured. If Prime Agent is using an already-running daemon, restart it after changing these variables.
 
 ## API Keys
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -123,6 +123,7 @@ import {
 } from "./context-tree.js";
 import type { AgentCronJob, AgentRlmHeartbeatController, AgentRlmHeartbeatStatusUpdate } from "./cron-jobs.js";
 import { normalizeHeartbeatDeliveryMode } from "./cron-jobs.js";
+import { registerCursorCliProvider } from "./cursor-cli-provider.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.js";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.js";
@@ -8773,6 +8774,7 @@ export class AgentSession {
 		// visible here so MCP skill gating sees the new credentials.
 		this._modelRegistry.authStorage.reload();
 		resetApiProviders();
+		registerCursorCliProvider();
 		// Re-read mcpServers and re-register user MCP providers from the reloaded settings.
 		this._mcpManager?.refresh();
 		await this._resourceLoader.reload();

--- a/packages/coding-agent/src/core/cursor-cli-provider.ts
+++ b/packages/coding-agent/src/core/cursor-cli-provider.ts
@@ -1,0 +1,777 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { accessSync, constants, existsSync, mkdtempSync, rm } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, isAbsolute, join } from "node:path";
+import { Readable, Writable } from "node:stream";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import * as acp from "@agentclientprotocol/sdk";
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
+	createAssistantMessageEventStream,
+	type ImageContent,
+	type Message,
+	type Model,
+	registerApiProvider,
+	type SimpleStreamOptions,
+	type TextContent,
+	type ThinkingContent,
+	type ToolCall,
+	type ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import { VERSION } from "../config.js";
+
+export const CURSOR_CLI_PROVIDER_ID = "cursor";
+export const CURSOR_CLI_API = "cursor-cli-acp";
+export const CURSOR_CLI_AUTH_TOKEN = "cursor-cli";
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const MAX_STDERR_CHARS = 8_000;
+const CURSOR_CLI_ENV_KEYS = [
+	"AGENT_CLI_CREDENTIAL_STORE",
+	"ALL_PROXY",
+	"APPDATA",
+	"COMSPEC",
+	"DBUS_SESSION_BUS_ADDRESS",
+	"HOME",
+	"HTTPS_PROXY",
+	"HTTP_PROXY",
+	"LANG",
+	"LC_ALL",
+	"LOCALAPPDATA",
+	"NODE_EXTRA_CA_CERTS",
+	"NODE_USE_ENV_PROXY",
+	"NO_PROXY",
+	"PATH",
+	"PATHEXT",
+	"SHELL",
+	"SSL_CERT_DIR",
+	"SSL_CERT_FILE",
+	"SystemRoot",
+	"TEMP",
+	"TMP",
+	"TMPDIR",
+	"USERPROFILE",
+	"WINDIR",
+	"XDG_CACHE_HOME",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_RUNTIME_DIR",
+	"XDG_STATE_HOME",
+	"all_proxy",
+	"https_proxy",
+	"http_proxy",
+	"no_proxy",
+] as const;
+const PASSTHROUGH_RECORD = {
+	parse(value: unknown): Record<string, unknown> {
+		return isRecord(value) ? value : {};
+	},
+};
+
+const EMPTY_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+export function getCursorCliModels(): Model<Api>[] {
+	return [
+		{
+			id: "composer-2.5",
+			name: "Composer 2.5 (Cursor)",
+			api: CURSOR_CLI_API,
+			provider: CURSOR_CLI_PROVIDER_ID,
+			baseUrl: "cursor-cli://local",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: EMPTY_COST,
+			contextWindow: 128_000,
+			maxTokens: 32_768,
+			featured: true,
+		},
+		{
+			id: "grok-4.5",
+			name: "Cursor Grok 4.5",
+			api: CURSOR_CLI_API,
+			provider: CURSOR_CLI_PROVIDER_ID,
+			baseUrl: "cursor-cli://local",
+			reasoning: true,
+			thinkingLevelMap: {
+				off: null,
+				minimal: null,
+				low: "low",
+				medium: "medium",
+				high: "high",
+				xhigh: null,
+				max: null,
+			},
+			input: ["text", "image"],
+			cost: EMPTY_COST,
+			contextWindow: 128_000,
+			maxTokens: 32_768,
+			featured: true,
+		},
+	];
+}
+
+export function getCursorCliCommand(): string {
+	return process.env.CURSOR_AGENT_PATH?.trim() || "cursor-agent";
+}
+
+function getCursorCliEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const key of CURSOR_CLI_ENV_KEYS) {
+		if (process.env[key] !== undefined) {
+			env[key] = process.env[key];
+		}
+	}
+	for (const [key, value] of Object.entries(process.env)) {
+		if (key.startsWith("CURSOR_") && value !== undefined) {
+			env[key] = value;
+		}
+	}
+	return env;
+}
+
+function executableExists(path: string): boolean {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function isCursorCliAvailable(): boolean {
+	const command = getCursorCliCommand();
+	if (isAbsolute(command) || command.includes("/") || command.includes("\\")) {
+		return executableExists(command);
+	}
+
+	const pathEntries = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+	const extensions =
+		process.platform === "win32"
+			? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").map((extension) => extension.toLowerCase())
+			: [""];
+	for (const directory of pathEntries) {
+		for (const extension of extensions) {
+			const candidate = join(directory, `${command}${extension}`);
+			if (existsSync(candidate) && executableExists(candidate)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+export function isCursorCliModel(model: Model<Api>): boolean {
+	return model.provider === CURSOR_CLI_PROVIDER_ID && model.api === CURSOR_CLI_API;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface SerializedContext {
+	text: string;
+	images: ImageContent[];
+}
+
+function serializeContent(
+	content: string | Array<TextContent | ThinkingContent | ToolCall | ImageContent>,
+	images: ImageContent[],
+): unknown {
+	if (typeof content === "string") {
+		return content;
+	}
+	return content.map((block) => {
+		if (block.type !== "image") {
+			return block;
+		}
+		const imageIndex = images.push(block);
+		return { type: "image", image: imageIndex, mimeType: block.mimeType };
+	});
+}
+
+function serializeMessage(message: Message, images: ImageContent[]): Record<string, unknown> {
+	if (message.role === "user") {
+		return { role: message.role, content: serializeContent(message.content, images) };
+	}
+	if (message.role === "assistant") {
+		return { role: message.role, content: serializeContent(message.content, images) };
+	}
+	return {
+		role: message.role,
+		toolCallId: message.toolCallId,
+		toolName: message.toolName,
+		content: serializeContent(message.content, images),
+		isError: message.isError,
+	};
+}
+
+function normalizeCursorMessages(messages: Message[]): Message[] {
+	const normalized: Message[] = [];
+	let pendingToolCalls: ToolCall[] = [];
+	let toolResultIds = new Set<string>();
+	const insertMissingToolResults = () => {
+		for (const toolCall of pendingToolCalls) {
+			if (!toolResultIds.has(toolCall.id)) {
+				normalized.push({
+					role: "toolResult",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					content: [{ type: "text", text: "No result provided" }],
+					isError: true,
+					timestamp: Date.now(),
+				} satisfies ToolResultMessage);
+			}
+		}
+		pendingToolCalls = [];
+		toolResultIds = new Set();
+	};
+
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			insertMissingToolResults();
+			if (message.stopReason === "error" || message.stopReason === "aborted") {
+				continue;
+			}
+			const content: AssistantMessage["content"] = [];
+			for (const block of message.content) {
+				if (block.type === "thinking") {
+					if (!block.redacted && block.thinking.trim()) {
+						content.push({ type: "text", text: block.thinking });
+					}
+				} else if (block.type === "toolCall") {
+					const toolCall = { ...block };
+					delete toolCall.thoughtSignature;
+					content.push(toolCall);
+				} else {
+					content.push({ type: "text", text: block.text });
+				}
+			}
+			const normalizedMessage: AssistantMessage = { ...message, content };
+			pendingToolCalls = content.filter((block): block is ToolCall => block.type === "toolCall");
+			normalized.push(normalizedMessage);
+		} else if (message.role === "toolResult") {
+			toolResultIds.add(message.toolCallId);
+			normalized.push(message);
+		} else {
+			insertMissingToolResults();
+			normalized.push(message);
+		}
+	}
+	insertMissingToolResults();
+	return normalized;
+}
+
+function serializeContext(context: Context): SerializedContext {
+	const images: ImageContent[] = [];
+	const envelope = {
+		systemPrompt: context.systemPrompt ?? "",
+		messages: normalizeCursorMessages(context.messages).map((message) => serializeMessage(message, images)),
+		tools: context.tools ?? [],
+	};
+	const text = `You are the model inference layer inside Prime Agent. Prime Agent, not Cursor, owns the agent loop and executes tools.
+
+Do not use Cursor tools, inspect the workspace, run commands, or edit files. Treat the request envelope below as the complete conversation. Follow its systemPrompt and messages. If a tool is needed, request it in the response JSON and let Prime Agent execute it.
+
+Return exactly one JSON object with no Markdown fence or surrounding text:
+{"content":[{"type":"text","text":"..."}|{"type":"toolCall","name":"exact tool name","arguments":{}}]}
+
+Rules:
+- content must be a non-empty array.
+- Use only tool names present in the envelope.
+- Tool arguments must match the supplied schema.
+- You may return text, one or more tool calls, or both.
+- Never claim a tool ran before its tool result appears in a later envelope.
+- Images referenced as {"type":"image","image":N} are attached after the envelope in one-based order.
+
+<prime_agent_request>
+${JSON.stringify(envelope)}
+</prime_agent_request>`;
+	return { text, images };
+}
+
+function flattenSelectOptions(option: SessionConfigOption): Array<{ value: string; name: string }> {
+	if (option.type !== "select") {
+		return [];
+	}
+	return option.options.flatMap((entry) =>
+		"value" in entry ? [{ value: entry.value, name: entry.name }] : entry.options,
+	);
+}
+
+function normalizeReasoning(value: string): string {
+	return value.trim().toLowerCase().replace(/[ _]+/g, "-").replace("extra-high", "xhigh");
+}
+
+function findReasoningValue(option: SessionConfigOption, requested: string): string | undefined {
+	const normalizedRequested = normalizeReasoning(requested);
+	return flattenSelectOptions(option).find(
+		(candidate) =>
+			normalizeReasoning(candidate.value) === normalizedRequested ||
+			normalizeReasoning(candidate.name) === normalizedRequested,
+	)?.value;
+}
+
+async function configureCursorSession(
+	ctx: acp.ClientContext,
+	sessionId: string,
+	initialOptions: SessionConfigOption[],
+	model: Model<Api>,
+	options: SimpleStreamOptions | undefined,
+	signal: AbortSignal,
+): Promise<void> {
+	const requestOptions = { cancellationSignal: signal };
+	const modelOption = initialOptions.find((option) => option.category === "model" || option.id === "model");
+	if (!modelOption || !flattenSelectOptions(modelOption).some((option) => option.value === model.id)) {
+		throw new Error(`Cursor CLI does not advertise model "${model.id}"`);
+	}
+	let response = await ctx.request(
+		acp.methods.agent.session.setConfigOption,
+		{ sessionId, configId: modelOption.id, value: model.id },
+		requestOptions,
+	);
+	let configOptions = response.configOptions;
+	if (!configOptions?.some((option) => option.id === modelOption.id && option.currentValue === model.id)) {
+		throw new Error(`Cursor CLI did not select model "${model.id}"`);
+	}
+
+	if (options?.reasoning) {
+		const reasoningOption = configOptions.find(
+			(option) => option.category === "thought_level" || option.id === "effort" || option.id === "reasoning",
+		);
+		const reasoningValue = reasoningOption && findReasoningValue(reasoningOption, options.reasoning);
+		if (!reasoningOption || !reasoningValue) {
+			throw new Error(`Cursor CLI does not support reasoning level "${options.reasoning}" for "${model.id}"`);
+		}
+		response = await ctx.request(
+			acp.methods.agent.session.setConfigOption,
+			{ sessionId, configId: reasoningOption.id, value: reasoningValue },
+			requestOptions,
+		);
+		configOptions = response.configOptions;
+		if (
+			!configOptions?.some((option) => option.id === reasoningOption.id && option.currentValue === reasoningValue)
+		) {
+			throw new Error(`Cursor CLI did not select reasoning level "${reasoningValue}"`);
+		}
+	}
+
+	const fastOption = configOptions.find((option) => option.id === "fast");
+	if (fastOption?.type === "select" && fastOption.currentValue === "true") {
+		if (!flattenSelectOptions(fastOption).some((option) => option.value === "false")) {
+			throw new Error("Cursor CLI cannot disable fast mode for the selected model");
+		}
+		response = await ctx.request(
+			acp.methods.agent.session.setConfigOption,
+			{ sessionId, configId: fastOption.id, value: "false" },
+			requestOptions,
+		);
+		configOptions = response.configOptions;
+		if (!configOptions?.some((option) => option.id === fastOption.id && option.currentValue === "false")) {
+			throw new Error("Cursor CLI did not disable fast mode");
+		}
+	} else if (fastOption?.type === "boolean" && fastOption.currentValue === true) {
+		response = await ctx.request(
+			acp.methods.agent.session.setConfigOption,
+			{ sessionId, configId: fastOption.id, type: "boolean", value: false },
+			requestOptions,
+		);
+		configOptions = response.configOptions;
+		if (!configOptions?.some((option) => option.id === fastOption.id && option.currentValue === false)) {
+			throw new Error("Cursor CLI did not disable fast mode");
+		}
+	}
+
+	const modeOption = configOptions.find((option) => option.category === "mode" || option.id === "mode");
+	if (!modeOption || !flattenSelectOptions(modeOption).some((option) => option.value === "ask")) {
+		throw new Error("Cursor CLI does not advertise Ask mode");
+	}
+	response = await ctx.request(
+		acp.methods.agent.session.setConfigOption,
+		{ sessionId, configId: modeOption.id, value: "ask" },
+		requestOptions,
+	);
+	if (!response.configOptions?.some((option) => option.id === modeOption.id && option.currentValue === "ask")) {
+		throw new Error("Cursor CLI did not enter Ask mode");
+	}
+}
+
+interface CursorResponseText {
+	type: "text";
+	text: string;
+}
+
+interface CursorResponseToolCall {
+	type: "toolCall";
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+type CursorResponseContent = CursorResponseText | CursorResponseToolCall;
+
+function extractJsonObject(text: string): unknown {
+	const trimmed = text.trim();
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch {
+		// Cursor occasionally wraps structured output despite the transport instruction.
+	}
+
+	const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+	if (fenced?.[1]) {
+		return JSON.parse(fenced[1].trim()) as unknown;
+	}
+
+	let start = -1;
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let index = 0; index < trimmed.length; index++) {
+		const character = trimmed[index];
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (character === "\\") escaped = true;
+			else if (character === '"') inString = false;
+			continue;
+		}
+		if (character === '"') {
+			inString = true;
+		} else if (character === "{") {
+			if (depth === 0) start = index;
+			depth++;
+		} else if (character === "}" && depth > 0) {
+			depth--;
+			if (depth === 0 && start >= 0) {
+				return JSON.parse(trimmed.slice(start, index + 1)) as unknown;
+			}
+		}
+	}
+	throw new Error("Cursor CLI did not return a JSON object");
+}
+
+function parseCursorResponse(text: string, tools: Context["tools"]): CursorResponseContent[] {
+	const parsed = extractJsonObject(text);
+	if (!isRecord(parsed) || !Array.isArray(parsed.content) || parsed.content.length === 0) {
+		throw new Error("Cursor CLI returned an invalid response envelope");
+	}
+	const toolNames = new Set(tools?.map((tool) => tool.name) ?? []);
+	return parsed.content.map((block): CursorResponseContent => {
+		if (!isRecord(block)) {
+			throw new Error("Cursor CLI returned an invalid content block");
+		}
+		if (block.type === "text" && typeof block.text === "string") {
+			return { type: "text", text: block.text };
+		}
+		if (
+			block.type === "toolCall" &&
+			typeof block.name === "string" &&
+			toolNames.has(block.name) &&
+			isRecord(block.arguments)
+		) {
+			return { type: "toolCall", name: block.name, arguments: block.arguments };
+		}
+		throw new Error("Cursor CLI returned an invalid or unknown tool call");
+	});
+}
+
+function emptyUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { ...EMPTY_COST, total: 0 },
+	};
+}
+
+function errorMessage(model: Model<Api>, error: unknown, aborted: boolean): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage(),
+		stopReason: aborted ? "aborted" : "error",
+		errorMessage: aborted ? "Request was aborted" : error instanceof Error ? error.message : String(error),
+		timestamp: Date.now(),
+	};
+}
+
+function finishStream(
+	stream: AssistantMessageEventStream,
+	model: Model<Api>,
+	content: CursorResponseContent[],
+	usage: AssistantMessage["usage"],
+	lengthLimited: boolean,
+): AssistantMessage {
+	const finalContent: Array<TextContent | ToolCall> = content.map((block) =>
+		block.type === "text"
+			? block
+			: { type: "toolCall", id: `cursor:${randomUUID()}`, name: block.name, arguments: block.arguments },
+	);
+	const hasToolCall = finalContent.some((block) => block.type === "toolCall");
+	const stopReason = hasToolCall ? "toolUse" : lengthLimited ? "length" : "stop";
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: finalContent,
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage,
+		stopReason,
+		timestamp: Date.now(),
+	};
+	const partial: AssistantMessage = { ...message, content: [] };
+	stream.push({ type: "start", partial: { ...partial } });
+	for (let index = 0; index < finalContent.length; index++) {
+		const block = finalContent[index];
+		if (block.type === "text") {
+			partial.content = [...partial.content, { type: "text", text: "" }];
+			stream.push({
+				type: "text_start",
+				contentIndex: index,
+				partial: { ...partial, content: [...partial.content] },
+			});
+			partial.content = partial.content.map((current, contentIndex) => (contentIndex === index ? block : current));
+			stream.push({
+				type: "text_delta",
+				contentIndex: index,
+				delta: block.text,
+				partial: { ...partial, content: [...partial.content] },
+			});
+			stream.push({
+				type: "text_end",
+				contentIndex: index,
+				content: block.text,
+				partial: { ...partial, content: [...partial.content] },
+			});
+		} else {
+			partial.content = [...partial.content, { ...block, arguments: {} }];
+			stream.push({
+				type: "toolcall_start",
+				contentIndex: index,
+				partial: { ...partial, content: [...partial.content] },
+			});
+			stream.push({
+				type: "toolcall_delta",
+				contentIndex: index,
+				delta: JSON.stringify(block.arguments),
+				partial: { ...partial, content: [...partial.content] },
+			});
+			partial.content = partial.content.map((current, contentIndex) => (contentIndex === index ? block : current));
+			stream.push({
+				type: "toolcall_end",
+				contentIndex: index,
+				toolCall: block,
+				partial: { ...partial, content: [...partial.content] },
+			});
+		}
+	}
+	return message;
+}
+
+function waitForChildExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return Promise.resolve(true);
+	}
+	return new Promise((resolve) => {
+		const onClose = () => {
+			clearTimeout(timer);
+			resolve(true);
+		};
+		const timer = setTimeout(() => {
+			child.removeListener("close", onClose);
+			resolve(false);
+		}, timeoutMs);
+		child.once("close", onClose);
+	});
+}
+
+function removeCursorCwd(path: string): Promise<void> {
+	return new Promise((resolve) => rm(path, { force: true, recursive: true }, () => resolve()));
+}
+
+async function runCursor(
+	stream: AssistantMessageEventStream,
+	model: Model<Api>,
+	context: Context,
+	options: SimpleStreamOptions | undefined,
+): Promise<void> {
+	let timeoutSignal: AbortSignal | undefined;
+	let signal: AbortSignal | undefined;
+	let cursorCwd: string | undefined;
+	let child: ChildProcessWithoutNullStreams | undefined;
+	let abortChild: (() => void) | undefined;
+	let stderr = "";
+	let spawnError: Error | undefined;
+	let finalMessage: AssistantMessage | undefined;
+
+	try {
+		timeoutSignal = AbortSignal.timeout(options?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+		signal = options?.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+		cursorCwd = mkdtempSync(join(tmpdir(), "prime-agent-cursor-"));
+		const spawned = spawn(getCursorCliCommand(), ["acp"], {
+			cwd: cursorCwd,
+			env: getCursorCliEnv(),
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		child = spawned;
+		spawned.stderr.setEncoding("utf8");
+		spawned.stderr.on("data", (chunk: string) => {
+			stderr = `${stderr}${chunk}`.slice(-MAX_STDERR_CHARS);
+		});
+		spawned.on("error", (error) => {
+			spawnError = error;
+		});
+		abortChild = () => spawned.kill("SIGTERM");
+		signal.addEventListener("abort", abortChild, { once: true });
+		const requestSignal = signal;
+		const sessionCwd = cursorCwd;
+
+		const transport = acp.ndJsonStream(
+			Writable.toWeb(spawned.stdin) as WritableStream<Uint8Array>,
+			Readable.toWeb(spawned.stdout) as ReadableStream<Uint8Array>,
+		);
+		const client = acp
+			.client({ name: "prime-agent-cursor" })
+			.onRequest(acp.methods.client.session.requestPermission, () => ({ outcome: { outcome: "cancelled" } }))
+			.onRequest("cursor/ask_question", PASSTHROUGH_RECORD, () => ({ answers: {} }))
+			.onRequest("cursor/create_plan", PASSTHROUGH_RECORD, () => ({ accepted: false }))
+			.onNotification("cursor/update_todos", PASSTHROUGH_RECORD, () => undefined);
+		const result = await client.connectWith(transport, async (ctx) => {
+			const requestOptions = { cancellationSignal: requestSignal };
+			await ctx.request(
+				acp.methods.agent.initialize,
+				{
+					protocolVersion: acp.PROTOCOL_VERSION,
+					clientCapabilities: {
+						fs: { readTextFile: false, writeTextFile: false },
+						terminal: false,
+						_meta: { parameterizedModelPicker: true },
+					},
+					clientInfo: { name: "prime-agent", version: VERSION },
+				},
+				requestOptions,
+			);
+			return ctx.buildSession(sessionCwd).withSession(async (session) => {
+				const configOptions = session.newSessionResponse.configOptions ?? [];
+				await configureCursorSession(ctx, session.sessionId, configOptions, model, options, requestSignal);
+				const serialized = serializeContext(context);
+				const prompt: acp.ContentBlock[] = [
+					{ type: "text", text: serialized.text },
+					...serialized.images.map((image) => ({
+						type: "image" as const,
+						mimeType: image.mimeType,
+						data: image.data,
+					})),
+				];
+				void session.prompt(prompt, requestOptions);
+				let output = "";
+				for (;;) {
+					const update = await session.nextUpdate();
+					if (update.kind === "stop") {
+						return { output, response: update.response };
+					}
+					if (update.update.sessionUpdate === "agent_message_chunk" && update.update.content.type === "text") {
+						output += update.update.content.text;
+					}
+				}
+			});
+		});
+
+		if (result.response.stopReason === "cancelled") {
+			throw new DOMException("Request was aborted", "AbortError");
+		}
+		if (result.response.stopReason === "refusal") {
+			throw new Error("Cursor CLI refused the request");
+		}
+		const parsed = parseCursorResponse(result.output, context.tools);
+		const cursorUsage = result.response.usage;
+		const usage: AssistantMessage["usage"] = cursorUsage
+			? {
+					input: cursorUsage.inputTokens,
+					output: cursorUsage.outputTokens,
+					cacheRead: cursorUsage.cachedReadTokens ?? 0,
+					cacheWrite: cursorUsage.cachedWriteTokens ?? 0,
+					totalTokens: cursorUsage.totalTokens,
+					cost: { ...EMPTY_COST, total: 0 },
+				}
+			: emptyUsage();
+		finalMessage = finishStream(
+			stream,
+			model,
+			parsed,
+			usage,
+			result.response.stopReason === "max_tokens" || result.response.stopReason === "max_turn_requests",
+		);
+	} catch (error) {
+		const aborted = options?.signal?.aborted === true;
+		const timedOut = timeoutSignal?.aborted === true && !aborted;
+		const detail =
+			spawnError ??
+			(timedOut
+				? new Error(`Cursor CLI request timed out after ${options?.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`)
+				: error);
+		const stderrDetail = stderr.trim();
+		finalMessage = errorMessage(
+			model,
+			stderrDetail && !aborted
+				? new Error(`${detail instanceof Error ? detail.message : String(detail)}: ${stderrDetail}`)
+				: detail,
+			aborted,
+		);
+	} finally {
+		if (signal && abortChild) {
+			signal.removeEventListener("abort", abortChild);
+		}
+		if (child && child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGTERM");
+			if (!(await waitForChildExit(child, 1_000))) {
+				child.kill("SIGKILL");
+				await waitForChildExit(child, 1_000);
+			}
+		}
+		if (cursorCwd) {
+			await removeCursorCwd(cursorCwd);
+		}
+	}
+	if (!finalMessage) {
+		finalMessage = errorMessage(model, new Error("Cursor CLI ended without a result"), false);
+	}
+	if (finalMessage.stopReason === "error" || finalMessage.stopReason === "aborted") {
+		stream.push({
+			type: "error",
+			reason: finalMessage.stopReason === "aborted" ? "aborted" : "error",
+			error: finalMessage,
+		});
+	} else {
+		stream.push({ type: "done", reason: finalMessage.stopReason, message: finalMessage });
+	}
+	stream.end(finalMessage);
+}
+
+export function streamCursorCli(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+	void runCursor(stream, model, context, options);
+	return stream;
+}
+
+export function registerCursorCliProvider(): void {
+	registerApiProvider(
+		{
+			api: CURSOR_CLI_API,
+			stream: streamCursorCli,
+			streamSimple: streamCursorCli,
+		},
+		"builtin:cursor-cli",
+	);
+}

--- a/packages/coding-agent/src/core/cursor-cli-provider.ts
+++ b/packages/coding-agent/src/core/cursor-cli-provider.ts
@@ -177,6 +177,18 @@ interface SerializedContext {
 	images: ImageContent[];
 }
 
+interface CursorPromptPayload {
+	sessionId: string;
+	prompt: acp.ContentBlock[];
+}
+
+function parseCursorPromptPayload(value: unknown, sessionId: string): CursorPromptPayload {
+	if (!isRecord(value) || value.sessionId !== sessionId || !Array.isArray(value.prompt)) {
+		throw new Error("before_provider_request returned an invalid Cursor ACP prompt payload");
+	}
+	return { sessionId, prompt: value.prompt as acp.ContentBlock[] };
+}
+
 function serializeContent(
 	content: string | Array<TextContent | ThinkingContent | ToolCall | ImageContent>,
 	images: ImageContent[],
@@ -662,15 +674,20 @@ async function runCursor(
 				const configOptions = session.newSessionResponse.configOptions ?? [];
 				await configureCursorSession(ctx, session.sessionId, configOptions, model, options, requestSignal);
 				const serialized = serializeContext(context);
-				const prompt: acp.ContentBlock[] = [
-					{ type: "text", text: serialized.text },
-					...serialized.images.map((image) => ({
-						type: "image" as const,
-						mimeType: image.mimeType,
-						data: image.data,
-					})),
-				];
-				void session.prompt(prompt, requestOptions);
+				let promptPayload: CursorPromptPayload = {
+					sessionId: session.sessionId,
+					prompt: [
+						{ type: "text", text: serialized.text },
+						...serialized.images.map((image) => ({
+							type: "image" as const,
+							mimeType: image.mimeType,
+							data: image.data,
+						})),
+					],
+				};
+				const nextPromptPayload = await options?.onPayload?.(promptPayload, model);
+				promptPayload = parseCursorPromptPayload(nextPromptPayload ?? promptPayload, session.sessionId);
+				void session.prompt(promptPayload.prompt, requestOptions);
 				let output = "";
 				for (;;) {
 					const update = await session.nextUpdate();

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -29,6 +29,15 @@ import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import { getAgentDir, VERSION } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
+import {
+	CURSOR_CLI_AUTH_TOKEN,
+	CURSOR_CLI_PROVIDER_ID,
+	getCursorCliCommand,
+	getCursorCliModels,
+	isCursorCliAvailable,
+	isCursorCliModel,
+	registerCursorCliProvider,
+} from "./cursor-cli-provider.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
 	fetchAuthorizedPrivatePrimeInferenceModelIds,
@@ -445,6 +454,7 @@ export class ModelRegistry {
 		readonly authStorage: AuthStorage,
 		private modelsJsonPath: string | undefined,
 	) {
+		registerCursorCliProvider();
 		this.loadModels();
 	}
 
@@ -478,6 +488,7 @@ export class ModelRegistry {
 
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
 		resetApiProviders();
+		registerCursorCliProvider();
 		resetOAuthProviders();
 		// reset drops everything but model-provider built-ins; re-add MCP integrations
 		// (built-in catalog + this session's user-declared servers via the hook).
@@ -520,7 +531,11 @@ export class ModelRegistry {
 		this.explicitPrivatePrimeInferenceModelIds = new Set(
 			customModels.filter(isPrivatePrimeInferenceModel).map((model) => model.id),
 		);
-		const builtInModels = [...this.loadBuiltInModels(overrides, modelOverrides), ...getPrivatePrimeInferenceModels()];
+		const builtInModels = [
+			...this.loadBuiltInModels(overrides, modelOverrides),
+			...getPrivatePrimeInferenceModels(),
+			...getCursorCliModels(),
+		];
 		let combined = this.mergeCustomModels(builtInModels, customModels);
 
 		// Let OAuth providers modify their models (e.g., update baseUrl)
@@ -1024,6 +1039,9 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
+		if (isCursorCliModel(model)) {
+			return isCursorCliAvailable();
+		}
 		return this.authStorage.hasAuth(model.provider) || this.hasConfiguredProviderRequestAuth(model.provider);
 	}
 
@@ -1295,6 +1313,14 @@ export class ModelRegistry {
 	 * Get API key and request headers for a model.
 	 */
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
+		if (isCursorCliModel(model)) {
+			return isCursorCliAvailable()
+				? { ok: true, apiKey: CURSOR_CLI_AUTH_TOKEN }
+				: {
+						ok: false,
+						error: `Cursor Agent CLI was not found. Install cursor-agent or set CURSOR_AGENT_PATH.`,
+					};
+		}
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
 			const authStorageAuth = await this.authStorage.getApiKeyWithSourceToken(model.provider, {
@@ -1356,6 +1382,11 @@ export class ModelRegistry {
 	 * This intentionally does not execute command-backed config values.
 	 */
 	getProviderAuthStatus(provider: string): AuthStatus {
+		if (provider === CURSOR_CLI_PROVIDER_ID) {
+			return isCursorCliAvailable()
+				? { configured: true, source: "environment", label: getCursorCliCommand() }
+				: { configured: false };
+		}
 		const authStatus = this.authStorage.getAuthStatus(provider);
 		if (authStatus.source && authStatus.source !== "stale") {
 			return authStatus;
@@ -1397,6 +1428,9 @@ export class ModelRegistry {
 	 * Get API key for a provider.
 	 */
 	async getApiKeyForProvider(provider: string): Promise<string | undefined> {
+		if (provider === CURSOR_CLI_PROVIDER_ID) {
+			return isCursorCliAvailable() ? CURSOR_CLI_AUTH_TOKEN : undefined;
+		}
 		const authStorageAuth = await this.authStorage.getApiKeyWithSourceToken(provider, { includeFallback: false });
 		if (authStorageAuth.apiKey !== undefined) {
 			this.setLastProviderAuthSourceToken(provider, authStorageAuth.sourceToken);

--- a/packages/coding-agent/src/core/provider-display-names.ts
+++ b/packages/coding-agent/src/core/provider-display-names.ts
@@ -5,6 +5,7 @@ export const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	cerebras: "Cerebras",
 	"cloudflare-ai-gateway": "Cloudflare AI Gateway",
 	"cloudflare-workers-ai": "Cloudflare Workers AI",
+	cursor: "Cursor CLI",
 	deepseek: "DeepSeek",
 	fireworks: "Fireworks",
 	google: "Google Gemini",

--- a/packages/coding-agent/src/modes/interactive/auth-flows.ts
+++ b/packages/coding-agent/src/modes/interactive/auth-flows.ts
@@ -11,6 +11,7 @@ import * as path from "node:path";
 import { getProviders, type OAuthProviderId, type OAuthSelectPrompt } from "@earendil-works/pi-ai";
 import type { OverlayHandle, TUI } from "@earendil-works/pi-tui";
 import { getAuthPath, getDocsPath } from "../../config.js";
+import { CURSOR_CLI_PROVIDER_ID } from "../../core/cursor-cli-provider.js";
 import type { ModelRegistry } from "../../core/model-registry.js";
 import {
 	checkPrimeAgentTracesAccess,
@@ -93,6 +94,9 @@ export function isApiKeyLoginProvider(
 	oauthProviderIds: ReadonlySet<string>,
 	builtInProviderIds: ReadonlySet<string> = BUILT_IN_MODEL_PROVIDERS,
 ): boolean {
+	if (providerId === CURSOR_CLI_PROVIDER_ID) {
+		return false;
+	}
 	if (BUILT_IN_PROVIDER_DISPLAY_NAMES[providerId]) {
 		return true;
 	}

--- a/packages/coding-agent/test/cursor-cli-provider.test.ts
+++ b/packages/coding-agent/test/cursor-cli-provider.test.ts
@@ -1,0 +1,325 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type AssistantMessageEvent, type Context, getApiProvider, resetApiProviders } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import {
+	CURSOR_CLI_API,
+	CURSOR_CLI_AUTH_TOKEN,
+	CURSOR_CLI_PROVIDER_ID,
+	getCursorCliCommand,
+	getCursorCliModels,
+	isCursorCliAvailable,
+	registerCursorCliProvider,
+	streamCursorCli,
+} from "../src/core/cursor-cli-provider.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { isApiKeyLoginProvider } from "../src/modes/interactive/auth-flows.js";
+
+const FAKE_CURSOR_AGENT = `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const logPath = process.env.CURSOR_TEST_LOG;
+const log = (entry) => appendFileSync(logPath, JSON.stringify(entry) + "\\n");
+log({ startup: true, cwd: process.cwd(), env: {
+  cursorApiKey: process.env.CURSOR_API_KEY,
+  primeApiKey: process.env.PRIME_API_KEY,
+} });
+let buffer = "";
+let configOptions = [
+  { id: "mode", name: "Mode", category: "mode", type: "select", currentValue: "agent", options: [
+    { value: "agent", name: "Agent" },
+    ...(process.env.CURSOR_TEST_NO_ASK ? [] : [{ value: "ask", name: "Ask" }]),
+  ] },
+  { id: "model", name: "Model", category: "model", type: "select", currentValue: "composer-2.5", options: [
+    { value: "composer-2.5", name: "Composer 2.5" },
+    { value: "grok-4.5", name: "Cursor Grok 4.5" },
+  ] },
+  { id: "effort", name: "Effort", category: "thought_level", type: "select", currentValue: "high", options: [
+    { value: "low", name: "Low" }, { value: "medium", name: "Medium" }, { value: "high", name: "High" },
+  ] },
+  { id: "fast", name: "Fast", category: "model_config", type: "select", currentValue: "true", options: [
+    { value: "false", name: "Off" }, { value: "true", name: "Fast" },
+  ] },
+];
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+const respond = (id, result) => send({ jsonrpc: "2.0", id, result });
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  for (;;) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) break;
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const request = JSON.parse(line);
+    log({ method: request.method, params: request.params });
+    if (request.method === "initialize") {
+      respond(request.id, { protocolVersion: 1, agentCapabilities: {}, authMethods: [] });
+    } else if (request.method === "session/new") {
+      respond(request.id, { sessionId: "fake-session", configOptions });
+    } else if (request.method === "session/set_config_option") {
+      configOptions = configOptions.map((option) => option.id === request.params.configId
+        ? { ...option, currentValue: request.params.value }
+        : option);
+      respond(request.id, { configOptions });
+    } else if (request.method === "session/prompt" && !process.env.CURSOR_TEST_HANG_PROMPT) {
+      const text = process.env.CURSOR_TEST_RESPONSE || JSON.stringify({ content: [
+        { type: "text", text: "ready" },
+        { type: "toolCall", name: "ipython", arguments: { code: "1 + 1" } },
+      ] });
+      send({ jsonrpc: "2.0", method: "session/update", params: {
+        sessionId: "fake-session",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+      } });
+      respond(request.id, { stopReason: "end_turn", usage: {
+        inputTokens: 10, outputTokens: 5, cachedReadTokens: 2, cachedWriteTokens: 1, totalTokens: 18,
+      } });
+    }
+  }
+});
+`;
+
+interface FakeLogEntry {
+	startup?: boolean;
+	cwd?: string;
+	env?: { cursorApiKey?: string; primeApiKey?: string };
+	method?: string;
+	params?: Record<string, unknown>;
+}
+
+async function collectStream(
+	stream: ReturnType<typeof streamCursorCli>,
+): Promise<{ events: AssistantMessageEvent[]; message: Awaited<ReturnType<typeof stream.result>> }> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return { events, message: await stream.result() };
+}
+
+describe("Cursor CLI provider", () => {
+	let tempDir: string;
+	let executablePath: string;
+	let logPath: string;
+	let originalCursorAgentPath: string | undefined;
+	let originalCursorApiKey: string | undefined;
+	let originalPrimeApiKey: string | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-cursor-test-"));
+		executablePath = join(tempDir, "cursor-agent");
+		logPath = join(tempDir, "cursor.log");
+		writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");
+		chmodSync(executablePath, 0o755);
+		originalCursorAgentPath = process.env.CURSOR_AGENT_PATH;
+		originalCursorApiKey = process.env.CURSOR_API_KEY;
+		originalPrimeApiKey = process.env.PRIME_API_KEY;
+		process.env.CURSOR_AGENT_PATH = executablePath;
+		process.env.CURSOR_TEST_LOG = logPath;
+		process.env.CURSOR_API_KEY = "cursor-secret";
+		process.env.PRIME_API_KEY = "prime-secret";
+	});
+
+	afterEach(() => {
+		for (const key of ["CURSOR_TEST_LOG", "CURSOR_TEST_NO_ASK", "CURSOR_TEST_HANG_PROMPT", "CURSOR_TEST_RESPONSE"]) {
+			delete process.env[key];
+		}
+		if (originalCursorAgentPath === undefined) delete process.env.CURSOR_AGENT_PATH;
+		else process.env.CURSOR_AGENT_PATH = originalCursorAgentPath;
+		if (originalCursorApiKey === undefined) delete process.env.CURSOR_API_KEY;
+		else process.env.CURSOR_API_KEY = originalCursorApiKey;
+		if (originalPrimeApiKey === undefined) delete process.env.PRIME_API_KEY;
+		else process.env.PRIME_API_KEY = originalPrimeApiKey;
+		resetApiProviders();
+		rmSync(tempDir, { force: true, recursive: true });
+	});
+
+	test("detects an explicitly configured executable", () => {
+		expect(getCursorCliCommand()).toBe(executablePath);
+		expect(isCursorCliAvailable()).toBe(true);
+		process.env.CURSOR_AGENT_PATH = join(tempDir, "missing");
+		expect(isCursorCliAvailable()).toBe(false);
+	});
+
+	test("registers Composer and Grok as locally authenticated models", async () => {
+		const registry = ModelRegistry.inMemory(AuthStorage.inMemory());
+		const models = getCursorCliModels();
+		expect(models.map((model) => model.id)).toEqual(["composer-2.5", "grok-4.5"]);
+		expect(models.every((model) => model.provider === CURSOR_CLI_PROVIDER_ID && model.api === CURSOR_CLI_API)).toBe(
+			true,
+		);
+		expect(registry.getAvailable().filter((model) => model.provider === CURSOR_CLI_PROVIDER_ID)).toHaveLength(2);
+		expect(registry.getProviderAuthStatus(CURSOR_CLI_PROVIDER_ID).configured).toBe(true);
+		await expect(registry.getApiKeyForProvider(CURSOR_CLI_PROVIDER_ID)).resolves.toBe(CURSOR_CLI_AUTH_TOKEN);
+		expect(getApiProvider(CURSOR_CLI_API)?.api).toBe(CURSOR_CLI_API);
+	});
+
+	test("does not offer Cursor as an API-key login", () => {
+		expect(isApiKeyLoginProvider(CURSOR_CLI_PROVIDER_ID, new Set(), new Set())).toBe(false);
+	});
+
+	test("re-registers the API provider after a registry reset", () => {
+		registerCursorCliProvider();
+		expect(getApiProvider(CURSOR_CLI_API)?.api).toBe(CURSOR_CLI_API);
+		resetApiProviders();
+		expect(getApiProvider(CURSOR_CLI_API)).toBeUndefined();
+		registerCursorCliProvider();
+		expect(getApiProvider(CURSOR_CLI_API)?.api).toBe(CURSOR_CLI_API);
+	});
+
+	test("negotiates Grok options and converts structured output to Prime events", async () => {
+		writeFileSync(executablePath, FAKE_CURSOR_AGENT);
+		chmodSync(executablePath, 0o755);
+		const model = getCursorCliModels().find((candidate) => candidate.id === "grok-4.5");
+		expect(model).toBeDefined();
+		const context: Context = {
+			systemPrompt: "Use Prime tools.",
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "encrypted", thinkingSignature: "opaque", redacted: true },
+						{ type: "text", text: "prior answer", textSignature: "opaque-text" },
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 1,
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "orphan",
+							name: "ipython",
+							arguments: { code: "old" },
+							thoughtSignature: "private",
+						},
+					],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "gemini",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 2,
+				},
+				{ role: "user", content: "continue", timestamp: 3 },
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "partial" }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "aborted",
+					timestamp: 4,
+				},
+			],
+			tools: [{ name: "ipython", description: "Run Python", parameters: Type.Object({ code: Type.String() }) }],
+		};
+		const { events, message } = await collectStream(streamCursorCli(model!, context, { reasoning: "medium" }));
+		expect(message.stopReason).toBe("toolUse");
+		expect(message.content.map((block) => block.type)).toEqual(["text", "toolCall"]);
+		expect(events.map((event) => event.type)).toEqual([
+			"start",
+			"text_start",
+			"text_delta",
+			"text_end",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"done",
+		]);
+
+		const log = readFileSync(logPath, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as FakeLogEntry);
+		expect(log[0]?.env).toEqual({ cursorApiKey: "cursor-secret" });
+		const configWrites = log.filter((entry) => entry.method === "session/set_config_option");
+		expect(configWrites.map((entry) => entry.params)).toMatchObject([
+			{ configId: "model", value: "grok-4.5" },
+			{ configId: "effort", value: "medium" },
+			{ configId: "fast", value: "false" },
+			{ configId: "mode", value: "ask" },
+		]);
+		const promptEntry = log.find((entry) => entry.method === "session/prompt");
+		const prompt =
+			(promptEntry?.params?.prompt as Array<{ type: string; text?: string }> | undefined)?.[0]?.text ?? "";
+		expect(prompt).not.toContain("opaque");
+		expect(prompt).not.toContain("textSignature");
+		expect(prompt).not.toContain("thoughtSignature");
+		expect(prompt).not.toContain("partial");
+		expect(prompt).toContain("No result provided");
+		expect(log[0]?.cwd).toMatch(/prime-agent-cursor-/);
+		expect(existsSync(log[0]?.cwd ?? "")).toBe(false);
+	});
+
+	test("fails closed when Ask mode is unavailable", async () => {
+		writeFileSync(executablePath, FAKE_CURSOR_AGENT);
+		chmodSync(executablePath, 0o755);
+		process.env.CURSOR_TEST_NO_ASK = "1";
+		const model = getCursorCliModels()[0];
+		const { message } = await collectStream(streamCursorCli(model!, { messages: [] }));
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Ask mode");
+		const log = readFileSync(logPath, "utf8");
+		expect(log).not.toContain("session/prompt");
+	});
+
+	test("terminates malformed, missing, and timed-out CLI requests as stream errors", async () => {
+		writeFileSync(executablePath, FAKE_CURSOR_AGENT);
+		chmodSync(executablePath, 0o755);
+		const model = getCursorCliModels()[0];
+		process.env.CURSOR_TEST_RESPONSE = "not json";
+		const malformed = await collectStream(streamCursorCli(model!, { messages: [] }));
+		expect(malformed.message.stopReason).toBe("error");
+		expect(malformed.message.errorMessage).toContain("JSON object");
+
+		process.env.CURSOR_AGENT_PATH = join(tempDir, "missing");
+		const missing = await collectStream(streamCursorCli(model!, { messages: [] }, { timeoutMs: 500 }));
+		expect(missing.message.stopReason).toBe("error");
+
+		process.env.CURSOR_AGENT_PATH = executablePath;
+		const invalidTimeout = await collectStream(streamCursorCli(model!, { messages: [] }, { timeoutMs: -1 }));
+		expect(invalidTimeout.message.stopReason).toBe("error");
+
+		const controller = new AbortController();
+		controller.abort();
+		const aborted = await collectStream(streamCursorCli(model!, { messages: [] }, { signal: controller.signal }));
+		expect(aborted.message.stopReason).toBe("aborted");
+
+		delete process.env.CURSOR_TEST_RESPONSE;
+		process.env.CURSOR_TEST_HANG_PROMPT = "1";
+		const timedOut = await collectStream(streamCursorCli(model!, { messages: [] }, { timeoutMs: 100 }));
+		expect(timedOut.message.stopReason).toBe("error");
+		expect(timedOut.message.errorMessage).toContain("timed out");
+	});
+});

--- a/packages/coding-agent/test/cursor-cli-provider.test.ts
+++ b/packages/coding-agent/test/cursor-cli-provider.test.ts
@@ -244,7 +244,28 @@ describe("Cursor CLI provider", () => {
 			],
 			tools: [{ name: "ipython", description: "Run Python", parameters: Type.Object({ code: Type.String() }) }],
 		};
-		const { events, message } = await collectStream(streamCursorCli(model!, context, { reasoning: "medium" }));
+		let hookCalls = 0;
+		const { events, message } = await collectStream(
+			streamCursorCli(model!, context, {
+				reasoning: "medium",
+				onPayload: (payload) => {
+					hookCalls++;
+					const cursorPayload = payload as {
+						sessionId: string;
+						prompt: Array<{ type: string; text?: string; [key: string]: unknown }>;
+					};
+					return {
+						...cursorPayload,
+						prompt: cursorPayload.prompt.map((block, index) =>
+							index === 0 && block.type === "text"
+								? { ...block, text: `${block.text ?? ""}\nprovider-hook-applied` }
+								: block,
+						),
+					};
+				},
+			}),
+		);
+		expect(hookCalls).toBe(1);
 		expect(message.stopReason).toBe("toolUse");
 		expect(message.content.map((block) => block.type)).toEqual(["text", "toolCall"]);
 		expect(events.map((event) => event.type)).toEqual([
@@ -278,6 +299,7 @@ describe("Cursor CLI provider", () => {
 		expect(prompt).not.toContain("thoughtSignature");
 		expect(prompt).not.toContain("partial");
 		expect(prompt).toContain("No result provided");
+		expect(prompt).toContain("provider-hook-applied");
 		expect(log[0]?.cwd).toMatch(/prime-agent-cursor-/);
 		expect(existsSync(log[0]?.cwd ?? "")).toBe(false);
 	});


### PR DESCRIPTION
## Summary

- add a local Cursor Agent CLI provider exposing `cursor/composer-2.5` and `cursor/grok-4.5`
- send Prime Agent context and tool schemas through Cursor ACP, then convert structured responses back into Prime text and tool-call events so Prime retains its agent loop, Python kernel, and subagents
- integrate executable detection, external Cursor authentication, model selection, reload handling, documentation, and focused fake-ACP coverage

## Safety and behavior

Cursor runs in Ask mode from an isolated temporary directory. Prime Agent rejects ACP permission requests, strips unrelated provider credentials from the child environment, normalizes cross-provider history, and fails closed if the requested model or Ask mode cannot be selected.

This is not an OS sandbox: Cursor still receives the full Prime context and retains read/search behavior. The provider documentation makes that trust boundary explicit.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cursor-cli-provider.test.ts test/model-registry.test.ts test/auth-flows.test.ts test/oauth-selector.test.ts test/agent-session-dynamic-provider.test.ts` (107 passed)
- `./prime-agent.sh model list cursor`
- live Cursor ACP initialization and model/config negotiation without an inference request


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor Agent CLI model support with Composer 2.5 and Grok 4.5
> - Introduces a new `cursor-cli-acp` API provider in [cursor-cli-provider.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/864/files#diff-838ef165d6854856009c20eb3c174416c2c68add79410a41257031c91c6590d5) that spawns `cursor-agent acp` and communicates via NDJSON ACP transport to stream responses as `AssistantMessage` events.
> - Exposes two models: `composer-2.5` (non-reasoning) and `grok-4.5` (reasoning), both available via a Cursor subscription with zero API cost.
> - Auth and availability are determined by presence of the `cursor-agent` executable on PATH (or `CURSOR_AGENT_PATH`), bypassing credential storage entirely.
> - Registers the provider during `ModelRegistry` construction and on refresh, and excludes the `cursor` provider from the interactive API-key login flow.
> - Risk: Cursor models depend on an external process (`cursor-agent`) being installed and authenticated separately; missing executable surfaces as a provider auth error rather than a credential prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc8cc8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->