### PR TITLE
fix(coding-agent): load tsconfig in source launcher

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed the source launcher failing outside the repository when workspace packages had not been built ([#904](https://github.com/PrimeIntellect-ai/prime-agent/issues/904)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/prime-agent.sh
+++ b/prime-agent.sh
@@ -78,4 +78,4 @@ if [[ ! -x "$TSX_BIN" ]]; then
   exit 1
 fi
 
-"$TSX_BIN" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}
+"$TSX_BIN" --tsconfig "$SCRIPT_DIR/tsconfig.json" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
## Summary

- pass the repository `tsconfig.json` explicitly when running the source launcher through `tsx`
- document the user-visible fix in the coding-agent changelog

## Validation

- `npm run check`
- launched `prime-agent.sh package list` from `/tmp` without building workspace packages

Fixes #904


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source launcher to load `tsconfig.json` when running outside the repository
> Adds `--tsconfig "$SCRIPT_DIR/tsconfig.json"` to the `tsx` invocation in [prime-agent.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/905/files#diff-198cb39262c59c7cd9cf3fcb366d4da29046dd498f688c143ceba9f7e6172b1a), so the CLI runs correctly even when workspace packages have not been built.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d9cac7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->