### PR TITLE
fix(coding-agent): spread an unqualified find_models across providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
+- Fixed `rlm.find_models()` with no query returning an alphabetical slice from the first provider, which read as the complete set of reachable models ([#799](https://github.com/PrimeIntellect-ai/prime-agent/issues/799)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -119,9 +119,39 @@ function normalizeModelSearchText(value: string): string {
 	return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
+interface RlmModelCandidate {
+	model: Model<Api>;
+	selector: string;
+	score: number;
+}
+
+/**
+ * Round-robin candidates across providers, preserving each provider's relative order.
+ * An unqualified search scores every model equally, so a plain sort would return the
+ * alphabetically first providers only and read as the complete reachable set.
+ */
+function spreadAcrossProviders(candidates: RlmModelCandidate[]): RlmModelCandidate[] {
+	const byProvider = new Map<string, RlmModelCandidate[]>();
+	for (const candidate of candidates) {
+		const bucket = byProvider.get(candidate.model.provider);
+		if (bucket) bucket.push(candidate);
+		else byProvider.set(candidate.model.provider, [candidate]);
+	}
+	const buckets = [...byProvider.values()];
+	const deepest = buckets.reduce((max, bucket) => Math.max(max, bucket.length), 0);
+	const spread: RlmModelCandidate[] = [];
+	for (let round = 0; round < deepest; round++) {
+		for (const bucket of buckets) {
+			const candidate = bucket[round];
+			if (candidate) spread.push(candidate);
+		}
+	}
+	return spread;
+}
+
 export function findRlmModelMatches(query: string, models: Model<Api>[], limit: number): RlmModelMatch[] {
 	const normalizedQuery = normalizeModelSearchText(query.trim());
-	return models
+	const ranked = models
 		.map((model) => {
 			const selector = `${model.provider}/${model.id}`;
 			const fields = [selector, model.id, model.name || model.id];
@@ -138,14 +168,14 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 			return { model, selector, score };
 		})
 		.filter((candidate) => Number.isFinite(candidate.score))
-		.sort((a, b) => a.score - b.score || a.selector.localeCompare(b.selector))
-		.slice(0, limit)
-		.map(({ model, selector }) => ({
-			provider: model.provider,
-			id: model.id,
-			name: model.name || model.id,
-			selector,
-		}));
+		.sort((a, b) => a.score - b.score || a.selector.localeCompare(b.selector));
+	const ordered = normalizedQuery ? ranked : spreadAcrossProviders(ranked);
+	return ordered.slice(0, limit).map(({ model, selector }) => ({
+		provider: model.provider,
+		id: model.id,
+		name: model.name || model.id,
+		selector,
+	}));
 }
 
 /** Adapt an RlmRunHandler into the typed "rlm.run" handler for the kernel host bridge. */

--- a/packages/coding-agent/test/suite/regressions/799-find-models-provider-spread.test.ts
+++ b/packages/coding-agent/test/suite/regressions/799-find-models-provider-spread.test.ts
@@ -1,0 +1,68 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { findRlmModelMatches } from "../../../src/core/rlm-runtime.js";
+
+function model(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://api.example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	} as Model<Api>;
+}
+
+// Mirrors the reported setup: several providers where one sorts first alphabetically
+// and carries more models than the default limit.
+function catalog(): Model<Api>[] {
+	const providers = ["anthropic", "openai-codex", "openrouter", "zai"];
+	return providers.flatMap((provider) =>
+		Array.from({ length: 10 }, (_, index) => model(provider, `${provider}-model-${index}`)),
+	);
+}
+
+describe("issue #799 unqualified find_models must not read as a single-vendor catalog", () => {
+	it("spans every provider instead of returning an alphabetical head slice", () => {
+		const matches = findRlmModelMatches("", catalog(), 8);
+
+		expect(matches).toHaveLength(8);
+		expect(new Set(matches.map((m) => m.provider))).toEqual(
+			new Set(["anthropic", "openai-codex", "openrouter", "zai"]),
+		);
+	});
+
+	it("does not return only the alphabetically first provider", () => {
+		const providers = findRlmModelMatches("", catalog(), 8).map((m) => m.provider);
+		expect(providers.every((provider) => provider === "anthropic")).toBe(false);
+	});
+
+	it("keeps each provider's own ordering stable", () => {
+		const anthropic = findRlmModelMatches("", catalog(), 40)
+			.filter((m) => m.provider === "anthropic")
+			.map((m) => m.id);
+		expect(anthropic).toEqual([...anthropic].sort((a, b) => a.localeCompare(b)));
+	});
+
+	it("returns every model when the limit exceeds the catalog", () => {
+		expect(findRlmModelMatches("", catalog(), 40)).toHaveLength(40);
+	});
+
+	it("leaves a real query ranked by relevance rather than spread", () => {
+		const matches = findRlmModelMatches("zai-model-3", catalog(), 8);
+		expect(matches[0].selector).toBe("zai/zai-model-3");
+	});
+
+	it("handles a single-provider catalog without dropping or reordering", () => {
+		const single = Array.from({ length: 3 }, (_, index) => model("anthropic", `anthropic-model-${index}`));
+		expect(findRlmModelMatches("", single, 8).map((m) => m.id)).toEqual([
+			"anthropic-model-0",
+			"anthropic-model-1",
+			"anthropic-model-2",
+		]);
+	});
+});


### PR DESCRIPTION
Closes #799.

## Problem

`rlm.find_models()` with no query scores every candidate the same, so ordering falls entirely to the
alphabetical tiebreak before truncation:

```ts
let score = normalizedQuery ? Number.POSITIVE_INFINITY : 0;   // empty query: everything ties at 0
...
.sort((a, b) => a.score - b.score || a.selector.localeCompare(b.selector))
.slice(0, limit)                                              // default limit 8
```

The bare call is the natural first move for an agent orienting itself before delegating, and it
returns the alphabetically first provider's models only. In the reported run that read as the
complete reachable set, so an orchestrator concluded only the anthropic family was natively
reachable and routed three delegations through shell-CLI fallbacks that were not needed. The failure
mode is a plausible subset rather than an error, so nothing downstream contradicts the inference.

## Change

Unqualified searches now round-robin across providers, preserving each provider's own ordering. A
query-driven search is untouched and still ranks purely by relevance.

The result is that a default `find_models()` samples the catalog instead of paging it alphabetically,
so every configured provider is visible in the first response.

## Scope

The issue also suggests returning a truncation marker or a provider summary. Both change the shape of
the response, and `find_models` is typed as `list[RLMModel]` in `prime-agent-runtime/src/rlm/__init__.py`,
where `_model_from_payload` validates each entry. Surfacing a marker means changing that return type,
which breaks existing callers, so this PR is limited to the ordering defect that produced the reported
misread. Happy to follow up on the response shape separately if you want it.

## Tests

`packages/coding-agent/test/suite/regressions/799-find-models-provider-spread.test.ts` covers a
four-provider catalog with ten models each: that a bare search spans all four rather than one, that
per-provider ordering stays stable, that a limit above the catalog size returns everything, that a
real query is still relevance-ranked, and that a single-provider catalog is unchanged.

The first two fail before this change with `expected Set{ 'anthropic' } to deeply equal
Set{ 'anthropic', 'openai-codex', 'openrouter', 'zai' }`.

Verified with `npm run check` plus the new test and the existing
`4649-subagent-model-selection.test.ts` on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `rlm.find_models()` to spread results across providers when query is empty
> - Previously, an empty query returned an alphabetical slice dominated by the first provider; now results are interleaved round-robin across providers while preserving each provider's internal order.
> - Introduces `spreadAcrossProviders` in [rlm-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/922/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7) to group candidates by provider and interleave them; non-empty queries retain relevance-based ranking.
> - Adds a regression test suite in [799-find-models-provider-spread.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/922/files#diff-01a9e9442cf9db1e777430135799f24aa50ccc3f209c9a4edadda4aff6da1a70) covering edge cases including limits, single-provider catalogs, and real queries.
> - Behavioral Change: empty-query results now return a different ordering and provider distribution than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0677e38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->