### PR TITLE
fix(cli): remove stale send delivery flags from help

### DIFF
--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -44,13 +44,9 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 	{
 		path: ["send"],
 		usage: "send [--from <agent>] <agent> <message>",
-		summary: "Send a message to an agent",
-		options: [
-			"--from <agent>  Identify the sending agent",
-			"--steer         Deliver as steering when the agent is busy",
-			"--follow-up     Queue the message after the current turn",
-			"--json          Print JSON",
-		],
+		summary: "Send a steering message to an agent",
+		description: "Messages always steer an active turn and are delivered at the next tool boundary.",
+		options: ["--from <agent>  Identify the sending agent", "--json          Print JSON"],
 	},
 	{
 		path: ["schedule"],

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -37,7 +37,7 @@ vi.mock("../src/cli/daemon-ps.js", () => ({
 }));
 
 import { INTERNAL_RUNTIME_COMMAND_MARKER } from "../src/cli/args.js";
-import { formatTopLevelHelp } from "../src/cli/command-registry.js";
+import { formatCommandHelp, formatTopLevelHelp } from "../src/cli/command-registry.js";
 import { DAEMON_UPDATE_RESTART_COORDINATOR_FLAG } from "../src/cli/daemon-update-restart.js";
 import { handlePublicCommand } from "../src/cli/public-command.js";
 
@@ -274,6 +274,13 @@ describe("public command routing", () => {
 		await handlePublicCommand(["schedule", "cancell", "job-1"]);
 		expect(mocks.daemonCommands).toEqual([]);
 		expect(console.error).toHaveBeenCalledWith(expect.stringContaining("schedule cancel"));
+	});
+
+	it("documents send as always-steering without removed delivery flags", () => {
+		const help = formatCommandHelp(["send"]);
+		expect(help).toContain("Messages always steer an active turn");
+		expect(help).not.toContain("--steer");
+		expect(help).not.toContain("--follow-up");
 	});
 
 	it("treats help-like message text after the separator literally", async () => {


### PR DESCRIPTION
## Summary

- remove the intentionally retired `--steer` and `--follow-up` flags from `prime-agent help send`
- describe `send` as always-steering and clarify tool-boundary delivery
- add a regression test for the rendered command help

The parser and 0.7.0 changelog already agree that agent messages always steer; only the command registry help remained stale.

Closes #901.

## Test plan

- `npm --prefix packages/coding-agent test -- test/public-command.test.ts` (31 passed)
- `npm exec -- biome check packages/coding-agent/src/cli/command-registry.ts packages/coding-agent/test/public-command.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `--steer` and `--follow-up` delivery flags from `send` command help
> Updates the `send` command spec in [command-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/902/files#diff-ba6fd689c2d87db9c6afe1cdb902b1644cb862c4434a4dbb41442f7b2ef466a8) to reflect that messages always steer an active turn and are delivered at the next tool boundary. The `--steer` and `--follow-up` flags are removed from the documented options, and a new test asserts their absence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f460c6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->