### PR TITLE
fix(coding-agent): await post-compaction continuation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed ACP rejecting an immediate follow-up prompt when injected work restarted the session; follow-ups now queue behind in-flight work, and cancellation drops queued follow-ups before they start.
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed ACP rejecting an immediate follow-up prompt when injected work restarted the session; follow-ups now queue behind in-flight work, and cancellation drops queued follow-ups before they start.
+- Fixed ACP returning a silent `end_turn` before a requested compaction resumed the agent.
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -814,6 +814,14 @@ function createAgentMessageDeferred(): AgentMessageDeferred {
 	return deferred;
 }
 
+interface PostCompactionContinuationCompletion extends AgentMessageDeferred {
+	settled: boolean;
+}
+
+function createPostCompactionContinuationCompletion(): PostCompactionContinuationCompletion {
+	return { ...createAgentMessageDeferred(), settled: false };
+}
+
 export interface ModelCycleResult {
 	model: Model<any>;
 	thinkingLevel: ThinkingLevel;
@@ -1149,6 +1157,7 @@ export class AgentSession {
 	private _turnIntervalAutoRefinePending = false;
 	private _postCompactionContinuationScheduled = false;
 	private _postCompactionContinuationTimer: ReturnType<typeof setTimeout> | undefined;
+	private _postCompactionContinuationCompletion: PostCompactionContinuationCompletion | undefined;
 	private _postCompactionContinuationMessages: AgentMessage[] = [];
 	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
 	private _queuedAutonomousThresholdContinuations = new WeakMap<AssistantMessage, AgentMessage>();
@@ -6411,10 +6420,25 @@ export class AgentSession {
 			await this.agent.waitForIdle();
 			const agentEventQueue = this._agentEventQueue;
 			await agentEventQueue;
+			const postCompactionContinuation = this._postCompactionContinuationCompletion;
+			if (postCompactionContinuation) {
+				try {
+					await postCompactionContinuation.promise;
+				} finally {
+					if (
+						this._postCompactionContinuationCompletion === postCompactionContinuation &&
+						postCompactionContinuation.settled
+					) {
+						this._postCompactionContinuationCompletion = undefined;
+					}
+				}
+				continue;
+			}
 			if (
 				pump === this._sessionInputPump &&
 				agentEventQueue === this._agentEventQueue &&
 				!this._sessionInputPumpRequested &&
+				!this._postCompactionContinuationScheduled &&
 				!this.agent.state.isStreaming &&
 				this.unfinishedActionCount === 0
 			) {
@@ -7086,6 +7110,7 @@ export class AgentSession {
 		}
 		this._postCompactionContinuationScheduled = false;
 		this._scheduledPostCompactionContinuationMessages = [];
+		this._settlePostCompactionContinuation();
 	}
 
 	private _discardPendingAutoRefine(options: { cancelPostCompactionContinue?: boolean } = {}): void {
@@ -7183,11 +7208,22 @@ export class AgentSession {
 			return;
 		}
 		this._postCompactionContinuationScheduled = true;
+		if (!this._postCompactionContinuationCompletion || this._postCompactionContinuationCompletion.settled) {
+			this._postCompactionContinuationCompletion = createPostCompactionContinuationCompletion();
+		}
 		this._scheduledPostCompactionContinuationMessages = [...this._postCompactionContinuationMessages];
 		this._postCompactionContinuationTimer = setTimeout(() => {
 			this._postCompactionContinuationTimer = undefined;
 			void this._runScheduledPostCompactionContinue();
 		}, 100);
+	}
+
+	private _settlePostCompactionContinuation(error?: Error): void {
+		const completion = this._postCompactionContinuationCompletion;
+		if (!completion || completion.settled) return;
+		completion.settled = true;
+		if (error) completion.reject(error);
+		else completion.resolve();
 	}
 
 	private _sessionOwnsScheduledContinuations(continuationMessages: AgentMessage[]): boolean {
@@ -7226,6 +7262,7 @@ export class AgentSession {
 				} else {
 					this._scheduledPostCompactionContinuationMessages = [];
 					this._scheduleAutoRefineAfterAgentEnd();
+					this._settlePostCompactionContinuation();
 				}
 			}
 			return;
@@ -7239,6 +7276,12 @@ export class AgentSession {
 			const message = error instanceof Error ? error.message : String(error);
 			if (message.includes("already processing")) {
 				this._schedulePostCompactionContinue();
+			} else {
+				this._settlePostCompactionContinuation(this._asError(error));
+			}
+		} finally {
+			if (!this._postCompactionContinuationScheduled) {
+				this._settlePostCompactionContinuation();
 			}
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4343,12 +4343,32 @@ export class AgentSession {
 		const outcome = this._agentMessageOutcome(agentMessageId);
 		outcome.completion = createAgentMessageDeferred();
 		const completion = outcome.completion.promise;
+		const signal = options?.signal;
+		let cancelQueuedPrompt: (() => void) | undefined;
 		try {
 			await this.promptUntilAccepted(text, { ...options, agentMessageId });
+			if (signal) {
+				cancelQueuedPrompt = () => {
+					const error = new Error("Prompt was cancelled before it started.");
+					const cancelled = this._cancelSessionActions(
+						(action) => action.agentMessageId === agentMessageId && action.payload.kind === "turn",
+						error,
+					);
+					if (cancelled.length > 0) {
+						this._settleAgentMessage(agentMessageId, "completion", error);
+					}
+				};
+				signal.addEventListener("abort", cancelQueuedPrompt, { once: true });
+				if (signal.aborted) cancelQueuedPrompt();
+			}
 			await completion;
 		} catch (error) {
 			this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
 			throw error;
+		} finally {
+			if (signal && cancelQueuedPrompt) {
+				signal.removeEventListener("abort", cancelQueuedPrompt);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6408,6 +6408,7 @@ export class AgentSession {
 
 	async waitForIdle(): Promise<void> {
 		while (true) {
+			const postCompactionContinuation = this._postCompactionContinuationCompletion;
 			if (this._actionStore.queuedActions().length > 0) {
 				if (this._sessionInputPumpSuspended || this._queuedWorkPauses.size > 0) {
 					await new Promise<void>((resolve) => this._sessionInputCheckpointWaiters.add(resolve));
@@ -6420,18 +6421,11 @@ export class AgentSession {
 			await this.agent.waitForIdle();
 			const agentEventQueue = this._agentEventQueue;
 			await agentEventQueue;
-			const postCompactionContinuation = this._postCompactionContinuationCompletion;
 			if (postCompactionContinuation) {
-				try {
-					await postCompactionContinuation.promise;
-				} finally {
-					if (
-						this._postCompactionContinuationCompletion === postCompactionContinuation &&
-						postCompactionContinuation.settled
-					) {
-						this._postCompactionContinuationCompletion = undefined;
-					}
-				}
+				await postCompactionContinuation.promise;
+				continue;
+			}
+			if (this._postCompactionContinuationCompletion) {
 				continue;
 			}
 			if (
@@ -7222,6 +7216,7 @@ export class AgentSession {
 		const completion = this._postCompactionContinuationCompletion;
 		if (!completion || completion.settled) return;
 		completion.settled = true;
+		this._postCompactionContinuationCompletion = undefined;
 		if (error) completion.reject(error);
 		else completion.resolve();
 	}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -336,7 +336,16 @@ export async function runAcpModeWithConnection(
 				// rebuild the transcript mid-turn, so record the pre-turn messages
 				// themselves rather than how many there were.
 				const priorMessages = turnBoundary(await connection.getMessages());
-				await connection.promptAndWait(text, images.length > 0 ? { images } : undefined);
+				// A follow-up prompt can arrive while injected work (subagent replies,
+				// heartbeats) keeps the resident session busy. ACP has no native queue
+				// field, so queue the host turn behind that work with follow-up
+				// semantics instead of rejecting it as "Agent is already processing".
+				await connection.promptAndWait(text, {
+					...(images.length > 0 ? { images } : {}),
+					streamingBehavior: "followUp",
+					queueIfBusy: true,
+					signal: abort.signal,
+				});
 				// Autonomous gates continue inside this same prompt turn: the turn is
 				// only over once the gate loop settles.
 				const status = await connection.waitForHeadlessCompletion();

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -834,6 +834,7 @@ export class DaemonAgentConnection implements AgentConnection {
 					type: "cancel_prompt_admission",
 					activeSessionId: this.activeSessionId,
 					admissionId,
+					...(this.client.supportsServerCapability("owned_prompt_cancellation") ? { cancelOwned: true } : {}),
 				});
 				status = result.status;
 			} catch {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4037,6 +4037,7 @@ export class AgentDaemon {
 					});
 				}
 				if (admission.status === "owned") {
+					if (command.cancelOwned) admission.controller?.abort();
 					return success(command.id, command.type, {
 						status: "owned" as const,
 					});

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 lets cancellation target a prompt the session owns but has not started.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-78200ccd9972";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -100,6 +101,7 @@ export type DaemonServerCapability =
 	| "transient_bash"
 	| "session_input_admission"
 	| "prompt_admission_cancellation"
+	| "owned_prompt_cancellation"
 	| "queue_message_mutation";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
@@ -138,6 +140,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"transient_bash",
 	"session_input_admission",
 	"prompt_admission_cancellation",
+	"owned_prompt_cancellation",
 	"queue_message_mutation",
 ];
 
@@ -414,6 +417,8 @@ export type DaemonCommand =
 			type: "cancel_prompt_admission";
 			activeSessionId: string;
 			admissionId: string;
+			/** Cancel session-owned work too when it has not started delivery. */
+			cancelOwned?: boolean;
 	  }
 	| {
 			id?: string;
@@ -639,6 +644,11 @@ const PROMPT_ADMISSION_CANCELLATION_COMMAND = {
 	minSchemaRevision: 8,
 	capability: "prompt_admission_cancellation",
 } as const;
+const OWNED_PROMPT_CANCELLATION_COMMAND = {
+	minProtocol: 7,
+	minSchemaRevision: 17,
+	capability: "owned_prompt_cancellation",
+} as const;
 const CLIENT_OWNED_DAEMON_COMMAND = {
 	minProtocol: 7,
 	capability: "client_owned_sessions",
@@ -761,6 +771,9 @@ export function getDaemonCommandCompatibilities(command: DaemonCommand): readonl
 	}
 	if ((command.type === "prompt" || command.type === "prompt_and_wait") && command.admissionId !== undefined) {
 		return [PROMPT_ADMISSION_CANCELLATION_COMMAND, compatibility];
+	}
+	if (command.type === "cancel_prompt_admission" && command.cancelOwned === true) {
+		return [OWNED_PROMPT_CANCELLATION_COMMAND, compatibility];
 	}
 	return [compatibility];
 }

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -799,8 +799,33 @@ describe("DaemonAgentConnection", () => {
 		await vi.waitFor(() =>
 			expect(fakeClient.requests.map((request) => request.type)).toContain("cancel_prompt_admission"),
 		);
+		expect(fakeClient.requests.find((request) => request.type === "cancel_prompt_admission")).not.toHaveProperty(
+			"cancelOwned",
+		);
 		releasePrompt();
 
+		await expect(prompt).resolves.toBeUndefined();
+	});
+
+	it("requests owned prompt cancellation when the daemon advertises it", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("owned_prompt_cancellation");
+		let releasePrompt = () => {};
+		fakeClient.promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		const abort = new AbortController();
+
+		const prompt = connection.prompt("startup", { signal: abort.signal });
+		abort.abort();
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.map((request) => request.type)).toContain("cancel_prompt_admission"),
+		);
+		expect(fakeClient.requests.find((request) => request.type === "cancel_prompt_admission")).toMatchObject({
+			cancelOwned: true,
+		});
+		releasePrompt();
 		await expect(prompt).resolves.toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -9053,7 +9053,7 @@ describe("daemon mode helpers", () => {
 		},
 	);
 
-	it("cancels only pre-ownership prompt admission and cleans up its controller", async () => {
+	it("capability-gates cancellation after prompt ownership", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -9112,7 +9112,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ success: true, data: { status: "cancelled" } });
 		await vi.waitFor(() => expect(internals.promptAdmissions.size).toBe(0));
 
-		// Once ownership commits the same cancellation is a no-op.
+		// Old clients retain the pre-ownership-only behavior.
 		internals.parseCommandAndRegisterPromptAdmission(
 			client,
 			JSON.stringify({
@@ -9139,6 +9139,19 @@ describe("daemon mode helpers", () => {
 				admissionId: "admission-2",
 			}),
 		).resolves.toMatchObject({ success: true, data: { status: "owned" } });
+		expect(promptOptions?.signal?.aborted).toBe(false);
+
+		// New clients request the capability-gated session-owned cancellation.
+		await expect(
+			internals.handleCommand(client, {
+				id: "cancel-3",
+				type: "cancel_prompt_admission",
+				activeSessionId: state.activeSessionId,
+				admissionId: "admission-2",
+				cancelOwned: true,
+			}),
+		).resolves.toMatchObject({ success: true, data: { status: "owned" } });
+		expect(promptOptions?.signal?.aborted).toBe(true);
 		rejectPrompt?.(new Error("test cleanup"));
 	});
 

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -130,6 +130,16 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("prompt_admission_cancellation");
 	});
 
+	it("capability-gates cancellation after prompt ownership", () => {
+		const legacy = { type: "cancel_prompt_admission", activeSessionId: "active-1", admissionId: "a-1" } as const;
+		expect(getDaemonCommandCompatibilities(legacy)).toEqual([DAEMON_COMMAND_COMPATIBILITY.cancel_prompt_admission]);
+		expect(getDaemonCommandCompatibilities({ ...legacy, cancelOwned: true })).toEqual([
+			{ minProtocol: 7, minSchemaRevision: 17, capability: "owned_prompt_cancellation" },
+			DAEMON_COMMAND_COMPATIBILITY.cancel_prompt_admission,
+		]);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("owned_prompt_cancellation");
+	});
+
 	it("gates honest worker-state reporting at its introducing schema revision", () => {
 		// Revision 16 adds the "stopping" workerState and stops reporting
 		// disconnected workers as "ready". The field is optional and old clients

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,6 +1,7 @@
 import * as acp from "@agentclientprotocol/sdk";
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
+import type { AgentSession } from "../../src/core/agent-session.js";
 import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
@@ -27,6 +28,29 @@ interface ClientHarness {
 	client: any;
 	updates: any[];
 	close: () => void;
+}
+
+function injectWorkAfterHeadlessCompletion(
+	connection: InProcessAgentConnection,
+	session: AgentSession,
+	text: string,
+): () => boolean {
+	const waitForHeadlessCompletion = connection.waitForHeadlessCompletion.bind(connection);
+	let injected = false;
+	connection.waitForHeadlessCompletion = async () => {
+		const status = await waitForHeadlessCompletion();
+		if (!injected) {
+			injected = true;
+			void session.prompt(text);
+			const deadline = Date.now() + 5_000;
+			while (!session.isStreaming && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 1));
+			}
+			expect(session.isStreaming).toBe(true);
+		}
+		return status;
+	};
+	return () => injected;
 }
 
 function connectAcpClient(connection: any): ClientHarness {
@@ -84,4 +108,169 @@ describe("ACP mode end to end", () => {
 
 		harness.cleanup();
 	}, 30_000);
+
+	it("queues a follow-up prompt behind injected work instead of rejecting it", async () => {
+		const harness = await createHarness();
+		let releaseInjected!: () => void;
+		const injectedHeld = new Promise<AssistantMessage>((resolve) => {
+			releaseInjected = () => resolve(fauxAssistantMessage("injected work done"));
+		});
+		harness.setResponses([
+			fauxAssistantMessage("turn one done"),
+			() => injectedHeld,
+			fauxAssistantMessage("turn two done"),
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const injected = injectWorkAfterHeadlessCompletion(connection, harness.session, "injected work");
+		const { client, updates } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		const first = await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "First turn" }],
+		});
+		expect(first.stopReason).toBe("end_turn");
+		expect(injected()).toBe(true);
+		expect(harness.session.isStreaming).toBe(true);
+
+		let secondSettled = false;
+		const second = client
+			.request("session/prompt", {
+				sessionId: session.sessionId,
+				prompt: [{ type: "text", text: "Second turn" }],
+			})
+			.finally(() => {
+				secondSettled = true;
+			});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(secondSettled).toBe(false);
+		releaseInjected();
+		await expect(second).resolves.toMatchObject({ stopReason: "end_turn" });
+
+		const text = updates
+			.filter((update) => update.update?.sessionUpdate === "agent_message_chunk")
+			.map((update) => update.update.content.text)
+			.join("");
+		expect(text).toContain("turn two done");
+		harness.cleanup();
+	}, 5_000);
+
+	it("reports the queued turn's stop reason from a fresh autonomous status", async () => {
+		const harness = await createHarness({
+			autonomous: {
+				enabled: true,
+				maxTurns: 2,
+				maxContinuations: 3,
+				maxTokens: 80_000,
+				gates: { commands: ["true"], maxRetries: 3 },
+			},
+		});
+		let releaseInjected!: () => void;
+		const injectedHeld = new Promise<AssistantMessage>((resolve) => {
+			releaseInjected = () => resolve(fauxAssistantMessage("injected work done"));
+		});
+		harness.setResponses([
+			fauxAssistantMessage("turn one done"),
+			() => injectedHeld,
+			fauxAssistantMessage("turn two done"),
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		injectWorkAfterHeadlessCompletion(connection, harness.session, "injected work");
+		const { client } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		const first = await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "First turn" }],
+		});
+		expect(first.stopReason).toBe("end_turn");
+		expect(harness.session.getAutonomousStatus().turnsUsed).toBe(1);
+
+		const second = client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "Second turn" }],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		releaseInjected();
+		await expect(second).resolves.toMatchObject({ stopReason: "max_turn_requests" });
+		expect(harness.session.getAutonomousStatus().turnsUsed).toBeGreaterThanOrEqual(
+			harness.session.getAutonomousStatus().limits.maxTurns,
+		);
+		harness.cleanup();
+	}, 5_000);
+
+	it("does not hold the prompt response open for detached work", async () => {
+		const harness = await createHarness();
+		let releaseInjected!: () => void;
+		const injectedHeld = new Promise<AssistantMessage>((resolve) => {
+			releaseInjected = () => resolve(fauxAssistantMessage("injected work done"));
+		});
+		harness.setResponses([fauxAssistantMessage("turn one done"), () => injectedHeld]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const injected = injectWorkAfterHeadlessCompletion(connection, harness.session, "injected work");
+		const { client } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		let settled = false;
+		const prompt = client
+			.request("session/prompt", {
+				sessionId: session.sessionId,
+				prompt: [{ type: "text", text: "First turn" }],
+			})
+			.finally(() => {
+				settled = true;
+			});
+		const deadline = Date.now() + 5_000;
+		while (!injected() && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+		expect(injected()).toBe(true);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(settled).toBe(true);
+		expect(harness.session.isStreaming).toBe(true);
+		releaseInjected();
+		await expect(prompt).resolves.toMatchObject({ stopReason: "end_turn" });
+		harness.cleanup();
+	}, 5_000);
+
+	it("cancels a prompt that is still queued behind busy work", async () => {
+		const harness = await createHarness();
+		let releaseInjected!: () => void;
+		const injectedHeld = new Promise<AssistantMessage>((resolve) => {
+			releaseInjected = () => resolve(fauxAssistantMessage("injected work done"));
+		});
+		harness.setResponses([
+			fauxAssistantMessage("turn one done"),
+			() => injectedHeld,
+			fauxAssistantMessage("queued turn done"),
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		injectWorkAfterHeadlessCompletion(connection, harness.session, "injected work");
+		const { client } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "First turn" }],
+		});
+
+		const queued = client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "Second turn" }],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		void client.notify("session/cancel", { sessionId: session.sessionId });
+		await expect(queued).resolves.toMatchObject({ stopReason: "cancelled" });
+		releaseInjected();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		const assistantText = harness.session.messages
+			.filter((message) => message.role === "assistant")
+			.map((message) => JSON.stringify(message.content))
+			.join("|");
+		expect(assistantText).not.toContain("queued turn done");
+		harness.cleanup();
+	}, 5_000);
 });

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,8 +1,9 @@
 import * as acp from "@agentclientprotocol/sdk";
