### PR TITLE
fix(goal): pause blocked autonomous continuation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed active goals repeatedly starting provider turns while waiting on external input by adding model-callable pause and resume controls.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/skills/goal/SKILL.md
+++ b/packages/coding-agent/skills/goal/SKILL.md
@@ -13,6 +13,8 @@ it. Call it directly from IPython:
 ```python
 await goal.get()
 await goal.create("ship the release notes", token_budget=200000)
+await goal.pause("waiting for release approval")
+await goal.resume()
 await goal.complete()
 ```
 
@@ -28,6 +30,11 @@ await goal.complete()
   the user or system/developer instructions explicitly ask for a persistent
   long-running goal; do not infer goals from ordinary tasks. Set `token_budget`
   only when an explicit token budget is requested.
+- `await goal.pause(reason)` — pause autonomous continuation when no concrete
+  action is possible because progress depends only on an external actor or
+  event. Give the exact blocker; do not keep emitting holding updates.
+- `await goal.resume()` — reactivate a paused goal after new input resolves the
+  blocker.
 - `await goal.complete()` — mark the existing goal achieved. Use only when the
   objective has actually been achieved and no required work remains; do not
   call it merely because the budget is nearly exhausted or because you are
@@ -36,9 +43,10 @@ await goal.complete()
 
 ## Rules
 
-- Goal status transitions other than completion (pause, resume, clear,
-  budget-limiting) are controlled by the user and the host; there is no API for
-  them here.
+- Pause an incomplete goal instead of repeatedly reporting an unchanged
+  external blocker. Resume it only after new input makes concrete progress
+  possible. Clear and budget-limit transitions remain controlled by the user
+  and host.
 - When an active goal is actually complete, call `await goal.complete()`; do
   not merely say it is done — the harness keeps continuing the goal until the
   completion call arrives.

--- a/packages/coding-agent/skills/goal/src/goal/__init__.py
+++ b/packages/coding-agent/skills/goal/src/goal/__init__.py
@@ -41,12 +41,24 @@ async def create(objective: str, token_budget: int | None = None) -> dict[str, A
     return await host_request("goal.create", payload)
 
 
+async def pause(reason: str) -> dict[str, Any]:
+    """Pause autonomous goal continuation while waiting for external input."""
+    if not isinstance(reason, str):
+        raise TypeError(f"reason must be str, got {type(reason).__name__}")
+    return await host_request("goal.pause", {"reason": reason})
+
+
+async def resume() -> dict[str, Any]:
+    """Resume a paused thread goal."""
+    return await host_request("goal.resume")
+
+
 async def complete() -> dict[str, Any]:
     """Mark the existing thread goal achieved.
 
     Use only when the objective has actually been achieved and no required
     work remains — not because the budget is nearly exhausted or because you
-    are stopping work. Pause, resume, and budget-limit transitions are
-    controlled by the user and the host.
+    are stopping work. Use `pause()` instead when progress depends only on
+    external input.
     """
     return await host_request("goal.complete")

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -168,6 +168,7 @@ import {
 	normalizeGoalState,
 	validateGoalBudget,
 	validateGoalObjective,
+	validateGoalPauseReason,
 } from "./goals.js";
 import type { HostRequestHandlers, KernelSentAgentMessage } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
@@ -1824,14 +1825,14 @@ export class AgentSession {
 		});
 	}
 
-	private async _resumeGoal(): Promise<void> {
+	private _resumeGoalState(): boolean {
 		if (!this._goalState.objective) {
 			this._emitGoalUpdate();
-			return;
+			return false;
 		}
 		if (this._goalState.status !== "paused" && this._goalState.status !== "budget_limited") {
 			this._emitGoalUpdate();
-			return;
+			return false;
 		}
 		const exhausted =
 			this._goalState.tokenBudget !== undefined && this._goalState.tokensUsed >= this._goalState.tokenBudget;
@@ -1843,7 +1844,11 @@ export class AgentSession {
 			lastReason: exhausted ? "Goal token budget already reached" : undefined,
 			lastError: undefined,
 		});
-		if (nextStatus === "active") {
+		return nextStatus === "active";
+	}
+
+	private async _resumeGoal(): Promise<void> {
+		if (this._resumeGoalState()) {
 			await this._runOrQueueGoalContext("continuation");
 		}
 	}
@@ -2836,6 +2841,14 @@ export class AgentSession {
 				}
 				return goalHostResponse(this._createGoalFromHost(payload.objective, payload.token_budget), false);
 			}
