### PR TITLE
chore: add npm >=11.10 engine constraint to enforce min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@
 # Requires npm >= 11.10 to be enforced; older npm ignores this key.
 # Urgent security patch override: npm install --min-release-age=0 <pkg>
 min-release-age=7
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"typescript": "^7.0.2"
 	},
 	"engines": {
-		"node": ">=22.8.0"
+		"node": ">=22.8.0",
+		"npm": ">=11.10"
 	},
 	"version": "0.7.2",
 	"dependencies": {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Added `"npm": ">=11.10"` to the root `engines` field and `engine-strict=true` to `.npmrc` so installs with npm < 11.10 fail fast instead of silently ignoring the `min-release-age=7` supply-chain cooldown ([#874](https://github.com/PrimeIntellect-ai/prime-agent/issues/874)).
 
 ## [0.7.1] - 2026-08-07
 


### PR DESCRIPTION
## Summary

- Added `"npm": ">=11.10"` to the root `engines` field in `package.json`.

Without this constraint, `min-release-age=7` in `.npmrc` is silently ignored by npm < 11.10, allowing dependency installs and version scripts to bypass the 7-day supply-chain cooldown. The engine floor makes the requirement explicit and enforced.

## Test plan

- [x] `npm run check` passes (biome, tsgo, installer render, browser smoke)
- [x] Running npm version (11.17.0) satisfies the new constraint — no false block

Fixes #874

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add npm >=11.10 engine constraint with strict enforcement
> - Adds `npm: '>=11.10'` to the `engines` field in [package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/918/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to enforce the minimum npm version required for `min-release-age` support.
> - Sets `engine-strict=true` in [.npmrc](https://github.com/PrimeIntellect-ai/prime-agent/pull/918/files#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35de) so that `npm install` errors out when the engine constraints are not met.
> - Risk: developers and CI using npm <11.10 will see install failures until they upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27efa18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->