### PR TITLE
fix(coding-agent): report the worker exit status when the startup gate fails

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.
+- Fixed a session worker that dies during startup reporting `write after end` instead of its exit status ([#813](https://github.com/PrimeIntellect-ai/prime-agent/issues/813)).
 
 ## [0.7.0] - 2026-08-05
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -358,6 +358,24 @@ function unrefDelay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms).unref());
 }
 
+type WorkerExitStatus = { code: number | null; signal: NodeJS.Signals | null };
+
+/**
+ * A worker that dies before the gate is committed closes its end of the pipe first, so the commit
+ * write rejects with ERR_STREAM_WRITE_AFTER_END. That reports the symptom, not the cause: the exit
+ * status does, and the worker's stderr is already in the daemon log.
+ */
+function describeStartupGateFailure(workerId: string, error: unknown, exit: WorkerExitStatus | undefined): Error {
+	if (!exit || (exit.code === null && exit.signal === null)) {
+		return error instanceof Error ? error : new Error(String(error));
+	}
+	const cause = exit.signal === null ? `exit code ${exit.code}` : `signal ${exit.signal}`;
+	return new Error(
+		`Session worker ${workerId} exited during startup (${cause}) before committing its startup gate. See the daemon log for the worker's stderr.`,
+		{ cause: error },
+	);
+}
+
 function commitWorkerStartupGate(gate: Writable): Promise<void> {
 	return new Promise((resolveCommit, rejectCommit) => {
 		let settled = false;
@@ -2137,7 +2155,13 @@ export class DaemonSupervisor {
 				})
 			: () => {};
 		child.once("close", detachWorkerStderr);
-		const childClosed = new Promise<void>((resolveClose) => child.once("close", () => resolveClose()));
+		let childExit: WorkerExitStatus | undefined;
+		const childClosed = new Promise<void>((resolveClose) =>
+			child.once("close", (code, signal) => {
+				childExit = { code, signal };
+				resolveClose();
+			}),
+		);
 		child.on("error", (error) => {
 			this.log(
 				`Session worker ${workerId} process error: ${error instanceof Error ? error.message : String(error)}`,
@@ -2225,7 +2249,7 @@ export class DaemonSupervisor {
 			} catch (error) {
 				startupGate.destroy();
 				await childClosed;
-				throw error;
+				throw describeStartupGateFailure(workerId, error, childExit);
 			} finally {
 				child.unref();
 			}

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -626,6 +626,13 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(result.value).toBe("rejected");
 		expect(result.error).not.toBe(timeoutError);
 		expect(result.error).toBeInstanceOf(Error);
+		// The gate write fails with ERR_STREAM_WRITE_AFTER_END only because the worker already
+		// closed its end. That says nothing about why it died, so the exit status has to survive.
+		const gateError = result.error as NodeJS.ErrnoException;
+		expect(gateError.code).not.toBe("ERR_STREAM_WRITE_AFTER_END");
+		expect(gateError.message).toContain("exited during startup");
+		expect(gateError.message).toMatch(/exit code \d+|signal \w+/);
+		expect((gateError.cause as NodeJS.ErrnoException | undefined)?.code).toBe("ERR_STREAM_WRITE_AFTER_END");
 		expect(connectWorker).not.toHaveBeenCalled();
 		expect(workers.size).toBe(0);
 		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toEqual([]);


### PR DESCRIPTION
Refs #813. This fixes the misleading error, not the underlying cause — see "What this does not do" below.

## The defect

When a session worker dies during startup, `launchWorker` reports `write after end`.

The worker's startup gate is fd 3. If the worker exits before the gate is committed, Node ends that pipe, so `commitWorkerStartupGate`'s `gate.end(COMMIT, cb)` rejects with `ERR_STREAM_WRITE_AFTER_END`. `launchWorker` rethrew it verbatim:

```ts
const childClosed = new Promise<void>((resolveClose) => child.once("close", () => resolveClose()));
...
} catch (error) {
	startupGate.destroy();
	await childClosed;
	throw error;
}
```

The exit status was already in hand and thrown away twice over: the `close` event carries `(code, signal)` and the promise ignores both, and the catch awaits `childClosed` purely to sequence the rollback. So the one fact that explains the failure is discarded, and the caller gets a stream error that describes only the symptom. The worker's stderr — which in #813 carries the dyld message — is already written to the daemon log by `attachJsonlLineReader` a few lines above, but nothing in the surfaced error points there.

## The change

Capture `(code, signal)` on `childClosed`, and when the child has exited, report that instead:

```
Session worker <id> exited during startup (exit code 1) before committing its startup gate.
See the daemon log for the worker's stderr.
```

The stream error is kept as `cause`, so nothing is lost. If the child has not exited, the original error is rethrown unchanged. No protocol change, no change on the success path, one function touched.

## Verification

Measured on Windows 11, Node 24.13.0, base `b9a4461`.

The repo already has a fixture for exactly this shape — `close-gate` in `daemon-supervisor-monitor.test.ts` spawns a worker that runs `require("node:fs").closeSync(3)` and exits. Before this change, the rejection it produces is:

```
message: "write after end"
code:    ERR_STREAM_WRITE_AFTER_END
```

The existing test `rolls back promptly when the child closes its startup gate before commit` asserted only `toBeInstanceOf(Error)`, so the message was unpinned. This PR strengthens that test rather than adding a new one; no existing assertion was removed or relaxed. Three mutations, each caught:

| Mutation | Result |
|---|---|
| rethrow the raw stream error | test fails |
| drop the `{ cause }` chain | test fails |
| stop capturing `(code, signal)` | test fails |

`packages/coding-agent/test/daemon-supervisor-monitor.test.ts`: 41 pass. One unrelated test, `limits abort admission to mutation drain`, fails on this machine — it also fails at unmodified `b9a4461`, so it is pre-existing and not touched by this change. I did not investigate it and am not claiming it is broken for you; flagging it only so the count is not mistaken for a regression here.

`npm run check` is clean.

- [x] Quoted lines checked against `b9a4461`.
- [x] Before/after behavior observed directly via the existing `close-gate` fixture.
- [ ] **The macOS scenario in #813 is not reproduced.** I have no macOS box and did not stage a stale Homebrew Node. What I reproduced is the stream defect and the message it produces; that the reporter's dyld failure takes this path is inferred from the traceback in the issue, not observed.

## What this does not do

It does not close #813. The reporter's ask is that the supervisor notice a stale Node runtime and relaunch workers under a current one. Which runtime is authoritative, and whether a live supervisor with attached sessions should restart itself, are design decisions I do not think an outside PR should make — and #723 is already working the `doctor`/`ps` side of the same problem. This PR only stops the real failure from being masked, so whatever lands on top has something to work with. Happy to close it if you would rather fix the message as part of that larger change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix coding agent startup gate failure to report worker exit status
> When a session worker exits before committing its startup gate, the thrown error previously surfaced a raw `ERR_STREAM_WRITE_AFTER_END` message. Now, a new `describeStartupGateFailure` helper in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/866/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) wraps the error to include the worker's exit code or signal in the message, with the original stream error preserved as the cause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fedb79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->