### PR TITLE
Enforce Node 22.8 in installer preflight

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -229,20 +229,15 @@ jobs:
       - name: Prepare installer
         run: |
           INSTALL_BASE_URL="${R2_PUBLIC_BASE_URL%/}"
-          export INSTALL_BASE_URL
           test -n "$INSTALL_BASE_URL"
-
-          node - <<'NODE'
-          const fs = require("node:fs");
-          const baseUrl = process.env.INSTALL_BASE_URL;
-          if (!baseUrl) throw new Error("INSTALL_BASE_URL is required");
-          const installer = fs.readFileSync("install.sh", "utf8");
-          const renderInstaller = (channel) => installer
-            .replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl)
-            .replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
-          fs.writeFileSync("/tmp/prime-agent-install.sh", renderInstaller("stable"));
-          fs.writeFileSync("/tmp/prime-agent-install-beta.sh", renderInstaller("beta"));
-          NODE
+          node scripts/render-installer.mjs \
+            --base-url "$INSTALL_BASE_URL" \
+            --channel stable \
+            --output /tmp/prime-agent-install.sh
+          node scripts/render-installer.mjs \
+            --base-url "$INSTALL_BASE_URL" \
+            --channel beta \
+            --output /tmp/prime-agent-install-beta.sh
 
       - name: Extract production release notes
         if: env.PUBLISH_PRODUCTION == 'true'

--- a/install.sh
+++ b/install.sh
@@ -1048,8 +1048,40 @@ apt_node_candidate_is_new_enough() {
 }
 
 apk_node_candidate_is_new_enough() {
-	version=$(apk search -x nodejs 2>/dev/null | awk -F- '/^nodejs-/ { print $2; exit }')
+	version=$(apk search -x nodejs 2>/dev/null | awk '/^nodejs-/ { sub(/^nodejs-/, ""); print; exit }')
 	[ -n "$version" ] && node_version_string_is_new_enough "$version"
+}
+
+node_version_string_is_digits() {
+	case "$1" in
+		""|*[!0-9]*) return 1 ;;
+	esac
+}
+
+node_version_suffix_is_stable() {
+	suffix="$1"
+	case "$suffix" in
+		"") return 0 ;;
+		+*)
+			metadata="${suffix#+}"
+			case "$metadata" in
+				""|.*|*.|*..*|*[!0-9A-Za-z.-]*) return 1 ;;
+			esac
+			return 0
+			;;
+		-r*)
+			node_version_string_is_digits "${suffix#-r}"
+			return
+			;;
+		-*nodesource*)
+			revision="${suffix#-}"
+			distro_revision="${revision%%nodesource*}"
+			node_revision="${revision#*nodesource}"
+			node_version_string_is_digits "$distro_revision" && node_version_string_is_digits "$node_revision"
+			return
+			;;
+		*) return 1 ;;
+	esac
 }
 
 node_version_string_is_new_enough() {
@@ -1060,20 +1092,19 @@ node_version_string_is_new_enough() {
 	esac
 	numeric_version="${version%%[!0-9.]*}"
 	suffix="${version#"$numeric_version"}"
-	case "$suffix" in
-		""|+*|-[0-9]*nodesource*|-r[0-9]*) ;;
-		*) return 1 ;;
-	esac
+	node_version_suffix_is_stable "$suffix" || return 1
 	version_ifs=${IFS- }
 	IFS=.
 	set -- $numeric_version
 	IFS=$version_ifs
+	[ "$#" -eq 3 ] || return 1
 	major="${1:-}"
-	minor="${2:-0}"
-	patch="${3:-0}"
-	case "$major" in ''|*[!0-9]*) return 1 ;; esac
-	case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
-	case "$patch" in ''|*[!0-9]*) patch=0 ;; esac
+	minor="${2:-}"
+	patch="${3:-}"
+	node_version_string_is_digits "$major" || return 1
+	node_version_string_is_digits "$minor" || return 1
+	node_version_string_is_digits "$patch" || return 1
+	[ "$numeric_version" = "$major.$minor.$patch" ] || return 1
 
 	IFS=.
 	set -- $prime_agent_min_node_version

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ fi
 prime_agent_release_channel="${PRIME_AGENT_RELEASE_CHANNEL:-$prime_agent_default_release_channel}"
 prime_agent_package="${PRIME_AGENT_PACKAGE:-prime-agent}"
 prime_agent_cmd="${PRIME_AGENT_CMD:-prime-agent}"
+prime_agent_min_node_version="22.8.0" # generated from packages/coding-agent/package.json engines.node
 prime_agent_esc=$(printf '\033')
 prime_agent_original_path="${PATH:-}"
 prime_agent_reset="${prime_agent_esc}[0m"
