### PR TITLE
fix(coding-agent): repair incomplete session JSONL tails

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed resumed sessions concatenating new entries onto incomplete or unterminated JSONL tails ([#928](https://github.com/PrimeIntellect-ai/prime-agent/issues/928)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -5,18 +5,24 @@ import {
 	appendFileSync,
 	chmodSync,
 	chownSync,
+	closeSync,
+	copyFileSync,
 	existsSync,
 	mkdirSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	realpathSync,
 	renameSync,
 	rmSync,
 	statSync,
+	truncateSync,
 	writeFileSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
+import { TextDecoder } from "util";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import { readFirstLineSync, readLinesAsBuffers } from "../utils/file-lines.js";
@@ -69,6 +75,24 @@ function statMetadataIfPresent(path: string): { mode: number; uid: number; gid: 
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
+	}
+}
+
+function replaceFileAtomically(path: string, writeTemp: (targetPath: string, tempPath: string) => void): void {
+	const targetPath = realpathIfPresent(path);
+	const directory = dirname(targetPath);
+	mkdirSync(directory, { recursive: true });
+	const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
+	try {
+		const metadata = statMetadataIfPresent(targetPath);
+		writeTemp(targetPath, tempPath);
+		if (metadata !== undefined) {
+			chownSync(tempPath, metadata.uid, metadata.gid);
+			chmodSync(tempPath, metadata.mode);
+		}
+		renameSync(tempPath, targetPath);
+	} finally {
+		rmSync(tempPath, { force: true });
 	}
 }
 
@@ -307,12 +331,20 @@ export interface SessionInfo {
 	agentStatus?: AgentStatus;
 }
 
+export interface SessionFileRecovery {
+	action: "appended_missing_newline" | "truncated_incomplete_tail";
+	originalSize: number;
+	repairedSize: number;
+	discardedBytes: number;
+}
+
 export type ReadonlySessionManager = Pick<
 	SessionManager,
 	| "getCwd"
 	| "getSessionDir"
 	| "getSessionId"
 	| "getSessionFile"
+	| "getFileRecovery"
 	| "getLeafId"
 	| "getLeafEntry"
 	| "getEntry"
@@ -629,6 +661,89 @@ function parseEntriesFromBuffer(buffer: Buffer): FileEntry[] {
 		start = end + 1;
 	}
 	return entries;
+}
+
+function readExactly(fd: number, length: number, position: number): Buffer {
+	const buffer = Buffer.allocUnsafe(length);
+	let offset = 0;
+	while (offset < length) {
+		const bytesRead = readSync(fd, buffer, offset, length - offset, position + offset);
+		if (bytesRead === 0) {
+			throw new Error("Session file changed while inspecting its final record");
+		}
+		offset += bytesRead;
+	}
+	return buffer;
+}
+
+function hasUnterminatedTail(filePath: string): boolean {
+	const fileSize = statSync(filePath).size;
+	if (fileSize === 0) return false;
+	const fd = openSync(filePath, "r");
+	try {
+		return readExactly(fd, 1, fileSize - 1)[0] !== 0x0a;
+	} finally {
+		closeSync(fd);
+	}
+}
+
+function readUnterminatedTail(filePath: string): { start: number; bytes: Buffer; fileSize: number } | undefined {
+	const fileSize = statSync(filePath).size;
+	if (fileSize === 0) return undefined;
+
+	const fd = openSync(filePath, "r");
+	try {
+		if (readExactly(fd, 1, fileSize - 1)[0] === 0x0a) return undefined;
+
+		const chunkSize = 64 * 1024;
+		let position = fileSize;
+		let start = 0;
+		while (position > 0) {
+			const chunkStart = Math.max(0, position - chunkSize);
+			const chunk = readExactly(fd, position - chunkStart, chunkStart);
+			const newlineIndex = chunk.lastIndexOf(0x0a);
+			if (newlineIndex !== -1) {
+				start = chunkStart + newlineIndex + 1;
+				break;
+			}
+			position = chunkStart;
+		}
+		return { start, bytes: readExactly(fd, fileSize - start, start), fileSize };
+	} finally {
+		closeSync(fd);
+	}
+}
+
+function isCompleteJsonRecord(bytes: Buffer): boolean {
+	try {
+		JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function repairUnterminatedSessionTail(filePath: string): SessionFileRecovery | undefined {
+	const tail = readUnterminatedTail(filePath);
+	if (!tail) return undefined;
+
+	const complete = isCompleteJsonRecord(tail.bytes);
+	const repairedSize = complete ? tail.fileSize + 1 : tail.start;
+	replaceFileAtomically(filePath, (targetPath, tempPath) => {
+		copyFileSync(targetPath, tempPath);
+		if (complete) {
+			appendFileSync(tempPath, "\n");
+		} else {
+			truncateSync(tempPath, repairedSize);
+		}
+	});
+
+	return {
+		action: complete ? "appended_missing_newline" : "truncated_incomplete_tail",
+		originalSize: tail.fileSize,
+		repairedSize,
+		discardedBytes: complete ? 0 : tail.bytes.length,
+	};
 }
 
 async function parseEntriesFromBufferAsync(buffer: Buffer): Promise<FileEntry[]> {
@@ -1200,6 +1315,8 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private fileRecovery: SessionFileRecovery | undefined;
+	private needsTailRepair: boolean = false;
 	private persistListeners = new Set<SessionPersistListener>();
 
 	private constructor(
@@ -1230,7 +1347,10 @@ export class SessionManager {
 	 */
 	setSessionFile(sessionFile: string, preloadedEntries?: FileEntry[]): void {
 		this.sessionFile = resolve(sessionFile);
+		this.fileRecovery = undefined;
+		this.needsTailRepair = false;
 		if (existsSync(this.sessionFile)) {
+			this.needsTailRepair = hasUnterminatedTail(this.sessionFile);
 			this.fileEntries = preloadedEntries ?? loadEntriesFromFile(this.sessionFile);
 
 			// If file was empty or corrupted (no valid header), truncate and start fresh
@@ -1313,6 +1433,8 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
+		this.fileRecovery = undefined;
+		this.needsTailRepair = false;
 		this.flushed = false;
 
 		if (this.persist) {
@@ -1344,23 +1466,22 @@ export class SessionManager {
 
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
+		this._repairPendingTail();
 		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-		const targetPath = realpathIfPresent(this.sessionFile);
-		const directory = dirname(targetPath);
-		mkdirSync(directory, { recursive: true });
-		const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
-		try {
+		replaceFileAtomically(this.sessionFile, (targetPath, tempPath) => {
 			const metadata = statMetadataIfPresent(targetPath);
 			writeFileSync(tempPath, content, metadata === undefined ? undefined : { mode: metadata.mode });
-			if (metadata !== undefined) {
-				chownSync(tempPath, metadata.uid, metadata.gid);
-				chmodSync(tempPath, metadata.mode);
-			}
-			renameSync(tempPath, targetPath);
-		} finally {
-			rmSync(tempPath, { force: true });
-		}
+		});
 		this._notifyPersistListeners();
+	}
+
+	private _repairPendingTail(): void {
+		if (!this.persist || !this.sessionFile || !this.needsTailRepair) return;
+		const recovery = repairUnterminatedSessionTail(this.sessionFile);
+		this.needsTailRepair = false;
+		if (recovery) {
+			this.fileRecovery = recovery;
+		}
 	}
 
 	private _notifyPersistListeners(): void {
@@ -1401,6 +1522,10 @@ export class SessionManager {
 
 	getSessionFile(): string | undefined {
 		return this.sessionFile;
+	}
+
+	getFileRecovery(): SessionFileRecovery | undefined {
+		return this.fileRecovery ? { ...this.fileRecovery } : undefined;
 	}
 
 	materializeSessionFile(sessionDir?: string): string {
@@ -1448,6 +1573,7 @@ export class SessionManager {
 	 */
 	flushNow(): void {
 		if (!this.persist || !this.sessionFile) return;
+		this._repairPendingTail();
 		if (this.flushed && existsSync(this.sessionFile)) return;
 		this._rewriteFile();
 		this.flushed = true;
@@ -1468,6 +1594,7 @@ export class SessionManager {
 			this._rewriteFile();
 			this.flushed = true;
 		} else {
+			this._repairPendingTail();
 			mkdirSync(dirname(this.sessionFile), { recursive: true });
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
 			this._notifyPersistListeners();

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -78,6 +78,17 @@ function statMetadataIfPresent(path: string): { mode: number; uid: number; gid: 
 	}
 }
 
+function restoreFileMetadata(path: string, metadata: { mode: number; uid: number; gid: number }): void {
+	if (process.platform !== "win32") {
+		try {
+			chownSync(path, metadata.uid, metadata.gid);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOSYS") throw error;
+		}
+	}
+	chmodSync(path, metadata.mode);
+}
+
 function replaceFileAtomically(path: string, writeTemp: (targetPath: string, tempPath: string) => void): void {
 	const targetPath = realpathIfPresent(path);
 	const directory = dirname(targetPath);
@@ -87,8 +98,7 @@ function replaceFileAtomically(path: string, writeTemp: (targetPath: string, tem
 		const metadata = statMetadataIfPresent(targetPath);
 		writeTemp(targetPath, tempPath);
 		if (metadata !== undefined) {
-			chownSync(tempPath, metadata.uid, metadata.gid);
-			chmodSync(tempPath, metadata.mode);
+			restoreFileMetadata(tempPath, metadata);
 		}
 		renameSync(tempPath, targetPath);
 	} finally {
@@ -1596,7 +1606,13 @@ export class SessionManager {
 		} else {
 			this._repairPendingTail();
 			mkdirSync(dirname(this.sessionFile), { recursive: true });
-			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			try {
+				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			} catch (error) {
+				this.needsTailRepair = true;
+				this.flushed = false;
+				throw error;
+			}
 			this._notifyPersistListeners();
 		}
 	}
@@ -2174,6 +2190,7 @@ export class SessionManager {
 		if (path.length === 0) {
 			throw new Error(`Entry ${leafId} not found`);
 		}
+		this._repairPendingTail();
 
 		// Filter out LabelEntry from path - we'll recreate them from the resolved map
 		const pathWithoutLabels = path.filter((e) => e.type !== "label");
@@ -2227,6 +2244,7 @@ export class SessionManager {
 			this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
 			this.sessionId = newSessionId;
 			this.sessionFile = newSessionFile;
+			this.needsTailRepair = false;
 			this._buildIndex();
 
 			// Only write the file now if it contains an assistant message.

--- a/packages/coding-agent/test/suite/regressions/928-jsonl-tail-repair.test.ts
+++ b/packages/coding-agent/test/suite/regressions/928-jsonl-tail-repair.test.ts
@@ -1,0 +1,174 @@
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../../src/core/session-manager.js";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("issue #928 incomplete JSONL tail repair", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	async function createPersistedHarness(): Promise<{ harness: Harness; sessionFile: string }> {
+		const harness = await createHarness({ persistSession: true });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("before crash")]);
+		await harness.session.prompt("persist a valid turn");
+		const sessionFile = harness.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		return { harness, sessionFile };
+	}
+
+	function expectAllRowsValid(sessionFile: string): void {
+		for (const row of readFileSync(sessionFile, "utf8").split("\n")) {
+			if (row) expect(() => JSON.parse(row)).not.toThrow();
+		}
+	}
+
+	it("discards a terminal record torn in the middle of a UTF-8 sequence", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const validBytes = readFileSync(sessionFile);
+		const tailPrefix = Buffer.from('{"type":"custom","data":"');
+		const partialCodePoint = Buffer.from("🙂").subarray(0, 2);
+		const tornTail = Buffer.concat([tailPrefix, partialCodePoint]);
+		appendFileSync(sessionFile, tornTail);
+
+		const resumed = SessionManager.open(sessionFile);
+
+		expect(resumed.getFileRecovery()).toBeUndefined();
+		expect(readFileSync(sessionFile)).toEqual(Buffer.concat([validBytes, tornTail]));
+		resumed.appendCustomEntry("after_recovery", { source: "mid-utf8" });
+		expect(resumed.getFileRecovery()).toEqual({
+			action: "truncated_incomplete_tail",
+			originalSize: validBytes.length + tailPrefix.length + partialCodePoint.length,
+			repairedSize: validBytes.length,
+			discardedBytes: tailPrefix.length + partialCodePoint.length,
+		});
+		expect(readFileSync(sessionFile).subarray(0, validBytes.length)).toEqual(validBytes);
+		expect(SessionManager.open(sessionFile).getEntries().at(-1)).toMatchObject({
+			type: "custom",
+			customType: "after_recovery",
+		});
+		expect(resumed.getEntries().slice(0, harness.sessionManager.getEntries().length)).toEqual(
+			harness.sessionManager.getEntries(),
+		);
+	});
+
+	it("discards a terminal record torn in the middle of JSON", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const validBytes = readFileSync(sessionFile);
+		const tornTail = Buffer.from('{"type":"message","id":"torn"');
+		appendFileSync(sessionFile, tornTail);
+
+		const resumed = SessionManager.open(sessionFile);
+
+		expect(resumed.getFileRecovery()).toBeUndefined();
+		expect(readFileSync(sessionFile)).toEqual(Buffer.concat([validBytes, tornTail]));
+		resumed.appendCustomEntry("after_mid_json");
+		expect(resumed.getFileRecovery()?.action).toBe("truncated_incomplete_tail");
+		expect(resumed.getFileRecovery()?.discardedBytes).toBe(tornTail.length);
+		expect(resumed.getEntries().slice(0, harness.sessionManager.getEntries().length)).toEqual(
+			harness.sessionManager.getEntries(),
+		);
+		expect(SessionManager.open(sessionFile).getEntries().at(-1)).toMatchObject({ customType: "after_mid_json" });
+	});
+
+	it("terminates and retains a complete final record that lacks a newline", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const completeTail = {
+			type: "custom",
+			customType: "complete_without_newline",
+			data: { retained: true },
+			id: "complete-tail",
+			parentId: harness.sessionManager.getLeafId(),
+			timestamp: "2026-08-08T00:00:00.000Z",
+		};
+		const encodedTail = Buffer.from(JSON.stringify(completeTail));
+		appendFileSync(sessionFile, encodedTail);
+		const originalSize = readFileSync(sessionFile).length;
+
+		const resumed = SessionManager.open(sessionFile);
+
+		expect(resumed.getFileRecovery()).toBeUndefined();
+		expect(readFileSync(sessionFile).length).toBe(originalSize);
+		resumed.appendCustomEntry("after_complete_tail");
+		expect(resumed.getFileRecovery()).toEqual({
+			action: "appended_missing_newline",
+			originalSize,
+			repairedSize: originalSize + 1,
+			discardedBytes: 0,
+		});
+		expect(readFileSync(sessionFile).at(-1)).toBe(0x0a);
+		expect(resumed.getEntry(completeTail.id)).toMatchObject(completeTail);
+		const reopened = SessionManager.open(sessionFile);
+		expect(reopened.getEntry(completeTail.id)).toMatchObject(completeTail);
+		expect(reopened.getEntries().at(-1)).toMatchObject({ customType: "after_complete_tail" });
+	});
+
+	it("preserves a malformed middle row while repairing the terminal record", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const validPrefix = readFileSync(sessionFile);
+		const malformedMiddle = Buffer.from("malformed middle row\n");
+		const completeTail = Buffer.from(
+			JSON.stringify({
+				type: "custom",
+				customType: "after_malformed_middle",
+				id: "after-malformed-middle",
+				parentId: harness.sessionManager.getLeafId(),
+				timestamp: "2026-08-08T00:00:00.000Z",
+			}),
+		);
+		appendFileSync(sessionFile, Buffer.concat([malformedMiddle, completeTail]));
+
+		const resumed = SessionManager.open(sessionFile);
+		const beforeAppend = readFileSync(sessionFile);
+
+		expect(resumed.getFileRecovery()).toBeUndefined();
+		expect(beforeAppend).toEqual(Buffer.concat([validPrefix, malformedMiddle, completeTail]));
+		resumed.appendCustomEntry("after_malformed_middle_append");
+		const repaired = readFileSync(sessionFile);
+		expect(resumed.getFileRecovery()?.action).toBe("appended_missing_newline");
+		expect(repaired.subarray(0, validPrefix.length)).toEqual(validPrefix);
+		expect(repaired.subarray(validPrefix.length, validPrefix.length + malformedMiddle.length)).toEqual(
+			malformedMiddle,
+		);
+		expect(resumed.getEntry("after-malformed-middle")).toBeDefined();
+	});
+
+	it("keeps empty-file recovery behavior and permits a subsequent round trip", async () => {
+		const { harness } = await createPersistedHarness();
+		const sessionFile = join(harness.tempDir, "empty.jsonl");
+		writeFileSync(sessionFile, "");
+
+		const resumed = SessionManager.open(sessionFile);
+
+		expect(resumed.getFileRecovery()).toBeUndefined();
+		expect(resumed.getHeader()?.type).toBe("session");
+		resumed.appendSessionInfo("Recovered empty session");
+		expect(SessionManager.open(sessionFile).getSessionName()).toBe("Recovered empty session");
+	});
+
+	it("commits the repair before a later append so restart is safe", async () => {
+		const { sessionFile } = await createPersistedHarness();
+		appendFileSync(sessionFile, '{"type":"custom","id":"interrupted"');
+		const interruptedBytes = readFileSync(sessionFile);
+
+		const repaired = SessionManager.open(sessionFile);
+		expect(repaired.getFileRecovery()).toBeUndefined();
+		expect(readFileSync(sessionFile)).toEqual(interruptedBytes);
+		repaired.flushNow();
+		expect(repaired.getFileRecovery()?.action).toBe("truncated_incomplete_tail");
+		expectAllRowsValid(sessionFile);
+
+		const afterRestart = SessionManager.open(sessionFile);
+		expect(afterRestart.getFileRecovery()).toBeUndefined();
+		afterRestart.appendCustomEntry("after_restart");
+		expect(SessionManager.open(sessionFile).getEntries().at(-1)).toMatchObject({ customType: "after_restart" });
+		expectAllRowsValid(sessionFile);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/928-jsonl-tail-repair.test.ts
+++ b/packages/coding-agent/test/suite/regressions/928-jsonl-tail-repair.test.ts
@@ -1,7 +1,36 @@
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, type chmodSync, type chownSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type AppendFileSync = typeof appendFileSync;
+type ChmodSync = typeof chmodSync;
+type ChownSync = typeof chownSync;
+
+const fsMocks = vi.hoisted(() => ({
+	actualAppendFileSync: undefined as AppendFileSync | undefined,
+	actualChmodSync: undefined as ChmodSync | undefined,
+	actualChownSync: undefined as ChownSync | undefined,
+	appendFileSync: vi.fn<AppendFileSync>(),
+	chmodSync: vi.fn<ChmodSync>(),
+	chownSync: vi.fn<ChownSync>(),
+}));
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	fsMocks.actualAppendFileSync = actual.appendFileSync;
+	fsMocks.actualChmodSync = actual.chmodSync;
+	fsMocks.actualChownSync = actual.chownSync;
+	fsMocks.appendFileSync.mockImplementation(actual.appendFileSync);
+	fsMocks.chmodSync.mockImplementation(actual.chmodSync);
+	fsMocks.chownSync.mockImplementation(actual.chownSync);
+	return {
+		...actual,
+		appendFileSync: fsMocks.appendFileSync,
+		chmodSync: fsMocks.chmodSync,
+		chownSync: fsMocks.chownSync,
+	};
+});
+
 import { SessionManager } from "../../../src/core/session-manager.js";
 import { createHarness, type Harness } from "../harness.js";
 
@@ -12,6 +41,13 @@ describe("issue #928 incomplete JSONL tail repair", () => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
+		fsMocks.appendFileSync.mockReset();
+		fsMocks.appendFileSync.mockImplementation(fsMocks.actualAppendFileSync!);
+		fsMocks.chmodSync.mockReset();
+		fsMocks.chmodSync.mockImplementation(fsMocks.actualChmodSync!);
+		fsMocks.chownSync.mockReset();
+		fsMocks.chownSync.mockImplementation(fsMocks.actualChownSync!);
+		vi.restoreAllMocks();
 	});
 
 	async function createPersistedHarness(): Promise<{ harness: Harness; sessionFile: string }> {
@@ -138,6 +174,77 @@ describe("issue #928 incomplete JSONL tail repair", () => {
 			malformedMiddle,
 		);
 		expect(resumed.getEntry("after-malformed-middle")).toBeDefined();
+	});
+
+	it("preserves mode without attempting ownership restoration on Windows", async () => {
+		const { sessionFile } = await createPersistedHarness();
+		appendFileSync(sessionFile, '{"type":"custom","id":"windows-torn"');
+		const resumed = SessionManager.open(sessionFile);
+		fsMocks.chmodSync.mockClear();
+		fsMocks.chownSync.mockClear();
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+		try {
+			resumed.appendCustomEntry("after_windows_recovery");
+		} finally {
+			platform.mockRestore();
+		}
+
+		expect(fsMocks.chownSync).not.toHaveBeenCalled();
+		expect(fsMocks.chmodSync).toHaveBeenCalled();
+		expect(SessionManager.open(sessionFile).getEntries().at(-1)).toMatchObject({
+			customType: "after_windows_recovery",
+		});
+	});
+
+	it("repairs the source before creating a branch from a resumed torn session", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const validBytes = readFileSync(sessionFile);
+		const leafId = harness.sessionManager.getLeafId();
+		if (!leafId) throw new Error("Expected a persisted session leaf");
+		appendFileSync(sessionFile, '{"type":"custom","id":"branch-torn"');
+		const resumed = SessionManager.open(sessionFile);
+
+		const branchFile = resumed.createBranchedSession(leafId);
+
+		expect(branchFile).toBeDefined();
+		expect(branchFile).not.toBe(sessionFile);
+		expect(resumed.getFileRecovery()?.action).toBe("truncated_incomplete_tail");
+		expect(readFileSync(sessionFile)).toEqual(validBytes);
+		expect(SessionManager.open(branchFile!).getEntries()).toEqual(resumed.getEntries());
+	});
+
+	it("reinspects and rewrites after a partial append fails in a live process", async () => {
+		const { harness, sessionFile } = await createPersistedHarness();
+		const validEntryIds = harness.sessionManager.getEntries().map((entry) => entry.id);
+		const resumed = SessionManager.open(sessionFile);
+		fsMocks.appendFileSync.mockImplementationOnce((path, data, options) => {
+			const partial = Buffer.from(String(data)).subarray(0, 18);
+			fsMocks.actualAppendFileSync!(path, partial, options);
+			throw new Error("simulated partial append");
+		});
+
+		expect(() => resumed.appendCustomEntry("partial_append_attempt")).toThrow("simulated partial append");
+		const tornBytes = readFileSync(sessionFile);
+		expect(tornBytes.at(-1)).not.toBe(0x0a);
+
+		resumed.appendCustomEntry("retry_after_partial_append");
+
+		expect(resumed.getFileRecovery()?.action).toBe("truncated_incomplete_tail");
+		expectAllRowsValid(sessionFile);
+		const reopened = SessionManager.open(sessionFile);
+		expect(
+			reopened
+				.getEntries()
+				.slice(0, validEntryIds.length)
+				.map((entry) => entry.id),
+		).toEqual(validEntryIds);
+		expect(
+			reopened
+				.getEntries()
+				.slice(-2)
+				.map((entry) => (entry.type === "custom" ? entry.customType : undefined)),
+		).toEqual(["partial_append_attempt", "retry_after_partial_append"]);
 	});
 
 	it("keeps empty-file recovery behavior and permits a subsequent round trip", async () => {


### PR DESCRIPTION
## What changed

- Detect unterminated JSONL tails when a persisted session is opened, without mutating read-only opens.
- At the first persistence boundary, atomically append a missing newline to a complete record or truncate an incomplete terminal record before writing the next entry.
- Preserve earlier raw bytes, including malformed middle rows, and retain per-open recovery metadata through `getFileRecovery()`.
- Add faux-provider regression coverage for mid-UTF-8 and mid-JSON tears, valid JSON without a newline, malformed middle rows, empty files, read-only opens, and restart safety after repair.

## Why

The session loaders either accepted a complete final JSON record without a newline or skipped an incomplete final fragment. `SessionManager` then treated the file as flushed, so the next fast-path append started at the existing EOF and concatenated the new entry with those terminal bytes.

## Impact

Resuming and writing to an interrupted session now preserves all earlier valid records and allows the next entry to round-trip. Catalog, export, and other read-only opens do not modify session files. Repair uses same-directory atomic replacement and preserves the existing file metadata and symlink target behavior.

## Checks

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/928-jsonl-tail-repair.test.ts`
- `npm run check`

Fixes #928


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix incomplete JSONL tail repair in `SessionManager` to prevent bad concatenation on resume
> - Detects unterminated JSONL tails when resuming a session file and marks them for repair before any subsequent writes.
> - Adds `repairUnterminatedSessionTail` which either appends a newline (if the final record is valid JSON) or truncates the file to discard an incomplete record.
> - File rewrites now use `replaceFileAtomically`, writing to a temp file in the same directory then renaming, preserving prior file ownership and mode.
> - Failed mid-write appends set a `needsTailRepair` flag so the next persist triggers a rewrite rather than concatenating onto a broken tail.
> - Adds a `getFileRecovery()` accessor on `SessionManager` exposing details of the last repair performed (action, original size, repaired size, discarded bytes).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7d7490.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->