### PR TITLE
fix(coding-agent): sanitize side-question tool history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed `/btw` and `/side` failing on Amazon Bedrock after the main conversation used tools ([#886](https://github.com/PrimeIntellect-ai/prime-agent/issues/886)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -1,5 +1,5 @@
 import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, UserMessage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message, UserMessage } from "@earendil-works/pi-ai";
 
 export type SideQuestionStatus = "running" | "complete" | "cancelled" | "error";
 
@@ -37,6 +37,39 @@ function readAssistantText(message: AgentMessage): string {
 		.filter((block) => block.type === "text")
 		.map((block) => block.text)
 		.join("");
+}
+
+function removeToolProtocol(messages: Message[]): Message[] {
+	const sanitized: Message[] = [];
+	for (const message of messages) {
+		if (message.role === "toolResult") {
+			continue;
+		}
+		const next =
+			message.role === "assistant"
+				? { ...message, content: message.content.filter((block) => block.type !== "toolCall") }
+				: message;
+		if (next.content.length === 0) {
+			continue;
+		}
+		const previous = sanitized.at(-1);
+		if (previous?.role === "assistant" && next.role === "assistant") {
+			sanitized[sanitized.length - 1] = { ...next, content: [...previous.content, ...next.content] };
+			continue;
+		}
+		if (previous?.role === "user" && next.role === "user") {
+			const previousContent =
+				typeof previous.content === "string"
+					? [{ type: "text" as const, text: previous.content }]
+					: previous.content;
+			const nextContent =
+				typeof next.content === "string" ? [{ type: "text" as const, text: next.content }] : next.content;
+			sanitized[sanitized.length - 1] = { ...next, content: [...previousContent, ...nextContent] };
+			continue;
+		}
+		sanitized.push(next);
+	}
+	return sanitized;
 }
 
 export function startSideQuestion(
@@ -87,7 +120,7 @@ export function startSideQuestion(
 			serviceTier: parent.state.serviceTier,
 			tools: [],
 		},
-		convertToLlm: parent.convertToLlm,
+		convertToLlm: async (messages) => removeToolProtocol(await parent.convertToLlm(messages)),
 		transformContext: parent.transformContext,
 		streamFn: parent.streamFn,
 		getApiKey: parent.getApiKey,

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -127,8 +127,7 @@ describe("ENG-4509 side questions", () => {
 				(context) => {
 					expect(context.tools).toEqual([]);
 					expect(context.messages.map(getMessageText)).toEqual([
-						"Run the main task.",
-						expect.stringContaining("Can I ask this concurrently?"),
+						expect.stringMatching(/Run the main task\.\n[\s\S]*Can I ask this concurrently\?/),
 					]);
 					return fauxAssistantMessage("yes");
 				},

--- a/packages/coding-agent/test/suite/regressions/886-bedrock-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/886-bedrock-side-questions.test.ts
@@ -1,0 +1,72 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxText, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { type SideQuestionEvent, startSideQuestion } from "../../../src/core/side-question.js";
+import { createHarness, getMessageText } from "../harness.js";
+
+describe("#886 Bedrock side-question context", () => {
+	it("removes tool protocol messages while preserving conversational text", async () => {
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params) => {
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				return {
+					content: [{ type: "text", text: `echo:${text}` }],
+					details: {},
+				};
+			},
+		};
+		const harness = await createHarness({ tools: [echoTool] });
+		try {
+			harness.setResponses([
+				fauxAssistantMessage([fauxText("I will inspect the value."), fauxToolCall("echo", { text: "kestrel" })], {
+					stopReason: "toolUse",
+				}),
+				fauxAssistantMessage("The inspected value is kestrel."),
+			]);
+			await harness.session.prompt("Inspect the project value.");
+
+			harness.setResponses([
+				(context) => {
+					expect(context.tools).toEqual([]);
+					expect(context.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+					expect(context.messages.map(getMessageText)).toEqual([
+						"Inspect the project value.",
+						"I will inspect the value.\nThe inspected value is kestrel.",
+						expect.stringContaining("What was the inspected value?"),
+					]);
+					for (let index = 1; index < context.messages.length; index++) {
+						expect(context.messages[index]?.role).not.toBe(context.messages[index - 1]?.role);
+					}
+					expect(context.messages.some((message) => message.role === "toolResult")).toBe(false);
+					expect(
+						context.messages.some(
+							(message) =>
+								message.role === "assistant" && message.content.some((block) => block.type === "toolCall"),
+						),
+					).toBe(false);
+					return fauxAssistantMessage("kestrel");
+				},
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(
+				harness.session.agent,
+				"bedrock-question",
+				"What was the inspected value?",
+				(event) => {
+					events.push(event);
+				},
+			);
+			await run.done;
+
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "kestrel" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- remove tool-call blocks and paired tool-result messages from side-question LLM context
- coalesce adjacent same-role messages after filtering so the Bedrock conversation still alternates roles
- keep `/btw` and `/side` tool-free while preserving ordinary user and assistant conversation content
- cover mixed assistant content, tool results, role alternation, and the empty `tools` invariant in regression tests

Amazon Bedrock requires `toolConfig` whenever history contains `toolUse` or `toolResult` blocks and requires conversation roles to alternate. Side questions intentionally provide no tools, so forwarding the main thread's tool protocol history caused the request to fail after any tool use.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4509-side-questions.test.ts test/suite/regressions/886-bedrock-side-questions.test.ts` (39 tests passed)
- `npm run check`

Fixes #886