@@ -33,7 +34,7 @@ prime_agent_color_dim="${prime_agent_esc}[38;2;113;113;122m"
 prime_agent_color_primary="${prime_agent_esc}[38;2;127;91;213m"
 prime_agent_color_scan="${prime_agent_esc}[38;2;14;165;233m"
 prime_agent_color_warning="${prime_agent_esc}[38;2;245;158;11m"
-readonly prime_agent_unconfigured_base_url prime_agent_unconfigured_default_release_channel prime_agent_base_url prime_agent_default_release_channel prime_agent_release_channel prime_agent_package prime_agent_cmd prime_agent_esc prime_agent_original_path
+readonly prime_agent_unconfigured_base_url prime_agent_unconfigured_default_release_channel prime_agent_base_url prime_agent_default_release_channel prime_agent_release_channel prime_agent_package prime_agent_cmd prime_agent_min_node_version prime_agent_esc prime_agent_original_path
 readonly prime_agent_reset prime_agent_bold prime_agent_italic prime_agent_hide_cursor prime_agent_show_cursor prime_agent_home_cursor prime_agent_clear_screen prime_agent_clear_line
 readonly prime_agent_sync_start prime_agent_sync_end
 readonly prime_agent_color_text prime_agent_color_muted prime_agent_color_dim prime_agent_color_primary prime_agent_color_scan prime_agent_color_warning
@@ -874,7 +875,7 @@ finish_preflight_checks() {
 	if [ "$prime_agent_screen_enabled" = 1 ]; then
 		if [ "$preflight_status" -ne 0 ]; then
 			preflight_summary=$(sed -n '1p' "$preflight_file")
-			prime_agent_screen "Node.js 20.6.0 or newer is required" "" "$preflight_summary" ""
+			prime_agent_screen "Node.js $prime_agent_min_node_version or newer is required" "" "$preflight_summary" ""
 			sleep 0.4
 		elif [ -s "$preflight_file" ]; then
 			preflight_summary="Existing $prime_agent_cmd command found on PATH."
@@ -895,12 +896,12 @@ run_preflight_checks() {
 
 	if command -v node >/dev/null 2>&1; then
 		node_version=$(node --version)
-		if ! node -e 'const [major, minor, patch] = process.versions.node.split(".").map(Number); process.exit(major > 20 || (major === 20 && (minor > 6 || (minor === 6 && patch >= 0))) ? 0 : 1)' >/dev/null; then
-			printf 'error: Prime Agent requires Node.js 20.6.0 or newer. Found %s.\n' "$node_version"
+		if ! node_version_string_is_new_enough "$node_version"; then
+			printf 'error: Prime Agent requires Node.js %s or newer. Found %s.\n' "$prime_agent_min_node_version" "$node_version"
 			status=1
 		fi
 	else
-		printf 'error: Node.js 20.6.0 or newer is required to install Prime Agent.\n'
+		printf 'error: Node.js %s or newer is required to install Prime Agent.\n' "$prime_agent_min_node_version"
 		status=1
 	fi
 
@@ -1010,9 +1011,9 @@ install_node_npm_interactive() {
 		prompt_status=$?
 	fi
 	if [ "$prompt_status" -eq 2 ]; then
-		printf 'No terminal detected; install Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+		printf 'No terminal detected; install Node.js %s or newer and npm, then run this installer again.\n' "$prime_agent_min_node_version"
 	else
-		printf '\nInstall Node.js 20.6.0 or newer and npm, then run this installer again.\n'
+		printf '\nInstall Node.js %s or newer and npm, then run this installer again.\n' "$prime_agent_min_node_version"
 	fi
 	return 1
 }
@@ -1057,10 +1058,15 @@ node_version_string_is_new_enough() {
 		[0-9]*) ;;
 		*) return 1 ;;
 	esac
-	version="${version%%[!0-9.]*}"
+	numeric_version="${version%%[!0-9.]*}"
+	suffix="${version#"$numeric_version"}"
+	case "$suffix" in
+		""|+*|-[0-9]*nodesource*|-r[0-9]*) ;;
+		*) return 1 ;;
+	esac
 	version_ifs=${IFS- }
 	IFS=.
-	set -- $version
+	set -- $numeric_version
 	IFS=$version_ifs
 	major="${1:-}"
 	minor="${2:-0}"
@@ -1069,10 +1075,20 @@ node_version_string_is_new_enough() {
 	case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
 	case "$patch" in ''|*[!0-9]*) patch=0 ;; esac
 
