### PR TITLE
fix(ai): map Codex stream errors from nested error fields

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -495,10 +495,21 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 		if (!type) continue;
 
 		if (type === "error") {
-			const code = (event as { code?: string }).code || "";
-			const message = (event as { message?: string }).message || "";
-			throw new CodexApiError(`Codex error: ${message || code || JSON.stringify(event)}`, {
-				code: code || undefined,
+			const nested = (event as { error?: CodexErrorDetails }).error;
+			const topLevel = event as { code?: string; message?: string; status_code?: number };
+			const status = typeof topLevel.status_code === "number" ? topLevel.status_code : undefined;
+			const formatted = formatCodexError(
+				{
+					code: nested?.type ?? nested?.code ?? topLevel.code,
+					type: nested?.type ?? nested?.code ?? topLevel.code,
+					message: nested?.message ?? topLevel.message,
+					plan_type: nested?.plan_type,
+					resets_at: nested?.resets_at,
+				},
+				{ status, fallbackMessage: JSON.stringify(event) },
+			);
+			throw new CodexApiError(formatted.friendlyMessage || `Codex error: ${formatted.message}`, {
+				code: formatted.code,
 				payload: event,
 			});
 		}
@@ -1222,33 +1233,47 @@ async function processWebSocketStream(
 // Error Handling
 // ============================================================================
 
-async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string }> {
-	const raw = await response.text();
-	let message = raw || response.statusText || "Request failed";
+type CodexErrorDetails = {
+	code?: string;
+	type?: string;
+	message?: string;
+	plan_type?: string;
+	resets_at?: number;
+};
+
+function formatCodexError(
+	err: CodexErrorDetails | undefined,
+	options?: { status?: number; fallbackMessage?: string },
+): { message: string; friendlyMessage?: string; code?: string } {
+	const code = err?.code || err?.type || "";
 	let friendlyMessage: string | undefined;
 
+	if (/usage_limit_reached|usage_not_included|rate_limit_exceeded/i.test(code) || options?.status === 429) {
+		const plan = err?.plan_type ? ` (${err.plan_type.toLowerCase()} plan)` : "";
+		const mins = err?.resets_at ? Math.max(0, Math.round((err.resets_at * 1000 - Date.now()) / 60000)) : undefined;
+		const when = mins !== undefined ? ` Try again in ~${mins} min.` : "";
+		friendlyMessage = `You have hit your ChatGPT usage limit${plan}.${when}`.trim();
+	}
+
+	// Prefer the quota-aware text over vague server copy when we built one.
+	const message = friendlyMessage || err?.message || options?.fallbackMessage || "Request failed";
+	return { message, friendlyMessage, code: code || undefined };
+}
+
+async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string }> {
+	const raw = await response.text();
+	const fallbackMessage = raw || response.statusText || "Request failed";
+
 	try {
-		const parsed = JSON.parse(raw) as {
-			error?: { code?: string; type?: string; message?: string; plan_type?: string; resets_at?: number };
-		};
-		const err = parsed?.error;
-		if (err) {
-			const code = err.code || err.type || "";
-			if (/usage_limit_reached|usage_not_included|rate_limit_exceeded/i.test(code) || response.status === 429) {
-				const plan = err.plan_type ? ` (${err.plan_type.toLowerCase()} plan)` : "";
-				const mins = err.resets_at
-					? Math.max(0, Math.round((err.resets_at * 1000 - Date.now()) / 60000))
-					: undefined;
-				const when = mins !== undefined ? ` Try again in ~${mins} min.` : "";
-				friendlyMessage = `You have hit your ChatGPT usage limit${plan}.${when}`.trim();
-			}
-			message = err.message || friendlyMessage || message;
+		const parsed = JSON.parse(raw) as { error?: CodexErrorDetails };
+		if (parsed?.error) {
+			return formatCodexError(parsed.error, { status: response.status, fallbackMessage });
 		}
 	} catch {
 		// Unparseable error body: fall back to the raw message.
 	}
 
-	return { message, friendlyMessage };
+	return { message: fallbackMessage };
 }
 
 // ============================================================================

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -252,6 +252,137 @@ describe("openai-codex streaming", () => {
 		expect(result.stopReason).toBe("stop");
 	});
 
+	it("maps nested SSE usage_limit_reached errors to a friendly quota message", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const resetsAt = Math.floor(Date.now() / 1000) + 45 * 60;
+		const encoder = new TextEncoder();
+		const sse = `data: ${JSON.stringify({
+			type: "error",
+			error: {
+				type: "usage_limit_reached",
+				message: "The usage limit has been reached",
+				plan_type: "prolite",
+				resets_at: resetsAt,
+			},
+			status_code: 429,
+		})}\n\n`;
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("prolite plan");
+		expect(result.errorMessage).toContain("Try again");
+		expect(result.errorMessage).not.toContain("usage_limit_reached");
+		expect(result.errorMessage).not.toContain('"type":"error"');
+		expect(result.errorMessage).not.toContain("The usage limit has been reached");
+	});
+
+	it("prefers friendly quota text for HTTP 429 usage_limit_reached responses", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const resetsAt = Math.floor(Date.now() / 1000) + 30 * 60;
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(
+					JSON.stringify({
+						error: {
+							type: "usage_limit_reached",
+							message: "The usage limit has been reached",
+							plan_type: "plus",
+							resets_at: resetsAt,
+						},
+					}),
+					{ status: 429, statusText: "Too Many Requests" },
+				);
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("plus plan");
+		expect(result.errorMessage).toContain("Try again");
+		expect(result.errorMessage).not.toContain("The usage limit has been reached");
+	});
+
 	it("maps response.incomplete to stopReason length even when the SSE body stays open", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
 		process.env.PI_CODING_AGENT_DIR = tempDir;


### PR DESCRIPTION
## Summary
Streamed Codex errors put `type`/`message` under `error`, but `mapCodexEvents` read them at the top level. That turned usage-limit failures into a raw JSON dump and dropped plan/reset info.

The non-stream path already formats these. This shares that formatting for stream errors and prefers the friendly quota text when we build one.

Fixes #863

## Test plan
- [x] Unit test SSE usage_limit_reached payload
- [x] Unit test HTTP 429 path still uses friendly quota text
- [x] packages/ai openai-codex-stream tests pass (19/19)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex stream error mapping to extract nested error fields and produce quota-aware messages
> - Updates `mapCodexEvents` in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/871/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) to read nested `event.error` and top-level `status_code` fields from SSE error events, replacing the previous top-level-only `code`/`message` extraction.
> - Adds a `formatCodexError` helper that normalizes error details into a structured response, generating user-friendly quota and retry messages for `usage_limit_reached`, `usage_not_included`, and `rate_limit_exceeded` codes (or HTTP 429), including plan label and approximate retry minutes from `resets_at`.
> - Refactors `parseErrorResponse` to delegate to `formatCodexError`, so HTTP error responses with quota/rate-limit codes also return friendly messages instead of raw server text.
> - Behavioral Change: `CodexApiError` messages for quota and rate-limit conditions now surface plan and retry timing; raw JSON is no longer used as a fallback message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6c1f65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->