### PR TITLE
fix(coding-agent): invalidate snapshot cache when worker recovery drops operations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the daemon supervisor leaving a stale snapshot cache after a worker recovery that dropped uncertain operations, which could make an attached client fail to re-sync its snapshot ([#966](https://github.com/PrimeIntellect-ai/prime-agent/pull/966) by [@avion23](https://github.com/avion23)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2854,6 +2854,7 @@ export class DaemonSupervisor {
 		if (uncertain.length === 0) {
 			return;
 		}
+		const uncertainActiveSessionIds = new Set(uncertain.map((record) => record.activeSessionId));
 		const interruptedSessions = new Map<
 			string,
 			{ activeSessionId: string; sessionFile: string; operations: Set<string> }
@@ -2893,10 +2894,10 @@ export class DaemonSupervisor {
 				operation: "recovery_hold",
 			});
 		}
-		for (const interrupted of interruptedSessions.values()) {
+		for (const activeSessionId of uncertainActiveSessionIds) {
 			this.failWorkerSnapshotCache(
 				worker,
-				interrupted.activeSessionId,
+				activeSessionId,
 				new Error("Worker recovery dropped uncertain operations; snapshot cache invalidated"),
 			);
 		}
@@ -3931,7 +3932,7 @@ export class DaemonSupervisor {
 						worker,
 						activeSessionId,
 						error instanceof Error ? error : new Error(String(error)),
-						false,
+						true,
 						generation.transcript.snapshotId,
 					);
 				}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2893,6 +2893,13 @@ export class DaemonSupervisor {
 				operation: "recovery_hold",
 			});
 		}
