### PR TITLE
feat(tui): show session cost in tray status line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Added session cost display to the TUI tray/status line alongside the existing token/context readout (e.g. `128.4k (61%) · $1.32`), updating after each completed turn ([#894](https://github.com/PrimeIntellect-ai/prime-agent/issues/894)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -54,7 +54,7 @@ export function createAgentConnectionState(
 			thinkingLevel: scoped.thinkingLevel,
 		})),
 		activeToolNames: session.getActiveToolNames(),
-		contextUsage: session.getContextUsage(),
+		contextUsage: sessionStats.contextUsage,
 		sessionCost: sessionStats.cost,
 		// Baseline recap; the daemon overlays the live summary on attach.
 		recap: persistedRecap(sessionManager),

--- a/packages/coding-agent/src/modes/agent-connection/snapshot.ts
+++ b/packages/coding-agent/src/modes/agent-connection/snapshot.ts
@@ -25,6 +25,7 @@ export function createAgentConnectionState(
 ): AgentConnectionState {
 	const session = runtime.session;
 	const sessionManager = session.sessionManager;
+	const sessionStats = session.getSessionStats();
 	return {
 		activeSessionId,
 		cwd: sessionManager.getCwd(),
@@ -54,6 +55,7 @@ export function createAgentConnectionState(
 		})),
 		activeToolNames: session.getActiveToolNames(),
 		contextUsage: session.getContextUsage(),
+		sessionCost: sessionStats.cost,
 		// Baseline recap; the daemon overlays the live summary on attach.
 		recap: persistedRecap(sessionManager),
 	};

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -348,6 +348,7 @@ export interface AgentConnectionState {
 	scopedModels: AgentConnectionScopedModel[];
 	activeToolNames: string[];
 	contextUsage: SessionStats["contextUsage"];
+	sessionCost?: number;
 	/** One-line recap of the agent's recent work, shown above the prompt. */
 	recap?: string;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2671,7 +2671,7 @@ export class InteractiveMode {
 		this.contextUsageRefresh.lastSuccessGeneration = generation;
 		// Anything counted so far is now reflected in the snapshot; only later output is in-flight.
 		this.contextUsageTokenBaseline = this.activityTracker.getStatus().tokens;
-		this.patchConnectionState({ contextUsage: stats.contextUsage });
+		this.patchConnectionState({ contextUsage: stats.contextUsage, sessionCost: stats.cost });
 	}
 
 	private updateConnectionStateFromEvent(event: AgentConnectionSessionEvent): void {
@@ -6080,6 +6080,12 @@ export class InteractiveMode {
 		return keyHint("app.agents.back", "agents/resume");
 	}
 
+	private formatSessionCost(cost: number): string {
+		if (cost === 0) return "$0.00";
+		if (cost < 0.01) return `$${cost.toFixed(4)}`;
+		return `$${cost.toFixed(2)}`;
+	}
+
 	private getTrayContextLabel(): string | undefined {
 		const goalLabel = this.getTrayGoalLabel();
 		const heartbeatLabel = this.getTrayHeartbeatLabel();
@@ -6088,7 +6094,13 @@ export class InteractiveMode {
 			usage && typeof usage.tokens === "number" && typeof usage.percent === "number"
 				? `${formatTokenCount(usage.tokens)} (${Math.round(usage.percent)}%)`
 				: undefined;
-		return [goalLabel, heartbeatLabel, contextLabel].filter((label) => label !== undefined).join(" · ") || undefined;
+		const cost = this.connectionState?.sessionCost;
+		const costLabel = typeof cost === "number" ? this.formatSessionCost(cost) : undefined;
+		const usageWithCost =
+			contextLabel !== undefined && costLabel !== undefined
+				? `${contextLabel} · ${costLabel}`
+				: (contextLabel ?? costLabel);
+		return [goalLabel, heartbeatLabel, usageWithCost].filter((label) => label !== undefined).join(" · ") || undefined;
 	}
 
 	private getTrayHeartbeatLabel(): string | undefined {


### PR DESCRIPTION
## Summary

Shows accumulated session spend in the TUI tray/status line next to the existing token/context readout:

```
main · 128.4k (61%) · $1.32
```

- Added `sessionCost?: number` to `AgentConnectionState` in `types.ts`
- Populated from `session.getSessionStats().cost` in `createAgentConnectionState` (`snapshot.ts`) so cost is available immediately on attach
- Persisted each turn via `refreshConnectionContextUsage` alongside the existing `contextUsage` patch (no extra RPC call — `getSessionStats` was already called here and the result discarded)
- Rendered in `getTrayContextLabel` with sub-cent precision: 4 decimal places for cost < $0.01 (e.g. `$0.0042`), 2 decimal places otherwise

All the plumbing already existed; this is a display-only change.

## Test plan

- [x] `npm run check` passes (biome, tsgo, installer render, browser smoke)
- [x] `$0.00` shown when cost is 0 (before first assistant turn)
- [x] Sub-cent cost shows 4 decimal places (e.g. `$0.0042`)
- [x] Normal cost shows 2 decimal places (e.g. `$1.32`)
- [x] Cost only appears when `sessionCost` is populated (no `undefined` rendered)

Fixes #894

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show session cost in TUI tray status line alongside token/context usage
> - Adds a `sessionCost` field to `AgentConnectionState` by reading `session.getSessionStats().cost` in [`snapshot.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/919/files#diff-b96224e5973d747681caa3b3b46b10300d0ad88870882a61fd1f8a27397eb2f3).
> - Adds `formatSessionCost` helper in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/919/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) that formats cost as `$0.00` for zero, 4 decimal places below `$0.01`, and 2 decimal places otherwise.
> - Updates `getTrayContextLabel` to append the formatted cost to the existing token/context readout using a middle dot, e.g. `128.4k (61%) · $1.32`.
> - Cost is refreshed after each completed turn via the `contextUsageRefreshSuccess` handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd18ad3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->