### PR TITLE
fix(launcher): pass root tsconfig to tsx, fix send help flags, match rlm attributes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed source launcher failing outside repository directory by passing root tsconfig to tsx ([#904](https://github.com/PrimeIntellect-ai/prime-agent/issues/904))
+- Fixed `send` command help listing removed `--steer` and `--follow-up` flags ([#901](https://github.com/PrimeIntellect-ai/prime-agent/issues/901))
+- Fixed Python `rlm` API `RLMSpawnHandle` / `RLMSubagent` name attribute mismatch and allowed passing `RLMSpawnHandle` objects directly to `rlm.delete_subagent` ([#824](https://github.com/PrimeIntellect-ai/prime-agent/issues/824))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -45,12 +45,7 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 		path: ["send"],
 		usage: "send [--from <agent>] <agent> <message>",
 		summary: "Send a message to an agent",
-		options: [
-			"--from <agent>  Identify the sending agent",
-			"--steer         Deliver as steering when the agent is busy",
-			"--follow-up     Queue the message after the current turn",
-			"--json          Print JSON",
-		],
+		options: ["--from <agent>  Identify the sending agent", "--json          Print JSON"],
 	},
 	{
 		path: ["schedule"],

--- a/packages/coding-agent/test/suite/regressions/901-send-help-options.test.ts
+++ b/packages/coding-agent/test/suite/regressions/901-send-help-options.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatCommandHelp } from "../../../src/cli/command-registry.js";
+
+describe("issue #901 send command help options", () => {
+	it("does not list removed --steer or --follow-up flags in send command help", () => {
+		const help = formatCommandHelp(["send"]);
+
+		expect(help).toBeTruthy();
+		expect(help).not.toContain("--steer");
+		expect(help).not.toContain("--follow-up");
+		expect(help).toContain("--from <agent>");
+		expect(help).toContain("--json");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/904-source-launcher-tsconfig.test.ts
+++ b/packages/coding-agent/test/suite/regressions/904-source-launcher-tsconfig.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("issue #904 source launcher tsconfig", () => {
+	it("passes --tsconfig to tsx in prime-agent.sh", () => {
+		const scriptPath = resolve(__dirname, "../../../../../prime-agent.sh");
+		const content = readFileSync(scriptPath, "utf-8");
+
+		expect(content).toContain(
+			'"$TSX_BIN" --tsconfig "$SCRIPT_DIR/tsconfig.json" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts"',
+		);
+	});
+});

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -31,6 +31,11 @@ class RLMSpawnHandle:
     session_dir: Path
     model: str
 
+    @property
+    def session_name(self) -> str:
+        """Alias for `name`; matches RLMSubagent.session_name."""
+        return self.name
+
 
 @dataclass(frozen=True)
 class RLMModel:
@@ -48,6 +53,11 @@ class RLMSubagent:
     session_name: str
     session_dir: Path
     status: str
+
+    @property
+    def name(self) -> str:
+        """Alias for `session_name`; matches RLMSpawnHandle.name."""
+        return self.session_name
 
 
 def _install_control_comm_handlers() -> None:
@@ -216,16 +226,16 @@ async def list_subagents() -> list[RLMSubagent]:
     return [_subagent_from_payload(entry) for entry in entries]
 
 
-async def delete_subagent(target: str | RLMSubagent) -> RLMSubagent:
+async def delete_subagent(target: str | RLMSubagent | RLMSpawnHandle) -> RLMSubagent:
     """Delete one running or retained direct child from the current parent session."""
-    if isinstance(target, RLMSubagent):
+    if isinstance(target, (RLMSubagent, RLMSpawnHandle)):
         selector = target.rlm_child_id
     elif isinstance(target, str):
         selector = target.strip()
         if not selector:
             raise ValueError("target must not be empty")
     else:
-        raise TypeError(f"target must be str or RLMSubagent, got {type(target).__name__}")
+        raise TypeError(f"target must be str, RLMSubagent, or RLMSpawnHandle, got {type(target).__name__}")
     payload = await host_request("rlm.delete_subagent", {"target": selector})
     return _subagent_from_payload(payload.get("subagent"), "rlm.delete_subagent")
 
@@ -294,7 +304,7 @@ class _RLMCallable:
     async def list_subagents(self) -> list[RLMSubagent]:
         return await list_subagents()
 
-    async def delete_subagent(self, target: str | RLMSubagent) -> RLMSubagent:
+    async def delete_subagent(self, target: str | RLMSubagent | RLMSpawnHandle) -> RLMSubagent:
         return await delete_subagent(target)
 
     async def __call__(self, prompt: str, **kwargs: Any) -> RLMSpawnHandle:

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -182,6 +182,45 @@ class RlmSubagentRegistryTest(unittest.TestCase):
             {"target": "sub-a1b2c3d4"},
         )
 
+    def test_deletes_subagent_spawn_handle_by_child_id(self) -> None:
+        handle = rlm_module.RLMSpawnHandle(
+            rlm_child_id="sub-a1b2c3d4",
+            name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            model="claude",
+        )
+        subagent = rlm_module.RLMSubagent(
+            rlm_child_id="sub-a1b2c3d4",
+            active_session_id=None,
+            session_id="session-child",
+            session_name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            status="running",
+        )
+        self.assertEqual(handle.session_name, "api-reviewer")
+        self.assertEqual(subagent.name, "api-reviewer")
+
+        host_request = AsyncMock(
+            return_value={
+                "subagent": {
+                    "rlm_child_id": subagent.rlm_child_id,
+                    "active_session_id": subagent.active_session_id,
+                    "session_id": subagent.session_id,
+                    "session_name": subagent.session_name,
+                    "session_dir": str(subagent.session_dir),
+                    "status": subagent.status,
+                }
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            asyncio.run(rlm_module.delete_subagent(handle))
+
+        host_request.assert_awaited_once_with(
+            "rlm.delete_subagent",
+            {"target": "sub-a1b2c3d4"},
+        )
+
     def test_rejects_invalid_delete_response_and_target(self) -> None:
         host_request = AsyncMock(return_value={"subagent": {"status": "completed"}})
 
@@ -191,7 +230,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "target must not be empty"):
             asyncio.run(rlm_module.delete_subagent("   "))
-        with self.assertRaisesRegex(TypeError, "target must be str or RLMSubagent"):
+        with self.assertRaisesRegex(TypeError, "target must be str, RLMSubagent, or RLMSpawnHandle"):
             asyncio.run(rlm_module.delete_subagent(123))
 
     def test_rejects_invalid_registry_payload(self) -> None:

--- a/prime-agent.sh
+++ b/prime-agent.sh
@@ -78,4 +78,4 @@ if [[ ! -x "$TSX_BIN" ]]; then
   exit 1
 fi
 
-"$TSX_BIN" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}
+"$TSX_BIN" --tsconfig "$SCRIPT_DIR/tsconfig.json" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
## Summary

This PR addresses the following issues:

1. **Source launcher tsconfig resolution** ([#904](https://github.com/PrimeIntellect-ai/prime-agent/issues/904)):
   Pass `--tsconfig "$SCRIPT_DIR/tsconfig.json"` to `tsx` in `prime-agent.sh` so monorepo workspace package aliases (such as `@earendil-works/pi-agent-core`) resolve correctly when `prime-agent.sh` is invoked from outside the repository directory.

2. **Send command help flags** ([#901](https://github.com/PrimeIntellect-ai/prime-agent/issues/901)):
   Remove outdated `--steer` and `--follow-up` options from `send` command help spec in `packages/coding-agent/src/cli/command-registry.ts`.

3. **Python `rlm` API handle and subagent attribute matching** ([#824](https://github.com/PrimeIntellect-ai/prime-agent/issues/824)):
   Add `session_name` property alias to `RLMSpawnHandle` and `name` property alias to `RLMSubagent`. Allow `rlm.delete_subagent()` to accept `RLMSpawnHandle` objects directly in addition to `RLMSubagent` and `str`.

## Changes

- Modified `prime-agent.sh`
- Modified `packages/coding-agent/src/cli/command-registry.ts`
- Modified `prime-agent-runtime/src/rlm/__init__.py`
- Added `packages/coding-agent/test/suite/regressions/904-source-launcher-tsconfig.test.ts`
- Added `packages/coding-agent/test/suite/regressions/901-send-help-options.test.ts`
- Updated `prime-agent-runtime/test/test_subagent_registry.py`
- Updated `packages/coding-agent/CHANGELOG.md`

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/904-source-launcher-tsconfig.test.ts` (passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/901-send-help-options.test.ts` (passed)
- `PYTHONPATH=src python test/test_subagent_registry.py` (passed)
- `npm run check` (all formatting, linting, tsgo, installer render, and browser smoke checks passed)

Fixes #904
Fixes #901
Fixes #824


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source launcher tsconfig, remove stale send flags, and align RLM API attributes
> - Adds `--tsconfig "$SCRIPT_DIR/tsconfig.json"` to the `tsx` invocation in [prime-agent.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/907/files#diff-198cb39262c59c7cd9cf3fcb366d4da29046dd498f688c143ceba9f7e6172b1a) so the launcher works correctly when run outside the repo directory.
> - Removes deprecated `--steer` and `--follow-up` flags from the `send` command help spec in [command-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/907/files#diff-ba6fd689c2d87db9c6afe1cdb902b1644cb862c4434a4dbb41442f7b2ef466a8).
> - Adds `session_name` alias to `RLMSpawnHandle` and `name` alias to `RLMSubagent` in [rlm/__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/907/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3) so both types expose matching attributes.
> - Extends `rlm.delete_subagent` to accept `RLMSpawnHandle` directly, deleting by `rlm_child_id`.
> - Adds regression tests for all three fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f5cb1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->