+			case "goal.pause": {
+				if (typeof payload.reason !== "string") {
+					throw new Error("goal.pause reason must be a string");
+				}
+				return goalHostResponse(this._pauseGoalFromHost(payload.reason), false);
+			}
+			case "goal.resume":
+				return goalHostResponse(this._resumeGoalFromHost(), false);
 			case "goal.complete":
 				return goalHostResponse(this._completeGoalFromHost(), true);
 			default:
@@ -3143,6 +3156,22 @@ export class AgentSession {
 				// idle, or a terminal record (complete / error): nothing pending, start fresh.
 				return this._startGoal(objective, tokenBudget);
 		}
+	}
+
+	private _pauseGoalFromHost(reasonText: string): GoalState {
+		if (this._goalState.status !== "active") {
+			throw new Error("cannot pause goal because this thread has no active goal");
+		}
+		this._pauseGoal(validateGoalPauseReason(reasonText));
+		return this._goalState;
+	}
+
+	private _resumeGoalFromHost(): GoalState {
+		if (this._goalState.status !== "paused") {
+			throw new Error("cannot resume goal because this thread has no paused goal");
+		}
+		this._resumeGoalState();
+		return this._goalState;
 	}
 
 	private _completeGoalFromHost(): GoalState {
@@ -8773,7 +8802,7 @@ export class AgentSession {
 			}),
 		};
 		if (this._includeGoals) {
-			for (const type of ["goal.get", "goal.create", "goal.complete"]) {
+			for (const type of ["goal.get", "goal.create", "goal.pause", "goal.resume", "goal.complete"]) {
 				handlers[type] = async (payload) => this.handleGoalHostRequest(type, payload);
 			}
 		}

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -6,6 +6,7 @@ export const GOAL_CONTEXT_CUSTOM_TYPE = "goal_context";
 export const GOAL_CONTEXT_PREVIEW_LABEL = "Goal context";
 export const GOAL_SKILL_NAME = "goal";
 export const MAX_THREAD_GOAL_OBJECTIVE_CHARS = 4000;
+export const MAX_THREAD_GOAL_PAUSE_REASON_CHARS = 1000;
 
 export type GoalStatus = "idle" | "active" | "paused" | "budget_limited" | "complete" | "error";
 export type GoalContextKind = "continuation" | "budget_limit" | "objective_updated";
@@ -81,6 +82,17 @@ export function validateGoalObjective(value: string): string {
 		throw new Error(`Goal objective must be at most ${MAX_THREAD_GOAL_OBJECTIVE_CHARS} characters.`);
 	}
 	return objective;
+}
+
+export function validateGoalPauseReason(value: string): string {
+	const reason = value.trim();
+	if (!reason) {
+		throw new Error("Goal pause reason must not be empty.");
+	}
+	if ([...reason].length > MAX_THREAD_GOAL_PAUSE_REASON_CHARS) {
+		throw new Error(`Goal pause reason must be at most ${MAX_THREAD_GOAL_PAUSE_REASON_CHARS} characters.`);
+	}
+	return reason;
 }
 
 export function validateGoalBudget(value: number | undefined): number | undefined {
@@ -225,6 +237,8 @@ Goal state:
 The goal persists across turns. Ending one turn does not reduce or redefine the objective. If the goal is not complete yet, make concrete progress toward the full objective.
 
 Before marking the goal complete, audit the current state against every requirement in the objective. Do not rely on intent, partial progress, memory of earlier work, or a plausible final answer as proof of completion. If the objective is achieved, run \`await goal.complete()\` in ipython so usage accounting is preserved.
+
+If no concrete action is possible because progress depends only on an external actor or event, run \`await goal.pause("waiting for …")\` in ipython. Do not keep emitting holding updates. After new input resolves the blocker, run \`await goal.resume()\` before continuing the goal.
 
 Do not call \`goal.complete()\` unless the goal is complete. Do not mark a goal complete merely because the budget is nearly exhausted or because you are stopping work.`;
 }

