### PR TITLE
fix(coding-agent): preserve sessions during daemon startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed slow daemon startup dropping resident sessions by waiting for the catalog and revalidating supervisors before replacement ([#911](https://github.com/PrimeIntellect-ai/prime-agent/pull/911) by [@traditio](https://github.com/traditio)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -64,10 +64,19 @@ async function canConnectToDaemon(socketPath: string, timeoutMs: number): Promis
 type DaemonVersionProbe =
 	| { status: "absent" }
 	| { status: "current"; hello: DaemonHello }
-	| { status: "stale"; hello?: DaemonHello };
+	| { status: "stale"; hello: DaemonHello }
+	| { status: "unresponsive" };
+
+function isCurrentDaemonHello(hello: DaemonHello): boolean {
+	return (
+		hello.protocol.version === DAEMON_PROTOCOL_VERSION &&
+		hello.schemaId === DAEMON_SCHEMA_ID &&
+		hello.appVersion === VERSION
+	);
+}
 
 /** Connect to a running daemon and check whether it matches this client's protocol and app version. */
-export async function probeDaemonVersion(socketPath: string): Promise<DaemonVersionProbe> {
+export async function probeDaemonVersion(socketPath: string, helloTimeoutMs = 2000): Promise<DaemonVersionProbe> {
 	let client: DaemonClient | undefined;
 	for (const timeoutMs of [250, 2000]) {
 		const candidate = new DaemonClient(socketPath);
@@ -83,11 +92,8 @@ export async function probeDaemonVersion(socketPath: string): Promise<DaemonVers
 		return { status: "absent" };
 	}
 	try {
-		const hello = await client.waitForHello(2000);
-		const current =
-			hello.protocol.version === DAEMON_PROTOCOL_VERSION &&
-			hello.schemaId === DAEMON_SCHEMA_ID &&
-			hello.appVersion === VERSION;
+		const hello = await client.waitForHello(helloTimeoutMs);
+		const current = isCurrentDaemonHello(hello);
 		if (!current) {
 			logDaemonLaunch(
 				`running daemon on ${socketPath} is stale: daemon v${hello.appVersion}/proto${hello.protocol.version}` +
@@ -100,9 +106,10 @@ export async function probeDaemonVersion(socketPath: string): Promise<DaemonVers
 		}
 		return { status: "stale", hello };
 	} catch {
-		// Connected but no recognizable greeting: assume a stale daemon.
-		logDaemonLaunch(`running daemon on ${socketPath} sent no recognizable hello; treating as stale`);
-		return { status: "stale" };
+		// A supervisor accepts connections before worker adoption completes. A
+		// missing greeting is therefore not proof that it is stale.
+		logDaemonLaunch(`running daemon on ${socketPath} sent no recognizable hello; waiting for startup`);
+		return { status: "unresponsive" };
 	} finally {
 		client.close();
 	}
@@ -299,52 +306,73 @@ export async function probeRunningDaemonSessions(socketPath: string): Promise<Ru
 	}
 }
 
+type StaleDaemonDisposition = "current" | "stopped" | "busy";
+
 // Idle-but-loaded sessions reload from disk on the fresh daemon, so only a busy
 // session blocks replacing a stale daemon.
-async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean> {
+async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<StaleDaemonDisposition> {
 	const client = new DaemonClient(socketPath);
-	let connected = false;
-	let hasBusySessions = false;
-	let loadedSessionCount = 0;
 	try {
 		await client.connect(1000);
-		connected = true;
-		try {
-			const result = await queryActiveDaemonSessions(client, { includeClientOwned: true });
-			loadedSessionCount = result.sessions.length;
-			hasBusySessions =
-				result.busyClientOwnedSessionCount !== 0 || result.sessions.some((summary) => isSessionBusy(summary));
-		} catch {
-			// Couldn't confirm idleness: treat as busy rather than risk interrupting work.
-			hasBusySessions = true;
-		}
 	} catch {
-		// Couldn't reach it to inspect; don't send a blind shutdown, just verify below.
-	} finally {
 		client.close();
+		// Couldn't reach it to inspect; don't send a blind shutdown, just verify below.
+		return (await waitForDaemonGone(socketPath)) ? "stopped" : "busy";
 	}
 
-	if (!connected) {
-		return waitForDaemonGone(socketPath);
+	let loadedSessionCount = 0;
+	let hasBusySessions = true;
+	try {
+		const result = await queryActiveDaemonSessions(client, { includeClientOwned: true });
+		loadedSessionCount = result.sessions.length;
+		hasBusySessions =
+			result.busyClientOwnedSessionCount !== 0 || result.sessions.some((summary) => isSessionBusy(summary));
+	} catch {
+		// Couldn't confirm idleness: treat as busy rather than risk interrupting work.
+	}
+
+	const hello = client.hello;
+	if (hello && isCurrentDaemonHello(hello)) {
+		client.close();
+		logDaemonLaunch(`daemon on ${socketPath} finished starting while staleness was being checked; reusing it`);
+		return "current";
 	}
 	if (hasBusySessions) {
+		client.close();
 		logDaemonLaunch(`refusing to replace stale daemon on ${socketPath}: busy session(s) present`);
-		return false;
+		return "busy";
 	}
 	logDaemonLaunch(
 		`replacing stale daemon on ${socketPath} (idle): ${loadedSessionCount} loaded session(s) will reload`,
 	);
-	return shutdownDaemonAndWait(socketPath);
+	return (await shutdownConnectedDaemonAndWait(client, socketPath, 5000, hello)) ? "stopped" : "busy";
 }
 
 async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promise<void> {
-	const probe = await probeDaemonVersion(socketPath);
+	const probeStartedAt = Date.now();
+	let probe = await probeDaemonVersion(socketPath);
+	if (probe.status === "unresponsive") {
+		const remainingStartupMs = Math.max(1, DAEMON_STARTUP_TIMEOUT_MS - (Date.now() - probeStartedAt));
+		probe = await probeDaemonVersion(socketPath, remainingStartupMs);
+	}
 	if (probe.status === "current") {
 		return;
 	}
+	if (probe.status === "unresponsive") {
+		throw new Error(
+			`Prime Agent daemon on ${socketPath} accepted connections but did not finish startup within ${DAEMON_STARTUP_TIMEOUT_MS / 1000} seconds. ` +
+				`It was left running to avoid interrupting active work.
+
+Run:
+${formatCurrentCliCommand(["shutdown", "--force"])}
+
+Then retry the original command.`,
+		);
+	}
 	if (probe.status === "stale") {
-		const stopped = await shutdownStaleDaemonIfNotBusy(socketPath);
-		if (!stopped) throw new StaleDaemonError(socketPath, probe.hello);
+		const disposition = await shutdownStaleDaemonIfNotBusy(socketPath);
+		if (disposition === "current") return;
+		if (disposition === "busy") throw new StaleDaemonError(socketPath, probe.hello);
 	}
 
 	const entrypoint = process.argv[1];

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-entry.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-entry.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runDaemonCatalogProcess } from "./daemon-catalog-process.js";
+
+await runDaemonCatalogProcess();

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,13 +1,31 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
+import { isBunBinary } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
+export const DAEMON_CATALOG_START_TIMEOUT_MS = 30_000;
+
+function resolveDaemonCatalogEntrypoint(): string {
+	const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		join(moduleDirectory, "daemon-catalog-entry.js"),
+		join(moduleDirectory, "daemon-catalog-entry.ts"),
+		resolve(moduleDirectory, "../modes/daemon/daemon-catalog-entry.js"),
+	];
+	const entrypoint = candidates.find((candidate) => existsSync(candidate));
+	if (!entrypoint) {
+		throw new Error("Cannot locate the daemon catalog entrypoint");
+	}
+	return entrypoint;
+}
 
 interface SessionInfoWire extends Omit<SessionInfo, "created" | "modified"> {
 	created: string;
@@ -391,7 +409,9 @@ export class DaemonCatalogClient {
 	}
 
 	private async spawnCatalog(): Promise<void> {
-		const launch = createCliSubprocessLaunchSpec(["--version"]);
+		const launch = isBunBinary
+			? createCliSubprocessLaunchSpec(["--version"])
+			: createCliSubprocessLaunchSpec([], process.execPath, process.execArgv, resolveDaemonCatalogEntrypoint());
 		const child = spawn(launch.command, launch.args, {
 			cwd: process.cwd(),
 			env: createCliSubprocessEnv({ ...process.env, [DAEMON_CATALOG_ROLE_ENV]: "1" }),
@@ -413,7 +433,7 @@ export class DaemonCatalogClient {
 				}
 				child.kill("SIGKILL");
 				rejectReady(error);
-			}, 5000);
+			}, DAEMON_CATALOG_START_TIMEOUT_MS);
 			const cleanup = () => {
 				clearTimeout(timeout);
 				child.off("message", onMessage);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2823,6 +2823,10 @@ export class DaemonSupervisor {
 	private async recoverUncertainWorkerOperations(worker: ResidentWorker, killWorkerProcess = true): Promise<void> {
 		await this.assertRecoveryAllowed();
 		if (killWorkerProcess) {
+			// Recovery needs the catalog to record interrupted work. Do not terminate a
+			// still-recoverable worker until that dependency is ready.
+			await this.catalog.start();
+			await this.assertRecoveryAllowed();
 			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
 		}
 		const orphanProcessJournalPath = worker.descriptor.orphanProcessJournalPath;

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
-import { listSavedSessionSiblings, resolveCatalogSessionMatch } from "../src/modes/daemon/daemon-catalog-process.js";
+import {
+	DAEMON_CATALOG_START_TIMEOUT_MS,
+	listSavedSessionSiblings,
+	resolveCatalogSessionMatch,
+} from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
 	return {
@@ -19,6 +23,12 @@ function session(id: string, name: string | undefined, path: string): SessionInf
 		allMessagesText: "",
 	};
 }
+
+describe("daemon catalog process", () => {
+	it("allows a cold catalog more than five seconds to become ready", () => {
+		expect(DAEMON_CATALOG_START_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+	});
+});
 
 describe("daemon catalog selector resolution", () => {
 	it("reads only a saved child's persisted sibling set", async () => {

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -24,6 +24,8 @@ interface FakeDaemonOptions {
 	respondToShutdown?: boolean;
 	protocolVersion?: number;
 	appVersion?: string;
+	firstHelloDelayMs?: number;
+	firstSchemaId?: string;
 	schemaId?: string;
 	serverCapabilities?: string[];
 	onCommand?: (command: { type: string }) => void;
@@ -41,17 +43,34 @@ function send(socket: Socket, message: unknown): void {
 async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-"));
 	const socketPath = join(dir, "d.sock");
+	const helloTimers = new Set<ReturnType<typeof setTimeout>>();
+	let connectionIndex = 0;
 	const server: Server = createServer((socket) => {
+		const currentConnectionIndex = connectionIndex++;
 		socket.on("error", () => undefined);
-		send(socket, {
-			type: "daemon_hello",
-			socketPath,
-			protocol: { name: "prime-agent.daemon", version: options.protocolVersion ?? DAEMON_PROTOCOL_VERSION },
-			appVersion: options.appVersion,
-			schemaId: options.schemaId ?? DAEMON_SCHEMA_ID,
-			clientId: "fake-client",
-			serverCapabilities: options.serverCapabilities ?? [],
-		});
+		const sendHello = () =>
+			send(socket, {
+				type: "daemon_hello",
+				socketPath,
+				protocol: { name: "prime-agent.daemon", version: options.protocolVersion ?? DAEMON_PROTOCOL_VERSION },
+				appVersion: options.appVersion,
+				schemaId:
+					currentConnectionIndex === 0 && options.firstSchemaId
+						? options.firstSchemaId
+						: (options.schemaId ?? DAEMON_SCHEMA_ID),
+				clientId: "fake-client",
+				serverCapabilities: options.serverCapabilities ?? [],
+			});
+		const helloDelayMs = currentConnectionIndex === 0 ? (options.firstHelloDelayMs ?? 0) : 0;
+		if (helloDelayMs > 0) {
+			const timer = setTimeout(() => {
+				helloTimers.delete(timer);
+				sendHello();
+			}, helloDelayMs);
+			helloTimers.add(timer);
+		} else {
+			sendHello();
+		}
 		let buffer = "";
 		socket.on("data", (chunk) => {
 			buffer += chunk.toString();
@@ -101,6 +120,8 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 		socketPath,
 		close: () =>
 			new Promise<void>((resolve) => {
+				for (const timer of helloTimers) clearTimeout(timer);
+				helloTimers.clear();
 				server.close(() => resolve());
 				rmSync(dir, { recursive: true, force: true });
 			}),
@@ -271,6 +292,38 @@ describe("ensureInteractiveDaemonRunning", () => {
 		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
 
 		await expect(probe).resolves.toMatchObject({ status: "current" });
+	});
+
+	it("waits for a current daemon that accepts connections before its hello is ready", async () => {
+		const commands: string[] = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			firstHelloDelayMs: 2500,
+			schemaId: DAEMON_SCHEMA_ID,
+			onCommand: (command) => commands.push(command.type),
+		});
+		cleanups.push(daemon.close);
+
+		await expect(ensureInteractiveDaemonRunning(daemon.socketPath)).resolves.toBeUndefined();
+		expect(commands).not.toContain("list");
+		expect(commands).not.toContain("shutdown");
+	});
+
+	it("reuses a daemon that becomes current while a stale verdict is being checked", async () => {
+		const commands: string[] = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			firstSchemaId: "stale-schema",
+			schemaId: DAEMON_SCHEMA_ID,
+			onCommand: (command) => commands.push(command.type),
+		});
+		cleanups.push(daemon.close);
+
+		await expect(ensureInteractiveDaemonRunning(daemon.socketPath)).resolves.toBeUndefined();
+		expect(commands).toContain("list");
+		expect(commands).not.toContain("shutdown");
 	});
 
 	it("fails fast with the daemon log tail when the spawned daemon exits during startup", async () => {


### PR DESCRIPTION
## Summary

- start the saved-session catalog through a dedicated lightweight entrypoint and allow slow filesystems a 30-second startup window
- treat a connected supervisor without a hello as still starting instead of stale, and revalidate the connected daemon before any stale shutdown
- start the catalog before terminating a recoverable worker so an interruption marker can be persisted before replacement

This prevents a slow cold start from cascading into supervisor churn, failed worker recovery, and `Unknown active session` errors while the durable session is still on disk.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-catalog-process.test.ts test/daemon-launch.test.ts` — 32 tests passed
- `npm run check` — passed (formatting, type checking, installer render, browser smoke)
- manually exercised `DaemonCatalogClient.start()` on the affected WSL-mounted checkout; the dedicated entrypoint reached `ready` consistently below the former 5-second cutoff


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix session loss during slow daemon startup by waiting for catalog readiness and revalidating supervisors
> - `probeDaemonVersion` in [daemon-launch.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/911/files#diff-6fb96bb6db15342f8a2c74a0e131c6a79950880f2c13d6410a6be9acf6f464a7) now distinguishes 'unresponsive' daemons (connected but no hello within timeout) from 'stale' ones, and `ensureDaemonRunning` waits within the startup window before giving up.
> - `shutdownStaleDaemonIfNotBusy` returns a tri-state (`'current' | 'stopped' | 'busy'`) and skips shutdown if the daemon sends a current hello during staleness checks, preventing replacement of a healthy daemon that was slow to start.
> - `DaemonSupervisor.recoverUncertainWorkerOperations` in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/911/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) now awaits `catalog.start()` before sending SIGKILL, ensuring the catalog is ready to record interrupted work.
> - The catalog process in [daemon-catalog-process.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/911/files#diff-0ce2cf2f0eda51eced7102df346434fc17d355dbc6022b11ebf5749da089d51d) now has a 30-second startup timeout and launches via a dedicated entrypoint under Node environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6407a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->