### PR TITLE
test(coding-agent): add issue #900 context eligibility regression

### DIFF
--- a/packages/coding-agent/test/suite/regressions/900-compaction-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/900-compaction-recovery.test.ts
@@ -1,0 +1,68 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { estimateRawContextTokens, prepareCompaction } from "../../../src/core/compaction/index.js";
+import { convertToLlm, createCompactionOutcomeMessage } from "../../../src/core/messages.js";
+import type { SessionEntry } from "../../../src/core/session-manager.js";
+
+function failedAssistant(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "faux-1",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage: "context_length_exceeded",
+		timestamp: 2,
+	};
+}
+
+describe("issue #900 compaction recovery", () => {
+	it("keeps retry evidence durable while excluding it from model and compaction context", () => {
+		const oldUser: AgentMessage = { role: "user", content: "old:" + "a".repeat(100), timestamp: 1 };
+		const failed = failedAssistant("failed partial:" + "b".repeat(100));
+		const outcome = createCompactionOutcomeMessage("compaction failed", {
+			reason: "overflow",
+			outcome: "failed",
+		});
+		const recentUser: AgentMessage = { role: "user", content: "recent:" + "c".repeat(100), timestamp: 4 };
+		const messages = [oldUser, failed, outcome, recentUser];
+
+		expect(convertToLlm(messages)).toEqual([oldUser, recentUser]);
+		expect(estimateRawContextTokens(messages)).toBe(estimateRawContextTokens([oldUser, recentUser]));
+
+		const entries: SessionEntry[] = [
+			{ type: "message", id: "u1", parentId: null, timestamp: new Date(1).toISOString(), message: oldUser },
+			{ type: "message", id: "a1", parentId: "u1", timestamp: new Date(2).toISOString(), message: failed },
+			{
+				type: "custom_message",
+				id: "o1",
+				parentId: "a1",
+				timestamp: new Date(3).toISOString(),
+				customType: outcome.customType,
+				content: outcome.content,
+				display: outcome.display,
+				details: outcome.details,
+			},
+			{ type: "message", id: "u2", parentId: "o1", timestamp: new Date(4).toISOString(), message: recentUser },
+		];
+		const preparation = prepareCompaction(entries, {
+			enabled: true,
+			reserveTokens: 1000,
+			keepRecentTokens: 1,
+		});
+
+		expect(preparation).toBeDefined();
+		expect(preparation!.messagesToSummarize).toEqual([oldUser]);
+		expect(preparation!.turnPrefixMessages).toEqual([]);
+	});
+});


### PR DESCRIPTION
Failed assistant retries and compaction_outcome diagnostics must remain durable in session entries while being excluded from both the provider context and the compaction input.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression test for issue #900 context eligibility in compaction recovery
> Adds a vitest regression suite in [900-compaction-recovery.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/963/files#diff-1f6a9174f95851263171b94aea7fc254de6f1027c68f46b963b913eba7f61e5e) to verify that failed assistant messages and compaction outcome messages are excluded from model context and compaction input while remaining in durable history.
>
> - Introduces a `failedAssistant` helper that builds a consistent `AssistantMessage` with `stopReason: 'error'` and `errorMessage: 'context_length_exceeded'`.
> - The test builds a conversation with an old user message, a failed assistant message, a compaction outcome message, and a recent user message, then asserts `convertToLlm` returns only the two user messages.
> - Verifies `estimateRawContextTokens` excludes the failed/outcome messages and that `prepareCompaction` schedules only the old user message for summarization with an empty `turnPrefixMessages`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3515afb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->