-	[ "$major" -gt 20 ] && return 0
-	[ "$major" -eq 20 ] && [ "$minor" -gt 6 ] && return 0
-	[ "$major" -eq 20 ] && [ "$minor" -eq 6 ] && [ "$patch" -ge 0 ] && return 0
-	return 1
+	IFS=.
+	set -- $prime_agent_min_node_version
+	IFS=$version_ifs
+	minimum_major="$1"
+	minimum_minor="$2"
+	minimum_patch="$3"
+
+	[ "$major" -gt "$minimum_major" ] && return 0
+	[ "$major" -lt "$minimum_major" ] && return 1
+	[ "$minor" -gt "$minimum_minor" ] && return 0
+	[ "$minor" -lt "$minimum_minor" ] && return 1
+	[ "$patch" -gt "$minimum_patch" ] && return 0
+	[ "$patch" -lt "$minimum_patch" ] && return 1
+	return 0
 }
 
 install_node_npm() {
@@ -1181,7 +1197,8 @@ install_node_standalone() {
 		printf 'Unsupported CPU architecture for automatic Node.js install: %s\n' "$(uname -m)"
 		return 1
 	}
-	node_dist_base="https://nodejs.org/dist/latest-v22.x"
+	minimum_node_major="${prime_agent_min_node_version%%.*}"
+	node_dist_base="https://nodejs.org/dist/latest-v${minimum_node_major}.x"
 	node_base_dir=$(node_standalone_base_dir)
 	node_tmp_dir=$(create_temp_dir)
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed installer preflight and package-manager selection accepting Node versions below 22.8.0 ([#933](https://github.com/PrimeIntellect-ai/prime-agent/issues/933)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/cli/node-version-check.ts
+++ b/packages/coding-agent/src/cli/node-version-check.ts
@@ -1,7 +1,7 @@
 // Dependency-free and Node-20-safe so it can never crash on the versions it rejects.
 
-const MIN_NODE_VERSION_PARTS = [22, 8, 0] as const;
-export const MIN_NODE_VERSION = MIN_NODE_VERSION_PARTS.join(".");
+export const MIN_NODE_VERSION = "22.8.0";
+const MIN_NODE_VERSION_PARTS = parseMinimumNodeVersion(MIN_NODE_VERSION);
 
 export interface NodeVersionGuardIO {
 	version: string;
@@ -12,6 +12,14 @@ export interface NodeVersionGuardIO {
 interface ParsedNodeVersion {
 	parts: readonly [number, number, number];
 	prerelease: boolean;
+}
+
+function parseMinimumNodeVersion(version: string): readonly [number, number, number] {
+	const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+	if (!match) {
+		throw new Error(`Invalid minimum Node version: ${version}`);
+	}
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function parseVersion(version: string): ParsedNodeVersion | undefined {
@@ -27,6 +35,9 @@ function parseVersion(version: string): ParsedNodeVersion | undefined {
 }
 
 function isSupportedNodeVersion(version: ParsedNodeVersion): boolean {
+	if (version.prerelease) {
+		return false;
+	}
 	for (let index = 0; index < MIN_NODE_VERSION_PARTS.length; index++) {
 		const part = version.parts[index]!;
 		const minimumPart = MIN_NODE_VERSION_PARTS[index]!;
@@ -34,7 +45,7 @@ function isSupportedNodeVersion(version: ParsedNodeVersion): boolean {
 			return part > minimumPart;
 		}
 	}
-	return !version.prerelease;
+	return true;
 }
 
 export function assertNodeVersion(io: NodeVersionGuardIO): boolean {
@@ -50,7 +61,9 @@ export function assertNodeVersion(io: NodeVersionGuardIO): boolean {
 
 	io.log(`prime-agent requires Node ${MIN_NODE_VERSION} or newer, but the active Node is v${io.version}.`);
 	io.log("");
-	io.log(`  1. Install Node ${MIN_NODE_VERSION}+ (e.g. "nvm install 22 && nvm use 22", or from https://nodejs.org)`);
+	io.log(
+		`  1. Install Node ${MIN_NODE_VERSION}+ (e.g. "nvm install ${MIN_NODE_VERSION_PARTS[0]} && nvm use ${MIN_NODE_VERSION_PARTS[0]}", or from https://nodejs.org)`,
+	);
 	io.log("  2. Reinstall prime-agent under that Node so the command resolves to it:");
 	io.log("     https://github.com/PrimeIntellect-ai/prime-agent/releases/latest");
 	io.exit(1);

--- a/packages/coding-agent/test/node-version-check.test.ts
+++ b/packages/coding-agent/test/node-version-check.test.ts
@@ -75,6 +75,20 @@ describe("assertNodeVersion", () => {
 		expect(exitCode).toBe(1);
 	});
 
+	test("rejects an arbitrary prerelease identifier", () => {
+		for (const prerelease of ["experimental", "0.experimental"]) {
+			const { ok, exitCode } = run(`${MIN_NODE_VERSION}-${prerelease}`);
+			expect(ok).toBe(false);
+			expect(exitCode).toBe(1);
+		}
+	});
+
+	test("rejects a prerelease from a newer major", () => {
+		const { ok, exitCode } = run("23.0.0-experimental");
+		expect(ok).toBe(false);
+		expect(exitCode).toBe(1);
+	});
+
 	test("lets an unparseable version through rather than blocking", () => {
 		const { ok, exitCode } = run("not-a-version");
 		expect(ok).toBe(true);

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -11,6 +11,7 @@ const mainCall = '\nmain "$@"';
 const mainCallIndex = installerSource.lastIndexOf(mainCall);
 const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const syncEnd = "\x1b[?2026l";
+const posixShell = "/bin/sh";
 const failures = [];
 
 if (mainCallIndex === -1) {
@@ -182,6 +183,13 @@ try {
 		'printf "  Candidate: %s\\n" "$PRIME_AGENT_TEST_NODE_VERSION"',
 	);
 	writeCommandStub(join(commandStubDir, "apk"), 'printf "nodejs-%s\\n" "$PRIME_AGENT_TEST_NODE_VERSION"');
+	for (const utility of ["awk", "cut", "sed", "tr", "wc"]) {
+		writeCommandStub(join(commandStubDir, utility), `exec /usr/bin/${utility} "$@"`);
+	}
+	const dashProbe = spawnSync("dash", ["-c", ":"], {
+		env: { ...process.env, PATH: commandStubDir },
+	});
+	check(dashProbe.error?.code === "ENOENT", "expected the portability test PATH not to provide dash");
 	assertInstallerRendering(tempDir);
 
 	const stableVisible = runCase("stable visible logo", 100, 30, 90, 30);
@@ -310,8 +318,11 @@ function assertInstallerRendering(outputDir) {
 		check(cliRendered.includes("https://downloads.example.test"), "expected CLI rendering to set the base URL");
 		check(cliRendered.includes('prime_agent_default_release_channel="beta"'), "expected CLI rendering to set beta");
 		check(!/__PRIME_AGENT_[A-Z0-9_]+__/.test(cliRendered), "expected CLI rendering to resolve all placeholders");
-		const syntax = spawnSync("dash", ["-n", cliOutput], { encoding: "utf8" });
-		check(syntax.status === 0, `expected CLI-rendered installer to pass dash syntax validation: ${syntax.stderr}`);
+		const syntax = spawnSync(posixShell, ["-n", cliOutput], {
+			encoding: "utf8",
+			env: { ...process.env, PATH: commandStubDir },
+		});
+		check(syntax.status === 0, `expected CLI-rendered installer to pass sh syntax validation: ${syntax.stderr}`);
 	}
 }
 
@@ -325,12 +336,12 @@ function assertRenderFails(name, source, options) {
 }
 
 function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
-	const result = spawnSync("dash", [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
+	const result = spawnSync(posixShell, [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
 		detached: true,
 		encoding: "utf-8",
 		env: {
 			...process.env,
-			PATH: `${commandStubDir}:${process.env.PATH ?? ""}`,
+			PATH: commandStubDir,
 		},
 	});
 	if (result.status !== 0) {

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertInstallerMinimumIsCurrent, renderInstallerMinimum } from "./render-installer.mjs";
+import { assertInstallerMinimumIsCurrent, renderInstaller, renderInstallerMinimum } from "./render-installer.mjs";
 
 const installerTemplate = readFileSync("install.sh", "utf-8");
 assertInstallerMinimumIsCurrent(installerTemplate);
@@ -115,6 +115,22 @@ node_version_case() {
 	printf '__NODE_VERSION__ %s\t%s\n' "$version" "$supported"
 }
 
+package_manager_candidate_case() {
+	manager="$1"
+	PRIME_AGENT_TEST_NODE_VERSION="$2"
+	export PRIME_AGENT_TEST_NODE_VERSION
+	case "$manager" in
+		apt) candidate_check=apt_node_candidate_is_new_enough ;;
+		apk) candidate_check=apk_node_candidate_is_new_enough ;;
+	esac
+	if "$candidate_check"; then
+		supported=1
+	else
+		supported=0
+	fi
+	printf '__NODE_CANDIDATE__ %s\t%s\t%s\n' "$manager" "$PRIME_AGENT_TEST_NODE_VERSION" "$supported"
+}
+
 render_case "$@"
 screen_case "$@"
 progress_case
@@ -129,13 +145,44 @@ node_version_case 23.0.0-experimental
 node_version_case 22.8.0+dfsg-1ubuntu1
 node_version_case 22.8.0-1nodesource1
 node_version_case 22.8.0-r0
+node_version_case 22.8
+node_version_case 22.8.0.1
+node_version_case 22.8.0.
+node_version_case 22.8.0+
+node_version_case 22.8.0-r0junk
+
+for candidate_version in \
+	20.6.0 \
+	22.7.0 \
+	22.8.0 \
+	23.0.0 \
+	22.8.0-experimental \
+	22.8.0+dfsg-1ubuntu1 \
+	22.8.0-1nodesource1 \
+	22.8.0-r0 \
+	22.8 \
+	22.8.0.1 \
+	22.8.0. \
+	22.8.0+ \
+	22.8.0-r0junk; do
+	package_manager_candidate_case apt "$candidate_version"
+	package_manager_candidate_case apk "$candidate_version"
+done
 `;
 
 const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-installer-render-"));
 const harnessPath = join(tempDir, "harness.sh");
+const commandStubDir = join(tempDir, "commands");
 
 try {
+	mkdirSync(commandStubDir);
 	writeFileSync(harnessPath, harnessSource, "utf-8");
+	writeCommandStub(
+		join(commandStubDir, "apt-cache"),
+		'printf "  Candidate: %s\\n" "$PRIME_AGENT_TEST_NODE_VERSION"',
+	);
+	writeCommandStub(join(commandStubDir, "apk"), 'printf "nodejs-%s\\n" "$PRIME_AGENT_TEST_NODE_VERSION"');
+	assertInstallerRendering(tempDir);
 
 	const stableVisible = runCase("stable visible logo", 100, 30, 90, 30);
 	check(stableVisible.meta.first.visible === "1", "expected the initial large render to show the logo");
@@ -146,6 +193,7 @@ try {
 	);
 	assertInstallerProgress(stableVisible.progress);
 	assertNodeVersions(stableVisible.nodeVersions);
+	assertPackageManagerCandidates(stableVisible.candidateVersions);
 
 	const stableExpand = runCase("stable expanded logo", 60, 24, 120, 32);
 	check(stableExpand.meta.first.visible === "1", "expected the initial medium render to show the logo");
@@ -188,10 +236,102 @@ if (failures.length > 0) {
 
 console.log("Installer render check passed.");
 
+function writeCommandStub(path, command) {
+	writeFileSync(path, `#!/bin/sh\n${command}\n`, "utf8");
+	chmodSync(path, 0o755);
+}
+
+function assertInstallerRendering(outputDir) {
+	const rendered = renderInstaller(installerTemplate, {
+		baseUrl: " https://downloads.example.test/// ",
+		channel: "stable",
+	});
+	check(rendered.includes("https://downloads.example.test"), "expected direct rendering to normalize the base URL");
+	check(rendered.includes('prime_agent_default_release_channel="stable"'), "expected direct rendering to set the channel");
+	check(!/__PRIME_AGENT_[A-Z0-9_]+__/.test(rendered), "expected direct rendering to resolve all placeholders");
+
+	assertRenderFails(
+		"missing base URL placeholder",
+		installerTemplate.replace("__PRIME_AGENT_DOWNLOAD_BASE_URL__", ""),
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"duplicate base URL placeholder",
+		`${installerTemplate}\n__PRIME_AGENT_DOWNLOAD_BASE_URL__\n`,
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"renamed base URL placeholder",
+		installerTemplate.replace("__PRIME_AGENT_DOWNLOAD_BASE_URL__", "__PRIME_AGENT_DOWNLOAD_URL__"),
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"missing release channel placeholder",
+		installerTemplate.replace("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", ""),
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"duplicate release channel placeholder",
+		`${installerTemplate}\n__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__\n`,
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"renamed release channel placeholder",
+		installerTemplate.replace(
+			"__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__",
+			"__PRIME_AGENT_RELEASE_CHANNEL__",
+		),
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails(
+		"unresolved installer placeholder",
+		`${installerTemplate}\n__PRIME_AGENT_UNKNOWN__\n`,
+		{ baseUrl: "https://downloads.example.test", channel: "stable" },
+	);
+	assertRenderFails("root-only base URL", installerTemplate, { baseUrl: " /// ", channel: "stable" });
+
+	const cliOutput = join(outputDir, "install.rendered.sh");
+	const cliResult = spawnSync(
+		process.execPath,
+		[
+			"scripts/render-installer.mjs",
+			"--base-url",
+			"https://downloads.example.test///",
+			"--channel",
+			"beta",
+			"--output",
+			cliOutput,
+		],
+		{ encoding: "utf8" },
+	);
+	check(cliResult.status === 0, `expected installer renderer CLI to succeed: ${cliResult.stderr}`);
+	if (cliResult.status === 0) {
+		const cliRendered = readFileSync(cliOutput, "utf8");
+		check(cliRendered.includes("https://downloads.example.test"), "expected CLI rendering to set the base URL");
+		check(cliRendered.includes('prime_agent_default_release_channel="beta"'), "expected CLI rendering to set beta");
+		check(!/__PRIME_AGENT_[A-Z0-9_]+__/.test(cliRendered), "expected CLI rendering to resolve all placeholders");
+		const syntax = spawnSync("dash", ["-n", cliOutput], { encoding: "utf8" });
+		check(syntax.status === 0, `expected CLI-rendered installer to pass dash syntax validation: ${syntax.stderr}`);
+	}
+}
+
+function assertRenderFails(name, source, options) {
+	try {
+		renderInstaller(source, options);
+		failures.push(`${name}: expected rendering to fail`);
+	} catch {
+		// Expected.
+	}
+}
+
 function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
-	const result = spawnSync("sh", [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
+	const result = spawnSync("dash", [harnessPath, String(initialCols), String(initialRows), String(resizedCols), String(resizedRows)], {
 		detached: true,
 		encoding: "utf-8",
+		env: {
+			...process.env,
+			PATH: `${commandStubDir}:${process.env.PATH ?? ""}`,
+		},
 	});
 	if (result.status !== 0) {
 		failures.push(`${name}: harness exited with ${result.status ?? "unknown"}\n${result.stderr}${result.stdout}`);
@@ -237,6 +377,11 @@ function parseRenderOutput(output) {
 			parsed.nodeVersions[version] = supported === "1";
 			continue;
 		}
+		if (line.startsWith("__NODE_CANDIDATE__ ")) {
+			const [manager, version, supported] = line.slice("__NODE_CANDIDATE__ ".length).split("\t");
+			parsed.candidateVersions[`${manager}:${version}`] = supported === "1";
+			continue;
+		}
 		if (activeRender) {
 			parsed.renders[activeRender].push(line.replace(ansiPattern, ""));
 		}
@@ -258,9 +403,40 @@ function assertNodeVersions(versions) {
 		"22.8.0+dfsg-1ubuntu1": true,
 		"22.8.0-1nodesource1": true,
 		"22.8.0-r0": true,
+		"22.8": false,
+		"22.8.0.1": false,
+		"22.8.0.": false,
+		"22.8.0+": false,
+		"22.8.0-r0junk": false,
 	};
 	for (const [version, supported] of Object.entries(expected)) {
 		check(versions[version] === supported, `expected Node ${version} support to be ${supported}`);
+	}
+}
+
+function assertPackageManagerCandidates(versions) {
+	const expected = {
+		"20.6.0": false,
+		"22.7.0": false,
+		"22.8.0": true,
+		"23.0.0": true,
+		"22.8.0-experimental": false,
+		"22.8.0+dfsg-1ubuntu1": true,
+		"22.8.0-1nodesource1": true,
+		"22.8.0-r0": true,
+		"22.8": false,
+		"22.8.0.1": false,
+		"22.8.0.": false,
+		"22.8.0+": false,
+		"22.8.0-r0junk": false,
+	};
+	for (const manager of ["apt", "apk"]) {
+		for (const [version, supported] of Object.entries(expected)) {
+			check(
+				versions[`${manager}:${version}`] === supported,
+				`expected ${manager} Node ${version} candidate support to be ${supported}`,
+			);
+		}
 	}
 }
 
@@ -361,5 +537,6 @@ function emptyParsedCase() {
 		screens: {},
 		progress: [],
 		nodeVersions: {},
+		candidateVersions: {},
 	};
 }

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -2,8 +2,11 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { assertInstallerMinimumIsCurrent, renderInstallerMinimum } from "./render-installer.mjs";
 
-const installerSource = readFileSync("install.sh", "utf-8");
+const installerTemplate = readFileSync("install.sh", "utf-8");
+assertInstallerMinimumIsCurrent(installerTemplate);
+const installerSource = renderInstallerMinimum(installerTemplate);
 const mainCall = '\nmain "$@"';
 const mainCallIndex = installerSource.lastIndexOf(mainCall);
 const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
@@ -102,9 +105,30 @@ Finalizing npm install."
 	done
 }
 
+node_version_case() {
+	version="$1"
+	if node_version_string_is_new_enough "$version"; then
+		supported=1
+	else
+		supported=0
+	fi
+	printf '__NODE_VERSION__ %s\t%s\n' "$version" "$supported"
+}
+
 render_case "$@"
 screen_case "$@"
 progress_case
+node_version_case 20.6.0
+node_version_case 22.7.0
+node_version_case 22.8.0
+node_version_case 23.0.0
+node_version_case 22.8.0-rc.1
+node_version_case 22.8.0-experimental
+node_version_case 22.8.0-0.experimental
+node_version_case 23.0.0-experimental
+node_version_case 22.8.0+dfsg-1ubuntu1
+node_version_case 22.8.0-1nodesource1
+node_version_case 22.8.0-r0
 `;
 
 const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-installer-render-"));
@@ -121,6 +145,7 @@ try {
 		"expected logo lab width to stay stable across a safe resize",
 	);
 	assertInstallerProgress(stableVisible.progress);
+	assertNodeVersions(stableVisible.nodeVersions);
 
 	const stableExpand = runCase("stable expanded logo", 60, 24, 120, 32);
 	check(stableExpand.meta.first.visible === "1", "expected the initial medium render to show the logo");
@@ -207,12 +232,36 @@ function parseRenderOutput(output) {
 			parsed.progress.push({ frame: Number(frame), status, detail });
 			continue;
 		}
+		if (line.startsWith("__NODE_VERSION__ ")) {
+			const [version, supported] = line.slice("__NODE_VERSION__ ".length).split("\t");
+			parsed.nodeVersions[version] = supported === "1";
+			continue;
+		}
 		if (activeRender) {
 			parsed.renders[activeRender].push(line.replace(ansiPattern, ""));
 		}
 	}
 
 	return parsed;
+}
+
+function assertNodeVersions(versions) {
+	const expected = {
+		"20.6.0": false,
+		"22.7.0": false,
+		"22.8.0": true,
+		"23.0.0": true,
+		"22.8.0-rc.1": false,
+		"22.8.0-experimental": false,
+		"22.8.0-0.experimental": false,
+		"23.0.0-experimental": false,
+		"22.8.0+dfsg-1ubuntu1": true,
+		"22.8.0-1nodesource1": true,
+		"22.8.0-r0": true,
+	};
+	for (const [version, supported] of Object.entries(expected)) {
+		check(versions[version] === supported, `expected Node ${version} support to be ${supported}`);
+	}
 }
 
 function parseScreenOutput(output) {
@@ -311,5 +360,6 @@ function emptyParsedCase() {
 		},
 		screens: {},
 		progress: [],
+		nodeVersions: {},
 	};
 }

--- a/scripts/render-installer.mjs
+++ b/scripts/render-installer.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const installerPath = resolve(root, "install.sh");
+const rootPackagePath = resolve(root, "package.json");
+const codingAgentPackagePath = resolve(root, "packages/coding-agent/package.json");
+const runtimeVersionGuardPath = resolve(root, "packages/coding-agent/src/cli/node-version-check.ts");
+const generatedMinimumPattern = /^prime_agent_min_node_version="([^"]+)" # generated from packages\/coding-agent\/package\.json engines\.node$/m;
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function exactMinimumFromEngine(path) {
+	const engine = readJson(path).engines?.node;
+	const match = typeof engine === "string" ? /^>=(\d+\.\d+\.\d+)$/.exec(engine) : null;
+	if (!match) {
+		throw new Error(`${path} must declare engines.node as an exact minimum such as >=22.8.0`);
+	}
+	return match[1];
+}
+
+export function getMinimumNodeVersion() {
+	const minimum = exactMinimumFromEngine(codingAgentPackagePath);
+	const rootMinimum = exactMinimumFromEngine(rootPackagePath);
+	if (rootMinimum !== minimum) {
+		throw new Error(`Root Node engine ${rootMinimum} does not match coding-agent minimum ${minimum}`);
+	}
+
+	const guardSource = readFileSync(runtimeVersionGuardPath, "utf8");
+	const guardMatch = /^export const MIN_NODE_VERSION = "(\d+\.\d+\.\d+)";$/m.exec(guardSource);
+	if (!guardMatch || guardMatch[1] !== minimum) {
+		throw new Error(`Runtime Node minimum does not match coding-agent engines.node ${minimum}`);
+	}
+	return minimum;
+}
+
+function installerMinimum(source) {
+	const matches = [...source.matchAll(new RegExp(generatedMinimumPattern.source, "gm"))];
+	if (matches.length !== 1) {
+		throw new Error(`install.sh must contain exactly one generated Node minimum assignment; found ${matches.length}`);
+	}
+	return matches[0][1];
+}
+
+export function assertInstallerMinimumIsCurrent(source) {
+	const expected = getMinimumNodeVersion();
+	const actual = installerMinimum(source);
+	if (actual !== expected) {
+		throw new Error(`install.sh Node minimum ${actual} is stale; expected ${expected}`);
+	}
+}
+
+export function renderInstallerMinimum(source) {
+	installerMinimum(source);
+	const minimum = getMinimumNodeVersion();
+	return source.replace(
+		generatedMinimumPattern,
+		`prime_agent_min_node_version="${minimum}" # generated from packages/coding-agent/package.json engines.node`,
+	);
+}
+
+export function renderInstaller(source, { baseUrl, channel }) {
+	if (!baseUrl) throw new Error("--base-url is required");
+	if (channel !== "stable" && channel !== "beta") throw new Error("--channel must be stable or beta");
+
+	return renderInstallerMinimum(source)
+		.replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl.replace(/\/+$/, ""))
+		.replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
+}
+
+function parseArgs(args) {
+	const parsed = { baseUrl: undefined, channel: undefined, output: undefined };
+	for (let index = 0; index < args.length; index += 1) {
+		const option = args[index];
+		const value = args[index + 1];
+		if (!value) throw new Error(`${option} requires a value`);
+		switch (option) {
+			case "--base-url":
+				parsed.baseUrl = value;
+				break;
+			case "--channel":
+				parsed.channel = value;
+				break;
+			case "--output":
+				parsed.output = value;
+				break;
+			default:
+				throw new Error(`Unknown argument: ${option}`);
+		}
+		index += 1;
+	}
+	if (!parsed.output) throw new Error("--output is required");
+	return parsed;
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const source = readFileSync(installerPath, "utf8");
+	const rendered = renderInstaller(source, { baseUrl: args.baseUrl, channel: args.channel });
+	writeFileSync(resolve(args.output), rendered, "utf8");
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	try {
+		main();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}

--- a/scripts/render-installer.mjs
+++ b/scripts/render-installer.mjs
@@ -10,6 +10,9 @@ const rootPackagePath = resolve(root, "package.json");
 const codingAgentPackagePath = resolve(root, "packages/coding-agent/package.json");
 const runtimeVersionGuardPath = resolve(root, "packages/coding-agent/src/cli/node-version-check.ts");
 const generatedMinimumPattern = /^prime_agent_min_node_version="([^"]+)" # generated from packages\/coding-agent\/package\.json engines\.node$/m;
+const baseUrlPlaceholder = "__PRIME_AGENT_DOWNLOAD_BASE_URL__";
+const releaseChannelPlaceholder = "__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__";
+const unresolvedPlaceholderPattern = /__PRIME_AGENT_[A-Z0-9_]+__/;
 
 function readJson(path) {
 	return JSON.parse(readFileSync(path, "utf8"));
@@ -64,13 +67,27 @@ export function renderInstallerMinimum(source) {
 	);
 }
 
+function replaceUniquePlaceholder(source, placeholder, value) {
+	const count = source.split(placeholder).length - 1;
+	if (count !== 1) {
+		throw new Error(`install.sh must contain exactly one ${placeholder} placeholder; found ${count}`);
+	}
+	return source.replace(placeholder, value);
+}
+
 export function renderInstaller(source, { baseUrl, channel }) {
-	if (!baseUrl) throw new Error("--base-url is required");
+	const normalizedBaseUrl = typeof baseUrl === "string" ? baseUrl.trim().replace(/\/+$/, "") : "";
+	if (!normalizedBaseUrl) throw new Error("--base-url must contain a non-root URL");
 	if (channel !== "stable" && channel !== "beta") throw new Error("--channel must be stable or beta");
 
-	return renderInstallerMinimum(source)
-		.replaceAll("__PRIME_AGENT_DOWNLOAD_BASE_URL__", baseUrl.replace(/\/+$/, ""))
-		.replaceAll("__PRIME_AGENT_DEFAULT_RELEASE_CHANNEL__", channel);
+	let rendered = renderInstallerMinimum(source);
+	rendered = replaceUniquePlaceholder(rendered, baseUrlPlaceholder, normalizedBaseUrl);
+	rendered = replaceUniquePlaceholder(rendered, releaseChannelPlaceholder, channel);
+	const unresolved = unresolvedPlaceholderPattern.exec(rendered);
+	if (unresolved) {
+		throw new Error(`Rendered installer contains unresolved placeholder ${unresolved[0]}`);
+	}
+	return rendered;
 }
 
 function parseArgs(args) {


### PR DESCRIPTION
## Summary

- derive the rendered installer minimum Node version from `packages/coding-agent/package.json` and validate that the root engine and runtime guard match
- use that generated minimum for installer preflight, package-manager candidate selection, upgrade guidance, and standalone Node major selection
- cover Node 20.6, 22.7, 22.8, 23, prerelease, and Debian/NodeSource-suffixed versions in the installer render check

## Verification

- `npm run check:installer`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/node-version-check.test.ts` from `packages/coding-agent`
- `npm run check`
- rendered stable installer smoke check with `sh -n` and placeholder validation

## Risk

Low. The change is limited to installer rendering and version validation. It does not alter the package engine requirement or daemon protocol.

Fixes #933


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce Node 22.8.0 minimum in installer preflight and CLI version check
> - Raises the minimum required Node.js version from 20.6.0 to 22.8.0 across [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/967/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f), [node-version-check.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/967/files#diff-0032b502f22f71fdd84202a0b03bf4899bce03c8f980cd7586649b8a28d6d90a), and the new [render-installer.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/967/files#diff-5039509a247a213fb2fb62030cd21e1fb87299900c91811f08ab448f3b1f2871) script, which validates all three stay in sync at build time.
> - Adds stricter version parsing in both the shell installer and the TypeScript CLI guard: prerelease builds are now explicitly rejected; only stable versions (or those with known distro suffixes) are accepted.
> - Replaces the inline Node snippet in the CI workflow with a dedicated [render-installer.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/967/files#diff-5039509a247a213fb2fb62030cd21e1fb87299900c91811f08ab448f3b1f2871) CLI that renders channel-specific installers and validates placeholder substitution.
> - Behavioral Change: any existing Node install below 22.8.0 or any prerelease Node (e.g. `22.8.0-rc.1`) will now fail preflight and the CLI version guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fdf115.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->