### PR TITLE
fix(coding-agent): prevent input corruption in external editors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed external Vim sessions receiving duplicate or corrupted key presses after opening from the composer ([#878](https://github.com/PrimeIntellect-ai/prime-agent/pull/878)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -3,10 +3,6 @@
  * Supports Ctrl+G for external editor.
  */
 
-import { spawnSync } from "node:child_process";
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import {
 	Container,
 	Editor,
@@ -18,6 +14,7 @@ import {
 	type TUI,
 } from "@earendil-works/pi-tui";
 import type { KeybindingsManager } from "../../../core/keybindings.js";
+import { runExternalEditor } from "../external-editor.js";
 import { getEditorTheme, theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -26,6 +23,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 	private editor: Editor;
 	private onSubmitCallback: (value: string) => void;
 	private onCancelCallback: () => void;
+	private onErrorCallback: (error: unknown) => void;
 	private tui: TUI;
 	private keybindings: KeybindingsManager;
 
@@ -46,6 +44,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		onSubmit: (value: string) => void,
 		onCancel: () => void,
 		options?: EditorOptions,
+		onError?: (error: unknown) => void,
 	) {
 		super();
 
@@ -53,6 +52,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.keybindings = keybindings;
 		this.onSubmitCallback = onSubmit;
 		this.onCancelCallback = onCancel;
+		this.onErrorCallback = onError ?? (() => undefined);
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -102,7 +102,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 
 		// External editor (app keybinding)
 		if (this.keybindings.matches(keyData, "app.editor.external")) {
-			this.openExternalEditor();
+			void this.openExternalEditor().catch((error) => this.onErrorCallback(error));
 			return;
 		}
 
@@ -110,38 +110,15 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.editor.handleInput(keyData);
 	}
 
-	private openExternalEditor(): void {
-		const editorCmd = process.env.VISUAL || process.env.EDITOR;
-		if (!editorCmd) {
+	private async openExternalEditor(): Promise<void> {
+		const command = process.env.VISUAL || process.env.EDITOR;
+		if (!command) {
 			return;
 		}
 
-		const currentText = this.editor.getText();
-		const tmpFile = path.join(os.tmpdir(), `pi-extension-editor-${Date.now()}.md`);
-
-		try {
-			fs.writeFileSync(tmpFile, currentText, "utf-8");
-			this.tui.stop();
-
-			const [editor, ...editorArgs] = editorCmd.split(" ");
-			const result = spawnSync(editor, [...editorArgs, tmpFile], {
-				stdio: "inherit",
-				shell: process.platform === "win32",
-			});
-
-			if (result.status === 0) {
-				const newContent = fs.readFileSync(tmpFile, "utf-8").replace(/\n$/, "");
-				this.editor.setText(newContent);
-			}
-		} finally {
-			try {
-				fs.unlinkSync(tmpFile);
-			} catch {
-				// Ignore cleanup errors
-			}
-			this.tui.start();
-			// Force full re-render since external editor uses alternate screen
-			this.tui.requestRender(true);
+		const content = await runExternalEditor({ tui: this.tui, command, content: this.editor.getText() });
+		if (content !== undefined) {
+			this.editor.setText(content);
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/external-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/external-editor.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+type ExternalEditorTui = {
+	terminal: { drainInput: (maxMs?: number, idleMs?: number) => Promise<void> };
+	start: () => void;
+	stop: () => void;
+	requestRender: (force?: boolean) => void;
+};
+
+export async function runExternalEditor(options: {
+	tui: ExternalEditorTui;
+	command: string;
+	content: string;
+	onTuiRestart?: () => void;
+}): Promise<string | undefined> {
+	const tmpFile = path.join(os.tmpdir(), `pi-editor-${Date.now()}.md`);
+	let tuiStopped = false;
+
+	try {
+		fs.writeFileSync(tmpFile, options.content, "utf-8");
+		await options.tui.terminal.drainInput(1000);
+		options.tui.stop();
+		tuiStopped = true;
+
+		const [editor, ...editorArgs] = options.command.split(" ");
+		const result = spawnSync(editor, [...editorArgs, tmpFile], {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+		if (result.error) {
+			throw result.error;
+		}
+		return result.status === 0 ? fs.readFileSync(tmpFile, "utf-8").replace(/\n$/, "") : undefined;
+	} finally {
+		try {
+			fs.unlinkSync(tmpFile);
+		} catch {
+			// Ignore cleanup errors
+		}
+		if (tuiStopped) {
+			options.tui.start();
+			options.onTuiRestart?.();
+			options.tui.requestRender(true);
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -218,6 +218,7 @@ import {
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
+import { runExternalEditor } from "./external-editor.js";
 import { FeatureHintDeck } from "./feature-hints.js";
 import { scopeHeartbeatsToSession } from "./heartbeat-scope.js";
 import {
@@ -3848,6 +3849,10 @@ export class InteractiveMode {
 					this.hideExtensionEditor();
 					resolve(undefined);
 				},
+				undefined,
+				(error) => {
+					this.showError(error instanceof Error ? error.message : String(error));
+				},
 			);
 
 			this.editorContainer.clear();
@@ -4110,7 +4115,11 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.heartbeats.open", () => {
 			void this.showHeartbeatManager();
 		});
-		this.defaultEditor.onAction("app.editor.external", () => this.openExternalEditor());
+		this.defaultEditor.onAction("app.editor.external", () => {
+			void this.openExternalEditor().catch((error) => {
+				this.showError(error instanceof Error ? error.message : String(error));
+			});
+		});
 		this.defaultEditor.onAction("app.prompt.stash", () => this.handlePromptStash());
 		this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 		this.defaultEditor.onAction("app.message.dequeue", () => {
@@ -6986,55 +6995,25 @@ export class InteractiveMode {
 		});
 	}
 
-	private openExternalEditor(): void {
-		// Determine editor (respect $VISUAL, then $EDITOR)
-		const editorCmd = process.env.VISUAL || process.env.EDITOR;
-		if (!editorCmd) {
+	private async openExternalEditor(): Promise<void> {
+		const command = process.env.VISUAL || process.env.EDITOR;
+		if (!command) {
 			this.showWarning("No editor configured. Set $VISUAL or $EDITOR environment variable.");
 			return;
 		}
 
-		const currentText = this.editor.getExpandedText?.() ?? this.editor.getText();
-		const tmpFile = path.join(os.tmpdir(), `pi-editor-${Date.now()}.pi.md`);
-
-		try {
-			// Write current content to temp file
-			fs.writeFileSync(tmpFile, currentText, "utf-8");
-
-			// Stop TUI to release terminal
-			this.ui.stop();
-
-			// Split by space to support editor arguments (e.g., "code --wait")
-			const [editor, ...editorArgs] = editorCmd.split(" ");
-
-			// Spawn editor synchronously with inherited stdio for interactive editing
-			const result = spawnSync(editor, [...editorArgs, tmpFile], {
-				stdio: "inherit",
-				shell: process.platform === "win32",
-			});
-
-			// On successful exit (status 0), replace editor content
-			if (result.status === 0) {
-				const newContent = fs.readFileSync(tmpFile, "utf-8").replace(/\n$/, "");
-				this.editor.setText(newContent);
-			}
-			// On non-zero exit, keep original text (no action needed)
-		} finally {
-			// Clean up temp file
-			try {
-				fs.unlinkSync(tmpFile);
-			} catch {
-				// Ignore cleanup errors
-			}
-
-			// Restart TUI
-			this.ui.start();
-			// ui.stop() left fullscreen so the editor got a clean terminal
-			if (this.fullscreenEnabled) {
-				this.applyFullscreen(true);
-			}
-			// Force full re-render since external editor uses alternate screen
-			this.ui.requestRender(true);
+		const content = await runExternalEditor({
+			tui: this.ui,
+			command,
+			content: this.editor.getExpandedText?.() ?? this.editor.getText(),
+			onTuiRestart: () => {
+				if (this.fullscreenEnabled) {
+					this.applyFullscreen(true);
+				}
+			},
+		});
+		if (content !== undefined) {
+			this.editor.setText(content);
 		}
 	}
 

--- a/packages/coding-agent/test/external-editor.test.ts
+++ b/packages/coding-agent/test/external-editor.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { runExternalEditor } from "../src/modes/interactive/external-editor.js";
+import { createDeferred } from "./suite/scheduling.js";
+
+const childProcessMocks = vi.hoisted(() => ({
+	spawnSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, spawnSync: childProcessMocks.spawnSync };
+});
+
+type ExternalEditorTui = Parameters<typeof runExternalEditor>[0]["tui"];
+
+function createTui(events: string[], drainInput: () => Promise<void>): ExternalEditorTui {
+	return {
+		terminal: {
+			drainInput: vi.fn(drainInput),
+		},
+		start: vi.fn(() => events.push("start")),
+		stop: vi.fn(() => events.push("stop")),
+		requestRender: vi.fn(() => events.push("render")),
+	};
+}
+
+describe("runExternalEditor", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		childProcessMocks.spawnSync.mockReset();
+	});
+
+	test("drains before spawning, returns edited content, and restores the TUI", async () => {
+		const drain = createDeferred();
+		const events: string[] = [];
+		const tui = createTui(events, () =>
+			drain.promise.then(() => {
+				events.push("drain");
+			}),
+		);
+		let tmpFile: string | undefined;
+		childProcessMocks.spawnSync.mockImplementation((command: string, args: string[]) => {
+			events.push("spawn");
+			tmpFile = args.at(-1);
+			if (!tmpFile) throw new Error("missing temp file");
+			writeFileSync(tmpFile, "edited\n", "utf-8");
+			return { command, status: 0 };
+		});
+
+		const result = runExternalEditor({
+			tui,
+			command: "vim -f",
+			content: "draft",
+			onTuiRestart: () => events.push("restart-hook"),
+		});
+
+		expect(tui.terminal.drainInput).toHaveBeenCalledWith(1000);
+		expect(tui.stop).not.toHaveBeenCalled();
+		expect(childProcessMocks.spawnSync).not.toHaveBeenCalled();
+		drain.resolve();
+
+		await expect(result).resolves.toBe("edited");
+		expect(events).toEqual(["drain", "stop", "spawn", "start", "restart-hook", "render"]);
+		expect(childProcessMocks.spawnSync).toHaveBeenCalledWith("vim", ["-f", tmpFile], {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+		expect(tmpFile && existsSync(tmpFile)).toBe(false);
+	});
+
+	test("preserves the draft after a nonzero editor exit", async () => {
+		const events: string[] = [];
+		const tui = createTui(events, async () => {
+			events.push("drain");
+		});
+		let tmpFile: string | undefined;
+		childProcessMocks.spawnSync.mockImplementation((_command: string, args: string[]) => {
+			events.push("spawn");
+			tmpFile = args.at(-1);
+			return { status: 1 };
+		});
+
+		await expect(runExternalEditor({ tui, command: "vim", content: "draft" })).resolves.toBeUndefined();
+
+		expect(events).toEqual(["drain", "stop", "spawn", "start", "render"]);
+		expect(tmpFile && existsSync(tmpFile)).toBe(false);
+	});
+
+	test("restores the stopped TUI when spawning throws", async () => {
+		const events: string[] = [];
+		const tui = createTui(events, async () => {
+			events.push("drain");
+		});
+		const spawnError = new Error("spawn failed");
+		childProcessMocks.spawnSync.mockImplementation(() => {
+			events.push("spawn");
+			throw spawnError;
+		});
+
+		await expect(runExternalEditor({ tui, command: "vim", content: "draft" })).rejects.toBe(spawnError);
+
+		expect(events).toEqual(["drain", "stop", "spawn", "start", "render"]);
+		expect(tui.start).toHaveBeenCalledTimes(1);
+		expect(tui.requestRender).toHaveBeenCalledWith(true);
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed fullscreen transitions leaving Kitty keyboard protocol state on the wrong terminal screen ([#878](https://github.com/PrimeIntellect-ai/prime-agent/pull/878)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -236,21 +236,14 @@ export class ProcessTerminal implements Terminal {
 			}
 
 			// Check for Kitty protocol response (only if not already enabled)
-			if (!this._kittyProtocolActive) {
-				const match = sequence.match(kittyResponsePattern);
-				if (match) {
-					this.clearKeyboardProtocolFallbackTimer();
+			if (!this._kittyProtocolActive && kittyResponsePattern.test(sequence)) {
+				this.clearKeyboardProtocolFallbackTimer();
+				if (this.inputHandler) {
 					this._kittyProtocolActive = true;
 					setKittyProtocolActive(true);
-
-					// Enable Kitty keyboard protocol (push flags)
-					// Flag 1 = disambiguate escape codes
-					// Flag 2 = report event types (press/repeat/release)
-					// Flag 4 = report alternate keys (shifted key, base layout key)
-					// Base layout key enables shortcuts to work with non-Latin keyboard layouts
-					process.stdout.write("\x1b[>7u");
-					return; // Don't forward protocol response to TUI
+					this.pushKittyProtocol();
 				}
+				return; // Don't forward protocol response to TUI
 			}
 
 			if (this.inputHandler) {
@@ -293,7 +286,7 @@ export class ProcessTerminal implements Terminal {
 		this.clearKeyboardProtocolFallbackTimer();
 		this.keyboardProtocolFallbackTimer = setTimeout(() => {
 			this.keyboardProtocolFallbackTimer = undefined;
-			if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {
+			if (this.inputHandler && !this._kittyProtocolActive && !this._modifyOtherKeysActive) {
 				process.stdout.write("\x1b[>4;2m");
 				this._modifyOtherKeysActive = true;
 			}
@@ -306,6 +299,28 @@ export class ProcessTerminal implements Terminal {
 		}
 		clearTimeout(this.keyboardProtocolFallbackTimer);
 		this.keyboardProtocolFallbackTimer = undefined;
+	}
+
+	private pushKittyProtocol(): void {
+		// Flags: disambiguate escape codes, report event types, and report alternate keys.
+		process.stdout.write("\x1b[>7u");
+	}
+
+	private popKittyProtocol(): void {
+		process.stdout.write("\x1b[<u");
+	}
+
+	private disableKeyboardProtocols(): void {
+		this.clearKeyboardProtocolFallbackTimer();
+		if (this._kittyProtocolActive) {
+			this.popKittyProtocol();
+			this._kittyProtocolActive = false;
+			setKittyProtocolActive(false);
+		}
+		if (this._modifyOtherKeysActive) {
+			process.stdout.write("\x1b[>4;0m");
+			this._modifyOtherKeysActive = false;
+		}
 	}
 
 	private queryDefaultTerminalColors(): void {
@@ -380,17 +395,9 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	async drainInput(maxMs = 1000, idleMs = 50): Promise<void> {
-		if (this._kittyProtocolActive) {
-			// Disable Kitty keyboard protocol first so any late key releases
-			// do not generate new Kitty escape sequences.
-			process.stdout.write("\x1b[<u");
-			this._kittyProtocolActive = false;
-			setKittyProtocolActive(false);
-		}
-		if (this._modifyOtherKeysActive) {
-			process.stdout.write("\x1b[>4;0m");
-			this._modifyOtherKeysActive = false;
-		}
+		// Disable keyboard protocols first so late key releases do not generate
+		// new escape sequences while pending input is consumed.
+		this.disableKeyboardProtocols();
 
 		const previousHandler = this.inputHandler;
 		this.inputHandler = undefined;
@@ -421,7 +428,7 @@ export class ProcessTerminal implements Terminal {
 		const wasStarted = this.started;
 		this.started = false;
 		this.finishDefaultColorProbe();
-		this.clearKeyboardProtocolFallbackTimer();
+		this.disableKeyboardProtocols();
 
 		if (this.clearProgressInterval()) {
 			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
@@ -444,17 +451,6 @@ export class ProcessTerminal implements Terminal {
 
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
-
-		// Disable Kitty keyboard protocol if not already done by drainInput()
-		if (this._kittyProtocolActive) {
-			process.stdout.write("\x1b[<u");
-			this._kittyProtocolActive = false;
-			setKittyProtocolActive(false);
-		}
-		if (this._modifyOtherKeysActive) {
-			process.stdout.write("\x1b[>4;0m");
-			this._modifyOtherKeysActive = false;
-		}
 
 		// Clean up StdinBuffer
 		if (this.stdinBuffer) {
@@ -545,8 +541,7 @@ export class ProcessTerminal implements Terminal {
 			this._altScreenActive = true;
 			return;
 		}
-		this._altScreenActive = true;
-		this.write("\x1b[?1049h");
+		this.switchAltScreen(true, "\x1b[?1049h");
 	}
 
 	leaveAltScreen(): void {
@@ -556,12 +551,22 @@ export class ProcessTerminal implements Terminal {
 	private releaseAltScreen(): void {
 		const ownsPendingHandoff = this.ownsPendingAltScreenHandoff();
 		if (!this._altScreenActive && !ownsPendingHandoff) return;
-		this._altScreenActive = false;
 		if (ownsPendingHandoff) {
 			pendingAltScreenHandoff = undefined;
 			cancelInputHandoff(this.altScreenHandoffToken);
 		}
-		this.write("\x1b[?1049l");
+		this.switchAltScreen(false, "\x1b[?1049l");
+	}
+
+	private switchAltScreen(active: boolean, sequence: string): void {
+		if (this._kittyProtocolActive) {
+			this.popKittyProtocol();
+		}
+		this._altScreenActive = active;
+		this.write(sequence);
+		if (this._kittyProtocolActive) {
+			this.pushKittyProtocol();
+		}
 	}
 
 	get altScreenActive(): boolean {

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -46,35 +46,11 @@ describe("ProcessTerminal dimensions", () => {
 
 describe("ProcessTerminal alternate screen handoff", () => {
 	it("keeps raw input active and discards keys until the next fullscreen TUI starts", () => {
-		const originalWrite = process.stdout.write;
-		const originalIsRaw = Object.getOwnPropertyDescriptor(process.stdin, "isRaw");
-		const originalSetRawMode = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
-		const originalResume = Object.getOwnPropertyDescriptor(process.stdin, "resume");
-		const originalPause = Object.getOwnPropertyDescriptor(process.stdin, "pause");
-		let isRaw = false;
-		const rawModeChanges: boolean[] = [];
+		const io = mockProcessTerminalIo();
 		const firstInputs: string[] = [];
 		const secondInputs: string[] = [];
-
-		Object.defineProperty(process.stdin, "isRaw", { configurable: true, get: () => isRaw });
-		Object.defineProperty(process.stdin, "setRawMode", {
-			configurable: true,
-			value: (enabled: boolean) => {
-				isRaw = enabled;
-				rawModeChanges.push(enabled);
-				return process.stdin;
-			},
-		});
-		Object.defineProperty(process.stdin, "resume", { configurable: true, value: () => process.stdin });
-		Object.defineProperty(process.stdin, "pause", { configurable: true, value: () => process.stdin });
-		process.stdout.write = ((...args: Parameters<typeof process.stdout.write>): boolean => {
-			const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
-			callback?.();
-			return true;
-		}) as typeof process.stdout.write;
-
 		try {
-			const first = new ProcessTerminal();
+			const first = io.createTerminal();
 			first.start(
 				(data) => firstInputs.push(data),
 				() => {},
@@ -83,11 +59,11 @@ describe("ProcessTerminal alternate screen handoff", () => {
 			first.enterAltScreen();
 			first.stop({ preserveAltScreen: true });
 
-			assert.equal(isRaw, true);
+			assert.equal(io.isRaw(), true);
 			process.stdin.emit("data", "\x1b[B");
 			assert.deepEqual(firstInputs, []);
 
-			const second = new ProcessTerminal();
+			const second = io.createTerminal();
 			second.start(
 				(data) => secondInputs.push(data),
 				() => {},
@@ -95,151 +71,140 @@ describe("ProcessTerminal alternate screen handoff", () => {
 			process.stdin.emit("data", "\x1b[?1u");
 			process.stdin.emit("data", "x");
 
-			assert.equal(isRaw, true);
+			assert.equal(io.isRaw(), true);
 			assert.deepEqual(secondInputs, ["x"]);
 			second.stop();
-			assert.equal(isRaw, false);
-			assert.deepEqual(rawModeChanges, [true, true, false]);
+			assert.equal(io.isRaw(), false);
+			assert.deepEqual(io.rawModeChanges, [true, true, false]);
 		} finally {
-			process.stdout.write = originalWrite;
-			restoreProperty(process.stdin, "isRaw", originalIsRaw);
-			restoreProperty(process.stdin, "setRawMode", originalSetRawMode);
-			restoreProperty(process.stdin, "resume", originalResume);
-			restoreProperty(process.stdin, "pause", originalPause);
+			io.restore();
 		}
 	});
 
 	it("does not inherit an active alternate screen before it is preserved", () => {
-		const originalWrite = process.stdout.write;
-		const writes: string[] = [];
-		const patchedWrite = ((...args: Parameters<typeof process.stdout.write>): boolean => {
-			const chunk = args[0];
-			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-			const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
-			callback?.();
-			return true;
-		}) as typeof process.stdout.write;
-
-		process.stdout.write = patchedWrite;
+		const io = mockProcessTerminalIo();
 		try {
-			const first = new ProcessTerminal();
+			const first = io.createTerminal();
 			first.enterAltScreen();
 
-			const second = new ProcessTerminal();
+			const second = io.createTerminal();
 			assert.equal(second.altScreenActive, false);
 			second.stop();
 
-			assert.equal(writes.filter((write) => write === "\x1b[?1049l").length, 0);
+			assert.equal(io.writes.filter((write) => write === "\x1b[?1049l").length, 0);
 			first.leaveAltScreen();
-			assert.equal(writes.filter((write) => write === "\x1b[?1049l").length, 1);
+			assert.equal(io.writes.filter((write) => write === "\x1b[?1049l").length, 1);
 		} finally {
-			const cleanup = new ProcessTerminal();
-			if (cleanup.altScreenActive) {
-				cleanup.stop();
-			}
-			process.stdout.write = originalWrite;
+			io.restore();
 		}
 	});
 
 	it("inherits a preserved alternate screen into the next terminal instance", () => {
-		const originalWrite = process.stdout.write;
-		const writes: string[] = [];
-		const patchedWrite = ((...args: Parameters<typeof process.stdout.write>): boolean => {
-			const chunk = args[0];
-			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-			const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
-			callback?.();
-			return true;
-		}) as typeof process.stdout.write;
-
-		process.stdout.write = patchedWrite;
+		const io = mockProcessTerminalIo();
 		try {
-			const first = new ProcessTerminal();
+			const first = io.createTerminal();
 			first.enterAltScreen();
 			first.stop({ preserveAltScreen: true });
 
-			const second = new ProcessTerminal();
+			const second = io.createTerminal();
 			assert.equal(second.altScreenActive, true);
 			second.stop();
 			assert.equal(second.altScreenActive, false);
 
-			const third = new ProcessTerminal();
+			const third = io.createTerminal();
 			assert.equal(third.altScreenActive, false);
-			assert.ok(writes.includes("\x1b[?1049h"));
-			assert.ok(writes.includes("\x1b[?1049l"));
+			assert.ok(io.writes.includes("\x1b[?1049h"));
+			assert.ok(io.writes.includes("\x1b[?1049l"));
 		} finally {
-			const cleanup = new ProcessTerminal();
-			if (cleanup.altScreenActive) {
-				cleanup.stop();
-			}
-			process.stdout.write = originalWrite;
+			io.restore();
 		}
 	});
 
 	it("lets the preserving terminal cancel a handoff before it is consumed", () => {
-		const originalWrite = process.stdout.write;
-		const writes: string[] = [];
-		const patchedWrite = ((...args: Parameters<typeof process.stdout.write>): boolean => {
-			const chunk = args[0];
-			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-			const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
-			callback?.();
-			return true;
-		}) as typeof process.stdout.write;
-
-		process.stdout.write = patchedWrite;
+		const io = mockProcessTerminalIo();
 		try {
-			const first = new ProcessTerminal();
+			const first = io.createTerminal();
 			first.enterAltScreen();
 			first.stop({ preserveAltScreen: true });
 			assert.equal(first.altScreenActive, false);
 
 			first.leaveAltScreen();
-			assert.equal(writes.filter((write) => write === "\x1b[?1049l").length, 1);
+			assert.equal(io.writes.filter((write) => write === "\x1b[?1049l").length, 1);
 
-			const second = new ProcessTerminal();
+			const second = io.createTerminal();
 			assert.equal(second.altScreenActive, false);
 		} finally {
-			const cleanup = new ProcessTerminal();
-			if (cleanup.altScreenActive) {
-				cleanup.stop();
-			}
-			process.stdout.write = originalWrite;
+			io.restore();
 		}
 	});
 
 	it("only hands a preserved alternate screen to one terminal instance", () => {
-		const originalWrite = process.stdout.write;
-		const writes: string[] = [];
-		const patchedWrite = ((...args: Parameters<typeof process.stdout.write>): boolean => {
-			const chunk = args[0];
-			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-			const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
-			callback?.();
-			return true;
-		}) as typeof process.stdout.write;
-
-		process.stdout.write = patchedWrite;
+		const io = mockProcessTerminalIo();
 		try {
-			const first = new ProcessTerminal();
+			const first = io.createTerminal();
 			first.enterAltScreen();
 			first.stop({ preserveAltScreen: true });
 
-			const second = new ProcessTerminal();
-			const third = new ProcessTerminal();
+			const second = io.createTerminal();
+			const third = io.createTerminal();
 			assert.equal(second.altScreenActive, true);
 			assert.equal(third.altScreenActive, false);
 
 			second.stop();
-			assert.equal(writes.filter((write) => write === "\x1b[?1049l").length, 1);
+			assert.equal(io.writes.filter((write) => write === "\x1b[?1049l").length, 1);
 		} finally {
-			const cleanup = new ProcessTerminal();
-			if (cleanup.altScreenActive) {
-				cleanup.stop();
-			}
-			process.stdout.write = originalWrite;
+			io.restore();
 		}
 	});
+
+	it("migrates Kitty mode when negotiation finishes before fullscreen", () =>
+		runWithMockTerminal(async (terminal, io) => {
+			process.stdin.emit("data", "\x1b[?0u");
+			terminal.enterAltScreen();
+
+			await terminal.drainInput(0);
+			terminal.leaveAltScreen();
+
+			assert.deepEqual(io.keyboardScreenWrites(), [
+				"\x1b[>7u",
+				"\x1b[<u",
+				"\x1b[?1049h",
+				"\x1b[>7u",
+				"\x1b[<u",
+				"\x1b[?1049l",
+			]);
+		}));
+
+	it("pops Kitty mode before leaving fullscreen when negotiation finishes there", () =>
+		runWithMockTerminal(async (terminal, io) => {
+			terminal.enterAltScreen();
+			process.stdin.emit("data", "\x1b[?0u");
+
+			await terminal.drainInput(0);
+			terminal.leaveAltScreen();
+
+			assert.deepEqual(io.keyboardScreenWrites(), ["\x1b[?1049h", "\x1b[>7u", "\x1b[<u", "\x1b[?1049l"]);
+		}));
+
+	it("suppresses a Kitty response that arrives while input is draining", () =>
+		runWithMockTerminal(async (terminal, io) => {
+			terminal.enterAltScreen();
+
+			const pendingDrain = terminal.drainInput(25, 5);
+			process.stdin.emit("data", "\x1b[?0u");
+			await pendingDrain;
+			assert.equal(terminal.kittyProtocolActive, false);
+			terminal.leaveAltScreen();
+
+			assert.deepEqual(io.keyboardScreenWrites(), ["\x1b[?1049h", "\x1b[?1049l"]);
+		}));
+
+	it("cancels the modifyOtherKeys fallback while input is draining", () =>
+		runWithMockTerminal(async (terminal, io) => {
+			await terminal.drainInput(200, 175);
+
+			assert.equal(io.writes.includes("\x1b[>4;2m"), false);
+		}));
 });
 
 function restoreProperty(object: object, key: PropertyKey, descriptor: PropertyDescriptor | undefined): void {
@@ -248,4 +213,78 @@ function restoreProperty(object: object, key: PropertyKey, descriptor: PropertyD
 	} else {
 		Reflect.deleteProperty(object, key);
 	}
+}
+
+async function runWithMockTerminal(
+	run: (terminal: ProcessTerminal, io: ReturnType<typeof mockProcessTerminalIo>) => Promise<void>,
+): Promise<void> {
+	const io = mockProcessTerminalIo();
+	const terminal = io.createTerminal();
+	try {
+		terminal.start(
+			() => {},
+			() => {},
+		);
+		await run(terminal, io);
+	} finally {
+		io.restore();
+	}
+}
+
+function mockProcessTerminalIo() {
+	const originalWrite = process.stdout.write;
+	const originalIsRaw = Object.getOwnPropertyDescriptor(process.stdin, "isRaw");
+	const originalSetRawMode = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+	const originalResume = Object.getOwnPropertyDescriptor(process.stdin, "resume");
+	const originalPause = Object.getOwnPropertyDescriptor(process.stdin, "pause");
+	const terminals: ProcessTerminal[] = [];
+	const rawModeChanges: boolean[] = [];
+	const writes: string[] = [];
+	let isRaw = false;
+
+	Object.defineProperty(process.stdin, "isRaw", { configurable: true, get: () => isRaw });
+	Object.defineProperty(process.stdin, "setRawMode", {
+		configurable: true,
+		value: (enabled: boolean) => {
+			isRaw = enabled;
+			rawModeChanges.push(enabled);
+			return process.stdin;
+		},
+	});
+	Object.defineProperty(process.stdin, "resume", { configurable: true, value: () => process.stdin });
+	Object.defineProperty(process.stdin, "pause", { configurable: true, value: () => process.stdin });
+	process.stdout.write = ((...args: Parameters<typeof process.stdout.write>): boolean => {
+		const chunk = args[0];
+		const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+		if (!text.startsWith("\x1b")) {
+			return Reflect.apply(originalWrite, process.stdout, args) as boolean;
+		}
+		writes.push(text);
+		const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === "function");
+		callback?.();
+		return true;
+	}) as typeof process.stdout.write;
+
+	return {
+		createTerminal: () => {
+			const terminal = new ProcessTerminal();
+			terminals.push(terminal);
+			return terminal;
+		},
+		isRaw: () => isRaw,
+		rawModeChanges,
+		writes,
+		keyboardScreenWrites: () =>
+			writes.filter((write) => ["\x1b[?1049h", "\x1b[>7u", "\x1b[<u", "\x1b[?1049l"].includes(write)),
+		restore: () => {
+			for (const terminal of terminals.reverse()) {
+				terminal.stop();
+			}
+			process.stdout.write = originalWrite;
+			restoreProperty(process.stdin, "isRaw", originalIsRaw);
+			restoreProperty(process.stdin, "setRawMode", originalSetRawMode);
+			restoreProperty(process.stdin, "resume", originalResume);
+			restoreProperty(process.stdin, "pause", originalPause);
+		},
+	};
 }


### PR DESCRIPTION
## Problem

(premise of #811) Opening an external editor (vim) from the fullscreen TUI could leak terminal keyboard events into the child process. In Ghostty with Vim, this appeared as corrupted input such as `w` becoming `ww`, `:` becoming `:;`, and `:q` becoming `:;qq`.

## Root cause

Kitty keyboard protocol state is scoped to the active terminal screen. The TUI could leave the alternate screen before popping its keyboard protocol state, causing cleanup to target the primary screen instead. Delayed negotiation responses or the `modifyOtherKeys` fallback could also reactivate a protocol while input was being drained.

## Fix

- Pop active keyboard protocols before releasing the current screen and restore them after switching screens.
- Cancel keyboard protocol negotiation and disable active protocols while draining terminal input.
- Share the external-editor lifecycle across the main and extension editor paths:
 write, drain, stop, spawn, clean up, restart, and render.
- Preserve the current draft when the editor exits unsuccessfully and surface asynchronous editor failures.
- Add focused regression coverage for protocol ordering, delayed responses, fallback cancellation, and editor lifecycle cleanup.

## Scope

This does not change the external-editor keybinding, editor command selection, or daemon protocol.

## Validation

- `npm run check`
- `packages/coding-agent/test/external-editor.test.ts`: 3 tests passed
- `packages/tui/test/terminal.test.ts`: 10 tests passed
- `packages/tui/test/fullscreen.test.ts`: 37 tests passed
- Deterministic terminal check confirmed Kitty mode is popped before leaving the
 alternate screen.
- Source Vim smoke confirmed exact `:q`, a single `w`, clean `:q!`, and TUI
 restoration.

Fixes #811

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate/corrupted key presses when opening external editors from the composer
> - Introduces [`runExternalEditor`](https://github.com/PrimeIntellect-ai/prime-agent/pull/878/files#diff-14ec2e34d43d41866f466ae75407680f44b0ae83819b02c753deaa501a2ede56), a centralized utility that drains pending terminal input, stops the TUI, synchronously spawns the configured editor, then restarts the TUI — preventing buffered keystrokes from corrupting input after the editor exits.
> - Refactors `ExtensionEditorComponent` and `InteractiveMode.openExternalEditor` to use this shared utility; editor content is only applied on a zero exit status, and errors are surfaced via the TUI rather than propagating synchronously.
> - Fixes Kitty keyboard protocol state across alt-screen transitions in [`terminal.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/878/files#diff-8ab159464d154b9985798a3156190c638cc9e8b8057e8bd66049960c1e3f6cec) by introducing `pushKittyProtocol`/`popKittyProtocol` helpers that rebind the protocol to the active screen when toggling fullscreen.
> - `drainInput` now disables keyboard protocols before draining and re-enables them after, preventing new escape sequences from being generated mid-drain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b780cfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->