### PR TITLE
Preserve usage from incomplete OpenAI Responses

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Fixed OpenAI Responses incomplete events dropping final usage and response IDs ([#914](https://github.com/PrimeIntellect-ai/prime-agent/pull/914) by [@paulbrav](https://github.com/paulbrav)).
+- Fixed OpenAI Responses turns that end in `response.incomplete` reporting a fake success. The event was ignored, so the turn kept zero usage, zero cost, and the initialized stop reason `stop`. Such a turn now records its final usage and cost ([#914](https://github.com/PrimeIntellect-ai/prime-agent/pull/914) by [@paulbrav](https://github.com/paulbrav)).
+- Changed the stop reason of an incomplete OpenAI Responses turn from `stop` to `length`, or to `error` with `stopReasonRaw` `content_filter` when `incomplete_details.reason` says the response was blocked. That is the mapping `openai-completions` already gives its `content_filter` finish reason. An `error` turn also carries an `errorMessage` naming the block, so a transport that pushes the message straight through instead of throwing does not report it as an unnamed failure. An `error` turn ends the agent loop with a classified provider failure and is dropped from replay, where the old `stop` let the loop continue as if the turn had finished ([#914](https://github.com/PrimeIntellect-ai/prime-agent/pull/914) by [@paulbrav](https://github.com/paulbrav)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed OpenAI Responses incomplete events dropping final usage and response IDs.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed OpenAI Responses incomplete events dropping final usage and response IDs.
+- Fixed OpenAI Responses incomplete events dropping final usage and response IDs ([#914](https://github.com/PrimeIntellect-ai/prime-agent/pull/914) by [@paulbrav](https://github.com/paulbrav)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -31,7 +31,7 @@ import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import { classifyStreamFailure, StreamFailureError } from "../utils/stream-failure.js";
+import { classifyStreamFailure, StreamFailureError, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -510,13 +510,22 @@ export async function processResponsesStream<TApi extends Api>(
 					: (response?.service_tier ?? options.serviceTier);
 				options.applyServiceTierPricing(output.usage, serviceTier);
 			}
-			// Map status to stop reason
-			output.stopReason = mapStopReason(response?.status);
+			// Map status to stop reason. An incomplete response says why it stopped in
+			// incomplete_details, which distinguishes truncation from a blocked response.
+			const incompleteReason = response?.incomplete_details?.reason;
+			output.stopReason = mapStopReason(response?.status, incompleteReason);
 			if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
-			if (output.stopReason === "error" && response?.status) {
-				output.stopReasonRaw = response.status;
+			// Prefer the incomplete reason over the status: "content_filter" classifies as a
+			// safety failure, "incomplete" classifies as nothing.
+			const rawStopReason = incompleteReason ?? response?.status;
+			if (output.stopReason === "error" && rawStopReason) {
+				output.stopReasonRaw = rawStopReason;
+				// The transports that throw on an error stop reason overwrite this from the
+				// same helper. The ones that push the message straight through would otherwise
+				// hand the user a turn that failed with no reason on it.
+				output.errorMessage = streamFailureFromStopReason(rawStopReason).message;
 			}
 		} else if (event.type === "error") {
 			throw new StreamFailureError(`Error Code ${event.code}: ${event.message}`, {
@@ -540,13 +549,39 @@ export async function processResponsesStream<TApi extends Api>(
 	}
 }
 
-function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): StopReason {
+/**
+ * The API declares two incomplete reasons: "max_output_tokens" (the turn was cut
+ * short) and "content_filter" (the response was blocked). A blocked response maps
+ * to "error", the same mapping openai-completions gives the "content_filter"
+ * finish reason.
+ */
+function mapIncompleteReason(reason: OpenAI.Responses.Response.IncompleteDetails["reason"]): StopReason {
+	switch (reason) {
+		case "content_filter":
+			return "error";
+		case "max_output_tokens":
+		case undefined:
+			return "length";
+		default:
+			// Unlike mapStopReason below, an unrecognized value does not throw: the
+			// "incomplete" status already says the turn was cut short, so a reason the
+			// API adds later still maps to "length". The check goes red when the SDK's
+			// declared union grows, so a new reason gets a deliberate mapping.
+			reason satisfies never;
+			return "length";
+	}
+}
+
+function mapStopReason(
+	status: OpenAI.Responses.ResponseStatus | undefined,
+	incompleteReason: OpenAI.Responses.Response.IncompleteDetails["reason"],
+): StopReason {
 	if (!status) return "stop";
 	switch (status) {
 		case "completed":
 			return "stop";
 		case "incomplete":
-			return "length";
+			return mapIncompleteReason(incompleteReason);
 		case "failed":
 		case "cancelled":
 			return "error";

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -486,7 +486,7 @@ export async function processResponsesStream<TApi extends Api>(
 				currentBlock = null;
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
-		} else if (event.type === "response.completed") {
+		} else if (event.type === "response.completed" || event.type === "response.incomplete") {
 			const response = event.response;
 			if (response?.id) {
 				output.responseId = response.id;

--- a/packages/ai/test/openai-responses-incomplete.test.ts
+++ b/packages/ai/test/openai-responses-incomplete.test.ts
@@ -1,0 +1,73 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, Model } from "../src/types.js";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.js";
+
+const model: Model<"openai-responses"> = {
+	id: "gpt-5.6-sol",
+	name: "GPT-5.6 Sol",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1050000,
+	maxTokens: 128000,
+};
+
+function createOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("OpenAI Responses incomplete events", () => {
+	it("records final usage, response ID, and length stop reason", async () => {
+		const output = createOutput();
+		const stream = new AssistantMessageEventStream();
+		const events = [
+			{
+				type: "response.incomplete",
+				response: {
+					id: "resp_incomplete",
+					status: "incomplete",
+					usage: {
+						input_tokens: 30,
+						output_tokens: 5,
+						total_tokens: 35,
+						input_tokens_details: { cached_tokens: 10 },
+					},
+				},
+			},
+		] as ResponseStreamEvent[];
+
+		await processResponsesStream(
+			(async function* () {
+				for (const event of events) yield event;
+			})(),
+			output,
+			stream,
+			model,
+		);
+
+		expect(output.stopReason).toBe("length");
+		expect(output.responseId).toBe("resp_incomplete");
+		expect(output.usage).toMatchObject({ input: 20, cacheRead: 10, output: 5, totalTokens: 35 });
+	});
+});

--- a/packages/ai/test/openai-responses-incomplete.test.ts
+++ b/packages/ai/test/openai-responses-incomplete.test.ts
@@ -1,9 +1,12 @@
 import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
+import type { OpenAIResponsesStreamOptions } from "../src/providers/openai-responses-shared.js";
 import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
 import type { AssistantMessage, Model } from "../src/types.js";
 import { AssistantMessageEventStream } from "../src/utils/event-stream.js";
+import { streamFailureFromStopReason } from "../src/utils/stream-failure.js";
 
+// Priced, so the cost an incomplete turn is charged is visible.
 const model: Model<"openai-responses"> = {
 	id: "gpt-5.6-sol",
 	name: "GPT-5.6 Sol",
@@ -12,10 +15,23 @@ const model: Model<"openai-responses"> = {
 	baseUrl: "https://api.openai.com/v1",
 	reasoning: true,
 	input: ["text"],
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	cost: { input: 3, output: 12, cacheRead: 0.3, cacheWrite: 0 },
 	contextWindow: 1050000,
 	maxTokens: 128000,
 };
+
+// 30 input tokens of which 10 were served from cache, plus 5 output tokens.
+const responseUsage = {
+	input_tokens: 30,
+	output_tokens: 5,
+	total_tokens: 35,
+	input_tokens_details: { cached_tokens: 10 },
+};
+
+// 20 * $3/M, 5 * $12/M, 10 * $0.3/M.
+const expectedCost = { input: 0.00006, output: 0.00006, cacheRead: 0.000003, total: 0.000123 };
+
+const serviceTierMultiplier = 0.5;
 
 function createOutput(): AssistantMessage {
 	return {
@@ -37,37 +53,169 @@ function createOutput(): AssistantMessage {
 	};
 }
 
-describe("OpenAI Responses incomplete events", () => {
-	it("records final usage, response ID, and length stop reason", async () => {
-		const output = createOutput();
-		const stream = new AssistantMessageEventStream();
-		const events = [
-			{
-				type: "response.incomplete",
-				response: {
-					id: "resp_incomplete",
-					status: "incomplete",
-					usage: {
-						input_tokens: 30,
-						output_tokens: 5,
-						total_tokens: 35,
-						input_tokens_details: { cached_tokens: 10 },
-					},
-				},
+/** Records the tier the stream resolved and halves the cost, like the flex tier does. */
+function createServiceTierOptions(): {
+	options: OpenAIResponsesStreamOptions;
+	resolvedTiers: (string | null | undefined)[];
+} {
+	const resolvedTiers: (string | null | undefined)[] = [];
+	return {
+		resolvedTiers,
+		options: {
+			serviceTier: "auto",
+			applyServiceTierPricing: (usage, serviceTier) => {
+				resolvedTiers.push(serviceTier);
+				usage.cost.input *= serviceTierMultiplier;
+				usage.cost.output *= serviceTierMultiplier;
+				usage.cost.cacheRead *= serviceTierMultiplier;
+				usage.cost.cacheWrite *= serviceTierMultiplier;
+				usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 			},
-		] as ResponseStreamEvent[];
+		},
+	};
+}
 
-		await processResponsesStream(
-			(async function* () {
-				for (const event of events) yield event;
-			})(),
-			output,
-			stream,
-			model,
+/**
+ * `incompleteDetails` is passed through verbatim so a case can send the field the
+ * way the API does: absent reason, `null` details, or one of the declared reasons.
+ */
+function incompleteEvent(options: {
+	id: string;
+	incompleteDetails?: { reason?: string } | null;
+	serviceTier?: string;
+}): ResponseStreamEvent {
+	return {
+		type: "response.incomplete",
+		response: {
+			id: options.id,
+			status: "incomplete",
+			incomplete_details: options.incompleteDetails ?? null,
+			...(options.serviceTier ? { service_tier: options.serviceTier } : {}),
+			usage: responseUsage,
+		},
+	} as ResponseStreamEvent;
+}
+
+function createdEvent(id: string): ResponseStreamEvent {
+	return { type: "response.created", response: { id, status: "in_progress" } } as ResponseStreamEvent;
+}
+
+async function runStream(
+	events: ResponseStreamEvent[],
+	options?: OpenAIResponsesStreamOptions,
+): Promise<AssistantMessage> {
+	const output = createOutput();
+	await processResponsesStream(
+		(async function* () {
+			for (const event of events) yield event;
+		})(),
+		output,
+		new AssistantMessageEventStream(),
+		model,
+		options,
+	);
+	return output;
+}
+
+describe("OpenAI Responses incomplete events", () => {
+	it("charges the usage and cost of a truncated turn and stops it with reason length", async () => {
+		const { options, resolvedTiers } = createServiceTierOptions();
+
+		const output = await runStream(
+			[
+				createdEvent("resp_incomplete"),
+				incompleteEvent({
+					id: "resp_incomplete",
+					incompleteDetails: { reason: "max_output_tokens" },
+					serviceTier: "flex",
+				}),
+			],
+			options,
 		);
 
 		expect(output.stopReason).toBe("length");
+		expect(output.stopReasonRaw).toBeUndefined();
+		expect(output.usage).toMatchObject({ input: 20, cacheRead: 10, output: 5, cacheWrite: 0, totalTokens: 35 });
+		// The response's own tier wins over the requested one, and it is applied here
+		// exactly as it is on response.completed.
+		expect(resolvedTiers).toEqual(["flex"]);
+		expect(output.usage.cost.input).toBeCloseTo(expectedCost.input * serviceTierMultiplier, 12);
+		expect(output.usage.cost.output).toBeCloseTo(expectedCost.output * serviceTierMultiplier, 12);
+		expect(output.usage.cost.cacheRead).toBeCloseTo(expectedCost.cacheRead * serviceTierMultiplier, 12);
+		expect(output.usage.cost.total).toBeCloseTo(expectedCost.total * serviceTierMultiplier, 12);
+		// response.created already set the ID on a full stream, so this is not what the
+		// incomplete arm restores. It pins that the arm does not overwrite or clear it.
 		expect(output.responseId).toBe("resp_incomplete");
-		expect(output.usage).toMatchObject({ input: 20, cacheRead: 10, output: 5, totalTokens: 35 });
+	});
+
+	it("takes the response ID from the incomplete event when no response.created arrived", async () => {
+		const output = await runStream([
+			incompleteEvent({ id: "resp_terminal_only", incompleteDetails: { reason: "max_output_tokens" } }),
+		]);
+
+		expect(output.responseId).toBe("resp_terminal_only");
+		expect(output.usage.cost.total).toBeCloseTo(expectedCost.total, 12);
+	});
+
+	it("keeps the length stop reason when the response carries no incomplete_details", async () => {
+		const output = await runStream([incompleteEvent({ id: "resp_no_details", incompleteDetails: null })]);
+
+		expect(output.stopReason).toBe("length");
+		expect(output.stopReasonRaw).toBeUndefined();
+		expect(output.usage.totalTokens).toBe(35);
+	});
+
+	it("keeps the length stop reason when incomplete_details carries no reason", async () => {
+		const output = await runStream([incompleteEvent({ id: "resp_empty_details", incompleteDetails: {} })]);
+
+		expect(output.stopReason).toBe("length");
+		expect(output.stopReasonRaw).toBeUndefined();
+	});
+
+	it("maps a content_filter incomplete response to an error stop reason", async () => {
+		const output = await runStream([
+			incompleteEvent({ id: "resp_filtered", incompleteDetails: { reason: "content_filter" } }),
+		]);
+
+		expect(output.stopReason).toBe("error");
+		// stopReasonRaw is what the provider hands the failure classifier. The status
+		// "incomplete" classifies as "unknown"; "content_filter" classifies as a block.
+		expect(output.stopReasonRaw).toBe("content_filter");
+		expect(streamFailureFromStopReason(output.stopReasonRaw).info.kind).toBe("safety");
+		// A transport that pushes this message straight through instead of throwing still
+		// has to name the block: an error stop reason with no message renders as "Unknown
+		// error" and classifies as non-retryable by accident.
+		expect(output.errorMessage).toBe(streamFailureFromStopReason("content_filter").message);
+		expect(output.errorMessage).toContain("content_filter");
+		// The request still ran, so its usage and cost are still charged.
+		expect(output.usage.totalTokens).toBe(35);
+		expect(output.usage.cost.total).toBeCloseTo(expectedCost.total, 12);
+	});
+
+	it("keeps the length stop reason for an incomplete turn that holds a tool call", async () => {
+		const output = await runStream([
+			createdEvent("resp_tool"),
+			{
+				type: "response.output_item.added",
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read", arguments: "" },
+			} as ResponseStreamEvent,
+			{ type: "response.function_call_arguments.done", arguments: '{"path":"README.md"}' } as ResponseStreamEvent,
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "read",
+					arguments: '{"path":"README.md"}',
+				},
+			} as ResponseStreamEvent,
+			incompleteEvent({ id: "resp_tool", incompleteDetails: { reason: "max_output_tokens" } }),
+		]);
+
+		// The toolUse promotion is deliberately limited to a turn that stopped normally.
+		// A turn the server cut short reports that it was cut short, not what it holds.
+		expect(output.content.some((block) => block.type === "toolCall")).toBe(true);
+		expect(output.stopReason).toBe("length");
 	});
 });


### PR DESCRIPTION
## Summary

- Process response.incomplete terminal events through the same final metadata path as response.completed.
- Preserve the final response ID and token usage, including cached-input accounting.
- Map the incomplete status to the existing length stop reason.

This is intentionally separate from #913 because incomplete-response accounting is independent of server-side compaction.

## Verification

- Focused OpenAI Responses incomplete-event test: 1 passed
- AI package type-check passed
- npm run check passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve usage and fix stop reason mapping for incomplete OpenAI Responses
> - `processResponsesStream` in [openai-responses-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/914/files#diff-75a92c85369ffe30444d6da4b398bb4fd5b852ff45a5eea02f95b3b2fa48df48) now handles `response.incomplete` events the same as `response.completed`, recording usage, cost, and `responseId`.
> - A new `mapIncompleteReason` helper maps `incomplete_details.reason` to stop reasons: `content_filter` → `error`, `max_output_tokens`/undefined → `length`.
> - Incomplete turns with `content_filter` get `stopReasonRaw: 'content_filter'` and a populated `errorMessage` via `streamFailureFromStopReason`.
> - Behavioral Change: incomplete turns no longer report `stopReason: 'stop'` and are never promoted to `'toolUse'`, which affects loop termination and replay logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a12b092.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->