--- a/packages/coding-agent/test/kernel-goal-skill.test.ts
+++ b/packages/coding-agent/test/kernel-goal-skill.test.ts
@@ -31,7 +31,7 @@ describe("goal skill over the kernel host bridge", { tags: ["kernel-heavy"] }, (
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("round-trips goal.create and goal.complete through a live kernel", async () => {
+	it("round-trips the goal lifecycle through a live kernel", async () => {
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledGoalSkill()],
@@ -41,6 +41,22 @@ describe("goal skill over the kernel host bridge", { tags: ["kernel-heavy"] }, (
 					return {
 						goal: { objective: payload.objective, status: "active", tokens_used: 0 },
 						remaining_tokens: payload.token_budget ?? null,
+						completion_budget_report: null,
+					};
+				},
+				"goal.pause": async (payload) => {
+					requests.push({ type: "goal.pause", payload });
+					return {
+						goal: { objective: "ship it", status: "paused", tokens_used: 3 },
+						remaining_tokens: 7,
+						completion_budget_report: null,
+					};
+				},
+				"goal.resume": async (payload) => {
+					requests.push({ type: "goal.resume", payload });
+					return {
+						goal: { objective: "ship it", status: "active", tokens_used: 3 },
+						remaining_tokens: 7,
 						completion_budget_report: null,
 					};
 				},
@@ -69,6 +85,20 @@ print(json.dumps(_created, sort_keys=True))
 			completion_budget_report: null,
 		});
 
+		const paused = await manager.execute(`
+_paused = await goal.pause("waiting for approval")
+print(_paused["goal"]["status"])
+`);
+		expect(paused.status).toBe("ok");
+		expect(paused.stdout.trim()).toBe("paused");
+
+		const resumed = await manager.execute(`
+_resumed = await goal.resume()
+print(_resumed["goal"]["status"])
+`);
+		expect(resumed.status).toBe("ok");
+		expect(resumed.stdout.trim()).toBe("active");
+
 		const completed = await manager.execute(`
 _completed = await goal.complete()
 print(_completed["goal"]["status"], _completed["completion_budget_report"])
@@ -78,8 +108,14 @@ print(_completed["goal"]["status"], _completed["completion_budget_report"])
 			"complete Goal achieved. Report final budget usage to the user: tokens used: 7 of 10.",
 		);
 
-		expect(requests.map((request) => request.type)).toEqual(["goal.create", "goal.complete"]);
+		expect(requests.map((request) => request.type)).toEqual([
+			"goal.create",
+			"goal.pause",
+			"goal.resume",
+			"goal.complete",
+		]);
 		expect(requests[0].payload).toMatchObject({ type: "goal.create", objective: "ship it", token_budget: 10 });
+		expect(requests[1].payload).toMatchObject({ type: "goal.pause", reason: "waiting for approval" });
 	});
 
 	it("surfaces host errors and missing handlers as Python exceptions", async () => {

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -94,6 +94,8 @@ function createFauxIpythonTool(sessionRef: { current?: AgentSession }): AgentToo
 }
 
 const COMPLETE_GOAL_CELL = { code: "goal.complete" };
+const PAUSE_GOAL_CELL = { code: 'goal.pause {"reason": "waiting for PR target"}' };
+const RESUME_GOAL_CELL = { code: "goal.resume" };
 
 function createWaitingTool(): {
 	tool: AgentTool;
@@ -188,6 +190,55 @@ describe("AgentSession goals", () => {
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
+	it("pauses autonomous continuation while waiting for external input", async () => {
+		const harness = await createGoalHarness();
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("ipython", PAUSE_GOAL_CELL), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Waiting for the PR target."),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("/goal publish the change");
+
+		expect(visibleAssistantTexts(harness)).toEqual(["Waiting for the PR target."]);
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "paused",
+			lastReason: "waiting for PR target",
+			continuationsUsed: 0,
+		});
+		expect(harness.getPendingResponseCount()).toBe(1);
+
+		await harness.session.reload();
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "paused",
+			lastReason: "waiting for PR target",
+		});
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
+	it("resumes a model-paused goal after external input arrives", async () => {
+		const harness = await createGoalHarness();
+		harness.session.handleGoalHostRequest("goal.create", { objective: "publish the change" });
+		harness.session.handleGoalHostRequest("goal.pause", { reason: "waiting for PR target" });
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("ipython", RESUME_GOAL_CELL), { stopReason: "toolUse" }),
+			fauxAssistantMessage(fauxToolCall("ipython", COMPLETE_GOAL_CELL), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Goal complete."),
+		]);
+
+		await harness.session.prompt("Target PrimeIntellect-ai/prime-agent:main.");
+
+		expect(visibleAssistantTexts(harness)).toEqual(["Goal complete."]);
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			lastReason: "Goal achieved",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
 	it("counts tokens from the goal completion turn", async () => {
 		const harness = await createGoalHarness();
 		harness.setResponses([
@@ -271,11 +322,23 @@ describe("AgentSession goals", () => {
 		expect(() => harness.session.handleGoalHostRequest("goal.nonsense")).toThrow(
 			'unknown goal request type "goal.nonsense"',
 		);
+		expect(() => harness.session.handleGoalHostRequest("goal.pause", {})).toThrow(
+			"goal.pause reason must be a string",
+		);
+		expect(() => harness.session.handleGoalHostRequest("goal.pause", { reason: "waiting" })).toThrow(
+			"cannot pause goal because this thread has no active goal",
+		);
+		expect(() => harness.session.handleGoalHostRequest("goal.resume")).toThrow(
+			"cannot resume goal because this thread has no paused goal",
+		);
 		expect(() => harness.session.handleGoalHostRequest("goal.complete")).toThrow(
 			"cannot complete goal because this thread has no goal",
 		);
 
 		harness.session.handleGoalHostRequest("goal.create", { objective: "first goal" });
+		expect(() => harness.session.handleGoalHostRequest("goal.pause", { reason: "   " })).toThrow(
+			"Goal pause reason must not be empty",
+		);
 		expect(() => harness.session.handleGoalHostRequest("goal.create", { objective: "second goal" })).toThrow(
 			"already has an active goal",
 		);


### PR DESCRIPTION
Active goals automatically continue after every normal assistant turn until the model marks them complete. When progress depends entirely on an external actor or event, the model currently has no way to yield, so it can spend repeated turns reporting the same blocker.

Expose `goal.pause(reason)` and `goal.resume()` through the existing goal host bridge and bundled Python skill. Pausing reuses the persisted paused state and clears queued goal contexts, while resuming reactivates the same goal after new input arrives.

Teach the continuation prompt and skill guidance to pause instead of emitting unchanged holding updates. Active goals that are not paused retain the existing continue-until-complete behavior, and the change adds no new daemon protocol status.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pause blocked autonomous goal continuation via `goal.pause()` and `goal.resume()`
> - Adds `goal.pause(reason)` and `goal.resume()` Python skill functions in [goal/__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/888/files#diff-bd071c73661774d8d701254d6367a1fd419fb6f7cc0bb4d274dcc10f7d908988) that send requests over the kernel host bridge.
> - Adds `_pauseGoalFromHost` and `_resumeGoalFromHost` methods to `AgentSession` in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/888/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae); pausing is only allowed when the goal is active, resuming only when paused.
> - Updates goal context instructions in [goals.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/888/files#diff-39cd9fde60e7a2aff7614731e605dc5b1f0208f96cc836237a1b169070d58ce7) to tell the model to call `goal.pause("waiting for …")` when blocked on external input and `goal.resume()` after new input arrives.
> - Pause reasons are validated: trimmed, must be non-empty, and capped at 1000 characters (`MAX_THREAD_GOAL_PAUSE_REASON_CHARS`).
> - Behavioral Change: a paused goal no longer enqueues autonomous continuation turns; a subsequent `goal.resume()` (without external queuing) also does not automatically enqueue a continuation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04a453b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->