### PR TITLE
fix(tui): enable negotiated tmux hyperlinks

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added OSC 8 hyperlink support for tmux clients that advertise the `hyperlinks` terminal feature ([#686](https://github.com/PrimeIntellect-ai/prime-agent/issues/686)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+
 export type ImageProtocol = "kitty" | "iterm2" | null;
 
 export interface TerminalCapabilities {
@@ -39,17 +41,29 @@ export function setCellDimensions(dims: CellDimensions): void {
 	cellDimensions = dims;
 }
 
+function tmuxSupportsHyperlinks(): boolean {
+	const result = spawnSync("tmux", ["display-message", "-p", "#{client_termfeatures}"], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout: 250,
+	});
+	if (result.status !== 0 || typeof result.stdout !== "string") return false;
+	return result.stdout.split(/[,:]/).some((feature) => feature.trim() === "hyperlinks");
+}
+
 export function detectCapabilities(): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
 	const term = process.env.TERM?.toLowerCase() || "";
 	const colorTerm = process.env.COLORTERM?.toLowerCase() || "";
 
-	// tmux and screen swallow OSC 8 by default (passthrough is opt-in and wraps
-	// sequences differently). Force hyperlinks off whenever we detect them, even
-	// when the outer terminal would otherwise support OSC 8. Image protocols are
-	// also unreliable under tmux/screen, so leave `images: null` for safety.
-	const inTmuxOrScreen = !!process.env.TMUX || term.startsWith("tmux") || term.startsWith("screen");
-	if (inTmuxOrScreen) {
+	// Image protocols are unreliable under tmux/screen, so leave `images: null`
+	// for safety. tmux can preserve OSC 8 when its client negotiated support;
+	// screen remains conservative because it has no equivalent probe here.
+	if (process.env.TMUX) {
+		const trueColor = colorTerm === "truecolor" || colorTerm === "24bit";
+		return { images: null, trueColor, hyperlinks: tmuxSupportsHyperlinks() };
+	}
+	if (term.startsWith("tmux") || term.startsWith("screen")) {
 		const trueColor = colorTerm === "truecolor" || colorTerm === "24bit";
 		return { images: null, trueColor, hyperlinks: false };
 	}

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -3,6 +3,10 @@
  */
 
 import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { Image } from "../src/components/image.js";
 import {
@@ -28,6 +32,7 @@ const ENV_KEYS = [
 	"WEZTERM_PANE",
 	"ITERM_SESSION_ID",
 	"CMUX_WORKSPACE_ID",
+	"PATH",
 ] as const;
 
 function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
@@ -197,6 +202,38 @@ describe("isImageLine", () => {
 });
 
 describe("detectCapabilities", () => {
+	function withFakeTmux(output: string, fn: () => void, exitCode = 0, delaySeconds = 0): void {
+		const directory = mkdtempSync(join(tmpdir(), "prime-agent-tmux-"));
+		const executable = join(directory, "tmux");
+		const originalPath = process.env.PATH ?? "";
+		writeFileSync(
+			executable,
+			`#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(output)}\n${
+				delaySeconds > 0 ? `sleep ${delaySeconds}` : ":"
+			}\nexit ${exitCode}\n`,
+		);
+		chmodSync(executable, 0o755);
+		try {
+			withEnv(
+				{
+					TMUX: "/tmp/tmux/default,1234,0",
+					TERM_PROGRAM: "ghostty",
+					PATH: `${directory}:${originalPath}`,
+				},
+				() => {
+					// Warm up command lookup for newly-created test executables on macOS.
+					spawnSync("tmux", ["display-message", "-p", "#{client_termfeatures}"], {
+						encoding: "utf8",
+						timeout: 250,
+					});
+					fn();
+				},
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}
+
 	it("defaults to hyperlinks: false for unknown terminals", () => {
 		withEnv({}, () => {
 			const caps = detectCapabilities();
@@ -206,11 +243,56 @@ describe("detectCapabilities", () => {
 	});
 
 	it("forces hyperlinks: false under tmux even if outer terminal supports OSC 8", () => {
-		withEnv({ TMUX: "/tmp/tmux-1000/default,1234,0", TERM_PROGRAM: "ghostty" }, () => {
+		withFakeTmux("RGB", () => {
 			const caps = detectCapabilities();
 			assert.strictEqual(caps.hyperlinks, false);
 			assert.strictEqual(caps.images, null);
 		});
+	});
+
+	it("enables hyperlinks when tmux negotiates the feature", () => {
+		withFakeTmux("RGB,hyperlinks", () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("parses hyperlinks embedded in a tmux feature group", () => {
+		withFakeTmux("RGB:hyperlinks", () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, true);
+		});
+	});
+
+	it("keeps hyperlinks disabled when tmux does not report support", () => {
+		withFakeTmux("RGB,256", () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, false);
+		});
+	});
+
+	it("keeps hyperlinks disabled when the tmux probe fails", () => {
+		withFakeTmux(
+			"hyperlinks",
+			() => {
+				const caps = detectCapabilities();
+				assert.strictEqual(caps.hyperlinks, false);
+			},
+			1,
+		);
+	});
+
+	it("keeps hyperlinks disabled when the tmux probe times out", () => {
+		withFakeTmux(
+			"hyperlinks",
+			() => {
+				const caps = detectCapabilities();
+				assert.strictEqual(caps.hyperlinks, false);
+			},
+			0,
+			1,
+		);
 	});
 
 	it("forces hyperlinks: false when TERM starts with 'tmux'", () => {


### PR DESCRIPTION
Fixes #686.

## Summary

- Detect tmux's negotiated `hyperlinks` feature via `tmux display-message`.
- Enable OSC 8 links only when tmux explicitly advertises support.
- Keep terminal images disabled under tmux and hyperlinks disabled under screen.
- Fall back safely when tmux is missing, fails, or exceeds the 250 ms probe timeout.

## Tests

- Focused terminal capability tests: 47/47.
- Full TUI test suite: 742/742.
- `npm run check` passes, including TypeScript, installer, and browser smoke checks.
- Manual tmux verification confirmed clickable OSC 8 output.


<img width="892" height="628" alt="image" src="https://github.com/user-attachments/assets/d967dee6-e42f-4a95-9242-c014b76e1a98" />
