### PR TITLE
fix(coding-agent): defer and report heartbeat fires a busy session declines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Fixed a heartbeat fire declined by a busy session restarting the schedule from the skip time instead of staying on its original cadence ([#820](https://github.com/PrimeIntellect-ai/prime-agent/issues/820))
+- Added a coalesced count of heartbeat fires skipped since the last delivery, shown in `/heartbeat status` and the daemon job listing ([#820](https://github.com/PrimeIntellect-ai/prime-agent/issues/820))
+- Changed delivered heartbeat prompts to carry the beat number, previous delivery time, and any skipped-fire backlog ([#820](https://github.com/PrimeIntellect-ai/prime-agent/issues/820))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -156,6 +156,25 @@ await rlm_heartbeat.update(first["heartbeat"]["id"], status="pause")
 
 RLM heartbeats are distinct from the user's `/heartbeat`; the Python skill cannot replace or clear the user-owned heartbeat.
 
+### Fires that land on a busy session
+
+A fire is declined when the session is busy — streaming, compacting, retrying, running bash, or holding unfinished actions. The declined fire is re-armed on the schedule's original phase rather than restarting the interval from the moment it was declined, and every fire that comes and goes during one busy window is coalesced into a single backlog count.
+
+The next delivered beat carries that context. Each heartbeat prompt is prefixed with a `<heartbeat>` block naming the beat number, the schedule, the previous delivery time, and — when there is a backlog — how many fires were skipped and when the most recent one was:
+
+```text
+<heartbeat>
+beat 7
+schedule every 5m
+previous delivery 2026-01-01T12:05:00.000Z
+2 scheduled fires skipped while this session was busy (most recent 2026-01-01T12:15:00.000Z)
+</heartbeat>
+
+Check the deployment and report meaningful changes
+```
+
+The backlog resets once a beat is delivered. `/heartbeat status` shows it as `Missed: <n> since last run`, and the daemon job listing as `missed=<n>`.
+
 ### General schedules
 
 Schedule a one-time or recurring prompt for an addressable agent:

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -50,6 +50,11 @@ export interface AgentCronJob {
 	nextRunAt?: string;
 	lastRunAt?: string;
 	lastSkippedAt?: string;
+	/**
+	 * Scheduled fires swallowed since the last delivered run, including fires
+	 * coalesced away while the session stayed busy. Reset when a run is delivered.
+	 */
+	missedRunCount?: number;
 	lastError?: string;
 	runCount: number;
 }
@@ -111,6 +116,8 @@ interface CronJobsState {
 export const SESSION_SCHEDULED_JOBS_FILENAME = "scheduled-jobs.json";
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
+/** Upper bound on schedule steps walked while coalescing skipped fires. */
+const MAX_COALESCED_SKIPS = 10_000;
 const ONE_SECOND_MS = 1000;
 const ONE_MINUTE_MS = 60_000;
 export const DEFAULT_HEARTBEAT_SCHEDULE = "every 5m";
@@ -651,7 +658,7 @@ export class AgentCronJobStore {
 					: job.schedule.kind === "interval"
 						? nextRunAtForSchedule(job.schedule, now)
 						: undefined;
-			updated = {
+			updated = withoutMissedRunCount({
 				...job,
 				status: job.schedule.kind === "once" ? "completed" : "active",
 				nextRunAt: nextRunAt?.toISOString(),
@@ -659,7 +666,7 @@ export class AgentCronJobStore {
 				lastError,
 				runCount: job.runCount + 1,
 				updatedAt: now.toISOString(),
-			};
+			});
 			return updated;
 		});
 		if (updated) {
@@ -668,7 +675,7 @@ export class AgentCronJobStore {
 		return updated;
 	}
 
-	recordSkipResult(id: string, result: { now?: Date }): AgentCronJob | undefined {
+	recordSkipResult(id: string, result: { now?: Date; scheduledFor?: string }): AgentCronJob | undefined {
 		const now = result.now ?? new Date();
 		let updated: AgentCronJob | undefined;
 		const jobs = this.readJobs().map((job) => {
@@ -679,13 +686,8 @@ export class AgentCronJobStore {
 				updated = job;
 				return job;
 			}
-			const nextRunAt = nextRunAtForSchedule(job.schedule, now);
-			updated = {
-				...job,
-				nextRunAt: nextRunAt?.toISOString(),
-				lastSkippedAt: now.toISOString(),
-				updatedAt: now.toISOString(),
-			};
+			const { nextRunAt, missed } = rescheduleAfterSkip(job, result.scheduledFor ?? job.nextRunAt, now);
+			updated = withSkipAccounting({ ...job, nextRunAt: nextRunAt?.toISOString() }, now, missed);
 			return updated;
 		});
 		if (updated) {
@@ -729,24 +731,26 @@ export class AgentCronJobStore {
 					return job;
 				}
 				if (result.outcome === "skipped" && result.error === undefined) {
-					const nextRunAt = nextRunAtForSchedule(job.schedule, now);
-					updated = {
-						...job,
-						status: job.schedule.kind === "once" ? "completed" : job.status,
-						nextRunAt: nextRunAt?.toISOString(),
-						lastSkippedAt: now.toISOString(),
-						updatedAt: now.toISOString(),
-					};
+					const { nextRunAt, missed } = rescheduleAfterSkip(job, dispatch.scheduledFor, now);
+					updated = withSkipAccounting(
+						{
+							...job,
+							status: job.schedule.kind === "once" ? "completed" : job.status,
+							nextRunAt: nextRunAt?.toISOString(),
+						},
+						now,
+						missed,
+					);
 					return updated;
 				}
-				updated = {
+				updated = withoutMissedRunCount({
 					...job,
 					status: job.schedule.kind === "once" ? "completed" : job.status,
 					lastRunAt: now.toISOString(),
 					lastError: result.error === undefined ? undefined : errorMessage(result.error),
 					runCount: job.runCount + 1,
 					updatedAt: now.toISOString(),
-				};
+				});
 				return updated;
 			});
 			return [];
@@ -1246,7 +1250,8 @@ export function formatAgentCronJob(job: AgentCronJob): string {
 	const error = job.lastError ? ` error=${job.lastError}` : "";
 	const label = job.label ? ` label="${job.label}"` : "";
 	const skipped = job.lastSkippedAt ? ` skipped=${new Date(job.lastSkippedAt).toLocaleString()}` : "";
-	return `${job.id} ${job.status}${label} next=${next} last=${last}${skipped} runs=${job.runCount} schedule="${job.schedule.expression}" prompt="${preview}"${error}`;
+	const missed = job.missedRunCount ? ` missed=${job.missedRunCount}` : "";
+	return `${job.id} ${job.status}${label} next=${next} last=${last}${skipped}${missed} runs=${job.runCount} schedule="${job.schedule.expression}" prompt="${preview}"${error}`;
 }
 
 function consumeDeliveryOption(text: string): { deliveryMode: AgentHeartbeatDeliveryMode | undefined; rest: string } {
@@ -1490,6 +1495,54 @@ function stripMatchingQuotes(value: string): string {
 	return value;
 }
 
+/**
+ * Re-arm a job whose fire was declined, advancing from the beat that was skipped
+ * rather than from the skip time.
+ *
+ * Advancing from `now` restarted an interval schedule's phase on every skip and
+ * erased the fact that a long busy window swallowed more than one beat. Stepping
+ * the schedule forward from `scheduledFor` keeps the cadence and counts every fire
+ * that was coalesced away, so the next delivered beat can report the gap. The
+ * returned time is always strictly after `now`, so a busy session cannot make the
+ * scheduler spin on an already-due job.
+ */
+function rescheduleAfterSkip(
+	job: AgentCronJob,
+	scheduledFor: string | undefined,
+	now: Date,
+): { nextRunAt: Date | undefined; missed: number } {
+	const missedAt = scheduledFor === undefined ? undefined : Date.parse(scheduledFor);
+	if (missedAt === undefined || !Number.isFinite(missedAt)) {
+		return { nextRunAt: nextRunAtForSchedule(job.schedule, now), missed: 1 };
+	}
+	let missed = 1;
+	let next = nextRunAtForSchedule(job.schedule, new Date(missedAt));
+	for (let step = 0; next && next.getTime() <= now.getTime() && step < MAX_COALESCED_SKIPS; step++) {
+		missed++;
+		next = nextRunAtForSchedule(job.schedule, next);
+	}
+	// A pathologically short schedule against a long busy window would otherwise
+	// walk the whole gap; fall back to the plain advance and keep the count honest.
+	if (next && next.getTime() <= now.getTime()) {
+		return { nextRunAt: nextRunAtForSchedule(job.schedule, now), missed };
+	}
+	return { nextRunAt: next, missed };
+}
+
+function withSkipAccounting(job: AgentCronJob, now: Date, missed: number): AgentCronJob {
+	return {
+		...job,
+		lastSkippedAt: now.toISOString(),
+		missedRunCount: (job.missedRunCount ?? 0) + missed,
+		updatedAt: now.toISOString(),
+	};
+}
+
+function withoutMissedRunCount(job: AgentCronJob): AgentCronJob {
+	const { missedRunCount: _missedRunCount, ...rest } = job;
+	return rest;
+}
+
 function isDueJob(job: AgentCronJob, now: Date): boolean {
 	return job.status === "active" && job.nextRunAt !== undefined && Date.parse(job.nextRunAt) <= now.getTime();
 }
@@ -1584,7 +1637,9 @@ function claimDueInState(state: CronJobsState, dueAt: Date, claimedAt: Date): Ag
 			? { ...job, nextRunAt, updatedAt: claimedAt.toISOString() }
 			: withoutNextRunAt({ ...job, updatedAt: claimedAt.toISOString() });
 		if (claimedJobIds.has(job.id)) {
-			return { ...advanced, lastSkippedAt: claimedAt.toISOString() };
+			// A fire that lands while the previous dispatch is still outstanding is
+			// swallowed just like one the session declines, so it is counted the same way.
+			return withSkipAccounting(advanced, claimedAt, 1);
 		}
 		const dispatch: AgentCronDispatchRecord = {
 			id: randomUUID(),

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -161,6 +161,9 @@ export interface HeartbeatPromptDetails {
 	runCount: number;
 	nextRunAt?: string;
 	lastRunAt?: string;
+	/** Scheduled fires swallowed since the previous delivery. */
+	missedRunCount?: number;
+	lastSkippedAt?: string;
 }
 
 export interface IpythonStateRestoredDetails {
@@ -398,6 +401,29 @@ export function isCompactionOutcomeMessage(message: unknown): message is Compact
 	);
 }
 
+/**
+ * The delivered heartbeat text.
+ *
+ * `runCount`/`lastRunAt` live in the message details, which `convertToLlm` drops,
+ * so a heartbeat-driven agent could not tell "beat 3 of 3" from "beat 3 of 40" and
+ * saw no sign that fires had been swallowed while it was busy. The instruction stays
+ * last so it remains the final thing the model reads.
+ */
+export function formatHeartbeatPromptContent(job: AgentCronJob): string {
+	const facts = [
+		`beat ${job.runCount + 1}`,
+		`schedule ${job.schedule.expression}`,
+		job.lastRunAt ? `previous delivery ${job.lastRunAt}` : "first delivery",
+	];
+	const missed = job.missedRunCount ?? 0;
+	if (missed > 0) {
+		const fires = missed === 1 ? "fire" : "fires";
+		const when = job.lastSkippedAt ? ` (most recent ${job.lastSkippedAt})` : "";
+		facts.push(`${missed} scheduled ${fires} skipped while this session was busy${when}`);
+	}
+	return `<heartbeat>\n${facts.join("\n")}\n</heartbeat>\n\n${job.prompt}`;
+}
+
 export function createHeartbeatPromptMessage(
 	job: AgentCronJob,
 	timestamp = Date.now(),
@@ -405,7 +431,7 @@ export function createHeartbeatPromptMessage(
 	return {
 		role: "custom",
 		customType: HEARTBEAT_PROMPT_CUSTOM_TYPE,
-		content: job.prompt,
+		content: formatHeartbeatPromptContent(job),
 		display: true,
 		details: {
 			jobId: job.id,
@@ -414,6 +440,8 @@ export function createHeartbeatPromptMessage(
 			runCount: job.runCount,
 			nextRunAt: job.nextRunAt,
 			lastRunAt: job.lastRunAt,
+			...(job.missedRunCount ? { missedRunCount: job.missedRunCount } : {}),
+			...(job.lastSkippedAt ? { lastSkippedAt: job.lastSkippedAt } : {}),
 		},
 		timestamp,
 	};

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 publishes the missed-fire count on cron/heartbeat job rows.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-1bcb9e7f1a49";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9617,6 +9617,10 @@ export class InteractiveMode {
 			`${theme.fg("dim", "Last:")} ${last}`,
 			`${theme.fg("dim", "Runs:")} ${job.runCount}`,
 		];
+		if (job.missedRunCount) {
+			const skipped = job.lastSkippedAt ? `, most recent ${new Date(job.lastSkippedAt).toLocaleString()}` : "";
+			lines.push(`${theme.fg("dim", "Missed:")} ${job.missedRunCount} since last run${skipped}`);
+		}
 		if (job.lastError) {
 			lines.push(`${theme.fg("dim", "Error:")} ${job.lastError}`);
 		}

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1128,11 +1128,14 @@ describe("AgentCronScheduler", () => {
 		const handled = await scheduler.runDue(new Date("2026-01-01T12:39:00.000Z"));
 
 		expect(handled).toBe(0);
+		// The skipped fire was due at 12:39, so the next one stays on the original
+		// cadence at 12:44 rather than restarting the interval from the skip time.
 		expect(store.getHeartbeat("active-1")).toMatchObject({
 			id: job.id,
 			status: "active",
-			nextRunAt: "2026-01-01T12:45:00.000Z",
+			nextRunAt: "2026-01-01T12:44:00.000Z",
 			lastSkippedAt: "2026-01-01T12:40:00.000Z",
+			missedRunCount: 1,
 			runCount: 0,
 		});
 		expect(store.getHeartbeat("active-1")).not.toHaveProperty("lastRunAt");
@@ -1277,7 +1280,7 @@ describe("AgentCronScheduler", () => {
 		});
 	});
 
-	it("reschedules a skipped dispatch from the skip time", () => {
+	it("reschedules a skipped dispatch on the original cadence", () => {
 		const store = new AgentCronJobStore(makeStorePath(tempDirs));
 		const heartbeat = store.createHeartbeat({
 			activeSessionId: "active-1",
@@ -1299,8 +1302,9 @@ describe("AgentCronScheduler", () => {
 		});
 
 		expect(store.list().find((job) => job.id === heartbeat.id)).toMatchObject({
-			nextRunAt: "2026-01-01T12:34:27.000Z",
+			nextRunAt: "2026-01-01T12:34:20.000Z",
 			lastSkippedAt: "2026-01-01T12:34:17.000Z",
+			missedRunCount: 1,
 			runCount: 0,
 		});
 	});

--- a/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4482-heartbeat-injected-prompt.test.ts
@@ -5,7 +5,11 @@ import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { type AgentCronJob, shouldDeferHeartbeatCronJob } from "../../../src/core/cron-jobs.js";
 import { createGoalContextMessage, type GoalState } from "../../../src/core/goals.js";
-import { createHeartbeatPromptMessage, HEARTBEAT_PROMPT_CUSTOM_TYPE } from "../../../src/core/messages.js";
+import {
+	createHeartbeatPromptMessage,
+	formatHeartbeatPromptContent,
+	HEARTBEAT_PROMPT_CUSTOM_TYPE,
+} from "../../../src/core/messages.js";
 import {
 	InjectedPromptMessageComponent,
 	isInjectedPromptMessage,
@@ -129,11 +133,9 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 			customType: HEARTBEAT_PROMPT_CUSTOM_TYPE,
 			display: true,
 		});
-		expect(getMessageText(harness.session.messages[0])).toBe(
-			"Check whether the long-running task needs another step.",
-		);
+		expect(getMessageText(harness.session.messages[0])).toBe(formatHeartbeatPromptContent(createHeartbeat()));
 		expect(providerMessages.at(-1)).toMatchObject({ role: "user" });
-		expect(getMessageText(providerMessages.at(-1))).toBe("Check whether the long-running task needs another step.");
+		expect(getMessageText(providerMessages.at(-1))).toBe(formatHeartbeatPromptContent(createHeartbeat()));
 	});
 
 	it("runs heartbeat prompts through before_agent_start handlers", async () => {
@@ -255,7 +257,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		await promptPromise;
 
 		expect(queuedPendingContextText).toBe("pending heartbeat context");
-		expect(queuedHeartbeatText).toBe("Check whether the long-running task needs another step.");
+		expect(queuedHeartbeatText).toBe(formatHeartbeatPromptContent(createHeartbeat()));
 		expect(
 			queueEvents.some((event) =>
 				event.followUp.includes("Heartbeat prompt: Check whether the long-running task needs another step."),
@@ -303,7 +305,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		await Promise.all([ordinary, heartbeat]);
 		await harness.session.waitForIdle();
 
-		expect(providerOrder).toEqual(["ordinary first", createHeartbeat().prompt]);
+		expect(providerOrder).toEqual(["ordinary first", formatHeartbeatPromptContent(createHeartbeat())]);
 	});
 
 	it("waits for a queued-work pause before admitting a streaming heartbeat", async () => {
@@ -363,7 +365,9 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 			(context) => {
 				deliveredOrder = context.messages
 					.map(getMessageText)
-					.filter((text) => ["context A", "context B", createHeartbeat().prompt].includes(text));
+					.filter((text) =>
+						["context A", "context B", formatHeartbeatPromptContent(createHeartbeat())].includes(text),
+					);
 				return fauxAssistantMessage("heartbeat handled");
 			},
 		]);
@@ -387,7 +391,7 @@ describe("ENG-4482 heartbeat injected prompt UI", () => {
 		await originalTurn;
 		await harness.session.waitForIdle();
 
-		expect(deliveredOrder).toEqual(["context A", "context B", createHeartbeat().prompt]);
+		expect(deliveredOrder).toEqual(["context A", "context B", formatHeartbeatPromptContent(createHeartbeat())]);
 	});
 
 	it("returns raw text when clearing queued heartbeat prompts while previews remain labeled", async () => {

--- a/packages/coding-agent/test/suite/regressions/820-heartbeat-missed-beats.test.ts
+++ b/packages/coding-agent/test/suite/regressions/820-heartbeat-missed-beats.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, type Message } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type AgentCronJob,
+	AgentCronJobStore,
+	AgentCronScheduler,
+	formatAgentCronJob,
+} from "../../../src/core/cron-jobs.js";
+import { formatHeartbeatPromptContent } from "../../../src/core/messages.js";
+import { createHarness, getMessageText, type Harness } from "../harness.js";
+
+const START = new Date("2026-01-01T12:00:00.000Z");
+
+function createStore(tempDirs: string[]): AgentCronJobStore {
+	const dir = mkdtempSync(join(tmpdir(), "prime-agent-820-"));
+	tempDirs.push(dir);
+	return new AgentCronJobStore(join(dir, "cron-jobs.json"));
+}
+
+function createEveryFiveMinuteHeartbeat(store: AgentCronJobStore): AgentCronJob {
+	return store.createHeartbeat({
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		scheduleText: "every 5m",
+		prompt: "Report which heartbeat number this is and what changed since the previous one.",
+		now: START,
+	});
+}
+
+function heartbeatJob(overrides: Partial<AgentCronJob> = {}): AgentCronJob {
+	return {
+		id: "heartbeat-1",
+		status: "active",
+		source: "heartbeat",
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		prompt: "Report which heartbeat number this is and what changed since the previous one.",
+		schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+		createdAt: START.toISOString(),
+		updatedAt: START.toISOString(),
+		nextRunAt: "2026-01-01T12:05:00.000Z",
+		runCount: 0,
+		...overrides,
+	};
+}
+
+/**
+ * A heartbeat that came due while its session was busy was consumed and lost:
+ * `claimDueInState` advanced `nextRunAt` before the busy check, and the skip branch
+ * advanced it again from the skip time. Nothing counted the swallowed fires, and the
+ * delivered prompt was byte-identical on every beat, so the agent could not tell
+ * "beat 3 of 3" from "beat 3 of 40".
+ */
+describe("issue #820 heartbeat fires skipped on a busy session", () => {
+	const tempDirs: string[] = [];
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+		while (tempDirs.length > 0) {
+			rmSync(tempDirs.pop()!, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the schedule phase and counts the fire when a beat is declined", async () => {
+		const store = createStore(tempDirs);
+		const job = createEveryFiveMinuteHeartbeat(store);
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:06:30.000Z"),
+			runJob: async () => "skipped",
+		});
+
+		await scheduler.runDue(new Date("2026-01-01T12:05:00.000Z"));
+
+		expect(store.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+			// Advancing from the skipped beat (12:05) instead of the skip time (12:06:30)
+			// keeps "every 5m" on its original phase.
+			nextRunAt: "2026-01-01T12:10:00.000Z",
+			missedRunCount: 1,
+			runCount: 0,
+		});
+	});
+
+	it("coalesces every fire swallowed by a long busy window into one count", async () => {
+		const store = createStore(tempDirs);
+		const job = createEveryFiveMinuteHeartbeat(store);
+		// The beat due at 12:05 is declined 22 minutes later, so 12:10, 12:15 and 12:20
+		// also came and went while the session stayed busy.
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => new Date("2026-01-01T12:27:00.000Z"),
+			runJob: async () => "skipped",
+		});
+
+		await scheduler.runDue(new Date("2026-01-01T12:05:00.000Z"));
+
+		const skipped = store.list().find((candidate) => candidate.id === job.id);
+		expect(skipped).toMatchObject({ missedRunCount: 5, runCount: 0 });
+		// The re-armed fire is always in the future, so a busy session cannot make the
+		// scheduler spin on an already-due job.
+		expect(Date.parse(skipped!.nextRunAt!)).toBeGreaterThan(Date.parse("2026-01-01T12:27:00.000Z"));
+	});
+
+	it("accumulates across skips and clears the backlog once a beat is delivered", async () => {
+		const store = createStore(tempDirs);
+		const job = createEveryFiveMinuteHeartbeat(store);
+
+		const [firstDispatch] = store.claimDue(new Date("2026-01-01T12:05:00.000Z"));
+		store.recordDispatchResult(firstDispatch.id, {
+			now: new Date("2026-01-01T12:06:00.000Z"),
+			outcome: "skipped",
+		});
+		const [secondDispatch] = store.claimDue(new Date("2026-01-01T12:10:00.000Z"));
+		store.recordDispatchResult(secondDispatch.id, {
+			now: new Date("2026-01-01T12:11:00.000Z"),
+			outcome: "skipped",
+		});
+
+		expect(store.list().find((candidate) => candidate.id === job.id)).toMatchObject({ missedRunCount: 2 });
+
+		const [thirdDispatch] = store.claimDue(new Date("2026-01-01T12:15:00.000Z"));
+		store.recordDispatchResult(thirdDispatch.id, {
+			now: new Date("2026-01-01T12:15:30.000Z"),
+			outcome: "ran",
+		});
+
+		const delivered = store.list().find((candidate) => candidate.id === job.id);
+		expect(delivered).toMatchObject({ runCount: 1 });
+		expect(delivered).not.toHaveProperty("missedRunCount");
+	});
+
+	it("reports the backlog in the daemon job listing", () => {
+		expect(formatAgentCronJob(heartbeatJob())).not.toContain("missed=");
+		expect(
+			formatAgentCronJob(heartbeatJob({ missedRunCount: 3, lastSkippedAt: "2026-01-01T12:20:00.000Z" })),
+		).toContain("missed=3");
+	});
+
+	it("puts the beat number, previous delivery, and skipped fires in the delivered text", () => {
+		const first = formatHeartbeatPromptContent(heartbeatJob());
+		expect(first).toContain("beat 1");
+		expect(first).toContain("schedule every 5m");
+		expect(first).toContain("first delivery");
+		expect(first).not.toContain("skipped");
+		expect(first.endsWith(heartbeatJob().prompt)).toBe(true);
+
+		const later = formatHeartbeatPromptContent(
+			heartbeatJob({
+				runCount: 2,
+				lastRunAt: "2026-01-01T12:05:00.000Z",
+				missedRunCount: 2,
+				lastSkippedAt: "2026-01-01T12:15:00.000Z",
+			}),
+		);
+		expect(later).toContain("beat 3");
+		expect(later).toContain("previous delivery 2026-01-01T12:05:00.000Z");
+		expect(later).toContain("2 scheduled fires skipped while this session was busy");
+		expect(later).toContain("most recent 2026-01-01T12:15:00.000Z");
+
+		expect(formatHeartbeatPromptContent(heartbeatJob({ missedRunCount: 1 }))).toContain("1 scheduled fire skipped");
+	});
+
+	it("delivers the backlog notice to the model", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let providerMessages: Message[] = [];
+		harness.setResponses([
+			(context) => {
+				providerMessages = [...context.messages];
+				return fauxAssistantMessage("heartbeat handled");
+			},
+		]);
+
+		await harness.session.promptHeartbeat(
+			heartbeatJob({
+				runCount: 2,
+				lastRunAt: "2026-01-01T12:05:00.000Z",
+				missedRunCount: 2,
+				lastSkippedAt: "2026-01-01T12:15:00.000Z",
+			}),
+		);
+
+		const delivered = getMessageText(providerMessages.at(-1));
+		expect(delivered).toContain("beat 3");
+		expect(delivered).toContain("2 scheduled fires skipped while this session was busy");
+		expect(delivered).toContain("Report which heartbeat number this is");
+	});
+});


### PR DESCRIPTION
Fixes #820.

A heartbeat fire that lands on a busy session is currently consumed and lost, and the beats that do land carry no way to notice the gap.

## The fire is consumed before the busy check

`claimDueInState` advances `job.nextRunAt` at claim time, before `runCronJob` ever asks `shouldDeferHeartbeatCronJob`. When the session turns out to be busy, `recordDispatchResult`'s skip branch advances `nextRunAt` a *second* time, from `now`. Three consequences:

- The missed beat is never re-armed.
- An interval schedule loses its phase on every skip: `every 5m` skipped 90s late becomes `every 5m` measured from the skip, so the cadence drifts by the length of every busy check.
- A busy window spanning several beats is indistinguishable from one skipped beat. `lastSkippedAt` is a single overwritten timestamp.

`rescheduleAfterSkip` now advances from the dispatch record's `scheduledFor` — the beat that was actually skipped — and steps the schedule forward until the next fire is strictly after `now`. So:

- `every 5m` due at 12:05 and declined at 12:06:30 re-arms at **12:10**, not 12:11:30.
- The same job declined at 12:27 re-arms at 12:30 and reports **5** swallowed fires (12:05, 12:10, 12:15, 12:20, 12:25).
- Because the result is always strictly after `now`, a busy session cannot make the scheduler spin on an already-due job. Dispatch attempts stay at one per interval, exactly as today.
- The step loop is bounded (`MAX_COALESCED_SKIPS`); a pathologically short schedule against a very long busy window falls back to the plain advance while keeping the count it accumulated.

Those fires land in a new `AgentCronJob.missedRunCount`, which accumulates across skips and is cleared when a beat is delivered. All three skip paths feed it: the `recordDispatchResult` skip branch, `recordSkipResult`, and `claimDueInState`'s already-claimed branch (a fire arriving while the previous dispatch is still outstanding is swallowed the same way).

I deliberately did not make a declined beat re-fire immediately. Re-arming at the original `scheduledFor` would leave the job due while the session is still busy, and `runCronJob` declines cheaply, so it would busy-loop for the length of the busy window. Coalescing forward preserves both the user's cadence and the scheduler's load profile.

## The delivered prompt could not report any of this

`createHeartbeatPromptMessage` put `runCount`/`lastRunAt`/`nextRunAt` in `HeartbeatPromptDetails`, which `convertToLlm` drops, and set `content: job.prompt`. Every delivery was byte-identical, so a heartbeat-driven agent could not tell "beat 3 of 3" from "beat 3 of 40".

The heartbeat message content is what `convertToLlm` turns into the provider's user message, so `formatHeartbeatPromptContent` now prefixes the instruction with a compact block:

```text
<heartbeat>
beat 7
schedule every 5m
previous delivery 2026-01-01T12:05:00.000Z
2 scheduled fires skipped while this session was busy (most recent 2026-01-01T12:15:00.000Z)
</heartbeat>

Check the deployment and report meaningful changes
```

The instruction stays last so it remains the final thing the model reads, and the skipped-fires line appears only when there is a backlog. Queue previews and `clearQueue()` are unaffected — they read the prompt text passed to `_promptInjectedMessage`, which is still the bare instruction, so `Heartbeat prompt: <instruction>` renders exactly as before.

## Human-visible surfaces

`/heartbeat status` gained `Missed: <n> since last run, most recent <date>`; previously it showed nothing about skips at all. `formatAgentCronJob` gained `missed=<n>` alongside the existing `skipped=<date>`.

## Daemon protocol

`DaemonCronJob` is an alias of `AgentCronJob`, so `missedRunCount` is published on cron/heartbeat job rows. That is an additive change on an existing response shape — a new daemon's extra field is ignored by an old client, and a new client renders nothing when an old daemon omits it — matching revisions 9/10/12, which also published new fields. `DAEMON_SCHEMA_REVISION` moves to 16 with a matching comment and `DAEMON_SCHEMA_ID` (14 was taken by the telemetry opt-out in #521 and 15 by the queued-message mutation command in #838, both of which landed while this was open; rebased onto each in turn). The schema digest is unchanged from `main` because it hashes the `daemon-protocol.ts` wire-type source, which this PR does not touch. The schema digest hashes the `daemon-protocol.ts` wire-type source only, so it is unchanged; `test/daemon-protocol.test.ts` verifies the identity stays synchronized.

## Tests

New: `packages/coding-agent/test/suite/regressions/820-heartbeat-missed-beats.test.ts` (6 cases) — phase preservation on a declined beat, coalescing five fires across a 22-minute busy window with the re-armed fire proven to be in the future, accumulation across two skips followed by a delivery that clears the backlog, `missed=` in the daemon listing, the composed prompt text in first-delivery/backlog/singular forms, and an end-to-end case asserting the model actually receives the backlog notice.

Updated (intentional behavior changes, not relaxations):

- `test/cron-jobs.test.ts` — two tests asserted the drifting reschedule. One is renamed from "reschedules a skipped dispatch from the skip time" to "...on the original cadence"; both now also assert `missedRunCount`.
- `test/suite/regressions/4482-heartbeat-injected-prompt.test.ts` — four assertions compared the delivered text to the bare instruction; they now compare against `formatHeartbeatPromptContent`. The queue-preview and `clearQueue` assertions were left untouched and still pass, which is the check that previews stayed clean.

Verified: `npm run check` clean; `cron-jobs`, `daemon-protocol`, `daemon-client`, `agent-connection-daemon`, `messages`, `4482`, and the new suite pass (180 + 6). `daemon-mode.test.ts` has 5 failures on this Windows machine (unix-socket bind and symlink cases) that reproduce identically on a clean `main` worktree.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix heartbeat cron jobs to preserve schedule cadence and track missed fires on busy session declines
> - When a heartbeat fire is declined (session busy), the scheduler now re-arms from the original scheduled beat rather than the skip time, preserving the schedule phase.
> - Missed fires during a busy window are coalesced into a `missedRunCount` on the job, reset to zero on the next successful delivery.
> - Delivered heartbeat prompts include a `<heartbeat>` block with beat number, schedule expression, previous delivery time, and a missed-fire summary when backlog exists.
> - `missed=<n>` appears in daemon job listings and the interactive `/heartbeat status` view when there is a backlog.
> - Behavioral Change: `recordSkipResult` and `recordDispatchResult` in [`cron-jobs.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/890/files#diff-fb783dad61580c3b11d0731df2a325b6e3dd852fc430a309a5f3ae7ebcc826dd) now advance `nextRunAt` along the original cadence instead of from the skip time; daemon schema bumped to revision 17.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d101619.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->