### PR TITLE
fix(coding-agent): accept sparse leap-day schedules

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed valid leap-day cron schedules being rejected when their next run was more than one year away ([#912](https://github.com/PrimeIntellect-ai/prime-agent/pull/912) by [@chai1any](https://github.com/chai1any)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -1377,9 +1377,9 @@ function nextCronRunAfter(expression: string, after: Date): Date {
 	candidate.setSeconds(0, 0);
 	candidate.setMinutes(candidate.getMinutes() + 1);
 
-	// Gregorian calendar dates repeat every 400 years. Scan that full cycle so
-	// valid sparse schedules such as leap day are not rejected, while skipping
-	// non-matching calendar days instead of checking every minute.
+	// Gregorian calendar date/weekday combinations repeat every 400 years. Scan
+	// that full cycle so valid sparse schedules such as leap day are not rejected,
+	// while skipping non-matching calendar days instead of checking every minute.
 	const deadline = new Date(candidate.getTime());
 	deadline.setFullYear(deadline.getFullYear() + 400);
 	while (candidate.getTime() <= deadline.getTime()) {

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -1377,14 +1377,23 @@ function nextCronRunAfter(expression: string, after: Date): Date {
 	candidate.setSeconds(0, 0);
 	candidate.setMinutes(candidate.getMinutes() + 1);
 
-	const deadline = candidate.getTime() + 366 * 24 * 60 * ONE_MINUTE_MS;
-	while (candidate.getTime() <= deadline) {
+	// Gregorian calendar dates repeat every 400 years. Scan that full cycle so
+	// valid sparse schedules such as leap day are not rejected, while skipping
+	// non-matching calendar days instead of checking every minute.
+	const deadline = new Date(candidate.getTime());
+	deadline.setFullYear(deadline.getFullYear() + 400);
+	while (candidate.getTime() <= deadline.getTime()) {
+		if (!matchesCronCalendarDay(candidate, fields)) {
+			candidate.setDate(candidate.getDate() + 1);
+			candidate.setHours(0, 0, 0, 0);
+			continue;
+		}
 		if (matchesCronFields(candidate, fields)) {
 			return candidate;
 		}
 		candidate.setMinutes(candidate.getMinutes() + 1);
 	}
-	throw new Error(`Cron schedule did not match within one year: ${expression}`);
+	throw new Error(`Cron schedule has no matching date: ${expression}`);
 }
 
 function parseCronExpression(expression: string): CronFields {
@@ -1453,15 +1462,15 @@ function parseCronNumber(value: string | undefined, min: number, max: number): n
 	return parsed;
 }
 
-function matchesCronFields(date: Date, fields: CronFields): boolean {
+function matchesCronCalendarDay(date: Date, fields: CronFields): boolean {
 	const day = date.getDay();
-	const dayMatches = fields.dayOfWeek.has(day) || (day === 0 && fields.dayOfWeek.has(7));
+	const dayOfWeekMatches = fields.dayOfWeek.has(day) || (day === 0 && fields.dayOfWeek.has(7));
+	return fields.dayOfMonth.has(date.getDate()) && fields.month.has(date.getMonth() + 1) && dayOfWeekMatches;
+}
+
+function matchesCronFields(date: Date, fields: CronFields): boolean {
 	return (
-		fields.minute.has(date.getMinutes()) &&
-		fields.hour.has(date.getHours()) &&
-		fields.dayOfMonth.has(date.getDate()) &&
-		fields.month.has(date.getMonth() + 1) &&
-		dayMatches
+		fields.minute.has(date.getMinutes()) && fields.hour.has(date.getHours()) && matchesCronCalendarDay(date, fields)
 	);
 }
 

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -43,6 +43,14 @@ describe("parseAgentCronSchedule", () => {
 		]).toEqual([2028, 1, 29, 0, 0]);
 	});
 
+	it("rejects impossible calendar dates after a finite scan", () => {
+		const after = new Date(2025, 2, 1, 0, 0, 0, 0);
+
+		expect(() => parseAgentCronSchedule("0 0 31 2 *", after)).toThrow(
+			"Cron schedule has no matching date: 0 0 31 2 *",
+		);
+	});
+
 	it("parses recurring heartbeat intervals with seconds", () => {
 		const parsed = parseAgentCronSchedule("every 30s", start);
 

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -30,6 +30,19 @@ describe("parseAgentCronSchedule", () => {
 		expect(parseAgentCronSchedule("*/30 * * * *", start).nextRunAt.toISOString()).toBe("2026-01-01T13:00:00.000Z");
 	});
 
+	it("finds valid leap-day schedules beyond the next year", () => {
+		const after = new Date(2025, 2, 1, 0, 0, 0, 0);
+		const nextRunAt = parseAgentCronSchedule("0 0 29 2 *", after).nextRunAt;
+
+		expect([
+			nextRunAt.getFullYear(),
+			nextRunAt.getMonth(),
+			nextRunAt.getDate(),
+			nextRunAt.getHours(),
+			nextRunAt.getMinutes(),
+		]).toEqual([2028, 1, 29, 0, 0]);
+	});
+
 	it("parses recurring heartbeat intervals with seconds", () => {
 		const parsed = parseAgentCronSchedule("every 30s", start);
 


### PR DESCRIPTION
## Summary

- search a complete Gregorian calendar cycle when resolving the next five-field cron run
- skip non-matching calendar days so sparse schedules remain fast without a minute-by-minute multi-year scan
- add a timezone-independent regression for a leap-day schedule created in 2025

## Problem

`nextCronRunAfter()` currently stops after 366 days. A valid schedule such as `0 0 29 2 *` is therefore rejected during creation in most years because its next occurrence can be several years away:

```text
Cron schedule did not match within one year: 0 0 29 2 *
```

Gregorian calendar dates repeat every 400 years, which provides a finite correctness bound. Skipping calendar days that cannot match keeps that bound practical and also rejects impossible dates deterministically.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cron-jobs.test.ts` (54 tests passed)
- `npm run check`
- cron suite also passed under `UTC`, `America/New_York`, `Europe/Berlin`, `Pacific/Apia`, and `Australia/Lord_Howe`
- manual reproduction now resolves `0 0 29 2 *` from March 2025 to February 29, 2028


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `nextCronRunAfter` to accept leap-day cron schedules beyond one year
> - Replaces the one-year minute-by-minute scan in `nextCronRunAfter` with a 400-year Gregorian window, allowing sparse schedules like `0 0 29 2 *` (leap day) to resolve correctly.
> - Adds a calendar-day prefilter via a new `matchesCronCalendarDay` helper that skips non-matching days in whole-day increments instead of iterating minute-by-minute.
> - Impossible dates (e.g. `0 0 31 2 *`) now throw `'Cron schedule has no matching date: ...'` instead of `'Cron schedule did not match within one year: ...'`.
> - Behavioral Change: the scan window is now 400 years instead of 1; schedules that previously errored after one year may now resolve.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d53b62e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->