### PR TITLE
fix(coding-agent): make continual harness state reachable from the prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Changed the continual harness overview to rank entries by recency instead of an alphabetical path sort, so the newest lessons survive truncation ([#819](https://github.com/PrimeIntellect-ai/prime-agent/issues/819))
+- Added the `harnessOverview` setting to raise the continual harness overview's per-kind entry cap and body length ([#819](https://github.com/PrimeIntellect-ai/prime-agent/issues/819))
+- Fixed the continual harness overview naming withheld entries by count alone, with no call that reads them ([#819](https://github.com/PrimeIntellect-ai/prime-agent/issues/819))
+- Added `include_global=True` to `rlm.harness.overview()` and `rlm.harness.list()`, and made a local overview name the global store, its counts, and how to read it ([#819](https://github.com/PrimeIntellect-ai/prime-agent/issues/819))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -212,6 +212,18 @@ Session-local state lives in the session artifact directory under `harness/harne
 
 `/refine` runs a dedicated review over the current trajectory and applies small create/update/delete edits. Rollback uses recorded before/after snapshots. The base system prompt remains immutable; refinements are supplemental state.
 
+### Reading state the prompt did not show
+
+The system-prompt overview is a truncated, most-recently-updated-first sample of the merged local + global state, capped by the `harnessOverview` setting. `rlm.harness` resolves to the session-local store, which is empty for a freshly spawned child, so a local read is not a view of everything the prompt was built from:
+
+```python
+rlm.harness.overview()                            # local store; names the global store and its counts
+rlm.harness.overview(global_=True)                # cross-session store only
+rlm.harness.overview(include_global=True)         # both, matching what built the system prompt
+rlm.harness.list("memory", include_global=True)   # merged entries; local shadows global on id collision
+rlm.harness.get("memory", "global:<id>")          # a single entry by its displayed id
+```
+
 ## Goal Requests
 
 The bundled `goal` Python skill is a thin host-bridge client:

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -126,6 +126,26 @@ prime-agent --offline
 }
 ```
 
+### Continual Harness Overview
+
+Budgets for the continual harness overview injected into the system prompt. Entries are listed most-recently-updated first, so raising the cap adds older entries rather than reshuffling the ones already shown.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `harnessOverview.maxEntriesPerKind` | number | `6` | Entries rendered per kind (prompt/memory/skill/subagent), clamped to 0-500 |
+| `harnessOverview.maxContentLength` | number | `180` | Characters of each entry's body, clamped to 40-4000 |
+
+```json
+{
+  "harnessOverview": {
+    "maxEntriesPerKind": 20,
+    "maxContentLength": 400
+  }
+}
+```
+
+Entries beyond the cap are not lost. The overview reports how many were withheld, and the kernel can read them with `rlm.harness.list("<kind>")` for the session-local store, `rlm.harness.list("<kind>", global_=True)` for the cross-session store, or `rlm.harness.list("<kind>", include_global=True)` for the merged view the prompt was built from.
+
 ### Branch Summary
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4310,6 +4310,7 @@ export class AgentSession {
 			rlmDepth: this._rlmDepth,
 			rlmParentAgent: this._rlmParentAgent,
 			harnessState: this._loadMergedHarnessState(),
+			harnessOverview: this.settingsManager.getHarnessOverviewSettings(),
 		};
 		return buildSystemPrompt(this._baseSystemPromptOptions);
 	}

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -26,6 +26,12 @@ const REFINEMENT_HISTORY_FILE_NAME = "refinements.jsonl";
 const DEFAULT_OVERVIEW_ENTRY_LIMIT = 6;
 const DEFAULT_OVERVIEW_REFINEMENT_LIMIT = 5;
 const DEFAULT_OVERVIEW_CONTENT_LIMIT = 180;
+const MIN_OVERVIEW_ENTRY_LIMIT = 0;
+const MAX_OVERVIEW_ENTRY_LIMIT = 500;
+const MIN_OVERVIEW_CONTENT_LIMIT = 40;
+const MAX_OVERVIEW_CONTENT_LIMIT = 4_000;
+/** Entries per kind handed to the refiner, which sees far more context than the system prompt. */
+const REFINER_OVERVIEW_ENTRY_LIMIT = 40;
 
 export type RefinementKind = "prompt" | "memory" | "skill" | "subagent";
 export type RefinementAction = "create" | "update" | "delete";
@@ -426,6 +432,61 @@ function compactText(text: string, maxLength: number): string {
 	return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
+/** Configurable overview budgets, surfaced to users as the `harnessOverview` setting. */
+export interface HarnessOverviewLimits {
+	maxEntriesPerKind?: number;
+	maxContentLength?: number;
+}
+
+function entryRecency(entry: HarnessEntry): number {
+	const updated = Date.parse(entry.updated_at);
+	if (Number.isFinite(updated)) {
+		return updated;
+	}
+	const created = Date.parse(entry.created_at);
+	return Number.isFinite(created) ? created : 0;
+}
+
+/**
+ * Overview slots are scarce, so the entries that survive truncation must be the ones
+ * most likely to matter rather than the ones whose paths sort first: most recently
+ * written, then most refined. The trailing path/title/id comparison only breaks exact
+ * ties, keeping the rendered order stable across builds of the same state.
+ */
+function compareHarnessEntriesForOverview(a: HarnessEntry, b: HarnessEntry): number {
+	const recency = entryRecency(b) - entryRecency(a);
+	if (recency !== 0) {
+		return recency;
+	}
+	if (b.version !== a.version) {
+		return b.version - a.version;
+	}
+	return [a.path, a.title, a.id].join("\0").localeCompare([b.path, b.title, b.id].join("\0"));
+}
+
+function rankHarnessEntriesForOverview(entries: Record<string, HarnessEntry>): HarnessEntry[] {
+	return Object.values(entries).sort(compareHarnessEntriesForOverview);
+}
+
+/**
+ * The overview is the only place the model learns that hidden entries exist, so the
+ * overflow line has to name the call that reads them. Without it the prompt advises
+ * inspecting the underlying entry while leaving no reachable path to do so.
+ */
+function overflowReadHint(kind: RefinementKind, includeIpythonExamples: boolean): string {
+	if (!includeIpythonExamples) {
+		return `raise \`harnessOverview.maxEntriesPerKind\` in settings.json to show more ${kind} entries`;
+	}
+	return `read them with \`rlm.harness.list("${kind}")\` for this session's local store and \`rlm.harness.list("${kind}", global_=True)\` for the cross-session global store, or raise \`harnessOverview.maxEntriesPerKind\` in settings.json`;
+}
+
+function clampOverviewLimit(value: number | undefined, fallback: number, min: number, max: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
 export function formatHarnessStateForPrompt(
 	state: HarnessState,
 	options: {
@@ -437,9 +498,19 @@ export function formatHarnessStateForPrompt(
 		includeRefineExamples?: boolean;
 	} = {},
 ): string {
-	const maxEntriesPerKind = options.maxEntriesPerKind ?? DEFAULT_OVERVIEW_ENTRY_LIMIT;
+	const maxEntriesPerKind = clampOverviewLimit(
+		options.maxEntriesPerKind,
+		DEFAULT_OVERVIEW_ENTRY_LIMIT,
+		MIN_OVERVIEW_ENTRY_LIMIT,
+		MAX_OVERVIEW_ENTRY_LIMIT,
+	);
 	const maxRefinements = options.maxRefinements ?? DEFAULT_OVERVIEW_REFINEMENT_LIMIT;
-	const maxContentLength = options.maxContentLength ?? DEFAULT_OVERVIEW_CONTENT_LIMIT;
+	const maxContentLength = clampOverviewLimit(
+		options.maxContentLength,
+		DEFAULT_OVERVIEW_CONTENT_LIMIT,
+		MIN_OVERVIEW_CONTENT_LIMIT,
+		MAX_OVERVIEW_CONTENT_LIMIT,
+	);
 	const includeIpythonExamples = options.includeIpythonExamples ?? true;
 	const includeRefineExamples = options.includeRefineExamples ?? includeIpythonExamples;
 	const lines = [
@@ -447,6 +518,7 @@ export function formatHarnessStateForPrompt(
 		"",
 		"Local continual harness entries belong to this Prime Agent session. Global continual harness entries persist across Prime Agent sessions.",
 		"The continual harness entries below are compact summaries, not full descriptions. Use them as routing/context hints; inspect or refine the underlying continual harness entry only when detail matters.",
+		`Each kind lists its most recently updated entries first, capped at ${maxEntriesPerKind} per kind. A "+N more" line means the remaining entries exist but are not shown here; read them from the store instead of assuming they are absent.`,
 		"Default to local continual harness refinement for current task progress, temporary blockers, and session coordination. Use global continual harness refinement only for stable cross-session lessons, durable user preferences, reusable skills/subagents, or explicitly project-qualified facts.",
 		"Use these continual harness prompt notes, memories, skills, and subagent specs when they are relevant. The base system prompt is immutable; prompt entries below are supplemental notes only.",
 		"",
@@ -464,9 +536,7 @@ export function formatHarnessStateForPrompt(
 
 	let totalEntries = 0;
 	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
-		const entries = Object.values(state.entries[kind]).sort((a, b) =>
-			[a.path, a.title, a.id].join("\0").localeCompare([b.path, b.title, b.id].join("\0")),
-		);
+		const entries = rankHarnessEntriesForOverview(state.entries[kind]);
 		totalEntries += entries.length;
 		// Render subagent specs as a task-shaped roster the model can match against — the
 		// analogue of Claude Code's agent-type menu — rather than a bare count. In
@@ -496,7 +566,7 @@ export function formatHarnessStateForPrompt(
 		}
 		const overflow = entries.length - Math.min(entries.length, maxEntriesPerKind);
 		if (overflow > 0) {
-			lines.push(`- +${overflow} more ${kind} entries`);
+			lines.push(`- +${overflow} more ${kind} entries not shown: ${overflowReadHint(kind, includeIpythonExamples)}`);
 		}
 		lines.push("");
 	}
@@ -522,9 +592,11 @@ export function formatHarnessStateForPrompt(
 function overviewForPrompt(state: HarnessState): string {
 	const lines: string[] = [];
 	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
-		const entries = Object.values(state.entries[kind]);
+		// Same recency ranking as the system-prompt overview: when this list is
+		// truncated the refiner must still see the entries most likely to need an edit.
+		const entries = rankHarnessEntriesForOverview(state.entries[kind]);
 		lines.push(`${kind}: ${entries.length}`);
-		for (const entry of entries.slice(0, 40)) {
+		for (const entry of entries.slice(0, REFINER_OVERVIEW_ENTRY_LIMIT)) {
 			const content = entry.content.replace(/\s+/g, " ").slice(0, 240);
 			const argumentsText =
 				entry.kind === "skill" && Object.keys(entry.arguments).length > 0
@@ -538,8 +610,8 @@ function overviewForPrompt(state: HarnessState): string {
 				`- [${entry.scope ?? "global"}:${entry.id}] ${entry.title} (${entry.path}, v${entry.version})${referenceText}${argumentsText}: ${content}`,
 			);
 		}
-		if (entries.length > 40) {
-			lines.push(`- +${entries.length - 40} more ${kind} entries`);
+		if (entries.length > REFINER_OVERVIEW_ENTRY_LIMIT) {
+			lines.push(`- +${entries.length - REFINER_OVERVIEW_ENTRY_LIMIT} more ${kind} entries`);
 		}
 	}
 	return lines.join("\n");

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -27,6 +27,12 @@ export interface AutoRefineSettings {
 	cooldownMs?: number; // default: 20 minutes
 }
 
+/** Budgets for the continual harness overview injected into the system prompt. */
+export interface HarnessOverviewSettings {
+	maxEntriesPerKind?: number; // default: 6 (0-500)
+	maxContentLength?: number; // default: 180 characters (40-4000)
+}
+
 export interface ProviderRetrySettings {
 	timeoutMs?: number; // SDK/provider request timeout in milliseconds
 	maxRetries?: number; // SDK/provider retry attempts
@@ -135,6 +141,7 @@ export interface Settings {
 	theme?: string;
 	compaction?: CompactionSettings;
 	autoRefine?: AutoRefineSettings;
+	harnessOverview?: HarnessOverviewSettings;
 	agentTraces?: AgentTracesSettings;
 	telemetry?: TelemetrySettings;
 	branchSummary?: BranchSummarySettings;
@@ -894,6 +901,17 @@ export class SettingsManager {
 				0,
 				typeof cooldownMs === "number" && Number.isFinite(cooldownMs) ? cooldownMs : 20 * 60_000,
 			),
+		};
+	}
+
+	/**
+	 * Overview budgets are returned unresolved: `formatHarnessStateForPrompt` owns the
+	 * defaults and the clamp, so a value set here cannot widen the prompt past its cap.
+	 */
+	getHarnessOverviewSettings(): HarnessOverviewSettings {
+		return {
+			maxEntriesPerKind: this.settings.harnessOverview?.maxEntriesPerKind,
+			maxContentLength: this.settings.harnessOverview?.maxContentLength,
 		};
 	}
 

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -3,7 +3,12 @@
  */
 
 import { buildChildAgentDoctrine, buildRlmPrompt, buildSubagentGuidance } from "./prompts/index.js";
-import { formatHarnessStateForPrompt, type HarnessState, REFINE_SKILL_NAME } from "./refinement/index.js";
+import {
+	formatHarnessStateForPrompt,
+	type HarnessOverviewLimits,
+	type HarnessState,
+	REFINE_SKILL_NAME,
+} from "./refinement/index.js";
 import { formatSkillsForPrompt, getPythonSkillRuntimeInfo, type Skill } from "./skills.js";
 
 export interface BuildSystemPromptOptions {
@@ -33,6 +38,8 @@ export interface BuildSystemPromptOptions {
 	rlmParentAgent?: string;
 	/** Global harness state to inject as compact persistent context. */
 	harnessState?: HarnessState;
+	/** Overview budgets for the injected harness state. Unset falls back to built-in defaults. */
+	harnessOverview?: HarnessOverviewLimits;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -48,6 +55,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		skills: providedSkills,
 		allowRecursion,
 		harnessState,
+		harnessOverview,
 	} = options;
 	const promptCwd = cwd.replace(/\\/g, "/");
 	const promptMessagesPath = (messagesPath ?? "not persisted").replace(/\\/g, "/");
@@ -103,7 +111,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		}
 
 		if (harnessState) {
-			prompt += `\n\n${formatHarnessStateForPrompt(harnessState, { includeIpythonExamples: hasIpython, includeShellExamples: hasBash, includeRefineExamples: hasIpython && hasRefineSkill })}`;
+			prompt += `\n\n${formatHarnessStateForPrompt(harnessState, { ...harnessOverview, includeIpythonExamples: hasIpython, includeShellExamples: hasBash, includeRefineExamples: hasIpython && hasRefineSkill })}`;
 		}
 
 		if (appendSection) {
@@ -138,7 +146,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	}
 
 	if (harnessState) {
-		prompt += `\n\n${formatHarnessStateForPrompt(harnessState, { includeIpythonExamples: hasIpython, includeShellExamples: hasBash, includeRefineExamples: hasIpython && hasRefineSkill })}`;
+		prompt += `\n\n${formatHarnessStateForPrompt(harnessState, { ...harnessOverview, includeIpythonExamples: hasIpython, includeShellExamples: hasBash, includeRefineExamples: hasIpython && hasRefineSkill })}`;
 	}
 
 	const guidelines = formatPromptGuidelines(promptGuidelines);

--- a/packages/coding-agent/test/suite/regressions/819-harness-overview-reachability.test.ts
+++ b/packages/coding-agent/test/suite/regressions/819-harness-overview-reachability.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.js";
+import {
+	formatHarnessStateForPrompt,
+	getGlobalHarnessStateDir,
+	type HarnessEntry,
+	type HarnessState,
+	saveHarnessState,
+} from "../../../src/core/refinement/index.js";
+import { SettingsManager } from "../../../src/core/settings-manager.js";
+import { buildSystemPrompt } from "../../../src/core/system-prompt.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function entry(overrides: Partial<HarnessEntry> & Pick<HarnessEntry, "id">): HarnessEntry {
+	return {
+		kind: "memory",
+		title: overrides.id,
+		content: "content",
+		path: "general",
+		scope: "global",
+		reference: {},
+		arguments: {},
+		metadata: {},
+		source: "test",
+		created_at: "2026-01-01T00:00:00.000Z",
+		updated_at: "2026-01-01T00:00:00.000Z",
+		version: 1,
+		...overrides,
+	};
+}
+
+function stateWith(memory: HarnessEntry[]): HarnessState {
+	return {
+		schema: 1,
+		entries: {
+			prompt: {},
+			memory: Object.fromEntries(memory.map((item) => [item.id, item])),
+			skill: {},
+			subagent: {},
+		},
+		refinements: [],
+	};
+}
+
+function renderedIds(overview: string): string[] {
+	return [...overview.matchAll(/^- \[(?:local|global):([\w-]+)\]/gm)].map((match) => match[1]);
+}
+
+/**
+ * The overview is the model's only view of continual harness state. Before this fix
+ * the surviving entries were the alphabetically-first 6 per kind, so which lessons
+ * reached the model depended on how their paths happened to be spelled, and the
+ * remaining entries were named by a bare count with no way to read them.
+ */
+describe("issue #819 continual harness overview reachability", () => {
+	const harnesses: Harness[] = [];
+	const tempDirs: string[] = [];
+	const originalAgentDir = process.env[ENV_AGENT_DIR];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+		while (tempDirs.length > 0) {
+			rmSync(tempDirs.pop()!, { recursive: true, force: true });
+		}
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+	});
+
+	it("keeps the most recently updated entries when the per-kind cap truncates", () => {
+		const entries: HarnessEntry[] = [];
+		for (let index = 0; index < 48; index++) {
+			const letter = String.fromCharCode(97 + (index % 26));
+			const id = `mem-${String(index).padStart(3, "0")}`;
+			entries.push(
+				entry({
+					id,
+					title: `${letter}-lesson-${index}`,
+					path: `memory/${letter}/${letter}-lesson-${index}.md`,
+					content: `Older lesson ${index}.`,
+					updated_at: "2026-01-01T00:00:00.000Z",
+				}),
+			);
+		}
+		// Newest entry, highest version, but its path sorts last alphabetically.
+		entries.push(
+			entry({
+				id: "mem-new",
+				title: "workspace-resolver-fix",
+				path: "memory/w/workspace-resolver-fix.md",
+				content: "Just learned: the resolver error is caused by a stale lockfile.",
+				updated_at: "2026-08-07T12:00:00.000Z",
+				version: 7,
+			}),
+		);
+
+		const shown = renderedIds(formatHarnessStateForPrompt(stateWith(entries)));
+
+		expect(shown).toHaveLength(6);
+		expect(shown[0]).toBe("mem-new");
+	});
+
+	it("falls back to created_at and stays deterministic for entries with equal recency", () => {
+		const overview = formatHarnessStateForPrompt(
+			stateWith([
+				entry({ id: "zeta", path: "z", updated_at: "not-a-date", created_at: "2026-05-01T00:00:00.000Z" }),
+				entry({ id: "alpha", path: "a", updated_at: "not-a-date", created_at: "2026-01-01T00:00:00.000Z" }),
+				entry({ id: "tie-b", path: "m", updated_at: "2026-03-01T00:00:00.000Z", version: 2 }),
+				entry({ id: "tie-a", path: "m", updated_at: "2026-03-01T00:00:00.000Z", version: 9 }),
+			]),
+		);
+
+		// zeta/alpha have unparseable updated_at, so created_at orders them; tie-a and
+		// tie-b share a timestamp and are ordered by version.
+		expect(renderedIds(overview)).toEqual(["zeta", "tie-a", "tie-b", "alpha"]);
+	});
+
+	it("names the call that reads the entries the cap hid", () => {
+		const entries = Array.from({ length: 10 }, (_, index) => entry({ id: `mem-${index}` }));
+
+		const withIpython = formatHarnessStateForPrompt(stateWith(entries), { includeIpythonExamples: true });
+		expect(withIpython).toContain("+4 more memory entries not shown");
+		expect(withIpython).toContain('rlm.harness.list("memory")');
+		expect(withIpython).toContain('rlm.harness.list("memory", global_=True)');
+
+		const withoutIpython = formatHarnessStateForPrompt(stateWith(entries), { includeIpythonExamples: false });
+		expect(withoutIpython).toContain("+4 more memory entries not shown");
+		expect(withoutIpython).toContain("harnessOverview.maxEntriesPerKind");
+		expect(withoutIpython).not.toContain("rlm.harness.list");
+	});
+
+	it("clamps out-of-range overview budgets instead of trusting them", () => {
+		const entries = Array.from({ length: 3 }, (_, index) => entry({ id: `mem-${index}` }));
+
+		expect(renderedIds(formatHarnessStateForPrompt(stateWith(entries), { maxEntriesPerKind: -5 }))).toEqual([]);
+		expect(
+			renderedIds(formatHarnessStateForPrompt(stateWith(entries), { maxEntriesPerKind: Number.NaN })),
+		).toHaveLength(3);
+		expect(renderedIds(formatHarnessStateForPrompt(stateWith(entries), { maxEntriesPerKind: 10_000 }))).toHaveLength(
+			3,
+		);
+
+		const clampedContent = formatHarnessStateForPrompt(
+			stateWith([entry({ id: "long", content: "abcdefghijklmnopqrstuvwxyz".repeat(10) })]),
+			{ maxContentLength: 1 },
+		);
+		// Below the floor the clamp applies, so the body is still readable.
+		expect(clampedContent).toContain("abcdefghijklmnopqrstuvwxyz");
+	});
+
+	it("reads harnessOverview from settings", () => {
+		const settings = SettingsManager.inMemory({
+			harnessOverview: { maxEntriesPerKind: 25, maxContentLength: 400 },
+		});
+
+		expect(settings.getHarnessOverviewSettings()).toEqual({ maxEntriesPerKind: 25, maxContentLength: 400 });
+		expect(SettingsManager.inMemory().getHarnessOverviewSettings()).toEqual({
+			maxEntriesPerKind: undefined,
+			maxContentLength: undefined,
+		});
+	});
+
+	it("applies harnessOverview to the built system prompt", () => {
+		const entries = Array.from({ length: 12 }, (_, index) => entry({ id: `mem-${index}` }));
+
+		const defaults = buildSystemPrompt({ cwd: process.cwd(), harnessState: stateWith(entries) });
+		expect(renderedIds(defaults)).toHaveLength(6);
+
+		const widened = buildSystemPrompt({
+			cwd: process.cwd(),
+			harnessState: stateWith(entries),
+			harnessOverview: { maxEntriesPerKind: 12 },
+		});
+		expect(renderedIds(widened)).toHaveLength(12);
+		expect(widened).not.toContain("more memory entries not shown");
+	});
+
+	it("carries the setting into a live session's system prompt", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-819-agent-"));
+		tempDirs.push(agentDir);
+		process.env[ENV_AGENT_DIR] = agentDir;
+
+		const entries: HarnessEntry[] = [];
+		for (let index = 0; index < 12; index++) {
+			entries.push(entry({ id: `mem-${String(index).padStart(2, "0")}`, path: `memory/${index}` }));
+		}
+		saveHarnessState(getGlobalHarnessStateDir(agentDir), stateWith(entries));
+
+		const harness = await createHarness({ settings: { harnessOverview: { maxEntriesPerKind: 12 } } });
+		harnesses.push(harness);
+
+		expect(renderedIds(harness.session.systemPrompt)).toHaveLength(12);
+	});
+});

--- a/prime-agent-runtime/src/rlm/harness.py
+++ b/prime-agent-runtime/src/rlm/harness.py
@@ -422,7 +422,20 @@ class HarnessState:
         self.save()
         return True
 
-    def list(self, kind: HarnessKind | None = None, *, global_: bool = False, **kwargs: Any) -> list[HarnessEntry]:
+    def list(
+        self,
+        kind: HarnessKind | None = None,
+        *,
+        global_: bool = False,
+        include_global: bool = False,
+        **kwargs: Any,
+    ) -> list[HarnessEntry]:
+        """Entries in this store, optionally merged with the global store.
+
+        ``include_global=True`` returns the same union the host builds this session's
+        system prompt from, so a spawned child can read every entry its prompt was
+        derived from in one call. ``global_=True`` still reads the global store alone.
+        """
         if target := self._global_target(global_, kwargs):
             return target.list(kind)
         self._sync_from_disk()
@@ -432,7 +445,24 @@ class HarnessState:
             if current_kind not in self.entries:
                 raise ValueError(f"unknown harness kind {current_kind!r}; expected one of {_KINDS}")
             records.extend(self.entries[current_kind].values())
+        if include_global and (global_state := self._global_peer()) is not None:
+            local_keys = {(entry.kind, entry.id) for entry in records}
+            records.extend(
+                entry for entry in global_state.list(kind) if (entry.kind, entry.id) not in local_keys
+            )
         return sorted(records, key=lambda entry: (entry.kind, entry.path, entry.title, entry.id))
+
+    def _global_peer(self) -> "HarnessState | None":
+        """The global store, when it exists and is not this store itself."""
+        if self.scope == "global":
+            return None
+        try:
+            target = get_harness_state(state_dir=self._global_target_state_dir, global_=True)
+        except (OSError, RuntimeError):
+            return None
+        if self.file_path is not None and target.file_path == self.file_path:
+            return None
+        return target
 
     def create(
         self,
@@ -718,10 +748,23 @@ class HarnessState:
             plan.append(f"Immediate validation step: {next_step}")
         return plan
 
-    def overview(self, *, max_entries_per_kind: int = 20, global_: bool = False, **kwargs: Any) -> str:
+    def overview(
+        self,
+        *,
+        max_entries_per_kind: int = 20,
+        global_: bool = False,
+        include_global: bool = False,
+        **kwargs: Any,
+    ) -> str:
         if target := self._global_target(global_, kwargs):
             return target.overview(max_entries_per_kind=max_entries_per_kind)
         self._sync_from_disk()
+        if include_global and (peer := self._global_peer()) is not None:
+            body = self._overview_body(max_entries_per_kind, include_global_pointer=False)
+            return f"{body}\n\n{peer.overview(max_entries_per_kind=max_entries_per_kind)}"
+        return self._overview_body(max_entries_per_kind)
+
+    def _overview_body(self, max_entries_per_kind: int, *, include_global_pointer: bool = True) -> str:
         lines = [
             f"Harness state ({self.scope}): {self.file_path}",
             "Call contract: installed Python skills use await <skill_import>(...) or a matching shell CLI; "
@@ -765,7 +808,29 @@ class HarnessState:
                 lines.append(f"  - [{event.id}] {event.trigger}: {', '.join(event.changes)}")
         else:
             lines.append("refinements: 0")
+        if include_global_pointer:
+            lines.extend(self._global_pointer_lines())
         return "\n".join(lines)
+
+    def _global_pointer_lines(self) -> list[str]:
+        """Name the global store from a local overview.
+
+        A spawned child starts with an empty local store while its system prompt was
+        built from the merged local + global state. Without this pointer the first
+        thing such a child reads is an empty overview that never mentions the global
+        store exists, so it concludes the harness is empty.
+        """
+        peer = self._global_peer()
+        if peer is None:
+            return []
+        peer._sync_from_disk()
+        counts = ", ".join(f"{kind}: {len(peer.entries[kind])}" for kind in _KINDS)
+        return [
+            f"global store (not listed above): {peer.file_path}",
+            f"  {counts}, refinements: {len(peer.refinements)}",
+            "  read it with overview(global_=True), list(<kind>, global_=True), or get(<kind>, 'global:<id>'); "
+            "pass include_global=True to overview()/list() for the merged view this session's system prompt was built from",
+        ]
 
     def snapshot(self, *, global_: bool = False, **kwargs: Any) -> dict[str, Any]:
         if target := self._global_target(global_, kwargs):

--- a/prime-agent-runtime/test/test_harness.py
+++ b/prime-agent-runtime/test/test_harness.py
@@ -917,6 +917,98 @@ class HarnessStateTest(unittest.TestCase):
             self.assertEqual(event.changes, ["single change"])
             self.assertEqual(state.refinements[0].changes, ["single change"])
 
+    def test_local_overview_points_at_the_global_store(self) -> None:
+        # Regression for #819: a spawned child starts with an empty local store while
+        # its system prompt was built from the merged local + global state. The local
+        # overview must name the global store, its counts, and how to read it.
+        previous_global = os.environ.get("RLM_GLOBAL_HARNESS_STATE_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            global_dir = Path(temp_dir) / "global"
+            os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = str(global_dir)
+            try:
+                global_state = HarnessState(global_dir / "harness_state.json", scope="global")
+                global_state.create_memory("Durable lesson", "global content", id="durable_lesson")
+
+                child = HarnessState(Path(temp_dir) / "child" / "harness_state.json")
+                overview = child.overview()
+
+                self.assertIn("Harness state (local)", overview)
+                self.assertIn("global store (not listed above)", overview)
+                self.assertIn(str(global_dir), overview)
+                self.assertIn("memory: 1", overview)
+                self.assertIn("list(<kind>, global_=True)", overview)
+                self.assertIn("include_global=True", overview)
+
+                # The global overview itself must not point at itself.
+                self.assertNotIn("global store (not listed above)", global_state.overview())
+            finally:
+                if previous_global is None:
+                    os.environ.pop("RLM_GLOBAL_HARNESS_STATE_DIR", None)
+                else:
+                    os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = previous_global
+
+    def test_include_global_returns_the_merged_view(self) -> None:
+        previous_global = os.environ.get("RLM_GLOBAL_HARNESS_STATE_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            global_dir = Path(temp_dir) / "global"
+            os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = str(global_dir)
+            try:
+                global_state = HarnessState(global_dir / "harness_state.json", scope="global")
+                global_state.create_memory("Global only", "global content", id="global_only")
+                global_state.create_memory("Shadowed", "global content", id="shadowed")
+
+                child = HarnessState(Path(temp_dir) / "child" / "harness_state.json")
+                child.create_memory("Shadowed", "local content", id="shadowed")
+
+                self.assertEqual([entry.id for entry in child.list("memory")], ["shadowed"])
+
+                merged = child.list("memory", include_global=True)
+                self.assertEqual(sorted(entry.id for entry in merged), ["global_only", "shadowed"])
+                # A local entry shadows the global entry with the same id, matching the
+                # host-side merge that produced the system prompt.
+                shadowed = next(entry for entry in merged if entry.id == "shadowed")
+                self.assertEqual(shadowed.content, "local content")
+                self.assertEqual(shadowed.scope, "local")
+
+                combined = child.overview(include_global=True)
+                self.assertIn("Harness state (local)", combined)
+                self.assertIn("Harness state (global)", combined)
+                self.assertIn("[global:global_only]", combined)
+
+                # global_=True still reads the global store alone.
+                self.assertEqual(
+                    sorted(entry.id for entry in child.list("memory", global_=True)),
+                    ["global_only", "shadowed"],
+                )
+            finally:
+                if previous_global is None:
+                    os.environ.pop("RLM_GLOBAL_HARNESS_STATE_DIR", None)
+                else:
+                    os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = previous_global
+
+    def test_overview_omits_global_pointer_without_a_global_store(self) -> None:
+        previous_global = os.environ.get("RLM_GLOBAL_HARNESS_STATE_DIR")
+        previous_agent_dir = os.environ.get("PRIME_AGENT_CODING_AGENT_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            shared = Path(temp_dir) / "shared" / "harness_state.json"
+            os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = str(shared.parent)
+            os.environ["PRIME_AGENT_CODING_AGENT_DIR"] = str(Path(temp_dir) / "agent")
+            try:
+                # A local store that resolves to the same file as the global store has
+                # nothing to point at.
+                state = HarnessState(shared)
+                self.assertNotIn("global store (not listed above)", state.overview())
+                self.assertEqual(state.list("memory", include_global=True), [])
+            finally:
+                if previous_global is None:
+                    os.environ.pop("RLM_GLOBAL_HARNESS_STATE_DIR", None)
+                else:
+                    os.environ["RLM_GLOBAL_HARNESS_STATE_DIR"] = previous_global
+                if previous_agent_dir is None:
+                    os.environ.pop("PRIME_AGENT_CODING_AGENT_DIR", None)
+                else:
+                    os.environ["PRIME_AGENT_CODING_AGENT_DIR"] = previous_agent_dir
+
     def test_unknown_kind_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             state = HarnessState(Path(temp_dir) / "harness_state.json")


### PR DESCRIPTION
Fixes #819.

Two defects compound so that a spawned child has no reachable path to the continual harness state its own system prompt was built from. Each is the workaround for the other, so they are fixed together.

## A. The prompt overview kept the alphabetically-first entries

`formatHarnessStateForPrompt` sorted every kind by `[path, title, id]` and kept the first 6. Which lessons reached the model was decided by how their paths happened to be spelled — a memory written seconds ago under `memory/w/...` lost its slot to 48 older entries under `memory/a/...`. The options object already accepted `maxEntriesPerKind`/`maxContentLength`, but neither production call site in `system-prompt.ts` passed them and no setting reached them, so the caps were hardcoded in practice.

- Entries are now ranked by recency: `updated_at`, falling back to `created_at` when it is unparseable, then `version`, then the old `[path, title, id]` comparison purely to break exact ties. Selection and render order are both recency-first, so the newest lesson is nearest the model and the output stays deterministic for a given state.
- A new `harnessOverview` setting (`maxEntriesPerKind`, `maxContentLength`) reaches both call sites through `SettingsManager.getHarnessOverviewSettings()` and `BuildSystemPromptOptions`. Values are clamped in `formatHarnessStateForPrompt` (0-500 entries, 40-4000 chars) so a bad settings value cannot blow up or collapse the prompt.
- `overviewForPrompt`, the refiner's own input, had the same defect in a milder form: an unordered 40-entry head slice. It now uses the same ranking, so a truncated list still shows the refiner the entries most likely to need an edit.

The overflow line was `- +42 more memory entries` while the surrounding prompt instructed the model to "inspect the underlying continual harness entry only when detail matters". It named a number and no way to act on it. It now names the call:

```
- +42 more memory entries not shown: read them with `rlm.harness.list("memory")` for this session's local store and `rlm.harness.list("memory", global_=True)` for the cross-session global store, or raise `harnessOverview.maxEntriesPerKind` in settings.json
```

Sessions without IPython get the settings half only, matching the existing `includeIpythonExamples` gating.

## B. `rlm.harness` was silent about the global store

`rlm.harness` resolves to the session-local store. For an `rlm()`-spawned child that store is new and empty, so `overview()` returns `memory: 0` — while the same child's system prompt was built from the merged global + local state and lists global entries. Nothing in the output mentioned that a global store existed, how many entries it held, or that `global_=True` reads it.

A local overview now ends with:

```
global store (not listed above): /home/u/.prime/agent/harness/harness_state.json
  prompt: 0, memory: 40, skill: 0, subagent: 0, refinements: 0
  read it with overview(global_=True), list(<kind>, global_=True), or get(<kind>, 'global:<id>'); pass include_global=True to overview()/list() for the merged view this session's system prompt was built from
```

`overview()` and `list()` also accept `include_global=True`, which returns the same union the host merges to build the prompt — local entries shadow global entries on id collision, matching `mergeHarnessStates`. The pointer is emitted only when a distinct global store resolves, so a global store never points at itself and a local store aliased onto the global file stays quiet.

Running the issue's repro B verbatim against this branch:

```
Harness state (local): /tmp/child-harness/harness_state.json
...
memory: 0
refinements: 0
global store (not listed above): /tmp/global-harness/harness_state.json
  prompt: 0, memory: 40, skill: 0, subagent: 0, refinements: 0
  read it with overview(global_=True), list(<kind>, global_=True), ...
```

## Deliberately not in scope

The issue's third observation — parent-*local* entries never reach children, while the prompt recommends local scope for session coordination — is a scope-inheritance design change rather than a reachability fix, and would need its own decision about whether a child sees a read-only view of its parent's local store. Left for a separate issue.

## Tests

`packages/coding-agent/test/suite/regressions/819-harness-overview-reachability.test.ts` (7 cases): the issue's repro A (the newest entry now renders, first, out of 49); `created_at` fallback and tie-break determinism; the overflow hint in both IPython and non-IPython prompts; clamping of negative, `NaN`, and oversized budgets; `SettingsManager` round-trip; `buildSystemPrompt` honoring the option; and an end-to-end case that writes a global harness file, boots a session with `harnessOverview.maxEntriesPerKind: 12`, and asserts the live `session.systemPrompt` renders all 12.

`prime-agent-runtime/test/test_harness.py` (3 cases): the local overview names the global store and its counts; `include_global=True` merges with local shadowing while `global_=True` still reads global alone; and no pointer is emitted when no distinct global store exists.

Verified: `npm run check` clean; `prime-agent-runtime` 38/38; `test/refinement.test.ts`, `test/system-prompt.test.ts`, `test/settings-manager.test.ts` pass except one pre-existing Windows-only path-separator assertion in `refinement.test.ts` that also fails on `main`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make continual harness state reachable from the system prompt via recency ranking and global store pointers
> - Harness overview entries in the system prompt are now ranked by recency (most-recently-updated first) instead of alphabetical path order, using new helpers in [refinement.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/889/files#diff-17b614d876315ad8ac0165562a8f07a5c4ada3b28928eb02d90f6b93a96ea91d).
> - Overflow lines now include explicit `rlm.harness.list` / `rlm.harness.overview` read instructions so agents know how to access withheld entries.
> - `rlm.harness.overview()` and `rlm.harness.list()` in [harness.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/889/files#diff-441d64dfc5d74f553c86b609beff62210693b468d021d8bded095dea768138cf) gain an `include_global=True` parameter that merges the global peer store, with local entries shadowing global ones.
> - Local overviews now append a pointer to the global store (path, per-kind counts, and read guidance) when a distinct global store exists.
> - New `harnessOverview.maxEntriesPerKind` and `harnessOverview.maxContentLength` settings are exposed via `SettingsManager` and forwarded through `buildSystemPrompt`, with clamping deferred to the formatter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7534c8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->