-import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { type AssistantMessage, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import type { AgentSession } from "../../src/core/agent-session.js";
 import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
+import type { ExtensionFactory } from "../../src/core/extensions/types.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
 import { InProcessAgentConnection } from "../../src/modes/agent-connection/in-process-agent-connection.js";
@@ -73,6 +74,31 @@ function connectAcpClient(connection: any): ClientHarness {
 
 	// connect() yields a handle whose `agent` proxy is the outbound call surface.
 	return { client: handle.agent, updates, close: () => handle.close() };
+}
+
+function compactTool(schedule: () => Record<string, unknown>) {
+	return {
+		name: "ipython",
+		description: "Schedule compaction",
+		parameters: { type: "object" as const, properties: {} },
+		execute: async () => ({
+			content: [{ type: "text" as const, text: JSON.stringify(schedule()) }],
+			details: {},
+		}),
+	};
+}
+
+function extensionCompaction(): ExtensionFactory {
+	return (pi) => {
+		pi.on("session_before_compact", async (event) => ({
+			compaction: {
+				summary: "requested summary",
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+				details: {},
+			},
+		}));
+	};
 }
 
 describe("ACP mode end to end", () => {
@@ -273,4 +299,40 @@ describe("ACP mode end to end", () => {
 		expect(assistantText).not.toContain("queued turn done");
 		harness.cleanup();
 	}, 5_000);
+
+	it("awaits compact.run continuation and returns its visible completion", async () => {
+		let harness: Awaited<ReturnType<typeof createHarness>>;
+		harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [extensionCompaction()],
+			tools: [compactTool(() => harness.session.handleCompactHostRequest("compact.run")) as never],
+		});
+		harness.setResponses([fauxAssistantMessage("seed one"), fauxAssistantMessage("seed two")]);
+		await harness.session.prompt("seed one");
+		await harness.session.prompt("seed two");
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("ipython", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("continued after compaction"),
+		]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const { client, updates } = connectAcpClient(connection);
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		const result = await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "compact now" }],
+		});
+		expect(result.stopReason).toBe("end_turn");
+		expect(
+			updates.filter((update) => update.update?.sessionUpdate === "tool_call_update").at(-1)?.update.status,
+		).toBe("completed");
+		const text = updates
+			.filter((update) => update.update?.sessionUpdate === "agent_message_chunk")
+			.map((update) => update.update.content.text)
+			.join("");
+		expect(text).toContain("continued after compaction");
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ reason: "requested" });
+		harness.cleanup();
+	}, 30_000);
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -947,14 +947,58 @@ describe("AgentSession compaction characterization", () => {
 		];
 		const continueSpy = vi
 			.spyOn(harness.session.agent, "continue")
-			.mockRejectedValueOnce(new Error("already processing"));
+			.mockRejectedValueOnce(new Error("already processing"))
+			.mockResolvedValueOnce();
 
 		sessionInternals._schedulePostCompactionContinue();
+		let idleSettled = false;
+		const idle = harness.session.waitForIdle().finally(() => {
+			idleSettled = true;
+		});
 		await vi.advanceTimersByTimeAsync(100);
 
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([queuedMessage]);
 		expect(sessionInternals._postCompactionContinuationScheduled).toBe(true);
+		expect(idleSettled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(100);
+		await idle;
+		expect(continueSpy).toHaveBeenCalledTimes(2);
+		expect(idleSettled).toBe(true);
+	});
+
+	it("releases post-compaction idle waiters when continuation is cancelled", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_cancelPostCompactionContinue(): void;
+		};
+
+		sessionInternals._schedulePostCompactionContinue();
+		const idle = harness.session.waitForIdle();
+		sessionInternals._cancelPostCompactionContinue();
+
+		await expect(idle).resolves.toBeUndefined();
+	});
+
+	it("rejects idle waiters when post-compaction continuation cannot start", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+		};
+		vi.spyOn(harness.session.agent, "continue").mockRejectedValueOnce(new Error("continuation failed"));
+
+		sessionInternals._schedulePostCompactionContinue();
+		const idle = harness.session.waitForIdle();
+		const rejectedIdle = expect(idle).rejects.toThrow("continuation failed");
+		await vi.advanceTimersByTimeAsync(100);
+
+		await rejectedIdle;
 	});
 
 	it("clears queued autonomous threshold continuations when autonomous mode is disabled", async () => {
@@ -1029,6 +1073,8 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.getFollowUpMessages()).toHaveLength(1);
 
 		await harness.session.prompt("/autonomous off");
+		// waitForIdle now owns the timer-scheduled post-compaction continuation.
+		await vi.advanceTimersByTimeAsync(100);
 		await harness.session.waitForIdle();
 		expect(harness.session.getAutonomousStatus().enabled).toBe(false);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1001,6 +1001,21 @@ describe("AgentSession compaction characterization", () => {
 		await rejectedIdle;
 	});
 
+	it("does not expose failed post-compaction continuations to later idle waiters", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+		};
+		vi.spyOn(harness.session.agent, "continue").mockRejectedValueOnce(new Error("continuation failed"));
+
+		sessionInternals._schedulePostCompactionContinue();
+		await vi.advanceTimersByTimeAsync(100);
+
+		await expect(harness.session.waitForIdle()).resolves.toBeUndefined();
+	});
+
 	it("clears queued autonomous threshold continuations when autonomous mode is disabled", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({


### PR DESCRIPTION
Linear: [ENG-5377](https://linear.app/primeintellect/issue/ENG-5377/include-scheduled-post-compaction-continuations-in-session-idle-state)

`compact.run` stops the current agent loop, compacts, then schedules a continuation. That scheduled work was not part of `waitForIdle()`, so ACP could return a silent `end_turn` before the continuation started.

Track the scheduled continuation in the session idle contract so headless clients wait for the resumed turn.

Verification:
- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/acp-mode.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentSession.waitForIdle` to await post-compaction continuation and queue ACP follow-up prompts
> - `waitForIdle` now awaits a post-compaction continuation deferred (`_postCompactionContinuationCompletion`) before returning, so the session does not report idle while a compaction-triggered continuation is scheduled or running. The deferred is created/refreshed on each (re)schedule and settled exactly once in `_settlePostCompactionContinuation`, covering cancel, success, reschedule, and error paths.
> - ACP follow-up prompts are now queued behind in-flight work via `queueIfBusy` and `streamingBehavior="followUp"` in [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/881/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae), instead of being rejected as already-processing. Queued prompts that haven't started can be cancelled through the shared `AbortSignal`.
> - Adds daemon protocol schema revision 17 with an `owned_prompt_cancellation` capability, letting clients cancel a prompt the session already owns (but hasn't started delivering) via `cancelOwned:true` on `cancel_prompt_admission`.
> - Behavioral Change: `DaemonCommand.cancel_prompt_admission` now carries optional `cancelOwned`; wire compat requires schema rev ≥ 17 and the `owned_prompt_cancellation` capability. `promptAndWait` callers that pass an `AbortSignal` will see queued, not-yet-started turns reject with a cancellation error rather than proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3a5e7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the session idle gate, ACP turn boundaries, and daemon worker relaunch env—incorrect timing could still false-quiesce or strand workers, but changes are heavily tested and client-owned credentials stay out of resident descriptors.
> 
> **Overview**
> Fixes **headless and ACP clients finishing a turn before compaction-scheduled work runs**, by tracking a settlement promise in `AgentSession.waitForIdle()` so timer-driven post-compaction continuations are part of the idle contract (including cancel/reschedule paths).
> 
> **ACP** now treats `session/prompt` as admissible only after an extra `waitForIdle()`, emits **`quiescence` `_meta`** (outstanding subagents + remaining autonomous continuations from a live roster snapshot), hardens **`session/new`** against concurrent creation and failed initial snapshots, and adjusts **daemon attach** so reattachable ACP sessions use **resident** lifecycle while still forwarding **`launchEnv`** for model/proxy credentials.
> 
> **Daemon supervisor** persists **`launchEnv` on resident worker descriptors** (not client-owned) and reapplies it on worker relaunch after supervisor restart; tests cover ACP kernel namespace reconnect and resident env recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a590f950084196f198de12519c67d68ead71ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->