### PR TITLE
fix(coding-agent): keep retried agent messages on one supervisor journal key

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Fixed a retried agent message delivering duplicate steering prompts when the transport failed after the supervisor had already accepted it ([#821](https://github.com/PrimeIntellect-ai/prime-agent/issues/821))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -6,10 +6,12 @@ import {
 	createDaemonCommandEnvelope,
 	DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION,
 	DAEMON_PROTOCOL_VERSION,
+	type DaemonClientId,
 	type DaemonClosingReason,
 	type DaemonCommand,
 	type DaemonCommandCompatibility,
 	type DaemonCommandEnvelope,
+	type DaemonCommandId,
 	type DaemonOutbound,
 	type DaemonProtocolVersion,
 	type DaemonRequestProgress,
@@ -34,6 +36,24 @@ export type DaemonClientProgressListener = (message: DaemonRequestProgress) => v
 
 export interface DaemonClientRequestOptions {
 	onProgress?: DaemonClientProgressListener;
+	/**
+	 * Wire id for this command, overriding the per-instance counter.
+	 *
+	 * The supervisor keys its command journal on [clientId, commandId], so a caller
+	 * that retries a mutating command across separate client instances must present
+	 * the same pair on every attempt for the retry to be recognized as a duplicate
+	 * rather than executed again.
+	 */
+	commandId?: DaemonCommandId;
+}
+
+export interface DaemonClientOptions {
+	/**
+	 * Protocol client id to present instead of a fresh per-instance one. Pair with
+	 * {@link DaemonClientRequestOptions.commandId} to keep a retried mutating command
+	 * on one journal key.
+	 */
+	clientId?: DaemonClientId;
 }
 
 interface PendingDaemonRequest {
@@ -111,7 +131,7 @@ export class DaemonClient {
 	private readonly closeListeners = new Set<DaemonClientCloseListener>();
 	private readonly pendingRequests = new Map<string, PendingDaemonRequest>();
 	private requestId = 0;
-	private readonly protocolClientId = `daemon-client:${randomUUID()}`;
+	private readonly protocolClientId: DaemonClientId;
 	private requestRecoveryEnabled = false;
 	private reconnectOptions?: DaemonClientReconnectOptions;
 	private autoReconnectPromise?: Promise<void>;
@@ -125,7 +145,12 @@ export class DaemonClient {
 		timeout: ReturnType<typeof setTimeout>;
 	}>();
 
-	constructor(private readonly socketPath: string) {}
+	constructor(
+		private readonly socketPath: string,
+		options: DaemonClientOptions = {},
+	) {
+		this.protocolClientId = options.clientId ?? `daemon-client:${randomUUID()}`;
+	}
 
 	get hello(): DaemonHello | undefined {
 		return this.helloMessage;
@@ -353,7 +378,10 @@ export class DaemonClient {
 			);
 		}
 
-		const id = `daemon_${++this.requestId}`;
+		const id = options.commandId ?? `daemon_${++this.requestId}`;
+		if (this.pendingRequests.has(id)) {
+			throw new Error(`Daemon command id "${id}" is already in flight on this client`);
+		}
 		const fullCommand = { ...command, id } as DaemonCommand | DaemonWorkerCommand;
 		const wireCommand: DaemonCommand | DaemonWorkerCommand | DaemonCommandEnvelope = publicEnvelopeProtocolVersion
 			? createDaemonCommandEnvelope(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5463,8 +5463,18 @@ export class AgentDaemon {
 		}
 		const deadline = Date.now() + 30_000;
 		let lastError: unknown;
+		// The supervisor journals mutating commands under [clientId, commandId] and
+		// replays a completed result instead of re-executing. A fresh DaemonClient
+		// mints a new protocol client id and restarts its request counter, so retrying
+		// on a new client presented a new key for the same logical message and the
+		// supervisor enqueued another steering prompt. Pin both halves of the key for
+		// the lifetime of this send so every attempt is recognized as the same command.
+		const idempotency = {
+			clientId: `daemon-client:${randomUUID()}`,
+			commandId: `send_message_${randomUUID()}`,
+		};
 		while (Date.now() < deadline && !this.shuttingDown) {
-			const client = new DaemonClient(supervisorSocketPath);
+			const client = new DaemonClient(supervisorSocketPath, { clientId: idempotency.clientId });
 			let receivedResponse = false;
 			try {
 				await client.connect(1000);
@@ -5478,6 +5488,7 @@ export class AgentDaemon {
 						agentOrigin: true,
 					},
 					30_000,
+					{ commandId: idempotency.commandId },
 				);
 				receivedResponse = true;
 				if (!response.success) {

--- a/packages/coding-agent/test/suite/regressions/821-agent-message-retry-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/821-agent-message-retry-idempotency.test.ts
@@ -1,0 +1,237 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CommandRecoveryJournal,
+	createCommandIdempotencyKey,
+} from "../../../src/modes/daemon/command-recovery-journal.js";
+import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import {
+	DAEMON_PROTOCOL_VERSION,
+	type DaemonCommandEnvelope,
+	type DaemonResponse,
+} from "../../../src/modes/daemon/daemon-protocol.js";
+
+const netMock = vi.hoisted(() => {
+	type Listener = (...args: unknown[]) => void;
+	type TrackedListener = Listener & { originalListener?: Listener };
+
+	class MockSocket {
+		private readonly listeners = new Map<string, Set<TrackedListener>>();
+		readonly writes: string[] = [];
+		destroyed = false;
+
+		constructor(readonly path: string) {}
+
+		on(event: string, listener: Listener): this {
+			const listeners = this.listeners.get(event) ?? new Set<TrackedListener>();
+			listeners.add(listener as TrackedListener);
+			this.listeners.set(event, listeners);
+			return this;
+		}
+
+		once(event: string, listener: Listener): this {
+			const onceListener: TrackedListener = (...args) => {
+				this.off(event, onceListener);
+				listener(...args);
+			};
+			onceListener.originalListener = listener;
+			return this.on(event, onceListener);
+		}
+
+		off(event: string, listener: Listener): this {
+			const listeners = this.listeners.get(event);
+			if (!listeners) return this;
+			for (const registered of [...listeners]) {
+				if (registered === listener || registered.originalListener === listener) {
+					listeners.delete(registered);
+				}
+			}
+			return this;
+		}
+
+		emit(event: string, ...args: unknown[]): boolean {
+			const listeners = this.listeners.get(event);
+			if (!listeners) return false;
+			for (const listener of [...listeners]) {
+				listener(...args);
+			}
+			return true;
+		}
+
+		destroy(): this {
+			this.destroyed = true;
+			return this;
+		}
+
+		end(): this {
+			return this;
+		}
+
+		write(chunk: string | Buffer): boolean {
+			this.writes.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+			return true;
+		}
+
+		listenerCount(event: string): number {
+			return this.listeners.get(event)?.size ?? 0;
+		}
+	}
+
+	const sockets: MockSocket[] = [];
+	const createConnection = vi.fn((path: string) => {
+		const socket = new MockSocket(path);
+		sockets.push(socket);
+		return socket;
+	});
+
+	return { createConnection, sockets };
+});
+
+vi.mock("node:net", () => ({ createConnection: netMock.createConnection }));
+
+function emitHello(socket: (typeof netMock.sockets)[number]): void {
+	socket.emit(
+		"data",
+		`${JSON.stringify({
+			type: "daemon_hello",
+			socketPath: "/tmp/prime-agent.sock",
+			protocol: { name: "prime-agent.daemon", version: DAEMON_PROTOCOL_VERSION },
+			appVersion: "9.9.9",
+			clientId: "supervisor-assigned",
+			serverCapabilities: [],
+		})}\n`,
+	);
+}
+
+function writtenEnvelopes(socket: (typeof netMock.sockets)[number]): DaemonCommandEnvelope[] {
+	return socket.writes
+		.flatMap((chunk) => chunk.split("\n"))
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as DaemonCommandEnvelope)
+		.filter((value) => value.type === "command");
+}
+
+/**
+ * A worker retrying `send_message` built a new DaemonClient per attempt. Both halves
+ * of the supervisor's journal key are per-instance — `protocolClientId` is a fresh
+ * uuid and the request counter restarts at 0 — so every retry presented a different
+ * key for the same logical message. The journal could not recognize the duplicate and
+ * the target received N independent steering prompts under N distinct ids.
+ */
+describe("issue #821 agent-message retry idempotency", () => {
+	const journalDirs: string[] = [];
+
+	beforeEach(() => {
+		netMock.sockets.length = 0;
+		netMock.createConnection.mockClear();
+	});
+
+	afterEach(() => {
+		while (journalDirs.length > 0) {
+			rmSync(journalDirs.pop()!, { recursive: true, force: true });
+		}
+	});
+
+	async function sendOnFreshClient(clientId?: string, commandId?: string): Promise<DaemonCommandEnvelope> {
+		const client = clientId ? new DaemonClient("/tmp/pa.sock", { clientId }) : new DaemonClient("/tmp/pa.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets.at(-1)!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket);
+		await client.waitForHello();
+		// The transport fails after the command is on the wire, which is exactly the
+		// window in which the supervisor may already have accepted and enqueued it.
+		void client
+			.request({ type: "send_message", targetActiveSessionId: "worker", message: "result ready" }, 50, {
+				...(commandId ? { commandId } : {}),
+			})
+			.catch(() => undefined);
+		await vi.waitFor(() => expect(writtenEnvelopes(socket)).toHaveLength(1));
+		client.close();
+		return writtenEnvelopes(socket)[0]!;
+	}
+
+	it("presents one journal key across retries when the identity is pinned", async () => {
+		const clientId = "daemon-client:pinned";
+		const commandId = "send_message_pinned";
+
+		const first = await sendOnFreshClient(clientId, commandId);
+		const second = await sendOnFreshClient(clientId, commandId);
+
+		expect(first.clientId).toBe(clientId);
+		expect(first.id).toBe(commandId);
+		expect(second.clientId).toBe(clientId);
+		expect(second.id).toBe(commandId);
+		expect(createCommandIdempotencyKey(second.clientId!, second.id)).toBe(
+			createCommandIdempotencyKey(first.clientId!, first.id),
+		);
+	});
+
+	it("still mints a distinct identity per client when nothing is pinned", async () => {
+		const first = await sendOnFreshClient();
+		const second = await sendOnFreshClient();
+
+		expect(first.clientId).not.toBe(second.clientId);
+		expect(createCommandIdempotencyKey(second.clientId!, second.id)).not.toBe(
+			createCommandIdempotencyKey(first.clientId!, first.id),
+		);
+	});
+
+	it("replays the recorded receipt instead of enqueuing the message twice", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pa-821-journal-"));
+		journalDirs.push(dir);
+		const journal = new CommandRecoveryJournal(join(dir, "commands.jsonl"));
+		const receipt: DaemonResponse = {
+			id: "send_message_pinned",
+			type: "response",
+			command: "send_message",
+			success: true,
+			data: { id: "agentmsg_1", deliveryStatus: "queued" },
+		};
+
+		const pinned = await sendOnFreshClient("daemon-client:pinned", "send_message_pinned");
+		const retry = await sendOnFreshClient("daemon-client:pinned", "send_message_pinned");
+
+		expect(journal.begin(pinned.clientId!, pinned.id, "send_message")).toEqual({ status: "new" });
+		journal.recordResult(pinned.clientId!, pinned.id, receipt);
+
+		// The retry is recognized as the same command, so the supervisor replays the
+		// original receipt rather than accepting a second agent message.
+		expect(journal.begin(retry.clientId!, retry.id, "send_message")).toEqual({
+			status: "complete",
+			response: receipt,
+		});
+
+		// Without pinning, the retry would have been admitted as a new command.
+		const unpinned = await sendOnFreshClient();
+		expect(journal.begin(unpinned.clientId!, unpinned.id, "send_message")).toEqual({ status: "new" });
+	});
+
+	it("rejects reusing a command id that is still in flight on one client", async () => {
+		const client = new DaemonClient("/tmp/pa.sock", { clientId: "daemon-client:pinned" });
+		const connect = client.connect();
+		const socket = netMock.sockets.at(-1)!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket);
+		await client.waitForHello();
+
+		const inFlight = client
+			.request({ type: "send_message", targetActiveSessionId: "worker", message: "first" }, 5_000, {
+				commandId: "send_message_pinned",
+			})
+			.catch(() => undefined);
+
+		await expect(
+			client.request({ type: "send_message", targetActiveSessionId: "worker", message: "second" }, 5_000, {
+				commandId: "send_message_pinned",
+			}),
+		).rejects.toThrow('Daemon command id "send_message_pinned" is already in flight on this client');
+
+		client.close();
+		await inFlight;
+	});
+});


### PR DESCRIPTION
Fixes #821.

The supervisor already has durable idempotency for mutating daemon commands: `CommandRecoveryJournal` keys completed results on `createCommandIdempotencyKey(clientId, commandId)` and replays the stored response instead of re-executing. `send_message` is mutating, so it is covered in principle.

`DaemonMode.sendRemoteAgentSessionMessage` — the one loop in the tree that re-sends `send_message` across the accept window — steps outside it. It constructs a **new `DaemonClient` on every attempt**, and both halves of the journal key are per-instance:

```ts
private requestId = 0;
private readonly protocolClientId = `daemon-client:${randomUUID()}`;
```

So each retry presented a different key for the same logical message. The journal could not recognize the duplicate, `acceptAgentSessionMessage` performs no dedupe of its own, and the target received N independent steering prompts under N distinct `agentmsg_` ids.

The window is real rather than theoretical. `DaemonClient.request` times out **locally** and sends no cancellation, so a timeout does not mean the supervisor declined the message — it may already have accepted and enqueued it. A socket drop mid-response or a supervisor restart has the same shape. The existing `receivedResponse` guard correctly refuses to retry once a response was *parsed*, but that is precisely the case this window excludes.

## Change

Let a caller pin the identity, and have the one loop that needs it do so:

- `DaemonClient` takes an optional `clientId`, used in place of the per-instance uuid.
- `DaemonClientRequestOptions` takes an optional `commandId`, used in place of `daemon_${++this.requestId}`.
- `sendRemoteAgentSessionMessage` mints one `clientId` + `commandId` per logical send, before the retry loop, and passes them to every attempt.

Behaviour after the change:

- Retry after the supervisor **completed** the command: the journal reports `complete` and replays the recorded receipt. Exactly one message is enqueued and the caller gets the real receipt rather than an error.
- Retry that races an attempt **still in flight**: the journal reports `pending` and the supervisor answers `command_result_uncertain`. That is a definite answer instead of a silent duplicate, which is what the journal was built to provide.
- Retry where nothing reached the supervisor (`connect`/`waitForHello` failed, the common restart case): no journal entry exists, so the attempt proceeds normally. Unchanged.
- The journal file is append-only and reloaded on construction, so the key also survives a supervisor restart.

Callers that pass neither option keep a fresh identity per client, so every other `DaemonClient` consumer is unchanged — this is opt-in, not a global behaviour change. Reusing a command id while it is still in flight on the *same* client would clobber that client's pending-request map, so it is rejected with a clear error.

No protocol or schema change: `clientId` and `id` are existing envelope fields, and this only controls what is put in them.

## Tests

`packages/coding-agent/test/suite/regressions/821-agent-message-retry-idempotency.test.ts` (4 cases), using the same mocked-socket harness as `daemon-client.test.ts` so it needs no real daemon:

- Two separate `DaemonClient` instances with a pinned identity write envelopes whose `clientId` and `id` are identical, and `createCommandIdempotencyKey` over the two envelopes produces the same key — the defect stated directly.
- Two unpinned clients still produce different keys, proving the default is untouched.
- Driving the real `CommandRecoveryJournal` with the two captured identities: the first `begin` is `new`, the recorded receipt is stored, and the retry's `begin` returns `complete` with that same receipt instead of admitting a second command. The same test then shows an unpinned identity would have been admitted as `new` — the duplicate steering prompt.
- Reusing an in-flight command id on one client rejects.

Verified: `npm run check` clean; the new suite plus `daemon-client.test.ts` pass (33). `command-recovery-journal.test.ts` has one pre-existing Windows-only failure (`EPERM` on directory `fsync`, tracked as #666) that does not touch this path.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate steering prompts on retried agent messages by pinning supervisor journal keys
> - When a `send_message` transport call fails after the supervisor has already accepted the message, retries previously enqueued duplicate steering prompts. This fix pins a stable `clientId` and `commandId` for the duration of each `send_message` operation so all retry attempts share the same supervisor journal key and replay the recorded receipt instead.
> - `DaemonClient` constructor now accepts an optional `clientId` to pin the protocol client identity, and `DaemonClient.request` accepts an optional `commandId` to pin the wire command id.
> - The client rejects a request if the chosen `commandId` is already in-flight on the same client instance, preventing accidental duplicate submissions.
> - A regression test suite in [`821-agent-message-retry-idempotency.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/892/files#diff-c1fdb7c44b5eb3090716b4c88590d49d6fbfdd61d589459ca0910939202b805f) covers pinned and default identity behavior, supervisor journal replay, and in-flight duplicate rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5cc2c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->