### PR TITLE
fix(ai): omit service tier for GitHub Copilot

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed GitHub Copilot Responses requests to omit the unsupported `service_tier` field.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed GitHub Copilot Responses requests to omit the unsupported `service_tier` field.
+- Fixed GitHub Copilot Responses requests to omit the unsupported `service_tier` field ([#897](https://github.com/PrimeIntellect-ai/prime-agent/pull/897) by [@traditio](https://github.com/traditio)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -244,7 +244,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		params.temperature = options?.temperature;
 	}
 
-	if (options?.serviceTier !== undefined) {
+	if (model.provider !== "github-copilot" && options?.serviceTier !== undefined) {
 		params.service_tier = options.serviceTier;
 	}
 

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -91,6 +91,72 @@ describe("openai-responses provider defaults", () => {
 		});
 	});
 
+	it("omits service_tier for GitHub Copilot requests", async () => {
+		const model = getModel("github-copilot", "gpt-5-mini");
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "priority",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).not.toHaveProperty("service_tier");
+	});
+
+	it("preserves service_tier for supported providers", async () => {
+		const model = getModel("openai", "gpt-5.4");
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "priority",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).toHaveProperty("service_tier", "priority");
+	});
+
 	it.each(["gpt-5.1", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.5"] as const)(
 		"sends none reasoning effort for OpenAI %s when no reasoning is requested",
 		async (modelId) => {


### PR DESCRIPTION
## Summary

GitHub Copilot rejects the OpenAI Responses `service_tier` field. Prime Agent currently supplies `"default"` when no tier is configured, causing requests to fail with HTTP 400.

- Omit `service_tier` for GitHub Copilot Responses requests.
- Preserve configured service tiers for supported providers.
- Cover both request paths with regression tests.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-responses-copilot-provider.test.ts` (25 passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `service_tier` from GitHub Copilot request payloads in openai-responses provider
> GitHub Copilot does not support the `service_tier` field, so including it in requests causes errors. The `buildParams` function in [openai-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/897/files#diff-4f45a06d4fa91c758631624991582298b307980aa919b7677cc82830bf2a6aa5) now skips setting `service_tier` when `model.provider` is `'github-copilot'`, while other providers (e.g. OpenAI) continue to receive it when `serviceTier` is specified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 704cb12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->