### PR TITLE
feat(rlm): configure a default subagent model

### DIFF
--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -153,14 +153,14 @@ Supported `rlm.run` options are:
 - `name`: a unique readable child session name; and
 - `model`: an exact `provider/model` selector from `rlm.find_models()`.
 
-Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. If an exact selection is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model. A child otherwise inherits the parent model.
+Unknown options fail instead of being ignored. Model search is bounded to active, non-expired credentials. Model resolution is, in order: the explicit `model` option, `subagents.defaultModel` in settings, then the parent model. If an explicit or configured selector is unavailable or fails auth preflight, spawn fails instead of silently falling back to another model.
 
 ## Child Execution
 
 `AgentSession.runRlmChild()` performs the following sequence:
 
 1. Check `RLM_DEPTH < RLM_MAX_DEPTH`.
-2. Resolve the requested model or inherit the parent model.
+2. Resolve the explicit model, the configured `subagents.defaultModel`, or the parent model.
 3. Create a `sub-xxxxxxxx` child directory under the parent artifact directory.
 4. Admit the task into the parent registry and return its `RLMSpawnHandle`.
 5. In detached work, create a child `SessionManager`, `Agent`, and `AgentSession`.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -34,6 +34,22 @@ Edit directly or use `/settings` for common options.
 }
 ```
 
+### Subagents
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `subagents.defaultModel` | string | Parent model | Exact `provider/model` selector used by `rlm()` when a child does not specify `model=`. |
+
+```json
+{
+  "subagents": {
+    "defaultModel": "tensorx/deepseek/deepseek-v4-flash-0731"
+  }
+}
+```
+
+An explicit `rlm(..., model="provider/model")` takes precedence. The selected model must be available with active credentials; an unavailable configured selector fails child admission rather than falling back to the parent. Project settings can override this value, so review checked-in `.prime/agent/settings.json` files before trusting them.
+
 ### UI & Display
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9628,7 +9628,9 @@ export class AgentSession {
 		let modelSelection: RlmSubagentModelSelection;
 		try {
 			if (requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(requestedSessionName, true);
-			modelSelection = await this._resolveRlmSubagentModel(requestedModel);
+			modelSelection = await this._resolveRlmSubagentModel(
+				requestedModel ?? this.settingsManager.getSubagentDefaultModel(),
+			);
 		} finally {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -68,6 +68,12 @@ export interface BundledSkillsSettings {
 	websearch?: boolean; // default: true
 }
 
+/** Default routing policy for RLM child agents. */
+export interface SubagentSettings {
+	/** Exact `provider/model` selector used when an rlm.run call omits `model`. */
+	defaultModel?: string;
+}
+
 export interface WarningSettings {
 	anthropicExtraUsage?: boolean; // default: true
 }
@@ -153,6 +159,7 @@ export interface Settings {
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
 	bundledSkills?: BundledSkillsSettings; // Configure built-in skills shipped with Prime Agent
 	enableBuiltinSkills?: boolean; // default: true - load built-in skills shipped with prime-agent
+	subagents?: SubagentSettings; // Default RLM child-agent routing policy
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
@@ -684,6 +691,10 @@ export class SettingsManager {
 
 	getDefaultModel(): string | undefined {
 		return this.settings.defaultModel;
+	}
+
+	getSubagentDefaultModel(): string | undefined {
+		return this.settings.subagents?.defaultModel;
 	}
 
 	setDefaultProvider(provider: string): void {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -24,6 +24,22 @@ describe("SettingsManager", () => {
 		}
 	});
 
+	describe("subagent defaults", () => {
+		it("uses the project default model over the global default", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ subagents: { defaultModel: "global-provider/global-model" } }),
+			);
+			writeFileSync(
+				join(projectDir, ".prime", "agent", "settings.json"),
+				JSON.stringify({ subagents: { defaultModel: "project-provider/project-model" } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getSubagentDefaultModel()).toBe("project-provider/project-model");
+		});
+	});
+
 	describe("preserves externally added settings", () => {
 		it("should preserve enabledModels when changing thinking level", async () => {
 			// Create initial settings file

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -327,6 +327,70 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("uses the configured default model when no override is supplied", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model" }, { id: "child-model" }],
+			settings: { subagents: { defaultModel: `${provider}/child-model` } },
+		});
+		try {
+			let seenModel: string | undefined;
+			harness.setResponses([
+				(_context, _options, _state, model) => {
+					seenModel = model.id;
+					return fauxAssistantMessage("configured child answer");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("use configured model");
+			expect(result.model).toBe(`${provider}/child-model`);
+			await vi.waitFor(() => expect(seenModel).toBe("child-model"));
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("gives an explicit model precedence over the configured default", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model" }, { id: "child-model" }],
+			settings: { subagents: { defaultModel: `${provider}/child-model` } },
+		});
+		try {
+			let seenModel: string | undefined;
+			harness.setResponses([
+				(_context, _options, _state, model) => {
+					seenModel = model.id;
+					return fauxAssistantMessage("explicit parent answer");
+				},
+			]);
+
+			const result = await harness.session.runRlmChild("use explicit model", {
+				model: `${provider}/parent-model`,
+			});
+			expect(result.model).toBe(`${provider}/parent-model`);
+			await vi.waitFor(() => expect(seenModel).toBe("parent-model"));
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rejects an unavailable configured default model without falling back", async () => {
+		const harness = await createHarness({
+			provider,
+			models: [{ id: "parent-model" }, { id: "child-model" }],
+			settings: { subagents: { defaultModel: `${provider}/missing-model` } },
+		});
+		try {
+			await expect(harness.session.runRlmChild("reject unavailable configured model")).rejects.toThrow(
+				`Requested subagent model "${provider}/missing-model" is unavailable, unauthenticated, or expired`,
+			);
+			expect((await harness.session.listRlmSubagents()).subagents).toEqual([]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("accepts a selected model authenticated by headers", async () => {
 		const harness = await createHarness({
 			provider,


### PR DESCRIPTION
## Summary

Adds `subagents.defaultModel` as a persistent global or project-level default for RLM child agents.

Resolution order is now:

1. Explicit `rlm(..., model=...)`
2. `subagents.defaultModel`
3. Parent-model inheritance

Configured selectors use the existing authenticated-catalog lookup and auth preflight. An unavailable selector fails admission rather than silently falling back.

Closes #921.

## Validation

- `npm test -- test/suite/regressions/4649-subagent-model-selection.test.ts test/settings-manager.test.ts`
- `npx biome check packages/coding-agent/src/core/settings-manager.ts packages/coding-agent/src/core/agent-session.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts`
- `npm run build`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `subagents.defaultModel` setting to configure a default subagent model in RLM
> - Adds a `subagents.defaultModel` field to the `Settings` interface and a `getSubagentDefaultModel()` accessor on `SettingsManager`.
> - In `AgentSession.runRlmChild`, the configured default is used when no explicit model is passed to `rlm.run`, falling back to the parent model only if neither is set.
> - Behavioral Change: if the configured default model is unavailable or fails auth preflight, spawn now fails rather than falling back to the parent model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4fe65d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->