### PR TITLE
docs(skills): add explicit API reference to agent-message and agent-observe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Added explicit API reference sections to `agent-message` and `agent-observe` skill docs: typed signatures, import patterns, correct broadcast syntax, and explicit list of non-existent functions ([#762](https://github.com/PrimeIntellect-ai/prime-agent/issues/762)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -24,28 +24,61 @@ if child is not None:
     # Keep the child until this follow-up finishes so its result remains observable.
 ```
 
-## API
+## Import
 
-- `await agent_message.list_agents()` — returns `current` (`name`, `id`, `depth`)
-  and family-scoped `entries` (`relationship`, `name`, `id`, `depth`, `status`)
-  for the current agent's parent, siblings, and children. It includes inactive
-  family members and sorts parent, siblings by name, then children by name; it
-  does not expose a global daemon session list.
-- `await agent_message.send(message, receiver_role="parent" | "sibling" | "child", receiver_name=None)` — sends one direct
-  text message to an active session. Sending to an idle completed subagent
-  starts an ordinary follow-up turn in that same child session and context.
-  The child remains available only until its parent session closes. The daemon
-  resolves `receiver_role` within the current agent family; `receiver_name` is
-  required for siblings and children and omitted for the unique parent.
-  `send("all", message)` broadcasts only to the family roster and returns
-  `{receipts: [...]}` in roster order; successful entries are ordinary receipts
-  and failed entries contain the target id and a short `error`. One failed delivery
-  does not reject successful deliveries. Messages always use steering delivery so
-  a busy target sees them during its active run. Returns a receipt with a
-  `deliveryStatus` field: `"delivered"` means the message reached an idle target's
-  context; `"queued"` means a steering message was accepted and will deliver when
-  the target's current work allows (`send` does not block waiting for that).
-  Delivered receipts carry `deliveredAt`, queued receipts carry `queuedAt`.
+```python
+import agent_message
+```
+
+## API Reference
+
+```python
+async def list_agents() -> dict
+```
+Returns `current` (`name`, `id`, `depth`) and family-scoped `entries` (each with
+`relationship`, `name`, `id`, `depth`, `status`) for parent, siblings, and direct
+children. Includes inactive family members. Does not expose a global daemon session
+list.
+
+---
+
+```python
+async def send(
+    message: str,
+    broadcast_message: str | None = None,
+    *,
+    receiver_role: "parent" | "sibling" | "child" | None = None,
+    receiver_name: str | None = None,
+) -> dict
+```
+
+**Direct message** (most common):
+```python
+receipt = await agent_message.send(
+    "Please inspect the latest result.",
+    receiver_role="child",
+    receiver_name=child.session_name,
+)
+```
+- `receiver_role`: required — `"parent"`, `"sibling"`, or `"child"`.
+- `receiver_name`: required for `"sibling"` and `"child"`; must be omitted for `"parent"`.
+- Returns a receipt dict with `deliveryStatus` (`"delivered"` or `"queued"`), plus
+  `deliveredAt` or `queuedAt` depending on status. Messages always use steering
+  delivery so a busy target sees them at the next tool boundary.
+
+**Broadcast to all family members:**
+```python
+receipt = await agent_message.send("all", broadcast_message="Status check — please reply.")
+```
+- First arg must be the literal string `"all"`.
+- `broadcast_message` carries the text to send.
+- `receiver_role` and `receiver_name` must be omitted for broadcasts.
+- Returns `{receipts: [...]}` in roster order; failed entries contain `id` and `error`.
+  One failed delivery does not cancel successful ones.
+
+**Functions that do NOT exist (common mistakes):**
+- `agent_message.list_messages()` — does not exist; use `agent_observe.recent_messages()`.
+- `agent_message.observe()` — does not exist; use the `agent-observe` skill.
 
 ## Safety
 

--- a/packages/coding-agent/skills/agent-message/SKILL.md
+++ b/packages/coding-agent/skills/agent-message/SKILL.md
@@ -47,7 +47,7 @@ async def send(
     message: str,
     broadcast_message: str | None = None,
     *,
-    receiver_role: "parent" | "sibling" | "child" | None = None,
+    receiver_role: str | None = None,  # "parent", "sibling", or "child"
     receiver_name: str | None = None,
 ) -> dict
 ```

--- a/packages/coding-agent/skills/agent-observe/SKILL.md
+++ b/packages/coding-agent/skills/agent-observe/SKILL.md
@@ -24,20 +24,47 @@ if child is not None:
     await rlm.delete_subagent(child)
 ```
 
-## API
+## Import
 
-- `await agent_observe.list_agents()` returns `current` and `agents`. Each
-  agent includes active session id, session id, optional name, runtime kind,
-  cwd, status, streaming state, message count, pending count, and a latest
-  message preview. The list is restricted to self, parent, siblings, and direct
-  children. For direct children, `await rlm.list_subagents()` also exposes
-  parent-owned lifecycle handles.
-- `await agent_observe.get_agent(target)` returns `agent`, where `agent`
-  contains one agent summary. `target` is resolved like other live-session
-  selectors: active id, session id/name, or unambiguous suffix.
-- `await agent_observe.recent_messages(target, limit=8, max_chars=800)`
-  returns up to `limit` recent bounded message previews for the target session.
-  `limit` must be 1-50, and `max_chars` must be 80-2000.
+```python
+import agent_observe
+```
+
+## API Reference
+
+```python
+async def list_agents() -> dict
+```
+Returns `current` and `agents`. Each agent includes active session id, session id,
+optional name, runtime kind, cwd, status, streaming state, message count, pending
+count, and a latest message preview. Restricted to self, parent, siblings, and direct
+children. For direct children, `await rlm.list_subagents()` also exposes parent-owned
+lifecycle handles.
+
+---
+
+```python
+async def get_agent(target: str) -> dict
+```
+Returns `agent` — one session summary. `target` is resolved as: active session id,
+session id/name, or unambiguous suffix.
+
+---
+
+```python
+async def recent_messages(
+    target: str,
+    limit: int = 8,
+    max_chars: int = 800,
+) -> dict
+```
+Returns up to `limit` recent bounded message previews for `target`.
+- `limit`: 1–50 (host-validated).
+- `max_chars`: 80–2000 per message (host-validated).
+
+**Functions that do NOT exist (common mistakes):**
+- `agent_observe.observe()` — does not exist; use `list_agents()` or `get_agent()`.
+- `agent_observe.list_messages()` — does not exist; use `recent_messages()`.
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Adds explicit API reference sections to both `agent-message` and `agent-observe` skill docs so agents can discover the full API without running `dir()` + `inspect.signature()`.

**agent-message:**
- Added `## Import` block with correct import statement.
- Added typed function signatures for `list_agents()` and `send()` in Python code blocks.
- Fixed broadcast documentation: the old prose described `send("all", message)` as positional, but the implementation raises `TypeError` for that form. Correct usage is `send("all", broadcast_message="...")`.
- Added explicit list of non-existent functions (`list_messages()`, `observe()`) to prevent incorrect calls.

**agent-observe:**
- Added `## Import` block.
- Added typed function signatures for `list_agents()`, `get_agent()`, and `recent_messages()` with parameter constraints (`limit` 1–50, `max_chars` 80–2000).
- Added explicit list of non-existent functions (`observe()`, `list_messages()`).

No code changes — doc-only.

## Test plan

- [x] `npm run check` passes (biome, tsgo, installer render, browser smoke)
- [x] All signatures verified against `__init__.py` implementations

Fixes #762

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add explicit API reference sections to agent-message and agent-observe skills
> - Rewrites the API sections in [agent-message/SKILL.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/920/files#diff-1544a1dd3b2a523dabd1e2a923c3059d3e084a296aae8a421a0d69ff7b186c45) and [agent-observe/SKILL.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/920/files#diff-53e9a6a00c9cd64788aab987d95799b5328d2b7e175dc95f19c2bb5a9dab3ac4) with typed function signatures, import patterns, and parameter/return field details.
> - Documents correct broadcast syntax for `send("all", broadcast_message="...")` and clarifies that messages are delivered via steering at the next tool boundary.
> - Adds a "Functions that do NOT exist" subsection in both docs to explicitly call out `agent_message.list_messages()`, `agent_message.observe()`, `agent_observe.observe()`, and `agent_observe.list_messages()` as non-existent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56e6fce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->