### PR TITLE
feat(coding-agent): report in-flight tool-call progress in agent_observe

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ## [0.7.2] - 2026-08-11
+- Added `AgentState.pendingToolCallStartedAt`, recording when each in-flight tool call started so observers can measure how long one has been running.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,15 +57,24 @@ const DEFAULT_MODEL = {
 
 type QueueMode = "all" | "one-at-a-time";
 
-type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "pendingToolCalls" | "errorMessage"> & {
+type MutableAgentState = Omit<
+	AgentState,
+	"isStreaming" | "streamingMessage" | "pendingToolCalls" | "pendingToolCallStartedAt" | "errorMessage"
+> & {
 	isStreaming: boolean;
 	streamingMessage?: AgentMessage;
 	pendingToolCalls: Set<string>;
+	pendingToolCallStartedAt: Map<string, number>;
 	errorMessage?: string;
 };
 
 function createMutableAgentState(
-	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>,
+	initialState?: Partial<
+		Omit<
+			AgentState,
+			"pendingToolCalls" | "pendingToolCallStartedAt" | "isStreaming" | "streamingMessage" | "errorMessage"
+		>
+	>,
 ): MutableAgentState {
 	let tools = initialState?.tools?.slice() ?? [];
 	let messages = initialState?.messages?.slice() ?? [];
@@ -90,13 +99,19 @@ function createMutableAgentState(
 		isStreaming: false,
 		streamingMessage: undefined,
 		pendingToolCalls: new Set<string>(),
+		pendingToolCallStartedAt: new Map<string, number>(),
 		errorMessage: undefined,
 	};
 }
 
 /** Options for constructing an {@link Agent}. */
 export interface AgentOptions {
-	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>;
+	initialState?: Partial<
+		Omit<
+			AgentState,
+			"pendingToolCalls" | "pendingToolCallStartedAt" | "isStreaming" | "streamingMessage" | "errorMessage"
+		>
+	>;
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	streamFn?: StreamFn;
@@ -342,6 +357,7 @@ export class Agent {
 		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;
 		this._state.pendingToolCalls = new Set<string>();
+		this._state.pendingToolCallStartedAt = new Map<string, number>();
 		this._state.errorMessage = undefined;
 		this.clearFollowUpQueue();
 		this.clearSteeringQueue();
@@ -551,6 +567,7 @@ export class Agent {
 		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;
 		this._state.pendingToolCalls = new Set<string>();
+		this._state.pendingToolCallStartedAt = new Map<string, number>();
 		this.activeRun?.resolve();
 		this.activeRun = undefined;
 	}
@@ -581,6 +598,10 @@ export class Agent {
 				const pendingToolCalls = new Set(this._state.pendingToolCalls);
 				pendingToolCalls.add(event.toolCallId);
 				this._state.pendingToolCalls = pendingToolCalls;
+				// Start times let an observer distinguish a fast call from a wedged one.
+				const startedAt = new Map(this._state.pendingToolCallStartedAt);
+				startedAt.set(event.toolCallId, Date.now());
+				this._state.pendingToolCallStartedAt = startedAt;
 				break;
 			}
 
@@ -588,6 +609,9 @@ export class Agent {
 				const pendingToolCalls = new Set(this._state.pendingToolCalls);
 				pendingToolCalls.delete(event.toolCallId);
 				this._state.pendingToolCalls = pendingToolCalls;
+				const startedAt = new Map(this._state.pendingToolCallStartedAt);
+				startedAt.delete(event.toolCallId);
+				this._state.pendingToolCallStartedAt = startedAt;
 				break;
 			}
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -340,6 +340,12 @@ export interface AgentState {
 	readonly streamingMessage?: AgentMessage;
 	/** Tool call ids currently executing. */
 	readonly pendingToolCalls: ReadonlySet<string>;
+	/**
+	 * Epoch milliseconds at which each in-flight tool call started executing.
+	 * Keyed by the same ids as {@link pendingToolCalls}, so an observer can tell a
+	 * call that started three seconds ago from one that has been blocked for an hour.
+	 */
+	readonly pendingToolCallStartedAt: ReadonlyMap<string, number>;
 	/** Error message from the most recent failed or aborted assistant turn, if any. */
 	readonly errorMessage?: string;
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Added in-flight tool-call count and elapsed time to `agent_observe` summaries, so an orchestrator can tell a child in a fast tool call from one wedged in a blocking call ([#822](https://github.com/PrimeIntellect-ai/prime-agent/issues/822))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -28,16 +28,44 @@ if child is not None:
 
 - `await agent_observe.list_agents()` returns `current` and `agents`. Each
   agent includes active session id, session id, optional name, runtime kind,
-  cwd, status, streaming state, message count, pending count, and a latest
-  message preview. The list is restricted to self, parent, siblings, and direct
-  children. For direct children, `await rlm.list_subagents()` also exposes
-  parent-owned lifecycle handles.
+  cwd, status, streaming state, message count, pending count, in-flight
+  tool-call progress, and a latest message preview. The list is restricted to
+  self, parent, siblings, and direct children. For direct children,
+  `await rlm.list_subagents()` also exposes parent-owned lifecycle handles.
 - `await agent_observe.get_agent(target)` returns `agent`, where `agent`
   contains one agent summary. `target` is resolved like other live-session
   selectors: active id, session id/name, or unambiguous suffix.
 - `await agent_observe.recent_messages(target, limit=8, max_chars=800)`
   returns up to `limit` recent bounded message previews for the target session.
   `limit` must be 1-50, and `max_chars` must be 80-2000.
+
+## Detecting a wedged child
+
+`status` is `"tool"` whenever a tool call is in flight, which is true of a child
+three seconds into a fast command and a child forty minutes into a blocked one.
+Every summary also carries the time dimension:
+
+- `pendingToolCallCount`: tool calls executing right now.
+- `oldestPendingToolCallStartedAt`: epoch milliseconds at which the
+  longest-running one started. Absent when nothing is in flight.
+- `pendingToolCallElapsedMs`: how long that call has been running, measured when
+  the summary was built.
+
+The `bash` tool's `timeout` is optional with no default, so a call that blocks
+indefinitely is ordinary behaviour rather than an error path. Write the policy
+against elapsed time:
+
+```python
+snapshot = await agent_observe.get_agent(handle.name)
+agent = snapshot["agent"]
+stuck_for = agent.get("pendingToolCallElapsedMs") or 0
+if agent["status"] == "tool" and stuck_for > 10 * 60 * 1000:
+    await agent_message.send(
+        "You have been in one tool call for over ten minutes. Report what it is waiting on.",
+        receiver_role="child",
+        receiver_name=handle.name,
+    )
+```
 
 ## Safety
 

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -18,6 +18,16 @@ export interface AgentObserveAgentSummary {
 	messageCount: number;
 	queuedCount: number;
 	isSessionActive: boolean;
+	/**
+	 * Tool calls the observed agent is executing right now. `status: "tool"` says a
+	 * call is in flight but not how many or for how long, so a child three seconds
+	 * into a bash call and a child forty minutes into a blocked one looked identical.
+	 */
+	pendingToolCallCount: number;
+	/** Epoch ms at which the longest-running in-flight tool call started. */
+	oldestPendingToolCallStartedAt?: number;
+	/** How long that call has been running, measured when the summary was built. */
+	pendingToolCallElapsedMs?: number;
 	parentActiveSessionId?: string;
 	parentSessionId?: string;
 	rlmChildId?: string;
@@ -86,6 +96,36 @@ export function createAgentObserveHostHandlers(controller: AgentObserveControlle
 				maxChars: normalizeOptionalInteger(payload.max_chars ?? payload.maxChars, "agent_observe.recent max_chars"),
 			})) as unknown as Record<string, unknown>;
 		},
+	};
+}
+
+/**
+ * Progress fields for an observed agent's in-flight tool calls. Both the start
+ * timestamp and the elapsed duration are reported: elapsed is what a "treat a child
+ * stuck for more than N minutes as wedged" policy reads directly, while the
+ * timestamp lets a caller recompute against its own clock or across two polls.
+ */
+export function summarizeInFlightToolCalls(
+	startedAt: ReadonlyMap<string, number>,
+	now = Date.now(),
+): Pick<
+	AgentObserveAgentSummary,
+	"pendingToolCallCount" | "oldestPendingToolCallStartedAt" | "pendingToolCallElapsedMs"
+> {
+	let oldest: number | undefined;
+	for (const value of startedAt.values()) {
+		if (oldest === undefined || value < oldest) {
+			oldest = value;
+		}
+	}
+	if (oldest === undefined) {
+		return { pendingToolCallCount: startedAt.size };
+	}
+	return {
+		pendingToolCallCount: startedAt.size,
+		oldestPendingToolCallStartedAt: oldest,
+		// A clock that moved backwards must not report a negative duration.
+		pendingToolCallElapsedMs: Math.max(0, now - oldest),
 	};
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -75,6 +75,7 @@ import {
 	createAgentObserveMessagePreview,
 	normalizeObserveLimit,
 	normalizeObserveMaxChars,
+	summarizeInFlightToolCalls,
 } from "../../core/agent-observe.js";
 import { type AgentSession, type PromptOptions, rlmChildLabel } from "../../core/agent-session.js";
 import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
@@ -2890,6 +2891,8 @@ export class AgentDaemon {
 				messageCount: passive.info.messageCount,
 				queuedCount: 0,
 				isSessionActive: false,
+				// A passive subagent has no live agent, so nothing is in flight.
+				pendingToolCallCount: 0,
 				...(passive.chain.length === 1 && passive.rootParentState
 					? { parentActiveSessionId: passive.rootParentState.activeSessionId }
 					: {}),
@@ -2971,6 +2974,7 @@ export class AgentDaemon {
 			messageCount: summary.messageCount,
 			queuedCount: summary.sessionActions.queuedCount,
 			isSessionActive: summary.isSessionActive,
+			...summarizeInFlightToolCalls(session.state.pendingToolCallStartedAt),
 			...(summary.parentActiveSessionId ? { parentActiveSessionId: summary.parentActiveSessionId } : {}),
 			...(summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
 			...(summary.rlmChildId ? { rlmChildId: summary.rlmChildId } : {}),

--- a/packages/coding-agent/test/agent-session-services.test.ts
+++ b/packages/coding-agent/test/agent-session-services.test.ts
@@ -251,6 +251,7 @@ describe("createAgentSessionFromServices", () => {
 					messageCount: 0,
 					queuedCount: 0,
 					isSessionActive: false,
+					pendingToolCallCount: 0,
 				},
 				agents: [],
 			}),

--- a/packages/coding-agent/test/suite/agent-session-observe.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-observe.test.ts
@@ -17,6 +17,7 @@ function createController(): AgentObserveController {
 				messageCount: 1,
 				queuedCount: 0,
 				isSessionActive: false,
+				pendingToolCallCount: 0,
 			},
 			agents: [],
 		})),
@@ -33,6 +34,7 @@ function createController(): AgentObserveController {
 				messageCount: 3,
 				queuedCount: 0,
 				isSessionActive: false,
+				pendingToolCallCount: 0,
 			},
 		})),
 		recentMessages: vi.fn((input) => ({
@@ -48,6 +50,7 @@ function createController(): AgentObserveController {
 				messageCount: 3,
 				queuedCount: 0,
 				isSessionActive: false,
+				pendingToolCallCount: 0,
 			},
 			messages: [{ index: 2, role: "assistant", text: "working", truncated: false }],
 			limit: input.limit ?? 8,

--- a/packages/coding-agent/test/suite/regressions/822-agent-observe-tool-elapsed.test.ts
+++ b/packages/coding-agent/test/suite/regressions/822-agent-observe-tool-elapsed.test.ts
@@ -1,0 +1,117 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { summarizeInFlightToolCalls } from "../../../src/core/agent-observe.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function blockingTool(name: string, release: Promise<void>): AgentTool {
+	return {
+		name,
+		label: name,
+		description: "Blocks until the test releases it",
+		parameters: Type.Object({}),
+		execute: async () => {
+			await release;
+			return { content: [{ type: "text", text: "released" }], details: {} };
+		},
+	};
+}
+
+/**
+ * `agent_observe` reported that a child was executing a tool call but never for how
+ * long, so a child three seconds into a fast command and a child forty minutes into a
+ * blocked one produced byte-identical summaries. The `bash` tool's timeout is optional
+ * with no default, so an indefinitely blocking call is ordinary behaviour.
+ */
+describe("issue #822 agent_observe in-flight tool call progress", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("reports nothing in flight for an empty map", () => {
+		expect(summarizeInFlightToolCalls(new Map())).toEqual({ pendingToolCallCount: 0 });
+	});
+
+	it("measures elapsed time from the longest-running call", () => {
+		const now = 1_800_000_000_000;
+		const summary = summarizeInFlightToolCalls(
+			new Map([
+				["call-recent", now - 3_000],
+				["call-oldest", now - 2_400_000],
+				["call-middle", now - 60_000],
+			]),
+			now,
+		);
+
+		expect(summary).toEqual({
+			pendingToolCallCount: 3,
+			oldestPendingToolCallStartedAt: now - 2_400_000,
+			pendingToolCallElapsedMs: 2_400_000,
+		});
+	});
+
+	it("never reports a negative duration when the clock moves backwards", () => {
+		const summary = summarizeInFlightToolCalls(new Map([["call", 2_000]]), 1_000);
+
+		expect(summary.pendingToolCallElapsedMs).toBe(0);
+	});
+
+	it("tracks start times across tool execution and clears them when the run ends", async () => {
+		let releaseFirst = () => {};
+		let releaseSecond = () => {};
+		const first = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const second = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+		const harness = await createHarness({
+			tools: [blockingTool("slow", first), blockingTool("slower", second)],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("slow", {}), fauxToolCall("slower", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		const sawBothStart = new Promise<void>((resolve) => {
+			let started = 0;
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start" && ++started === 2) {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		const before = Date.now();
+		const turn = harness.session.prompt("start");
+		await sawBothStart;
+
+		const state = harness.session.agent.state;
+		expect(state.pendingToolCallStartedAt.size).toBe(2);
+		expect([...state.pendingToolCallStartedAt.keys()].sort()).toEqual([...state.pendingToolCalls].sort());
+		for (const startedAt of state.pendingToolCallStartedAt.values()) {
+			expect(startedAt).toBeGreaterThanOrEqual(before);
+		}
+
+		const inFlight = summarizeInFlightToolCalls(state.pendingToolCallStartedAt);
+		expect(inFlight.pendingToolCallCount).toBe(2);
+		expect(inFlight.pendingToolCallElapsedMs).toBeGreaterThanOrEqual(0);
+
+		releaseFirst();
+		releaseSecond();
+		await turn;
+		await harness.session.waitForIdle();
+
+		expect(harness.session.agent.state.pendingToolCallStartedAt.size).toBe(0);
+		expect(summarizeInFlightToolCalls(harness.session.agent.state.pendingToolCallStartedAt)).toEqual({
+			pendingToolCallCount: 0,
+		});
+	});
+});


### PR DESCRIPTION
Fixes #822.

`agent_observe` told an orchestrator *that* a child was executing a tool call, never *how long*. `AgentObserveAgentSummary` collapsed the whole in-flight set into `status: "tool"` — no count, no start time, no duration — so a child three seconds into a fast `bash` call and a child forty minutes into one blocked on a subprocess that never exits produced byte-identical summaries. Since `bash`'s `timeout` is optional with no default, an indefinitely blocking call is ordinary behaviour rather than an error path, and there was no way to write "treat a child stuck in one tool call for more than N minutes as wedged" against the API.

## The time dimension did not exist

`AgentState` tracked `pendingToolCalls` as a bare `Set<string>` of ids; nothing anywhere recorded when a call started, so this could not be fixed in the coding-agent alone.

`packages/agent` now keeps `AgentState.pendingToolCallStartedAt: ReadonlyMap<string, number>` alongside it — populated in the `tool_execution_start` reducer, removed in `tool_execution_end`, and cleared by `reset()` and `finishRun()` exactly where `pendingToolCalls` is. It is replaced rather than mutated in place, matching how the existing set is updated, so snapshot readers keep seeing a stable value. It joins the `Omit` lists that keep runtime-owned state out of `initialState`, so it cannot be seeded from the outside.

## What summaries now carry

Every `AgentObserveAgentSummary` gains:

- `pendingToolCallCount` — tool calls executing right now. Required, so a caller can always branch on it. A passive (non-resident) subagent has no live agent and reports `0`.
- `oldestPendingToolCallStartedAt` — epoch ms of the longest-running in-flight call. Absent when nothing is in flight.
- `pendingToolCallElapsedMs` — how long that call has been running, measured when the summary was built.

Both the timestamp and the duration are reported deliberately: elapsed is what a policy reads directly, while the timestamp lets a caller recompute against its own clock or diff across two polls without trusting the daemon's wall clock. `summarizeInFlightToolCalls` is a small exported pure function so all three fields have one definition and one test surface, and it clamps elapsed at `0` rather than reporting a negative duration if the clock moves backwards.

The Python `agent_observe` skill passes host payloads through unchanged, so the fields are available from the kernel with no skill change. `SKILL.md` documents them with the policy this issue asks for:

```python
snapshot = await agent_observe.get_agent(handle.name)
agent = snapshot["agent"]
stuck_for = agent.get("pendingToolCallElapsedMs") or 0
if agent["status"] == "tool" and stuck_for > 10 * 60 * 1000:
    await agent_message.send(
        "You have been in one tool call for over ten minutes. Report what it is waiting on.",
        receiver_role="child",
        receiver_name=handle.name,
    )
```

## Scope

`status` was already correct for a wedged child — it reports `"tool"`, and `latestMessage.toolCalls` names the tools — so nothing about status classification changed. This adds only the missing time and count.

No daemon schema revision: `AgentObserveAgentSummary` is carried inside `agent_observe.*` host-bridge results, not the daemon command/event wire types the schema id covers.

## Tests

`packages/coding-agent/test/suite/regressions/822-agent-observe-tool-elapsed.test.ts` (4 cases): the empty case reports a zero count and no timestamps; a three-call map picks the *oldest* start rather than the most recent and derives elapsed from it; a backwards clock yields `0` rather than a negative; and a live-session case runs two tools that block until released, asserting the tracked ids match `pendingToolCalls` exactly, that the recorded starts are not earlier than the moment the turn began, that both calls are counted concurrently, and that the map is empty again once the run finishes.

Three existing controller fixtures construct summaries by hand and were updated for the now-required count.

Verified: `npm run check` clean; `packages/agent` full suite 69/69; `agent-session-observe`, `agent-session-services`, and the new suite 9/9.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report in-flight tool-call progress in `agent_observe` summaries
> - Adds `pendingToolCallStartedAt` (a `ReadonlyMap<string, number>`) to `AgentState` in [types.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/891/files#diff-a882de319ec56787d70c4545d2d565440cb96de1b96bac234f4605144969c825), recording epoch-ms start times for each active tool call alongside the existing `pendingToolCalls` set.
> - Introduces `summarizeInFlightToolCalls` in [agent-observe.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/891/files#diff-cbcb012ae0b9420e72441c880504a42316b1c46d476747795b63c9d4aa7574c1) which computes `pendingToolCallCount`, `oldestPendingToolCallStartedAt`, and `pendingToolCallElapsedMs` from the map.
> - Spreads those fields into live agent summaries returned by `agent_observe` list/summary calls; passive subagents report `pendingToolCallCount: 0`.
> - Adds a regression test suite in [822-agent-observe-tool-elapsed.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/891/files#diff-15e5eec0fa7fd10cea1dcd0320273f30793e0983f2977da43a52bc7fc71c8182) covering empty maps, clock skew, and integration with session state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8675661.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->