### PR TITLE
fix(coding-agent): resume suspended input pump on programmatic admission

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5338,6 +5338,19 @@ export class AgentSession {
 			if (action.payload.kind === "turn" && action.wake === "immediate") this._sessionInputPumpSuspended = false;
 			this._scheduleSessionInputPump();
 		}
+		if (
+			!options.restore &&
+			options.wake !== false &&
+			action.payload.kind === "turn" &&
+			!this.isStreaming &&
+			this._sessionInputPumpSuspended
+		) {
+			// Programmatic admissions resume a pump suspended by an abort, matching _prompt():
+			// otherwise queued agent messages, heartbeats, and wake prompts starve at idle.
+			this._sessionInputPumpSuspended = false;
+			this._notifySessionInputCheckpointChange();
+			this._scheduleSessionInputPump();
+		}
 		return { accepted: true, disposition, ticket: controller.ticket };
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5304,6 +5304,13 @@ export class AgentSession {
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
+			// A coalesced re-fire is still evidence a producer wants delivery: resume a
+			// pump suspended by an abort so the owning queued action can drain at idle.
+			if (options.wake !== false && !this.isStreaming && this._sessionInputPumpSuspended) {
+				this._sessionInputPumpSuspended = false;
+				this._notifySessionInputCheckpointChange();
+				this._scheduleSessionInputPump();
+			}
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
 				this._rejectAgentMessage(
 					action.agentMessageId,

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -729,7 +729,17 @@ export class AgentCronJobStore {
 					return job;
 				}
 				if (result.outcome === "skipped" && result.error === undefined) {
-					const nextRunAt = nextRunAtForSchedule(job.schedule, now);
+					const scheduledNextRunAt = nextRunAtForSchedule(job.schedule, now);
+					// A deferred heartbeat fire retries at the next scheduler tick instead of
+					// losing the fire until the following full interval.
+					const heartbeatRetryAt =
+						isHeartbeatCronJob(job) && job.schedule.kind !== "once"
+							? new Date(now.getTime() + ONE_MINUTE_MS)
+							: undefined;
+					const nextRunAt =
+						heartbeatRetryAt && (!scheduledNextRunAt || heartbeatRetryAt < scheduledNextRunAt)
+							? heartbeatRetryAt
+							: scheduledNextRunAt;
 					updated = {
 						...job,
 						status: job.schedule.kind === "once" ? "completed" : job.status,

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1128,10 +1128,12 @@ describe("AgentCronScheduler", () => {
 		const handled = await scheduler.runDue(new Date("2026-01-01T12:39:00.000Z"));
 
 		expect(handled).toBe(0);
+		// A skipped heartbeat fire retries at the next scheduler tick instead of
+		// waiting out the whole interval.
 		expect(store.getHeartbeat("active-1")).toMatchObject({
 			id: job.id,
 			status: "active",
-			nextRunAt: "2026-01-01T12:45:00.000Z",
+			nextRunAt: "2026-01-01T12:41:00.000Z",
 			lastSkippedAt: "2026-01-01T12:40:00.000Z",
 			runCount: 0,
 		});

--- a/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
+++ b/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
@@ -1,0 +1,50 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
+
+describe("suspended input pump resumes on programmatic admission", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("delivers a queued agent message at idle after an abort suspended the pump", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("agent mail handled")]);
+
+		// An abort at idle leaves the input pump suspended.
+		harness.session.requestAbort();
+		await harness.session.agent.waitForIdle();
+
+		await harness.session.queueAgentMessagePrompt("queued agent mail", "followUp");
+
+		await vi.waitFor(() => expect(getAssistantTexts(harness)).toContain("agent mail handled"));
+		expect(getUserTexts(harness)).toContain("queued agent mail");
+	});
+
+	it("delivers items queued before an abort once a later programmatic admission arrives", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("backlog handled"), fauxAssistantMessage("second handled")]);
+
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.queueAgentMessagePrompt("queued before abort", "followUp");
+		harness.session.requestAbort();
+		pause.release();
+		await harness.session.agent.waitForIdle();
+
+		// Without the fix, the backlog starves forever: only a user-typed prompt or
+		// resumeQueuedWork() revives delivery.
+		await harness.session.queueAgentMessagePrompt("queued after abort", "followUp");
+
+		await vi.waitFor(() => {
+			const users = getUserTexts(harness);
+			expect(users).toContain("queued before abort");
+			expect(users).toContain("queued after abort");
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
+++ b/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
@@ -47,4 +47,23 @@ describe("suspended input pump resumes on programmatic admission", () => {
 			expect(users).toContain("queued after abort");
 		});
 	});
+
+	it("resumes the pump when a coalesced follow-up re-fires at idle", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("wake handled")]);
+
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.followUp("wake fire", undefined, { queueKey: "wake:test" });
+		harness.session.requestAbort();
+		pause.release();
+		await harness.session.agent.waitForIdle();
+
+		// A re-fire with the same queueKey coalesces into the queued owner. Without the
+		// fix it is dropped without resuming the pump, so the owner starves forever.
+		await harness.session.followUp("wake fire", undefined, { queueKey: "wake:test" });
+
+		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("wake fire"));
+		expect(getAssistantTexts(harness)).toContain("wake handled");
+	});
 });


