### PR TITLE
feat(ai): add fast mode support for claude-opus-5 and claude-opus-4-8

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ## [0.7.2] - 2026-08-11
+- Added fast mode support (`speed: "fast"`) for `claude-opus-5` and `claude-opus-4-8` on the Anthropic API, enabling up to 2.5× higher output tokens/second via the `fast-mode-2026-02-01` beta ([#867](https://github.com/PrimeIntellect-ai/prime-agent/issues/867)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -37,15 +37,20 @@ export function getModels<TProvider extends KnownProvider>(
 }
 
 export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean {
-	if (model.provider === "openai-codex" && model.api === "openai-codex-responses") {
-		return (
-			model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-")
-		);
-	}
-	if (model.provider === "anthropic" && model.api === "anthropic-messages") {
-		return model.id === "claude-opus-5" || model.id === "claude-opus-4-8";
-	}
-	return false;
+	return (
+		model.provider === "openai-codex" &&
+		model.api === "openai-codex-responses" &&
+		(model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-"))
+	);
+}
+
+/** Whether the model supports Anthropic fast mode (speed="fast" + fast-mode-2026-02-01 beta). */
+export function supportsAnthropicFastMode<TApi extends Api>(model: Model<TApi>): boolean {
+	return (
+		model.provider === "anthropic" &&
+		model.api === "anthropic-messages" &&
+		(model.id === "claude-opus-5" || model.id === "claude-opus-4-8")
+	);
 }
 
 export interface CostOverrides {

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -37,11 +37,15 @@ export function getModels<TProvider extends KnownProvider>(
 }
 
 export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean {
-	return (
-		model.provider === "openai-codex" &&
-		model.api === "openai-codex-responses" &&
-		(model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-"))
-	);
+	if (model.provider === "openai-codex" && model.api === "openai-codex-responses") {
+		return (
+			model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-")
+		);
+	}
+	if (model.provider === "anthropic" && model.api === "anthropic-messages") {
+		return model.id === "claude-opus-5" || model.id === "claude-opus-4-8";
+	}
+	return false;
 }
 
 export interface CostOverrides {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -173,6 +173,7 @@ export type AnthropicThinkingDisplay = "summarized" | "omitted";
 
 const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
+const FAST_MODE_BETA = "fast-mode-2026-02-01";
 
 function getAnthropicCompat(model: Model<"anthropic-messages">): Required<AnthropicMessagesCompat> {
 	return {
@@ -224,6 +225,13 @@ export interface AnthropicOptions extends StreamOptions {
 	 * `AnthropicVertex` that shares the same messaging API.
 	 */
 	client?: Anthropic;
+	/**
+	 * Enable fast mode for supported models (claude-opus-5, claude-opus-4-8).
+	 * Adds the fast-mode-2026-02-01 beta header and routes through the beta
+	 * messages endpoint with speed="fast" in the request body.
+	 * Claude API only — not available on Bedrock, Vertex, or Foundry.
+	 */
+	speed?: "fast";
 }
 
 function mergeHeaders(...headerSources: (Record<string, string | null> | undefined)[]): Record<string, string | null> {
@@ -507,6 +515,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					shouldUseFineGrainedToolStreamingBeta(model, context),
 					options?.headers,
 					copilotDynamicHeaders,
+					options?.speed === "fast",
 				);
 				client = created.client;
 				isOAuth = created.isOAuthToken;
@@ -527,7 +536,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
 				...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
 			};
-			const response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+			// beta.messages.create accepts a superset of params; cast to match the non-beta overload signature
+			const createFn =
+				options?.speed === "fast"
+					? (client.beta.messages.create.bind(client.beta.messages) as typeof client.messages.create)
+					: client.messages.create.bind(client.messages);
+			const response = await createFn({ ...params, stream: true }, requestOptions).asResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			const requestId = response.headers.get("request-id") ?? undefined;
 			stream.push({ type: "start", partial: output });
@@ -853,6 +867,7 @@ function createClient(
 	useFineGrainedToolStreamingBeta: boolean,
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
+	useFastMode?: boolean,
 ): { client: Anthropic; isOAuthToken: boolean } {
 	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
 	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
@@ -863,6 +878,9 @@ function createClient(
 	}
 	if (needsInterleavedBeta) {
 		betaFeatures.push(INTERLEAVED_THINKING_BETA);
+	}
+	if (useFastMode) {
+		betaFeatures.push(FAST_MODE_BETA);
 	}
 
 	if (model.provider === "cloudflare-ai-gateway") {
@@ -1053,6 +1071,11 @@ function buildParams(
 		} else {
 			params.tool_choice = options.toolChoice;
 		}
+	}
+
+	if (options?.speed === "fast") {
+		// speed is in the beta MessageCreateParamsStreaming but not yet in the base type
+		(params as MessageCreateParamsStreaming & { speed?: "fast" }).speed = "fast";
 	}
 
 	return params;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -34,6 +34,7 @@ import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js"
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	classifyStreamFailure,
+	extractStreamFailureInfo,
 	formatStreamFailureMessage,
 	recordStreamFailure,
 	StreamFailureError,
@@ -489,11 +490,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			timestamp: Date.now(),
 		};
 
+		// Fast mode: explicit speed="fast" or serviceTier="priority" on a supported model
+		const isFastModeActive =
+			supportsAnthropicFastMode(model) && (options?.speed === "fast" || options?.serviceTier === "priority");
+
 		try {
 			let client: Anthropic;
-			// Fast mode: explicit speed="fast" or serviceTier="priority" on a supported model
-			const isFastModeActive =
-				supportsAnthropicFastMode(model) && (options?.speed === "fast" || options?.serviceTier === "priority");
 
 			let isOAuth: boolean;
 
@@ -760,6 +762,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatStreamFailureMessage(error);
+			if (isFastModeActive && extractStreamFailureInfo(error).kind === "auth") {
+				output.errorMessage = `Fast mode requires preview access for your account (contact your Anthropic account manager). ${output.errorMessage}`;
+			}
 			recordStreamFailure(model, output, error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { getAnthropicCacheWriteCost, hasStandardAnthropicCachePricing } from "../cache-pricing.js";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { calculateCost, clampThinkingLevel } from "../models.js";
+import { calculateCost, clampThinkingLevel, supportsAnthropicFastMode } from "../models.js";
 import type {
 	AnthropicMessagesCompat,
 	Api,
@@ -491,6 +491,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 
 		try {
 			let client: Anthropic;
+			// Fast mode: explicit speed="fast" or serviceTier="priority" on a supported model
+			const isFastModeActive =
+				supportsAnthropicFastMode(model) && (options?.speed === "fast" || options?.serviceTier === "priority");
+
 			let isOAuth: boolean;
 
 			if (options?.client) {
@@ -515,7 +519,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					shouldUseFineGrainedToolStreamingBeta(model, context),
 					options?.headers,
 					copilotDynamicHeaders,
-					options?.speed === "fast",
+					isFastModeActive,
 				);
 				client = created.client;
 				isOAuth = created.isOAuthToken;
@@ -526,7 +530,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 				cacheControl && usesAnthropicCachePricing
 					? getAnthropicCacheWriteCost(model.cost.input, cacheControl.ttl === "1h" ? "1h" : "5m")
 					: undefined;
-			let params = buildParams(model, context, isOAuth, options, cacheControl);
+			let params = buildParams(model, context, isOAuth, options, cacheControl, isFastModeActive);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
 				params = nextParams as MessageCreateParamsStreaming;
@@ -537,10 +541,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 				...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
 			};
 			// beta.messages.create accepts a superset of params; cast to match the non-beta overload signature
-			const createFn =
-				options?.speed === "fast"
-					? (client.beta.messages.create.bind(client.beta.messages) as typeof client.messages.create)
-					: client.messages.create.bind(client.messages);
+			const createFn = isFastModeActive
+				? (client.beta.messages.create.bind(client.beta.messages) as typeof client.messages.create)
+				: client.messages.create.bind(client.messages);
 			const response = await createFn({ ...params, stream: true }, requestOptions).asResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			const requestId = response.headers.get("request-id") ?? undefined;
@@ -573,6 +576,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						output.usage,
 						cacheWriteCost === undefined ? undefined : { cacheWrite: cacheWriteCost },
 					);
+					if (isFastModeActive) {
+						output.usage.cost.input *= 2;
+						output.usage.cost.output *= 2;
+						output.usage.cost.cacheRead *= 2;
+						output.usage.cost.cacheWrite *= 2;
+						output.usage.cost.total *= 2;
+					}
 				} else if (event.type === "content_block_start") {
 					if (event.content_block.type === "text") {
 						const block: Block = {
@@ -722,6 +732,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						output.usage,
 						cacheWriteCost === undefined ? undefined : { cacheWrite: cacheWriteCost },
 					);
+					if (isFastModeActive) {
+						output.usage.cost.input *= 2;
+						output.usage.cost.output *= 2;
+						output.usage.cost.cacheRead *= 2;
+						output.usage.cost.cacheWrite *= 2;
+						output.usage.cost.total *= 2;
+					}
 				}
 			}
 
@@ -976,6 +993,7 @@ function buildParams(
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
 	cacheControl?: CacheControlEphemeral,
+	isFastMode?: boolean,
 ): MessageCreateParamsStreaming {
 	const params: MessageCreateParamsStreaming = {
 		model: model.id,
@@ -1073,7 +1091,7 @@ function buildParams(
 		}
 	}
 
-	if (options?.speed === "fast") {
+	if (isFastMode) {
 		// speed is in the beta MessageCreateParamsStreaming but not yet in the base type
 		(params as MessageCreateParamsStreaming & { speed?: "fast" }).speed = "fast";
 	}

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -33,4 +33,18 @@ describe("Fast mode", () => {
 		const testModel = model("openai-codex", "gpt-5.5", "openai-codex-responses");
 		expect(buildBaseOptions(testModel, { serviceTier: "priority" }).serviceTier).toBe("priority");
 	});
+
+	it.each(["claude-opus-5", "claude-opus-4-8"])("supports %s on Anthropic API", (id) => {
+		expect(supportsFastMode(model("anthropic", id, "anthropic-messages"))).toBe(true);
+	});
+
+	it("rejects Anthropic models that do not support fast mode", () => {
+		expect(supportsFastMode(model("anthropic", "claude-opus-4-7", "anthropic-messages"))).toBe(false);
+		expect(supportsFastMode(model("anthropic", "claude-sonnet-5", "anthropic-messages"))).toBe(false);
+		expect(supportsFastMode(model("anthropic", "claude-haiku-4-5", "anthropic-messages"))).toBe(false);
+	});
+
+	it("rejects anthropic models on non-anthropic-messages api", () => {
+		expect(supportsFastMode(model("anthropic", "claude-opus-5", "openai-completions"))).toBe(false);
+	});
 });

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { supportsFastMode } from "../src/models.js";
+import { supportsAnthropicFastMode, supportsFastMode } from "../src/models.js";
 import { buildBaseOptions } from "../src/providers/simple-options.js";
 import type { Api, Model } from "../src/types.js";
 
@@ -35,16 +35,16 @@ describe("Fast mode", () => {
 	});
 
 	it.each(["claude-opus-5", "claude-opus-4-8"])("supports %s on Anthropic API", (id) => {
-		expect(supportsFastMode(model("anthropic", id, "anthropic-messages"))).toBe(true);
+		expect(supportsAnthropicFastMode(model("anthropic", id, "anthropic-messages"))).toBe(true);
 	});
 
 	it("rejects Anthropic models that do not support fast mode", () => {
-		expect(supportsFastMode(model("anthropic", "claude-opus-4-7", "anthropic-messages"))).toBe(false);
-		expect(supportsFastMode(model("anthropic", "claude-sonnet-5", "anthropic-messages"))).toBe(false);
-		expect(supportsFastMode(model("anthropic", "claude-haiku-4-5", "anthropic-messages"))).toBe(false);
+		expect(supportsAnthropicFastMode(model("anthropic", "claude-opus-4-7", "anthropic-messages"))).toBe(false);
+		expect(supportsAnthropicFastMode(model("anthropic", "claude-sonnet-5", "anthropic-messages"))).toBe(false);
+		expect(supportsAnthropicFastMode(model("anthropic", "claude-haiku-4-5", "anthropic-messages"))).toBe(false);
 	});
 
 	it("rejects anthropic models on non-anthropic-messages api", () => {
-		expect(supportsFastMode(model("anthropic", "claude-opus-5", "openai-completions"))).toBe(false);
+		expect(supportsAnthropicFastMode(model("anthropic", "claude-opus-5", "openai-completions"))).toBe(false);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Added fast mode support for `claude-opus-5` and `claude-opus-4-8` on the Anthropic API (`speed: "fast"` option) ([#867](https://github.com/PrimeIntellect-ai/prime-agent/issues/867)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
 - Added fast mode support for `claude-opus-5` and `claude-opus-4-8` on the Anthropic API (`speed: "fast"` option) ([#867](https://github.com/PrimeIntellect-ai/prime-agent/issues/867)).
+- Added fast mode support for `claude-opus-5` and `claude-opus-4-8`: selecting the priority service tier on these models now routes requests through the Anthropic fast-mode beta (`fast-mode-2026-02-01`) and applies correct 2× pricing ([#867](https://github.com/PrimeIntellect-ai/prime-agent/issues/867)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -46,6 +46,7 @@ import {
 	isContextOverflow,
 	modelsAreEqual,
 	resetApiProviders,
+	supportsAnthropicFastMode,
 	supportsFastMode,
 } from "@earendil-works/pi-ai";
 import { theme } from "../modes/interactive/theme/theme.js";
@@ -6883,7 +6884,7 @@ export class AgentSession {
 		this._serviceTierPreference = effectiveServiceTier;
 		if (preferenceChanged) {
 			this.sessionManager.appendServiceTierChange(effectiveServiceTier);
-			if (this.model && supportsFastMode(this.model)) {
+			if (this.model && (supportsFastMode(this.model) || supportsAnthropicFastMode(this.model))) {
 				this.settingsManager.setDefaultServiceTier(effectiveServiceTier);
 			}
 		}
@@ -6897,7 +6898,10 @@ export class AgentSession {
 	}
 
 	private _getEffectiveServiceTier(serviceTier: ServiceTier): ServiceTier {
-		return serviceTier === "priority" && (!this.model || !supportsFastMode(this.model)) ? "default" : serviceTier;
+		return serviceTier === "priority" &&
+			(!this.model || (!supportsFastMode(this.model) && !supportsAnthropicFastMode(this.model)))
+			? "default"
+			: serviceTier;
 	}
 
 	private _getServiceTierForModelSwitch(): ServiceTier {
@@ -9024,7 +9028,11 @@ export class AgentSession {
 			model: options.model,
 			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
 			serviceTier:
-				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
+				this.serviceTier === "priority" &&
+				!supportsFastMode(options.model) &&
+				!supportsAnthropicFastMode(options.model)
+					? "default"
+					: this.serviceTier,
 			scopedModels: [...this._scopedModels],
 			activeToolNames: this.getActiveToolNames(),
 			allowedToolNames: this._allowedToolNames ? [...this._allowedToolNames] : undefined,

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,6 +1,13 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { clampThinkingLevel, type Message, type Model, streamSimple, supportsFastMode } from "@earendil-works/pi-ai";
+import {
+	clampThinkingLevel,
+	type Message,
+	type Model,
+	streamSimple,
+	supportsAnthropicFastMode,
+	supportsFastMode,
+} from "@earendil-works/pi-ai";
 import { getAgentDir } from "../config.js";
 import { AgentSession } from "./agent-session.js";
 import type { AgentSessionCreationOptions } from "./agent-session-services.js";
@@ -246,7 +253,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		options.serviceTier ??
 		(hasServiceTierEntry ? existingSession.serviceTier : settingsManager.getDefaultServiceTier());
 	const serviceTier =
-		serviceTierPreference === "priority" && (!model || !supportsFastMode(model)) ? "default" : serviceTierPreference;
+		serviceTierPreference === "priority" &&
+		(!model || (!supportsFastMode(model) && !supportsAnthropicFastMode(model)))
+			? "default"
+			: serviceTierPreference;
 
 	const allowedToolNames = options.allowedToolNames ?? options.tools ?? (options.noTools === "all" ? [] : undefined);
 	const includeGoals = options.includeGoals ?? (options.tools !== undefined || options.noTools !== "all");


### PR DESCRIPTION
## Summary

Adds fast mode support for \`claude-opus-5\` and \`claude-opus-4-8\` on the Anthropic API (Claude API only — not Bedrock, Vertex, or Foundry).

Fast mode enables up to 2.5× higher output tokens/second at premium pricing. Per the Anthropic docs, three things are required:

1. Use the beta messages endpoint (\`client.beta.messages.create\`)
2. Pass the \`fast-mode-2026-02-01\` beta header
3. Set \`speed: "fast"\` as a top-level request body parameter

**Changes:**

- \`packages/ai/src/models.ts\` — extended \`supportsFastMode\` to return \`true\` for \`claude-opus-5\` and \`claude-opus-4-8\` on the \`anthropic\` provider
- \`packages/ai/src/providers/anthropic.ts\`:
  - Added \`FAST_MODE_BETA = "fast-mode-2026-02-01"\` constant
  - Added \`speed?: "fast"\` to \`AnthropicOptions\`
  - Added \`useFastMode\` param to \`createClient\`; pushes the beta to \`betaFeatures\` when set
  - Updated the \`createClient\` call site to pass \`options?.speed === "fast"\`
  - Sets \`speed: "fast"\` on the params in \`buildParams\` when fast mode is active
  - Routes through \`client.beta.messages.create\` instead of \`client.messages.create\` when fast mode is active
- \`packages/ai/test/fast-mode.test.ts\` — added 4 new test cases covering supported models, unsupported models, and API mismatch

## Test plan

- [x] \`npm run check\` passes (biome, tsgo, installer render, browser smoke)
- [x] \`test/fast-mode.test.ts\` — 9/9 tests pass including 4 new Anthropic cases
- [x] All Anthropic unit tests pass: \`anthropic-sse-parsing\`, \`anthropic-eager-tool-input-compat\`, \`anthropic-thinking-disable\`, \`anthropic-tool-name-normalization\`, \`xhigh\`, \`supports-xhigh\`, \`interleaved-thinking\` — 50 pass, 0 fail
- [x] Broader unit suite — 87 pass, 0 fail

Fixes #867

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fast mode support for `claude-opus-5` and `claude-opus-4-8` on Anthropic API
> - Adds a `speed: "fast"` option to `AnthropicOptions` that routes requests through the `fast-mode-2026-02-01` beta endpoint for `claude-opus-5` and `claude-opus-4-8`.
> - Fast mode is also activated when `serviceTier` is `"priority"` on supported models; costs are doubled to reflect 2× pricing.
> - Adds `supportsAnthropicFastMode(model)` in [models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/924/files#diff-9d03087de13641e60bdb725ae786441aa71caf6626582728660f2a30328138b7) so callers and agent sessions can detect fast-mode-capable models.
> - Updates `AgentSession` and `createAgentSession` in the coding-agent package to preserve the `priority` service tier for Anthropic fast-mode models instead of demoting to `default`.
> - Auth errors during fast mode include a hint that preview access is required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d808690.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->