### PR TITLE
fix(coding-agent): reject ctx.ui.custom() under daemon/RPC instead of silent no-op

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed `ctx.ui.custom()` silently no-opping under the daemon/worker architecture and over RPC instead of surfacing an error, and added `ctx.ui.supportsCustom` so extensions can detect terminal-takeover support instead of relying on `ctx.hasUI` ([#680](https://github.com/PrimeIntellect-ai/prime-agent/issues/680))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -201,7 +201,10 @@ const noOpUIContext: ExtensionUIContext = {
 	setFooter: () => {},
 	setHeader: () => {},
 	setTitle: () => {},
-	custom: async () => undefined as never,
+	supportsCustom: false,
+	custom: async () => {
+		throw new Error("ctx.ui.custom() is not available: no UI is attached to this session.");
+	},
 	pasteToEditor: () => {},
 	setEditorText: () => {},
 	getEditorText: () => "",

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -178,7 +178,19 @@ export interface ExtensionUIContext {
 	/** Set the terminal window/tab title. */
 	setTitle(title: string): void;
 
-	/** Show a custom component with keyboard focus. */
+	/**
+	 * Whether `custom()` can actually take over the terminal in this UI context.
+	 *
+	 * `hasUI` only indicates that a (non-no-op) UI context is bound; it does not
+	 * guarantee every method is functional. In particular, under the daemon/worker
+	 * architecture and over RPC, the extension handler runs in a process that does
+	 * not own a real terminal, so `custom()` cannot render anything even though
+	 * other UI methods (select, confirm, input, etc.) work over the wire protocol.
+	 * Check this flag before calling `custom()` to detect that case.
+	 */
+	readonly supportsCustom: boolean;
+
+	/** Show a custom component with keyboard focus. Rejects if `supportsCustom` is false. */
 	custom<T>(
 		factory: (
 			tui: TUI,

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -217,8 +217,17 @@ function createExtensionUIContext(
 		setFooter: () => {},
 		setHeader: () => {},
 		setTitle: (title) => emitUiRequest("setTitle", { title }),
+		supportsCustom: false,
 		async custom<T>(): Promise<T> {
-			return undefined as T;
+			// Terminal-takeover UI has no wire-protocol path under the daemon/worker
+			// architecture: the worker running this handler doesn't own a real
+			// terminal, only the socket-attached client does. Reject instead of
+			// silently resolving so callers can't mistake this for a successful
+			// no-op render. See ctx.ui.supportsCustom to detect this ahead of time.
+			throw new Error(
+				"ctx.ui.custom() is not supported under the daemon/worker architecture. " +
+					"Check ctx.ui.supportsCustom before calling custom().",
+			);
 		},
 		pasteToEditor: (text) => emitUiRequest("setEditorText", { text }),
 		setEditorText: (text) => emitUiRequest("setEditorText", { text }),

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3664,6 +3664,7 @@ export class InteractiveMode {
 			setFooter: (factory) => this.setExtensionFooter(factory),
 			setHeader: (factory) => this.setExtensionHeader(factory),
 			setTitle: (title) => this.ui.terminal.setTitle(title),
+			supportsCustom: true,
 			custom: (factory, options) => this.showExtensionCustom(factory, options),
 			pasteToEditor: (text) => this.editor.handleInput(`\x1b[200~${text}\x1b[201~`),
 			setEditorText: (text) => this.editor.setText(text),

--- a/packages/coding-agent/src/modes/rpc/rpc-extension-ui-context.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-extension-ui-context.ts
@@ -108,7 +108,16 @@ export function createRpcExtensionUiBridge(output: (request: RpcExtensionUIReque
 		setFooter: (_factory: unknown) => {},
 		setHeader: (_factory: unknown) => {},
 		setTitle: (title) => fireAndForget({ method: "setTitle", title }),
-		custom: async () => undefined as never,
+		supportsCustom: false,
+		custom: async () => {
+			// The RPC client is a wire protocol, not a terminal; there's no
+			// mechanism to hand it a component to render. Reject rather than
+			// silently resolving so callers can detect the failure. Check
+			// ctx.ui.supportsCustom before calling custom() to avoid this.
+			throw new Error(
+				"ctx.ui.custom() is not supported over RPC. Check ctx.ui.supportsCustom before calling custom().",
+			);
+		},
 		pasteToEditor(text) {
 			this.setEditorText(text);
 		},


### PR DESCRIPTION
## Summary
Fixes #680

`ctx.ui.custom()` was silently no-opping under the daemon/worker architecture and over RPC, returning `undefined` instead of surfacing an error. This made it impossible for extensions to detect that terminal-takeover rendering wasn't available.

## Changes

- **`ExtensionUIContext.supportsCustom`** (new property): a `readonly boolean` flag that extensions can check before calling `custom()` to detect whether terminal-takeover rendering is supported in the current UI context.
- **`noOpUIContext`** (`runner.ts`): `custom()` now throws instead of returning `undefined as never`.
- **Daemon binding** (`daemon-extension-binding.ts`): `custom()` now throws with a descriptive error explaining the daemon/worker limitation.
- **RPC bridge** (`rpc-extension-ui-context.ts`): `custom()` now throws with a descriptive error explaining the RPC limitation.
- **Interactive mode** (`interactive-mode.ts`): sets `supportsCustom: true` since it owns a real terminal.
- **CHANGELOG**: documents the fix.

## How to test

1. Call `ctx.ui.custom()` from an extension running under the daemon — it should now throw instead of silently resolving.
2. Check `ctx.ui.supportsCustom` — it should be `false` under daemon/RPC and `true` in interactive mode.
3. Type-check: `npx tsgo --noEmit -p tsconfig.build.json`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ctx.ui.custom()` to throw instead of silently no-op in daemon and RPC modes
> - Adds a `supportsCustom: boolean` flag to the `ExtensionUIContext` interface so callers can check whether terminal takeover is available before calling `custom()`.
> - In daemon/worker and RPC modes, `ctx.ui.custom()` now throws an `Error` instead of silently resolving; interactive mode sets `supportsCustom: true`.
> - Behavioral Change: extensions that previously relied on `custom()` silently no-oping in non-interactive contexts will now receive a thrown error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9981c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->