### PR TITLE
fix(coding-agent): stabilize macOS process identity

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed macOS timezone changes invalidating the running daemon's process identity ([#879](https://github.com/PrimeIntellect-ai/prime-agent/issues/879)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -110,12 +110,17 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-type ProcessQuery = (command: string, args: string[]) => string;
+interface ProcessQueryOptions {
+	env?: NodeJS.ProcessEnv;
+}
 
-function runProcessQuery(command: string, args: string[]): string {
+type ProcessQuery = (command: string, args: string[], options?: ProcessQueryOptions) => string;
+
+function runProcessQuery(command: string, args: string[], options?: ProcessQueryOptions): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		env: options?.env,
 	});
 }
 
@@ -132,6 +137,20 @@ export function getWindowsProcessStartId(pid: number, query: ProcessQuery = runP
 			`([System.Diagnostics.Process]::GetProcessById(${pid})).StartTime.ToUniversalTime().Ticks`,
 		]).trim();
 		return /^\d+$/.test(startTicks) ? `win:${startTicks}` : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function getPsProcessStartId(pid: number, query: ProcessQuery = runProcessQuery): string | undefined {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return undefined;
+	}
+	try {
+		const startTime = query("ps", ["-p", String(pid), "-o", "lstart="], {
+			env: { ...process.env, TZ: "UTC", LC_ALL: "C" },
+		}).trim();
+		return startTime ? `ps:${startTime}` : undefined;
 	} catch {
 		return undefined;
 	}
@@ -155,12 +174,7 @@ export function getProcessStartId(pid: number): string | undefined {
 	} catch {
 		// Fall through to the portable process listing used on macOS and BSD.
 	}
-	try {
-		const startTime = runProcessQuery("ps", ["-p", String(pid), "-o", "lstart="]).trim();
-		return startTime ? `ps:${startTime}` : undefined;
-	} catch {
-		return undefined;
-	}
+	return getPsProcessStartId(pid);
 }
 
 let currentProcessStartId: string | undefined;

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -15,7 +15,7 @@ import {
 	sortDaemons,
 	verifyHelloSupervisorPid,
 } from "../src/cli/daemon-ps.js";
-import { getProcessStartId } from "../src/core/session-lease.js";
+import { getProcessStartId, getPsProcessStartId } from "../src/core/session-lease.js";
 import { defaultDaemonSocketDir } from "../src/modes/daemon/daemon-socket.js";
 
 describe("worker socket classification", () => {
@@ -112,6 +112,38 @@ describe("verifyHelloSupervisorPid", () => {
 		expect(verifyHelloSupervisorPid(process.pid, processStartId)).toBe(process.pid);
 		if (processStartId) {
 			expect(verifyHelloSupervisorPid(process.pid, `${processStartId}-stale`)).toBeUndefined();
+		}
+	});
+});
+
+describe("getPsProcessStartId", () => {
+	it("uses a stable timezone and locale for the portable process identity", () => {
+		let queryEnvironment: NodeJS.ProcessEnv | undefined;
+		const result = getPsProcessStartId(1234, (_command, _args, options) => {
+			queryEnvironment = options?.env;
+			return "Sat Aug  8 06:00:00 2026\n";
+		});
+
+		expect(result).toBe("ps:Sat Aug  8 06:00:00 2026");
+		expect(queryEnvironment).toMatchObject({ TZ: "UTC", LC_ALL: "C" });
+	});
+
+	it("preserves the surrounding environment", () => {
+		let queryEnvironment: NodeJS.ProcessEnv | undefined;
+		const previous = process.env.PRIME_AGENT_PROCESS_START_TEST;
+		process.env.PRIME_AGENT_PROCESS_START_TEST = "preserved";
+		try {
+			getPsProcessStartId(1234, (_command, _args, options) => {
+				queryEnvironment = options?.env;
+				return "Sat Aug  8 06:00:00 2026\n";
+			});
+			expect(queryEnvironment?.PRIME_AGENT_PROCESS_START_TEST).toBe("preserved");
+		} finally {
+			if (previous === undefined) {
+				delete process.env.PRIME_AGENT_PROCESS_START_TEST;
+			} else {
+				process.env.PRIME_AGENT_PROCESS_START_TEST = previous;
+			}
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- run the portable `ps -o lstart=` process identity query with `TZ=UTC` and `LC_ALL=C`
- preserve the caller environment while making daemon start IDs stable across macOS timezone and locale changes
- add regression coverage for the fixed query environment

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-ps.test.ts` (24 tests passed)
- `npm run check`
- manually queried the current PID after switching `process.env.TZ` between `America/Los_Angeles` and `Asia/Kolkata`; both IDs were identical

Fixes #879


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS process identity invalidation caused by timezone changes
> - On macOS, `getProcessStartId` in [session-lease.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/908/files#diff-74865e03a1e2d7f4025a576ca8f4c09dbc1ec7c9e2776b5d93f2691ee29e6cda) uses `ps` to derive a stable process start identifier, but the output varies with system timezone or locale, causing the running daemon's identity to change.
> - Extracts the `ps` call into a new `getPsProcessStartId` helper that forces `TZ=UTC` and `LC_ALL=C` in the subprocess environment, ensuring a consistent output regardless of system settings.
> - Extends `runProcessQuery` to accept an optional `env` override so callers can supply a custom environment without affecting the default behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7053d4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->