### PR TITLE
fix(coding-agent): reclaim reused Termux lease pids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed stale session leases becoming permanent on Android/Termux when a dead worker PID is reused by a protected process ([#868](https://github.com/PrimeIntellect-ai/prime-agent/issues/868)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -101,12 +101,38 @@ function readLeaseOwner(directory: string): SessionLeaseOwner | undefined {
 	}
 }
 
-function isProcessAlive(pid: number): boolean {
+type ProcessProbe = (pid: number) => void;
+
+const probeProcessSignal: ProcessProbe = (pid) => {
+	process.kill(pid, 0);
+};
+
+const probeProcStat: ProcessProbe = (pid) => {
+	readFileSync(`/proc/${pid}/stat`);
+};
+
+export function isProcessAlive(
+	pid: number,
+	signalProbe: ProcessProbe = probeProcessSignal,
+	procStatProbe: ProcessProbe = probeProcStat,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
 	try {
-		process.kill(pid, 0);
+		signalProbe(pid);
 		return true;
 	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
+		if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+			return false;
+		}
+	}
+	if (platform !== "linux" && platform !== "android") {
+		return true;
+	}
+	try {
+		procStatProbe(pid);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ENOENT";
 	}
 }
 

--- a/packages/coding-agent/test/session-lease.test.ts
+++ b/packages/coding-agent/test/session-lease.test.ts
@@ -8,6 +8,7 @@ import {
 	acquireSessionLease,
 	canonicalSessionPath,
 	getWindowsProcessStartId,
+	isProcessAlive,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 	SessionAlreadyActiveError,
@@ -33,6 +34,76 @@ function enabledEnvironment(owner: string): NodeJS.ProcessEnv {
 		[SESSION_LEASE_OWNER_ID_ENV]: owner,
 	};
 }
+
+function errno(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(code), { code });
+}
+
+describe("process liveness", () => {
+	it.each(["linux", "android"] as const)(
+		"treats EPERM with a missing proc entry as a stale or reused pid on %s",
+		(platform) => {
+			expect(
+				isProcessAlive(
+					42,
+					() => {
+						throw errno("EPERM");
+					},
+					() => {
+						throw errno("ENOENT");
+					},
+					platform,
+				),
+			).toBe(false);
+		},
+	);
+
+	it("keeps treating EPERM as alive when the proc entry is readable", () => {
+		expect(
+			isProcessAlive(
+				42,
+				() => {
+					throw errno("EPERM");
+				},
+				() => {},
+				"android",
+			),
+		).toBe(true);
+	});
+
+	it("stays conservative when procfs fails for a reason other than a missing entry", () => {
+		expect(
+			isProcessAlive(
+				42,
+				() => {
+					throw errno("EPERM");
+				},
+				() => {
+					throw errno("EACCES");
+				},
+				"android",
+			),
+		).toBe(true);
+	});
+
+	it("does not use procfs to reinterpret EPERM on non-procfs platforms", () => {
+		let procProbeCalls = 0;
+		expect(
+			isProcessAlive(
+				42,
+				() => {
+					throw errno("EPERM");
+				},
+				() => {
+					procProbeCalls++;
+					throw errno("ENOENT");
+				},
+				"darwin",
+			),
+		).toBe(true);
+		expect(procProbeCalls).toBe(0);
+	});
+});
 
 describe("session leases", () => {
 	it("reads an invariant process start identity on Windows", () => {


### PR DESCRIPTION
## Summary

- refine `kill(pid, 0)` `EPERM` handling on Linux and Android with a `/proc/<pid>/stat` probe
- treat a missing proc entry as a stale or reused lease-owner PID so the session lease can be reclaimed
- retain conservative alive behavior for readable proc entries, other procfs errors, and non-procfs platforms
- add platform-specific liveness regression coverage

On Termux, a dead worker PID can be reused by a SELinux-protected process. The signal probe then returns `EPERM` while the proc entry is hidden as `ENOENT`; previously both conditions were treated as proof that the original lease owner was still alive.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-lease.test.ts` (13 tests passed)
- `npm run check`

Fixes #868


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale session lease detection for reused PIDs on Android/Termux
> On Linux/Android, `isProcessAlive` previously treated `EPERM` from `process.kill(pid, 0)` as alive, which caused stale leases to become permanent when a dead worker's PID was reused by a protected process.
>
> - `isProcessAlive` in [`session-lease.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/910/files#diff-74865e03a1e2d7f4025a576ca8f4c09dbc1ec7c9e2776b5d93f2691ee29e6cda) now falls back to reading `/proc/<pid>/stat` when `EPERM` is received on Linux/Android; `ENOENT` in procfs means the process is dead.
> - On non-procfs platforms (e.g. Darwin), `EPERM` continues to be treated as alive.
> - The function is now exported and accepts injectable `ProcessProbe` dependencies for testing.
> - Behavioral Change: PIDs returning `EPERM` on Linux/Android are now considered dead if they have no `/proc` entry, changing the previous unconditional alive result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c30502b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->