### PR TITLE
fix: auto-continue responses truncated at the output-token limit (stopReason length)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed responses being silently truncated at the provider's output-token limit (`stopReason: "length"` with non-empty text): the agent now queues a bounded auto-continuation so the model finishes where it left off instead of delivering a partial answer as final.
 
-
 ## [0.7.1] - 2026-08-07
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed responses being silently truncated at the provider's output-token limit (`stopReason: "length"` with non-empty text): the agent now queues a bounded auto-continuation so the model finishes where it left off instead of delivering a partial answer as final.
+
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -538,6 +538,42 @@ export type SerializedBackgroundPlanResult =
 export type AutoRefineReviewer = (request: AutoRefineReviewRequest, signal?: AbortSignal) => Promise<AutoRefineReview>;
 
 /** Options for AgentSession.prompt() */
+
+/**
+ * A terminal assistant message with stopReason "length" and non-empty text means the
+ * response was cut off by the provider's output-token limit (max_tokens). Without
+ * handling, the truncated text is delivered as if it were the complete answer.
+ */
+const MAX_LENGTH_CONTINUATIONS = 3;
+const LENGTH_CONTINUATION_PROMPT =
+	"Your previous response was truncated by the output token limit. Continue from exactly where you left off; do not repeat content you already produced.";
+
+/**
+ * Whether a terminal assistant message warrants an automatic continuation because
+ * the provider's output-token limit cut the response off mid-generation.
+ *
+ * A "length" stop with non-empty text is a truncation; a "length" stop with no
+ * output is the context-overflow case (handled separately by overflow recovery),
+ * and a response whose only content is tool calls is actionable as-is (the loop
+ * already continues after executing them).
+ */
+export function shouldAutoContinueTruncatedResponse(
+	message: AssistantMessage,
+	continuationCount: number,
+	maxContinuations: number = MAX_LENGTH_CONTINUATIONS,
+): boolean {
+	if (message.stopReason !== "length") {
+		return false;
+	}
+	if (continuationCount >= maxContinuations) {
+		return false;
+	}
+	if (message.content.some((content) => content.type === "toolCall")) {
+		return false;
+	}
+	return message.content.some((content) => content.type === "text" && content.text.length > 0);
+}
+
 export interface PromptOptions {
 	/** Whether to expand file-based prompt templates (default: true) */
 	expandPromptTemplates?: boolean;
@@ -1134,6 +1170,10 @@ export class AgentSession {
 	private _compactionOperation: Promise<void> | undefined = undefined;
 	/** One recovery attempt per overflow; "reported" dedups the failure notice. */
 	private _overflowRecovery: "idle" | "attempted" | "reported" = "idle";
+	/** Consecutive auto-continuations for output-token-truncated responses. */
+	private _lengthContinuations = 0;
+	/** True between queueing a truncation continuation and its steer prompt start. */
+	private _lengthContinuationPending = false;
 	private _continueAfterThresholdCompaction = false;
 	private _pendingRequestedCompaction: { customInstructions?: string } | undefined;
 	private _pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
@@ -2193,9 +2233,31 @@ export class AgentSession {
 		if (await this._shouldStopForThresholdCompaction(context)) {
 			return true;
 		}
+		// Auto-continue responses truncated by the model's output-token limit.
+		// stopReason "length" with non-empty text means the reply was cut off
+		// mid-generation (the output==0 context-overflow case is handled
+		// separately); queue a bounded follow-up so the model finishes where it
+		// left off instead of silently delivering a partial answer.
+		if (!this._steeringStopPending && this._shouldAutoContinueTruncation(context.message)) {
+			this._lengthContinuations++;
+			this._lengthContinuationPending = true;
+			await this._queuePreparedPrompt("steer", LENGTH_CONTINUATION_PROMPT, undefined, {
+				source: "internal",
+				resumeIfIdle: true,
+				suppressAutonomousContinuation: true,
+			});
+			return false;
+		}
 		// Steering stops continuation only after mandatory serialized checkpoints.
 		// Returning true here still prevents the agent loop from starting another turn.
 		return this._steeringStopPending;
+	}
+
+	private _shouldAutoContinueTruncation(message: AssistantMessage): boolean {
+		if (this._disposed || this._disposing) {
+			return false;
+		}
+		return shouldAutoContinueTruncatedResponse(message, this._lengthContinuations);
 	}
 
 	private async _shouldStopForThresholdCompaction(context: ShouldStopAfterTurnContext): Promise<boolean> {
@@ -3458,8 +3520,15 @@ export class AgentSession {
 			}
 		}
 
-		if (event.type === "message_start" && this._isPromptTurnStartMessage(event.message)) {
-			this._overflowRecovery = "idle";
+		if (event.type === "message_start") {
+			if (this._lengthContinuationPending) {
+				// This is the steer prompt we injected to continue a truncated
+				// response; keep the per-run continuation budget intact.
+				this._lengthContinuationPending = false;
+			} else if (this._isPromptTurnStartMessage(event.message)) {
+				this._overflowRecovery = "idle";
+				this._lengthContinuations = 0;
+			}
 		}
 
 		// Emit to extensions first
@@ -3518,6 +3587,11 @@ export class AgentSession {
 				}
 				if (assistantMsg.stopReason !== "error") {
 					this._overflowRecovery = "idle";
+				}
+				if (assistantMsg.stopReason === "stop" || assistantMsg.stopReason === "toolUse") {
+					// A naturally completed response resets the truncation
+					// continuation budget for the next run.
+					this._lengthContinuations = 0;
 				}
 				if (this._isConcreteProviderAuthFailure(assistantMsg)) {
 					this._captureRetryAuthFailureSource(assistantMsg);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1172,8 +1172,10 @@ export class AgentSession {
 	private _overflowRecovery: "idle" | "attempted" | "reported" = "idle";
 	/** Consecutive auto-continuations for output-token-truncated responses. */
 	private _lengthContinuations = 0;
-	/** True between queueing a truncation continuation and its steer prompt start. */
-	private _lengthContinuationPending = false;
+	/** The injected truncation continuation steer, tracked by identity until its
+	 *  message_start, so only that message can clear the pending marker (an
+	 *  interloping message_start cannot consume it and reset the budget). */
+	private _pendingLengthContinuationMessage: UserMessage | undefined = undefined;
 	private _continueAfterThresholdCompaction = false;
 	private _pendingRequestedCompaction: { customInstructions?: string } | undefined;
 	private _pendingRequestedRefine: { instructions?: string; global?: boolean } | undefined;
@@ -2230,23 +2232,41 @@ export class AgentSession {
 			await this._agentEventQueue;
 			await this._runSerializedRefineCheckpoint();
 		}
-		if (await this._shouldStopForThresholdCompaction(context)) {
-			return true;
-		}
 		// Auto-continue responses truncated by the model's output-token limit.
 		// stopReason "length" with non-empty text means the reply was cut off
 		// mid-generation (the output==0 context-overflow case is handled
 		// separately); queue a bounded follow-up so the model finishes where it
-		// left off instead of silently delivering a partial answer.
-		if (!this._steeringStopPending && this._shouldAutoContinueTruncation(context.message)) {
-			this._lengthContinuations++;
-			this._lengthContinuationPending = true;
-			await this._queuePreparedPrompt("steer", LENGTH_CONTINUATION_PROMPT, undefined, {
+		// left off instead of silently delivering a partial answer. This is
+		// queued BEFORE the threshold-compaction check: if we're also over the
+		// compaction threshold, the queued steer counts as pending session work,
+		// so _runAutoCompaction schedules a post-compaction continue and the
+		// truncated reply is still finished rather than silently dropped.
+		const truncationContinuation = !this._steeringStopPending && this._shouldAutoContinueTruncation(context.message);
+		if (truncationContinuation) {
+			const message: UserMessage = {
+				role: "user",
+				content: [{ type: "text", text: LENGTH_CONTINUATION_PROMPT }],
+				timestamp: Date.now(),
+			};
+			const accepted = await this._queuePreparedPrompt("steer", LENGTH_CONTINUATION_PROMPT, undefined, {
+				message,
 				source: "internal",
 				resumeIfIdle: true,
 				suppressAutonomousContinuation: true,
+				// Non-visible so an ACP/daemon abort cancels this like other
+				// internal control turns, instead of stranding a stale
+				// continuation that runs ahead of the user's next prompt.
+				queueVisible: false,
 			});
-			return false;
+			if (accepted) {
+				// Track the injected message by identity so only its own
+				// message_start consumes the pending marker.
+				this._lengthContinuations++;
+				this._pendingLengthContinuationMessage = message;
+			}
+		}
+		if (await this._shouldStopForThresholdCompaction(context)) {
+			return true;
 		}
 		// Steering stops continuation only after mandatory serialized checkpoints.
 		// Returning true here still prevents the agent loop from starting another turn.
@@ -3521,13 +3541,18 @@ export class AgentSession {
 		}
 
 		if (event.type === "message_start") {
-			if (this._lengthContinuationPending) {
+			if (
+				this._pendingLengthContinuationMessage !== undefined &&
+				event.message === this._pendingLengthContinuationMessage
+			) {
 				// This is the steer prompt we injected to continue a truncated
 				// response; keep the per-run continuation budget intact.
-				this._lengthContinuationPending = false;
+				this._pendingLengthContinuationMessage = undefined;
 			} else if (this._isPromptTurnStartMessage(event.message)) {
 				this._overflowRecovery = "idle";
 				this._lengthContinuations = 0;
+				// Drop any stale marker from a cancelled continuation.
+				this._pendingLengthContinuationMessage = undefined;
 			}
 		}
 
@@ -5429,6 +5454,7 @@ export class AgentSession {
 			suppressAutonomousContinuation?: boolean;
 			resumeIfIdle?: boolean;
 			source?: InputSource | "internal";
+			queueVisible?: boolean;
 		} = {},
 	): Promise<boolean> {
 		const action = this._createPreparedTurnAction(schedule, text, images, options);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2241,8 +2241,13 @@ export class AgentSession {
 		// compaction threshold, the queued steer counts as pending session work,
 		// so _runAutoCompaction schedules a post-compaction continue and the
 		// truncated reply is still finished rather than silently dropped.
-		const truncationContinuation = !this._steeringStopPending && this._shouldAutoContinueTruncation(context.message);
-		if (truncationContinuation) {
+		// Whether a length-continuation steer was actually admitted. When it was
+		// AND we're also over the compaction threshold, we must not let threshold
+		// compaction queue its own autonomous continuation as well, or the model
+		// would get two post-compaction turns and burn an autonomous credit for
+		// work the bounded steer already covers.
+		let lengthContinuationQueued = false;
+		if (!this._steeringStopPending && this._shouldAutoContinueTruncation(context.message)) {
 			const message: UserMessage = {
 				role: "user",
 				content: [{ type: "text", text: LENGTH_CONTINUATION_PROMPT }],
@@ -2263,9 +2268,10 @@ export class AgentSession {
 				// message_start consumes the pending marker.
 				this._lengthContinuations++;
 				this._pendingLengthContinuationMessage = message;
+				lengthContinuationQueued = true;
 			}
 		}
-		if (await this._shouldStopForThresholdCompaction(context)) {
+		if (await this._shouldStopForThresholdCompaction(context, lengthContinuationQueued)) {
 			return true;
 		}
 		// Steering stops continuation only after mandatory serialized checkpoints.
@@ -2280,9 +2286,15 @@ export class AgentSession {
 		return shouldAutoContinueTruncatedResponse(message, this._lengthContinuations);
 	}
 
-	private async _shouldStopForThresholdCompaction(context: ShouldStopAfterTurnContext): Promise<boolean> {
+	private async _shouldStopForThresholdCompaction(
+		context: ShouldStopAfterTurnContext,
+		suppressAutonomousContinuation = false,
+	): Promise<boolean> {
 		this._continueAfterThresholdCompaction = false;
-		if (this._pendingRequestedCompaction === undefined && !(await this._thresholdCompactionNeeded(context))) {
+		if (
+			this._pendingRequestedCompaction === undefined &&
+			!(await this._thresholdCompactionNeeded(context, suppressAutonomousContinuation))
+		) {
 			return false;
 		}
 
@@ -2757,7 +2769,10 @@ export class AgentSession {
 		}
 	}
 
-	private async _thresholdCompactionNeeded(context: ShouldStopAfterTurnContext): Promise<boolean> {
+	private async _thresholdCompactionNeeded(
+		context: ShouldStopAfterTurnContext,
+		suppressAutonomousContinuation = false,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
 
@@ -2773,7 +2788,14 @@ export class AgentSession {
 			return false;
 		}
 
-		if (await this._queueAutonomousContinuationForThresholdCompaction(context.message)) {
+		// With autonomous mode on, a truncated response that is also over the
+		// threshold already has a length-continuation steer pending, so skip
+		// queueing a separate autonomous continuation (it would run in addition
+		// to the steer after compaction and burn an autonomous credit).
+		if (
+			!suppressAutonomousContinuation &&
+			(await this._queueAutonomousContinuationForThresholdCompaction(context.message))
+		) {
 			this._continueAfterThresholdCompaction = true;
 		}
 		return true;

--- a/packages/coding-agent/test/agent-session-length-continuation-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-length-continuation-loop.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Loop-level integration tests for auto-continuing responses truncated at the
+ * provider's output-token limit (stopReason "length").
+ *
+ * Unlike the pure `shouldAutoContinueTruncatedResponse` unit tests, these drive
+ * a real AgentSession with a mocked model stream so the session-loop behavior
+ * is exercised: continuation queuing, budget accounting across turns, budget
+ * reset on a fresh prompt, and the threshold-compaction ordering.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	getModel,
+	type ImageContent,
+	type TextContent,
+} from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+const CONTINUATION_MARKER = "Continue from exactly where you left off";
+const FINAL_TEXT = "finished reply after continuation";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function assistantMessage(text: string, stopReason: AssistantMessage["stopReason"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function userTexts(context: { messages: unknown[] }): string[] {
+	return context.messages
+		.filter((message) => (message as { role?: string }).role === "user")
+		.map((message) => {
+			const content = (message as { content?: unknown }).content;
+			if (typeof content === "string") return content;
+			return (content as Array<TextContent | ImageContent>)
+				.filter((part) => typeof part === "object" && part !== null && part.type === "text")
+				.map((part) => (part as TextContent).text)
+				.join("\n");
+		});
+}
+
+describe("AgentSession length-continuation loop", () => {
+	let session: AgentSession;
+	let tempDir: string;
+	let calls: number;
+	let isContinuation: (context: { messages: unknown[] }) => boolean;
+	let respond: (stream: MockAssistantStream, context: { messages: unknown[] }) => void;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-length-cont-${Date.now()}-${Math.random()}`);
+		mkdirSync(tempDir, { recursive: true });
+		calls = 0;
+	});
+
+	afterEach(async () => {
+		if (session) {
+			try {
+				session.dispose();
+			} catch {
+				// ignore
+			}
+		}
+		if (tempDir && existsSync(tempDir)) {
+			try {
+				rmSync(tempDir, { recursive: true });
+			} catch {
+				// ignore
+			}
+		}
+	});
+
+	function createSession() {
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: (_model, context) => {
+				calls++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const cont = isContinuation?.(context);
+					if (respond) {
+						respond(stream, context);
+					} else if (cont) {
+						stream.push({ type: "start", partial: assistantMessage("", "stop") });
+						stream.push({ type: "done", reason: "stop", message: assistantMessage(FINAL_TEXT, "stop") });
+					} else {
+						stream.push({ type: "start", partial: assistantMessage("", "length") });
+						stream.push({
+							type: "done",
+							reason: "length",
+							message: assistantMessage("partial answer", "length"),
+						});
+					}
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+	}
+
+	function sessionMessagesText(): string {
+		const messages = (session.agent.state.messages ?? []) as Array<{
+			role?: string;
+			content?: unknown;
+		}>;
+		return messages
+			.map((message) => {
+				const content = message.content;
+				if (typeof content === "string") return `${message.role}: ${content}`;
+				return `${message.role}:${(content as Array<{ text?: string }>)
+					.filter((part) => typeof part === "object" && part !== null && part.text !== undefined)
+					.map((part) => part.text)
+					.join(" ")}`;
+			})
+			.join(" | ");
+	}
+
+	async function waitForIdle() {
+		await session.agent.waitForIdle();
+	}
+
+	it("auto-continues a response truncated at the output token limit", async () => {
+		createSession();
+		isContinuation = (context) => userTexts(context).some((t) => t.includes(CONTINUATION_MARKER));
+
+		await session.prompt("First message");
+		await waitForIdle();
+
+		// First model call truncated; a second call followed with the steer prompt.
+		expect(calls).toBe(2);
+		const text = sessionMessagesText();
+		expect(text).toContain("partial answer");
+		expect(text).toContain(FINAL_TEXT);
+	});
+
+	it("stops auto-continuing after the bound is exhausted", async () => {
+		createSession();
+		// Every call returns a truncated response so the budget is what stops it.
+		respond = (stream) => {
+			stream.push({ type: "start", partial: assistantMessage("", "length") });
+			stream.push({ type: "done", reason: "length", message: assistantMessage("still partial", "length") });
+		};
+		isContinuation = () => true;
+
+		await session.prompt("First message");
+		await waitForIdle();
+
+		// 1 initial + MAX_LENGTH_CONTINUATIONS (3) continuation attempts, then stop.
+		expect(calls).toBe(4);
+	});
+});

--- a/packages/coding-agent/test/agent-session-length-continuation.test.ts
+++ b/packages/coding-agent/test/agent-session-length-continuation.test.ts
@@ -1,0 +1,56 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { shouldAutoContinueTruncatedResponse } from "../src/core/agent-session.js";
+
+function assistant(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "partial answer" }],
+		api: "openai",
+		provider: "openai",
+		model: "test-model",
+		usage: { input: 10, output: 10, cacheRead: 0, cacheWrite: 0, totalTokens: 20 },
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	} as AssistantMessage;
+}
+
+describe("shouldAutoContinueTruncatedResponse", () => {
+	it("auto-continues a response cut off by the output-token limit", () => {
+		const msg = assistant({ stopReason: "length", content: [{ type: "text", text: "and then..." }] });
+		expect(shouldAutoContinueTruncatedResponse(msg, 0)).toBe(true);
+	});
+
+	it("does not continue when the response completed normally", () => {
+		expect(shouldAutoContinueTruncatedResponse(assistant({ stopReason: "stop" }), 0)).toBe(false);
+	});
+
+	it("does not continue a length stop whose only content is tool calls", () => {
+		const msg = assistant({
+			stopReason: "length",
+			content: [{ type: "toolCall", id: "c1", name: "ipython", arguments: {} }],
+		});
+		expect(shouldAutoContinueTruncatedResponse(msg, 0)).toBe(false);
+	});
+
+	it("does not continue a length stop with no output (context-overflow case)", () => {
+		expect(shouldAutoContinueTruncatedResponse(assistant({ stopReason: "length", content: [] }), 0)).toBe(false);
+	});
+
+	it("respects the per-run continuation budget", () => {
+		const msg = assistant({ stopReason: "length", content: [{ type: "text", text: "more..." }] });
+		expect(shouldAutoContinueTruncatedResponse(msg, 2, 3)).toBe(true);
+		expect(shouldAutoContinueTruncatedResponse(msg, 3, 3)).toBe(false);
+	});
+
+	it("does not continue on other stop reasons", () => {
+		const toolUse = assistant({
+			stopReason: "toolUse",
+			content: [{ type: "toolCall", id: "c1", name: "ipython", arguments: {} }],
+		});
+		expect(shouldAutoContinueTruncatedResponse(toolUse, 0)).toBe(false);
+		expect(shouldAutoContinueTruncatedResponse(assistant({ stopReason: "aborted" }), 0)).toBe(false);
+		expect(shouldAutoContinueTruncatedResponse(assistant({ stopReason: "error" }), 0)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -794,6 +794,92 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
 	});
 
+	it("suppresses the autonomous continuation when a truncation continuation is queued ahead of threshold compaction", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness({
+			autonomous: {
+				enabled: true,
+				maxContinuations: 2,
+				maxTurns: 100,
+				gates: { commands: [failingGateCommand()], maxRetries: 5 },
+			},
+			settings: { compaction: { enabled: true, reserveTokens: 1000, keepRecentTokens: 1 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals & {
+			_pendingLengthContinuationMessage: unknown;
+		};
+		// Non-empty text so the bounded truncation continuation is eligible, plus
+		// enough output tokens (and a huge tool result) to trip threshold compaction.
+		const model = harness.getModel();
+		const truncatedAssistant: AssistantMessage = {
+			...fauxAssistantMessage("partial answer cut off here", {
+				stopReason: "length",
+				timestamp: Date.now(),
+			}),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(10_000),
+		};
+		const toolResult: ToolResultMessage<unknown> = {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "large-context",
+			content: [{ type: "text", text: "x".repeat(800_000) }],
+			isError: false,
+			timestamp: Date.now() + 500,
+		};
+		const currentUser = {
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			timestamp: Date.now() - 1000,
+		} satisfies Parameters<typeof harness.sessionManager.appendMessage>[0];
+		const oldUser = {
+			role: "user",
+			content: [{ type: "text", text: "old" }],
+			timestamp: Date.now() - 3000,
+		} satisfies Parameters<typeof harness.sessionManager.appendMessage>[0];
+		const oldAssistant = createAssistant(harness, {
+			stopReason: "stop",
+			totalTokens: 100,
+			timestamp: Date.now() - 2000,
+		});
+		const oldMessages: AgentMessage[] = [oldUser, oldAssistant];
+		const messages: AgentMessage[] = [currentUser, truncatedAssistant, toolResult];
+		for (const message of [oldUser, oldAssistant, currentUser, truncatedAssistant]) {
+			harness.sessionManager.appendMessage(message);
+		}
+		harness.session.agent.state.messages = [...oldMessages, ...messages];
+
+		const followUpSpy = vi.spyOn(harness.session.agent, "followUp");
+
+		const shouldStop = await sessionInternals._shouldStopAfterTurn({
+			message: truncatedAssistant,
+			toolResults: [toolResult],
+			context: { systemPrompt: harness.session.systemPrompt, messages, tools: [] },
+			newMessages: [truncatedAssistant, toolResult],
+		});
+
+		// Threshold compaction is still needed, so the loop should stop...
+		expect(shouldStop).toBe(true);
+		// ...but the autonomous gate continuation must NOT be queued as well: the
+		// bounded truncation steer already covers resuming the partial reply.
+		expect(followUpSpy).not.toHaveBeenCalled();
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);
+		// The truncation continuation steer itself was admitted and identity-tracked.
+		expect(sessionInternals._pendingLengthContinuationMessage).toBeDefined();
+
+		await sessionInternals._runAutoCompaction("threshold", false);
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(followUpSpy).not.toHaveBeenCalled();
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.getAutonomousStatus().continuationsUsed).toBe(0);
+	});
+
 	it("keeps autonomous continuation bookkeeping when only steering queue is drained", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({


### PR DESCRIPTION
## Problem

Assistant responses are silently truncated mid-sentence at the provider's output-token limit. In a real session, **10 of 172 assistant turns ended with `stopReason: "length"` and `usage.output == 4096` exactly** (routed via `openrouter/auto-beta` → `deepseek-v4-flash-0731`). The agent loop treated every `stopReason` other than `error`/`aborted` as a successful terminal message, so the **partial text was delivered as if it were the complete answer** — no continuation, no notice to the user, no signal to the agent that its reply was incomplete.

This bites hardest on long analytical deliverables (reviews, multi-part plans), which are exactly the responses that exceed a 4096-token cap.

## Fix

Add bounded **auto-continuation** for truncated responses in the coding-agent session loop:

- When a terminal assistant message has `stopReason === "length"` and non-empty text content, `_shouldStopAfterTurn` now queues an internal **steer** prompt (`"Continue from exactly where you left off..."`) and lets the loop continue, so the model finishes the reply in a follow-up stream — using the same internal-prompt mechanism the goal-budget path already uses.
- **Bounded**: max 3 consecutive auto-continuations per run (`MAX_LENGTH_CONTINUATIONS`), reset on natural completions (`stop` / `toolUse`) and on fresh prompt turns, so a pathological model cannot spin forever.
- **Conservative exclusions**:
  - no output (`length` with empty content) — that is the context-overflow case already handled by `overflow.ts` overflow recovery;
  - responses whose only content is tool calls — those are actionable as-is and the loop already continues after executing them;
  - disposed sessions and pending user steering stops are respected.
- The decision logic is extracted into a pure exported helper `shouldAutoContinueTruncatedResponse(message, continuationCount, maxContinuations)` with **6 unit tests** (`test/agent-session-length-continuation.test.ts`).

## Verification

- `npx vitest run test/agent-session-length-continuation.test.ts` — 6/6 pass.
- `npx vitest run test/agent-session-config.test.ts test/agent-session-stats.test.ts` — 12/12 pass (no regressions in touched module).
- `npx tsgo --noEmit -p packages/coding-agent/tsconfig.build.json` — no errors in `agent-session.ts` (remaining errors are pre-existing in untouched TUI files).
- Repo pre-commit hook (`biome check`, root `tsgo --noEmit`, installer render, browser smoke) passed.

## Notes for reviewers

- Alternative/complementary fix considered: raise the output-token cap (e.g., pass `maxTokens` explicitly). Auto-continuation is provider-agnostic and also helps when the *route* caps output regardless of the requested `maxTokens`, so it is the more robust first fix; a follow-up could also raise the cap.
- The continuation prompt is delivered via the existing prepared-prompt steering queue, so it flows through the same input plumbing as other internal prompts (goal budget limits, heartbeats) and is surfaced appropriately.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silently truncated agent responses by auto-continuing when `stopReason` is `length`
> - When an assistant message ends with `stopReason: "length"`, `AgentSession` now automatically queues a non-visible continuation steer (`LENGTH_CONTINUATION_PROMPT`) that tells the model to continue from where it left off.
> - Continuations are bounded by `MAX_LENGTH_CONTINUATIONS` (3) tracked per run via `_lengthContinuations`; the counter resets on a clean `stop` or `toolUse` finish.
> - When a truncation continuation is already queued, threshold-compaction's autonomous continuation is suppressed to prevent double-queuing.
> - A new exported predicate `shouldAutoContinueTruncatedResponse` centralizes the decision logic (non-empty text content, no tool-call-only turns, budget not exhausted).
> - Behavioral Change: truncated responses that were previously silently dropped now produce up to 3 additional model calls per turn automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c16a3fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->