### PR TITLE
feat(coding-agent): reap orphaned empty session files at daemon start

### DIFF
--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -185,6 +185,18 @@ function isLeaseOwnerAlive(owner: SessionLeaseOwner): boolean {
 	return currentStartId === undefined || currentStartId === owner.processStartId;
 }
 
+/**
+ * True when the given session file currently holds a live ownership lease.
+ * Used by the daemon's orphaned-session sweep to avoid deleting a session a
+ * live process is still attached to. A lease is active only while its owner
+ * process is alive; stale owners left by crashed/killed daemons read as
+ * inactive and are safe to reap.
+ */
+export function hasActiveSessionLease(sessionPath: string, agentDir: string): boolean {
+	const owner = readLeaseOwner(leaseDirectory(agentDir, canonicalSessionPath(sessionPath)));
+	return owner !== undefined && isLeaseOwnerAlive(owner);
+}
+
 function withLeaseGuard<T>(directory: string, action: () => T): T {
 	let release: (() => void) | undefined;
 	for (let attempt = 0; attempt < 100; attempt++) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -15,6 +15,7 @@ import {
 	mkdirSync,
 	openSync,
 	readFileSync,
+	readdirSync,
 	renameSync,
 	rmSync,
 	writeFileSync,
@@ -107,8 +108,15 @@ import {
 	type SessionPassivationSnapshot,
 } from "../../core/session-action-store.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "../../core/session-lease.js";
 import {
+	acquireSessionLease,
+	canonicalSessionPath,
+	hasActiveSessionLease,
+	type SessionLease,
+} from "../../core/session-lease.js";
+import {
+	getDefaultSessionDir,
+	loadEntriesFromFile,
 	readSessionInfo,
 	resolveSessionRlmDepth,
 	type SessionInfo,
@@ -406,6 +414,19 @@ type PassiveRlmSubagent = PassiveRlmRoot & {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
+
+// Entry types a session file can hold without any real user content.
+const SESSION_BOOKKEEPING_ENTRY_TYPES = new Set([
+	"session",
+	"model_change",
+	"thinking_level_change",
+	"service_tier_change",
+	"session_state",
+	"agent_status",
+	"git_state",
+	"child_usage_attributed",
+]);
+
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
 	const daemon = new AgentDaemon(socketPath, options);
@@ -582,6 +603,7 @@ export class AgentDaemon {
 		}
 		this.installCrashHandlers();
 		await prepareDaemonSocketPath(this.socketPath);
+		await this.reapOrphanedEmptySessions();
 
 		this.server = createServer((socket) => this.handleConnection(socket));
 
@@ -623,6 +645,32 @@ export class AgentDaemon {
 			this.cronScheduler.start();
 		}
 		this.startSupervisorMonitor();
+	}
+
+	/** Delete session files left by crashed daemons that never captured a user turn. */
+	private async reapOrphanedEmptySessions(): Promise<void> {
+		const sessionDir =
+			this.options.defaultSessionConfig.sessionDir ??
+			getDefaultSessionDir(this.options.defaultSessionConfig.cwd ?? process.cwd(), this.agentDir);
+		let files: string[];
+		try {
+			files = readdirSync(sessionDir).filter((name) => name.endsWith(".jsonl"));
+		} catch {
+			return;
+		}
+		for (const file of files) {
+			const sessionPath = join(sessionDir, file);
+			if (hasActiveSessionLease(sessionPath, this.agentDir)) continue;
+			let empty: boolean;
+			try {
+				empty = loadEntriesFromFile(sessionPath).every((entry) =>
+					SESSION_BOOKKEEPING_ENTRY_TYPES.has(entry.type),
+				);
+			} catch {
+				continue; // corrupt/unreadable — leave it for the user
+			}
+			await deleteSessionFile(sessionPath);
+		}
 	}
 
 	private startSupervisorMonitor(): void {


### PR DESCRIPTION
When the daemon (or a worker) gets killed mid-flight, it can leave a `sessions/*.jsonl` behind that never captured a single message — just the header and a few model/state bookkeeping lines. They pile up and clutter the session list.

This cleans those up: on daemon start it scans the session dir and deletes any file whose entries are purely bookkeeping. Things that actually contain a message, a custom entry, or a label are left alone, and any session a live process still holds is skipped (via a new `hasActiveSessionLease()` helper). Deletion goes through the existing trash-first path, so it's recoverable.

Small, self-contained, no test balloon — code speaks for itself.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reap orphaned empty session files on daemon startup
> - On startup, `AgentDaemon` now calls a new `reapOrphanedEmptySessions` method that scans `.jsonl` session files and deletes those containing only bookkeeping entries (e.g. `session`, `model_change`, `agent_status`) with no active lease.
> - A new `hasActiveSessionLease` function in [session-lease.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/903/files#diff-74865e03a1e2d7f4025a576ca8f4c09dbc1ec7c9e2776b5d93f2691ee29e6cda) checks whether a session file's lease owner process is still alive, protecting files from active sessions.
> - Files that are unreadable or corrupt are silently skipped to avoid blocking startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f50fa1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->