### PR DESCRIPTION
## Problem

Any abort — `requestAbort()` from Esc/TUI interrupt, a daemon `abort`, a goal abort, or `abortForUpdateRestart()` — sets `_sessionInputPumpSuspended = true`. The user-typed prompt path (`_prompt`) clears that flag when the session is not streaming, but the programmatic admission path (`queueAgentMessagePrompt` → `_queuePreparedPrompt` → `_admitSessionInput`) never does. After one abort, every programmatically queued item — agent messages from children, heartbeat prompts, injected wake prompts — sits in the queue forever while the session is idle. Only a human-typed prompt or an explicit `resume_queue` revives delivery.

Reproduced clean-room on a pristine 0.7.0 install with a stub provider, driven over the daemon socket:

| scenario | result |
|---|---|
| long tool call / long streaming turn with items queued | delivered at boundary — fine |
| idle session, items queued | delivered immediately — fine |
| **abort during streaming with items queued** | **starved forever** (`queuedCount` persisted >90s idle) |
| then one user-typed prompt | flushes the entire starved backlog in ~2s |
| starved queue + heartbeat cron due | heartbeat silently skipped every fire |

The starved queue also blackholes heartbeats: `shouldDeferHeartbeatCronJob` defers while `unfinishedActionCount > 0`, and a skipped fire is lost until the next full interval because `nextRunAt` is recomputed from the skip time (adjacent to #820).

Related: #820 (heartbeat fires dropped when coincident with busy), #821 (send retry duplication), #823 (queued agent mail delivery). None of them names the suspended-pump starvation itself.

## Fix

- `_admitSessionInput`: when a programmatic turn admission arrives while the session is not streaming and the pump is suspended, clear the suspension, notify checkpoint waiters, and schedule the pump — the same resume semantics `_prompt()` already gives user-typed input.
- `recordDispatchResult`: a skipped heartbeat fire reschedules to the next scheduler tick (1 minute) instead of the next full interval, so a deferred fire retries instead of being lost.

## Testing

- New regression test `resume-suspended-input-pump.test.ts`: queued agent mail after an idle abort delivers; a backlog queued before an abort drains once a later programmatic admission arrives. Both fail without the fix.
- Updated `cron-jobs.test.ts` skip-reschedule expectation to the new retry-next-tick semantics.
- `vitest run` on cron-jobs, agent-session-queue, agent-session-prompt, agent-session-action-races: no new failures versus the unpatched baseline.

---
*This PR was prepared with agent assistance.*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentSession.admitSessionAction` to resume suspended input pump on programmatic admission
> - After an abort suspends the input pump, queued agent messages, heartbeats, and wake prompts would starve. This fix resumes the pump on two paths: coalesced follow-up re-fires and direct programmatic admissions of `turn` actions.
> - Skipped heartbeat cron jobs now reschedule to retry at `now + 1 minute` instead of waiting for the full schedule interval, preventing long stalls after a skip.
> - Regression tests in [`resume-suspended-input-pump.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/895/files#diff-438f3a089cf28ce1fdac679c877d5174f3e2cbd512421e2fdca5f0cde174d489) cover the three resume scenarios.
> - Behavioral Change: skipped heartbeat jobs retry sooner than before; non-heartbeat and once-kind jobs retain prior scheduling behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f77b4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->