+		for (const interrupted of interruptedSessions.values()) {
+			this.failWorkerSnapshotCache(
+				worker,
+				interrupted.activeSessionId,
+				new Error("Worker recovery dropped uncertain operations; snapshot cache invalidated"),
+			);
+		}
 		this.log(
 			`Recovered worker ${worker.descriptor.workerId} without replaying uncertain operations: ${uncertain
 				.map((record) => record.operation)
@@ -3924,7 +3931,7 @@ export class DaemonSupervisor {
 						worker,
 						activeSessionId,
 						error instanceof Error ? error : new Error(String(error)),
-						true,
+						false,
 						generation.transcript.snapshotId,
 					);
 				}

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1919,10 +1919,16 @@ describe("daemon worker supervisor monitoring", () => {
 				activeSessionId,
 				new Map([[snapshotId, { transcript, result, incoming: false, retired: false }]]),
 			);
+			return { transcript, result };
 		};
-		cacheSnapshot("root-active", "root-snapshot");
-		cacheSnapshot("child-active", "child-snapshot");
-		cacheSnapshot("unrelated-active", "unrelated-snapshot");
+		const cachedSnapshots = new Map([
+			["root-active", cacheSnapshot("root-active", "root-snapshot")],
+			["child-active", cacheSnapshot("child-active", "child-snapshot")],
+			["unrelated-active", cacheSnapshot("unrelated-active", "unrelated-snapshot")],
+		]);
+		const unrelated = cachedSnapshots.get("unrelated-active")!;
+		unrelated.transcript.appendEncodedChunk(Buffer.from("unrelated\n"));
+		unrelated.transcript.markComplete();
 		const markInterrupted = vi.fn(async () => undefined);
 		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
@@ -1933,19 +1939,41 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations(worker: RecoveryWorker, killWorkerProcess: boolean): Promise<void>;
 		};
 
+		const invalidationError = "Worker recovery dropped uncertain operations; snapshot cache invalidated";
+		const pendingReaders = new Map(
+			["root-active", "child-active"].map((activeSessionId) => {
+				const reader = cachedSnapshots.get(activeSessionId)!.transcript.waitForChunk(0);
+				return [activeSessionId, expect(reader).rejects.toThrow(invalidationError)] as const;
+			}),
+		);
+
 		try {
 			await supervisor.recoverUncertainWorkerOperations(worker, false);
 			expect(kill).not.toHaveBeenCalled();
 			expect(markInterrupted).toHaveBeenCalledTimes(1);
 			expect(markInterrupted).toHaveBeenCalledWith("/tmp/root.jsonl", "root-active", ["model_stream"]);
 			for (const activeSessionId of ["root-active", "child-active"]) {
+				await pendingReaders.get(activeSessionId);
+				const { transcript } = cachedSnapshots.get(activeSessionId)!;
+				expect(transcript.complete).toBe(false);
+				expect(() => transcript.retain()).toThrow(`Snapshot transcript ${transcript.snapshotId} was disposed`);
+				expect(() => transcript.appendEncodedChunk(Buffer.from("late\n"))).toThrow(
+					`Snapshot transcript ${transcript.snapshotId} is not writable`,
+				);
 				expect(worker.snapshotCache.has(activeSessionId)).toBe(false);
 				expect(worker.transcriptCaches.has(activeSessionId)).toBe(false);
 				expect(worker.snapshotGenerations.has(activeSessionId)).toBe(false);
 			}
-			expect(worker.snapshotCache.has("unrelated-active")).toBe(true);
-			expect(worker.transcriptCaches.has("unrelated-active")).toBe(true);
-			expect(worker.snapshotGenerations.has("unrelated-active")).toBe(true);
+			expect(worker.snapshotCache.get("unrelated-active")).toBe(unrelated.result);
+			expect(worker.transcriptCaches.get("unrelated-active")).toBe(unrelated.transcript);
+			expect(worker.snapshotGenerations.get("unrelated-active")).toBeDefined();
+			const releaseUnrelated = unrelated.transcript.retain();
+			try {
+				expect(unrelated.transcript.complete).toBe(true);
+				expect(unrelated.transcript.readChunk(0)).toEqual(Buffer.from("unrelated\n"));
+			} finally {
+				releaseUnrelated();
+			}
 		} finally {
 			kill.mockRestore();
 			rmSync(root, { recursive: true, force: true });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1859,6 +1859,9 @@ describe("daemon worker supervisor monitoring", () => {
 				recoveryJournalPath: string;
 				orphanProcessJournalPath: string;
 			};
+			snapshotCache: Map<string, unknown>;
+			transcriptCaches: Map<string, unknown>;
+			snapshotGenerations: Map<string, unknown>;
 		};
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-test-"));
 		const journalPath = join(root, "worker.recovery.jsonl");
@@ -1897,6 +1900,9 @@ describe("daemon worker supervisor monitoring", () => {
 				recoveryJournalPath: journalPath,
 				orphanProcessJournalPath: orphanJournalPath,
 			},
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
 		};
 		const markInterrupted = vi.fn(async () => undefined);
 		const kill = vi.spyOn(process, "kill").mockReturnValue(true);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -25,6 +25,7 @@ import {
 	type DaemonWorkerFrameHeader,
 } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { MutationDrainLatch } from "../src/modes/daemon/mutation-drain-latch.js";
+import { SnapshotTranscriptCache } from "../src/modes/daemon/snapshot-transcript-cache.js";
 import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
 import type { PrivateFrame } from "../src/modes/session-worker/private-framing.js";
 import { createDeferred } from "./suite/scheduling.js";
@@ -1850,7 +1851,13 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(client.attachedActiveSessionIds).toEqual(new Set());
 	});
 
-	it("marks each busy worker session interrupted independently", async () => {
+	it("invalidates every uncertain worker session cache independently", async () => {
+		type SnapshotGeneration = {
+			transcript: SnapshotTranscriptCache;
+			result: DaemonAttachResult;
+			incoming: boolean;
+			retired: boolean;
+		};
 		type RecoveryWorker = {
 			descriptor: {
 				workerId: string;
@@ -1859,9 +1866,9 @@ describe("daemon worker supervisor monitoring", () => {
 				recoveryJournalPath: string;
 				orphanProcessJournalPath: string;
 			};
-			snapshotCache: Map<string, unknown>;
-			transcriptCaches: Map<string, unknown>;
-			snapshotGenerations: Map<string, unknown>;
+			snapshotCache: Map<string, DaemonAttachResult>;
+			transcriptCaches: Map<string, SnapshotTranscriptCache>;
+			snapshotGenerations: Map<string, Map<string, SnapshotGeneration>>;
 		};
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-test-"));
 		const journalPath = join(root, "worker.recovery.jsonl");
@@ -1888,7 +1895,6 @@ describe("daemon worker supervisor monitoring", () => {
 		journal.record({
 			activeSessionId: "child-active",
 			sessionId: "child-session",
-			sessionFile: "/tmp/child.jsonl",
 			busy: true,
 			operation: "tool_execution",
 		});
@@ -1904,6 +1910,19 @@ describe("daemon worker supervisor monitoring", () => {
 			transcriptCaches: new Map(),
 			snapshotGenerations: new Map(),
 		};
+		const cacheSnapshot = (activeSessionId: string, snapshotId: string) => {
+			const transcript = new SnapshotTranscriptCache({ activeSessionId, snapshotId, cacheRoot: root });
+			const result = { snapshotStream: { id: snapshotId } } as DaemonAttachResult;
+			worker.snapshotCache.set(activeSessionId, result);
+			worker.transcriptCaches.set(activeSessionId, transcript);
+			worker.snapshotGenerations.set(
+				activeSessionId,
+				new Map([[snapshotId, { transcript, result, incoming: false, retired: false }]]),
+			);
+		};
+		cacheSnapshot("root-active", "root-snapshot");
+		cacheSnapshot("child-active", "child-snapshot");
+		cacheSnapshot("unrelated-active", "unrelated-snapshot");
 		const markInterrupted = vi.fn(async () => undefined);
 		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
@@ -1917,9 +1936,16 @@ describe("daemon worker supervisor monitoring", () => {
 		try {
 			await supervisor.recoverUncertainWorkerOperations(worker, false);
 			expect(kill).not.toHaveBeenCalled();
-			expect(markInterrupted).toHaveBeenCalledTimes(2);
+			expect(markInterrupted).toHaveBeenCalledTimes(1);
 			expect(markInterrupted).toHaveBeenCalledWith("/tmp/root.jsonl", "root-active", ["model_stream"]);
-			expect(markInterrupted).toHaveBeenCalledWith("/tmp/child.jsonl", "child-active", ["tool_execution"]);
+			for (const activeSessionId of ["root-active", "child-active"]) {
+				expect(worker.snapshotCache.has(activeSessionId)).toBe(false);
+				expect(worker.transcriptCaches.has(activeSessionId)).toBe(false);
+				expect(worker.snapshotGenerations.has(activeSessionId)).toBe(false);
+			}
+			expect(worker.snapshotCache.has("unrelated-active")).toBe(true);
+			expect(worker.transcriptCaches.has("unrelated-active")).toBe(true);
+			expect(worker.snapshotGenerations.has("unrelated-active")).toBe(true);
 		} finally {
 			kill.mockRestore();
 			rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

- Invalidate the supervisor snapshot cache for every unique active session with uncertain operations dropped during worker recovery, including child records that do not have a `sessionFile`.
- Keep unexpected duplicate-snapshot byte or protocol mismatches fatal to the worker channel; recovery-time invalidation removes the known stale-cache cause before the worker reconnects.
- Add recovery scenario coverage for root and child sessions, pending snapshot readers, transcript disposal, and isolation of unrelated cached snapshots.

## Why

Snapshot IDs are derived from event counters rather than transcript content. When recovery drops an in-flight operation, the recovered transcript can have different bytes under the same snapshot ID. A stale supervisor cache then treats the transfer as a duplicate and rejects it, which can leave attached clients unable to re-sync.

Recovery journal entries can omit `sessionFile` for non-root sessions. Catalog interruption marking still needs a session file, but cache invalidation does not. Separating those sets ensures every uncertain active session is invalidated without weakening duplicate-stream containment.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-supervisor-monitor.test.ts test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts test/worker-recovery-journal.test.ts` — 56 passed
- `npm run check` — passed (`biome`, `tsgo`, installer render, browser smoke)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Invalidate snapshot cache for uncertain sessions during worker recovery in `DaemonSupervisor`
> When `DaemonSupervisor.recoverUncertainWorkerOperations` drops uncertain operations, it now collects the affected active session IDs and calls `failWorkerSnapshotCache` for each one, preventing stale cached snapshots from being used after recovery.
>
> - Uncertain sessions have their snapshot cache and transcript caches disposed; unrelated sessions are unaffected.
> - A new test verifies that each uncertain session's cache reader rejects with an invalidation error and that unrelated session caches remain valid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 345c0e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->